### PR TITLE
Upgrade dependencies to address high severity CVE-2021-20270

### DIFF
--- a/sql-cli/setup.py
+++ b/sql-cli/setup.py
@@ -30,7 +30,7 @@ from setuptools import setup, find_packages
 install_requirements = [
     "click == 7.1.1",
     "prompt_toolkit == 2.0.6",
-    "Pygments == 2.6.1",
+    "Pygments >= 2.7.4",
     "cli_helpers[styles] == 1.2.1",
     "elasticsearch == 7.10.1",
     "pyfiglet == 0.8.post1",


### PR DESCRIPTION
### Description
Upgrade SQL CLI dependency Pygments to `>=2.7.4`
 
### Issues Resolved
 CVE-2021-20270
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).