### PR TITLE
Rename remaining beta1 references in sql-cli/workbench

### DIFF
--- a/.github/workflows/sql-workbench-release-workflow.yml
+++ b/.github/workflows/sql-workbench-release-workflow.yml
@@ -7,8 +7,8 @@ on:
 
 env: 
   PLUGIN_NAME: queryWorkbenchDashboards
-  OPENSEARCH_VERSION: 1.0.0-beta1
-  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0-beta1
+  OPENSEARCH_VERSION: 1.x
+  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0-rc1
 
 jobs:
 

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -4,8 +4,8 @@ on: [pull_request, push]
 
 env: 
   PLUGIN_NAME: queryWorkbenchDashboards
-  OPENSEARCH_VERSION: 1.0.0-beta1
-  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0-beta1
+  OPENSEARCH_VERSION: 1.x
+  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0-rc1
 
 jobs:
 

--- a/sql-cli/src/opensearch_sql_cli/__init__.py
+++ b/sql-cli/src/opensearch_sql_cli/__init__.py
@@ -22,4 +22,4 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-__version__ = "1.0.0.0-beta1"
+__version__ = "1.0.0.0-rc1"

--- a/workbench/opensearch_dashboards.json
+++ b/workbench/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "queryWorkbenchDashboards",
-  "version": "1.0.0.0-beta1",
-  "opensearchDashboardsVersion": "1.0.0-beta1",
+  "version": "1.0.0.0-rc1",
+  "opensearchDashboardsVersion": "1.0.0-rc1",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation"],

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,13 +1,13 @@
 {
   "name": "opensearch-query-workbench",
-  "version": "1.0.0.0-beta1",
+  "version": "1.0.0.0-rc1",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/sql/tree/main/workbench",
   "opensearchDashboards": {
-    "version": "1.0.0-beta1",
-    "templateVersion": "1.0.0-beta1"
+    "version": "1.0.0-rc1",
+    "templateVersion": "1.0.0-rc1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

### Description
Renames remaining references to beta1 in sql-cli and workbench
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/86
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).