### PR TITLE
Update workbench documentation links, complete renaming

### DIFF
--- a/workbench/CODE_OF_CONDUCT.md
+++ b/workbench/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 ## Code of Conduct
 
-This project has adopted an [Open Source Code of Conduct](https://opendistro.github.io/for-elasticsearch/codeofconduct.html).
+This project has adopted an [Open Source Code of Conduct](https://github.com/opensearch-project/project-website/blob/main/CONTRIBUTING.md#code-of-conduct).

--- a/workbench/CONTRIBUTING.md
+++ b/workbench/CONTRIBUTING.md
@@ -41,12 +41,12 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any issue tagged ["good first issue"](https://github.com/opendistro-for-elasticsearch/sql/issues?q=is%3Aopen+label%3A%22help+wanted%22+label%3A%22good+first+issue%22+label%3AWorkbench) is a great place to start.
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any issue tagged ["good first issue"](https://github.com/opensearch-project/sql/issues?q=is%3Aopen+is%3Aissue+label%3Aworkbench+label%3A%22good+first+issue%22) is a great place to start.
 
 
 ## Code of Conduct
 
-This project has adopted an [Open Source Code of Conduct](https://opendistro.github.io/for-elasticsearch/codeofconduct.html).
+This project has adopted an [Open Source Code of Conduct](https://github.com/opensearch-project/project-website/blob/main/CONTRIBUTING.md#code-of-conduct).
 
 
 ## Security issue notifications

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -5,7 +5,7 @@ The OpenSearch Dashboards Query Workbench enables you to query your OpenSearch d
 
 ## Documentation
 
-Please see our technical [documentation](https://opendistro.github.io/for-elasticsearch-docs/) to learn more about its features.
+Please see our technical [documentation](https://docs-beta.opensearch.org/) to learn more about its features.
 
 
 ## Setup

--- a/workbench/common/index.ts
+++ b/workbench/common/index.ts
@@ -24,5 +24,5 @@
  *   permissions and limitations under the License.
  */
 
-export const PLUGIN_ID = 'openSearchQueryWorkbench';
+export const PLUGIN_ID = 'queryWorkbenchDashboards';
 export const PLUGIN_NAME = 'Query Workbench';

--- a/workbench/common/index.ts
+++ b/workbench/common/index.ts
@@ -24,5 +24,5 @@
  *   permissions and limitations under the License.
  */
 
-export const PLUGIN_ID = 'opendistroQueryWorkbench';
+export const PLUGIN_ID = 'openSearchQueryWorkbench';
 export const PLUGIN_NAME = 'Query Workbench';

--- a/workbench/public/components/Main/__snapshots__/main.test.tsx.snap
+++ b/workbench/public/components/Main/__snapshots__/main.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`<Main /> spec click clear button 1`] = `
           >
             <a
               class="euiButton euiButton--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/sql/"
+              href="https://docs-beta.opensearch.org/docs/sql/"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -477,7 +477,7 @@ exports[`<Main /> spec click run button, and response causes an error 1`] = `
           >
             <a
               class="euiButton euiButton--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/sql/"
+              href="https://docs-beta.opensearch.org/docs/sql/"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -856,7 +856,7 @@ exports[`<Main /> spec click run button, and response is not ok 1`] = `
           >
             <a
               class="euiButton euiButton--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/sql/"
+              href="https://docs-beta.opensearch.org/docs/sql/"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1235,7 +1235,7 @@ exports[`<Main /> spec click run button, and response is ok 1`] = `
           >
             <a
               class="euiButton euiButton--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/sql/"
+              href="https://docs-beta.opensearch.org/docs/sql/"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1614,7 +1614,7 @@ exports[`<Main /> spec click run button, response fills null and missing values 
           >
             <a
               class="euiButton euiButton--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/sql/"
+              href="https://docs-beta.opensearch.org/docs/sql/"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -1996,7 +1996,7 @@ exports[`<Main /> spec click translation button, and response is ok 1`] = `
           >
             <a
               class="euiButton euiButton--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/sql/"
+              href="https://docs-beta.opensearch.org/docs/sql/"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -2375,7 +2375,7 @@ exports[`<Main /> spec renders the component 1`] = `
           >
             <a
               class="euiButton euiButton--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/sql/"
+              href="https://docs-beta.opensearch.org/docs/sql/"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/workbench/public/components/Main/main.tsx
+++ b/workbench/public/components/Main/main.tsx
@@ -623,7 +623,7 @@ export class Main extends React.Component<MainProps, MainState> {
           updateSQLQueries={this.updateSQLQueries}
         />
       );
-      link = 'https://opendistro.github.io/for-elasticsearch-docs/docs/sql/';
+      link = 'https://docs-beta.opensearch.org/docs/sql/';
       linkTitle = 'SQL documentation';
     } else {
       page = (
@@ -636,7 +636,7 @@ export class Main extends React.Component<MainProps, MainState> {
           updatePPLQueries={this.updatePPLQueries}
         />
       );
-      link = 'https://opendistro.github.io/for-elasticsearch-docs/docs/ppl/';
+      link = 'https://docs-beta.opensearch.org/docs/ppl/';
       linkTitle = 'PPL documentation';
     }
 

--- a/workbench/server/plugin.ts
+++ b/workbench/server/plugin.ts
@@ -46,7 +46,7 @@ export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPl
   }
 
   public setup(core: CoreSetup) {
-    this.logger.debug('openSearchQueryWorkbench: Setup');
+    this.logger.debug('queryWorkbenchDashboards: Setup');
     const router = core.http.createRouter();
     const client: ILegacyClusterClient = core.opensearch.legacy.createClient(
       'query_workbench',
@@ -62,7 +62,7 @@ export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPl
   }
 
   public start(core: CoreStart) {
-    this.logger.debug('openSearchQueryWorkbench: Started');
+    this.logger.debug('queryWorkbenchDashboards: Started');
     return {};
   }
 

--- a/workbench/server/plugin.ts
+++ b/workbench/server/plugin.ts
@@ -46,7 +46,7 @@ export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPl
   }
 
   public setup(core: CoreSetup) {
-    this.logger.debug('opendistroQueryWorkbench: Setup');
+    this.logger.debug('openSearchQueryWorkbench: Setup');
     const router = core.http.createRouter();
     const client: ILegacyClusterClient = core.opensearch.legacy.createClient(
       'query_workbench',
@@ -62,7 +62,7 @@ export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPl
   }
 
   public start(core: CoreStart) {
-    this.logger.debug('opendistroQueryWorkbench: Started');
+    this.logger.debug('openSearchQueryWorkbench: Started');
     return {};
   }
 


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

### Description
* Update documentation links to OpenSearch
* Rename remaining occurrences of `opendistro`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).