### PR TITLE
Bump OpenSearch Dashboards version to 1.0 in Workbench

### DIFF
--- a/.github/workflows/sql-workbench-release-workflow.yml
+++ b/.github/workflows/sql-workbench-release-workflow.yml
@@ -7,7 +7,7 @@ on:
 
 env: 
   PLUGIN_NAME: queryWorkbenchDashboards
-  OPENSEARCH_VERSION: 1.x
+  OPENSEARCH_VERSION: '1.0'
   OPENSEARCH_PLUGIN_VERSION: 1.0.0.0-rc1
 
 jobs:

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 
 env: 
   PLUGIN_NAME: queryWorkbenchDashboards
-  OPENSEARCH_VERSION: 1.x
+  OPENSEARCH_VERSION: '1.0'
   OPENSEARCH_PLUGIN_VERSION: 1.0.0.0-rc1
 
 jobs:

--- a/release-notes/opensearch-sql.release-notes-1.0.0.0-rc1.md
+++ b/release-notes/opensearch-sql.release-notes-1.0.0.0-rc1.md
@@ -31,6 +31,7 @@ Compatible with OpenSearch and OpenSearch Dashboards Version 1.0.0-rc1
 * Rename remaining beta1 references in sql-cli/workbench ([#91](https://github.com/opensearch-project/sql/pull/91))
 * Build SQL/PPL against OpenSearch 1.0 branch ([#94](https://github.com/opensearch-project/sql/pull/94))
 * Bug Fix: Enable legacy settings in new setting action ([#97](https://github.com/opensearch-project/sql/pull/97))
+* Bump OpenSearch Dashboards version to 1.0 in Workbench ([#98](https://github.com/opensearch-project/sql/pull/98))
 
 ### Enhancements
 


### PR DESCRIPTION
### Description
Bump OpenSearch Dashboards version to 1.0 in Workbench workflows
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).