### PR TITLE
Bump version to 1.1 for Opensearch 1.1.0.0 release 

### DIFF
--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           config-name: draft-release-notes-config.yml
           tag: (None)
-          version: 1.0.0.0
+          version: 1.1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sql-odbc-release-workflow.yml
+++ b/.github/workflows/sql-odbc-release-workflow.yml
@@ -12,7 +12,7 @@ env:
   ODBC_BUILD_PATH: "./build/odbc/build"
   AWS_SDK_INSTALL_PATH: "./build/aws-sdk/install"
   PLUGIN_NAME: opensearch-sql-odbc
-  OD_VERSION: 1.0.0.0
+  OD_VERSION: 1.1.0.0
 
 jobs:
   build-mac:

--- a/.github/workflows/sql-odbc-rename-and-release-workflow.yml
+++ b/.github/workflows/sql-odbc-rename-and-release-workflow.yml
@@ -8,7 +8,7 @@ on:
       - rename*
 
 env:
-  OD_VERSION: 1.0.0.0
+  OD_VERSION: 1.1.0.0
 
 jobs:
   upload-odbc:

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -4,8 +4,8 @@ on: [pull_request, push]
 
 env: 
   PLUGIN_NAME: query-workbench-dashboards
-  OPENSEARCH_VERSION: '1.0'
-  OPENSEARCH_PLUGIN_VERSION: 1.0.0.0
+  OPENSEARCH_VERSION: '1.x'
+  OPENSEARCH_PLUGIN_VERSION: 1.1.0.0
 
 jobs:
 

--- a/release-notes/opensearch-sql.release-notes-1.1.0.0.md
+++ b/release-notes/opensearch-sql.release-notes-1.1.0.0.md
@@ -1,0 +1,24 @@
+## 2021-09-02 Version 1.1.0.0
+
+Compatible with OpenSearch and OpenSearch Dashboards Version 1.1.0
+
+### Enhancements
+
+* Support implicit type conversion from string to boolean ([#166](https://github.com/opensearch-project/sql/pull/166))
+* Support distinct count aggregation ([#167](https://github.com/opensearch-project/sql/pull/167))
+* Support implicit type conversion from string to temporal ([#171](https://github.com/opensearch-project/sql/pull/171))
+* Workbench: auto dump cypress test data, support security ([#199](https://github.com/opensearch-project/sql/pull/199))
+
+### Bug Fixes
+
+* Fix for SQL-ODBC AWS Init and Shutdown Behaviour ([#163](https://github.com/opensearch-project/sql/pull/163))
+* Fix import path for cypress constant ([#201](https://github.com/opensearch-project/sql/pull/201))
+
+
+### Infrastructure
+
+* Add Integtest.sh for OpenSearch integtest setups (workbench) ([#157](https://github.com/opensearch-project/sql/pull/157))
+* Bump path-parse from 1.0.6 to 1.0.7 in /workbench ([#178](https://github.com/opensearch-project/sql/pull/178))
+* Use externally-defined OpenSearch version when specified. ([#179](https://github.com/opensearch-project/sql/pull/179))
+* Use OpenSearch 1.1 and build snapshot by default in CI. ([#181](https://github.com/opensearch-project/sql/pull/181))
+* Workbench: remove curl commands in integtest.sh ([#200](https://github.com/opensearch-project/sql/pull/200))

--- a/sql-cli/src/opensearch_sql_cli/__init__.py
+++ b/sql-cli/src/opensearch_sql_cli/__init__.py
@@ -22,4 +22,4 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-__version__ = "1.0.0.0"
+__version__ = "1.1.0.0"

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -43,7 +43,7 @@ plugins {
 group 'org.opensearch.client'
 
 // keep version in sync with version in Driver source
-version '1.0.0.0'
+version '1.1.0.0'
 
 boolean snapshot = "true".equals(System.getProperty("build.snapshot", "false"));
 if (snapshot) {

--- a/sql-odbc/src/CMakeLists.txt
+++ b/sql-odbc/src/CMakeLists.txt
@@ -87,8 +87,8 @@ set(INSTALL_SRC "${CMAKE_CURRENT_SOURCE_DIR}/installer")
 set(DSN_INSTALLER_SRC "${CMAKE_CURRENT_SOURCE_DIR}/DSNInstaller")
 
 # ODBC Driver version 
-set(DRIVER_PACKAGE_VERSION "1.0.0.0")
-set(DRIVER_PACKAGE_VERSION_COMMA_SEPARATED "1,0,0,0")
+set(DRIVER_PACKAGE_VERSION "1.1.0.0")
+set(DRIVER_PACKAGE_VERSION_COMMA_SEPARATED "1,1,0,0")
 add_compile_definitions( OPENSEARCH_ODBC_VERSION="${DRIVER_PACKAGE_VERSION}"
                          # Comma separated version is required for odbc administrator's driver file.
                          OPENSEARCH_ODBC_DRVFILE_VERSION=${DRIVER_PACKAGE_VERSION_COMMA_SEPARATED} )

--- a/sql-odbc/src/TableauConnector/opensearch_sql_odbc/manifest.xml
+++ b/sql-odbc/src/TableauConnector/opensearch_sql_odbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='opensearch_sql_odbc' superclass='odbc' plugin-version='1.0.0.0' name='SQL' version='18.1' min-version-tableau='2020.1'>
+<connector-plugin class='opensearch_sql_odbc' superclass='odbc' plugin-version='1.1.0.0' name='SQL' version='18.1' min-version-tableau='2020.1'>
   <vendor-information>
       <company name="OpenSearch for ES"/>
       <support-link url="https://github.com/opensearch-project/sql"/>

--- a/sql-odbc/src/TableauConnector/opensearch_sql_odbc_dev/manifest.xml
+++ b/sql-odbc/src/TableauConnector/opensearch_sql_odbc_dev/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='opensearch_sql_odbc_dev' superclass='odbc' plugin-version='1.0.0.0' name='OpenSearch SQL ODBC DEV' version='18.1' min-version-tableau='2020.1'>
+<connector-plugin class='opensearch_sql_odbc_dev' superclass='odbc' plugin-version='1.1.0.0' name='OpenSearch SQL ODBC DEV' version='18.1' min-version-tableau='2020.1'>
   <vendor-information>
       <company name="OpenSearch"/>
       <support-link url="https://github.com/opensearch-project/sql"/>

--- a/workbench/opensearch_dashboards.json
+++ b/workbench/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "queryWorkbenchDashboards",
-  "version": "1.0.0.0",
-  "opensearchDashboardsVersion": "1.0.0",
+  "version": "1.1.0.0",
+  "opensearchDashboardsVersion": "1.1.0",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation"],

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-query-workbench",
-  "version": "1.0.0.0",
+  "version": "1.1.0.0",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/sql/tree/main/workbench",
   "opensearchDashboards": {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "templateVersion": "1.0.0"
   },
   "repository": {


### PR DESCRIPTION
### Description
Bump versions from `1.0.0.0` to `1.1.0.0` for Opensearch 1.1 release
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).