### PR TITLE
Doctest/SQL-CLI API migration to OpenSearch, renaming and version reset

### DIFF
--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -27,34 +27,36 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           pip install setuptools wheel
-
-      - name: Set up ES and install SQL plugin
-        run: |
-          sudo add-apt-repository ppa:openjdk-r/ppa
-          sudo apt update
-          sudo apt install openjdk-13-jdk
-          sudo apt install unzip
-          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.10.0-amd64.deb
-          sudo dpkg -i elasticsearch-oss-7.10.0-amd64.deb
-          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.12.0.0.zip
-          sudo systemctl start elasticsearch.service
+      
+      #TODO: will setup CI for IT once we have OpenSearch and sql plugin release. Not it only runs UT
+      
+      # - name: Set up ES and install SQL plugin
+      #   run: |
+      #     sudo add-apt-repository ppa:openjdk-r/ppa
+      #     sudo apt update
+      #     sudo apt install openjdk-14-jdk
+      #     sudo apt install unzip
+      #     wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.10.0-amd64.deb
+      #     sudo dpkg -i elasticsearch-oss-7.10.0-amd64.deb
+      #     sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opensearch-sql/opensearch_sql-1.12.0.0.zip
+      #     sudo systemctl start elasticsearch.service
 
       - name: Run Tox Testing
         run: tox
 
-      - name: Stop ES
-        run: sudo systemctl stop elasticsearch.service
+      # - name: Stop ES
+      #   run: sudo systemctl stop elasticsearch.service
 
       - name: Build Artifact
         run: python setup.py sdist bdist_wheel
 
       - name: Create Artifact Path
         run: |
