### PR TITLE
Build against OpenSearch 1.0.0 and bump artifact version to 1.0.0.0

### DIFF
--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   update_release_draft:
@@ -16,6 +16,6 @@ jobs:
         with:
           config-name: draft-release-notes-config.yml
           tag: (None)
-          version: 1.0.0.0-rc1
+          version: 1.0.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
     
     - name: Build with Gradle
       run: ./gradlew build assemble

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
+      run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
     
     - name: Build with Gradle
       run: ./gradlew build assemble

--- a/.github/workflows/sql-workbench-release-workflow.yml
+++ b/.github/workflows/sql-workbench-release-workflow.yml
@@ -8,7 +8,7 @@ on:
 env: 
   PLUGIN_NAME: query-workbench-dashboards
   OPENSEARCH_VERSION: '1.0'
-  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0-rc1
+  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0
 
 jobs:
 

--- a/.github/workflows/sql-workbench-release-workflow.yml
+++ b/.github/workflows/sql-workbench-release-workflow.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.23.1'
+          node-version: '10.24.1'
 
       - name: Move Workbench to Plugins Dir
         run: |

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 env: 
   PLUGIN_NAME: query-workbench-dashboards
   OPENSEARCH_VERSION: '1.0'
-  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0-rc1
+  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0
 
 jobs:
 

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.23.1'
+          node-version: '10.24.1'
 
       - name: Move Workbench to Plugins Dir
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = "1.0.0"
+        opensearch_version = "1.0.0-rc1"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = "1.0.0-rc1"
+        opensearch_version = "1.0.0"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ ext {
 }
 
 allprojects {
-    version = "${opensearchVersion}.0-rc1"
+    version = "${opensearchVersion}.0"
 
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -93,7 +93,7 @@ compileTestJava {
 }
 
 testClusters.all {
-    testDistribution = 'integ_test'
+    testDistribution = 'archive'
     plugin ":plugin"
 }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -93,7 +93,7 @@ compileTestJava {
 }
 
 testClusters.all {
-    testDistribution = 'archive'
+    testDistribution = 'integ_test'
     plugin ":plugin"
 }
 

--- a/sql-cli/src/opensearch_sql_cli/__init__.py
+++ b/sql-cli/src/opensearch_sql_cli/__init__.py
@@ -22,4 +22,4 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-__version__ = "1.0.0.0-rc1"
+__version__ = "1.0.0.0"

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -43,7 +43,7 @@ plugins {
 group 'org.opensearch.client'
 
 // keep version in sync with version in Driver source
-version '1.0.0.0-rc1'
+version '1.0.0.0'
 
 boolean snapshot = "true".equals(System.getProperty("build.snapshot", "false"));
 if (snapshot) {

--- a/workbench/opensearch_dashboards.json
+++ b/workbench/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "queryWorkbenchDashboards",
-  "version": "1.0.0.0-rc1",
-  "opensearchDashboardsVersion": "1.0.0-rc1",
+  "version": "1.0.0.0",
+  "opensearchDashboardsVersion": "1.0.0",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation"],

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -47,7 +47,7 @@
     "tslint-plugin-prettier": "^2.0.1"
   },
   "engines": {
-    "node": "10.23.1",
+    "node": "10.24.1",
     "yarn": "^1.21.1"
   },
   "resolutions": {

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,13 +1,13 @@
 {
   "name": "opensearch-query-workbench",
-  "version": "1.0.0.0-rc1",
+  "version": "1.0.0.0",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/sql/tree/main/workbench",
   "opensearchDashboards": {
-    "version": "1.0.0-rc1",
-    "templateVersion": "1.0.0-rc1"
+    "version": "1.0.0",
+    "templateVersion": "1.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description
Bump OpenSearch to version 1.0.0 and rename all artifacts by removing `-rc1`, including SQL/PPL, JDBC, ODBC, SQL CLI, and Query Workbench.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/144
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).