### PR TITLE
Deprecated legacy settings instead of removing

### DIFF
--- a/common/src/main/java/org/opensearch/sql/common/setting/LegacySettings.java
+++ b/common/src/main/java/org/opensearch/sql/common/setting/LegacySettings.java
@@ -61,8 +61,13 @@ public abstract class LegacySettings {
     /**
      * Deprecated Settings.
      */
-    CURSOR_ENABLED("opendistro.sql.cursor.enabled"),
-    CURSOR_FETCH_SIZE("opendistro.sql.cursor.fetch_size");
+    SQL_NEW_ENGINE_ENABLED("opendistro.sql.engine.new.enabled"),
+    QUERY_ANALYSIS_ENABLED("opendistro.sql.query.analysis.enabled"),
+    QUERY_ANALYSIS_SEMANTIC_SUGGESTION("opendistro.sql.query.analysis.semantic.suggestion"),
+    QUERY_ANALYSIS_SEMANTIC_THRESHOLD("opendistro.sql.query.analysis.semantic.threshold"),
+    QUERY_RESPONSE_FORMAT("opendistro.sql.query.response.format"),
+    SQL_CURSOR_ENABLED("opendistro.sql.cursor.enabled"),
+    SQL_CURSOR_FETCH_SIZE("opendistro.sql.cursor.fetch_size");
 
     @Getter
     private final String keyValue;

--- a/common/src/main/java/org/opensearch/sql/common/setting/LegacySettings.java
+++ b/common/src/main/java/org/opensearch/sql/common/setting/LegacySettings.java
@@ -56,7 +56,13 @@ public abstract class LegacySettings {
     /**
      * Legacy Common Settings.
      */
-    QUERY_SIZE_LIMIT("opendistro.query.size_limit");
+    QUERY_SIZE_LIMIT("opendistro.query.size_limit"),
+
+    /**
+     * Deprecated Settings.
+     */
+    CURSOR_ENABLED("opendistro.sql.cursor.enabled"),
+    CURSOR_FETCH_SIZE("opendistro.sql.cursor.fetch_size");
 
     @Getter
     private final String keyValue;

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -18,14 +18,33 @@ When OpenSearch bootstraps, SQL plugin will register a few settings in OpenSearc
 
 Breaking Change
 ===============
+opendistro.sql.engine.new.enabled
+---------------------------------
+The opendistro.sql.engine.new.enabled setting is deprecated and will be removed then. From OpenSearch 1.0, the new engine is always enabled.
+
+opendistro.sql.query.analysis.enabled
+-------------------------------------
+The opendistro.sql.query.analysis.enabled setting is deprecated and will be removed then. From OpenSearch 1.0, the query analysis in legacy engine is disabled.
+
+opendistro.sql.query.analysis.semantic.suggestion
+-------------------------------------------------
+The opendistro.sql.query.analysis.semantic.suggestion setting is deprecated and will be removed then. From OpenSearch 1.0, the query analysis suggestion in legacy engine is disabled.
+
+opendistro.sql.query.analysis.semantic.threshold
+------------------------------------------------
+The opendistro.sql.query.analysis.semantic.threshold setting is deprecated and will be removed then. From OpenSearch 1.0, the query analysis threshold in legacy engine is disabled.
+
+opendistro.sql.query.response.format
+------------------------------------
+The opendistro.sql.query.response.format setting is deprecated and will be removed then. From OpenSearch 1.0, the query response format is default to JDBC format. `You can change the format by using query parameters<../interfaces/protocol.rst>`_.
 
 opendistro.sql.cursor.enabled
 -----------------------------
-The opendistro.sql.cursor.enabled is deprecated and will be removed then. From OpenSearch 1.0, the cursor feature is enabled by default.
+The opendistro.sql.cursor.enabled setting is deprecated and will be removed then. From OpenSearch 1.0, the cursor feature is enabled by default.
 
 opendistro.sql.cursor.fetch_size
 --------------------------------
-The opendistro.sql.cursor.fetch_size is deprecated and will be removed then. From OpenSearch 1.0, the fetch_size in query body will decide whether create the cursor context. No cursor will be created if the fetch_size = 0.
+The opendistro.sql.cursor.fetch_size setting is deprecated and will be removed then. From OpenSearch 1.0, the fetch_size in query body will decide whether create the cursor context. No cursor will be created if the fetch_size = 0.
 
 plugins.sql.enabled
 ======================

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -16,6 +16,16 @@ Introduction
 
 When OpenSearch bootstraps, SQL plugin will register a few settings in OpenSearch cluster settings. Most of the settings are able to change dynamically so you can control the behavior of SQL plugin without need to bounce your cluster. You can update the settings by sending requests to either ``_cluster/settings`` or ``_plugins/_query/settings`` endpoint, though the examples are sending to the latter.
 
+Breaking Change
+===============
+
+opendistro.sql.cursor.enabled
+-----------------------------
+The opendistro.sql.cursor.enabled is deprecated and will be removed then. From OpenSearch 1.0, the cursor feature is enabled by default.
+
+opendistro.sql.cursor.fetch_size
+--------------------------------
+The opendistro.sql.cursor.fetch_size is deprecated and will be removed then. From OpenSearch 1.0, the fetch_size in query body will decide whether create the cursor context. No cursor will be created if the fetch_size = 0.
 
 plugins.sql.enabled
 ======================

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/LegacyOpenDistroSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/LegacyOpenDistroSettings.java
@@ -13,6 +13,8 @@ package org.opensearch.sql.opensearch.setting;
 
 import static org.opensearch.common.unit.TimeValue.timeValueMinutes;
 
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import lombok.experimental.UtilityClass;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.ByteSizeValue;
@@ -84,7 +86,7 @@ public class LegacyOpenDistroSettings {
    * Deprecated.
    * From OpenSearch 1.0, the cursor is always enabled and the setting will be removed then.
    */
-  public static final Setting<Boolean> CURSOR_ENABLED = Setting.boolSetting(
+  public static final Setting<Boolean> CURSOR_ENABLED_SETTING = Setting.boolSetting(
       LegacySettings.Key.CURSOR_ENABLED.getKeyValue(),
       true,
       Setting.Property.NodeScope,
@@ -95,10 +97,28 @@ public class LegacyOpenDistroSettings {
    * From OpenSearch 1.0, only the fetch_size in the context take effect and the setting will
    * be removed then.
    */
-  public static final Setting<Integer> CURSOR_FETCH_SIZE = Setting.intSetting(
+  public static final Setting<Integer> CURSOR_FETCH_SIZE_SETTING = Setting.intSetting(
       LegacySettings.Key.CURSOR_FETCH_SIZE.getKeyValue(),
       1000,
       Setting.Property.NodeScope,
       Setting.Property.Dynamic,
       Setting.Property.Deprecated);
+
+  /**
+   * Used by Plugin to init Setting.
+   */
+  public static List<Setting<?>> legacySettings() {
+    return new ImmutableList.Builder<Setting<?>>()
+        .add(SQL_ENABLED_SETTING)
+        .add(SQL_QUERY_SLOWLOG_SETTING)
+        .add(SQL_CURSOR_KEEPALIVE_SETTING)
+        .add(METRICS_ROLLING_WINDOW_SETTING)
+        .add(METRICS_ROLLING_INTERVAL_SETTING)
+        .add(PPL_ENABLED_SETTING)
+        .add(PPL_QUERY_MEMORY_LIMIT_SETTING)
+        .add(QUERY_SIZE_LIMIT_SETTING)
+        .add(CURSOR_ENABLED_SETTING)
+        .add(CURSOR_FETCH_SIZE_SETTING)
+        .build();
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/LegacyOpenDistroSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/LegacyOpenDistroSettings.java
@@ -82,27 +82,88 @@ public class LegacyOpenDistroSettings {
       Setting.Property.NodeScope,
       Setting.Property.Dynamic,
       Setting.Property.Deprecated);
+
   /**
-   * Deprecated.
-   * From OpenSearch 1.0, the cursor is always enabled and the setting will be removed then.
+   * Deprecated and will be removed then.
+   * From OpenSearch 1.0, the new engine is always enabled.
    */
-  public static final Setting<Boolean> CURSOR_ENABLED_SETTING = Setting.boolSetting(
-      LegacySettings.Key.CURSOR_ENABLED.getKeyValue(),
+  public static final Setting<Boolean> SQL_NEW_ENGINE_ENABLED_SETTING = Setting.boolSetting(
+      LegacySettings.Key.SQL_NEW_ENGINE_ENABLED.getKeyValue(),
       true,
       Setting.Property.NodeScope,
       Setting.Property.Dynamic,
       Setting.Property.Deprecated);
+
   /**
-   * Deprecated.
-   * From OpenSearch 1.0, only the fetch_size in the context take effect and the setting will
-   * be removed then.
+   * Deprecated and will be removed then.
+   * From OpenSearch 1.0, the query analysis in legacy engine is disabled.
    */
-  public static final Setting<Integer> CURSOR_FETCH_SIZE_SETTING = Setting.intSetting(
-      LegacySettings.Key.CURSOR_FETCH_SIZE.getKeyValue(),
-      1000,
+  public static final Setting<Boolean> QUERY_ANALYSIS_ENABLED_SETTING = Setting.boolSetting(
+      LegacySettings.Key.QUERY_ANALYSIS_ENABLED.getKeyValue(),
+      false,
       Setting.Property.NodeScope,
       Setting.Property.Dynamic,
       Setting.Property.Deprecated);
+
+  /**
+   * Deprecated and will be removed then.
+   * From OpenSearch 1.0, the query analysis suggestion in legacy engine is disabled.
+   */
+  public static final Setting<Boolean> QUERY_ANALYSIS_SEMANTIC_SUGGESTION_SETTING =
+      Setting.boolSetting(
+      LegacySettings.Key.QUERY_ANALYSIS_SEMANTIC_SUGGESTION.getKeyValue(),
+      false,
+      Setting.Property.NodeScope,
+      Setting.Property.Dynamic,
+      Setting.Property.Deprecated);
+
+  /**
+   * Deprecated and will be removed then.
+   * From OpenSearch 1.0, the query analysis threshold in legacy engine is disabled.
+   */
+  public static final Setting<Integer> QUERY_ANALYSIS_SEMANTIC_THRESHOLD_SETTING =
+      Setting.intSetting(
+          LegacySettings.Key.QUERY_ANALYSIS_SEMANTIC_THRESHOLD.getKeyValue(),
+          200,
+          Setting.Property.NodeScope,
+          Setting.Property.Dynamic,
+          Setting.Property.Deprecated);
+
+  /**
+   * Deprecated and will be removed then.
+   * From OpenSearch 1.0, the query response format is default to JDBC format.
+   */
+  public static final Setting<String> QUERY_RESPONSE_FORMAT_SETTING =
+      Setting.simpleString(
+          LegacySettings.Key.QUERY_RESPONSE_FORMAT.getKeyValue(),
+          "jdbc",
+          Setting.Property.NodeScope,
+          Setting.Property.Dynamic,
+          Setting.Property.Deprecated);
+
+  /**
+   * Deprecated and will be removed then.
+   * From OpenSearch 1.0, the cursor feature is enabled by default.
+   */
+  public static final Setting<Boolean> SQL_CURSOR_ENABLED_SETTING =
+      Setting.boolSetting(
+          LegacySettings.Key.SQL_CURSOR_ENABLED.getKeyValue(),
+          true,
+          Setting.Property.NodeScope,
+          Setting.Property.Dynamic,
+          Setting.Property.Deprecated);
+  /**
+   * Deprecated and will be removed then.
+   * From OpenSearch 1.0, the fetch_size in query body will decide whether create the cursor
+   * context. No cursor will be created if the fetch_size = 0.
+   */
+  public static final Setting<Integer> SQL_CURSOR_FETCH_SIZE_SETTING =
+      Setting.intSetting(
+          LegacySettings.Key.SQL_CURSOR_FETCH_SIZE.getKeyValue(),
+          1000,
+          Setting.Property.NodeScope,
+          Setting.Property.Dynamic,
+          Setting.Property.Deprecated);
 
   /**
    * Used by Plugin to init Setting.
@@ -117,8 +178,13 @@ public class LegacyOpenDistroSettings {
         .add(PPL_ENABLED_SETTING)
         .add(PPL_QUERY_MEMORY_LIMIT_SETTING)
         .add(QUERY_SIZE_LIMIT_SETTING)
-        .add(CURSOR_ENABLED_SETTING)
-        .add(CURSOR_FETCH_SIZE_SETTING)
+        .add(SQL_NEW_ENGINE_ENABLED_SETTING)
+        .add(QUERY_ANALYSIS_ENABLED_SETTING)
+        .add(QUERY_ANALYSIS_SEMANTIC_SUGGESTION_SETTING)
+        .add(QUERY_ANALYSIS_SEMANTIC_THRESHOLD_SETTING)
+        .add(QUERY_RESPONSE_FORMAT_SETTING)
+        .add(SQL_CURSOR_ENABLED_SETTING)
+        .add(SQL_CURSOR_FETCH_SIZE_SETTING)
         .build();
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/LegacyOpenDistroSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/LegacyOpenDistroSettings.java
@@ -80,5 +80,25 @@ public class LegacyOpenDistroSettings {
       Setting.Property.NodeScope,
       Setting.Property.Dynamic,
       Setting.Property.Deprecated);
-
+  /**
+   * Deprecated.
+   * From OpenSearch 1.0, the cursor is always enabled and the setting will be removed then.
+   */
+  public static final Setting<Boolean> CURSOR_ENABLED = Setting.boolSetting(
+      LegacySettings.Key.CURSOR_ENABLED.getKeyValue(),
+      true,
+      Setting.Property.NodeScope,
+      Setting.Property.Dynamic,
+      Setting.Property.Deprecated);
+  /**
+   * Deprecated.
+   * From OpenSearch 1.0, only the fetch_size in the context take effect and the setting will
+   * be removed then.
+   */
+  public static final Setting<Integer> CURSOR_FETCH_SIZE = Setting.intSetting(
+      LegacySettings.Key.CURSOR_FETCH_SIZE.getKeyValue(),
+      1000,
+      Setting.Property.NodeScope,
+      Setting.Property.Dynamic,
+      Setting.Property.Deprecated);
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/setting/OpenSearchSettingsTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/setting/OpenSearchSettingsTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opensearch.common.unit.TimeValue.timeValueMinutes;
+import static org.opensearch.sql.opensearch.setting.LegacyOpenDistroSettings.legacySettings;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -147,5 +148,11 @@ class OpenSearchSettingsTest {
     assertEquals(OpenSearchSettings.QUERY_SIZE_LIMIT_SETTING.get(settings), 100);
     assertEquals(OpenSearchSettings.METRICS_ROLLING_WINDOW_SETTING.get(settings), 2000L);
     assertEquals(OpenSearchSettings.METRICS_ROLLING_INTERVAL_SETTING.get(settings), 100L);
+  }
+
+
+  @Test
+  void legacySettingsShouldBeDeprecatedBeforeRemove() {
+    assertEquals(15, legacySettings().size());
   }
 }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -152,15 +152,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
   @Override
   public List<Setting<?>> getSettings() {
     return new ImmutableList.Builder<Setting<?>>()
-        .add(LegacyOpenDistroSettings.SQL_ENABLED_SETTING)
-        .add(LegacyOpenDistroSettings.SQL_QUERY_SLOWLOG_SETTING)
-        .add(LegacyOpenDistroSettings.METRICS_ROLLING_WINDOW_SETTING)
-        .add(LegacyOpenDistroSettings.METRICS_ROLLING_INTERVAL_SETTING)
-        .add(LegacyOpenDistroSettings.PPL_ENABLED_SETTING)
-        .add(LegacyOpenDistroSettings.PPL_QUERY_MEMORY_LIMIT_SETTING)
-        .add(LegacyOpenDistroSettings.QUERY_SIZE_LIMIT_SETTING)
-        .add(LegacyOpenDistroSettings.CURSOR_ENABLED)
-        .add(LegacyOpenDistroSettings.CURSOR_FETCH_SIZE)
+        .addAll(LegacyOpenDistroSettings.legacySettings())
         .addAll(OpenSearchSettings.pluginSettings())
         .build();
   }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -159,6 +159,8 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
         .add(LegacyOpenDistroSettings.PPL_ENABLED_SETTING)
         .add(LegacyOpenDistroSettings.PPL_QUERY_MEMORY_LIMIT_SETTING)
         .add(LegacyOpenDistroSettings.QUERY_SIZE_LIMIT_SETTING)
+        .add(LegacyOpenDistroSettings.CURSOR_ENABLED)
+        .add(LegacyOpenDistroSettings.CURSOR_FETCH_SIZE)
         .addAll(OpenSearchSettings.pluginSettings())
         .build();
   }


### PR DESCRIPTION
### Description
1. Address #75, deprecated opendistro.sql.cursor.enabled and opendistro.sql.cursor.fetch_size
2. Address #70, deprecated opendistro.sql.engine.new.enabled
3. Address #76, deprecated opensearch.sql.query.analysis.*
4. Address #77, deprecated opensearch.sql.query.response.format

### Upgrade Test
Before rolling upgrade, put the deprecated setting.
```
curl -X PUT "localhost:9200/_opendistro/_sql/settings" -H 'Content-Type: application/json' -d'
{
  "persistent" : {
      "opendistro": {
        "sql": {
          "cursor": {
            "enabled" : true,
            "keep_alive": "10m"
          }
        }
      }
  },
  "transient" : {
    "opendistro.sql.query.analysis.enabled" : false
  }
}'
```

After the rolling upgrade from ODFE 1.13.2 to OpenSearch 1.0, Then update the deprecated setting. The warning will returned.
```
➜  upgrade-test curl -i -X PUT "localhost:9200/_plugins/_query/settings" -H 'Content-Type: application/json' -d'
{
  "transient" : {
    "opendistro.sql.cursor.enabled" : "false"
  }
}'
HTTP/1.1 200 OK
Warning: 299 OpenSearch-1.0.0-26d579287f50bb33e17c8fe1f05ea208d5c64d1f "[opendistro.sql.cursor.keep_alive] setting was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation for the next major version."
Warning: 299 OpenSearch-1.0.0-26d579287f50bb33e17c8fe1f05ea208d5c64d1f "[opendistro.sql.cursor.enabled] setting was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation for the next major version."
content-type: application/json; charset=UTF-8
content-length: 103

{"acknowledged":true,"persistent":{},"transient":{"opendistro":{"sql":{"cursor":{"enabled":"false"}}}}}
```
 
### Issues Resolved
Resolved, #136 

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).