-          mkdir -p opendistro-sql-cli-builds
-          cp -r ./dist/*.tar.gz ./dist/*.whl opendistro-sql-cli-builds/
+          mkdir -p opensearch-sql-cli-builds
+          cp -r ./dist/*.tar.gz ./dist/*.whl opensearch-sql-cli-builds/
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: opendistro-sql-cli
-          path: sql-cli/opendistro-sql-cli-builds
+          name: opensearch-sql-cli
+          path: sql-cli/opensearch-sql-cli-builds

--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -29,6 +29,7 @@ jobs:
           pip install setuptools wheel
       
       #TODO: will setup CI for IT once we have OpenSearch and sql plugin release. Not it only runs UT
+      # It can also be refactored by launching OpenSearch instance with plugin installed from gradle.
       
       # - name: Set up ES and install SQL plugin
       #   run: |

--- a/docs/dev/Doctest.md
+++ b/docs/dev/Doctest.md
@@ -152,7 +152,7 @@ To support PPL, we need to add PPL support to SQL-CLI. Since PPL and SQL expose 
 The code example in a doc using `CLI` should be like this
 
 ```
-odfesql> SELECT firstname, lastname FROM accounts;
+opensearchsql> SELECT firstname, lastname FROM accounts;
 fetched rows / total rows = 4/4
 +-------------+------------+
 | firstname   | lastname   |

--- a/docs/experiment/ppl/cmd/dedup.rst
+++ b/docs/experiment/ppl/cmd/dedup.rst
@@ -32,7 +32,7 @@ The example show dedup the document with gender field.
 
 PPL query::
 
-    od> source=accounts | dedup gender | fields account_number, gender;
+    os> source=accounts | dedup gender | fields account_number, gender;
     fetched rows / total rows = 2/2
     +------------------+----------+
     | account_number   | gender   |
@@ -48,7 +48,7 @@ The example show dedup the document with gender field keep 2 duplication.
 
 PPL query::
 
-    od> source=accounts | dedup 2 gender | fields account_number, gender;
+    os> source=accounts | dedup 2 gender | fields account_number, gender;
     fetched rows / total rows = 3/3
     +------------------+----------+
     | account_number   | gender   |
@@ -65,7 +65,7 @@ The example show dedup the document by keep null value field.
 
 PPL query::
 
-    od> source=accounts | dedup email keepempty=true | fields account_number, email;
+    os> source=accounts | dedup email keepempty=true | fields account_number, email;
     fetched rows / total rows = 4/4
     +------------------+-----------------------+
     | account_number   | email                 |
@@ -81,7 +81,7 @@ The example show dedup the document by ignore the empty value field.
 
 PPL query::
 
-    od> source=accounts | dedup email | fields account_number, email;
+    os> source=accounts | dedup email | fields account_number, email;
     fetched rows / total rows = 3/3
     +------------------+-----------------------+
     | account_number   | email                 |
@@ -99,7 +99,7 @@ The example show dedup the consecutive document.
 
 PPL query::
 
-    od> source=accounts | dedup gender consecutive=true | fields account_number, gender;
+    os> source=accounts | dedup gender consecutive=true | fields account_number, gender;
     fetched rows / total rows = 3/3
     +------------------+----------+
     | account_number   | gender   |

--- a/docs/experiment/ppl/cmd/eval.rst
+++ b/docs/experiment/ppl/cmd/eval.rst
@@ -28,7 +28,7 @@ The example show to create new field doubleAge for each document. The new double
 
 PPL query::
 
-    od> source=accounts | eval doubleAge = age * 2 | fields age, doubleAge ;
+    os> source=accounts | eval doubleAge = age * 2 | fields age, doubleAge ;
     fetched rows / total rows = 4/4
     +-------+-------------+
     | age   | doubleAge   |
@@ -47,7 +47,7 @@ The example show to override the exist age field with age plus 1.
 
 PPL query::
 
-    od> source=accounts | eval age = age + 1 | fields age ;
+    os> source=accounts | eval age = age + 1 | fields age ;
     fetched rows / total rows = 4/4
     +-------+
     | age   |
@@ -65,7 +65,7 @@ The example show to create a new field ddAge with field defined in eval command.
 
 PPL query::
 
-    od> source=accounts | eval doubleAge = age * 2, ddAge = doubleAge * 2 | fields age, doubleAge, ddAge ;
+    os> source=accounts | eval doubleAge = age * 2, ddAge = doubleAge * 2 | fields age, doubleAge, ddAge ;
     fetched rows / total rows = 4/4
     +-------+-------------+---------+
     | age   | doubleAge   | ddAge   |

--- a/docs/experiment/ppl/cmd/fields.rst
+++ b/docs/experiment/ppl/cmd/fields.rst
@@ -29,7 +29,7 @@ The example show fetch account_number, firstname and lastname fields from search
 
 PPL query::
 
-    od> source=accounts | fields account_number, firstname, lastname;
+    os> source=accounts | fields account_number, firstname, lastname;
     fetched rows / total rows = 4/4
     +------------------+-------------+------------+
     | account_number   | firstname   | lastname   |
@@ -47,7 +47,7 @@ The example show fetch remove account_number field from search results.
 
 PPL query::
 
-    od> source=accounts | fields account_number, firstname, lastname | fields - account_number ;
+    os> source=accounts | fields account_number, firstname, lastname | fields - account_number ;
     fetched rows / total rows = 4/4
     +-------------+------------+
     | firstname   | lastname   |

--- a/docs/experiment/ppl/cmd/head.rst
+++ b/docs/experiment/ppl/cmd/head.rst
@@ -27,7 +27,7 @@ The example show first 10 results from accounts index.
 
 PPL query::
 
-    od> source=accounts | fields firstname, age | head;
+    os> source=accounts | fields firstname, age | head;
     fetched rows / total rows = 10/10
     +---------------+-----------+
     | firstname     | age       |
@@ -51,7 +51,7 @@ The example show first N results from accounts index.
 
 PPL query::
 
-    od> source=accounts | fields firstname, age | head 3;
+    os> source=accounts | fields firstname, age | head 3;
     fetched rows / total rows = 3/3
     +---------------+-----------+
     | firstname     | age       |

--- a/docs/experiment/ppl/cmd/rare.rst
+++ b/docs/experiment/ppl/cmd/rare.rst
@@ -30,7 +30,7 @@ The example finds least common gender of all the accounts.
 
 PPL query::
 
-    od> source=accounts | rare gender;
+    os> source=accounts | rare gender;
     fetched rows / total rows = 2/2
     +------------+
     | gender     |
@@ -48,7 +48,7 @@ The example finds least common age of all the accounts group by gender.
 
 PPL query::
 
-    od> source=accounts | rare age by gender;
+    os> source=accounts | rare age by gender;
     fetched rows / total rows = 20/20
     +----------+----------+
     | gender   | age      |

--- a/docs/experiment/ppl/cmd/rename.rst
+++ b/docs/experiment/ppl/cmd/rename.rst
@@ -29,7 +29,7 @@ The example show rename one field.
 
 PPL query::
 
-    od> source=accounts | rename account_number as an | fields an;
+    os> source=accounts | rename account_number as an | fields an;
     fetched rows / total rows = 4/4
     +------+
     | an   |
@@ -48,7 +48,7 @@ The example show rename multiple fields.
 
 PPL query::
 
-    od> source=accounts | rename account_number as an, employer as emp | fields an, emp;
+    os> source=accounts | rename account_number as an, employer as emp | fields an, emp;
     fetched rows / total rows = 4/4
     +------+---------+
     | an   | emp     |

--- a/docs/experiment/ppl/cmd/search.rst
+++ b/docs/experiment/ppl/cmd/search.rst
@@ -30,7 +30,7 @@ The example show fetch all the document from accounts index.
 
 PPL query::
 
-    od> source=accounts;
+    os> source=accounts;
     fetched rows / total rows = 4/4
     +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
     | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
@@ -48,7 +48,7 @@ The example show fetch all the document from accounts index with .
 
 PPL query::
 
-    od> source=accounts account_number=1 or gender="F";
+    os> source=accounts account_number=1 or gender="F";
     fetched rows / total rows = 2/2
     +------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------+
     | account_number   | firstname   | address            | balance   | gender   | city   | employer   | state   | age   | email                | lastname   |

--- a/docs/experiment/ppl/cmd/sort.rst
+++ b/docs/experiment/ppl/cmd/sort.rst
@@ -30,7 +30,7 @@ The example show sort all the document with age field in ascending order.
 
 PPL query::
 
-    od> source=accounts | sort age | fields account_number, age;
+    os> source=accounts | sort age | fields account_number, age;
     fetched rows / total rows = 4/4
     +------------------+-------+
     | account_number   | age   |
@@ -49,7 +49,7 @@ The example show sort all the document with age field in ascending order.
 
 PPL query::
 
-    od> source=accounts | sort age | fields account_number, age;
+    os> source=accounts | sort age | fields account_number, age;
     fetched rows / total rows = 4/4
     +------------------+-------+
     | account_number   | age   |
@@ -68,7 +68,7 @@ The example show sort all the document with age field in descending order.
 
 PPL query::
 
-    od> source=accounts | sort - age | fields account_number, age;
+    os> source=accounts | sort - age | fields account_number, age;
     fetched rows / total rows = 4/4
     +------------------+-------+
     | account_number   | age   |
@@ -86,7 +86,7 @@ The example show sort all the document with gender field in ascending order and 
 
 PPL query::
 
-    od> source=accounts | sort + gender, - age | fields account_number, gender, age;
+    os> source=accounts | sort + gender, - age | fields account_number, gender, age;
     fetched rows / total rows = 4/4
     +------------------+----------+-------+
     | account_number   | gender   | age   |
@@ -104,7 +104,7 @@ The example show sort employer field by default option (ascending order and null
 
 PPL query::
 
-    od> source=accounts | sort employer | fields employer;
+    os> source=accounts | sort employer | fields employer;
     fetched rows / total rows = 4/4
     +------------+
     | employer   |

--- a/docs/experiment/ppl/cmd/stats.rst
+++ b/docs/experiment/ppl/cmd/stats.rst
@@ -45,7 +45,7 @@ The example show calculate the count of events in the accounts.
 
 PPL query::
 
-    od> source=accounts | stats count();
+    os> source=accounts | stats count();
     fetched rows / total rows = 1/1
     +-----------+
     | count()   |
@@ -61,7 +61,7 @@ The example show calculate the average age of all the accounts.
 
 PPL query::
 
-    od> source=accounts | stats avg(age);
+    os> source=accounts | stats avg(age);
     fetched rows / total rows = 1/1
     +------------+
     | avg(age)   |
@@ -77,7 +77,7 @@ The example show calculate the average age of all the accounts group by gender.
 
 PPL query::
 
-    od> source=accounts | stats avg(age) by gender;
+    os> source=accounts | stats avg(age) by gender;
     fetched rows / total rows = 2/2
     +--------------------+----------+
     | avg(age)           | gender   |
@@ -94,7 +94,7 @@ The example show calculate the average age, sum age and count of events of all t
 
 PPL query::
 
-    od> source=accounts | stats avg(age), sum(age), count() by gender;
+    os> source=accounts | stats avg(age), sum(age), count() by gender;
     fetched rows / total rows = 2/2
     +--------------------+------------+-----------+----------+
     | avg(age)           | sum(age)   | count()   | gender   |
@@ -110,7 +110,7 @@ The example calculates the max age of all the accounts.
 
 PPL query::
 
-    od> source=accounts | stats max(age);
+    os> source=accounts | stats max(age);
     fetched rows / total rows = 1/1
     +------------+
     | max(age)   |
@@ -125,7 +125,7 @@ The example calculates the max and min age values of all the accounts group by g
 
 PPL query::
 
-    od> source=accounts | stats max(age), min(age) by gender;
+    os> source=accounts | stats max(age), min(age) by gender;
     fetched rows / total rows = 2/2
     +------------+------------+----------+
     | max(age)   | min(age)   | gender   |

--- a/docs/experiment/ppl/cmd/top.rst
+++ b/docs/experiment/ppl/cmd/top.rst
@@ -30,7 +30,7 @@ The example finds most common gender of all the accounts.
 
 PPL query::
 
-    od> source=accounts | top gender;
+    os> source=accounts | top gender;
     fetched rows / total rows = 2/2
     +------------+
     | gender     |
@@ -47,7 +47,7 @@ The example finds most common gender of all the accounts.
 
 PPL query::
 
-    od> source=accounts | top 1 gender;
+    os> source=accounts | top 1 gender;
     fetched rows / total rows = 1/1
     +------------+
     | gender     |
@@ -62,7 +62,7 @@ The example finds most common age of all the accounts group by gender.
 
 PPL query::
 
-    od> source=accounts | top 1 age by gender;
+    os> source=accounts | top 1 age by gender;
     fetched rows / total rows = 2/2
     +----------+----------+
     | gender   | age      |

--- a/docs/experiment/ppl/cmd/where.rst
+++ b/docs/experiment/ppl/cmd/where.rst
@@ -27,7 +27,7 @@ The example show fetch all the document from accounts index with .
 
 PPL query::
 
-    od> source=accounts | where account_number=1 or gender="F" | fields account_number, gender;
+    os> source=accounts | where account_number=1 or gender="F" | fields account_number, gender;
     fetched rows / total rows = 2/2
     +------------------+----------+
     | account_number   | gender   |

--- a/docs/experiment/ppl/functions/condition.rst
+++ b/docs/experiment/ppl/functions/condition.rst
@@ -22,7 +22,7 @@ Return type: BOOLEAN
 
 Example::
 
-    od> source=accounts | eval result = isnull(employer) | fields result, employer, firstname
+    os> source=accounts | eval result = isnull(employer) | fields result, employer, firstname
     fetched rows / total rows = 4/4
     +----------+------------+-------------+
     | result   | employer   | firstname   |
@@ -47,7 +47,7 @@ Return type: BOOLEAN
 
 Example::
 
-    od> source=accounts | where not isnotnull(employer) | fields account_number, employer
+    os> source=accounts | where not isnotnull(employer) | fields account_number, employer
     fetched rows / total rows = 1/1
     +------------------+------------+
     | account_number   | employer   |
@@ -62,7 +62,7 @@ EXISTS
 
 Example, the account 13 doesn't have email field::
 
-    od> source=accounts | where isnull(email) | fields account_number, email
+    os> source=accounts | where isnull(email) | fields account_number, email
     fetched rows / total rows = 1/1
     +------------------+---------+
     | account_number   | email   |
@@ -84,7 +84,7 @@ Return type: any
 
 Example::
 
-    od> source=accounts | eval result = ifnull(employer, 'default') | fields result, employer, firstname
+    os> source=accounts | eval result = ifnull(employer, 'default') | fields result, employer, firstname
     fetched rows / total rows = 4/4
     +----------+------------+-------------+
     | result   | employer   | firstname   |
@@ -109,7 +109,7 @@ Return type: any
 
 Example::
 
-    od> source=accounts | eval result = nullif(employer, 'Pyrami') | fields result, employer, firstname
+    os> source=accounts | eval result = nullif(employer, 'Pyrami') | fields result, employer, firstname
     fetched rows / total rows = 4/4
     +----------+------------+-------------+
     | result   | employer   | firstname   |
@@ -135,7 +135,7 @@ Return type: any
 
 Example::
 
-    od> source=accounts | eval result = isnull(employer) | fields result, employer, firstname
+    os> source=accounts | eval result = isnull(employer) | fields result, employer, firstname
     fetched rows / total rows = 4/4
     +----------+------------+-------------+
     | result   | employer   | firstname   |
@@ -160,7 +160,7 @@ Return type: any
 
 Example::
 
-    od> source=accounts | eval result = if(true, firstname, lastname) | fields result, firstname, lastname
+    os> source=accounts | eval result = if(true, firstname, lastname) | fields result, firstname, lastname
     fetched rows / total rows = 4/4
     +----------+-------------+------------+
     | result   | firstname   | lastname   |
@@ -171,7 +171,7 @@ Example::
     | Dale     | Dale        | Adams      |
     +----------+-------------+------------+
 
-    od> source=accounts | eval result = if(false, firstname, lastname) | fields result, firstname, lastname
+    os> source=accounts | eval result = if(false, firstname, lastname) | fields result, firstname, lastname
     fetched rows / total rows = 4/4
     +----------+-------------+------------+
     | result   | firstname   | lastname   |

--- a/docs/experiment/ppl/functions/datetime.rst
+++ b/docs/experiment/ppl/functions/datetime.rst
@@ -30,7 +30,7 @@ Synonyms: `DATE_ADD`_
 
 Example::
 
-    od> source=people | eval `ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)` = ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR), `ADDDATE(DATE('2020-08-26'), 1)` = ADDDATE(DATE('2020-08-26'), 1), `ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)` = ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)`, `ADDDATE(DATE('2020-08-26'), 1)`, `ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)`
+    os> source=people | eval `ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)` = ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR), `ADDDATE(DATE('2020-08-26'), 1)` = ADDDATE(DATE('2020-08-26'), 1), `ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)` = ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)`, `ADDDATE(DATE('2020-08-26'), 1)`, `ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)`
     fetched rows / total rows = 1/1
     +------------------------------------------------+----------------------------------+------------------------------------------------+
     | ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)   | ADDDATE(DATE('2020-08-26'), 1)   | ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
@@ -84,7 +84,7 @@ Synonyms: `ADDDATE`_
 
 Example::
 
-    od> source=people | eval `DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)` = DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR), `DATE_ADD(DATE('2020-08-26'), 1)` = DATE_ADD(DATE('2020-08-26'), 1), `DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)` = DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)`, `DATE_ADD(DATE('2020-08-26'), 1)`, `DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)`
+    os> source=people | eval `DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)` = DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR), `DATE_ADD(DATE('2020-08-26'), 1)` = DATE_ADD(DATE('2020-08-26'), 1), `DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)` = DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)`, `DATE_ADD(DATE('2020-08-26'), 1)`, `DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)`
     fetched rows / total rows = 1/1
     +-------------------------------------------------+-----------------------------------+-------------------------------------------------+
     | DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)   | DATE_ADD(DATE('2020-08-26'), 1)   | DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
@@ -211,7 +211,7 @@ Synonyms: `SUBDATE`_
 
 Example::
 
-    od> source=people | eval `DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)` = DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY), `DATE_SUB(DATE('2020-08-26'), 1)` = DATE_SUB(DATE('2020-08-26'), 1), `DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)` = DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)`, `DATE_SUB(DATE('2020-08-26'), 1)`, `DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)`
+    os> source=people | eval `DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)` = DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY), `DATE_SUB(DATE('2020-08-26'), 1)` = DATE_SUB(DATE('2020-08-26'), 1), `DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)` = DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)`, `DATE_SUB(DATE('2020-08-26'), 1)`, `DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)`
     fetched rows / total rows = 1/1
     +-------------------------------------------------+-----------------------------------+-------------------------------------------------+
     | DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)   | DATE_SUB(DATE('2020-08-26'), 1)   | DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
@@ -236,7 +236,7 @@ Synonyms: DAYOFMONTH
 
 Example::
 
-    od> source=people | eval `DAY(DATE('2020-08-26'))` = DAY(DATE('2020-08-26')) | fields `DAY(DATE('2020-08-26'))`
+    os> source=people | eval `DAY(DATE('2020-08-26'))` = DAY(DATE('2020-08-26')) | fields `DAY(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +---------------------------+
     | DAY(DATE('2020-08-26'))   |
@@ -259,7 +259,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `DAYNAME(DATE('2020-08-26'))` = DAYNAME(DATE('2020-08-26')) | fields `DAYNAME(DATE('2020-08-26'))`
+    os> source=people | eval `DAYNAME(DATE('2020-08-26'))` = DAYNAME(DATE('2020-08-26')) | fields `DAYNAME(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +-------------------------------+
     | DAYNAME(DATE('2020-08-26'))   |
@@ -284,7 +284,7 @@ Synonyms: DAY
 
 Example::
 
-    od> source=people | eval `DAYOFMONTH(DATE('2020-08-26'))` = DAYOFMONTH(DATE('2020-08-26')) | fields `DAYOFMONTH(DATE('2020-08-26'))`
+    os> source=people | eval `DAYOFMONTH(DATE('2020-08-26'))` = DAYOFMONTH(DATE('2020-08-26')) | fields `DAYOFMONTH(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +----------------------------------+
     | DAYOFMONTH(DATE('2020-08-26'))   |
@@ -307,7 +307,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `DAYOFWEEK(DATE('2020-08-26'))` = DAYOFWEEK(DATE('2020-08-26')) | fields `DAYOFWEEK(DATE('2020-08-26'))`
+    os> source=people | eval `DAYOFWEEK(DATE('2020-08-26'))` = DAYOFWEEK(DATE('2020-08-26')) | fields `DAYOFWEEK(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +---------------------------------+
     | DAYOFWEEK(DATE('2020-08-26'))   |
@@ -331,7 +331,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `DAYOFYEAR(DATE('2020-08-26'))` = DAYOFYEAR(DATE('2020-08-26')) | fields `DAYOFYEAR(DATE('2020-08-26'))`
+    os> source=people | eval `DAYOFYEAR(DATE('2020-08-26'))` = DAYOFYEAR(DATE('2020-08-26')) | fields `DAYOFYEAR(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +---------------------------------+
     | DAYOFYEAR(DATE('2020-08-26'))   |
@@ -354,7 +354,7 @@ Return type: DATE
 
 Example::
 
-    od> source=people | eval `FROM_DAYS(733687)` = FROM_DAYS(733687) | fields `FROM_DAYS(733687)`
+    os> source=people | eval `FROM_DAYS(733687)` = FROM_DAYS(733687) | fields `FROM_DAYS(733687)`
     fetched rows / total rows = 1/1
     +---------------------+
     | FROM_DAYS(733687)   |
@@ -377,7 +377,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `HOUR(TIME('01:02:03'))` = HOUR(TIME('01:02:03')) | fields `HOUR(TIME('01:02:03'))`
+    os> source=people | eval `HOUR(TIME('01:02:03'))` = HOUR(TIME('01:02:03')) | fields `HOUR(TIME('01:02:03'))`
     fetched rows / total rows = 1/1
     +--------------------------+
     | HOUR(TIME('01:02:03'))   |
@@ -411,7 +411,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `MICROSECOND(TIME('01:02:03.123456'))` = MICROSECOND(TIME('01:02:03.123456')) | fields `MICROSECOND(TIME('01:02:03.123456'))`
+    os> source=people | eval `MICROSECOND(TIME('01:02:03.123456'))` = MICROSECOND(TIME('01:02:03.123456')) | fields `MICROSECOND(TIME('01:02:03.123456'))`
     fetched rows / total rows = 1/1
     +----------------------------------------+
     | MICROSECOND(TIME('01:02:03.123456'))   |
@@ -434,7 +434,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `MINUTE(TIME('01:02:03'))` =  MINUTE(TIME('01:02:03')) | fields `MINUTE(TIME('01:02:03'))`
+    os> source=people | eval `MINUTE(TIME('01:02:03'))` =  MINUTE(TIME('01:02:03')) | fields `MINUTE(TIME('01:02:03'))`
     fetched rows / total rows = 1/1
     +----------------------------+
     | MINUTE(TIME('01:02:03'))   |
@@ -457,7 +457,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `MONTH(DATE('2020-08-26'))` =  MONTH(DATE('2020-08-26')) | fields `MONTH(DATE('2020-08-26'))`
+    os> source=people | eval `MONTH(DATE('2020-08-26'))` =  MONTH(DATE('2020-08-26')) | fields `MONTH(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +-----------------------------+
     | MONTH(DATE('2020-08-26'))   |
@@ -480,7 +480,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `MONTHNAME(DATE('2020-08-26'))` = MONTHNAME(DATE('2020-08-26')) | fields `MONTHNAME(DATE('2020-08-26'))`
+    os> source=people | eval `MONTHNAME(DATE('2020-08-26'))` = MONTHNAME(DATE('2020-08-26')) | fields `MONTHNAME(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +---------------------------------+
     | MONTHNAME(DATE('2020-08-26'))   |
@@ -514,7 +514,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `QUARTER(DATE('2020-08-26'))` = QUARTER(DATE('2020-08-26')) | fields `QUARTER(DATE('2020-08-26'))`
+    os> source=people | eval `QUARTER(DATE('2020-08-26'))` = QUARTER(DATE('2020-08-26')) | fields `QUARTER(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +-------------------------------+
     | QUARTER(DATE('2020-08-26'))   |
@@ -537,7 +537,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `SECOND(TIME('01:02:03'))` = SECOND(TIME('01:02:03')) | fields `SECOND(TIME('01:02:03'))`
+    os> source=people | eval `SECOND(TIME('01:02:03'))` = SECOND(TIME('01:02:03')) | fields `SECOND(TIME('01:02:03'))`
     fetched rows / total rows = 1/1
     +----------------------------+
     | SECOND(TIME('01:02:03'))   |
@@ -568,7 +568,7 @@ Synonyms: `DATE_SUB`_
 
 Example::
 
-    od> source=people | eval `SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)` = SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY), `SUBDATE(DATE('2020-08-26'), 1)` = SUBDATE(DATE('2020-08-26'), 1), `SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)` = SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)`, `SUBDATE(DATE('2020-08-26'), 1)`, `SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)`
+    os> source=people | eval `SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)` = SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY), `SUBDATE(DATE('2020-08-26'), 1)` = SUBDATE(DATE('2020-08-26'), 1), `SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)` = SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)`, `SUBDATE(DATE('2020-08-26'), 1)`, `SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)`
     fetched rows / total rows = 1/1
     +------------------------------------------------+----------------------------------+------------------------------------------------+
     | SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)   | SUBDATE(DATE('2020-08-26'), 1)   | SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
@@ -614,7 +614,7 @@ Return type: LONG
 
 Example::
 
-    od> source=people | eval `TIME_TO_SEC(TIME('22:23:00'))` = TIME_TO_SEC(TIME('22:23:00')) | fields `TIME_TO_SEC(TIME('22:23:00'))`
+    os> source=people | eval `TIME_TO_SEC(TIME('22:23:00'))` = TIME_TO_SEC(TIME('22:23:00')) | fields `TIME_TO_SEC(TIME('22:23:00'))`
     fetched rows / total rows = 1/1
     +---------------------------------+
     | TIME_TO_SEC(TIME('22:23:00'))   |
@@ -660,7 +660,7 @@ Return type: LONG
 
 Example::
 
-    od> source=people | eval `TO_DAYS(DATE('2008-10-07'))` = TO_DAYS(DATE('2008-10-07')) | fields `TO_DAYS(DATE('2008-10-07'))`
+    os> source=people | eval `TO_DAYS(DATE('2008-10-07'))` = TO_DAYS(DATE('2008-10-07')) | fields `TO_DAYS(DATE('2008-10-07'))`
     fetched rows / total rows = 1/1
     +-------------------------------+
     | TO_DAYS(DATE('2008-10-07'))   |
@@ -747,7 +747,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `YEAR(DATE('2020-08-26'))` = YEAR(DATE('2020-08-26')) | fields `YEAR(DATE('2020-08-26'))`
+    os> source=people | eval `YEAR(DATE('2020-08-26'))` = YEAR(DATE('2020-08-26')) | fields `YEAR(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
     +----------------------------+
     | YEAR(DATE('2020-08-26'))   |

--- a/docs/experiment/ppl/functions/math.rst
+++ b/docs/experiment/ppl/functions/math.rst
@@ -23,7 +23,7 @@ Return type: INTEGER/LONG/FLOAT/DOUBLE
 
 Example::
 
-    od> source=people | eval `ABS(-1)` = ABS(-1) | fields `ABS(-1)`
+    os> source=people | eval `ABS(-1)` = ABS(-1) | fields `ABS(-1)`
     fetched rows / total rows = 1/1
     +-----------+
     | ABS(-1)   |
@@ -46,7 +46,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `ACOS(0)` = ACOS(0) | fields `ACOS(0)`
+    os> source=people | eval `ACOS(0)` = ACOS(0) | fields `ACOS(0)`
     fetched rows / total rows = 1/1
     +--------------------+
     | ACOS(0)            |
@@ -69,7 +69,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `ASIN(0)` = ASIN(0) | fields `ASIN(0)`
+    os> source=people | eval `ASIN(0)` = ASIN(0) | fields `ASIN(0)`
     fetched rows / total rows = 1/1
     +-----------+
     | ASIN(0)   |
@@ -92,7 +92,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `ATAN(2)` = ATAN(2), `ATAN(2, 3)` = ATAN(2, 3) | fields `ATAN(2)`, `ATAN(2, 3)`
+    os> source=people | eval `ATAN(2)` = ATAN(2), `ATAN(2, 3)` = ATAN(2, 3) | fields `ATAN(2)`, `ATAN(2, 3)`
     fetched rows / total rows = 1/1
     +--------------------+--------------------+
     | ATAN(2)            | ATAN(2, 3)         |
@@ -115,7 +115,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `ATAN2(2, 3)` = ATAN2(2, 3) | fields `ATAN2(2, 3)`
+    os> source=people | eval `ATAN2(2, 3)` = ATAN2(2, 3) | fields `ATAN2(2, 3)`
     fetched rows / total rows = 1/1
     +--------------------+
     | ATAN2(2, 3)        |
@@ -138,7 +138,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `CEIL(2.75)` = CEIL(2.75) | fields `CEIL(2.75)`
+    os> source=people | eval `CEIL(2.75)` = CEIL(2.75) | fields `CEIL(2.75)`
     fetched rows / total rows = 1/1
     +--------------+
     | CEIL(2.75)   |
@@ -161,7 +161,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `CONV('12', 10, 16)` = CONV('12', 10, 16), `CONV('2C', 16, 10)` = CONV('2C', 16, 10), `CONV(12, 10, 2)` = CONV(12, 10, 2), `CONV(1111, 2, 10)` = CONV(1111, 2, 10) | fields `CONV('12', 10, 16)`, `CONV('2C', 16, 10)`, `CONV(12, 10, 2)`, `CONV(1111, 2, 10)`
+    os> source=people | eval `CONV('12', 10, 16)` = CONV('12', 10, 16), `CONV('2C', 16, 10)` = CONV('2C', 16, 10), `CONV(12, 10, 2)` = CONV(12, 10, 2), `CONV(1111, 2, 10)` = CONV(1111, 2, 10) | fields `CONV('12', 10, 16)`, `CONV('2C', 16, 10)`, `CONV(12, 10, 2)`, `CONV(1111, 2, 10)`
     fetched rows / total rows = 1/1
     +----------------------+----------------------+-------------------+---------------------+
     | CONV('12', 10, 16)   | CONV('2C', 16, 10)   | CONV(12, 10, 2)   | CONV(1111, 2, 10)   |
@@ -183,7 +183,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `COS(0)` = COS(0) | fields `COS(0)`
+    os> source=people | eval `COS(0)` = COS(0) | fields `COS(0)`
     fetched rows / total rows = 1/1
     +----------+
     | COS(0)   |
@@ -206,7 +206,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `COT(1)` = COT(1) | fields `COT(1)`
+    os> source=people | eval `COT(1)` = COT(1) | fields `COT(1)`
     fetched rows / total rows = 1/1
     +--------------------+
     | COT(1)             |
@@ -229,7 +229,7 @@ Return type: LONG
 
 Example::
 
-    od> source=people | eval `CRC32('MySQL')` = CRC32('MySQL') | fields `CRC32('MySQL')`
+    os> source=people | eval `CRC32('MySQL')` = CRC32('MySQL') | fields `CRC32('MySQL')`
     fetched rows / total rows = 1/1
     +------------------+
     | CRC32('MySQL')   |
@@ -252,7 +252,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `DEGREES(1.57)` = DEGREES(1.57) | fields `DEGREES(1.57)`
+    os> source=people | eval `DEGREES(1.57)` = DEGREES(1.57) | fields `DEGREES(1.57)`
     fetched rows / total rows  = 1/1
     +-------------------+
     | DEGREES(1.57)     |
@@ -272,7 +272,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `E()` = E() | fields `E()`
+    os> source=people | eval `E()` = E() | fields `E()`
     fetched rows / total rows = 1/1
     +-------------------+
     | E()               |
@@ -295,7 +295,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `EXP(2)` = EXP(2) | fields `EXP(2)`
+    os> source=people | eval `EXP(2)` = EXP(2) | fields `EXP(2)`
     fetched rows / total rows = 1/1
     +------------------+
     | EXP(2)           |
@@ -318,7 +318,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `FLOOR(2.75)` = FLOOR(2.75) | fields `FLOOR(2.75)`
+    os> source=people | eval `FLOOR(2.75)` = FLOOR(2.75) | fields `FLOOR(2.75)`
     fetched rows / total rows = 1/1
     +---------------+
     | FLOOR(2.75)   |
@@ -341,7 +341,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `LN(2)` = LN(2) | fields `LN(2)`
+    os> source=people | eval `LN(2)` = LN(2) | fields `LN(2)`
     fetched rows / total rows = 1/1
     +--------------------+
     | LN(2)              |
@@ -366,7 +366,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `LOG(2)` = LOG(2), `LOG(2, 8)` = LOG(2, 8) | fields `LOG(2)`, `LOG(2, 8)`
+    os> source=people | eval `LOG(2)` = LOG(2), `LOG(2, 8)` = LOG(2, 8) | fields `LOG(2)`, `LOG(2, 8)`
     fetched rows / total rows = 1/1
     +--------------------+-------------+
     | LOG(2)             | LOG(2, 8)   |
@@ -391,7 +391,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `LOG2(8)` = LOG2(8) | fields `LOG2(8)`
+    os> source=people | eval `LOG2(8)` = LOG2(8) | fields `LOG2(8)`
     fetched rows / total rows = 1/1
     +-----------+
     | LOG2(8)   |
@@ -416,7 +416,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `LOG10(100)` = LOG10(100) | fields `LOG10(100)`
+    os> source=people | eval `LOG10(100)` = LOG10(100) | fields `LOG10(100)`
     fetched rows / total rows = 1/1
     +--------------+
     | LOG10(100)   |
@@ -439,7 +439,7 @@ Return type: Wider type between types of n and m if m is nonzero value. If m equ
 
 Example::
 
-    od> source=people | eval `MOD(3, 2)` = MOD(3, 2), `MOD(3.1, 2)` = MOD(3.1, 2) | fields `MOD(3, 2)`, `MOD(3.1, 2)`
+    os> source=people | eval `MOD(3, 2)` = MOD(3, 2), `MOD(3.1, 2)` = MOD(3.1, 2) | fields `MOD(3, 2)`, `MOD(3.1, 2)`
     fetched rows / total rows = 1/1
     +-------------+---------------+
     | MOD(3, 2)   | MOD(3.1, 2)   |
@@ -460,7 +460,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `PI()` = PI() | fields `PI()`
+    os> source=people | eval `PI()` = PI() | fields `PI()`
     fetched rows / total rows = 1/1
     +-------------------+
     | PI()              |
@@ -485,7 +485,7 @@ Synonyms: `POWER`_
 
 Example::
 
-    od> source=people | eval `POW(3, 2)` = POW(3, 2), `POW(-3, 2)` = POW(-3, 2), `POW(3, -2)` = POW(3, -2) | fields `POW(3, 2)`, `POW(-3, 2)`, `POW(3, -2)`
+    os> source=people | eval `POW(3, 2)` = POW(3, 2), `POW(-3, 2)` = POW(-3, 2), `POW(3, -2)` = POW(3, -2) | fields `POW(3, 2)`, `POW(-3, 2)`, `POW(3, -2)`
     fetched rows / total rows = 1/1
     +-------------+--------------+--------------------+
     | POW(3, 2)   | POW(-3, 2)   | POW(3, -2)         |
@@ -510,7 +510,7 @@ Synonyms: `POW`_
 
 Example::
 
-    od> source=people | eval `POWER(3, 2)` = POWER(3, 2), `POWER(-3, 2)` = POWER(-3, 2), `POWER(3, -2)` = POWER(3, -2) | fields `POWER(3, 2)`, `POWER(-3, 2)`, `POWER(3, -2)`
+    os> source=people | eval `POWER(3, 2)` = POWER(3, 2), `POWER(-3, 2)` = POWER(-3, 2), `POWER(3, -2)` = POWER(3, -2) | fields `POWER(3, 2)`, `POWER(-3, 2)`, `POWER(3, -2)`
     fetched rows / total rows = 1/1
     +---------------+----------------+--------------------+
     | POWER(3, 2)   | POWER(-3, 2)   | POWER(3, -2)       |
@@ -533,7 +533,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `RADIANS(90)` = RADIANS(90) | fields `RADIANS(90)`
+    os> source=people | eval `RADIANS(90)` = RADIANS(90) | fields `RADIANS(90)`
     fetched rows / total rows  = 1/1
     +--------------------+
     | RADIANS(90)        |
@@ -556,7 +556,7 @@ Return type: FLOAT
 
 Example::
 
-    od> source=people | eval `RAND(3)` = RAND(3) | fields `RAND(3)`
+    os> source=people | eval `RAND(3)` = RAND(3) | fields `RAND(3)`
     fetched rows / total rows = 1/1
     +------------+
     | RAND(3)    |
@@ -582,7 +582,7 @@ Return type map:
 
 Example::
 
-    od> source=people | eval `ROUND(12.34)` = ROUND(12.34), `ROUND(12.34, 1)` = ROUND(12.34, 1), `ROUND(12.34, -1)` = ROUND(12.34, -1), `ROUND(12, 1)` = ROUND(12, 1) | fields `ROUND(12.34)`, `ROUND(12.34, 1)`, `ROUND(12.34, -1)`, `ROUND(12, 1)`
+    os> source=people | eval `ROUND(12.34)` = ROUND(12.34), `ROUND(12.34, 1)` = ROUND(12.34, 1), `ROUND(12.34, -1)` = ROUND(12.34, -1), `ROUND(12, 1)` = ROUND(12, 1) | fields `ROUND(12.34)`, `ROUND(12.34, 1)`, `ROUND(12.34, -1)`, `ROUND(12, 1)`
     fetched rows / total rows = 1/1
     +----------------+-------------------+--------------------+----------------+
     | ROUND(12.34)   | ROUND(12.34, 1)   | ROUND(12.34, -1)   | ROUND(12, 1)   |
@@ -605,7 +605,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `SIGN(1)` = SIGN(1), `SIGN(0)` = SIGN(0), `SIGN(-1.1)` = SIGN(-1.1) | fields `SIGN(1)`, `SIGN(0)`, `SIGN(-1.1)`
+    os> source=people | eval `SIGN(1)` = SIGN(1), `SIGN(0)` = SIGN(0), `SIGN(-1.1)` = SIGN(-1.1) | fields `SIGN(1)`, `SIGN(0)`, `SIGN(-1.1)`
     fetched rows / total rows = 1/1
     +-----------+-----------+--------------+
     | SIGN(1)   | SIGN(0)   | SIGN(-1.1)   |
@@ -628,7 +628,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> source=people | eval `SIN(0)` = SIN(0) | fields `SIN(0)`
+    os> source=people | eval `SIN(0)` = SIN(0) | fields `SIN(0)`
     fetched rows / total rows = 1/1
     +----------+
     | SIN(0)   |
@@ -654,7 +654,7 @@ Return type map:
 
 Example::
 
-    od> source=people | eval `SQRT(4)` = SQRT(4), `SQRT(4.41)` = SQRT(4.41) | fields `SQRT(4)`, `SQRT(4.41)`
+    os> source=people | eval `SQRT(4)` = SQRT(4), `SQRT(4.41)` = SQRT(4.41) | fields `SQRT(4)`, `SQRT(4.41)`
     fetched rows / total rows = 1/1
     +-----------+--------------+
     | SQRT(4)   | SQRT(4.41)   |

--- a/docs/experiment/ppl/functions/string.rst
+++ b/docs/experiment/ppl/functions/string.rst
@@ -22,7 +22,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `CONCAT('hello', 'world')` = CONCAT('hello', 'world') | fields `CONCAT('hello', 'world')`
+    os> source=people | eval `CONCAT('hello', 'world')` = CONCAT('hello', 'world') | fields `CONCAT('hello', 'world')`
     fetched rows / total rows = 1/1
     +----------------------------+
     | CONCAT('hello', 'world')   |
@@ -45,7 +45,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `CONCAT_WS(',', 'hello', 'world')` = CONCAT_WS(',', 'hello', 'world') | fields `CONCAT_WS(',', 'hello', 'world')`
+    os> source=people | eval `CONCAT_WS(',', 'hello', 'world')` = CONCAT_WS(',', 'hello', 'world') | fields `CONCAT_WS(',', 'hello', 'world')`
     fetched rows / total rows = 1/1
     +------------------------------------+
     | CONCAT_WS(',', 'hello', 'world')   |
@@ -72,7 +72,7 @@ Return type: INTEGER
 
 Example::
 
-    od> source=people | eval `LENGTH('helloworld')` = LENGTH('helloworld') | fields `LENGTH('helloworld')`
+    os> source=people | eval `LENGTH('helloworld')` = LENGTH('helloworld') | fields `LENGTH('helloworld')`
     fetched rows / total rows = 1/1
     +------------------------+
     | LENGTH('helloworld')   |
@@ -96,7 +96,7 @@ There are two wildcards often used in conjunction with the LIKE operator:
 
 Example::
 
-    od> source=people | eval `LIKE('hello world', '_ello%')` = LIKE('hello world', '_ello%') | fields `LIKE('hello world', '_ello%')`
+    os> source=people | eval `LIKE('hello world', '_ello%')` = LIKE('hello world', '_ello%') | fields `LIKE('hello world', '_ello%')`
     fetched rows / total rows = 1/1
     +---------------------------------+
     | LIKE('hello world', '_ello%')   |
@@ -118,7 +118,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `LOWER('helloworld')` = LOWER('helloworld'), `LOWER('HELLOWORLD')` = LOWER('HELLOWORLD') | fields `LOWER('helloworld')`, `LOWER('HELLOWORLD')`
+    os> source=people | eval `LOWER('helloworld')` = LOWER('helloworld'), `LOWER('HELLOWORLD')` = LOWER('HELLOWORLD') | fields `LOWER('helloworld')`, `LOWER('HELLOWORLD')`
     fetched rows / total rows = 1/1
     +-----------------------+-----------------------+
     | LOWER('helloworld')   | LOWER('HELLOWORLD')   |
@@ -141,7 +141,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `LTRIM('   hello')` = LTRIM('   hello'), `LTRIM('hello   ')` = LTRIM('hello   ') | fields `LTRIM('   hello')`, `LTRIM('hello   ')`
+    os> source=people | eval `LTRIM('   hello')` = LTRIM('   hello'), `LTRIM('hello   ')` = LTRIM('hello   ') | fields `LTRIM('   hello')`, `LTRIM('hello   ')`
     fetched rows / total rows = 1/1
     +---------------------+---------------------+
     | LTRIM('   hello')   | LTRIM('hello   ')   |
@@ -164,7 +164,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `RIGHT('helloworld', 5)` = RIGHT('helloworld', 5), `RIGHT('HELLOWORLD', 0)` = RIGHT('HELLOWORLD', 0) | fields `RIGHT('helloworld', 5)`, `RIGHT('HELLOWORLD', 0)`
+    os> source=people | eval `RIGHT('helloworld', 5)` = RIGHT('helloworld', 5), `RIGHT('HELLOWORLD', 0)` = RIGHT('HELLOWORLD', 0) | fields `RIGHT('helloworld', 5)`, `RIGHT('HELLOWORLD', 0)`
     fetched rows / total rows = 1/1
     +--------------------------+--------------------------+
     | RIGHT('helloworld', 5)   | RIGHT('HELLOWORLD', 0)   |
@@ -187,7 +187,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `RTRIM('   hello')` = RTRIM('   hello'), `RTRIM('hello   ')` = RTRIM('hello   ') | fields `RTRIM('   hello')`, `RTRIM('hello   ')`
+    os> source=people | eval `RTRIM('   hello')` = RTRIM('   hello'), `RTRIM('hello   ')` = RTRIM('hello   ') | fields `RTRIM('   hello')`, `RTRIM('hello   ')`
     fetched rows / total rows = 1/1
     +---------------------+---------------------+
     | RTRIM('   hello')   | RTRIM('hello   ')   |
@@ -212,7 +212,7 @@ Synonyms: SUBSTR
 
 Example::
 
-    od> source=people | eval `SUBSTRING('helloworld', 5)` = SUBSTRING('helloworld', 5), `SUBSTRING('helloworld', 5, 3)` = SUBSTRING('helloworld', 5, 3) | fields `SUBSTRING('helloworld', 5)`, `SUBSTRING('helloworld', 5, 3)`
+    os> source=people | eval `SUBSTRING('helloworld', 5)` = SUBSTRING('helloworld', 5), `SUBSTRING('helloworld', 5, 3)` = SUBSTRING('helloworld', 5, 3) | fields `SUBSTRING('helloworld', 5)`, `SUBSTRING('helloworld', 5, 3)`
     fetched rows / total rows = 1/1
     +------------------------------+---------------------------------+
     | SUBSTRING('helloworld', 5)   | SUBSTRING('helloworld', 5, 3)   |
@@ -233,7 +233,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `TRIM('   hello')` = TRIM('   hello'), `TRIM('hello   ')` = TRIM('hello   ') | fields `TRIM('   hello')`, `TRIM('hello   ')`
+    os> source=people | eval `TRIM('   hello')` = TRIM('   hello'), `TRIM('hello   ')` = TRIM('hello   ') | fields `TRIM('   hello')`, `TRIM('hello   ')`
     fetched rows / total rows = 1/1
     +--------------------+--------------------+
     | TRIM('   hello')   | TRIM('hello   ')   |
@@ -256,7 +256,7 @@ Return type: STRING
 
 Example::
 
-    od> source=people | eval `UPPER('helloworld')` = UPPER('helloworld'), `UPPER('HELLOWORLD')` = UPPER('HELLOWORLD') | fields `UPPER('helloworld')`, `UPPER('HELLOWORLD')`
+    os> source=people | eval `UPPER('helloworld')` = UPPER('helloworld'), `UPPER('HELLOWORLD')` = UPPER('HELLOWORLD') | fields `UPPER('helloworld')`, `UPPER('HELLOWORLD')`
     fetched rows / total rows = 1/1
     +-----------------------+-----------------------+
     | UPPER('helloworld')   | UPPER('HELLOWORLD')   |

--- a/docs/experiment/ppl/general/datatypes.rst
+++ b/docs/experiment/ppl/general/datatypes.rst
@@ -383,7 +383,7 @@ The example show fetch city (top level), city.name (second level), city.location
 
 PPL query::
 
-    od> source=people | fields city, city.name, city.location.latitude;
+    os> source=people | fields city, city.name, city.location.latitude;
     fetched rows / total rows = 1/1
     +-----------------------------------------------------+-------------+--------------------------+
     | city                                                | city.name   | city.location.latitude   |
@@ -399,7 +399,7 @@ The example show group by object field inner attribute.
 
 PPL query::
 
-    od> source=people | stats count() by city.name;
+    os> source=people | stats count() by city.name;
     fetched rows / total rows = 1/1
     +-----------+-------------+
     | count()   | city.name   |
@@ -412,7 +412,7 @@ Example 3: Selecting Field of Array Value
 
 Select deeper level for object fields of array value which returns the first element in the array. For example, because inner field ``accounts.id`` has three values instead of a tuple in this document, the first entry is returned.::
 
-    od> source = people | fields accounts, accounts.id;
+    os> source = people | fields accounts, accounts.id;
     fetched rows / total rows = 1/1
     +------------+---------------+
     | accounts   | accounts.id   |

--- a/docs/experiment/ppl/general/identifiers.rst
+++ b/docs/experiment/ppl/general/identifiers.rst
@@ -37,7 +37,7 @@ Examples
 
 Here are examples for using index pattern directly without quotes::
 
-    od> source=accounts | fields account_number, firstname, lastname;
+    os> source=accounts | fields account_number, firstname, lastname;
     fetched rows / total rows = 4/4
     +------------------+-------------+------------+
     | account_number   | firstname   | lastname   |
@@ -71,7 +71,7 @@ Examples
 
 Here are examples for quoting an index name by back ticks::
 
-    od> source=`accounts` | fields `account_number`;
+    os> source=`accounts` | fields `account_number`;
     fetched rows / total rows = 4/4
     +------------------+
     | account_number   |

--- a/docs/user/beyond/partiql.rst
+++ b/docs/user/beyond/partiql.rst
@@ -200,7 +200,7 @@ Example 1: Selecting Top Level
 
 Selecting top level for object fields, object fields of array value and nested fields returns original JSON object or array of the field. For example, object field ``city`` is a JSON object, object field (of array value) ``accounts`` and nested field ``projects`` are JSON arrays::
 
-    od> SELECT city, accounts, projects FROM people;
+    os> SELECT city, accounts, projects FROM people;
     fetched rows / total rows = 1/1
     +-----------------------------------------------------+-----------------------+----------------------------------------------------------------------------------------------------------------+
     | city                                                | accounts              | projects                                                                                                       |
@@ -213,7 +213,7 @@ Example 2: Selecting Deeper Levels
 
 Selecting at deeper levels for object fields of regular value returns inner field value. For example, ``city.location`` is an inner object field and ``city.location.altitude`` is a regular double field::
 
-    od> SELECT city.location, city.location.latitude FROM people;
+    os> SELECT city.location, city.location.latitude FROM people;
     fetched rows / total rows = 1/1
     +--------------------+--------------------------+
     | city.location      | city.location.latitude   |

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -32,7 +32,7 @@ Identifier
 
 The group by expression could be identifier::
 
-    od> SELECT gender, sum(age) FROM accounts GROUP BY gender;
+    os> SELECT gender, sum(age) FROM accounts GROUP BY gender;
     fetched rows / total rows = 2/2
     +----------+------------+
     | gender   | sum(age)   |
@@ -47,7 +47,7 @@ Ordinal
 
 The group by expression could be ordinal::
 
-    od> SELECT gender, sum(age) FROM accounts GROUP BY 1;
+    os> SELECT gender, sum(age) FROM accounts GROUP BY 1;
     fetched rows / total rows = 2/2
     +----------+------------+
     | gender   | sum(age)   |
@@ -62,7 +62,7 @@ Expression
 
 The group by expression could be expression::
 
-    od> SELECT abs(account_number), sum(age) FROM accounts GROUP BY abs(account_number);
+    os> SELECT abs(account_number), sum(age) FROM accounts GROUP BY abs(account_number);
     fetched rows / total rows = 4/4
     +-----------------------+------------+
     | abs(account_number)   | sum(age)   |
@@ -89,7 +89,7 @@ Aggregation in Select
 
 The aggregation could be used select::
 
-    od> SELECT gender, sum(age) FROM accounts GROUP BY gender;
+    os> SELECT gender, sum(age) FROM accounts GROUP BY gender;
     fetched rows / total rows = 2/2
     +----------+------------+
     | gender   | sum(age)   |
@@ -103,7 +103,7 @@ Expression over Aggregation
 
 The aggregation could be used as arguments of expression::
 
-    od> SELECT gender, sum(age) * 2 as sum2 FROM accounts GROUP BY gender;
+    os> SELECT gender, sum(age) * 2 as sum2 FROM accounts GROUP BY gender;
     fetched rows / total rows = 2/2
     +----------+--------+
     | gender   | sum2   |
@@ -117,7 +117,7 @@ Expression as argument of Aggregation
 
 The aggregation could has expression as arguments::
 
-    od> SELECT gender, sum(age * 2) as sum2 FROM accounts GROUP BY gender;
+    os> SELECT gender, sum(age * 2) as sum2 FROM accounts GROUP BY gender;
     fetched rows / total rows = 2/2
     +----------+--------+
     | gender   | sum2   |
@@ -153,7 +153,7 @@ Aggregate expressions or its alias defined in ``SELECT`` clause can be used in `
 
 Here is an example for typical use of ``HAVING`` clause::
 
-    od> SELECT
+    os> SELECT
     ...  gender, sum(age)
     ... FROM accounts
     ... GROUP BY gender
@@ -167,7 +167,7 @@ Here is an example for typical use of ``HAVING`` clause::
 
 Here is another example for using alias in ``HAVING`` condition. Note that if an identifier is ambiguous, for example present both as a select alias and an index field, preference is alias. This means the identifier will be replaced by expression aliased in ``SELECT`` clause::
 
-    od> SELECT
+    os> SELECT
     ...  gender, sum(age) AS s
     ... FROM accounts
     ... GROUP BY gender
@@ -184,7 +184,7 @@ HAVING without GROUP BY
 
 Additionally, a ``HAVING`` clause can work without ``GROUP BY`` clause. This is useful because aggregation is not allowed to be present in ``WHERE`` clause::
 
-    od> SELECT
+    os> SELECT
     ...  'Total of age > 100'
     ... FROM accounts
     ... HAVING sum(age) > 100;
@@ -209,7 +209,7 @@ FILTER with GROUP BY
 
 The group by aggregation with ``FILTER`` clause can set different conditions for each aggregation bucket. Here is an example to use ``FILTER`` in group by aggregation::
 
-    od> SELECT avg(age) FILTER(WHERE balance > 10000) AS filtered, gender FROM accounts GROUP BY gender
+    os> SELECT avg(age) FILTER(WHERE balance > 10000) AS filtered, gender FROM accounts GROUP BY gender
     fetched rows / total rows = 2/2
     +------------+----------+
     | filtered   | gender   |
@@ -223,7 +223,7 @@ FILTER without GROUP BY
 
 The ``FILTER`` clause can be used in aggregation functions without GROUP BY as well. For example::
 
-    od> SELECT
+    os> SELECT
     ...   count(*) AS unfiltered,
     ...   count(*) FILTER(WHERE age > 34) AS filtered
     ... FROM accounts

--- a/docs/user/dql/basics.rst
+++ b/docs/user/dql/basics.rst
@@ -257,7 +257,7 @@ Result set:
 
 In fact your can use any expression in a ``DISTINCT`` clause as follows::
 
-    od> SELECT DISTINCT SUBSTRING(lastname, 1, 1) FROM accounts;
+    os> SELECT DISTINCT SUBSTRING(lastname, 1, 1) FROM accounts;
     fetched rows / total rows = 3/3
     +-----------------------------+
     | SUBSTRING(lastname, 1, 1)   |
@@ -942,7 +942,7 @@ Result set:
 
 Note that the example above is essentially sorting on a predicate expression. In this case, nulls are put first because it's evaluated to false (0), though all the rest are evaluated to true and still in random order. If you want to specify order for both nulls and non-nulls, ``NULLS FIRST`` or ``NULLS LAST`` in SQL standard can help. Basically, it allows you to specify an independent order for nulls along with ``ASC`` or ``DESC`` keyword::
 
-    od> SELECT employer FROM accounts ORDER BY employer ASC NULLS LAST;
+    os> SELECT employer FROM accounts ORDER BY employer ASC NULLS LAST;
     fetched rows / total rows = 4/4
     +------------+
     | employer   |
@@ -964,7 +964,7 @@ The sorting rule can be summarized as follows:
 
 Here is another example for sort in descending order without ``NULLS`` clause::
 
-    od> SELECT employer FROM accounts ORDER BY employer DESC;
+    os> SELECT employer FROM accounts ORDER BY employer DESC;
     fetched rows / total rows = 4/4
     +------------+
     | employer   |
@@ -981,7 +981,7 @@ Example 3: Ordering by Aggregate Functions
 
 Aggregate functions are allowed to be used in ``ORDER BY`` clause. You can reference it by same function call or its alias or ordinal in select list::
 
-    od> SELECT gender, MAX(age) FROM accounts GROUP BY gender ORDER BY MAX(age) DESC;
+    os> SELECT gender, MAX(age) FROM accounts GROUP BY gender ORDER BY MAX(age) DESC;
     fetched rows / total rows = 2/2
     +----------+------------+
     | gender   | MAX(age)   |
@@ -992,7 +992,7 @@ Aggregate functions are allowed to be used in ``ORDER BY`` clause. You can refer
 
 Even if it's not present in ``SELECT`` clause, it can be also used as follows::
 
-    od> SELECT gender, MIN(age) FROM accounts GROUP BY gender ORDER BY MAX(age) DESC;
+    os> SELECT gender, MIN(age) FROM accounts GROUP BY gender ORDER BY MAX(age) DESC;
     fetched rows / total rows = 2/2
     +----------+------------+
     | gender   | MIN(age)   |

--- a/docs/user/dql/complex.rst
+++ b/docs/user/dql/complex.rst
@@ -243,7 +243,7 @@ Result set:
 
 Here is another example with aggregation function and GROUP BY in subquery::
 
-    od> SELECT avg_balance FROM (
+    os> SELECT avg_balance FROM (
     ...   SELECT AVG(balance) AS avg_balance FROM accounts GROUP BY gender, age
     ... ) AS a;
     fetched rows / total rows = 4/4
@@ -259,7 +259,7 @@ Here is another example with aggregation function and GROUP BY in subquery::
 
 Query with multiple layers of subquery is supported as well, here follows a example::
 
-    od> SELECT name FROM (
+    os> SELECT name FROM (
     ...   SELECT lastname AS name, age FROM (
     ...     SELECT * FROM accounts WHERE gender = 'M'
     ...   ) AS accounts WHERE age < 35

--- a/docs/user/dql/expressions.rst
+++ b/docs/user/dql/expressions.rst
@@ -34,7 +34,7 @@ Examples
 
 Here is an example for different type of literals::
 
-    od> SELECT 123, 'hello', false, -4.567, DATE '2020-07-07', TIME '01:01:01', TIMESTAMP '2020-07-07 01:01:01';
+    os> SELECT 123, 'hello', false, -4.567, DATE '2020-07-07', TIME '01:01:01', TIMESTAMP '2020-07-07 01:01:01';
     fetched rows / total rows = 1/1
     +-------+-----------+---------+----------+---------------------+-------------------+-----------------------------------+
     | 123   | 'hello'   | false   | -4.567   | DATE '2020-07-07'   | TIME '01:01:01'   | TIMESTAMP '2020-07-07 01:01:01'   |
@@ -84,7 +84,7 @@ Examples
 
 Here is an example for different type of arithmetic expressions::
 
-    od> SELECT 1 + 2, (9 - 1) % 3, 2 * 4 / 3;
+    os> SELECT 1 + 2, (9 - 1) % 3, 2 * 4 / 3;
     fetched rows / total rows = 1/1
     +---------+---------------+-------------+
     | 1 + 2   | (9 - 1) % 3   | 2 * 4 / 3   |
@@ -137,7 +137,7 @@ Basic Comparison Operator
 
 Here is an example for different type of comparison operators::
 
-    od> SELECT 2 > 1, 2 >= 1, 2 < 1, 2 != 1, 2 <= 1, 2 = 1;
+    os> SELECT 2 > 1, 2 >= 1, 2 < 1, 2 != 1, 2 <= 1, 2 = 1;
     fetched rows / total rows = 1/1
     +---------+----------+---------+----------+----------+---------+
     | 2 > 1   | 2 >= 1   | 2 < 1   | 2 != 1   | 2 <= 1   | 2 = 1   |
@@ -150,7 +150,7 @@ LIKE
 
 expr LIKE pattern. The expr is string value, pattern is supports literal text, a percent ( % ) character for a wildcard, and an underscore ( _ ) character for a single character match::
 
-    od> SELECT 'axyzb' LIKE 'a%b', 'acb' LIKE 'a_b', 'axyzb' NOT LIKE 'a%b', 'acb' NOT LIKE 'a_b';
+    os> SELECT 'axyzb' LIKE 'a%b', 'acb' LIKE 'a_b', 'axyzb' NOT LIKE 'a%b', 'acb' NOT LIKE 'a_b';
     fetched rows / total rows = 1/1
     +----------------------+--------------------+--------------------------+------------------------+
     | 'axyzb' LIKE 'a%b'   | 'acb' LIKE 'a_b'   | 'axyzb' NOT LIKE 'a%b'   | 'acb' NOT LIKE 'a_b'   |
@@ -163,7 +163,7 @@ NULL value test
 
 Here is an example for null value test::
 
-    od> SELECT 0 IS NULL, 0 IS NOT NULL, NULL IS NULL, NULL IS NOT NULL;
+    os> SELECT 0 IS NULL, 0 IS NOT NULL, NULL IS NULL, NULL IS NOT NULL;
     fetched rows / total rows = 1/1
     +-------------+-----------------+----------------+--------------------+
     | 0 IS NULL   | 0 IS NOT NULL   | NULL IS NULL   | NULL IS NOT NULL   |
@@ -177,7 +177,7 @@ REGEXP value test
 
 expr REGEXP pattern. The expr is string value, pattern is supports regular expression patterns::
 
-    od> SELECT 'Hello!' REGEXP '.*', 'a' REGEXP 'b';
+    os> SELECT 'Hello!' REGEXP '.*', 'a' REGEXP 'b';
     fetched rows / total rows = 1/1
     +------------------------+------------------+
     | 'Hello!' REGEXP '.*'   | 'a' REGEXP 'b'   |
@@ -210,7 +210,7 @@ Arithmetic function examples
 
 Here is an example for different type of arithmetic expressions::
 
-    od> SELECT abs(-1.234), abs(-1 * abs(-5));
+    os> SELECT abs(-1.234), abs(-1 * abs(-5));
     fetched rows / total rows = 1/1
     +---------------+---------------------+
     | abs(-1.234)   | abs(-1 * abs(-5))   |
@@ -223,7 +223,7 @@ Date function examples
 
 Here is an example for different type of arithmetic expressions::
 
-    od> SELECT dayofmonth(DATE '2020-07-07');
+    os> SELECT dayofmonth(DATE '2020-07-07');
     fetched rows / total rows = 1/1
     +---------------------------------+
     | dayofmonth(DATE '2020-07-07')   |

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -47,7 +47,7 @@ Note1: the conversion follow the JDK specification.
 
 Cast to string example::
 
-    od> SELECT cast(true as string) as cbool, cast(1 as string) as cint, cast(DATE '2012-08-07' as string) as cdate
+    os> SELECT cast(true as string) as cbool, cast(1 as string) as cint, cast(DATE '2012-08-07' as string) as cdate
     fetched rows / total rows = 1/1
     +---------+--------+------------+
     | cbool   | cint   | cdate      |
@@ -57,7 +57,7 @@ Cast to string example::
 
 Cast to number example::
 
-    od> SELECT cast(true as int) as cbool, cast('1' as integer) as cstring
+    os> SELECT cast(true as int) as cbool, cast('1' as integer) as cstring
     fetched rows / total rows = 1/1
     +---------+-----------+
     | cbool   | cstring   |
@@ -67,7 +67,7 @@ Cast to number example::
 
 Cast to date example::
 
-    od> SELECT cast('2012-08-07' as date) as cdate, cast('01:01:01' as time) as ctime, cast('2012-08-07 01:01:01' as timestamp) as ctimestamp
+    os> SELECT cast('2012-08-07' as date) as cdate, cast('01:01:01' as time) as ctime, cast('2012-08-07 01:01:01' as timestamp) as ctimestamp
     fetched rows / total rows = 1/1
     +------------+----------+---------------------+
     | cdate      | ctime    | ctimestamp          |
@@ -77,7 +77,7 @@ Cast to date example::
 
 Cast function can be chained::
 
-    od> SELECT cast(cast(true as string) as boolean) as cbool
+    os> SELECT cast(cast(true as string) as boolean) as cbool
     fetched rows / total rows = 1/1
     +---------+
     | cbool   |
@@ -114,7 +114,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT ACOS(0)
+    os> SELECT ACOS(0)
     fetched rows / total rows = 1/1
     +--------------------+
     | ACOS(0)            |
@@ -148,7 +148,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT ASIN(0)
+    os> SELECT ASIN(0)
     fetched rows / total rows = 1/1
     +-----------+
     | ASIN(0)   |
@@ -171,7 +171,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT ATAN(2), ATAN(2, 3)
+    os> SELECT ATAN(2), ATAN(2, 3)
     fetched rows / total rows = 1/1
     +--------------------+--------------------+
     | ATAN(2)            | ATAN(2, 3)         |
@@ -194,7 +194,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT ATAN2(2, 3)
+    os> SELECT ATAN2(2, 3)
     fetched rows / total rows = 1/1
     +--------------------+
     | ATAN2(2, 3)        |
@@ -239,7 +239,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT CONV('12', 10, 16), CONV('2C', 16, 10), CONV(12, 10, 2), CONV(1111, 2, 10)
+    os> SELECT CONV('12', 10, 16), CONV('2C', 16, 10), CONV(12, 10, 2), CONV(1111, 2, 10)
     fetched rows / total rows = 1/1
     +----------------------+----------------------+-------------------+---------------------+
     | CONV('12', 10, 16)   | CONV('2C', 16, 10)   | CONV(12, 10, 2)   | CONV(1111, 2, 10)   |
@@ -261,7 +261,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT COS(0)
+    os> SELECT COS(0)
     fetched rows / total rows = 1/1
     +----------+
     | COS(0)   |
@@ -295,7 +295,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT COT(1)
+    os> SELECT COT(1)
     fetched rows / total rows = 1/1
     +--------------------+
     | COT(1)             |
@@ -318,7 +318,7 @@ Return type: LONG
 
 Example::
 
-    od> SELECT CRC32('MySQL')
+    os> SELECT CRC32('MySQL')
     fetched rows / total rows = 1/1
     +------------------+
     | CRC32('MySQL')   |
@@ -341,7 +341,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT DEGREES(1.57)
+    os> SELECT DEGREES(1.57)
     fetched rows / total rows  = 1/1
     +-------------------+
     | DEGREES(1.57)     |
@@ -373,7 +373,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT E()
+    os> SELECT E()
     fetched rows / total rows = 1/1
     +-------------------+
     | E()               |
@@ -474,7 +474,7 @@ Return type: Wider type between types of n and m if m is nonzero value. If m equ
 
 Example::
 
-    od> SELECT MOD(3, 2), MOD(3.1, 2)
+    os> SELECT MOD(3, 2), MOD(3.1, 2)
     fetched rows / total rows = 1/1
     +-------------+---------------+
     | MOD(3, 2)   | MOD(3.1, 2)   |
@@ -505,7 +505,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT PI()
+    os> SELECT PI()
     fetched rows / total rows = 1/1
     +-------------------+
     | PI()              |
@@ -530,7 +530,7 @@ Synonyms: `POWER`_
 
 Example::
 
-    od> SELECT POW(3, 2), POW(-3, 2), POW(3, -2)
+    os> SELECT POW(3, 2), POW(-3, 2), POW(3, -2)
     fetched rows / total rows = 1/1
     +-------------+--------------+--------------------+
     | POW(3, 2)   | POW(-3, 2)   | POW(3, -2)         |
@@ -555,7 +555,7 @@ Synonyms: `POW`_
 
 Example::
 
-    od> SELECT POWER(3, 2), POWER(-3, 2), POWER(3, -2)
+    os> SELECT POWER(3, 2), POWER(-3, 2), POWER(3, -2)
     fetched rows / total rows = 1/1
     +---------------+----------------+--------------------+
     | POWER(3, 2)   | POWER(-3, 2)   | POWER(3, -2)       |
@@ -578,7 +578,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT RADIANS(90)
+    os> SELECT RADIANS(90)
     fetched rows / total rows  = 1/1
     +--------------------+
     | RADIANS(90)        |
@@ -601,7 +601,7 @@ Return type: FLOAT
 
 Example::
 
-    od> SELECT RAND(3)
+    os> SELECT RAND(3)
     fetched rows / total rows = 1/1
     +------------+
     | RAND(3)    |
@@ -638,7 +638,7 @@ Return type map:
 
 Example::
 
-    od> SELECT ROUND(12.34), ROUND(12.34, 1), ROUND(12.34, -1), ROUND(12, 1)
+    os> SELECT ROUND(12.34), ROUND(12.34, 1), ROUND(12.34, -1), ROUND(12, 1)
     fetched rows / total rows = 1/1
     +----------------+-------------------+--------------------+----------------+
     | ROUND(12.34)   | ROUND(12.34, 1)   | ROUND(12.34, -1)   | ROUND(12, 1)   |
@@ -661,7 +661,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT SIGN(1), SIGN(0), SIGN(-1.1)
+    os> SELECT SIGN(1), SIGN(0), SIGN(-1.1)
     fetched rows / total rows = 1/1
     +-----------+-----------+--------------+
     | SIGN(1)   | SIGN(0)   | SIGN(-1.1)   |
@@ -695,7 +695,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT SIN(0)
+    os> SELECT SIN(0)
     fetched rows / total rows = 1/1
     +----------+
     | SIN(0)   |
@@ -732,7 +732,7 @@ Return type map:
 
 Example::
 
-    od> SELECT SQRT(4), SQRT(4.41)
+    os> SELECT SQRT(4), SQRT(4.41)
     fetched rows / total rows = 1/1
     +-----------+--------------+
     | SQRT(4)   | SQRT(4.41)   |
@@ -755,7 +755,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT STRCMP('hello', 'world'), STRCMP('hello', 'hello')
+    os> SELECT STRCMP('hello', 'world'), STRCMP('hello', 'hello')
     fetched rows / total rows = 1/1
     +----------------------------+----------------------------+
     | STRCMP('hello', 'world')   | STRCMP('hello', 'hello')   |
@@ -790,7 +790,7 @@ Return type: DOUBLE
 
 Example::
 
-    od> SELECT TAN(0)
+    os> SELECT TAN(0)
     fetched rows / total rows = 1/1
     +----------+
     | TAN(0)   |
@@ -850,7 +850,7 @@ Synonyms: `DATE_ADD`_
 
 Example::
 
-    od> SELECT ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR), ADDDATE(DATE('2020-08-26'), 1), ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)
+    os> SELECT ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR), ADDDATE(DATE('2020-08-26'), 1), ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)
     fetched rows / total rows = 1/1
     +------------------------------------------------+----------------------------------+------------------------------------------------+
     | ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)   | ADDDATE(DATE('2020-08-26'), 1)   | ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
@@ -915,7 +915,7 @@ Synonyms: `ADDDATE`_
 
 Example::
 
-    od> SELECT DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR), DATE_ADD(DATE('2020-08-26'), 1), DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)
+    os> SELECT DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR), DATE_ADD(DATE('2020-08-26'), 1), DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)
     fetched rows / total rows = 1/1
     +-------------------------------------------------+-----------------------------------+-------------------------------------------------+
     | DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)   | DATE_ADD(DATE('2020-08-26'), 1)   | DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
@@ -1042,7 +1042,7 @@ Synonyms: `SUBDATE`_
 
 Example::
 
-    od> SELECT DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY), DATE_SUB(DATE('2020-08-26'), 1), DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)
+    os> SELECT DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY), DATE_SUB(DATE('2020-08-26'), 1), DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)
     fetched rows / total rows = 1/1
     +-------------------------------------------------+-----------------------------------+-------------------------------------------------+
     | DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)   | DATE_SUB(DATE('2020-08-26'), 1)   | DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
@@ -1067,7 +1067,7 @@ Synonyms: DAYOFMONTH
 
 Example::
 
-    od> SELECT DAY(DATE('2020-08-26'))
+    os> SELECT DAY(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +---------------------------+
     | DAY(DATE('2020-08-26'))   |
@@ -1090,7 +1090,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT DAYNAME(DATE('2020-08-26'))
+    os> SELECT DAYNAME(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +-------------------------------+
     | DAYNAME(DATE('2020-08-26'))   |
@@ -1115,7 +1115,7 @@ Synonyms: DAY
 
 Example::
 
-    od> SELECT DAYOFMONTH(DATE('2020-08-26'))
+    os> SELECT DAYOFMONTH(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +----------------------------------+
     | DAYOFMONTH(DATE('2020-08-26'))   |
@@ -1138,7 +1138,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT DAYOFWEEK(DATE('2020-08-26'))
+    os> SELECT DAYOFWEEK(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +---------------------------------+
     | DAYOFWEEK(DATE('2020-08-26'))   |
@@ -1162,7 +1162,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT DAYOFYEAR(DATE('2020-08-26'))
+    os> SELECT DAYOFYEAR(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +---------------------------------+
     | DAYOFYEAR(DATE('2020-08-26'))   |
@@ -1185,7 +1185,7 @@ Return type: DATE
 
 Example::
 
-    od> SELECT FROM_DAYS(733687)
+    os> SELECT FROM_DAYS(733687)
     fetched rows / total rows = 1/1
     +---------------------+
     | FROM_DAYS(733687)   |
@@ -1208,7 +1208,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT HOUR((TIME '01:02:03'))
+    os> SELECT HOUR((TIME '01:02:03'))
     fetched rows / total rows = 1/1
     +---------------------------+
     | HOUR((TIME '01:02:03'))   |
@@ -1242,7 +1242,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT MICROSECOND((TIME '01:02:03.123456'))
+    os> SELECT MICROSECOND((TIME '01:02:03.123456'))
     fetched rows / total rows = 1/1
     +-----------------------------------------+
     | MICROSECOND((TIME '01:02:03.123456'))   |
@@ -1265,7 +1265,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT MINUTE((TIME '01:02:03'))
+    os> SELECT MINUTE((TIME '01:02:03'))
     fetched rows / total rows = 1/1
     +-----------------------------+
     | MINUTE((TIME '01:02:03'))   |
@@ -1288,7 +1288,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT MONTH(DATE('2020-08-26'))
+    os> SELECT MONTH(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +-----------------------------+
     | MONTH(DATE('2020-08-26'))   |
@@ -1311,7 +1311,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT MONTHNAME(DATE('2020-08-26'))
+    os> SELECT MONTHNAME(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +---------------------------------+
     | MONTHNAME(DATE('2020-08-26'))   |
@@ -1345,7 +1345,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT QUARTER(DATE('2020-08-26'))
+    os> SELECT QUARTER(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +-------------------------------+
     | QUARTER(DATE('2020-08-26'))   |
@@ -1368,7 +1368,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT SECOND((TIME '01:02:03'))
+    os> SELECT SECOND((TIME '01:02:03'))
     fetched rows / total rows = 1/1
     +-----------------------------+
     | SECOND((TIME '01:02:03'))   |
@@ -1399,7 +1399,7 @@ Synonyms: `DATE_SUB`_
 
 Example::
 
-    od> SELECT SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY), SUBDATE(DATE('2020-08-26'), 1), SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)
+    os> SELECT SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY), SUBDATE(DATE('2020-08-26'), 1), SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)
     fetched rows / total rows = 1/1
     +------------------------------------------------+----------------------------------+------------------------------------------------+
     | SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)   | SUBDATE(DATE('2020-08-26'), 1)   | SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
@@ -1445,7 +1445,7 @@ Return type: LONG
 
 Example::
 
-    od> SELECT TIME_TO_SEC(TIME '22:23:00')
+    os> SELECT TIME_TO_SEC(TIME '22:23:00')
     fetched rows / total rows = 1/1
     +--------------------------------+
     | TIME_TO_SEC(TIME '22:23:00')   |
@@ -1491,7 +1491,7 @@ Return type: LONG
 
 Example::
 
-    od> SELECT TO_DAYS(DATE '2008-10-07')
+    os> SELECT TO_DAYS(DATE '2008-10-07')
     fetched rows / total rows = 1/1
     +------------------------------+
     | TO_DAYS(DATE '2008-10-07')   |
@@ -1578,7 +1578,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT YEAR(DATE('2020-08-26'))
+    os> SELECT YEAR(DATE('2020-08-26'))
     fetched rows / total rows = 1/1
     +----------------------------+
     | YEAR(DATE('2020-08-26'))   |
@@ -1615,7 +1615,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT CONCAT('hello', 'world')
+    os> SELECT CONCAT('hello', 'world')
     fetched rows / total rows = 1/1
     +----------------------------+
     | CONCAT('hello', 'world')   |
@@ -1638,7 +1638,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT CONCAT_WS(',', 'hello', 'world')
+    os> SELECT CONCAT_WS(',', 'hello', 'world')
     fetched rows / total rows = 1/1
     +------------------------------------+
     | CONCAT_WS(',', 'hello', 'world')   |
@@ -1676,7 +1676,7 @@ Return type: INTEGER
 
 Example::
 
-    od> SELECT LENGTH('helloworld')
+    os> SELECT LENGTH('helloworld')
     fetched rows / total rows = 1/1
     +------------------------+
     | LENGTH('helloworld')   |
@@ -1711,7 +1711,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT LOWER('helloworld'), LOWER('HELLOWORLD')
+    os> SELECT LOWER('helloworld'), LOWER('HELLOWORLD')
     fetched rows / total rows = 1/1
     +-----------------------+-----------------------+
     | LOWER('helloworld')   | LOWER('HELLOWORLD')   |
@@ -1734,7 +1734,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT LTRIM('   hello'), LTRIM('hello   ')
+    os> SELECT LTRIM('   hello'), LTRIM('hello   ')
     fetched rows / total rows = 1/1
     +---------------------+---------------------+
     | LTRIM('   hello')   | LTRIM('hello   ')   |
@@ -1768,7 +1768,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT RIGHT('helloworld', 5), RIGHT('HELLOWORLD', 0)
+    os> SELECT RIGHT('helloworld', 5), RIGHT('HELLOWORLD', 0)
     fetched rows / total rows = 1/1
     +--------------------------+--------------------------+
     | RIGHT('helloworld', 5)   | RIGHT('HELLOWORLD', 0)   |
@@ -1791,7 +1791,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT RTRIM('   hello'), RTRIM('hello   ')
+    os> SELECT RTRIM('   hello'), RTRIM('hello   ')
     fetched rows / total rows = 1/1
     +---------------------+---------------------+
     | RTRIM('   hello')   | RTRIM('hello   ')   |
@@ -1816,7 +1816,7 @@ Synonyms: SUBSTR
 
 Example::
 
-    od> SELECT SUBSTRING('helloworld', 5), SUBSTRING('helloworld', 5, 3)
+    os> SELECT SUBSTRING('helloworld', 5), SUBSTRING('helloworld', 5, 3)
     fetched rows / total rows = 1/1
     +------------------------------+---------------------------------+
     | SUBSTRING('helloworld', 5)   | SUBSTRING('helloworld', 5, 3)   |
@@ -1837,7 +1837,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT TRIM('   hello'), TRIM('hello   ')
+    os> SELECT TRIM('   hello'), TRIM('hello   ')
     fetched rows / total rows = 1/1
     +--------------------+--------------------+
     | TRIM('   hello')   | TRIM('hello   ')   |
@@ -1860,7 +1860,7 @@ Return type: STRING
 
 Example::
 
-    od> SELECT UPPER('helloworld'), UPPER('HELLOWORLD')
+    os> SELECT UPPER('helloworld'), UPPER('HELLOWORLD')
     fetched rows / total rows = 1/1
     +-----------------------+-----------------------+
     | UPPER('helloworld')   | UPPER('HELLOWORLD')   |
@@ -1900,7 +1900,7 @@ Return type: Any (NOTE : if two parameters has different type, you will fail sem
 
 Example One::
 
-    od> SELECT IFNULL(123, 321), IFNULL(321, 123)
+    os> SELECT IFNULL(123, 321), IFNULL(321, 123)
     fetched rows / total rows = 1/1
     +--------------------+--------------------+
     | IFNULL(123, 321)   | IFNULL(321, 123)   |
@@ -1910,7 +1910,7 @@ Example One::
 
 Example Two::
 
-    od> SELECT IFNULL(321, 1/0), IFNULL(1/0, 123)
+    os> SELECT IFNULL(321, 1/0), IFNULL(1/0, 123)
     fetched rows / total rows = 1/1
     +--------------------+--------------------+
     | IFNULL(321, 1/0)   | IFNULL(1/0, 123)   |
@@ -1920,7 +1920,7 @@ Example Two::
 
 Example Three::
 
-    od> SELECT IFNULL(1/0, 1/0)
+    os> SELECT IFNULL(1/0, 1/0)
     fetched rows / total rows = 1/1
     +--------------------+
     | IFNULL(1/0, 1/0)   |
@@ -1947,7 +1947,7 @@ Return type: Any (NOTE : if two parametershas different type, you will fail sema
 
 Example::
 
-    od> SELECT NULLIF(123, 123), NULLIF(321, 123), NULLIF(1/0, 321), NULLIF(321, 1/0), NULLIF(1/0, 1/0)
+    os> SELECT NULLIF(123, 123), NULLIF(321, 123), NULLIF(1/0, 321), NULLIF(321, 1/0), NULLIF(1/0, 1/0)
     fetched rows / total rows = 1/1
     +--------------------+--------------------+--------------------+--------------------+--------------------+
     | NULLIF(123, 123)   | NULLIF(321, 123)   | NULLIF(1/0, 321)   | NULLIF(321, 1/0)   | NULLIF(1/0, 1/0)   |
@@ -1974,7 +1974,7 @@ Return type: boolean
 
 Example::
 
-    od> SELECT ISNULL(1/0), ISNULL(123)
+    os> SELECT ISNULL(1/0), ISNULL(123)
     fetched rows / total rows = 1/1
     +---------------+---------------+
     | ISNULL(1/0)   | ISNULL(123)   |
@@ -2000,7 +2000,7 @@ Return type: Any (NOTE : if parameters #2 and #3 has different type, you will fa
 
 Example::
 
-    od> SELECT IF(100 > 200, '100', '200')
+    os> SELECT IF(100 > 200, '100', '200')
     fetched rows / total rows = 1/1
     +-------------------------------+
     | IF(100 > 200, '100', '200')   |
@@ -2008,7 +2008,7 @@ Example::
     | 200                           |
     +-------------------------------+
 
-    od> SELECT IF(200 > 100, '100', '200')
+    os> SELECT IF(200 > 100, '100', '200')
     fetched rows / total rows = 1/1
     +-------------------------------+
     | IF(200 > 100, '100', '200')   |
@@ -2055,7 +2055,7 @@ Examples
 
 Here are examples for simple case syntax::
 
-    od> SELECT
+    os> SELECT
     ...   CASE 1
     ...     WHEN 1 THEN 'One'
     ...   END AS simple_case,
@@ -2076,7 +2076,7 @@ Here are examples for simple case syntax::
 
 Here are examples for searched case syntax::
 
-    od> SELECT
+    os> SELECT
     ...   CASE
     ...     WHEN 1 = 1 THEN 'One'
     ...   END AS single_search,

--- a/docs/user/dql/window.rst
+++ b/docs/user/dql/window.rst
@@ -46,7 +46,7 @@ COUNT
 
 Here is an example for ``COUNT`` function::
 
-    od> SELECT
+    os> SELECT
     ...   gender, balance,
     ...   COUNT(balance) OVER(
     ...     PARTITION BY gender ORDER BY balance
@@ -67,7 +67,7 @@ MIN
 
 Here is an example for ``MIN`` function::
 
-    od> SELECT
+    os> SELECT
     ...   gender, balance,
     ...   MIN(balance) OVER(
     ...     PARTITION BY gender ORDER BY balance
@@ -88,7 +88,7 @@ MAX
 
 Here is an example for ``MAX`` function::
 
-    od> SELECT
+    os> SELECT
     ...   gender, balance,
     ...   MAX(balance) OVER(
     ...     PARTITION BY gender ORDER BY balance
@@ -109,7 +109,7 @@ AVG
 
 Here is an example for ``AVG`` function::
 
-    od> SELECT
+    os> SELECT
     ...   gender, balance,
     ...   AVG(balance) OVER(
     ...     PARTITION BY gender ORDER BY balance
@@ -130,7 +130,7 @@ SUM
 
 Here is an example for ``SUM`` function::
 
-    od> SELECT
+    os> SELECT
     ...   gender, balance,
     ...   SUM(balance) OVER(
     ...     PARTITION BY gender ORDER BY balance
@@ -162,7 +162,7 @@ ROW_NUMBER
 
 ``ROW_NUMBER`` function assigns a row number to each row. As a special case, the row number is always increased by one regardless of the fields specified in ``ORDER BY`` list. Here is an example for ``ROW_NUMBER`` function::
 
-    od> SELECT gender, balance, ROW_NUMBER() OVER(PARTITION BY gender ORDER BY balance) AS num FROM accounts;
+    os> SELECT gender, balance, ROW_NUMBER() OVER(PARTITION BY gender ORDER BY balance) AS num FROM accounts;
     fetched rows / total rows = 4/4
     +----------+-----------+-------+
     | gender   | balance   | num   |
@@ -175,7 +175,7 @@ ROW_NUMBER
 
 Similarly as regular ``ORDER BY`` clause, you can specify null ordering by ``NULLS FIRST`` or ``NULLS LAST`` which has exactly same behavior::
 
-    od> SELECT
+    os> SELECT
     ...  employer,
     ...  ROW_NUMBER() OVER(
     ...   ORDER BY employer NULLS LAST
@@ -197,7 +197,7 @@ RANK
 
 ``RANK`` function assigns a rank to each row. For rows that have same values for fields specified in ``ORDER BY`` list, same rank is assigned. If this is the case, the next few ranks will be skipped depending on how many ties. Here is an example for ``RANK`` function::
 
-    od> SELECT gender, RANK() OVER(ORDER BY gender DESC) AS rnk FROM accounts;
+    os> SELECT gender, RANK() OVER(ORDER BY gender DESC) AS rnk FROM accounts;
     fetched rows / total rows = 4/4
     +----------+-------+
     | gender   | rnk   |
@@ -214,7 +214,7 @@ DENSE_RANK
 
 Similarly as ``RANK``, ``DENSE_RANK`` function also assigns a rank to each row. The difference is there is no gap between ranks. Here is an example for ``DENSE_RANK`` function::
 
-    od> SELECT gender, DENSE_RANK() OVER(ORDER BY gender DESC) AS rnk FROM accounts;
+    os> SELECT gender, DENSE_RANK() OVER(ORDER BY gender DESC) AS rnk FROM accounts;
     fetched rows / total rows = 4/4
     +----------+-------+
     | gender   | rnk   |

--- a/docs/user/general/comments.rst
+++ b/docs/user/general/comments.rst
@@ -21,7 +21,7 @@ Single-line Comments
 
 A single-line comment starts with either ``#`` or ``--``. All characters in the sequence to the end of the line are commented::
 
-    od> #comments
+    os> #comments
     ... SELECT
     ... -- comments
     ... 123; -- comments
@@ -40,7 +40,7 @@ Block Comments
 
 A block comment is enclosed within ``/*`` and ``*/`` across one or multiple lines. Nested comments are not supported::
 
