### PR TITLE
Remove debug logging in ODBC driver

### DIFF
--- a/sql-odbc/src/odfesqlodbc/setup.c
+++ b/sql-odbc/src/odfesqlodbc/setup.c
@@ -448,7 +448,6 @@ void test_connection(HANDLE hwnd, ConnInfo *ci, BOOL withDTC) {
     dsn_1st = ci->dsn[0];
     ci->dsn[0] = '\0';
     makeConnectString(out_conn, ci, sizeof(out_conn));
-    MYLOG(OPENSEARCH_DEBUG, "conn_string=%s\n", out_conn);
 #ifdef UNICODE_SUPPORT
     MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, out_conn, -1, wout_conn,
                         sizeof(wout_conn) / sizeof(wout_conn[0]));

--- a/sql-odbc/src/odfesqlodbc/win_unicode.c
+++ b/sql-odbc/src/odfesqlodbc/win_unicode.c
@@ -215,7 +215,6 @@ char *ucs2_to_utf8(const SQLWCHAR *ucs2str, SQLLEN ilen, SQLLEN *olen,
         if (olen)
             *olen = len;
     }
-    MYPRINTF(0, " olen=%d utf8str=%s\n", len, utf8str ? utf8str : "");
     return utf8str;
 }
 
@@ -255,7 +254,6 @@ utf8_to_ucs2_lf(const char *utf8str, SQLLEN ilen, BOOL lfconv,
           bufcount);
     if (!utf8str)
         return 0;
-    MYPRINTF(OPENSEARCH_DEBUG, " string=%s", utf8str);
 
     if (!bufcount)
         ucs2str = NULL;
@@ -455,7 +453,6 @@ static char *ucs4_to_utf8(const UInt4 *ucs4str, SQLLEN ilen, SQLLEN *olen,
         if (olen)
             *olen = len;
     }
-    MYLOG(OPENSEARCH_DEBUG, " olen=%d %s\n", len, utf8str ? utf8str : "");
     return utf8str;
 }
 
@@ -483,7 +480,6 @@ static SQLULEN utf8_to_ucs4_lf(const char *utf8str, SQLLEN ilen, BOOL lfconv,
     MYLOG(OPENSEARCH_DEBUG, " ilen=" FORMAT_LEN " bufcount=" FORMAT_ULEN "\n", ilen, bufcount);
     if (!utf8str)
         return 0;
-    MYLOG(99, " string=%s\n", utf8str);
 
     if (!bufcount)
         ucs4str = NULL;


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description
Remove debug logging due to security risk. Copy from the following ODFE PRs:

1. https://github.com/opendistro-for-elasticsearch/sql/pull/1099
2. https://github.com/opendistro-for-elasticsearch/sql/pull/1100
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).