### PR TITLE
Fix for SQL-ODBC AWS Init and Shutdown Behaviour

### DIFF
--- a/sql-odbc/src/sqlodbc/opensearch_communication.h
+++ b/sql-odbc/src/sqlodbc/opensearch_communication.h
@@ -116,7 +116,6 @@ class OpenSearchCommunication {
     OpenSearchResultQueue m_result_queue;
     runtime_options m_rt_opts;
     std::string m_client_encoding;
-    Aws::SDKOptions m_options;
     std::string m_response_str;
     std::shared_ptr< Aws::Http::HttpClient > m_http_client;
     std::string m_error_message_to_user;


### PR DESCRIPTION
### Description
Fixed aws init and shutdown behaviour. The current code can cause segmentation faults in multithreaded environments
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/164

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).