-    od> /*
+    os> /*
     ...  comment1
     ...  comment2
     ... */

--- a/docs/user/general/datatypes.rst
+++ b/docs/user/general/datatypes.rst
@@ -113,7 +113,7 @@ The type of a null literal is special and different from any existing one. In th
 
 Here are examples for NULL literal and expressions with NULL literal involved::
 
-    od> SELECT NULL, NULL = NULL, 1 + NULL, LENGTH(NULL);
+    os> SELECT NULL, NULL = NULL, 1 + NULL, LENGTH(NULL);
     fetched rows / total rows = 1/1
     +--------+---------------+------------+----------------+
     | NULL   | NULL = NULL   | 1 + NULL   | LENGTH(NULL)   |
@@ -239,7 +239,7 @@ String Data Types
 
 A string is a sequence of characters enclosed in either single or double quotes. For example, both 'text' and "text" will be treated as string literal. To use quote characters in a string literal, you can include double quotes within single quoted string or single quotes within double quoted string::
 
-    od> SELECT 'hello', "world", '"hello"', "'world'"
+    os> SELECT 'hello', "world", '"hello"', "'world'"
     fetched rows / total rows = 1/1
     +-----------+-----------+-------------+-------------+
     | 'hello'   | "world"   | '"hello"'   | "'world'"   |

