### PR TITLE
Fix issue of workbench not outputting errors

### DIFF
--- a/workbench/public/components/Main/main.tsx
+++ b/workbench/public/components/Main/main.tsx
@@ -276,8 +276,11 @@ export class Main extends React.Component<MainProps, MainState> {
       let err = response.data.resp;
       console.log("Error occurred when processing query response: ", err)
 
-      // Mark fulfilled to true as long as the data is fulfilled
-      if (response.data.body) {
+      // Exclude a special case from the error cases:
+      // When downloading the csv result, it gets the "Unable to parse/serialize body" response
+      // But data is also returned in data body. For this case:
+      // Mark fulfilled to true for this case to write the csv result to downloading file
+      if (response.data.body && err == "Unable to parse/serialize body") {
         return {
           fulfilled: true,
           errorMessage: err,
@@ -287,6 +290,7 @@ export class Main extends React.Component<MainProps, MainState> {
       return {
         fulfilled: false,
         errorMessage: err,
+        data: ''
       };
     }
 


### PR DESCRIPTION
Signed-off-by: Chloe Zhang chloezh1102@gmail.com

### Description
Here was a rule to mark the result as a proper output from http response rather than error output, which is applied when the http response has data body even though the status is not "ok" (response ok is false). This condition was added specially to fix the csv downloading issue, details: https://github.com/opendistro-for-elasticsearch/sql/issues/1023

But the temporary fix gave a much wider condition than necessary to mark a result as a "good result". This results in some improper behaviors, it does not show any error message in the output windows now when it should. 

This fix is to give a restriction to the last fix of the csv downloading issue. However this fix is only a temporary solution to unblock the release. We should dive deep for better solution to stabilize the workbench.

### Issues Resolved
Errors are not output in workbench. No GitHub issues are applicable.
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).