### PR TITLE
Disable DELETE clause by defaut and add opensearch.sql.delete.enabled setting

### DIFF
--- a/docs/category.json
+++ b/docs/category.json
@@ -3,7 +3,8 @@
     "experiment/ppl/interfaces/endpoint.rst",
     "experiment/ppl/interfaces/protocol.rst",
     "experiment/ppl/admin/settings.rst",
-    "user/optimization/optimization.rst"
+    "user/optimization/optimization.rst",
+    "user/admin/settings.rst"
   ],
   "ppl_cli": [
     "experiment/ppl/cmd/dedup.rst",

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -318,7 +318,7 @@ Query result after the setting updated is like:
 
 SQL query::
 
-    sh$ curl -sS -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql \
+    sh$ curl -sS -H 'Content-Type: application/json' -X POST localhost:9200/_plugins/_sql \
     ... -d '{"query" : "DELETE * FROM accounts"}'
     {
       "error": {

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -275,3 +275,66 @@ Result set::
       }
     }
 
+opensearch.sql.delete.enabled
+======================
+
+Description
+-----------
+
+By default, DELETE clause disabled. You can enable DELETE clause by this setting.
+
+1. The default value is false.
+2. This setting is node scope.
+3. This setting can be updated dynamically.
+
+
+Example 1
+---------
+
+You can update the setting with a new value like this.
+
+SQL query::
+
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_sql/settings -d '{
+	  "transient" : {
+	    "opensearch.sql.delete.enabled" : "false"
+	  }
+	}'
+
+Result set::
+
+	{
+	  "acknowledged" : true,
+	  "persistent" : { },
+	  "transient" : {
+	    "opensearch" : {
+	      "sql" : {
+	        "delete": {
+	          "enabled" : "false"
+	        }
+	      }
+	    }
+	  }
+	}
+
+Example 2
+---------
+
+Query result after the setting updated is like:
+
+SQL query::
+
+	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_plugins/_sql -d '{
+	  "query" : "DELETE * FROM accounts"
+	}'
+
+Result set::
+
+	{
+	  "error" : {
+	    "reason" : "Invalid SQL query",
+	    "details" : "DELETE clause is disabled by default and will be deprecated. Using the opensearch.sql.delete.enabled setting to enable it",
+	    "type" : "SQLFeatureDisabledException"
+	  },
+	  "status" : 400
+	}

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -295,27 +295,21 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_sql/settings -d '{
-	  "transient" : {
-	    "opensearch.sql.delete.enabled" : "false"
-	  }
-	}'
-
-Result set::
-
-	{
-	  "acknowledged" : true,
-	  "persistent" : { },
-	  "transient" : {
-	    "opensearch" : {
-	      "sql" : {
-	        "delete": {
-	          "enabled" : "false"
-	        }
-	      }
-	    }
-	  }
-	}
+    sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_sql/settings \
+    ... -d '{"transient":{"opensearch.sql.delete.enabled":"false"}}'
+    {
+      "acknowledged": true,
+      "persistent": {},
+      "transient": {
+        "opensearch": {
+          "sql": {
+            "delete": {
+              "enabled": "false"
+            }
+          }
+        }
+      }
+    }
 
 Example 2
 ---------
@@ -324,17 +318,13 @@ Query result after the setting updated is like:
 
 SQL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_plugins/_sql -d '{
-	  "query" : "DELETE * FROM accounts"
-	}'
-
-Result set::
-
-	{
-	  "error" : {
-	    "reason" : "Invalid SQL query",
-	    "details" : "DELETE clause is disabled by default and will be deprecated. Using the opensearch.sql.delete.enabled setting to enable it",
-	    "type" : "SQLFeatureDisabledException"
-	  },
-	  "status" : 400
-	}
+    sh$ curl -sS -H 'Content-Type: application/json' -X POST localhost:9200/_opendistro/_sql \
+    ... -d '{"query" : "DELETE * FROM accounts"}'
+    {
+      "error": {
+        "reason": "Invalid SQL query",
+        "details": "DELETE clause is disabled by default and will be deprecated. Using the opensearch.sql.delete.enabled setting to enable it",
+        "type": "SQLFeatureDisabledException"
+      },
+      "status": 400
+    }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/DeleteIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/DeleteIT.java
@@ -28,6 +28,7 @@
 package org.opensearch.sql.legacy;
 
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.opensearch.sql.legacy.plugin.SqlSettings.SQL_DELETE_ENABLED;
 
 import java.io.IOException;
 import org.json.JSONObject;
