### PR TITLE
SQL/PPL API migration for OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ The package uses the [Gradle](https://docs.gradle.org/4.10.2/userguide/userguide
 
 ## Basic Usage
 
-To use the feature, send requests to the `_opendistro/_sql` URI. You can use a request parameter or the request body (recommended).
+To use the feature, send requests to the `_opensearch/_sql` URI. You can use a request parameter or the request body (recommended).
 
 * Simple query
 
 ```
-POST https://<host>:<port>/_opendistro/_sql
+POST https://<host>:<port>/_opensearch/_sql
 {
   "query": "SELECT * FROM my-index LIMIT 50"
 }
@@ -61,7 +61,7 @@ POST https://<host>:<port>/_opendistro/_sql
 
 * Explain SQL to OpenSearch query DSL
 ```
-POST _opendistro/_sql/_explain
+POST _opensearch/_sql/_explain
 {
   "query": "SELECT * FROM my-index LIMIT 50"
 }
@@ -69,7 +69,7 @@ POST _opendistro/_sql/_explain
 
 * For a sample curl command with the OpenSearch Security plugin, try:
 ```
-curl -XPOST https://localhost:9200/_opendistro/_sql -u admin:admin -k -d '{"query": "SELECT * FROM my-index LIMIT 10"}' -H 'Content-Type: application/json'
+curl -XPOST https://localhost:9200/_opensearch/_sql -u admin:admin -k -d '{"query": "SELECT * FROM my-index LIMIT 10"}' -H 'Content-Type: application/json'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The package uses the [Gradle](https://docs.gradle.org/4.10.2/userguide/userguide
 
 ## Basic Usage
 
-To use the feature, send requests to the `_opensearch/_sql` URI. You can use a request parameter or the request body (recommended).
+To use the feature, send requests to the `_opensearch/_sql` URI. You can use a request parameter or the request body (recommended). Note that for backward compatibility, old `_opendistro/_sql` endpoint is still available, though any future API will be only accessible by new OpenSearch endpoint.
 
 * Simple query
 

--- a/docs/dev/Doctest.md
+++ b/docs/dev/Doctest.md
@@ -229,7 +229,7 @@ Doctest: explain.rst
 File "/Users/szhongna/Desktop/Projects/sql/doctest/docs/dql/explain.rst", line 6, in explain.rst
 Failed example:
     pretty_print(sh("""curl -sS -H 'Content-Type: application/json' \
-    -X POST localhost:9200/_opendistro/_sql/_explain \
+    -X POST localhost:9200/_opensearch/_sql/_explain \
     -d '{"query" : "SELECT firstname, lastname FROM accounts WHERE age > 20"}'
     """).stdout.decode("utf-8"))
 Expected:

--- a/docs/dev/Doctest.md
+++ b/docs/dev/Doctest.md
@@ -175,7 +175,7 @@ fetched rows / total rows = 4/4
 The code example in a doc using `bash` should be like this
 
 ```
-sh$ curl -XPOST "localhost:9200/_opendistro/_ppl/" 
+sh$ curl -XPOST "localhost:9200/_opensearch/_ppl/" 
           -H 'Content-Type: application/json' 
           -d'{  "query": "search source=opensearch_dashboards_sample_data_flights OriginCountry = "IT" 
           DestiContry = "US" | fields FlightNum, DestCountry, OriginCountry "}'

--- a/docs/dev/Pagination.md
+++ b/docs/dev/Pagination.md
@@ -101,7 +101,7 @@ Since we are implementing server side cursors, either OpenSearch SQL plugin or O
 
 ```
 # 1.Creates a cursor
-POST _opendistro/_sql?format=jdbc
+POST _opensearch/_sql?format=jdbc
 {
   "query": "SELECT * FROM accounts",
   "fetch_size": 5
@@ -118,7 +118,7 @@ POST _opendistro/_sql?format=jdbc
 }
 
 # 2.Fetch next page by cursor provided in previous response
-POST _opendistro/_sql?format=jdbc
+POST _opensearch/_sql?format=jdbc
 {
   "cursor": "cursorId"
 }
@@ -135,7 +135,7 @@ POST _opendistro/_sql?format=jdbc
 
 
 # 4.Clear the state forcibly earlier than last page be reached
-POST _opendistro/_sql/close
+POST _opensearch/_sql/close
 {
   "cursor": "cursorId"
 }

--- a/docs/dev/SemanticAnalysis.md
+++ b/docs/dev/SemanticAnalysis.md
@@ -23,7 +23,7 @@ Firstly, you could go through the following examples of semantic check with our 
 ### 2.1 Field Name Typo
 
 ```
-POST _opendistro/_sql
+POST _opensearch/_sql
 {
   "query": "SELECT balace FROM accounts"
 }
@@ -41,7 +41,7 @@ POST _opendistro/_sql
 ### 2.2 Function Call on Incompatible Field Type
 
 ```
-POST _opendistro/_sql
+POST _opensearch/_sql
 {
   "query": "SELECT * FROM accounts WHERE SUBSTRING(balance, 0, 1) = 'test'"
 }
@@ -59,7 +59,7 @@ POST _opendistro/_sql
 ### 2.3 An index Join Non-nested Field
 
 ```
-POST _opendistro/_sql
+POST _opensearch/_sql
 {
   "query": "SELECT * FROM accounts a, a.firstname"
 }
@@ -77,7 +77,7 @@ POST _opendistro/_sql
 ### 2.4 Wrong Reference in Subquery
 
 ```
-POST _opendistro/_sql
+POST _opensearch/_sql
 {
   "query": "SELECT * FROM accounts a WHERE EXISTS (SELECT * FROM accounts b WHERE b.address LIKE 'Seattle') AND b.age > 10"
 }
@@ -95,7 +95,7 @@ POST _opendistro/_sql
 ### 2.5 Operator Use on Incompatible Field Type
 
 ```
-POST _opendistro/_sql
+POST _opensearch/_sql
 {
   "query": "SELECT * FROM accounts WHERE lastname IS FALSE"
 }
@@ -113,7 +113,7 @@ POST _opendistro/_sql
 ### 2.6 Subquery Return Incompatible Type
 
 ```
-POST _opendistro/_sql
+POST _opensearch/_sql
 {
   "query": "SELECT * FROM accounts WHERE lastname IN (SELECT age FROM accounts)"
 }
@@ -131,7 +131,7 @@ POST _opendistro/_sql
 ### 2.7 Multi-query On Incompatible Type
 
 ```
-POST _opendistro/_sql
+POST _opensearch/_sql
 {
   "query": "SELECT balance FROM accounts UNION ALL SELECT city FROM accounts"
 }

--- a/docs/experiment/ppl/admin/monitoring.rst
+++ b/docs/experiment/ppl/admin/monitoring.rst
@@ -42,7 +42,7 @@ Example
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X GET localhost:9200/_opendistro/_ppl/stats
+	>> curl -H 'Content-Type: application/json' -X GET localhost:9200/_opensearch/_ppl/stats
 
 Result set::
 

--- a/docs/experiment/ppl/admin/settings.rst
+++ b/docs/experiment/ppl/admin/settings.rst
@@ -28,7 +28,7 @@ You can disable SQL plugin to reject all coming requests.
 2. This setting is node scope.
 3. This setting can be updated dynamically.
 
-Notes. Calls to _opendistro/_ppl include index names in the request body, so they have the same access policy considerations as the bulk, mget, and msearch operations. if rest.action.multi.allow_explicit_index set to false, PPL plugin will be disabled.
+Notes. Calls to _opensearch/_ppl include index names in the request body, so they have the same access policy considerations as the bulk, mget, and msearch operations. if rest.action.multi.allow_explicit_index set to false, PPL plugin will be disabled.
 
 Example 1
 ---------
@@ -60,7 +60,7 @@ Query result after the setting updated is like:
 PPL query::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_ppl \
+    ... -X POST localhost:9200/_opensearch/_ppl \
     {
       "error": {
         "reason": "Invalid Query",

--- a/docs/experiment/ppl/interfaces/endpoint.rst
+++ b/docs/experiment/ppl/interfaces/endpoint.rst
@@ -22,7 +22,7 @@ POST
 Description
 -----------
 
-You can send HTTP POST request to endpoint **/_opendistro/_ppl** with your query in request body.
+You can send HTTP POST request to endpoint **/_opensearch/_ppl** with your query in request body.
 
 Example
 -------
@@ -30,7 +30,7 @@ Example
 PPL query::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_ppl \
+    ... -X POST localhost:9200/_opensearch/_ppl \
     ... -d '{"query" : "source=accounts | fields firstname, lastname"}'
     {
       "schema": [
@@ -71,7 +71,7 @@ Explain
 Description
 -----------
 
-You can send HTTP explain request to endpoint **/_opendistro/_ppl/_explain** with your query in request body to understand the execution plan for the PPL query. The explain endpoint is useful when user want to get insight how the query is executed in the engine.
+You can send HTTP explain request to endpoint **/_opensearch/_ppl/_explain** with your query in request body to understand the execution plan for the PPL query. The explain endpoint is useful when user want to get insight how the query is executed in the engine.
 
 Example
 -------
@@ -79,7 +79,7 @@ Example
 The following PPL query demonstrated that where and stats command were pushed down to OpenSearch DSL aggregation query::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_ppl/_explain \
+    ... -X POST localhost:9200/_opensearch/_ppl/_explain \
     ... -d '{"query" : "source=accounts | where age > 10 | stats avg(age)"}'
     {
       "root": {

--- a/docs/experiment/ppl/interfaces/protocol.rst
+++ b/docs/experiment/ppl/interfaces/protocol.rst
@@ -30,7 +30,7 @@ Example 1
 PPL query::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_ppl \
+    ... -X POST localhost:9200/_opensearch/_ppl \
     ... -d '{"query" : "source=accounts | fields firstname, lastname"}'
     {
       "schema": [
@@ -81,7 +81,7 @@ Here is an example for normal response. The `schema` includes field name and its
 PPL query::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_ppl \
+    ... -X POST localhost:9200/_opensearch/_ppl \
     ... -d '{"query" : "source=accounts | fields firstname, lastname"}'
     {
       "schema": [
@@ -124,7 +124,7 @@ If any error occurred, error message and the cause will be returned instead.
 PPL query::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_ppl \
+    ... -X POST localhost:9200/_opensearch/_ppl \
     ... -d '{"query" : "source=unknown | fields firstname, lastname"}'
     {
       "error": {

--- a/docs/user/admin/monitoring.rst
+++ b/docs/user/admin/monitoring.rst
@@ -48,7 +48,7 @@ Example
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X GET localhost:9200/_opendistro/_sql/stats
+	>> curl -H 'Content-Type: application/json' -X GET localhost:9200/_opensearch/_sql/stats
 
 Result set::
 

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -37,7 +37,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.enabled" : "false"
 	  }
@@ -64,7 +64,7 @@ Query result after the setting updated is like:
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
 	  "query" : "SELECT * FROM accounts"
 	}'
 
@@ -99,7 +99,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.query.slowlog" : "10"
 	  }
@@ -141,7 +141,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.query.analysis.enabled" : "false"
 	  }
@@ -185,7 +185,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.query.analysis.semantic.suggestion" : "true"
 	  }
@@ -218,7 +218,7 @@ Query result after the setting updated is like:
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
 	  "query" : "SELECT first FROM accounts"
 	}'
 
@@ -253,7 +253,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.query.analysis.semantic.threshold" : "50"
 	  }
@@ -299,7 +299,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.query.response.format" : "json"
 	  }
@@ -330,7 +330,7 @@ Query result after the setting updated is like:
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
 	  "query" : "SELECT firstname, lastname, age FROM accounts ORDER BY age LIMIT 2"
 	}'
 
@@ -404,7 +404,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.cursor.enabled" : "true"
 	  }
@@ -446,7 +446,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.cursor.fetch_size" : "50"
 	  }
@@ -488,7 +488,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.cursor.keep_alive" : "5m"
 	  }
@@ -530,7 +530,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opendistro/_sql/settings -d '{
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_opensearch/_sql/settings -d '{
 	  "transient" : {
 	    "opendistro.sql.engine.new.enabled" : "false"
 	  }

--- a/docs/user/beyond/fulltext.rst
+++ b/docs/user/beyond/fulltext.rst
@@ -29,7 +29,7 @@ Both functions can accept field name as first argument and a text as second argu
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number, address
@@ -99,7 +99,7 @@ Both functions can also accept single argument and be used in the following mann
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number, address
@@ -177,7 +177,7 @@ Each preceding function accepts ``query`` for a text and ``fields`` for field na
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT firstname, lastname
@@ -257,7 +257,7 @@ Example
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number, address
@@ -340,7 +340,7 @@ Example
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number, address
@@ -413,7 +413,7 @@ The first argument is a match query expression and the second argument is for an
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number, address, _score

--- a/docs/user/beyond/partiql.rst
+++ b/docs/user/beyond/partiql.rst
@@ -239,7 +239,7 @@ In the following example, it finds nested document (project) with field value (n
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT e.name AS employeeName,
@@ -332,7 +332,7 @@ Alternatively, a nested collection can be unnested in subquery to check if it sa
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT e.name AS employeeName

--- a/docs/user/dml/delete.rst
+++ b/docs/user/dml/delete.rst
@@ -32,7 +32,7 @@ The ``datarows`` field in this case shows rows impacted, in other words how many
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		DELETE FROM accounts

--- a/docs/user/dql/basics.rst
+++ b/docs/user/dql/basics.rst
@@ -88,7 +88,7 @@ You can use ``*`` to fetch all fields in the index which is very convenient when
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT * FROM accounts"
 	}
@@ -122,7 +122,7 @@ More often you would give specific field name(s) in ``SELECT`` clause to avoid l
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT firstname, lastname FROM accounts"
 	}
