### PR TITLE
Support querying a data stream

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/LocalClusterState.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/LocalClusterState.java
@@ -219,7 +219,7 @@ public class LocalClusterState {
     }
 
     private String[] resolveIndexExpression(ClusterState state, String[] indices) {
-        String[] concreteIndices = resolver.concreteIndexNames(state, IndicesOptions.strictExpandOpen(), indices);
+        String[] concreteIndices = resolver.concreteIndexNames(state, IndicesOptions.strictExpandOpen(), true, indices);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Resolved index expression {} to concrete index names {}",

--- a/legacy/src/test/java/org/opensearch/sql/legacy/util/CheckScriptContents.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/util/CheckScriptContents.java
@@ -28,6 +28,7 @@ package org.opensearch.sql.legacy.util;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -266,10 +267,10 @@ public class CheckScriptContents {
 
     public static IndexNameExpressionResolver mockIndexNameExpressionResolver() {
         IndexNameExpressionResolver mockResolver = mock(IndexNameExpressionResolver.class);
-        when(mockResolver.concreteIndexNames(any(), any(), anyString())).thenAnswer(
+        when(mockResolver.concreteIndexNames(any(), any(), anyBoolean(), anyString())).thenAnswer(
             (Answer<String[]>) invocation -> {
                 // Return index expression directly without resolving
-                Object indexExprs = invocation.getArguments()[2];
+                Object indexExprs = invocation.getArguments()[3];
                 if (indexExprs instanceof String) {
                     return new String[]{ (String) indexExprs };
                 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
@@ -169,7 +169,7 @@ public class OpenSearchNodeClient implements OpenSearchClient {
   }
 
   private String[] resolveIndexExpression(ClusterState state, String[] indices) {
-    return resolver.concreteIndexNames(state, IndicesOptions.strictExpandOpen(), indices);
+    return resolver.concreteIndexNames(state, IndicesOptions.strictExpandOpen(), true, indices);
   }
 
   private Map<String, IndexMapping> populateIndexMappings(


### PR DESCRIPTION
### Description
Fixed index expression resolution to include backing indices of a data stream. This will make querying a data stream consistent with querying an index alias.
 
### Issues Resolved
- Closes https://github.com/opensearch-project/sql/issues/55
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma <ketan9495@gmail.com>