--- a/docs/user/general/identifiers.rst
+++ b/docs/user/general/identifiers.rst
@@ -38,7 +38,7 @@ Examples
 
 Here are examples for using index pattern directly without quotes::
 
-    od> SELECT * FROM *cc*nt*;
+    os> SELECT * FROM *cc*nt*;
     fetched rows / total rows = 4/4
     +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
     | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
@@ -74,7 +74,7 @@ Examples
 
 Here are examples for quoting an index name by back ticks::
 
-    od> SELECT * FROM `accounts`;
+    os> SELECT * FROM `accounts`;
     fetched rows / total rows = 4/4
     +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
     | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
@@ -119,7 +119,7 @@ Examples
 
 The first example is to show a column name qualified by full table name originally in ``FROM`` clause. The qualifier is optional if no ambiguity::
 
-    od> SELECT city, accounts.age, ABS(accounts.balance) FROM accounts WHERE accounts.age < 30;
+    os> SELECT city, accounts.age, ABS(accounts.balance) FROM accounts WHERE accounts.age < 30;
     fetched rows / total rows = 1/1
     +--------+-------+-------------------------+
     | city   | age   | ABS(accounts.balance)   |
@@ -129,7 +129,7 @@ The first example is to show a column name qualified by full table name original
 
 The second example is to show a field name qualified by index alias specified. Similarly, the alias qualifier is optional in this case::
 