@@ -163,7 +163,7 @@ Alias is often used to make your query more readable by giving your field a shor
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT account_number AS num FROM accounts"
 	}
@@ -203,7 +203,7 @@ By default, ``SELECT ALL`` takes effect to return all rows. ``DISTINCT`` is usef
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT DISTINCT age FROM accounts"
 	}
@@ -291,7 +291,7 @@ Similarly you can give index in ``FROM`` clause an alias and use it across claus
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT acc.account_number FROM accounts acc"
 	}
@@ -303,7 +303,7 @@ Alternatively you can query from multiple indices of similar names by index patt
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT account_number FROM account*"
 	}
@@ -315,7 +315,7 @@ You can also specify type name explicitly though this has been deprecated in lat
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT account_number FROM accounts/account"
 	}
@@ -339,7 +339,7 @@ Basic comparison operators, such as ``=``, ``<>``, ``>``, ``>=``, ``<``, ``<=``,
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number
@@ -403,7 +403,7 @@ Note that for now we don't differentiate missing field and field set to ``NULL``
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number, employer
@@ -480,7 +480,7 @@ Example 1: Grouping by Fields
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT age
@@ -544,7 +544,7 @@ Field alias is accessible in ``GROUP BY`` clause.
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number AS num
@@ -608,7 +608,7 @@ Alternatively field ordinal in ``SELECT`` clause can be used too. However this i
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT age
@@ -672,7 +672,7 @@ Scalar function can be used in ``GROUP BY`` clause and it's required to be prese
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT ABS(age) AS a
@@ -754,7 +754,7 @@ Example
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT age, MAX(balance)
@@ -849,7 +849,7 @@ Besides regular field names, ordinal, alias or scalar function can also be used 
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT account_number FROM accounts ORDER BY account_number DESC"
 	}
