### PR TITLE
Use OpenSearch 1.1 and build snapshot by default in CI.

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -21,14 +21,14 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
-        ref: '1.0'
+        ref: '1.x'
 
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+      run: ./gradlew publishToMavenLocal
     
     - name: Build with Gradle
-      run: ./gradlew build assemble
+      run: ./gradlew build assemble -Dopensearch.version=1.1.0-SNAPSHOT
 
     - name: Create Artifact Path
       run: |

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
     }
 
     repositories {
@@ -55,13 +55,11 @@ repositories {
 }
 
 ext {
-    opensearchVersion = System.getProperty("opensearch.version", "1.0.0")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
 allprojects {
-    version = "${opensearchVersion}" - "-SNAPSHOT" + ".0"
-
+    version = opensearch_version - "-SNAPSHOT" + ".0"
     if (isSnapshot) {
         version += "-SNAPSHOT"
     }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description
Use OpenSearch 1.1 and build snapshot by default in CI.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).