-    od> SELECT city, acc.age, ABS(acc.balance) FROM accounts AS acc WHERE acc.age > 30;
+    os> SELECT city, acc.age, ABS(acc.balance) FROM accounts AS acc WHERE acc.age > 30;
     fetched rows / total rows = 3/3
     +--------+-------+--------------------+
     | city   | age   | ABS(acc.balance)   |

--- a/docs/user/general/values.rst
+++ b/docs/user/general/values.rst
@@ -17,7 +17,7 @@ Please note, when response is in table format, the MISSING value is translate to
 
 Here is an example, Nanette doesn't have email field and Dail has employer filed with NULL value::
 
-    od> SELECT firstname, employer, email FROM accounts;
+    os> SELECT firstname, employer, email FROM accounts;
     fetched rows / total rows = 4/4
     +-------------+------------+-----------------------+
     | firstname   | employer   | email                 |
@@ -35,7 +35,7 @@ In general, if any operand evaluates to a MISSING value, the enclosing operator 
 
 Here is an example::
 
-    od> SELECT firstname, employer LIKE 'Quility', email LIKE '%com' FROM accounts;
+    os> SELECT firstname, employer LIKE 'Quility', email LIKE '%com' FROM accounts;
     fetched rows / total rows = 4/4
     +-------------+---------------------------+---------------------+
     | firstname   | employer LIKE 'Quility'   | email LIKE '%com'   |

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -56,7 +56,6 @@ clean.dependsOn(cleanBootstrap)
 testClusters {
     docTestCluster {
         plugin ':plugin'
-        // testDistribution = 'oss'
     }
 }
 tasks.register("runRestTestCluster", RunTask) {

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -56,7 +56,7 @@ clean.dependsOn(cleanBootstrap)
 testClusters {
     docTestCluster {
         plugin ':plugin'
-        testDistribution = 'oss'
+        // testDistribution = 'oss'
     }
 }
 tasks.register("runRestTestCluster", RunTask) {

--- a/doctest/test_docs.py
+++ b/doctest/test_docs.py
@@ -83,17 +83,17 @@ def ppl_cli_transform(s):
 
 def bash_transform(s):
     # TODO: add ppl support, be default cli uses sql
-    if s.startswith("odfesql"):
-        s = re.search(r"odfesql\s+-q\s+\"(.*?)\"", s).group(1)
+    if s.startswith("opensearchsql"):
+        s = re.search(r"opensearchsql\s+-q\s+\"(.*?)\"", s).group(1)
         return u'cmd.process({0})'.format(repr(s.strip().rstrip(';')))
     return (r'pretty_print(sh("""%s""").stdout.decode("utf-8"))' % s) + '\n'
 
 
 sql_cli_parser = zc.customdoctests.DocTestParser(
-    ps1='od>', comment_prefix='#', transform=sql_cli_transform)
+    ps1='os>', comment_prefix='#', transform=sql_cli_transform)
 
 ppl_cli_parser = zc.customdoctests.DocTestParser(
-    ps1='od>', comment_prefix='#', transform=ppl_cli_transform)
+    ps1='os>', comment_prefix='#', transform=ppl_cli_transform)
 
 bash_parser = zc.customdoctests.DocTestParser(
     ps1=r'sh\$', comment_prefix='#', transform=bash_transform)

