### PR TITLE
Bump opensearch ref to 1.1 in CI

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" --exclude "http://localhost*" "https://localhost" "https://odfe-node1:9200/" "https://community.tableau.com/docs/DOC-17978" ".*family.zzz" "https://pypi.python.org/pypi/opensearch-sql-cli/" "opensearch*" ".*@amazon.com" ".*email.com" "git@github.com" "http://timestamp.verisign.com/scripts/timstamp.dll"
+          args: --accept=200,403,429,999  "**/*.html" "**/*.md" "**/*.txt" --exclude "http://localhost*" "https://localhost" "https://odfe-node1:9200/" "https://community.tableau.com/docs/DOC-17978" ".*family.zzz" "https://pypi.python.org/pypi/opensearch-sql-cli/" "opensearch*" ".*@amazon.com" ".*email.com" "git@github.com" "http://timestamp.verisign.com/scripts/timstamp.dll"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/.github/workflows/sql-cli-release-workflow.yml
+++ b/.github/workflows/sql-cli-release-workflow.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: [ubuntu-16.04]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: sql-cli

--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 jobs:
   build:
 
-    runs-on: [ubuntu-16.04]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: sql-cli

--- a/.github/workflows/sql-jdbc-push-jdbc-maven.yml
+++ b/.github/workflows/sql-jdbc-push-jdbc-maven.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   upload-jdbc-jar:
-    runs-on: [ubuntu-16.04]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: sql-jdbc

--- a/.github/workflows/sql-release-workflow.yml
+++ b/.github/workflows/sql-release-workflow.yml
@@ -12,7 +12,7 @@ jobs:
         java: [14]
 
     name: Build and Release SQL Plugin
-    runs-on: [ubuntu-16.04]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout SQL

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         repository: 'opensearch-project/OpenSearch'
         path: OpenSearch
