### PR TITLE
Workbench: auto dump cypress test data, support security

### DIFF
--- a/workbench/.cypress/integration/ui.spec.js
+++ b/workbench/.cypress/integration/ui.spec.js
@@ -26,9 +26,32 @@
 
 /// <reference types="cypress" />
 
-import { edit } from "brace";
-import { delay, testQueries, verifyDownloadData, files } from "../utils/constants";
+import { edit } from 'brace';
+import { delay, files, testDataSet, testQueries, verifyDownloadData } from '../utils/constants';
 
+describe('Dump test data', () => {
+  it('Indexes test data for SQL and PPL', () => {
+    const dumpDataSet = (url, index) =>
+      cy.request(url).then((response) => {
+        cy.request({
+          method: 'POST',
+          form: true,
+          url: 'api/console/proxy',
+          headers: {
+            'content-type': 'application/json;charset=UTF-8',
+            'osd-xsrf': true,
+          },
+          qs: {
+            path: `${index}/_bulk`,
+            method: 'POST',
+          },
+          body: response.body,
+        });
+      });
+
+    testDataSet.forEach(({url, index}) => dumpDataSet(url, index));
+  });
+});
 
 describe('Test PPL UI', () => {
   beforeEach(() => {
@@ -183,13 +206,12 @@ describe('Test and verify SQL downloads', () => {
           'osd-xsrf': true,
         },
         body: {
-          'query': 'select * from accounts where balance > 49500'
-        }
+          query: 'select * from accounts where balance > 49500',
+        },
       }).then((response) => {
         if (title === 'Download and verify CSV' || title === 'Download and verify Text') {
           expect(response.body.data.body).to.have.string(files[file]);
-        }
-        else {
+        } else {
           expect(response.body.data.resp).to.have.string(files[file]);
         }
       });

--- a/workbench/.cypress/support/constants.js
+++ b/workbench/.cypress/support/constants.js
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+export const ADMIN_AUTH = {
+  username: 'admin',
+  password: 'admin',
+};

--- a/workbench/.cypress/support/index.js
+++ b/workbench/.cypress/support/index.js
@@ -44,3 +44,8 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// Switch the base URL of OpenSearch when security enabled in the cluster
+if (Cypress.env('security_enabled')) {
+  Cypress.env('opensearch', 'https://localhost:9200');
+}

--- a/workbench/.cypress/utils/constants.js
+++ b/workbench/.cypress/utils/constants.js
@@ -26,6 +26,17 @@
 
 export const delay = 1000;
 
+export const testDataSet = [
+  {
+    url: 'https://raw.githubusercontent.com/opensearch-project/sql/main/integ-test/src/test/resources/accounts.json',
+    index: 'accounts',
+  },
+  {
+    url: 'https://raw.githubusercontent.com/opensearch-project/sql/main/integ-test/src/test/resources/employee_nested.json',
+    index: 'employee_nested'
+  }
+]
+
 export const verifyDownloadData = [
   {
     title: 'Download and verify JSON',

--- a/workbench/cypress.json
+++ b/workbench/cypress.json
@@ -9,5 +9,10 @@
   "videosFolder": ".cypress/videos",
   "requestTimeout": 60000,
   "responseTimeout": 60000,
-  "defaultCommandTimeout": 60000
+  "defaultCommandTimeout": 60000,
+  "env": {
+    "opensearch": "localhost:9200",
+    "opensearchDashboards": "localhost:5601",
+    "security_enabled": true
+  }
 }


### PR DESCRIPTION
### Description
- Auto dump cypress test data (`accounts` and `employee_nested` to test sql/ppl query correctness) for workbench
- Add security support for cypress
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).