### PR TITLE
Use externally-defined OpenSearch version when specified.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = "1.0.0"
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
     }
 
     repositories {
@@ -55,12 +55,16 @@ repositories {
 }
 
 ext {
-    opensearchVersion = '1.0.0'
+    opensearchVersion = System.getProperty("opensearch.version", "1.0.0")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
 allprojects {
-    version = "${opensearchVersion}.0"
+    version = "${opensearchVersion}" - "-SNAPSHOT" + ".0"
+
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
 
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Allows one to run `./gradlew build --no-daemon -Dopensearch.version=1.0.0-SNAPSHOT -Dbuild.snapshot=true` to produce a `-SNAPSHOT` artifact that correctly depends on the `-SNAPSHOT` build of OpenSearch.
 
### Issues Resolved

Closes #177 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).