@@ -40,6 +41,7 @@ public class DeleteIT extends SQLIntegTestCase {
   protected void init() throws Exception {
     loadIndex(Index.ACCOUNT);
     loadIndex(Index.PHRASE);
+    updateClusterSettings(new ClusterSetting(PERSISTENT, SQL_DELETE_ENABLED, "true"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PluginIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PluginIT.java
@@ -85,14 +85,17 @@ public class PluginIT extends SQLIntegTestCase {
     final ResponseException exception =
         expectThrows(ResponseException.class, () -> executeQuery(deleteQuery));
     JSONObject actual = new JSONObject(TestUtils.getResponseBody(exception.getResponse()));
-    JSONObject expected = new JSONObject("{\n"
-        + "  \"error\": {\n"
-        + "    \"reason\": \"Invalid SQL query\",\n"
-        + "    \"details\": \"DELETE clause is disabled by default and will be deprecated. Using the opendistro.sql.delete.enabled setting to enable it\",\n"
-        + "    \"type\": \"SQLFeatureDisabledException\"\n"
-        + "  },\n"
-        + "  \"status\": 400\n"
-        + "}");
+    JSONObject expected =
+        new JSONObject(
+            "{\n"
+                + "  \"error\": {\n"
+                + "    \"reason\": \"Invalid SQL query\",\n"
+                + "    \"details\": \"DELETE clause is disabled by default and will be deprecated. Using "
+                + "the opensearch.sql.delete.enabled setting to enable it\",\n"
+                + "    \"type\": \"SQLFeatureDisabledException\"\n"
+                + "  },\n"
+                + "  \"status\": 400\n"
+                + "}");
     assertTrue(actual.toString(), actual.similar(expected));
 
     wipeAllClusterSettings();

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -214,7 +214,7 @@ public class RestSqlAction extends BaseRestHandler {
     }
 
     private static QueryAction explainRequest(final NodeClient client, final SqlRequest sqlRequest, Format format)
-            throws SQLFeatureNotSupportedException, SqlParseException {
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
 
         ColumnTypeProvider typeProvider = performAnalysis(sqlRequest.getSql());
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/SearchDao.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/SearchDao.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.opensearch.client.Client;
 import org.opensearch.sql.legacy.domain.QueryActionRequest;
+import org.opensearch.sql.legacy.exception.SQLFeatureDisabledException;
 import org.opensearch.sql.legacy.exception.SqlParseException;
 import org.opensearch.sql.legacy.query.OpenSearchActionFactory;
 import org.opensearch.sql.legacy.query.QueryAction;
@@ -67,7 +68,7 @@ public class SearchDao {
      * @throws SqlParseException
      */
     public QueryAction explain(QueryActionRequest queryActionRequest)
-            throws SqlParseException, SQLFeatureNotSupportedException {
+        throws SqlParseException, SQLFeatureNotSupportedException, SQLFeatureDisabledException {
         return OpenSearchActionFactory.create(client, queryActionRequest);
     }
 }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/SqlSettings.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/SqlSettings.java
@@ -52,6 +52,7 @@ public class SqlSettings {
     public static final String QUERY_SLOWLOG = "opensearch.sql.query.slowlog";
     public static final String METRICS_ROLLING_WINDOW = "opensearch.sql.metrics.rollingwindow";
     public static final String METRICS_ROLLING_INTERVAL = "opensearch.sql.metrics.rollinginterval";
+    public static final String SQL_DELETE_ENABLED = "opensearch.sql.delete.enabled";
 
     public static final String CURSOR_ENABLED= "opensearch.sql.cursor.enabled";
     public static final String CURSOR_FETCH_SIZE = "opensearch.sql.cursor.fetch_size";
@@ -65,6 +66,8 @@ public class SqlSettings {
         Map<String, Setting<?>> settings = new HashMap<>();
         settings.put(SQL_ENABLED, Setting.boolSetting(SQL_ENABLED, true, NodeScope, Dynamic));
         settings.put(QUERY_SLOWLOG, Setting.intSetting(QUERY_SLOWLOG, 2, NodeScope, Dynamic));
+        settings.put(SQL_DELETE_ENABLED, Setting.boolSetting(SQL_DELETE_ENABLED, false, NodeScope,
+            Dynamic));
 
         settings.put(METRICS_ROLLING_WINDOW, Setting.longSetting(METRICS_ROLLING_WINDOW, 3600L, 2L,
                 NodeScope, Dynamic));

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/JSONRequestTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/JSONRequestTest.java
@@ -29,7 +29,9 @@ package org.opensearch.sql.legacy.unittest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.alibaba.druid.sql.parser.ParserException;
@@ -41,14 +43,20 @@ import java.sql.SQLFeatureNotSupportedException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opensearch.client.Client;
+import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.legacy.domain.ColumnTypeProvider;
 import org.opensearch.sql.legacy.domain.QueryActionRequest;
+import org.opensearch.sql.legacy.esdomain.LocalClusterState;
+import org.opensearch.sql.legacy.exception.SQLFeatureDisabledException;
 import org.opensearch.sql.legacy.exception.SqlParseException;
 import org.opensearch.sql.legacy.executor.Format;
 import org.opensearch.sql.legacy.executor.format.Schema;
@@ -306,15 +314,39 @@ public class JSONRequestTest {
 
     @Test
     public void deleteSanity() throws IOException {
-        String result = explain(String.format("{\"query\":\"" +
+        try (MockedStatic<LocalClusterState> localClusterStateMockedStatic =
+            Mockito.mockStatic(LocalClusterState.class)) {
+            LocalClusterState state = mock(LocalClusterState.class);
+            localClusterStateMockedStatic.when(LocalClusterState::state).thenReturn(state);
+            when(state.getSettingValue(anyString())).thenReturn(true);
+
+            String result = explain(String.format("{\"query\":\"" +
                 "DELETE " +
                 "FROM %s " +
                 "WHERE firstname LIKE 'A%%' AND age > 20\"}", TestsConstants.TEST_INDEX_ACCOUNT));
-        String expectedOutput = Files.toString(
+            String expectedOutput = Files.toString(
                 new File(getResourcePath() + "src/test/resources/expectedOutput/delete_explain.json"), StandardCharsets.UTF_8)
                 .replaceAll("\r", "");
+            assertThat(removeSpaces(result), equalTo(removeSpaces(expectedOutput)));
+        }
+    }
 
-        assertThat(removeSpaces(result), equalTo(removeSpaces(expectedOutput)));
+    @Test(expected = SQLFeatureDisabledException.class)
+    public void deleteShouldThrowExceptionWhenDisabled()
+        throws SQLFeatureDisabledException, SQLFeatureNotSupportedException,
+        SqlParseException {
+        try (MockedStatic<LocalClusterState> localClusterStateMockedStatic =
+                 Mockito.mockStatic(LocalClusterState.class)) {
+            LocalClusterState state = mock(LocalClusterState.class);
+            localClusterStateMockedStatic.when(LocalClusterState::state).thenReturn(state);
+            when(state.getSettingValue(anyString())).thenReturn(false);
+
+            JSONObject jsonRequest = new JSONObject(StringUtils.format("{\"query\":\"" +
+                "DELETE " +
+                "FROM %s " +
+                "WHERE firstname LIKE 'A%%' AND age > 20\"}", TestsConstants.TEST_INDEX_ACCOUNT));
+            translate(jsonRequest.getString("query"), jsonRequest);
+        }
     }
 
     @Test
@@ -366,13 +398,14 @@ public class JSONRequestTest {
             String sql = jsonRequest.getString("query");
 
             return translate(sql, jsonRequest);
-        } catch (SqlParseException | SQLFeatureNotSupportedException e) {
+        } catch (SqlParseException | SQLFeatureNotSupportedException | SQLFeatureDisabledException e) {
             throw new ParserException("Illegal sql expr in request: " + request);
         }
     }
 
-    private String translate(String sql, JSONObject jsonRequest) throws SQLFeatureNotSupportedException, SqlParseException {
-        Client mockClient = Mockito.mock(Client.class);
+    private String translate(String sql, JSONObject jsonRequest)
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
+        Client mockClient = mock(Client.class);
         CheckScriptContents.stubMockClient(mockClient);
         QueryAction queryAction =
                 OpenSearchActionFactory

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/QueryFunctionsTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/QueryFunctionsTest.java
@@ -48,6 +48,7 @@ import org.opensearch.common.Strings;
 import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.MultiMatchQueryBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder.ScriptField;
+import org.opensearch.sql.legacy.exception.SQLFeatureDisabledException;
 import org.opensearch.sql.legacy.exception.SqlParseException;
 import org.opensearch.sql.legacy.query.OpenSearchActionFactory;
 import org.opensearch.sql.legacy.util.CheckScriptContents;
@@ -283,27 +284,32 @@ public class QueryFunctionsTest {
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void emptyQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void emptyQueryShouldThrowSQLFeatureNotSupportedException()
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
         OpenSearchActionFactory.create(Mockito.mock(Client.class), "");
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException()
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
         OpenSearchActionFactory.create(Mockito.mock(Client.class), "\n");
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException2() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException2()
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
         OpenSearchActionFactory.create(Mockito.mock(Client.class), "\r\n");
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void queryWithoutSpaceShouldSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void queryWithoutSpaceShouldSQLFeatureNotSupportedException()
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
         OpenSearchActionFactory.create(Mockito.mock(Client.class), "SELE");
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void spacesOnlyQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void spacesOnlyQueryShouldThrowSQLFeatureNotSupportedException()
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
         OpenSearchActionFactory.create(Mockito.mock(Client.class), "      ");
     }
 

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/WhereWithBoolConditionTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/WhereWithBoolConditionTest.java
@@ -37,6 +37,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opensearch.client.Client;
+import org.opensearch.sql.legacy.exception.SQLFeatureDisabledException;
 import org.opensearch.sql.legacy.exception.SqlParseException;
 import org.opensearch.sql.legacy.query.OpenSearchActionFactory;
 import org.opensearch.sql.legacy.query.QueryAction;
@@ -48,12 +49,15 @@ import org.opensearch.sql.legacy.utils.StringUtils;
 public class WhereWithBoolConditionTest {
 
     @Test
-    public void whereWithBoolCompilationTest() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void whereWithBoolCompilationTest()
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
        query(StringUtils.format("SELECT * FROM %s WHERE male = false", TestsConstants.TEST_INDEX_BANK));
     }
 
     @Test
-    public void selectAllTest() throws SQLFeatureNotSupportedException, SqlParseException, IOException {
+    public void selectAllTest()
+        throws SQLFeatureNotSupportedException, SqlParseException, IOException,
+        SQLFeatureDisabledException {
         String expectedOutput = Files.toString(
                 new File(getResourcePath() + "src/test/resources/expectedOutput/select_where_true.json"), StandardCharsets.UTF_8)
                 .replaceAll("\r", "");
@@ -70,11 +74,13 @@ public class WhereWithBoolConditionTest {
         );
     }
 
-    private String query(String query) throws SQLFeatureNotSupportedException, SqlParseException {
+    private String query(String query)
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
         return explain(query);
     }
 
-    private String explain(String sql) throws SQLFeatureNotSupportedException, SqlParseException {
+    private String explain(String sql)
+        throws SQLFeatureNotSupportedException, SqlParseException, SQLFeatureDisabledException {
         Client mockClient = Mockito.mock(Client.class);
         CheckScriptContents.stubMockClient(mockClient);
         QueryAction queryAction = OpenSearchActionFactory.create(mockClient, sql);

--- a/legacy/src/test/java/org/opensearch/sql/legacy/util/CheckScriptContents.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/util/CheckScriptContents.java
@@ -68,6 +68,7 @@ import org.opensearch.sql.legacy.domain.Condition;
 import org.opensearch.sql.legacy.domain.Select;
 import org.opensearch.sql.legacy.domain.Where;
 import org.opensearch.sql.legacy.esdomain.LocalClusterState;
+import org.opensearch.sql.legacy.exception.SQLFeatureDisabledException;
 import org.opensearch.sql.legacy.exception.SqlParseException;
 import org.opensearch.sql.legacy.parser.ElasticSqlExprParser;
 import org.opensearch.sql.legacy.parser.ScriptFilter;
@@ -97,7 +98,7 @@ public class CheckScriptContents {
 
             return scriptFields.get(0);
 
-        } catch (SQLFeatureNotSupportedException | SqlParseException e) {
+        } catch (SQLFeatureNotSupportedException | SqlParseException | SQLFeatureDisabledException e) {
             throw new ParserException("Unable to parse query: " + query, e);
         }
     }

--- a/legacy/src/test/java/org/opensearch/sql/legacy/util/SqlExplainUtils.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/util/SqlExplainUtils.java
@@ -30,6 +30,7 @@ import com.alibaba.druid.sql.parser.ParserException;
 import java.sql.SQLFeatureNotSupportedException;
 import org.mockito.Mockito;
 import org.opensearch.client.Client;
+import org.opensearch.sql.legacy.exception.SQLFeatureDisabledException;
 import org.opensearch.sql.legacy.exception.SqlParseException;
 import org.opensearch.sql.legacy.query.OpenSearchActionFactory;
 import org.opensearch.sql.legacy.query.QueryAction;
@@ -46,7 +47,7 @@ public class SqlExplainUtils {
             QueryAction queryAction = OpenSearchActionFactory.create(mockClient, query);
 
             return queryAction.explain().explain();
-        } catch (SqlParseException | SQLFeatureNotSupportedException e) {
+        } catch (SqlParseException | SQLFeatureNotSupportedException | SQLFeatureDisabledException e) {
             throw new ParserException("Illegal sql expr in: " + query);
         }
     }


### PR DESCRIPTION
### Description
1. By default, the DELETE clause is disabled in SQL engine.
2. Add the opensearch.sql.delete.enabled setting which could be used to enable the DELETE clause.
3. Update the docs, https://github.com/penghuo/os-sql/blob/pr-issue59/docs/user/admin/settings.rst#opensearch-sql-delete-enabled
 
### Issues Resolved
#59 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).