### PR TITLE
Build zip artifact for ODBC driver on mac

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -55,7 +55,7 @@ jobs:
         mkdir installer
         cp ./build/odbc/lib/*.dylib build-output/
         cp ./build/odbc/lib/*.a build-output/
-        cp ./cmake-build64/*.pkg installer/
+        cp ./cmake-build64/*.zip installer/
     # cp $(ls -d ./build/odbc/bin/* | grep -v "\.") build-output
     #    cp ./bin64/*.html test-output
     #    cp ./bin64/*.log test-output

--- a/sql-odbc/src/CMakeLists.txt
+++ b/sql-odbc/src/CMakeLists.txt
@@ -168,7 +168,7 @@ endif()
 
 # Projects to build
 if (APPLE)
-	add_subdirectory(${aws-cpp-sdk-base})
+	add_subdirectory(${aws-cpp-sdk-base} EXCLUDE_FROM_ALL)
 endif()
 add_subdirectory(${OPENSEARCHODBC_SRC})
 add_subdirectory(${OPENSEARCHENLIST_SRC})

--- a/sql-odbc/src/gtest/googletest.cmake
+++ b/sql-odbc/src/gtest/googletest.cmake
@@ -53,5 +53,5 @@ macro(fetch_googletest _download_module_path _download_root)
     add_subdirectory(
         ${_download_root}/googletest-src
         ${_download_root}/googletest-build
-        )
+        EXCLUDE_FROM_ALL)
 endmacro()

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -64,8 +64,8 @@ else()
 
     # Ignore source code folders by tricky regex way
     set(CPACK_SOURCE_IGNORE_FILES
-        /include
-        /lib
+        "/include/"
+        "/lib/"
     )
 
     # This script will be run once the Driver component has finished installing.

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -63,26 +63,13 @@ else()
     set(CPACK_GENERATOR "ZIP")
 
     # This script will be run once the Driver component has finished installing.
-    #set(CPACK_POSTFLIGHT_DRIVER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/postinstall")
-
-    # The productbuild generator copies files from this directory
-    #set(CPACK_PRODUCTBUILD_RESOURCES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Resources")
-
-    # Background setup to Distribution XML
-    #set(CPACK_PRODUCTBUILD_BACKGROUND "background.bmp")
-    #set(CPACK_PRODUCTBUILD_BACKGROUND_ALIGNMENT "bottomleft")
-    #set(CPACK_PRODUCTBUILD_BACKGROUND_SCALING "none")
-
-    # Background setup for the Dark Aqua theme to Distribution XML
-    #set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA "background_darkaqua.bmp")
-    #set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA_ALIGNMENT "bottomleft")
-    #set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA_SCALING "none")
+    set(CPACK_POSTFLIGHT_DRIVER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/postinstall")
 
     # CPack doesn't allow extensionless licenses, need to make a copy with an extension, .txt is appropriate
-    #configure_file("${PROJECT_ROOT}/LICENSE" "${PROJECT_ROOT}/LICENSE.txt" COPYONLY)
-    #set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_ROOT}/LICENSE.txt")
-    #set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/Resources/README.txt")
-    #set(CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Welcome.txt")
+    configure_file("${PROJECT_ROOT}/LICENSE" "${PROJECT_ROOT}/LICENSE.txt" COPYONLY)
+    set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_ROOT}/LICENSE.txt")
+    set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/Resources/README.txt")
+    set(CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Welcome.txt")
 endif()
 
 # Set up components for installer

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -62,6 +62,9 @@ if(WIN32)
 else()
     set(CPACK_GENERATOR "ZIP")
 
+    # Ignore source code folders by tricky regex way
+    set(CPACK_SOURCE_IGNORE_FILES "include")
+
     # This script will be run once the Driver component has finished installing.
     set(CPACK_POSTFLIGHT_DRIVER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/postinstall")
 

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -63,7 +63,10 @@ else()
     set(CPACK_GENERATOR "ZIP")
 
     # Ignore source code folders by tricky regex way
-    set(CPACK_SOURCE_IGNORE_FILES "/include/;/lib/")
+    set(CPACK_SOURCE_IGNORE_FILES
+        /include
+        /lib
+    )
 
     # This script will be run once the Driver component has finished installing.
     set(CPACK_POSTFLIGHT_DRIVER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/postinstall")

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -62,15 +62,6 @@ if(WIN32)
 else()
     set(CPACK_GENERATOR "ZIP")
 
-    # Ignore source code folders by tricky regex way
-    set(CPACK_SOURCE_IGNORE_FILES
-        "${PROJECT_SOURCE_DIR}/include"
-        "${PROJECT_SOURCE_DIR}/lib"
-    )
-
-    # This script will be run once the Driver component has finished installing.
-    set(CPACK_POSTFLIGHT_DRIVER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/postinstall")
-
     # CPack doesn't allow extensionless licenses, need to make a copy with an extension, .txt is appropriate
     configure_file("${PROJECT_ROOT}/LICENSE" "${PROJECT_ROOT}/LICENSE.txt" COPYONLY)
     set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_ROOT}/LICENSE.txt")

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -64,8 +64,8 @@ else()
 
     # Ignore source code folders by tricky regex way
     set(CPACK_SOURCE_IGNORE_FILES
-        "/include/"
-        "/lib/"
+        "${PROJECT_SOURCE_DIR}/include"
+        "${PROJECT_SOURCE_DIR}/lib"
     )
 
     # This script will be run once the Driver component has finished installing.

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -63,7 +63,7 @@ else()
     set(CPACK_GENERATOR "ZIP")
 
     # Ignore source code folders by tricky regex way
-    set(CPACK_SOURCE_IGNORE_FILES "include")
+    set(CPACK_SOURCE_IGNORE_FILES "/include/;/lib/")
 
     # This script will be run once the Driver component has finished installing.
     set(CPACK_POSTFLIGHT_DRIVER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/postinstall")

--- a/sql-odbc/src/installer/CMakeLists.txt
+++ b/sql-odbc/src/installer/CMakeLists.txt
@@ -60,29 +60,29 @@ if(WIN32)
     configure_file("${PROJECT_ROOT}/LICENSE" "${PROJECT_ROOT}/LICENSE.txt" COPYONLY)
     set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_ROOT}/LICENSE.txt")
 else()
-    set(CPACK_GENERATOR "productbuild")
+    set(CPACK_GENERATOR "ZIP")
 
     # This script will be run once the Driver component has finished installing.
-    set(CPACK_POSTFLIGHT_DRIVER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/postinstall")
+    #set(CPACK_POSTFLIGHT_DRIVER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/postinstall")
 
     # The productbuild generator copies files from this directory
-    set(CPACK_PRODUCTBUILD_RESOURCES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Resources")
+    #set(CPACK_PRODUCTBUILD_RESOURCES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Resources")
 
     # Background setup to Distribution XML
-    set(CPACK_PRODUCTBUILD_BACKGROUND "background.bmp")
-    set(CPACK_PRODUCTBUILD_BACKGROUND_ALIGNMENT "bottomleft")
-    set(CPACK_PRODUCTBUILD_BACKGROUND_SCALING "none")
+    #set(CPACK_PRODUCTBUILD_BACKGROUND "background.bmp")
+    #set(CPACK_PRODUCTBUILD_BACKGROUND_ALIGNMENT "bottomleft")
+    #set(CPACK_PRODUCTBUILD_BACKGROUND_SCALING "none")
 
     # Background setup for the Dark Aqua theme to Distribution XML
-    set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA "background_darkaqua.bmp")
-    set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA_ALIGNMENT "bottomleft")
-    set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA_SCALING "none")
+    #set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA "background_darkaqua.bmp")
+    #set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA_ALIGNMENT "bottomleft")
+    #set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA_SCALING "none")
 
     # CPack doesn't allow extensionless licenses, need to make a copy with an extension, .txt is appropriate
-    configure_file("${PROJECT_ROOT}/LICENSE" "${PROJECT_ROOT}/LICENSE.txt" COPYONLY)
-    set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_ROOT}/LICENSE.txt")
-    set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/Resources/README.txt")
-    set(CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Welcome.txt")
+    #configure_file("${PROJECT_ROOT}/LICENSE" "${PROJECT_ROOT}/LICENSE.txt" COPYONLY)
+    #set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_ROOT}/LICENSE.txt")
+    #set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/Resources/README.txt")
+    #set(CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Welcome.txt")
 endif()
 
 # Set up components for installer


### PR DESCRIPTION
### Description
Replace `pkg` artifact with `zip` for ODBC driver on mac to avoid signing complexity. This is done by cpack zip generator and excluding third party dependencies aws, googletest and gmock.

Testing: The zip artifact works without issue. The only prerequisite is that it has to be unzip to original location `/Library/ODBC/opensearch-sql-odbc`. Need to check if any hardcoding dependency in code.

[TODO] Update user manual and dev docs
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/145
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).