@@ -896,7 +896,7 @@ Additionally you can specify if documents with missing field be put first or las
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT employer
@@ -1016,7 +1016,7 @@ Given a positive number, ``LIMIT`` uses it as page size to fetch result of that 
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number
@@ -1061,7 +1061,7 @@ Offset position can be given as first argument to indicate where to start fetchi
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT account_number

--- a/docs/user/dql/complex.rst
+++ b/docs/user/dql/complex.rst
@@ -24,7 +24,7 @@ Example 1: Table Subquery
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT a1.firstname, a1.lastname, a1.balance
@@ -174,7 +174,7 @@ Example 2: Subquery in FROM Clause
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT a.f, a.l, a.a
@@ -301,7 +301,7 @@ Inner join is very commonly used that creates a new result set by combining colu
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT
@@ -399,7 +399,7 @@ Cross join or Cartesian join combines each document from the first index with ea
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT
@@ -448,7 +448,7 @@ Outer join is used to retain documents from one or both indices although it does
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : """
 		SELECT

--- a/docs/user/dql/metadata.rst
+++ b/docs/user/dql/metadata.rst
@@ -36,7 +36,7 @@ Example 1: Show All Indices Information
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SHOW TABLES LIKE %"
 	}
@@ -59,7 +59,7 @@ Here is an example that searches metadata for index name prefixed by 'acc'. Besi
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SHOW TABLES LIKE acc%"
 	}
@@ -80,7 +80,7 @@ Example 3: Describe Index Fields Information
 
 SQL query::
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "DESCRIBE TABLES LIKE accounts"
 	}

--- a/docs/user/dql/newsql.rst
+++ b/docs/user/dql/newsql.rst
@@ -16,7 +16,7 @@ Introduction
 To use the SQL features present in documentation correctly, you need to enable our new SQL query engine by the following command::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X PUT localhost:9200/_opendistro/_sql/settings \
+    ... -X PUT localhost:9200/_opensearch/_sql/settings \
     ... -d '{"transient" : {"opendistro.sql.engine.new.enabled" : "true"}}'
     {
       "acknowledged": true,

--- a/docs/user/dql/troubleshooting.rst
+++ b/docs/user/dql/troubleshooting.rst
@@ -25,7 +25,7 @@ Query:
 
 .. code-block:: JSON
 
-	POST /_opendistro/_sql
+	POST /_opensearch/_sql
 	{
 	  "query" : "SELECT * FROM sample:data"
 	}
@@ -51,7 +51,7 @@ You need to confirm if the syntax is not supported and disable query analysis if
 
 .. code-block:: JSON
 
-    POST /_opendistro/_sql
+    POST /_opensearch/_sql
 	{
 	  "query" : "SELECT * FROM `sample:data`"
 	}
@@ -74,7 +74,7 @@ Go to the step 2 if not working.
     }'
 
     #Verify if the query can pass the verification now
-    curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+    curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
       "query" : "SELECT * FROM ..."
     }'
 

--- a/docs/user/interfaces/endpoint.rst
+++ b/docs/user/interfaces/endpoint.rst
@@ -29,7 +29,7 @@ Example
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
 	  "query" : "SELECT * FROM accounts"
 	}'
 
@@ -46,7 +46,7 @@ Example
 
 Explain query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql/_explain -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql/_explain -d '{
 	  "query" : "SELECT firstname, lastname FROM accounts WHERE age > 20"
 	}'
 
@@ -104,7 +104,7 @@ Example
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
 	  "fetch_size" : 5,
 	  "query" : "SELECT firstname, lastname FROM accounts WHERE age > 20 ORDER BY state ASC"
 	}'

--- a/docs/user/interfaces/protocol.rst
+++ b/docs/user/interfaces/protocol.rst
@@ -32,7 +32,7 @@ Use `filter` to add more conditions to OpenSearch DSL directly.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
 	  "query" : "SELECT firstname, lastname, balance FROM accounts",
 	  "filter" : {
 	    "range" : {
@@ -92,7 +92,7 @@ Use `parameters` for actual parameter value in prepared SQL query.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
 	  "query" : "SELECT * FROM accounts WHERE age = ?",
 	  "parameters" : [
 	    {
@@ -148,7 +148,7 @@ Here is an example for normal response. The `schema` includes field name and its
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql -d '{
 	  "query" : "SELECT firstname, lastname, age FROM accounts ORDER BY age LIMIT 2"
 	}'
 
@@ -193,7 +193,7 @@ If any error occurred, error message and the cause will be returned instead.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql?format=jdbc -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql?format=jdbc -d '{
 	  "query" : "SELECT unknown FROM accounts"
 	}'
 
@@ -221,7 +221,7 @@ Example
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql?format=json -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql?format=json -d '{
 	  "query" : "SELECT firstname, lastname, age FROM accounts ORDER BY age LIMIT 2"
 	}'
 
@@ -288,7 +288,7 @@ Example
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql?format=csv -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql?format=csv -d '{
 	  "query" : "SELECT firstname, lastname, age FROM accounts ORDER BY age"
 	}'
 
@@ -314,7 +314,7 @@ For example::
       "=lastname": "@Bond",
       "address": "671 Bristol Street, Dente, TN"
     }'
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql?format=csv -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql?format=csv -d '{
 	  "query" : "SELECT firstname, lastname, address FROM userdata"
 	}'
 
@@ -326,7 +326,7 @@ Result set::
 
 If you prefer escaping the sanitization and keeping the original csv result, you can add a "sanitize" param and set it to false value to skip sanitizing. For example::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql?format=csv&sanitize=false -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql?format=csv&sanitize=false -d '{
 	  "query" : "SELECT firstname, lastname, address FROM userdata"
 	}'
 
@@ -350,7 +350,7 @@ Example
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql?format=raw -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql?format=raw -d '{
 	  "query" : "SELECT firstname, lastname, age FROM accounts ORDER BY age"
 	}'
 
@@ -374,7 +374,7 @@ For example::
       "=lastname": "@Bond",
       "address": "671 Bristol Street|, Dente, TN"
     }'
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql?format=csv -d '{
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql?format=csv -d '{
 	  "query" : "SELECT firstname, lastname, address FROM userdata"
 	}'
 

--- a/docs/user/limitations/limitations.rst
+++ b/docs/user/limitations/limitations.rst
@@ -88,7 +88,7 @@ Limitations on Pagination
 Pagination only supports basic queries for now. The pagination query enables you to get back paginated responses.
 Currently, the pagination only supports basic queries. For example, the following query returns the data with cursor id::
 
-    POST _opendistro/_sql/
+    POST _opensearch/_sql/
     {
       "fetch_size" : 5,
       "query" : "SELECT OriginCountry, DestCountry FROM opensearch_dashboards_sample_data_flights ORDER BY OriginCountry ASC"

--- a/docs/user/optimization/optimization.rst
+++ b/docs/user/optimization/optimization.rst
@@ -90,7 +90,7 @@ Push Project Into Query DSL
 The Project list will push down to Query DSL to `filter the source <https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-fields.html#source-filtering>`_::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_sql/_explain \
+    ... -X POST localhost:9200/_opensearch/_sql/_explain \
     ... -d '{"query" : "SELECT age FROM accounts"}'
     {
       "root": {
@@ -116,7 +116,7 @@ Filter Merge Into Query DSL
 The Filter operator will merge into OpenSearch Query DSL::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_sql/_explain \
+    ... -X POST localhost:9200/_opensearch/_sql/_explain \
     ... -d '{"query" : "SELECT age FROM accounts WHERE age > 30"}'
     {
       "root": {
@@ -142,7 +142,7 @@ Sort Merge Into Query DSL
 The Sort operator will merge into OpenSearch Query DSL::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_sql/_explain \
+    ... -X POST localhost:9200/_opensearch/_sql/_explain \
     ... -d '{"query" : "SELECT age FROM accounts ORDER BY age"}'
     {
       "root": {
@@ -165,7 +165,7 @@ The Sort operator will merge into OpenSearch Query DSL::
 Because the OpenSearch Script Based Sorting can't handle NULL/MISSING value, there is one exception is that if the sort list include expression other than field reference, it will not be merged into Query DSL::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_sql/_explain \
+    ... -X POST localhost:9200/_opensearch/_sql/_explain \
     ... -d '{"query" : "SELECT age FROM accounts ORDER BY abs(age)"}'
     {
       "root": {
@@ -204,7 +204,7 @@ Limit Merge Into Query DSL
 The Limit operator will merge in OpenSearch Query DSL::
 
         sh$ curl -sS -H 'Content-Type: application/json' \
-        ... -X POST localhost:9200/_opendistro/_sql/_explain \
+        ... -X POST localhost:9200/_opensearch/_sql/_explain \
         ... -d '{"query" : "SELECT age FROM accounts LIMIT 10 OFFSET 5"}'
         {
           "root": {
@@ -227,7 +227,7 @@ The Limit operator will merge in OpenSearch Query DSL::
 If sort that includes expression, which cannot be merged into query DSL, also exists in the query, the Limit operator will not be merged into query DSL as well::
 
         sh$ curl -sS -H 'Content-Type: application/json' \
-        ... -X POST localhost:9200/_opendistro/_sql/_explain \
+        ... -X POST localhost:9200/_opensearch/_sql/_explain \
         ... -d '{"query" : "SELECT age FROM accounts ORDER BY abs(age) LIMIT 10"}'
         {
           "root": {
@@ -275,7 +275,7 @@ Aggregation Merge Into OpenSearch Aggregation
 The Aggregation operator will merge into OpenSearch Aggregation::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_sql/_explain \
+    ... -X POST localhost:9200/_opensearch/_sql/_explain \
     ... -d '{"query" : "SELECT gender, avg(age) FROM accounts GROUP BY gender"}'
     {
       "root": {
@@ -301,7 +301,7 @@ Sort Merge Into OpenSearch Aggregation
 The Sort operator will merge into OpenSearch Aggregation.::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_sql/_explain \
+    ... -X POST localhost:9200/_opensearch/_sql/_explain \
     ... -d '{"query" : "SELECT gender, avg(age) FROM accounts GROUP BY gender ORDER BY gender DESC NULLS LAST"}'
     {
       "root": {
@@ -324,7 +324,7 @@ The Sort operator will merge into OpenSearch Aggregation.::
 Because the OpenSearch Composite Aggregation order doesn't support separate NULL_FIRST/NULL_LAST option. only the default sort option (ASC NULL_FIRST/DESC NULL_LAST) will be supported for push down to OpenSearch Aggregation, otherwise it will fall back to the default memory based operator::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_sql/_explain \
+    ... -X POST localhost:9200/_opensearch/_sql/_explain \
     ... -d '{"query" : "SELECT gender, avg(age) FROM accounts GROUP BY gender ORDER BY gender ASC NULLS LAST"}'
     {
       "root": {
@@ -360,7 +360,7 @@ Because the OpenSearch Composite Aggregation order doesn't support separate NULL
 Because the OpenSearch Composite Aggregation doesn't support order by metrics field, then if the sort list include fields which refer to metrics aggregation, then the sort operator can't be push down to OpenSearch Aggregation::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_sql/_explain \
+    ... -X POST localhost:9200/_opensearch/_sql/_explain \
     ... -d '{"query" : "SELECT gender, avg(age) FROM accounts GROUP BY gender ORDER BY avg(age)"}'
     {
       "root": {

--- a/docs/user/optimization/optimization.rst
+++ b/docs/user/optimization/optimization.rst
@@ -32,7 +32,7 @@ Filter Merge Rule
 The consecutive Filter operator will be merged as one Filter operator::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_ppl/_explain \
+    ... -X POST localhost:9200/_opensearch/_ppl/_explain \
     ... -d '{"query" : "source=accounts | where age > 10 | where age < 20 | fields age"}'
     {
       "root": {
@@ -59,7 +59,7 @@ Filter Push Down Under Sort
 The Filter operator should be push down under Sort operator::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST localhost:9200/_opendistro/_ppl/_explain \
+    ... -X POST localhost:9200/_opensearch/_ppl/_explain \
     ... -d '{"query" : "source=accounts | sort age | where age < 20 | fields age"}'
     {
       "root": {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/doctest/core/builder/DocBuilder.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/doctest/core/builder/DocBuilder.java
@@ -33,6 +33,7 @@ import static com.amazon.opendistroforelasticsearch.sql.doctest.core.response.Sq
 import static com.amazon.opendistroforelasticsearch.sql.doctest.core.response.SqlResponseFormat.TABLE_RESPONSE;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAction.EXPLAIN_API_ENDPOINT;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlSettingsAction.SETTINGS_API_ENDPOINT;
 
 import com.amazon.opendistroforelasticsearch.sql.doctest.core.markup.Document;
 import com.amazon.opendistroforelasticsearch.sql.doctest.core.request.SqlRequest;
@@ -209,7 +210,7 @@ public interface DocBuilder {
         StringUtils.format("\"%s\": {\"%s\": \"%s\"}", "transient", name, value);
     return new Requests(
         restClient(),
-        new SqlRequest("PUT", "/_opendistro/_sql/settings", new Body(setting).toString()),
+        new SqlRequest("PUT", SETTINGS_API_ENDPOINT, new Body(setting).toString()),
         null
     );
   }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/doctest/core/test/DocBuilderTest.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/doctest/core/test/DocBuilderTest.java
@@ -128,7 +128,7 @@ public class DocBuilderTest implements DocBuilder {
         paragraph("This is an example for the test").
         codeBlock(
             "SQL query",
-            "POST /_opendistro/_sql\n" +
+            "POST /_opensearch/_sql\n" +
                 "{\n" +
                 "  \"query\" : \"\"\"\n" +
                 "\tSELECT firstname\n" +
@@ -159,7 +159,7 @@ public class DocBuilderTest implements DocBuilder {
         paragraph("This is an example for the test").
         codeBlock(
             "SQL query",
-            "POST /_opendistro/_sql\n" +
+            "POST /_opensearch/_sql\n" +
                 "{\n" +
                 "  \"query\" : \"SELECT firstname FROM accounts\"\n" +
                 "}"

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/doctest/core/test/SqlRequestFormatTest.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/doctest/core/test/SqlRequestFormatTest.java
@@ -29,6 +29,7 @@ package com.amazon.opendistroforelasticsearch.sql.doctest.core.test;
 import static com.amazon.opendistroforelasticsearch.sql.doctest.core.request.SqlRequestFormat.CURL_REQUEST;
 import static com.amazon.opendistroforelasticsearch.sql.doctest.core.request.SqlRequestFormat.IGNORE_REQUEST;
 import static com.amazon.opendistroforelasticsearch.sql.doctest.core.request.SqlRequestFormat.OPENSEARCH_DASHBOARD_REQUEST;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -45,7 +46,7 @@ public class SqlRequestFormatTest {
 
   private final SqlRequest sqlRequest = new SqlRequest(
       "POST",
-      "/_opendistro/_sql",
+      QUERY_API_ENDPOINT,
       "{\"query\":\"SELECT * FROM accounts\"}",
       new UrlParam("format", "jdbc")
   );
@@ -58,7 +59,7 @@ public class SqlRequestFormatTest {
   @Test
   public void testCurlFormat() {
     String expected =
-        ">> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql?format=jdbc -d '{\n" +
+        ">> curl -H 'Content-Type: application/json' -X POST localhost:9200/_opensearch/_sql?format=jdbc -d '{\n" +
             "  \"query\" : \"SELECT * FROM accounts\"\n" +
             "}'";
     assertThat(CURL_REQUEST.format(sqlRequest), is(expected));
@@ -67,7 +68,7 @@ public class SqlRequestFormatTest {
   @Test
   public void testOpenSearchDashboardsFormat() {
     String expected =
-        "POST /_opendistro/_sql?format=jdbc\n" +
+        "POST /_opensearch/_sql?format=jdbc\n" +
             "{\n" +
             "  \"query\" : \"SELECT * FROM accounts\"\n" +
             "}";
@@ -78,12 +79,12 @@ public class SqlRequestFormatTest {
   public void multiLineSqlInOpenSearchDashboardRequestShouldBeWellFormatted() {
     SqlRequest multiLineSqlRequest = new SqlRequest(
         "POST",
-        "/_opendistro/_sql",
+        "/_opensearch/_sql",
         "{\"query\":\"SELECT *\\nFROM accounts\\nWHERE age > 30\"}"
     );
 
     String expected =
-        "POST /_opendistro/_sql\n" +
+        "POST /_opensearch/_sql\n" +
             "{\n" +
             "  \"query\" : \"\"\"\n" +
             "\tSELECT *\n" +

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/doctest/core/test/SqlRequestTest.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/doctest/core/test/SqlRequestTest.java
@@ -26,6 +26,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.doctest.core.test;
 
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -52,7 +53,7 @@ public class SqlRequestTest {
   @Test
   public void requestShouldIncludeAllFields() throws IOException {
     String method = "POST";
-    String endpoint = "/_opendistro/_sql";
+    String endpoint = QUERY_API_ENDPOINT;
     String body = "{\"query\":\"SELECT * FROM accounts\"}";
     String key = "format";
     String value = "jdbc";

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/CsvFormatResponseIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/CsvFormatResponseIT.java
@@ -754,7 +754,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     final String requestBody = super.makeRequest(query);
     final String endpoint = String.format(Locale.ROOT,
-        "/_opendistro/_sql?format=csv&flat=%b&_id=%b&_score=%b&_type=%b",
+        "/_opensearch/_sql?format=csv&flat=%b&_id=%b&_score=%b&_type=%b",
         flat, includeId, includeScore, includeType);
     final Request sqlRequest = new Request("POST", endpoint);
     sqlRequest.setJsonEntity(requestBody);

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/CursorIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/CursorIT.java
@@ -31,6 +31,7 @@ import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getResp
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_TIME;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -487,7 +488,7 @@ public class CursorIT extends SQLIntegTestCase {
 
   public String executeFetchAsStringQuery(String query, String fetchSize, String requestType)
       throws IOException {
-    String endpoint = "/_opendistro/_sql?format=" + requestType;
+    String endpoint = QUERY_API_ENDPOINT + "?format=" + requestType;
     String requestBody = makeRequest(query, fetchSize);
 
     Request sqlRequest = new Request("POST", endpoint);

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetricsIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetricsIT.java
@@ -28,6 +28,7 @@
 package com.amazon.opendistroforelasticsearch.sql.legacy;
 
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_DOG;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlStatsAction.STATS_API_ENDPOINT;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.amazon.opendistroforelasticsearch.sql.legacy.metrics.MetricName;
@@ -68,7 +69,7 @@ public class MetricsIT extends SQLIntegTestCase {
 
   private Request makeStatRequest() {
     return new Request(
-        "GET", "/_opendistro/_sql/stats"
+        "GET", STATS_API_ENDPOINT
     );
   }
 

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/PluginIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/PluginIT.java
@@ -29,6 +29,7 @@ package com.amazon.opendistroforelasticsearch.sql.legacy;
 
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getResponseBody;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlSettingsAction.SETTINGS_API_ENDPOINT;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;
@@ -453,7 +454,7 @@ public class PluginIT extends SQLIntegTestCase {
   }
 
   protected static JSONObject updateViaSQLSettingsAPI(String body) throws IOException {
-    Request request = new Request("PUT", "/_opendistro/_sql/settings");
+    Request request = new Request("PUT", SETTINGS_API_ENDPOINT);
     request.setJsonEntity(body);
     RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
     restOptionsBuilder.addHeader("Content-Type", "application/json");

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/PrettyFormatterIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/PrettyFormatterIT.java
@@ -68,7 +68,7 @@ public class PrettyFormatterIT extends SQLIntegTestCase {
   }
 
   private String executeExplainRequest(String query, String explainParam) throws IOException {
-    String endpoint = "/_opendistro/_sql/_explain?" + explainParam;
+    String endpoint = "/_opensearch/_sql/_explain?" + explainParam;
     String request = makeRequest(query);
 
     Request sqlRequest = new Request("POST", endpoint);

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/QueryAnalysisIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/QueryAnalysisIT.java
@@ -326,7 +326,7 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
   }
 
   private void queryShouldPassAnalysis(String query) {
-    String endpoint = "/_opendistro/_sql?";
+    String endpoint = "/_opensearch/_sql?";
     String requestBody = makeRequest(query);
     Request sqlRequest = new Request("POST", endpoint);
     sqlRequest.setJsonEntity(requestBody);

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/SQLIntegTestCase.java
@@ -234,7 +234,7 @@ public abstract class SQLIntegTestCase extends ODFERestTestCase {
 
   protected String executeQuery(String query, String requestType) {
     try {
-      String endpoint = "/_opendistro/_sql?format=" + requestType;
+      String endpoint = "/_opensearch/_sql?format=" + requestType;
       String requestBody = makeRequest(query);
 
       Request sqlRequest = new Request("POST", endpoint);
@@ -252,7 +252,7 @@ public abstract class SQLIntegTestCase extends ODFERestTestCase {
 
   protected String executeFetchQuery(String query, int fetchSize, String requestType)
       throws IOException {
-    String endpoint = "/_opendistro/_sql?format=" + requestType;
+    String endpoint = "/_opensearch/_sql?format=" + requestType;
     String requestBody = makeRequest(query, fetchSize);
 
     Request sqlRequest = new Request("POST", endpoint);
@@ -265,7 +265,7 @@ public abstract class SQLIntegTestCase extends ODFERestTestCase {
 
   protected String executeFetchLessQuery(String query, String requestType) throws IOException {
 
-    String endpoint = "/_opendistro/_sql?format=" + requestType;
+    String endpoint = "/_opensearch/_sql?format=" + requestType;
     String requestBody = makeFetchLessRequest(query);
 
     Request sqlRequest = new Request("POST", endpoint);

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/LegacyAPICompatibilityIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/LegacyAPICompatibilityIT.java
@@ -1,0 +1,46 @@
+package com.amazon.opendistroforelasticsearch.sql.ppl;
+
+import static com.amazon.opendistroforelasticsearch.sql.plugin.rest.RestPPLQueryAction.LEGACY_EXPLAIN_API_ENDPOINT;
+import static com.amazon.opendistroforelasticsearch.sql.plugin.rest.RestPPLQueryAction.LEGACY_QUERY_API_ENDPOINT;
+import static com.amazon.opendistroforelasticsearch.sql.plugin.rest.RestPPLStatsAction.PPL_LEGACY_STATS_API_ENDPOINT;
+
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+/**
+ * For backward compatibility, check if legacy API endpoints are accessible.
+ */
+public class LegacyAPICompatibilityIT extends PPLIntegTestCase {
+
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.ACCOUNT);
+  }
+
+  @Test
+  public void query() throws IOException {
+    String query = "source=opensearch-sql_test_index_account | where age > 30";
+    Request request = buildRequest(query, LEGACY_QUERY_API_ENDPOINT);
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void explain() throws IOException {
+    String query = "source=opensearch-sql_test_index_account | where age > 30";
+    Request request = buildRequest(query, LEGACY_EXPLAIN_API_ENDPOINT);
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void stats() throws IOException {
+    Request request = new Request("GET", PPL_LEGACY_STATS_API_ENDPOINT);
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+}

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/MetricsIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/MetricsIT.java
@@ -67,7 +67,7 @@ public class MetricsIT extends PPLIntegTestCase {
 
   private Request makeStatRequest() {
     return new Request(
-        "GET", "/_opendistro/_ppl/stats"
+        "GET", "/_opensearch/_ppl/stats"
     );
   }
 

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLPluginIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLPluginIT.java
@@ -108,7 +108,7 @@ public class PPLPluginIT extends PPLIntegTestCase {
   }
 
   protected Request makePPLRequest(String query) {
-    Request post = new Request("POST", "/_opendistro/_ppl");
+    Request post = new Request("POST", "/_opensearch/_ppl");
     post.setJsonEntity(String.format(Locale.ROOT, "{\n" + "  \"query\": \"%s\"\n" + "}", query));
     return post;
   }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/LegacyAPICompatibilityIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/LegacyAPICompatibilityIT.java
@@ -1,0 +1,91 @@
+package com.amazon.opendistroforelasticsearch.sql.sql;
+
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAction.LEGACY_EXPLAIN_API_ENDPOINT;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAction.LEGACY_QUERY_API_ENDPOINT;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlSettingsAction.LEGACY_SETTINGS_API_ENDPOINT;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlStatsAction.LEGACY_STATS_API_ENDPOINT;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase;
+import com.amazon.opendistroforelasticsearch.sql.legacy.utils.StringUtils;
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+
+/**
+ * For backward compatibility, check if legacy API endpoints are accessible.
+ */
+public class LegacyAPICompatibilityIT extends SQLIntegTestCase {
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.ACCOUNT);
+  }
+
+  @Test
+  public void query() throws IOException {
+    String requestBody = makeRequest("SELECT 1");
+    Request request = new Request("POST", LEGACY_QUERY_API_ENDPOINT);
+    request.setJsonEntity(requestBody);
+
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void explain() throws IOException {
+    String requestBody = makeRequest("SELECT 1");
+    Request request = new Request("POST", LEGACY_EXPLAIN_API_ENDPOINT);
+    request.setJsonEntity(requestBody);
+
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void closeCursor() throws IOException {
+    updateClusterSettings(
+        new ClusterSetting("transient", "opendistro.sql.cursor.enabled", "true"));
+
+    try {
+      String selectQuery = StringUtils.format(
+          "SELECT firstname, state FROM %s WHERE balance > 100 and age < 40", TEST_INDEX_ACCOUNT);
+      JSONObject result = new JSONObject(executeFetchQuery(selectQuery, 50, "jdbc"));
+      JSONObject closeResp = executeCursorCloseQuery(result.getString("cursor"));
+      assertThat(closeResp.getBoolean("succeeded"), equalTo(true));
+    } finally {
+      updateClusterSettings(
+          new ClusterSetting("transient", "opendistro.sql.cursor.enabled", "false"));
+    }
+  }
+
+  @Test
+  public void stats() throws IOException {
+    Request request = new Request("GET", LEGACY_STATS_API_ENDPOINT);
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void updateSettings() throws IOException {
+    String requestBody = "{" +
+        "  \"persistent\": {" +
+        "    \"opendistro.sql.metrics.rollinginterval\": \"80\"" +
+        "  }" +
+        "}";
+    Request request = new Request("PUT", LEGACY_SETTINGS_API_ENDPOINT);
+    request.setJsonEntity(requestBody);
+
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+}

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/MetricsIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/MetricsIT.java
@@ -28,6 +28,7 @@
 package com.amazon.opendistroforelasticsearch.sql.sql;
 
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlStatsAction.STATS_API_ENDPOINT;
 
 import com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase;
 import com.amazon.opendistroforelasticsearch.sql.legacy.metrics.MetricName;
@@ -61,7 +62,7 @@ public class MetricsIT extends SQLIntegTestCase {
 
   private Request makeStatRequest() {
     return new Request(
-        "GET", "/_opendistro/_sql/stats"
+        "GET", STATS_API_ENDPOINT
     );
   }
 

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSqlAction.java
@@ -100,9 +100,12 @@ public class RestSqlAction extends BaseRestHandler {
     /**
      * API endpoint path
      */
-    public static final String QUERY_API_ENDPOINT = "/_opendistro/_sql";
+    public static final String QUERY_API_ENDPOINT = "/_opensearch/_sql";
     public static final String EXPLAIN_API_ENDPOINT = QUERY_API_ENDPOINT + "/_explain";
     public static final String CURSOR_CLOSE_ENDPOINT = QUERY_API_ENDPOINT + "/close";
+    public static final String LEGACY_QUERY_API_ENDPOINT = "/_opendistro/_sql";
+    public static final String LEGACY_EXPLAIN_API_ENDPOINT = LEGACY_QUERY_API_ENDPOINT + "/_explain";
+    public static final String LEGACY_CURSOR_CLOSE_ENDPOINT = LEGACY_QUERY_API_ENDPOINT + "/close";
 
     /**
      * New SQL query request handler.
@@ -121,7 +124,10 @@ public class RestSqlAction extends BaseRestHandler {
         return ImmutableList.of(
             new Route(RestRequest.Method.POST, QUERY_API_ENDPOINT),
             new Route(RestRequest.Method.POST, EXPLAIN_API_ENDPOINT),
-            new Route(RestRequest.Method.POST, CURSOR_CLOSE_ENDPOINT)
+            new Route(RestRequest.Method.POST, CURSOR_CLOSE_ENDPOINT),
+            new Route(RestRequest.Method.POST, LEGACY_QUERY_API_ENDPOINT),
+            new Route(RestRequest.Method.POST, LEGACY_EXPLAIN_API_ENDPOINT),
+            new Route(RestRequest.Method.POST, LEGACY_CURSOR_CLOSE_ENDPOINT)
         );
     }
 

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSqlSettingsAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSqlSettingsAction.java
@@ -71,7 +71,8 @@ public class RestSqlSettingsAction extends BaseRestHandler {
     /**
      * API endpoint path
      */
-    public static final String SETTINGS_API_ENDPOINT = "/_opendistro/_sql/settings";
+    public static final String SETTINGS_API_ENDPOINT = "/_opensearch/_sql/settings";
+    public static final String LEGACY_SETTINGS_API_ENDPOINT = "/_opendistro/_sql/settings";
 
     public RestSqlSettingsAction(Settings settings, RestController restController) {
         super();
@@ -85,7 +86,8 @@ public class RestSqlSettingsAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return ImmutableList.of(
-                new Route(RestRequest.Method.PUT, SETTINGS_API_ENDPOINT)
+                new Route(RestRequest.Method.PUT, SETTINGS_API_ENDPOINT),
+                new Route(RestRequest.Method.PUT, LEGACY_SETTINGS_API_ENDPOINT)
         );
     }
 

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSqlStatsAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSqlStatsAction.java
@@ -57,7 +57,8 @@ public class RestSqlStatsAction extends BaseRestHandler {
     /**
      * API endpoint path
      */
-    public static final String STATS_API_ENDPOINT = "/_opendistro/_sql/stats";
+    public static final String STATS_API_ENDPOINT = "/_opensearch/_sql/stats";
+    public static final String LEGACY_STATS_API_ENDPOINT = "/_opendistro/_sql/stats";
 
     public RestSqlStatsAction(Settings settings, RestController restController) {
         super();
@@ -72,7 +73,9 @@ public class RestSqlStatsAction extends BaseRestHandler {
     public List<Route> routes() {
         return ImmutableList.of(
                 new Route(RestRequest.Method.POST, STATS_API_ENDPOINT),
-                new Route(RestRequest.Method.GET, STATS_API_ENDPOINT)
+                new Route(RestRequest.Method.GET, STATS_API_ENDPOINT),
+                new Route(RestRequest.Method.POST, LEGACY_STATS_API_ENDPOINT),
+                new Route(RestRequest.Method.GET, LEGACY_STATS_API_ENDPOINT)
         );
     }
 

--- a/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/rest/RestPPLQueryAction.java
+++ b/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/rest/RestPPLQueryAction.java
@@ -77,8 +77,10 @@ import org.opensearch.rest.RestStatus;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class RestPPLQueryAction extends BaseRestHandler {
-  public static final String QUERY_API_ENDPOINT = "/_opendistro/_ppl";
-  public static final String EXPLAIN_API_ENDPOINT = "/_opendistro/_ppl/_explain";
+  public static final String QUERY_API_ENDPOINT = "/_opensearch/_ppl";
+  public static final String EXPLAIN_API_ENDPOINT = "/_opensearch/_ppl/_explain";
+  public static final String LEGACY_QUERY_API_ENDPOINT = "/_opendistro/_ppl";
+  public static final String LEGACY_EXPLAIN_API_ENDPOINT = "/_opendistro/_ppl/_explain";
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -114,7 +116,9 @@ public class RestPPLQueryAction extends BaseRestHandler {
   public List<Route> routes() {
     return Arrays.asList(
         new Route(RestRequest.Method.POST, QUERY_API_ENDPOINT),
-        new Route(RestRequest.Method.POST, EXPLAIN_API_ENDPOINT)
+        new Route(RestRequest.Method.POST, EXPLAIN_API_ENDPOINT),
+        new Route(RestRequest.Method.POST, LEGACY_QUERY_API_ENDPOINT),
+        new Route(RestRequest.Method.POST, LEGACY_EXPLAIN_API_ENDPOINT)
     );
   }
 

--- a/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/rest/RestPPLStatsAction.java
+++ b/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/rest/RestPPLStatsAction.java
@@ -58,7 +58,8 @@ public class RestPPLStatsAction extends BaseRestHandler {
   /**
    * API endpoint path.
    */
-  public static final String PPL_STATS_API_ENDPOINT = "/_opendistro/_ppl/stats";
+  public static final String PPL_STATS_API_ENDPOINT = "/_opensearch/_ppl/stats";
+  public static final String PPL_LEGACY_STATS_API_ENDPOINT = "/_opendistro/_ppl/stats";
 
   public RestPPLStatsAction(Settings settings, RestController restController) {
     super();
@@ -73,7 +74,9 @@ public class RestPPLStatsAction extends BaseRestHandler {
   public List<Route> routes() {
     return ImmutableList.of(
         new Route(RestRequest.Method.POST, PPL_STATS_API_ENDPOINT),
-        new Route(RestRequest.Method.GET, PPL_STATS_API_ENDPOINT)
+        new Route(RestRequest.Method.GET, PPL_STATS_API_ENDPOINT),
+        new Route(RestRequest.Method.POST, PPL_LEGACY_STATS_API_ENDPOINT),
+        new Route(RestRequest.Method.GET, PPL_LEGACY_STATS_API_ENDPOINT)
     );
   }
 

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLServiceTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLServiceTest.java
@@ -118,7 +118,7 @@ public class PPLServiceTest {
       return null;
     }).when(executionEngine).execute(any(), any());
 
-    pplService.execute(new PPLQueryRequest("search source=t a=1", null, "/_opendistro/_ppl", "csv"),
+    pplService.execute(new PPLQueryRequest("search source=t a=1", null, "/_opensearch/_ppl", "csv"),
         new ResponseListener<QueryResponse>() {
           @Override
           public void onResponse(QueryResponse pplQueryResponse) {

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/domain/PPLQueryRequestTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/domain/PPLQueryRequestTest.java
@@ -48,28 +48,28 @@ public class PPLQueryRequestTest {
   @Test
   public void testExplainRequest() {
     PPLQueryRequest request = new PPLQueryRequest(
-        "source=t a=1", null, "/_opendistro/_ppl/_explain");
+        "source=t a=1", null, "/_opensearch/_ppl/_explain");
     assertTrue(request.isExplainRequest());
   }
 
   @Test
   public void testDefaultFormat() {
     PPLQueryRequest request = new PPLQueryRequest(
-        "source=test", null, "/_opendistro/_ppl");
+        "source=test", null, "/_opensearch/_ppl");
     assertEquals(request.format(), Format.JDBC);
   }
 
   @Test
   public void testJDBCFormat() {
     PPLQueryRequest request = new PPLQueryRequest(
-        "source=test", null, "/_opendistro/_ppl", "jdbc");
+        "source=test", null, "/_opensearch/_ppl", "jdbc");
     assertEquals(request.format(), Format.JDBC);
   }
 
   @Test
   public void testCSVFormat() {
     PPLQueryRequest request = new PPLQueryRequest(
-        "source=test", null, "/_opendistro/_ppl", "csv");
+        "source=test", null, "/_opensearch/_ppl", "csv");
     assertEquals(request.format(), Format.CSV);
   }
 
@@ -77,7 +77,7 @@ public class PPLQueryRequestTest {
   public void testUnsupportedFormat() {
     String format = "notsupport";
     PPLQueryRequest request = new PPLQueryRequest(
-            "source=test", null, "/_opendistro/_ppl", format);
+            "source=test", null, "/_opensearch/_ppl", format);
     exceptionRule.expect(IllegalArgumentException.class);
     exceptionRule.expectMessage("response in " + format + " format is not supported.");
     request.format();

--- a/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
+++ b/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
@@ -172,14 +172,14 @@ class OpenSearchConnection:
         try:
             if self.query_language == "sql":
                 data = self.client.transport.perform_request(
-                    url="/_opensearch/_sql/_explain" if explain else "/_opensearch/_sql/",
+                    url="/_opendistro/_sql/_explain" if explain else "/_opendistro/_sql/",
                     method="POST",
                     params=None if explain else {"format": output_format},
                     body={"query": final_query},
                 )
             else:
                 data = self.client.transport.perform_request(
-                    url="/_opensearch/_ppl/_explain" if explain else "/_opensearch/_ppl/",
+                    url="/_opendistro/_ppl/_explain" if explain else "/_opendistro/_ppl/",
                     method="POST",
                     params=None if explain else {"format": output_format},
                     body={"query": final_query},

--- a/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
+++ b/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
@@ -172,7 +172,7 @@ class OpenSearchConnection:
         try:
             if self.query_language == "sql":
                 data = self.client.transport.perform_request(
-                    url="/_opendistro/_sql/_explain" if explain else "/_opendistro/_sql/",
+                    url="/_opensearch/_sql/_explain" if explain else "/_opendistro/_sql/",
                     method="POST",
                     params=None if explain else {"format": output_format},
                     body={"query": final_query},

--- a/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
+++ b/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
@@ -172,14 +172,14 @@ class OpenSearchConnection:
         try:
             if self.query_language == "sql":
                 data = self.client.transport.perform_request(
-                    url="/_opensearch/_sql/_explain" if explain else "/_opendistro/_sql/",
+                    url="/_opensearch/_sql/_explain" if explain else "/_opensearch/_sql/",
                     method="POST",
                     params=None if explain else {"format": output_format},
                     body={"query": final_query},
                 )
             else:
                 data = self.client.transport.perform_request(
-                    url="/_opendistro/_ppl/_explain" if explain else "/_opendistro/_ppl/",
+                    url="/_opensearch/_ppl/_explain" if explain else "/_opensearch/_ppl/",
                     method="POST",
                     params=None if explain else {"format": output_format},
                     body={"query": final_query},

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/protocol/http/JsonHttpProtocol.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/protocol/http/JsonHttpProtocol.java
@@ -49,7 +49,7 @@ public class JsonHttpProtocol implements Protocol {
 
     // the value is based on the API endpoint the sql plugin sets up,
     // but this could be made configurable if required
-    public static final String DEFAULT_SQL_CONTEXT_PATH = "/_opendistro/_sql";
+    public static final String DEFAULT_SQL_CONTEXT_PATH = "/_opensearch/_sql";
 
     private static final Header acceptJson = new BasicHeader(HttpHeaders.ACCEPT, "application/json");
     private static final Header contentTypeJson = new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json");

--- a/sql-odbc/src/odfesqlodbc/opensearch_communication.cpp
+++ b/sql-odbc/src/odfesqlodbc/opensearch_communication.cpp
@@ -43,8 +43,8 @@
 
 static const std::string ctype = "application/json";
 static const std::string SQL_ENDPOINT_FORMAT_JDBC =
-    "/_opendistro/_sql?format=jdbc";
-static const std::string SQL_ENDPOINT_CLOSE_CURSOR = "/_opendistro/_sql/close";
+    "/_opensearch/_sql?format=jdbc";
+static const std::string SQL_ENDPOINT_CLOSE_CURSOR = "/_opensearch/_sql/close";
 static const std::string PLUGIN_ENDPOINT_FORMAT_JSON =
     "/_cat/plugins?format=json";
 static const std::string OPENDISTRO_SQL_PLUGIN_NAME = "opendistro-sql";

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLServiceTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLServiceTest.java
@@ -86,7 +86,7 @@ class SQLServiceTest {
     }).when(executionEngine).execute(any(), any());
 
     sqlService.execute(
-        new SQLQueryRequest(new JSONObject(), "SELECT 123", "_opendistro/_sql", "jdbc"),
+        new SQLQueryRequest(new JSONObject(), "SELECT 123", "_opensearch/_sql", "jdbc"),
         new ResponseListener<QueryResponse>() {
           @Override
           public void onResponse(QueryResponse response) {
@@ -109,7 +109,7 @@ class SQLServiceTest {
     }).when(executionEngine).execute(any(), any());
 
     sqlService.execute(
-        new SQLQueryRequest(new JSONObject(), "SELECT 123", "_opendistro/_sql", "csv"),
+        new SQLQueryRequest(new JSONObject(), "SELECT 123", "_opensearch/_sql", "csv"),
         new ResponseListener<QueryResponse>() {
           @Override
           public void onResponse(QueryResponse response) {
@@ -170,7 +170,7 @@ class SQLServiceTest {
   @Test
   public void canCaptureErrorDuringExecution() {
     sqlService.execute(
-        new SQLQueryRequest(new JSONObject(), "SELECT", "_opendistro/_sql", ""),
+        new SQLQueryRequest(new JSONObject(), "SELECT", "_opensearch/_sql", ""),
         new ResponseListener<QueryResponse>() {
           @Override
           public void onResponse(QueryResponse response) {

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -95,7 +95,7 @@ public class SQLQueryRequestTest {
   public void shouldSupportExplain() {
     SQLQueryRequest explainRequest =
         SQLQueryRequestBuilder.request("SELECT 1")
-                              .path("_opendistro/_sql/_explain")
+                              .path("_opensearch/_sql/_explain")
                               .build();
     assertTrue(explainRequest.isExplainRequest());
     assertTrue(explainRequest.isSupported());

--- a/workbench/server/services/utils/constants.ts
+++ b/workbench/server/services/utils/constants.ts
@@ -26,10 +26,10 @@
 
 import { ParsedUrlQuery } from 'querystring';
 
-export const SQL_TRANSLATE_ROUTE = `/_opendistro/_sql/_explain`;
-export const PPL_TRANSLATE_ROUTE = `/_opendistro/_ppl/_explain`;
-export const SQL_QUERY_ROUTE = `/_opendistro/_sql`;
-export const PPL_QUERY_ROUTE = `/_opendistro/_ppl`;
+export const SQL_TRANSLATE_ROUTE = `/_opensearch/_sql/_explain`;
+export const PPL_TRANSLATE_ROUTE = `/_opensearch/_ppl/_explain`;
+export const SQL_QUERY_ROUTE = `/_opensearch/_sql`;
+export const PPL_QUERY_ROUTE = `/_opensearch/_ppl`;
 export const FORMAT_CSV = `format=csv`;
 export const FORMAT_JSON = `format=json`;
 export const FORMAT_TEXT = `format=raw`;

--- a/workbench/server/services/utils/constants.ts
+++ b/workbench/server/services/utils/constants.ts
@@ -26,10 +26,10 @@
 
 import { ParsedUrlQuery } from 'querystring';
 
-export const SQL_TRANSLATE_ROUTE = `/_opensearch/_sql/_explain`;
-export const PPL_TRANSLATE_ROUTE = `/_opensearch/_ppl/_explain`;
-export const SQL_QUERY_ROUTE = `/_opensearch/_sql`;
-export const PPL_QUERY_ROUTE = `/_opensearch/_ppl`;
+export const SQL_TRANSLATE_ROUTE = `/_opendistro/_sql/_explain`;
+export const PPL_TRANSLATE_ROUTE = `/_opendistro/_ppl/_explain`;
+export const SQL_QUERY_ROUTE = `/_opendistro/_sql`;
+export const PPL_QUERY_ROUTE = `/_opendistro/_ppl`;
 export const FORMAT_CSV = `format=csv`;
 export const FORMAT_JSON = `format=json`;
 export const FORMAT_TEXT = `format=raw`;


### PR DESCRIPTION
### Description

1. Support `_opensearch/_sql` and `_opensearch/_ppl` API endpoint.
2. Meanwhile old `_opendistro` endpoint is still accessible for backward compatibility.
3. Change endpoint URL in JDBC and ODBC to use new endpoint accordingly.
4. Change endpoint URL in user manual and dev docs to new endpoint accordingly.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest: all old IT is pointing to new `_opensearch` endpoint and `LegacyAPICompatibilityIT` added for SQL and PPL
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added: https://github.com/dai-chen/sql-1/tree/sql-ppl-api-migration-for-opensearch#basic-usage
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).