-        ref: '1.x'
+        ref: '1.1'
 
     - name: Build OpenSearch
       working-directory: ./OpenSearch

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following projects have been merged into this repository as separate folders
 
 Besides basic filtering and aggregation, OpenSearch SQL also supports complex queries, such as querying semi-structured data, JOINs, set operations, sub-queries etc. Beyond the standard functions, OpenSearch functions are provided for better analytics and visualization. Please check our [documentation](#documentation) for more details.
 
-Recently we have been actively improving our query engine primarily for better correctness and extensibility. Behind the scene, the new enhanced engine has already supported both SQL and Piped Processing Language. Please find more details in [SQL Engine V2 - Release Notes](/docs/dev/NewSQLEngine.md).
+Recently we have been actively improving our query engine primarily for better correctness and extensibility. Behind the scene, the new enhanced engine has already supported both SQL and Piped Processing Language. Please find more details in [SQL Engine V2 - Release Notes](./docs/dev/NewSQLEngine.md).
 
 
 ## Documentation

--- a/docs/dev/NewSQLEngine.md
+++ b/docs/dev/NewSQLEngine.md
@@ -12,23 +12,23 @@ The current SQL query engine provides users the basic query capability for using
 With the architecture and extensibility improved significantly, the following SQL features are able to be introduced in the new query engine:
 
 * **Language Structure**
-    * [Identifiers](/docs/user/general/identifiers.rst): added support for identifier names with special characters
-    * [Data types](/docs/user/general/datatypes.rst): added support for date and interval types
-    * [Expressions](/docs/user/dql/expressions.rst): complex nested expression support
-    * [SQL functions](/docs/user/dql/functions.rst): more date function support, `ADDDATE`, `DATE_ADD`, `DATE_SUB`, `DAY`, `DAYNAME`, `DAYOFMONTH`, `DAYOFWEEK`, `DAYOFYEAR`, `FROM_DAYS`, `HOUR`, `MICROSECOND`, `MINUTE`, `QUARTER`, `SECOND`, `SUBDATE`, `TIME`, `TIME_TO_SEC`, `TO_DAYS`, `WEEK`
-    * [Comments](/docs/user/general/comments.rst): SQL comment support
+    * [Identifiers](../../docs/user/general/identifiers.rst): added support for identifier names with special characters
+    * [Data types](../../docs/user/general/datatypes.rst): added support for date and interval types
+    * [Expressions](../../docs/user/dql/expressions.rst): complex nested expression support
+    * [SQL functions](../../docs/user/dql/functions.rst): more date function support, `ADDDATE`, `DATE_ADD`, `DATE_SUB`, `DAY`, `DAYNAME`, `DAYOFMONTH`, `DAYOFWEEK`, `DAYOFYEAR`, `FROM_DAYS`, `HOUR`, `MICROSECOND`, `MINUTE`, `QUARTER`, `SECOND`, `SUBDATE`, `TIME`, `TIME_TO_SEC`, `TO_DAYS`, `WEEK`
+    * [Comments](../../docs/user/general/comments.rst): SQL comment support
 * **Basic queries**
-    * [HAVING without GROUP BY clause](/docs/user/dql/aggregations.rst#having-without-group-by)
-    * [Aggregate over arbitrary expression](/docs/user/dql/aggregations.rst#expression)
-    * [Ordering by NULLS FIRST/LAST](/docs/user/dql/basics.rst#example-2-specifying-order-for-null)
-    * [Ordering by aggregate function](/docs/user/dql/basics.rst#example-3-ordering-by-aggregate-functions)
+    * [HAVING without GROUP BY clause](../../docs/user/dql/aggregations.rst#having-without-group-by)
+    * [Aggregate over arbitrary expression](../../docs/user/dql/aggregations.rst#expression)
+    * [Ordering by NULLS FIRST/LAST](../../docs/user/dql/basics.rst#example-2-specifying-order-for-null)
+    * [Ordering by aggregate function](../../docs/user/dql/basics.rst#example-3-ordering-by-aggregate-functions)
 * **Complex queries**
-    * [Subqueries in FROM clause](/docs/user/dql/complex.rst#example-2-subquery-in-from-clause): support arbitrary nesting level and aggregation
+    * [Subqueries in FROM clause](../../docs/user/dql/complex.rst#example-2-subquery-in-from-clause): support arbitrary nesting level and aggregation
 * **Advanced Features**
-    * [Window functions](/docs/user/dql/window.rst): ranking and aggregate window functions
-    * [Selective aggregation](/docs/user/dql/aggregations.rst#filter-clause): by standard `FILTER` function
+    * [Window functions](../../docs/user/dql/window.rst): ranking and aggregate window functions
+    * [Selective aggregation](../../docs/user/dql/aggregations.rst#filter-clause): by standard `FILTER` function
 * **Beyond SQL**
-    * [Semi-structured data query](/docs/user/beyond/partiql.rst#example-2-selecting-deeper-levels): support querying OpenSearch object fields on arbitrary level
+    * [Semi-structured data query](../../docs/user/beyond/partiql.rst#example-2-selecting-deeper-levels): support querying OpenSearch object fields on arbitrary level
     * OpenSearch multi-field: handled automatically and users won't have the access, ex. `text` is converted to `text.keyword` if it’s a multi-field
 
 As for correctness, besides full coverage of unit and integration test, we developed a new comparison test framework to ensure correctness by comparing with other databases. Please find more details in [Testing](./Testing.md).
@@ -57,7 +57,7 @@ For the following features unsupported in the new engine, the query will be forw
 
 ### 3.3 Limitations
 
-You can find all the limitations in [Limitations](/docs/user/limitations/limitations.rst). 
+You can find all the limitations in [Limitations](../../docs/user/limitations/limitations.rst). 
 
 
 ---

--- a/release-notes/opensearch-sql.release-notes-1.1.0.0.md
+++ b/release-notes/opensearch-sql.release-notes-1.1.0.0.md
@@ -22,3 +22,4 @@ Compatible with OpenSearch and OpenSearch Dashboards Version 1.1.0
 * Use externally-defined OpenSearch version when specified. ([#179](https://github.com/opensearch-project/sql/pull/179))
 * Use OpenSearch 1.1 and build snapshot by default in CI. ([#181](https://github.com/opensearch-project/sql/pull/181))
 * Workbench: remove curl commands in integtest.sh ([#200](https://github.com/opensearch-project/sql/pull/200))
+* Bump opensearch ref to 1.1 in CI ([#205](https://github.com/opensearch-project/dashboards-reports/pull/205))

--- a/sql-cli/CONTRIBUTING.md
+++ b/sql-cli/CONTRIBUTING.md
@@ -58,11 +58,11 @@ If you've thought of a way that OpenSearch could be better, we want to hear abou
 
 As with other types of contributions, the first step is to [**open an issue on GitHub**](https://github.com/opensearch-project/OpenSearch/issues/new/choose).  Opening an issue before you make changes makes sure that someone else isn't already working on that particular problem.  It also lets us all work together to find the right approach before you spend a bunch of time on a PR.  So again, when in doubt, open an issue.
 
-Once you've opened an issue, check out our [Developer Guide](./DEVELOPER_GUIDE.md) for instructions on how to get started.
+Once you've opened an issue, check out our [Developer Guide](../DEVELOPER_GUIDE.rst) for instructions on how to get started.
 
 ## Developer Certificate of Origin
 
-OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache site](https://www.apache.org/licenses/LICENSE-2.0) or the [LICENSE.txt file](./LICENSE.txt)).  The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
+OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache site](https://www.apache.org/licenses/LICENSE-2.0) or the [LICENSE.txt file](../LICENSE.txt)).  The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
 
 We respect intellectual property rights of others and we want to make sure all incoming contributions are correctly attributed and licensed. A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
 

--- a/sql-cli/README.md
+++ b/sql-cli/README.md
@@ -123,7 +123,7 @@ Run single query from command line with options
 
 ## Code of Conduct
 
-This project has adopted an [Open Source Code of Conduct](/CODE_OF_CONDUCT.md).
+This project has adopted an [Open Source Code of Conduct](./CODE_OF_CONDUCT.md).
 
 
 
@@ -133,7 +133,7 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](/LICENSE.TXT) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](./LICENSE.TXT) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 
 

--- a/sql-jdbc/CONTRIBUTING.md
+++ b/sql-jdbc/CONTRIBUTING.md
@@ -20,7 +20,7 @@ reported the issue. Please try to include as much information as you can. Detail
 * Anything unusual about your environment or deployment
 
 ## Sign your work
-OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache site](https://www.apache.org/licenses/LICENSE-2.0) or the [LICENSE.txt file](./LICENSE.txt)).  The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
+OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache site](https://www.apache.org/licenses/LICENSE-2.0) or the [LICENSE.txt file](../LICENSE.txt)).  The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
 
 We respect intellectual property rights of others and we want to make sure all incoming contributions are correctly attributed and licensed. A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
 

--- a/sql-odbc/CONTRIBUTING.md
+++ b/sql-odbc/CONTRIBUTING.md
@@ -20,7 +20,7 @@ reported the issue. Please try to include as much information as you can. Detail
 * Anything unusual about your environment or deployment
 
 ## Sign your work
-OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache site](https://www.apache.org/licenses/LICENSE-2.0) or the [LICENSE.txt file](./LICENSE.txt)).  The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
+OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache site](https://www.apache.org/licenses/LICENSE-2.0) or the [LICENSE.txt file](../LICENSE.txt)).  The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
 
 We respect intellectual property rights of others and we want to make sure all incoming contributions are correctly attributed and licensed. A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
 

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -28,7 +28,7 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## License
 
-This project is licensed under the [Apache v2.0 License](LICENSE.txt).
+This project is licensed under the [Apache v2.0 License](../LICENSE.txt).
 
 ## Copyright
 

--- a/workbench/release-notes/sql-workbench.release-notes-1.7.0.0.md
+++ b/workbench/release-notes/sql-workbench.release-notes-1.7.0.0.md
@@ -18,7 +18,7 @@ To use the SQL Workbench, you will need the [Open Distro SQL plugin](https://git
 - Updated configureation for v7.3 compatibility ([#7](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/7))
 - Opendistro-1.3 compatible with ES and Kibana 7.3 ([#8](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/8))
 - Changed kibana version to v7.3.2 ([#9](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/9))
-- Support v7.1.1 Compatibility ([#13](v13))
+- Support v7.1.1 Compatibility ([#13](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/13))
 - Bump pr-branch to v1.3 ([#21](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/21))
 - Support v7.4 compatibility for kibana and sql-plugin ([#23](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/23))
 - Improve the performance by ridding of sending redundant requests ([#24](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/24))


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
- Core has `1.1` branch cut and bumped `1.x` minor version to `1.2`, use opensearch ref to 1.1 in CI
- Ignore 999 status code in link checker for now, possibly caused by github rate limit. Pending fix from upstream `lycheeverse/lychee` issue 234.
- use ubuntu-latest instead of 16.04

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