--- a/sql-cli/src/opensearch_sql_cli/__init__.py
+++ b/sql-cli/src/opensearch_sql_cli/__init__.py
@@ -22,4 +22,4 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-__version__ = "1.0.0.0-Beta1"
+__version__ = "1.0.0.0-beta1"

--- a/sql-cli/src/opensearch_sql_cli/__init__.py
+++ b/sql-cli/src/opensearch_sql_cli/__init__.py
@@ -22,4 +22,4 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-__version__ = "1.0.0"
+__version__ = "1.0.0.0-Beta1"

--- a/sql-cli/src/opensearch_sql_cli/__init__.py
+++ b/sql-cli/src/opensearch_sql_cli/__init__.py
@@ -22,4 +22,4 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-__version__ = "1.13.0.0"
+__version__ = "1.0.0"

--- a/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
+++ b/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
@@ -102,7 +102,7 @@ class OpenSearchConnection:
 
     def is_sql_plugin_installed(self, opensearch_client):
         self.plugins = opensearch_client.cat.plugins(params={"s": "component", "v": "true"})
-        sql_plugin_name_list = ["opendistro-sql", "opendistro_sql", "opensearch-sql"]
+        sql_plugin_name_list = ["opensearch-sql"]
         return any(x in self.plugins for x in sql_plugin_name_list)
 
     def set_connection(self, is_reconnect=False):
