### PR TITLE
Fix ODBC build failures

### DIFF
--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -16,9 +16,11 @@ $INSTALL_DIR = $args[4]
 Write-Host $args
 
 # Clone the AWS SDK CPP repo
-# $SDK_VER = "1.7.29"
+$SDK_VER = "1.8.186"
 # -b "$SDK_VER" `
 git clone `
+    --branch `
+    $SDK_VER `
     --single-branch `
     "https://github.com/aws/aws-sdk-cpp.git" `
     $SRC_DIR


### PR DESCRIPTION
### Description
Changed aws sdk cpp version to the last success version `1.8.186`. This PR is a temporary solution to fix the build errors, but we probably need to dive deeper to adapt our future versions to the new releases of aws sdk. 
 
### Issues Resolved
https://github.com/opendistro-for-elasticsearch/sql/pull/1092
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
~~- [ ] New functionality has been documented.~~
  ~~- [ ] New functionality has javadoc added~~
  ~~- [ ] New functionality has user manual doc added~~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).