### PR TITLE
Build SQL/PPL against OpenSearch 1.0 branch

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
-        ref: 1.x
+        ref: 1.0
 
     - name: Build OpenSearch
       working-directory: ./OpenSearch

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
-        ref: 1.0
+        ref: '1.0'
 
     - name: Build OpenSearch
       working-directory: ./OpenSearch


### PR DESCRIPTION
### Description
As OpenSearch 1.0 ready, move SQL/PPL build from 1.x to 1.0 branch.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/86
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).