### PR TITLE
Rename doctest gradle tasks in the manner of Opensearch

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -31,7 +31,7 @@ task bootstrap(type: Exec) {
 }
 
 //evaluationDependsOn(':')
-task startES(type: SpawnProcessTask) {
+task startOpenSearch(type: SpawnProcessTask) {
     command "${path}/gradlew -p ${plugin_path} runRestTestCluster"
     ready 'started'
 }
@@ -45,10 +45,10 @@ task doctest(type: Exec, dependsOn: ['bootstrap']) {
     }
 }
 
-task stopES(type: KillProcessTask)
+task stopOpenSearch(type: KillProcessTask)
 
-doctest.dependsOn startES
-doctest.finalizedBy stopES
+doctest.dependsOn startOpenSearch
+doctest.finalizedBy stopOpenSearch
 
 build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
@@ -56,7 +56,7 @@ clean.dependsOn(cleanBootstrap)
 testClusters {
     docTestCluster {
         plugin ':plugin'
-        testDistribution = 'archive'
+        testDistribution = 'integ_test'
     }
 }
 tasks.register("runRestTestCluster", RunTask) {


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
1. Rename gradle tasks in the manner of Opensearch
2. Fix testDistribution flag to pass local test.
 
### Issues Resolved
#118 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).