@@ -172,14 +172,14 @@ class OpenSearchConnection:
         try:
             if self.query_language == "sql":
                 data = self.client.transport.perform_request(
-                    url="/_opendistro/_sql/_explain" if explain else "/_opendistro/_sql/",
+                    url="/_opensearch/_sql/_explain" if explain else "/_opensearch/_sql/",
                     method="POST",
                     params=None if explain else {"format": output_format},
                     body={"query": final_query},
                 )
             else:
                 data = self.client.transport.perform_request(
-                    url="/_opendistro/_ppl/_explain" if explain else "/_opendistro/_ppl/",
+                    url="/_opensearch/_ppl/_explain" if explain else "/_opensearch/_ppl/",
                     method="POST",
                     params=None if explain else {"format": output_format},
                     body={"query": final_query},

--- a/sql-cli/tests/test_main.py
+++ b/sql-cli/tests/test_main.py
@@ -43,7 +43,21 @@ class TestMain:
         load_data(connection, doc)
 
         err_message = "Can not connect to endpoint %s" % INVALID_ENDPOINT
-        expected_output = {"from": 0, "size": 200}
+        expected_output = {
+            "root": {
+                "name": "ProjectOperator",
+                "description": {"fields": "[a]"},
+                "children": [
+                    {
+                        "name": "OpenSearchIndexScan",
+                        "description": {
+                            "request": 'OpenSearchQueryRequest(indexName=opensearchsql_cli_test, sourceBuilder={"from":0,"size":200,"timeout":"1m","_source":{"includes":["a"],"excludes":[]}}, searchDone=false)'
+                        },
+                        "children": [],
+                    }
+                ],
+            }
+        }
         expected_tabular_output = dedent(
             """\
             fetched rows / total rows = 1/1
@@ -54,7 +68,9 @@ class TestMain:
             +-----+"""
         )
 
-        with mock.patch("src.opensearch_sql_cli.main.click.echo") as mock_echo, mock.patch("src.opensearch_sql_cli.main.click.secho") as mock_secho:
+        with mock.patch("src.opensearch_sql_cli.main.click.echo") as mock_echo, mock.patch(
+            "src.opensearch_sql_cli.main.click.secho"
+        ) as mock_secho:
             runner = CliRunner()
 
             # test -q -e

--- a/sql-cli/tests/test_opensearch_connection.py
+++ b/sql-cli/tests/test_opensearch_connection.py
@@ -27,7 +27,7 @@ import mock
 from textwrap import dedent
 
 from elasticsearch.exceptions import ConnectionError
-from elasticsearch import Elasticsearch, RequestsHttpConnection
+from elasticsearch import Elasticsearch as OpenSearch, RequestsHttpConnection
 
 from .utils import estest, load_data, run, TEST_INDEX_NAME
 from src.opensearch_sql_cli.opensearch_connection import OpenSearchConnection
@@ -62,9 +62,9 @@ class TestExecutor:
         self.load_data_to_es(connection)
 
         expected = {
-            "reason": "Error occurred in Elasticsearch engine: no such index [non-existed]",
-            "details": "org.elasticsearch.index.IndexNotFoundException: no such index [non-existed]\nFor more "
-            "details, please send request for Json format to see the raw response from elasticsearch "
+            "reason": "Error occurred in OpenSearch engine: no such index [non-existed]",
+            "details": "org.opensearch.index.IndexNotFoundException: no such index [non-existed]\nFor more "
+            "details, please send request for Json format to see the raw response from OpenSearch "
             "engine.",
             "type": "IndexNotFoundException",
         }
@@ -136,7 +136,7 @@ class TestExecutor:
     def test_get_od_client(self):
         od_test_executor = OpenSearchConnection(endpoint=OPEN_DISTRO_ENDPOINT, http_auth=AUTH)
 
-        with mock.patch.object(Elasticsearch, "__init__", return_value=None) as mock_es:
+        with mock.patch.object(OpenSearch, "__init__", return_value=None) as mock_es:
             od_test_executor.get_open_distro_client()
 
             mock_es.assert_called_with(
@@ -147,7 +147,7 @@ class TestExecutor:
     def test_get_aes_client(self):
         aes_test_executor = OpenSearchConnection(endpoint=AES_ENDPOINT, use_aws_authentication=True)
 
-        with mock.patch.object(Elasticsearch, "__init__", return_value=None) as mock_es:
+        with mock.patch.object(OpenSearch, "__init__", return_value=None) as mock_es:
             aes_test_executor.get_aes_client()
 
             mock_es.assert_called_with(

--- a/sql-cli/tests/utils.py
+++ b/sql-cli/tests/utils.py
@@ -70,7 +70,7 @@ def load_data(test_executor, doc):
 
 def get_connection():
     test_es_connection = OpenSearchConnection(endpoint=ENDPOINT)
-    test_es_connection.set_connection()
+    test_es_connection.set_connection(is_reconnect=True)
 
     return test_es_connection
 


### PR DESCRIPTION
### Description
1. Migrate sql plugin API from opendistro to opensearch
2. fix some UT related to the naming change
3. rename version to `1.0.0`
4. temporarily fix github CI since we don't have opensearch, sql plugin public artifact ready. But this can be refactored by lanuching OpenSearch instance with plugin installed from gradle.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).