### PR TITLE
Add Codecov to SQL 

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        target: 99%    # the required coverage value
+        threshold: 1%  # the leniency in hitting the target 

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -38,6 +38,8 @@ jobs:
     # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
     - name: Upload SQL Coverage Report
       uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v1

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -35,6 +35,10 @@ jobs:
         mkdir -p opensearch-sql-builds
         cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
 
+    # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+    - name: Upload SQL Coverage Report
+      uses: codecov/codecov-action@v1
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
### Description
Adds Codecov back to SQL repo. 
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).