### PR TITLE
Fix import path for cypress constant

### DIFF
--- a/docs/dev/Pagination.md
+++ b/docs/dev/Pagination.md
@@ -149,7 +149,7 @@ POST _plugins/_sql/close
 
 ### 3.3 Support in JDBC
 
-To use the pagination functionality programmatically using the[JDBC 4.1 specification](https://download.oracle.com/otn-pub/jcp/jdbc-4_1-mrel-spec/jdbc4.1-fr-spec.pdf?AuthParam=1574798710_305327d63d91e91e19dd80953454597a), page size is being used as performance hint given by `Statement.setFetchSize()` and “applied to each result set produced by the statement”. We need to re-implement `Statement.executequery()` and `ResultSet.next()` to take advantage of cursor.
+To use the pagination functionality programmatically using the[JDBC 4.1 specification](https://download.oracle.com/otn-pub/jcp/jdbc-4_1-mrel-spec/jdbc4.1-fr-spec.pdf), page size is being used as performance hint given by `Statement.setFetchSize()` and “applied to each result set produced by the statement”. We need to re-implement `Statement.executequery()` and `ResultSet.next()` to take advantage of cursor.
 
 We will not support backward scroll on result set. The `Statement` must be created with a `ResultSet` type of `ResultSet.TYPE_FORWARD_ONLY`. Attempt to scroll backwards or otherwise jump around in the `ResultSet` should throw an exception.
 

--- a/workbench/.cypress/support/commands.js
+++ b/workbench/.cypress/support/commands.js
@@ -50,7 +50,7 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-import { ADMIN_AUTH } from '../utils/constants';
+const { ADMIN_AUTH } = require('./constants');
 
 Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   // Add the basic auth header when security enabled in the OpenSearch cluster

--- a/workbench/.cypress/tsconfig.json
+++ b/workbench/.cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "../node_modules",
+    "types": ["cypress"]
+  },
+  "include": ["**/*.*"]
+}


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
the import path for auth info was incorrect
add tsconfig.json for cypress

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).