### PR TITLE
Support span aggregation in SQL/PPL query engine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/NamedExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/NamedExpressionAnalyzer.java
@@ -32,9 +32,11 @@ import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.Span;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.span.SpanExpression;
 
 /**
  * Analyze the Alias node in the {@link AnalysisContext} to construct the list of
@@ -59,6 +61,15 @@ public class NamedExpressionAnalyzer extends
         unqualifiedNameIfFieldOnly(node, context),
         node.getDelegated().accept(expressionAnalyzer, context),
         node.getAlias());
+  }
+
+  @Override
+  public NamedExpression visitSpan(Span node, AnalysisContext context) {
+    SpanExpression spanExpression = new SpanExpression(
+        node.getField().accept(expressionAnalyzer, context),
+        node.getValue().accept(expressionAnalyzer, context),
+        node.getUnit());
+    return DSL.named(node.toString(), spanExpression, null);
   }
 
   private String unqualifiedNameIfFieldOnly(Alias node, AnalysisContext context) {

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -46,6 +46,7 @@ import org.opensearch.sql.ast.expression.Map;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.Span;
 import org.opensearch.sql.ast.expression.UnresolvedArgument;
 import org.opensearch.sql.ast.expression.UnresolvedAttribute;
 import org.opensearch.sql.ast.expression.When;
@@ -247,6 +248,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitLimit(Limit node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitSpan(Span node, C context) {
     return visitChildren(node, context);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -50,6 +50,8 @@ import org.opensearch.sql.ast.expression.Map;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.Span;
+import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.expression.UnresolvedArgument;
 import org.opensearch.sql.ast.expression.UnresolvedAttribute;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
@@ -379,6 +381,10 @@ public class AstDSL {
 
   public static List<Argument> defaultSortFieldArgs() {
     return exprList(argument("asc", booleanLiteral(true)), argument("type", nullLiteral()));
+  }
+
+  public static Span span(UnresolvedExpression field, UnresolvedExpression value, SpanUnit unit) {
+    return new Span(field, value, unit);
   }
 
   public static Sort sort(UnresolvedPlan input, Field... sorts) {

--- a/core/src/main/java/org/opensearch/sql/ast/expression/Span.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/Span.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.ast.expression;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+
+/**
+ * Span expression node.
+ * Params include field expression and the span value.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@ToString
+public class Span extends UnresolvedExpression {
+  private final UnresolvedExpression field;
+  private final UnresolvedExpression value;
+  private final SpanUnit unit;
+
+  @Override
+  public List<UnresolvedExpression> getChild() {
+    return ImmutableList.of(field, value);
+  }
+
+  @Override
+  public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
+    return nodeVisitor.visitSpan(this, context);
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.ast.expression;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SpanUnit {
+  UNKNOWN("unknown"),
+  NONE(""),
+  MICROSECOND("ms"),
+  MS("ms"),
+  SECOND("s"),
+  S("s"),
+  MINUTE("m"),
+  m("m"),
+  HOUR("h"),
+  H("h"),
+  DAY("d"),
+  D("d"),
+  WEEK("w"),
+  W("w"),
+  MONTH("M"),
+  M("M"),
+  QUARTER("q"),
+  Q("q"),
+  YEAR("y"),
+  Y("y");
+
+  private final String name;
+  private static final List<SpanUnit> SPAN_UNITS;
+
+  static {
+    ImmutableList.Builder<SpanUnit> builder = ImmutableList.builder();
+    SPAN_UNITS = builder.add(SpanUnit.values()).build();
+  }
+
+  /**
+   * Util method to get span unit given the unit name.
+   */
+  public static SpanUnit of(String unit) {
+    switch (unit) {
+      case "":
+        return NONE;
+      case "M":
+        return M;
+      case "m":
+        return m;
+      default:
+        return SPAN_UNITS.stream()
+            .filter(v -> unit.equalsIgnoreCase(v.name()))
+            .findFirst()
+            .orElse(UNKNOWN);
+    }
+  }
+
+  public static String getName(SpanUnit unit) {
+    return unit.name;
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 public enum SpanUnit {
   UNKNOWN("unknown"),
   NONE(""),
-  MICROSECOND("ms"),
+  MILLISECOND("ms"),
   MS("ms"),
   SECOND("s"),
   S("s"),

--- a/core/src/main/java/org/opensearch/sql/data/model/AbstractExprNumberValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/AbstractExprNumberValue.java
@@ -74,6 +74,11 @@ public abstract class AbstractExprNumberValue extends AbstractExprValue {
   }
 
   @Override
+  public String stringValue() {
+    return value.toString();
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hashCode(value);
   }

--- a/core/src/main/java/org/opensearch/sql/data/model/AbstractExprNumberValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/AbstractExprNumberValue.java
@@ -74,11 +74,6 @@ public abstract class AbstractExprNumberValue extends AbstractExprValue {
   }
 
   @Override
-  public String stringValue() {
-    return value.toString();
-  }
-
-  @Override
   public int hashCode() {
     return Objects.hashCode(value);
   }

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprValueUtils.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprValueUtils.java
@@ -86,7 +86,8 @@ public class ExprValueUtils {
    */
   public static ExprValue tupleValue(Map<String, Object> map) {
     LinkedHashMap<String, ExprValue> valueMap = new LinkedHashMap<>();
-    map.forEach((k, v) -> valueMap.put(k, fromObjectValue(v)));
+    map.forEach((k, v) -> valueMap
+        .put(k, v instanceof ExprValue ? (ExprValue) v : fromObjectValue(v)));
     return new ExprTupleValue(valueMap);
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -29,6 +29,7 @@ package org.opensearch.sql.expression;
 import java.util.Arrays;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.data.model.ExprShortValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
@@ -39,6 +40,7 @@ import org.opensearch.sql.expression.conditional.cases.CaseClause;
 import org.opensearch.sql.expression.conditional.cases.WhenClause;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.span.SpanExpression;
 import org.opensearch.sql.expression.window.ranking.RankingWindowFunction;
 
 @RequiredArgsConstructor
@@ -126,6 +128,10 @@ public class DSL {
 
   public static NamedAggregator named(String name, Aggregator aggregator) {
     return new NamedAggregator(name, aggregator);
+  }
+
+  public static SpanExpression span(Expression field, Expression value, String unit) {
+    return new SpanExpression(field, value, SpanUnit.of(unit));
   }
 
   public FunctionExpression abs(Expression... expressions) {

--- a/core/src/main/java/org/opensearch/sql/expression/ExpressionNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/expression/ExpressionNodeVisitor.java
@@ -27,6 +27,7 @@
 
 package org.opensearch.sql.expression;
 
+import org.opensearch.sql.ast.expression.Span;
 import org.opensearch.sql.expression.aggregation.Aggregator;
 import org.opensearch.sql.expression.aggregation.NamedAggregator;
 import org.opensearch.sql.expression.conditional.cases.CaseClause;

--- a/core/src/main/java/org/opensearch/sql/expression/span/SpanExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/span/SpanExpression.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.expression.span;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.expression.SpanUnit;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ExpressionNodeVisitor;
+import org.opensearch.sql.expression.env.Environment;
+
+@RequiredArgsConstructor
+@Getter
+@ToString
+public class SpanExpression implements Expression {
+  private final Expression field;
+  private final Expression value;
+  private final SpanUnit unit;
+
+  @Override
+  public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+    return value.valueOf(valueEnv);
+  }
+
+  @Override
+  public ExprType type() {
+    return field.type();
+  }
+
+  @Override
+  public <T, C> T accept(ExpressionNodeVisitor<T, C> visitor, C context) {
+    return visitor.visitNode(this, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/span/SpanExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/span/SpanExpression.java
@@ -46,7 +46,9 @@ public class SpanExpression implements Expression {
    */
   @Override
   public ExprType type() {
-    if (value.type().isCompatible(field.type())) {
+    if (field.type().isCompatible(value.type())) {
+      return field.type();
+    } else if (value.type().isCompatible(field.type())) {
       return value.type();
     } else {
       return field.type();

--- a/core/src/main/java/org/opensearch/sql/expression/span/SpanExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/span/SpanExpression.java
@@ -35,9 +35,22 @@ public class SpanExpression implements Expression {
     return value.valueOf(valueEnv);
   }
 
+  /**
+   * Return type follows the following table.
+   *  FIELD         VALUE     RETURN_TYPE
+   *  int/long      integer   int/long (field type)
+   *  int/long      double    double
+   *  float/double  integer   float/double (field type)
+   *  float/double  double    float/double (field type)
+   *  other         any       field type
+   */
   @Override
   public ExprType type() {
-    return field.type();
+    if (value.type().isCompatible(field.type())) {
+      return value.type();
+    } else {
+      return field.type();
+    }
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/planner/physical/AggregationOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/AggregationOperator.java
@@ -117,7 +117,7 @@ public class AggregationOperator extends PhysicalPlan {
   @RequiredArgsConstructor
   public class Group {
 
-    private final Map<GroupKey, List<Map.Entry<NamedAggregator, AggregationState>>> groupListMap =
+    protected final Map<GroupKey, List<Map.Entry<NamedAggregator, AggregationState>>> groupListMap =
         new HashMap<>();
 
     /**

--- a/core/src/main/java/org/opensearch/sql/planner/physical/AggregationOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/AggregationOperator.java
@@ -26,28 +26,20 @@
 
 package org.opensearch.sql.planner.physical;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
-import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.NamedExpression;
-import org.opensearch.sql.expression.aggregation.AggregationState;
 import org.opensearch.sql.expression.aggregation.Aggregator;
 import org.opensearch.sql.expression.aggregation.NamedAggregator;
+import org.opensearch.sql.expression.span.SpanExpression;
+import org.opensearch.sql.planner.physical.bucket.Group;
+import org.opensearch.sql.planner.physical.bucket.SpanBucket;
 import org.opensearch.sql.storage.bindingtuple.BindingTuple;
 
 /**
@@ -80,7 +72,8 @@ public class AggregationOperator extends PhysicalPlan {
     this.input = input;
     this.aggregatorList = aggregatorList;
     this.groupByExprList = groupByExprList;
-    this.group = new Group();
+    this.group = groupBySpan(groupByExprList) ? new SpanBucket(aggregatorList, groupByExprList)
+        : new Group(aggregatorList, groupByExprList);
   }
 
   @Override
@@ -113,79 +106,9 @@ public class AggregationOperator extends PhysicalPlan {
     iterator = group.result().iterator();
   }
 
-  @VisibleForTesting
-  @RequiredArgsConstructor
-  public class Group {
-
-    protected final Map<GroupKey, List<Map.Entry<NamedAggregator, AggregationState>>> groupListMap =
-        new HashMap<>();
-
-    /**
-     * Push the BindingTuple to Group. Two functions will be applied to each BindingTuple to
-     * generate the {@link GroupKey} and {@link AggregationState}
-     * Key = GroupKey(bindingTuple), State = Aggregator(bindingTuple)
-     */
-    public void push(ExprValue inputValue) {
-      GroupKey groupKey = new GroupKey(inputValue);
-      groupListMap.computeIfAbsent(groupKey, k ->
-          aggregatorList.stream()
-              .map(aggregator -> new AbstractMap.SimpleEntry<>(aggregator,
-                  aggregator.create()))
-              .collect(Collectors.toList())
-      );
-      groupListMap.computeIfPresent(groupKey, (key, aggregatorList) -> {
-        aggregatorList
-            .forEach(entry -> entry.getKey().iterate(inputValue.bindingTuples(), entry.getValue()));
-        return aggregatorList;
-      });
-    }
-
-    /**
-     * Get the list of {@link BindingTuple} for each group.
-     */
-    public List<ExprValue> result() {
-      ImmutableList.Builder<ExprValue> resultBuilder = new ImmutableList.Builder<>();
-      for (Map.Entry<GroupKey, List<Map.Entry<NamedAggregator, AggregationState>>>
-          entry : groupListMap.entrySet()) {
-        LinkedHashMap<String, ExprValue> map = new LinkedHashMap<>();
-        map.putAll(entry.getKey().groupKeyMap());
-        for (Map.Entry<NamedAggregator, AggregationState> stateEntry : entry.getValue()) {
-          map.put(stateEntry.getKey().getName(), stateEntry.getValue().result());
-        }
-        resultBuilder.add(ExprTupleValue.fromExprValueMap(map));
-      }
-      return resultBuilder.build();
-    }
+  private boolean groupBySpan(List<NamedExpression> namedExpressionList) {
+    return namedExpressionList.size() == 1
+        && namedExpressionList.get(0).getDelegated() instanceof SpanExpression;
   }
 
-  /**
-   * Group Key.
-   */
-  @EqualsAndHashCode
-  @VisibleForTesting
-  public class GroupKey {
-
-    private final List<ExprValue> groupByValueList;
-
-    /**
-     * GroupKey constructor.
-     */
-    public GroupKey(ExprValue value) {
-      this.groupByValueList = new ArrayList<>();
-      for (Expression groupExpr : groupByExprList) {
-        this.groupByValueList.add(groupExpr.valueOf(value.bindingTuples()));
-      }
-    }
-
-    /**
-     * Return the Map of group field and group field value.
-     */
-    public LinkedHashMap<String, ExprValue> groupKeyMap() {
-      LinkedHashMap<String, ExprValue> map = new LinkedHashMap<>();
-      for (int i = 0; i < groupByExprList.size(); i++) {
-        map.put(groupByExprList.get(i).getNameOrAlias(), groupByValueList.get(i));
-      }
-      return map;
-    }
-  }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/bucket/Group.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/bucket/Group.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.planner.physical.bucket;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.aggregation.AggregationState;
+import org.opensearch.sql.expression.aggregation.NamedAggregator;
+import org.opensearch.sql.storage.bindingtuple.BindingTuple;
+
+@VisibleForTesting
+@RequiredArgsConstructor
+public class Group {
+  @Getter
+  private final List<NamedAggregator> aggregatorList;
+  @Getter
+  private final List<NamedExpression> groupByExprList;
+
+  protected final Map<Key, List<Map.Entry<NamedAggregator, AggregationState>>> groupListMap =
+      new HashMap<>();
+
+  /**
+   * Push the BindingTuple to Group. Two functions will be applied to each BindingTuple to
+   * generate the {@link Key} and {@link AggregationState}
+   * Key = GroupKey(bindingTuple), State = Aggregator(bindingTuple)
+   */
+  public void push(ExprValue inputValue) {
+    Key groupKey = new Key(inputValue, groupByExprList);
+    groupListMap.computeIfAbsent(groupKey, k ->
+        aggregatorList.stream()
+            .map(aggregator -> new AbstractMap.SimpleEntry<>(aggregator,
+                aggregator.create()))
+            .collect(Collectors.toList())
+    );
+    groupListMap.computeIfPresent(groupKey, (key, aggregatorList) -> {
+      aggregatorList
+          .forEach(entry -> entry.getKey().iterate(inputValue.bindingTuples(), entry.getValue()));
+      return aggregatorList;
+    });
+  }
+
+  /**
+   * Get the list of {@link BindingTuple} for each group.
+   */
+  public List<ExprValue> result() {
+    ImmutableList.Builder<ExprValue> resultBuilder = new ImmutableList.Builder<>();
+    for (Map.Entry<Key, List<Map.Entry<NamedAggregator, AggregationState>>>
+        entry : groupListMap.entrySet()) {
+      LinkedHashMap<String, ExprValue> map = new LinkedHashMap<>(entry.getKey().groupKeyMap());
+      for (Map.Entry<NamedAggregator, AggregationState> stateEntry : entry.getValue()) {
+        map.put(stateEntry.getKey().getName(), stateEntry.getValue().result());
+      }
+      resultBuilder.add(ExprTupleValue.fromExprValueMap(map));
+    }
+    return resultBuilder.build();
+  }
+
+  /**
+   * Group Key.
+   */
+  @EqualsAndHashCode
+  @VisibleForTesting
+  public static class Key {
+    private final List<ExprValue> groupByValueList;
+    private final List<NamedExpression> groupByExprList;
+
+    /**
+     * GroupKey constructor.
+     */
+    public Key(ExprValue value, List<NamedExpression> groupByExprList) {
+      this.groupByValueList = new ArrayList<>();
+      this.groupByExprList = groupByExprList;
+      for (Expression groupExpr : groupByExprList) {
+        this.groupByValueList.add(groupExpr.valueOf(value.bindingTuples()));
+      }
+    }
+
+    /**
+     * Return the Map of group field and group field value.
+     */
+    public LinkedHashMap<String, ExprValue> groupKeyMap() {
+      LinkedHashMap<String, ExprValue> map = new LinkedHashMap<>();
+      for (int i = 0; i < groupByExprList.size(); i++) {
+        map.put(groupByExprList.get(i).getNameOrAlias(), groupByValueList.get(i));
+      }
+      return map;
+    }
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/bucket/Rounding.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/bucket/Rounding.java
@@ -1,0 +1,641 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.planner.physical.bucket;
+
+import static org.opensearch.sql.data.type.ExprCoreType.DATE;
+import static org.opensearch.sql.data.type.ExprCoreType.DATETIME;
+import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.data.type.ExprCoreType.TIME;
+import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.span.SpanExpression;
+import org.opensearch.sql.utils.DateTimeUtils;
+
+/**
+ * Rounding.
+ */
+@EqualsAndHashCode
+public abstract class Rounding<T> {
+  @Getter
+  protected T maxRounded;
+  @Getter
+  protected T minRounded;
+
+  /**
+   * Create Rounding instance.
+   */
+  public static Rounding<?> createRounding(SpanExpression span) {
+    ExprValue interval = span.getValue().valueOf(null);
+    ExprType type = span.type();
+
+    if (LONG.isCompatible(type)) {
+      return new LongRounding(interval);
+    }
+    if (DOUBLE.isCompatible(type)) {
+      return new DoubleRounding(interval);
+    }
+    if (type.equals(DATETIME)) {
+      return new DatetimeRounding(interval, span.getUnit().getName());
+    }
+    if (type.equals(TIMESTAMP)) {
+      return new TimestampRounding(interval, span.getUnit().getName());
+    }
+    if (type.equals(DATE)) {
+      return new DateRounding(interval, span.getUnit().getName());
+    }
+    if (type.equals(TIME)) {
+      return new TimeRounding(interval, span.getUnit().getName());
+    }
+    return new UnknownRounding();
+  }
+
+  public abstract ExprValue round(ExprValue value);
+
+  public abstract Integer locate(ExprValue value);
+
+  public abstract ExprValue[] createBuckets();
+
+  public abstract ExprValue[] fillBuckets(ExprValue[] buckets, Map<String, ExprValue> map,
+                                          String key);
+
+
+  static class TimestampRounding extends Rounding<Instant> {
+    private final ExprValue interval;
+    private final DateTimeUnit dateTimeUnit;
+
+    public TimestampRounding(ExprValue interval, String unit) {
+      this.interval = interval;
+      this.dateTimeUnit = DateTimeUnit.resolve(unit);
+    }
+
+    @Override
+    public ExprValue round(ExprValue var) {
+      Instant instant = Instant.ofEpochMilli(dateTimeUnit.round(var.timestampValue()
+          .toEpochMilli(), interval.integerValue()));
+      updateRounded(instant);
+      return new ExprTimestampValue(instant);
+    }
+
+    @Override
+    public ExprValue[] createBuckets() {
+      if (dateTimeUnit.isMillisBased) {
+        int size = (int) ((maxRounded.toEpochMilli() - minRounded.toEpochMilli()) / (interval
+            .integerValue() * dateTimeUnit.ratio)) + 1;
+        return new ExprValue[size];
+      } else {
+        ZonedDateTime maxZonedDateTime = maxRounded.atZone(ZoneId.of("UTC"));
+        ZonedDateTime minZonedDateTime = minRounded.atZone(ZoneId.of("UTC"));
+        int monthDiff = (maxZonedDateTime.getYear() - minZonedDateTime
+            .getYear()) * 12 + maxZonedDateTime.getMonthValue() - minZonedDateTime.getMonthValue();
+        int size = monthDiff / ((int) dateTimeUnit.ratio * interval.integerValue()) + 1;
+        return new ExprValue[size];
+      }
+    }
+
+    @Override
+    public ExprValue[] fillBuckets(ExprValue[] buckets,
+                                   Map<String, ExprValue> map,
+                                   String key) {
+      for (int id = 0; id < buckets.length; id++) {
+        ExprValue tuple = buckets[id];
+        if (tuple == null) {
+          long placeHolder;
+          if (dateTimeUnit.isMillisBased) {
+            placeHolder = minRounded.toEpochMilli() + dateTimeUnit.ratio * interval
+                .integerValue() * id;
+          } else {
+            placeHolder = minRounded.atZone(ZoneId.of("UTC")).plusMonths(dateTimeUnit
+                .ratio * interval.integerValue()).toInstant().toEpochMilli();
+          }
+          map.replace(key, new ExprTimestampValue(Instant.ofEpochMilli(placeHolder)));
+          buckets[id] = ExprTupleValue.fromExprValueMap(map);
+        }
+      }
+      return buckets;
+    }
+
+    @Override
+    public Integer locate(ExprValue value) {
+      if (dateTimeUnit.isMillisBased) {
+        long intervalInEpochMillis = dateTimeUnit.ratio;
+        return Long.valueOf((value.timestampValue()
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli() - minRounded
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()) / (intervalInEpochMillis
+            * interval.integerValue())).intValue();
+      } else {
+        int monthDiff = (value.dateValue().getYear() - minRounded.atZone(ZoneId.of("UTC"))
+            .getYear()) * 12 + value.dateValue().getMonthValue() - minRounded
+            .atZone(ZoneId.of("UTC")).getMonthValue();
+        return (int) (monthDiff / (dateTimeUnit.ratio * interval.integerValue()));
+      }
+    }
+
+    private void updateRounded(Instant value) {
+      if (maxRounded == null || value.isAfter(maxRounded)) {
+        maxRounded = value;
+      }
+      if (minRounded == null || value.isBefore(minRounded)) {
+        minRounded = value;
+      }
+    }
+  }
+
+
+  static class DatetimeRounding extends Rounding<LocalDateTime> {
+    private final ExprValue interval;
+    private final DateTimeUnit dateTimeUnit;
+
+    public DatetimeRounding(ExprValue interval, String unit) {
+      this.interval = interval;
+      this.dateTimeUnit = DateTimeUnit.resolve(unit);
+    }
+
+    @Override
+    public ExprValue round(ExprValue var) {
+      Instant instant = Instant.ofEpochMilli(dateTimeUnit.round(var.datetimeValue()
+          .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli(), interval.integerValue()));
+      updateRounded(instant);
+      return new ExprDatetimeValue(instant.atZone(ZoneId.of("UTC")).toLocalDateTime());
+    }
+
+    @Override
+    public ExprValue[] createBuckets() {
+      if (dateTimeUnit.isMillisBased) {
+        int size = (int) ((maxRounded.atZone(ZoneId.of("UTC")).toInstant()
+            .toEpochMilli() - minRounded.atZone(ZoneId.of("UTC")).toInstant()
+            .toEpochMilli()) / (interval.integerValue() * dateTimeUnit.ratio)) + 1;
+        return new ExprValue[size];
+      } else {
+        ZonedDateTime maxZonedDateTime = maxRounded.atZone(ZoneId.of("UTC"));
+        ZonedDateTime minZonedDateTime = minRounded.atZone(ZoneId.of("UTC"));
+        int monthDiff = (maxZonedDateTime.getYear() - minZonedDateTime
+            .getYear()) * 12 + maxZonedDateTime.getMonthValue() - minZonedDateTime.getMonthValue();
+        int size = monthDiff / ((int) dateTimeUnit.ratio * interval.integerValue()) + 1;
+        return new ExprValue[size];
+      }
+    }
+
+    @Override
+    public ExprValue[] fillBuckets(ExprValue[] buckets,
+                                   Map<String, ExprValue> map,
+                                   String key) {
+      for (int id = 0; id < buckets.length; id++) {
+        ExprValue tuple = buckets[id];
+        if (tuple == null) {
+          long placeHolder;
+          if (dateTimeUnit.isMillisBased) {
+            placeHolder = minRounded.atZone(ZoneId.of("UTC")).toInstant()
+                .toEpochMilli() + dateTimeUnit.ratio * interval.integerValue() * id;
+          } else {
+            placeHolder = minRounded.atZone(ZoneId.of("UTC")).plusMonths(dateTimeUnit
+                .ratio * interval.integerValue() * id).toInstant().toEpochMilli();
+          }
+          map.replace(key, new ExprDatetimeValue(Instant.ofEpochMilli(placeHolder)
+              .atZone(ZoneId.of("UTC")).toLocalDateTime()));
+          buckets[id] = ExprTupleValue.fromExprValueMap(map);
+        }
+      }
+      return buckets;
+    }
+
+    @Override
+    public Integer locate(ExprValue value) {
+      if (dateTimeUnit.isMillisBased) {
+        long intervalInEpochMillis = dateTimeUnit.ratio;
+        return Long.valueOf((value.datetimeValue()
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli() - minRounded
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()) / (intervalInEpochMillis
+            * interval.integerValue())).intValue();
+      } else {
+        int monthDiff = (value.datetimeValue().getYear() - minRounded.getYear()) * 12
+            + value.dateValue().getMonthValue() - minRounded.getMonthValue();
+        return (int) (monthDiff / (dateTimeUnit.ratio * interval.integerValue()));
+      }
+    }
+
+    private void updateRounded(Instant value) {
+      if (maxRounded == null || value.isAfter(maxRounded
+          .atZone(ZoneId.of("UTC")).toInstant())) {
+        maxRounded = value.atZone(ZoneId.of("UTC")).toLocalDateTime();
+      }
+      if (minRounded == null || value.isBefore(minRounded
+          .atZone(ZoneId.of("UTC")).toInstant())) {
+        minRounded = value.atZone(ZoneId.of("UTC")).toLocalDateTime();
+      }
+    }
+  }
+
+
+  static class DateRounding extends Rounding<LocalDate> {
+    private final ExprValue interval;
+    private final DateTimeUnit dateTimeUnit;
+
+    public DateRounding(ExprValue interval, String unit) {
+      this.interval = interval;
+      this.dateTimeUnit = DateTimeUnit.resolve(unit);
+    }
+
+    @Override
+    public ExprValue round(ExprValue var) {
+      Instant instant = Instant.ofEpochMilli(dateTimeUnit.round(var.dateValue().atStartOfDay()
+          .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli(), interval.integerValue()));
+      updateRounded(instant);
+      return new ExprDateValue(instant.atZone(ZoneId.of("UTC")).toLocalDate());
+    }
+
+    @Override
+    public ExprValue[] createBuckets() {
+      if (dateTimeUnit.isMillisBased) {
+        int size = (int) ((maxRounded.atStartOfDay().atZone(ZoneId.of("UTC")).toInstant()
+            .toEpochMilli() - minRounded.atStartOfDay().atZone(ZoneId.of("UTC")).toInstant()
+            .toEpochMilli()) / (interval.integerValue() * dateTimeUnit.ratio)) + 1;
+        return new ExprValue[size];
+      } else {
+        ZonedDateTime maxZonedDateTime = maxRounded.atStartOfDay().atZone(ZoneId.of("UTC"));
+        ZonedDateTime minZonedDateTime = minRounded.atStartOfDay().atZone(ZoneId.of("UTC"));
+        int monthDiff = (maxZonedDateTime.getYear() - minZonedDateTime
+            .getYear()) * 12 + maxZonedDateTime.getMonthValue() - minZonedDateTime.getMonthValue();
+        int size = monthDiff / ((int) dateTimeUnit.ratio * interval.integerValue()) + 1;
+        return new ExprValue[size];
+      }
+    }
+
+    @Override
+    public ExprValue[] fillBuckets(ExprValue[] buckets,
+                                   Map<String, ExprValue> map,
+                                   String key) {
+      for (int id = 0; id < buckets.length; id++) {
+        ExprValue tuple = buckets[id];
+        if (tuple == null) {
+          long placeHolder;
+          if (dateTimeUnit.isMillisBased) {
+            placeHolder = minRounded.atStartOfDay().atZone(ZoneId.of("UTC")).toInstant()
+                .toEpochMilli() + dateTimeUnit.ratio * interval.integerValue() * id;
+          } else {
+            placeHolder = minRounded.atStartOfDay().atZone(ZoneId.of("UTC"))
+                .plusMonths(dateTimeUnit.ratio * interval.integerValue()).toInstant()
+                .toEpochMilli();
+          }
+          map.replace(key, new ExprDateValue(Instant.ofEpochMilli(placeHolder)
+              .atZone(ZoneId.of("UTC")).toLocalDate()));
+          buckets[id] = ExprTupleValue.fromExprValueMap(map);
+        }
+      }
+      return buckets;
+    }
+
+    @Override
+    public Integer locate(ExprValue value) {
+      if (dateTimeUnit.isMillisBased) {
+        long intervalInEpochMillis = dateTimeUnit.ratio;
+        return Long.valueOf((value.dateValue().atStartOfDay()
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli() - minRounded.atStartOfDay()
+            .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()) / (intervalInEpochMillis
+            * interval.integerValue())).intValue();
+      } else {
+        int monthDiff = (value.dateValue().getYear() - minRounded.getYear()) * 12
+            + value.dateValue().getMonthValue() - minRounded.getMonthValue();
+        return (int) (monthDiff / (dateTimeUnit.ratio * interval.integerValue()));
+      }
+    }
+
+    private void updateRounded(Instant value) {
+      if (maxRounded == null || value.isAfter(maxRounded.atStartOfDay()
+          .atZone(ZoneId.of("UTC")).toInstant())) {
+        maxRounded = value.atZone(ZoneId.of("UTC")).toLocalDate();
+      }
+      if (minRounded == null || value.isBefore(minRounded.atStartOfDay()
+          .atZone(ZoneId.of("UTC")).toInstant())) {
+        minRounded = value.atZone(ZoneId.of("UTC")).toLocalDate();
+      }
+    }
+  }
+
+  static class TimeRounding extends Rounding<LocalTime> {
+    private final ExprValue interval;
+    private final DateTimeUnit dateTimeUnit;
+
+    public TimeRounding(ExprValue interval, String unit) {
+      this.interval = interval;
+      this.dateTimeUnit = DateTimeUnit.resolve(unit);
+    }
+
+    @Override
+    public ExprValue round(ExprValue var) {
+      if (dateTimeUnit.id > 4) {
+        throw new ExpressionEvaluationException(String
+            .format("Unable to set span unit %s for TIME type", dateTimeUnit.getName()));
+      }
+
+      Instant instant = Instant.ofEpochMilli(dateTimeUnit.round(var.timeValue().getLong(
+          ChronoField.MILLI_OF_DAY), interval.integerValue()));
+      updateRounded(instant);
+      return new ExprTimeValue(instant.atZone(ZoneId.of("UTC")).toLocalTime());
+    }
+
+    @Override
+    public ExprValue[] createBuckets() {
+      // local time is converted to timestamp on 1970-01-01 for aggregations
+      int size = (int) ((maxRounded.atDate(LocalDate.of(1970, 1, 1))
+          .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli() - minRounded
+          .atDate(LocalDate.of(1970, 1, 1)).atZone(ZoneId.of("UTC")).toInstant()
+          .toEpochMilli()) / (interval.integerValue() * dateTimeUnit.ratio)) + 1;
+      return new ExprValue[size];
+    }
+
+    @Override
+    public ExprValue[] fillBuckets(ExprValue[] buckets,
+                                   Map<String, ExprValue> map,
+                                   String key) {
+      for (int id = 0; id < buckets.length; id++) {
+        ExprValue tuple = buckets[id];
+        if (tuple == null) {
+          long placeHolder  = minRounded.atDate(LocalDate.of(1970, 1, 1))
+              .atZone(ZoneId.of("UTC"))
+              .toInstant().toEpochMilli() + dateTimeUnit.ratio * interval.integerValue() * id;
+          map.replace(key, new ExprTimeValue(Instant.ofEpochMilli(placeHolder)
+              .atZone(ZoneId.of("UTC")).toLocalTime()));
+          buckets[id] = ExprTupleValue.fromExprValueMap(map);
+        }
+      }
+      return buckets;
+    }
+
+    @Override
+    public Integer locate(ExprValue value) {
+      long intervalInEpochMillis = dateTimeUnit.ratio;
+      return Long.valueOf((value.timeValue().atDate(LocalDate.of(1970, 1, 1))
+          .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli() - minRounded
+          .atDate(LocalDate.of(1970, 1, 1))
+          .atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()) / (intervalInEpochMillis * interval
+          .integerValue())).intValue();
+    }
+
+    private void updateRounded(Instant value) {
+      if (maxRounded == null || value.isAfter(maxRounded.atDate(LocalDate.of(1970, 1, 1))
+          .atZone(ZoneId.of("UTC")).toInstant())) {
+        maxRounded = value.atZone(ZoneId.of("UTC")).toLocalTime();
+      }
+      if (minRounded == null) {
+        minRounded = value.atZone(ZoneId.of("UTC")).toLocalTime();
+      }
+    }
+  }
+
+
+  static class LongRounding extends Rounding<Long> {
+    private final Long longInterval;
+
+    protected LongRounding(ExprValue interval) {
+      longInterval = interval.longValue();
+    }
+
+    @Override
+    public ExprValue round(ExprValue value) {
+      long rounded = Math.floorDiv(value.longValue(), longInterval) * longInterval;
+      updateRounded(rounded);
+      return ExprValueUtils.longValue(rounded);
+    }
+
+    @Override
+    public Integer locate(ExprValue value) {
+      return Long.valueOf((value.longValue() - minRounded) / longInterval).intValue();
+    }
+
+    @Override
+    public ExprValue[] createBuckets() {
+      int size = Long.valueOf((maxRounded - minRounded) / longInterval).intValue() + 1;
+      return new ExprValue[size];
+    }
+
+    @Override
+    public ExprValue[] fillBuckets(ExprValue[] buckets,
+                                   Map<String, ExprValue> map,
+                                   String key) {
+      for (int id = 0; id < buckets.length; id++) {
+        ExprValue tuple = buckets[id];
+        if (tuple == null) {
+          map.replace(key, ExprValueUtils.longValue(minRounded + longInterval * id));
+          buckets[id] = ExprTupleValue.fromExprValueMap(map);
+        }
+      }
+      return buckets;
+    }
+
+    private void updateRounded(Long value) {
+      if (maxRounded == null || value > maxRounded) {
+        maxRounded = value;
+      }
+      if (minRounded == null || value < minRounded) {
+        minRounded = value;
+      }
+    }
+  }
+
+
+  static class DoubleRounding extends Rounding<Double> {
+    private final Double doubleInterval;
+
+    protected DoubleRounding(ExprValue interval) {
+      doubleInterval = interval.doubleValue();
+    }
+
+    @Override
+    public ExprValue round(ExprValue value) {
+      double rounded = Double
+          .valueOf(value.doubleValue() / doubleInterval).intValue() * doubleInterval;
+      updateRounded(rounded);
+      return ExprValueUtils.doubleValue(rounded);
+    }
+
+    @Override
+    public Integer locate(ExprValue value) {
+      return Double.valueOf((value.doubleValue() - minRounded) / doubleInterval).intValue();
+    }
+
+    @Override
+    public ExprValue[] createBuckets() {
+      int size = Double.valueOf((maxRounded - minRounded) / doubleInterval).intValue() + 1;
+      return new ExprValue[size];
+    }
+
+    @Override
+    public ExprValue[] fillBuckets(ExprValue[] buckets, Map<String, ExprValue> map,
+                                   String key) {
+      for (int id = 0; id < buckets.length; id++) {
+        ExprValue tuple = buckets[id];
+        if (tuple == null) {
+          map.replace(key, ExprValueUtils.doubleValue(minRounded + doubleInterval * id));
+          buckets[id] = ExprTupleValue.fromExprValueMap(map);
+        }
+      }
+      return buckets;
+    }
+
+    private void updateRounded(Double value) {
+      if (maxRounded == null || value > maxRounded) {
+        maxRounded = value;
+      }
+      if (minRounded == null || value < minRounded) {
+        minRounded = value;
+      }
+    }
+  }
+
+
+  @RequiredArgsConstructor
+  static class UnknownRounding extends Rounding<Object> {
+    @Override
+    public ExprValue round(ExprValue var) {
+      return null;
+    }
+
+    @Override
+    public Integer locate(ExprValue value) {
+      return null;
+    }
+
+    @Override
+    public ExprValue[] createBuckets() {
+      return new ExprValue[0];
+    }
+
+    @Override
+    public ExprValue[] fillBuckets(ExprValue[] buckets, Map<String, ExprValue> map,
+                                   String key) {
+      return new ExprValue[0];
+    }
+  }
+
+
+  @RequiredArgsConstructor
+  public enum DateTimeUnit {
+    MILLISECOND(1, "ms", true, ChronoField.MILLI_OF_SECOND
+        .getBaseUnit().getDuration().toMillis()) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundFloor(utcMillis, ratio * interval);
+      }
+    },
+
+    SECOND(2, "s", true, ChronoField.SECOND_OF_MINUTE
+        .getBaseUnit().getDuration().toMillis()) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundFloor(utcMillis, ratio * interval);
+      }
+    },
+
+    MINUTE(3, "m", true, ChronoField.MINUTE_OF_HOUR
+        .getBaseUnit().getDuration().toMillis()) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundFloor(utcMillis, ratio * interval);
+      }
+    },
+
+    HOUR(4, "h", true, ChronoField.HOUR_OF_DAY
+        .getBaseUnit().getDuration().toMillis()) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundFloor(utcMillis, ratio * interval);
+      }
+    },
+
+    DAY(5, "d", true, ChronoField.DAY_OF_MONTH
+        .getBaseUnit().getDuration().toMillis()) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundFloor(utcMillis, ratio * interval);
+      }
+    },
+
+    WEEK(6, "w", true, TimeUnit.DAYS.toMillis(7L)) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundWeek(utcMillis, interval);
+      }
+    },
+
+    MONTH(7, "M", false, 1) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundMonth(utcMillis, interval);
+      }
+    },
+
+    QUARTER(8, "q", false, 3) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundQuarter(utcMillis, interval);
+      }
+    },
+
+    YEAR(9, "y", false, 12) {
+      @Override
+      long round(long utcMillis, int interval) {
+        return DateTimeUtils.roundYear(utcMillis, interval);
+      }
+    };
+
+    @Getter
+    private final int id;
+    @Getter
+    private final String name;
+    protected final boolean isMillisBased;
+    protected final long ratio;
+
+    abstract long round(long utcMillis, int interval);
+
+    /**
+     * Resolve the date time unit.
+     */
+    public static Rounding.DateTimeUnit resolve(String name) {
+      switch (name) {
+        case "M":
+          return MONTH;
+        case "m":
+          return MINUTE;
+        default:
+          return Arrays.stream(values())
+              .filter(v -> v.getName().equalsIgnoreCase(name))
+              .findFirst()
+              .orElseThrow(() -> new IllegalArgumentException("Unable to resolve unit " + name));
+      }
+    }
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/bucket/SpanBucket.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/bucket/SpanBucket.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.planner.physical.bucket;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.AbstractMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.opensearch.sql.ast.expression.SpanUnit;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.aggregation.AggregationState;
+import org.opensearch.sql.expression.aggregation.NamedAggregator;
+import org.opensearch.sql.expression.span.SpanExpression;
+
+public class SpanBucket extends Group {
+  private final List<NamedAggregator> aggregatorList;
+  private final List<NamedExpression> groupByExprList;
+  private final Rounding<?> rounding;
+
+  /**
+   * SpanBucket Constructor.
+   */
+  public SpanBucket(List<NamedAggregator> aggregatorList, List<NamedExpression> groupByExprList) {
+    super(aggregatorList, groupByExprList);
+    this.aggregatorList = aggregatorList;
+    this.groupByExprList = groupByExprList;
+    rounding = Rounding.createRounding(((SpanExpression) groupByExprList.get(0).getDelegated()));
+  }
+
+  @Override
+  public void push(ExprValue inputValue) {
+    Key spanKey = new Key(inputValue, groupByExprList, rounding);
+    groupListMap.computeIfAbsent(spanKey, k ->
+        aggregatorList.stream()
+            .map(aggregator -> new AbstractMap.SimpleEntry<>(aggregator,
+                aggregator.create()))
+            .collect(Collectors.toList())
+    );
+    groupListMap.computeIfPresent(spanKey, (key, aggregatorList) -> {
+      aggregatorList
+          .forEach(entry -> entry.getKey().iterate(inputValue.bindingTuples(), entry.getValue()));
+      return aggregatorList;
+    });
+  }
+
+  @Override
+  public List<ExprValue> result() {
+    ExprValue[] buckets = rounding.createBuckets();
+    LinkedHashMap<String, ExprValue> emptyBucketTuple = new LinkedHashMap<>();
+    String spanKey = null;
+    for (Map.Entry<Group.Key, List<Map.Entry<NamedAggregator, AggregationState>>>
+        entry : groupListMap.entrySet()) {
+      LinkedHashMap<String, ExprValue> tupleMap = new LinkedHashMap<>(entry.getKey().groupKeyMap());
+      if (spanKey == null) {
+        spanKey = ((Key) entry.getKey()).namedSpan.getNameOrAlias();
+      }
+      for (Map.Entry<NamedAggregator, AggregationState> stateEntry : entry.getValue()) {
+        tupleMap.put(stateEntry.getKey().getName(), stateEntry.getValue().result());
+        if (emptyBucketTuple.isEmpty()) {
+          entry.getKey().groupKeyMap().keySet().forEach(key -> emptyBucketTuple.put(key, null));
+          emptyBucketTuple.put(stateEntry.getKey().getName(), ExprValueUtils.fromObjectValue(0));
+        }
+      }
+      int index = rounding.locate(((SpanBucket.Key) entry.getKey()).getRoundedValue());
+      buckets[index] = ExprTupleValue.fromExprValueMap(tupleMap);
+    }
+    return ImmutableList.copyOf(rounding.fillBuckets(buckets, emptyBucketTuple, spanKey));
+  }
+
+  @EqualsAndHashCode(callSuper = false)
+  @VisibleForTesting
+  public static class Key extends Group.Key {
+    @Getter
+    private final ExprValue roundedValue;
+    private final NamedExpression namedSpan;
+
+    /**
+     * SpanBucket.Key Constructor.
+     */
+    public Key(ExprValue value, List<NamedExpression> groupByExprList, Rounding<?> rounding) {
+      super(value, groupByExprList);
+      namedSpan = groupByExprList.get(0);
+      ExprValue actualValue =  ((SpanExpression) namedSpan.getDelegated()).getField()
+          .valueOf(value.bindingTuples());
+      roundedValue = rounding.round(actualValue);
+    }
+
+    /**
+     * Return the Map of span key and its actual value.
+     */
+    @Override
+    public LinkedHashMap<String, ExprValue> groupKeyMap() {
+      LinkedHashMap<String, ExprValue> map = new LinkedHashMap<>();
+      map.put(namedSpan.getNameOrAlias(), roundedValue);
+      return map;
+    }
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/utils/DateTimeUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/DateTimeUtils.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.utils;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class DateTimeUtils {
+
+  /**
+   * Util method to round the date/time with given unit.
+   *
+   * @param utcMillis     Date/time value to round, given in utc millis
+   * @param unitMillis    Date/time interval unit in utc millis
+   * @return              Rounded date/time value in utc millis
+   */
+  public static long roundFloor(long utcMillis, long unitMillis) {
+    return utcMillis - utcMillis % unitMillis;
+  }
+
+  /**
+   * Util method to round the date/time in week(s).
+   *
+   * @param utcMillis     Date/time value to round, given in utc millis
+   * @param interval      Number of weeks as the rounding interval
+   * @return              Rounded date/time value in utc millis
+   */
+  public static long roundWeek(long utcMillis, int interval) {
+    return roundFloor(utcMillis + 259200000L, 604800000L * interval) - 259200000L;
+  }
+
+  /**
+   * Util method to round the date/time in month(s).
+   *
+   * @param utcMillis     Date/time value to round, given in utc millis
+   * @param interval      Number of months as the rounding interval
+   * @return              Rounded date/time value in utc millis
+   */
+  public static long roundMonth(long utcMillis, int interval) {
+    ZonedDateTime initDateTime = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+    ZonedDateTime zonedDateTime = Instant.ofEpochMilli(utcMillis).atZone(ZoneId.of("UTC"))
+        .plusMonths(interval);
+    long monthDiff = (zonedDateTime.getYear() - initDateTime.getYear()) * 12L + zonedDateTime
+        .getMonthValue() - initDateTime.getMonthValue();
+    long monthToAdd = (monthDiff / interval - 1) * interval;
+    return initDateTime.plusMonths(monthToAdd).toInstant().toEpochMilli();
+  }
+
+  /**
+   * Util method to round the date/time in quarter(s).
+   *
+   * @param utcMillis     Date/time value to round, given in utc millis
+   * @param interval      Number of quarters as the rounding interval
+   * @return              Rounded date/time value in utc millis
+   */
+  public static long roundQuarter(long utcMillis, int interval) {
+    ZonedDateTime initDateTime = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+    ZonedDateTime zonedDateTime = Instant.ofEpochMilli(utcMillis).atZone(ZoneId.of("UTC"))
+        .plusMonths(interval * 3L);
+    long monthDiff = ((zonedDateTime.getYear() - initDateTime.getYear()) * 12L + zonedDateTime
+        .getMonthValue() - initDateTime.getMonthValue());
+    long monthToAdd = (monthDiff / (interval * 3L) - 1) * interval * 3;
+    return initDateTime.plusMonths(monthToAdd).toInstant().toEpochMilli();
+  }
+
+  /**
+   * Util method to round the date/time in year(s).
+   *
+   * @param utcMillis     Date/time value to round, given in utc millis
+   * @param interval      Number of years as the rounding interval
+   * @return              Rounded date/time value in utc millis
+   */
+  public static long roundYear(long utcMillis, int interval) {
+    ZonedDateTime initDateTime = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+    ZonedDateTime zonedDateTime = Instant.ofEpochMilli(utcMillis).atZone(ZoneId.of("UTC"));
+    int yearDiff = zonedDateTime.getYear() - initDateTime.getYear();
+    int yearToAdd = (yearDiff / interval) * interval;
+    return initDateTime.plusYears(yearToAdd).toInstant().toEpochMilli();
+  }
+
+}

--- a/core/src/test/java/org/opensearch/sql/analysis/NamedExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/NamedExpressionAnalyzerTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.Span;
+import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.springframework.context.annotation.Configuration;
@@ -45,7 +47,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(classes = {ExpressionConfig.class, AnalyzerTestBase.class})
 class NamedExpressionAnalyzerTest extends AnalyzerTestBase {
   @Test
-  void visit_named_seleteitem() {
+  void visit_named_select_item() {
     Alias alias = AstDSL.alias("integer_value", AstDSL.qualifiedName("integer_value"));
 
     NamedExpressionAnalyzer analyzer =
@@ -53,5 +55,16 @@ class NamedExpressionAnalyzerTest extends AnalyzerTestBase {
 
     NamedExpression analyze = analyzer.analyze(alias, analysisContext);
     assertEquals("integer_value", analyze.getNameOrAlias());
+  }
+
+  @Test
+  void visit_span() {
+    NamedExpressionAnalyzer analyzer =
+        new NamedExpressionAnalyzer(expressionAnalyzer);
+
+    Span span = AstDSL.span(AstDSL.qualifiedName("integer_value"), AstDSL.intLiteral(
+        1), SpanUnit.NONE);
+    NamedExpression named = analyzer.analyze(span, analysisContext);
+    assertEquals(span.toString(), named.getNameOrAlias());
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/ExpressionNodeVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/ExpressionNodeVisitorTest.java
@@ -64,6 +64,7 @@ class ExpressionNodeVisitorTest {
         INTEGER)).accept(visitor, null));
     assertNull(new CaseClause(ImmutableList.of(), null).accept(visitor, null));
     assertNull(new WhenClause(literal("test"), literal(10)).accept(visitor, null));
+    assertNull(DSL.span(ref("age", INTEGER), literal(1), "").accept(visitor, null));
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/expression/NamedExpressionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/NamedExpressionTest.java
@@ -28,10 +28,12 @@
 package org.opensearch.sql.expression;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.opensearch.sql.expression.span.SpanExpression;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class NamedExpressionTest extends ExpressionTestBase {
@@ -60,6 +62,13 @@ class NamedExpressionTest extends ExpressionTestBase {
 
     NamedExpression namedExpression = DSL.named(expression);
     assertEquals("ten", namedExpression.getNameOrAlias());
+  }
+
+  @Test
+  void name_a_span_expression() {
+    SpanExpression span = DSL.span(DSL.ref("integer_value", INTEGER), DSL.literal(1), "");
+    NamedExpression named = DSL.named(span);
+    assertEquals(span, named.getDelegated());
   }
 
 }

--- a/core/src/test/java/org/opensearch/sql/expression/span/SpanExpressionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/span/SpanExpressionTest.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.expression.span;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.ExpressionTestBase;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class SpanExpressionTest extends ExpressionTestBase {
+  @Test
+  void span() {
+    SpanExpression span = DSL.span(DSL.ref("integer_value", INTEGER), DSL.literal(1), "");
+    assertEquals(INTEGER, span.type());
+    assertEquals(ExprValueUtils.integerValue(1), span.valueOf(valueEnv()));
+
+    span = DSL.span(DSL.ref("integer_value", INTEGER), DSL.literal(1.5), "");
+    assertEquals(DOUBLE, span.type());
+    assertEquals(ExprValueUtils.doubleValue(1.5), span.valueOf(valueEnv()));
+
+    span = DSL.span(DSL.ref("double_value", DOUBLE), DSL.literal(1), "");
+    assertEquals(DOUBLE, span.type());
+    assertEquals(ExprValueUtils.doubleValue(1.0), span.valueOf(valueEnv()));
+
+    span = DSL.span(DSL.ref("timestamp_value", TIMESTAMP), DSL.literal(1), "d");
+    assertEquals(TIMESTAMP, span.type());
+    assertEquals(ExprValueUtils.integerValue(1), span.valueOf(valueEnv()));
+  }
+
+}

--- a/core/src/test/java/org/opensearch/sql/planner/physical/AggregationOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/AggregationOperatorTest.java
@@ -28,15 +28,27 @@ package org.opensearch.sql.planner.physical;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opensearch.sql.data.type.ExprCoreType.DATE;
+import static org.opensearch.sql.data.type.ExprCoreType.DATETIME;
+import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
+import static org.opensearch.sql.data.type.ExprCoreType.FLOAT;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.data.type.ExprCoreType.TIME;
+import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.expression.DSL;
@@ -88,4 +100,391 @@ class AggregationOperatorTest extends PhysicalPlanTestBase {
         ExprValueUtils.tupleValue(ImmutableMap.of("action", "POST", "sum(response)", 700))
     ));
   }
+
+  @Test
+  public void millisecond_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTimeTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("second", TIMESTAMP)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("second", TIMESTAMP), DSL.literal(6 * 1000), "ms"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(3, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2021-01-01 00:00:00"), "count", 2)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2021-01-01 00:00:06"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2021-01-01 00:00:12"), "count", 3))
+    ));
+  }
+
+  @Test
+  public void second_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTimeTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("second", TIMESTAMP)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("second", TIMESTAMP), DSL.literal(6), "s"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(3, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2021-01-01 00:00:00"), "count", 2)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2021-01-01 00:00:06"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2021-01-01 00:00:12"), "count", 3))
+    ));
+  }
+
+  @Test
+  public void minute_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTimeTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("minute", DATETIME)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("minute", DATETIME), DSL.literal(5), "m"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2020-12-31 23:50:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2020-12-31 23:55:00"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2021-01-01 00:00:00"), "count", 3)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2021-01-01 00:05:00"), "count", 1))
+    ));
+
+    plan = new AggregationOperator(new DateTimeTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("hour", TIME)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("hour", TIME), DSL.literal(30), "m"))));
+    result = execute(plan);
+    assertEquals(5, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimeValue("17:00:00"), "count", 2)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimeValue("17:30:00"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimeValue("18:00:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimeValue("18:30:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimeValue("19:00:00"), "count", 1))
+    ));
+  }
+
+  @Test
+  public void hour_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTimeTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("hour", TIME)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("hour", TIME), DSL.literal(1), "h"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(3, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimeValue("17:00:00"), "count", 2)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimeValue("18:00:00"), "count", 2)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimeValue("19:00:00"), "count", 1))
+    ));
+  }
+
+  @Test
+  public void day_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count(day)", dsl.count(DSL.ref("day", DATE)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("day", DATE), DSL.literal(1), "d"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-01-01"), "count(day)", 2)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-01-02"), "count(day)", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-01-03"), "count(day)", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-01-04"), "count(day)", 1))
+    ));
+
+    plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("month", DATE)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("month", DATE), DSL.literal(30), "d"))));
+    result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2020-12-04"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-01-03"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-02-02"), "count", 3)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-03-04"), "count", 1))
+    ));
+  }
+
+  @Test
+  public void week_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("month", DATE)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("month", DATE), DSL.literal(5), "w"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2020-11-16"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2020-12-21"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-01-25"), "count", 3)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-03-01"), "count", 1))
+    ));
+  }
+
+  @Test
+  public void month_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("month", DATE)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("month", DATE), DSL.literal(1), "M"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2020-12-01"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-01-01"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-02-01"), "count", 3)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDateValue("2021-03-01"), "count", 1))
+    ));
+
+    plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("quarter", DATETIME)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("quarter", DATETIME), DSL.literal(2), "M"))));
+    result = execute(plan);
+    assertEquals(5, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2020-09-01 00:00:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2020-11-01 00:00:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2021-01-01 00:00:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2021-03-01 00:00:00"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2021-05-01 00:00:00"), "count", 2))
+    ));
+
+    plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("year", TIMESTAMP)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("year", TIMESTAMP), DSL.literal(10 * 12), "M"))));
+    result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("1990-01-01 00:00:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2000-01-01 00:00:00"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2010-01-01 00:00:00"), "count", 3)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2020-01-01 00:00:00"), "count", 1))
+    ));
+
+  }
+
+  @Test
+  public void quarter_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("quarter", DATETIME)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("quarter", DATETIME), DSL.literal(2), "q"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(2, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2020-07-01 00:00:00"), "count", 2)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprDatetimeValue("2021-01-01 00:00:00"), "count", 3))
+    ));
+
+    plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("year", TIMESTAMP)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("year", TIMESTAMP), DSL.literal(10 * 4), "q"))));
+    result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("1990-01-01 00:00:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2000-01-01 00:00:00"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2010-01-01 00:00:00"), "count", 3)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2020-01-01 00:00:00"), "count", 1))
+    ));
+  }
+
+  @Test
+  public void year_span() {
+    PhysicalPlan plan = new AggregationOperator(new DateTestScan(),
+        Collections.singletonList(DSL
+            .named("count", dsl.count(DSL.ref("year", TIMESTAMP)))),
+        Collections.singletonList(DSL
+            .named("span", DSL.span(DSL.ref("year", TIMESTAMP), DSL.literal(10), "y"))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("1990-01-01 00:00:00"), "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2000-01-01 00:00:00"), "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2010-01-01 00:00:00"), "count", 3)),
+        ExprValueUtils.tupleValue(ImmutableMap
+            .of("span", new ExprTimestampValue("2020-01-01 00:00:00"), "count", 1))
+    ));
+  }
+
+  @Test
+  public void integer_field() {
+    PhysicalPlan plan = new AggregationOperator(new NumericTestScan(),
+        Collections.singletonList(DSL.named("count", dsl.count(DSL.ref("integer", INTEGER)))),
+        Collections.singletonList(DSL.named("span", DSL.span(DSL.ref("integer", INTEGER), DSL
+            .literal(1), ""))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(5, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 1, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 2, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 3, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 4, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 5, "count", 1))));
+
+    plan = new AggregationOperator(new NumericTestScan(),
+        Collections.singletonList(DSL.named("count", dsl.count(DSL.ref("integer", INTEGER)))),
+        Collections.singletonList(DSL.named("span", DSL.span(DSL.ref("integer", INTEGER), DSL
+            .literal(1.5), ""))));
+    result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 0D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 1.5D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 3.0D, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 4.5D, "count", 1))));
+  }
+
+  @Test
+  public void long_field() {
+    PhysicalPlan plan = new AggregationOperator(new NumericTestScan(),
+        Collections.singletonList(DSL.named("count", dsl.count(DSL.ref("long", LONG)))),
+        Collections.singletonList(DSL.named("span", DSL.span(DSL.ref("long", LONG), DSL
+            .literal(1), ""))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(5, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 1L, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 2L, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 3L, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 4L, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 5L, "count", 1))));
+
+    plan = new AggregationOperator(new NumericTestScan(),
+        Collections.singletonList(DSL.named("count", dsl.count(DSL.ref("long", LONG)))),
+        Collections.singletonList(DSL.named("span", DSL.span(DSL.ref("long", LONG), DSL
+            .literal(1.5), ""))));
+    result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 0D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 1.5D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 3.0D, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 4.5D, "count", 1))));
+  }
+
+  @Test
+  public void float_field() {
+    PhysicalPlan plan = new AggregationOperator(new NumericTestScan(),
+        Collections.singletonList(DSL.named("count", dsl.count(DSL.ref("float", FLOAT)))),
+        Collections.singletonList(DSL.named("span", DSL.span(DSL.ref("float", FLOAT), DSL
+            .literal(1), ""))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(5, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 1F, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 2F, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 3F, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 4F, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 5F, "count", 1))));
+
+    plan = new AggregationOperator(new NumericTestScan(),
+        Collections.singletonList(DSL.named("count", dsl.count(DSL.ref("float", FLOAT)))),
+        Collections.singletonList(DSL.named("span", DSL.span(DSL.ref("float", FLOAT), DSL
+            .literal(1.5), ""))));
+    result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 0D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 1.5D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 3.0D, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 4.5D, "count", 1))));
+  }
+
+  @Test
+  public void double_field() {
+    PhysicalPlan plan = new AggregationOperator(new NumericTestScan(),
+        Collections.singletonList(DSL.named("count", dsl.count(DSL.ref("double", DOUBLE)))),
+        Collections.singletonList(DSL.named("span", DSL.span(DSL.ref("double", DOUBLE), DSL
+            .literal(1), ""))));
+    List<ExprValue> result = execute(plan);
+    assertEquals(5, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 1D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 2D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 3D, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 4D, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 5D, "count", 1))));
+
+    plan = new AggregationOperator(new NumericTestScan(),
+        Collections.singletonList(DSL.named("count", dsl.count(DSL.ref("double", DOUBLE)))),
+        Collections.singletonList(DSL.named("span", DSL.span(DSL.ref("double", DOUBLE), DSL
+            .literal(1.5), ""))));
+    result = execute(plan);
+    assertEquals(4, result.size());
+    assertThat(result, containsInRelativeOrder(
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 0D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 1.5D, "count", 1)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 3.0D, "count", 0)),
+        ExprValueUtils.tupleValue(ImmutableMap.of("span", 4.5D, "count", 1))));
+  }
+
 }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
@@ -32,6 +32,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.data.type.ExprCoreType;
@@ -104,6 +108,75 @@ public class PhysicalPlanTestBase {
           .put("referer", ExprCoreType.STRING)
           .build();
 
+  protected static final List<ExprValue> dateInputs = new ImmutableList.Builder<ExprValue>()
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "day", new ExprDateValue("2021-01-03"),
+          "month", new ExprDateValue("2021-02-04"),
+          "quarter", new ExprDatetimeValue("2021-01-01 12:25:02"),
+          "year", new ExprTimestampValue("2013-01-01 12:25:02"))))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "day", new ExprDateValue("2021-01-01"),
+          "month", new ExprDateValue("2021-03-17"),
+          "quarter", new ExprDatetimeValue("2021-05-17 12:25:01"),
+          "year", new ExprTimestampValue("2021-01-01 12:25:02"))))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "day", new ExprDateValue("2021-01-04"),
+          "month", new ExprDateValue("2021-02-08"),
+          "quarter", new ExprDatetimeValue("2021-06-08 12:25:02"),
+          "year", new ExprTimestampValue("2016-01-01 12:25:02"))))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "day", new ExprDateValue("2021-01-02"),
+          "month", new ExprDateValue("2020-12-12"),
+          "quarter", new ExprDatetimeValue("2020-12-12 12:25:03"),
+          "year", new ExprTimestampValue("1999-01-01 12:25:02"))))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "day", new ExprDateValue("2021-01-01"),
+          "month", new ExprDateValue("2021-02-28"),
+          "quarter", new ExprDatetimeValue("2020-09-28 12:25:01"),
+          "year", new ExprTimestampValue("2018-01-01 12:25:02"))))
+      .build();
+
+  protected static final List<ExprValue> datetimeInputs = new ImmutableList.Builder<ExprValue>()
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "hour", new ExprTimeValue("17:17:00"),
+          "minute", new ExprDatetimeValue("2020-12-31 23:54:12"),
+          "second", new ExprTimestampValue("2021-01-01 00:00:05"))))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "hour", new ExprTimeValue("18:17:00"),
+          "minute", new ExprDatetimeValue("2021-01-01 00:05:12"),
+          "second", new ExprTimestampValue("2021-01-01 00:00:12"))))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "hour", new ExprTimeValue("17:15:00"),
+          "minute", new ExprDatetimeValue("2021-01-01 00:03:12"),
+          "second", new ExprTimestampValue("2021-01-01 00:00:17"))))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "hour", new ExprTimeValue("19:01:00"),
+          "minute", new ExprDatetimeValue("2021-01-01 00:02:12"),
+          "second", new ExprTimestampValue("2021-01-01 00:00:03"))))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "hour", new ExprTimeValue("18:50:00"),
+          "minute", new ExprDatetimeValue("2021-01-01 00:00:12"),
+          "second", new ExprTimestampValue("2021-01-01 00:00:13"))))
+      .build();
+
+  protected static final List<ExprValue> numericInputs = new ImmutableList.Builder<ExprValue>()
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "integer", 2,
+          "long", 2L,
+          "float", 2F,
+          "double", 2D)))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "integer", 1,
+          "long", 1L,
+          "float", 1F,
+          "double", 1D)))
+      .add(ExprValueUtils.tupleValue(ImmutableMap.of(
+          "integer", 5,
+          "long", 5L,
+          "float", 5F,
+          "double", 5D)))
+      .build();
+
   @Bean
   protected Environment<Expression, ExprCoreType> typeEnv() {
     return var -> {
@@ -160,6 +233,90 @@ public class PhysicalPlanTestBase {
 
     public CountTestScan() {
       iterator = countTestInputs.iterator();
+    }
+
+    @Override
+    public <R, C> R accept(PhysicalPlanNodeVisitor<R, C> visitor, C context) {
+      return null;
+    }
+
+    @Override
+    public List<PhysicalPlan> getChild() {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public ExprValue next() {
+      return iterator.next();
+    }
+  }
+
+  protected static class DateTimeTestScan extends PhysicalPlan {
+    private final Iterator<ExprValue> iterator;
+
+    public DateTimeTestScan() {
+      iterator = datetimeInputs.iterator();
+    }
+
+    @Override
+    public <R, C> R accept(PhysicalPlanNodeVisitor<R, C> visitor, C context) {
+      return null;
+    }
+
+    @Override
+    public List<PhysicalPlan> getChild() {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public ExprValue next() {
+      return iterator.next();
+    }
+  }
+
+  protected static class DateTestScan extends PhysicalPlan {
+    private final Iterator<ExprValue> iterator;
+
+    public DateTestScan() {
+      iterator = dateInputs.iterator();
+    }
+
+    @Override
+    public <R, C> R accept(PhysicalPlanNodeVisitor<R, C> visitor, C context) {
+      return null;
+    }
+
+    @Override
+    public List<PhysicalPlan> getChild() {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public ExprValue next() {
+      return iterator.next();
+    }
+  }
+
+  protected static class NumericTestScan extends PhysicalPlan {
+    private final Iterator<ExprValue> iterator;
+
+    public NumericTestScan() {
+      iterator = numericInputs.iterator();
     }
 
     @Override

--- a/core/src/test/java/org/opensearch/sql/planner/physical/bucket/RoundingTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/bucket/RoundingTest.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.planner.physical.bucket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.data.type.ExprCoreType.TIME;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.span.SpanExpression;
+
+public class RoundingTest {
+  @Test
+  void time_rounding_illegal_span() {
+    SpanExpression span = DSL.span(DSL.ref("time", TIME), DSL.literal(1), "d");
+    Rounding rounding = Rounding.createRounding(span);
+    assertThrows(ExpressionEvaluationException.class,
+        () -> rounding.round(new ExprTimeValue("23:30:00")));
+  }
+
+  @Test
+  void round_unknown_type() {
+    SpanExpression span = DSL.span(DSL.ref("unknown", STRING), DSL.literal(1), "");
+    Rounding rounding = Rounding.createRounding(span);
+    assertNull(rounding.round(ExprValueUtils.integerValue(1)));
+    assertNull(rounding.locate(ExprValueUtils.integerValue(1)));
+    assertEquals(0, rounding.createBuckets().length);
+    assertEquals(0, rounding.fillBuckets(new ExprValue[0], ImmutableMap.of(), "span").length);
+  }
+
+  @Test
+  void resolve() {
+    String illegalUnit = "illegal";
+    assertThrows(IllegalArgumentException.class,
+        () -> Rounding.DateTimeUnit.resolve(illegalUnit),
+        "Unable to resolve unit " + illegalUnit);
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/utils/DateTimeUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/utils/DateTimeUtilsTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class DateTimeUtilsTest {
+  @Test
+  void round() {
+    long actual = LocalDateTime.parse("2021-09-28T23:40:00").atZone(ZoneId.systemDefault())
+        .toInstant().toEpochMilli();
+    long rounded = DateTimeUtils.roundFloor(actual, TimeUnit.HOURS.toMillis(1));
+    assertEquals(
+        LocalDateTime.parse("2021-09-28T23:00:00").atZone(ZoneId.systemDefault()).toInstant()
+            .toEpochMilli(),
+        Instant.ofEpochMilli(rounded).toEpochMilli());
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
@@ -43,29 +43,33 @@ public class ObjectContent implements Content {
 
   private final Object value;
 
+  /**
+   * The parse method parses the value as double value,
+   * since the key values histogram buckets are defaulted to double.
+   */
   @Override
   public Integer intValue() {
-    return parseNumberValue(value, Integer::valueOf, Number::intValue);
+    return parseNumberValue(value, v -> Double.valueOf(v).intValue(), Number::intValue);
   }
 
   @Override
   public Long longValue() {
-    return parseNumberValue(value, Long::valueOf, Number::longValue);
+    return parseNumberValue(value, v -> Double.valueOf(v).longValue(), Number::longValue);
   }
 
   @Override
   public Short shortValue() {
-    return parseNumberValue(value, Short::valueOf, Number::shortValue);
+    return parseNumberValue(value, v -> Double.valueOf(v).shortValue(), Number::shortValue);
   }
 
   @Override
   public Byte byteValue() {
-    return parseNumberValue(value, Byte::valueOf, Number::byteValue);
+    return parseNumberValue(value, v -> Double.valueOf(v).byteValue(), Number::byteValue);
   }
 
   @Override
   public Float floatValue() {
-    return parseNumberValue(value, Float::valueOf, Number::floatValue);
+    return parseNumberValue(value, v -> Double.valueOf(v).floatValue(), Number::floatValue);
   }
 
   @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
@@ -69,7 +69,7 @@ public class ObjectContent implements Content {
 
   @Override
   public Float floatValue() {
-    return parseNumberValue(value, v -> Double.valueOf(v).floatValue(), Number::floatValue);
+    return parseNumberValue(value, Float::valueOf, Number::floatValue);
   }
 
   @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/SpanAggregationParser.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/SpanAggregationParser.java
@@ -31,7 +31,8 @@ public class SpanAggregationParser implements OpenSearchAggregationResponseParse
   @Override
   public List<Map<String, Object>> parse(Aggregations aggregations) {
     ImmutableList.Builder<Map<String, Object>> list = ImmutableList.builder();
-    aggregations.asList().forEach(aggregation -> list.addAll(parseHistogram((Histogram) aggregation)));
+    aggregations.asList().forEach(aggregation -> list
+        .addAll(parseHistogram((Histogram) aggregation)));
     return list.build();
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/SpanAggregationParser.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/SpanAggregationParser.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.opensearch.response.agg;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.search.aggregations.Aggregation;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.bucket.histogram.InternalDateHistogram;
+import org.opensearch.search.aggregations.bucket.histogram.InternalHistogram;
+
+public class SpanAggregationParser implements OpenSearchAggregationResponseParser {
+  private final MetricParserHelper metricsParser;
+
+  public SpanAggregationParser(MetricParser metricParser) {
+    this.metricsParser = new MetricParserHelper(Collections.singletonList(metricParser));
+  }
+
+  @Override
+  public List<Map<String, Object>> parse(Aggregations aggregations) {
+    ImmutableList.Builder<Map<String, Object>> list = ImmutableList.builder();
+    aggregations.asList().forEach(aggregation -> list.addAll(parseInternal(aggregation)));
+    return list.build();
+  }
+
+  private List<Map<String, Object>> parseInternal(Aggregation aggregation) {
+    if (aggregation instanceof InternalHistogram) {
+      return parseInternalHistogram((InternalHistogram) aggregation);
+    } else {
+      return parseInternalDateHistogram((InternalDateHistogram) aggregation);
+    }
+  }
+
+  private List<Map<String, Object>> parseInternalDateHistogram(
+      InternalDateHistogram histogram) {
+    ImmutableList.Builder<Map<String, Object>> mapList = ImmutableList.builder();
+    histogram.getBuckets().forEach(bucket -> {
+      Map<String, Object> map = new HashMap<>();
+      map.put(histogram.getName(), bucket.getKey().toString());
+      Aggregation aggregation = bucket.getAggregations().asList().get(0);
+      Map<String, Object> metricsAggMap = metricsParser.parse(bucket.getAggregations());
+      map.put(aggregation.getName(), metricsAggMap.get(aggregation.getName()));
+      mapList.add(map);
+    });
+    return mapList.build();
+  }
+
+  private List<Map<String, Object>> parseInternalHistogram(InternalHistogram histogram) {
+    ImmutableList.Builder<Map<String, Object>> mapList = ImmutableList.builder();
+    histogram.getBuckets().forEach(bucket -> {
+      Map<String, Object> map = new HashMap<>();
+      map.put(histogram.getName(), bucket.getKey().toString());
+      Aggregation aggregation = bucket.getAggregations().asList().get(0);
+      Map<String, Object> metricsAggMap = metricsParser.parse(bucket.getAggregations());
+      map.put(aggregation.getName(), metricsAggMap.get(aggregation.getName()));
+      mapList.add(map);
+    });
+    return mapList.build();
+  }
+
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
@@ -51,12 +51,15 @@ import org.opensearch.sql.expression.ExpressionNodeVisitor;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.aggregation.NamedAggregator;
+import org.opensearch.sql.expression.span.SpanExpression;
 import org.opensearch.sql.opensearch.response.agg.CompositeAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.MetricParser;
 import org.opensearch.sql.opensearch.response.agg.NoBucketAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.OpenSearchAggregationResponseParser;
+import org.opensearch.sql.opensearch.response.agg.SpanAggregationParser;
 import org.opensearch.sql.opensearch.storage.script.aggregation.dsl.BucketAggregationBuilder;
 import org.opensearch.sql.opensearch.storage.script.aggregation.dsl.MetricAggregationBuilder;
+import org.opensearch.sql.opensearch.storage.script.aggregation.dsl.SpanAggregationBuilder;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
 
 /**
@@ -81,10 +84,13 @@ public class AggregationQueryBuilder extends ExpressionNodeVisitor<AggregationBu
    */
   private final MetricAggregationBuilder metricBuilder;
 
+  private final SpanAggregationBuilder spanAggregationBuilder;
+
   public AggregationQueryBuilder(
       ExpressionSerializer serializer) {
     this.bucketBuilder = new BucketAggregationBuilder(serializer);
     this.metricBuilder = new MetricAggregationBuilder(serializer);
+    this.spanAggregationBuilder = new SpanAggregationBuilder();
   }
 
   /** Build AggregationBuilder. */
@@ -102,6 +108,14 @@ public class AggregationQueryBuilder extends ExpressionNodeVisitor<AggregationBu
       return Pair.of(
           ImmutableList.copyOf(metrics.getLeft().getAggregatorFactories()),
           new NoBucketAggregationParser(metrics.getRight()));
+    } else if (groupByList.size() == 1 && groupByList.get(0)
+        .getDelegated() instanceof SpanExpression) {
+      // span aggregation
+      return Pair.of(
+          Collections.singletonList(spanAggregationBuilder.build(groupByList.get(0))
+              .subAggregations(metrics.getLeft())),
+          new SpanAggregationParser(metrics.getRight().get(0))
+      );
     } else {
       GroupSortOrder groupSortOrder = new GroupSortOrder(sortList);
       return Pair.of(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
@@ -84,8 +84,14 @@ public class AggregationQueryBuilder extends ExpressionNodeVisitor<AggregationBu
    */
   private final MetricAggregationBuilder metricBuilder;
 
+  /**
+   * Span Aggregation Builder.
+   */
   private final SpanAggregationBuilder spanAggregationBuilder;
 
+  /**
+   * Aggregation Query Builder Constructor.
+   */
   public AggregationQueryBuilder(
       ExpressionSerializer serializer) {
     this.bucketBuilder = new BucketAggregationBuilder(serializer);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/SpanAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/SpanAggregationBuilder.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.opensearch.storage.script.aggregation.dsl;
+
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.opensearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.opensearch.sql.ast.expression.SpanUnit;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.span.SpanExpression;
+
+/**
+ * Span Aggregation Builder.
+ */
+public class SpanAggregationBuilder {
+  /**
+   * Build corresponding aggregation builder for span aggregation.
+   * For general span aggregation with no unit:
+   * build {@link HistogramAggregationBuilder}
+   * For time span aggregation with time span unit:
+   * build {@link DateHistogramAggregationBuilder}
+   */
+  public AggregationBuilder build(NamedExpression namedExpression) {
+    SpanExpression spanExpr = (SpanExpression) namedExpression.getDelegated();
+    return makeBuilder(namedExpression.getNameOrAlias(), spanExpr.getField()
+        .toString(), spanExpr.getValue().valueOf(null).stringValue(), spanExpr.getUnit());
+  }
+
+  private AggregationBuilder makeBuilder(
+      String name, String field, String value, SpanUnit unit) {
+    switch (unit) {
+      case NONE:
+        return new HistogramAggregationBuilder(name)
+            .field(field)
+            .interval(Double.parseDouble(value));
+      case UNKNOWN:
+        throw new IllegalStateException("Invalid span unit");
+      default:
+        return makeDateHistogramBuilder(name, field, value, unit);
+    }
+  }
+
+  private DateHistogramAggregationBuilder makeDateHistogramBuilder(
+      String name, String field, String value, SpanUnit unit) {
+    String spanValue = value + unit.getName();
+    switch (unit) {
+      case MICROSECOND:
+      case MS:
+      case SECOND:
+      case S:
+      case MINUTE:
+      case m:
+      case HOUR:
+      case H:
+      case DAY:
+      case D:
+        return new DateHistogramAggregationBuilder(name)
+            .field(field)
+            .fixedInterval(new DateHistogramInterval(spanValue));
+      default:
+        return new DateHistogramAggregationBuilder(name)
+            .field(field)
+            .calendarInterval(new DateHistogramInterval(spanValue));
+    }
+  }
+
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/SpanAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/SpanAggregationBuilder.java
@@ -34,25 +34,25 @@ public class SpanAggregationBuilder {
   public AggregationBuilder build(NamedExpression namedExpression) {
     SpanExpression spanExpr = (SpanExpression) namedExpression.getDelegated();
     return makeBuilder(namedExpression.getNameOrAlias(), spanExpr.getField()
-        .toString(), spanExpr.getValue().valueOf(null).stringValue(), spanExpr.getUnit());
+        .toString(), spanExpr.getValue().valueOf(null).doubleValue(), spanExpr.getUnit());
   }
 
   private AggregationBuilder makeBuilder(
-      String name, String field, String value, SpanUnit unit) {
+      String name, String field, Double value, SpanUnit unit) {
     switch (unit) {
       case NONE:
         return new HistogramAggregationBuilder(name)
             .field(field)
-            .interval(Double.parseDouble(value));
+            .interval(value);
       case UNKNOWN:
         throw new IllegalStateException("Invalid span unit");
       default:
-        return makeDateHistogramBuilder(name, field, value, unit);
+        return makeDateHistogramBuilder(name, field, value.intValue(), unit);
     }
   }
 
   private DateHistogramAggregationBuilder makeDateHistogramBuilder(
-      String name, String field, String value, SpanUnit unit) {
+      String name, String field, Integer value, SpanUnit unit) {
     String spanValue = value + unit.getName();
     switch (unit) {
       case MICROSECOND:

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/SpanAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/SpanAggregationBuilder.java
@@ -55,7 +55,7 @@ public class SpanAggregationBuilder {
       String name, String field, Integer value, SpanUnit unit) {
     String spanValue = value + unit.getName();
     switch (unit) {
-      case MICROSECOND:
+      case MILLISECOND:
       case MS:
       case SECOND:
       case S:

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -125,18 +125,21 @@ class OpenSearchExprValueFactoryTest {
   public void constructByte() {
     assertEquals(byteValue((byte) 1), tupleValue("{\"byteV\":1}").get("byteV"));
     assertEquals(byteValue((byte) 1), constructFromObject("byteV", 1));
+    assertEquals(byteValue((byte) 1), constructFromObject("byteV", "1.0"));
   }
 
   @Test
   public void constructShort() {
     assertEquals(shortValue((short) 1), tupleValue("{\"shortV\":1}").get("shortV"));
     assertEquals(shortValue((short) 1), constructFromObject("shortV", 1));
+    assertEquals(shortValue((short) 1), constructFromObject("shortV", "1.0"));
   }
 
   @Test
   public void constructInteger() {
     assertEquals(integerValue(1), tupleValue("{\"intV\":1}").get("intV"));
     assertEquals(integerValue(1), constructFromObject("intV", 1));
+    assertEquals(integerValue(1), constructFromObject("intV", "1.0"));
   }
 
   @Test
@@ -148,6 +151,7 @@ class OpenSearchExprValueFactoryTest {
   public void constructLong() {
     assertEquals(longValue(1L), tupleValue("{\"longV\":1}").get("longV"));
     assertEquals(longValue(1L), constructFromObject("longV", 1L));
+    assertEquals(longValue(1L), constructFromObject("longV", "1.0"));
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/AggregationResponseUtils.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/AggregationResponseUtils.java
@@ -47,7 +47,9 @@ import org.opensearch.search.aggregations.bucket.composite.ParsedComposite;
 import org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.filter.ParsedFilter;
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
+import org.opensearch.search.aggregations.bucket.histogram.ParsedHistogram;
 import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
 import org.opensearch.search.aggregations.bucket.terms.LongTerms;
 import org.opensearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
@@ -87,6 +89,8 @@ public class AggregationResponseUtils {
               (p, c) -> ParsedPercentilesBucket.fromXContent(p, (String) c))
           .put(DateHistogramAggregationBuilder.NAME,
               (p, c) -> ParsedDateHistogram.fromXContent(p, (String) c))
+          .put(HistogramAggregationBuilder.NAME,
+              (p, c) -> ParsedHistogram.fromXContent(p, (String) c))
           .put(CompositeAggregationBuilder.NAME,
               (p, c) -> ParsedComposite.fromXContent(p, (String) c))
           .put(FilterAggregationBuilder.NAME,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchAggregationResponseParserTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchAggregationResponseParserTest.java
@@ -49,6 +49,7 @@ import org.opensearch.sql.opensearch.response.agg.FilterParser;
 import org.opensearch.sql.opensearch.response.agg.NoBucketAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.OpenSearchAggregationResponseParser;
 import org.opensearch.sql.opensearch.response.agg.SingleValueParser;
+import org.opensearch.sql.opensearch.response.agg.SpanAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.StatsParser;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -290,6 +291,74 @@ class OpenSearchAggregationResponseParserTest {
     );
     assertThat(parse(parser, response),
         contains(entry("esField", 93.71390409320287, "maxField", 360D)));
+  }
+
+  @Test
+  void parse_histogram() {
+    String response = "{\n"
+        + "  \"histogram#span\":{\n"
+        + "    \"buckets\":[\n"
+        + "      {\n"
+        + "        \"key\":0.0,\n"
+        + "        \"doc_count\":87,\n"
+        + "        \"avg#avg\":{\n"
+        + "          \"value\":48.04521372126437\n"
+        + "        }\n"
+        + "      },\n"
+        + "      {\n"
+        + "        \"key\":1.5,\n"
+        + "        \"doc_count\":4176,\n"
+        + "        \"avg#avg\":{\n"
+        + "          \"value\":68.71430682770594\n"
+        + "        }\n"
+        + "      },\n"
+        + "      {\n"
+        + "        \"key\":3.0,\n"
+        + "        \"doc_count\":412,\n"
+        + "        \"avg#avg\":{\n"
+        + "          \"value\":145.03216019417476\n"
+        + "        }\n"
+        + "      }\n"
+        + "    ]\n"
+        + "  }\n"
+        + "}";
+    OpenSearchAggregationResponseParser parser = new SpanAggregationParser(
+        new SingleValueParser("avg"));
+    assertThat(parse(parser, response), contains(
+        entry("avg", 48.04521372126437, "span", "0.0"),
+        entry("avg", 68.71430682770594, "span", "1.5"),
+        entry("avg", 145.03216019417476, "span", "3.0")));
+  }
+
+  @Test
+  void parse_date_histogram() {
+    String response = "{\n"
+        + "  \"date_histogram#timespan\":{\n"
+        + "    \"buckets\":[\n"
+        + "      {\n"
+        + "        \"key_as_string\":\"2021-07-01T00:00:00.000Z\",\n"
+        + "        \"key\":1625097600000,\n"
+        + "        \"doc_count\":3586,\n"
+        + "        \"value_count#count\":{\n"
+        + "          \"value\":3586\n"
+        + "        }\n"
+        + "      },\n"
+        + "      {\n"
+        + "        \"key_as_string\":\"2021-08-01T00:00:00.000Z\",\n"
+        + "        \"key\":1627776000000,\n"
+        + "        \"doc_count\":1089,\n"
+        + "        \"value_count#count\":{\n"
+        + "          \"value\":1089\n"
+        + "        }\n"
+        + "      }\n"
+        + "    ]\n"
+        + "  }\n"
+        + "}";
+    OpenSearchAggregationResponseParser parser = new SpanAggregationParser(
+        new SingleValueParser("count"));
+    assertThat(parse(parser, response), contains(
+        entry("count", 3586D, "timespan", "2021-07-01T00:00Z"),
+        entry("count", 1089D, "timespan", "2021-08-01T00:00Z")));
   }
 
   public List<Map<String, Object>> parse(OpenSearchAggregationResponseParser parser, String json) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilderTest.java
@@ -39,6 +39,7 @@ import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.expression.DSL.literal;
 import static org.opensearch.sql.expression.DSL.named;
 import static org.opensearch.sql.expression.DSL.ref;
+import static org.opensearch.sql.expression.DSL.span;
 import static org.opensearch.sql.opensearch.data.type.OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD;
 import static org.opensearch.sql.opensearch.utils.Utils.agg;
 import static org.opensearch.sql.opensearch.utils.Utils.avg;
@@ -67,6 +68,7 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.aggregation.AvgAggregator;
+import org.opensearch.sql.expression.aggregation.CountAggregator;
 import org.opensearch.sql.expression.aggregation.NamedAggregator;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
@@ -414,6 +416,35 @@ class AggregationQueryBuilderTest {
         containsInAnyOrder(
             map("avg(balance)", INTEGER)
         ));
+  }
+
+  @Test
+  void should_build_histogram() {
+    assertEquals(
+        "{\n"
+            + "  \"SpanExpression(field=age, value=10, unit=NONE)\" : {\n"
+            + "    \"histogram\" : {\n"
+            + "      \"field\" : \"age\",\n"
+            + "      \"interval\" : 10.0,\n"
+            + "      \"offset\" : 0.0,\n"
+            + "      \"order\" : {\n"
+            + "        \"_key\" : \"asc\"\n"
+            + "      },\n"
+            + "      \"keyed\" : false,\n"
+            + "      \"min_doc_count\" : 0\n"
+            + "    },\n"
+            + "    \"aggregations\" : {\n"
+            + "      \"count(a)\" : {\n"
+            + "        \"value_count\" : {\n"
+            + "          \"field\" : \"a\"\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(Arrays.asList(named("count(a)", new CountAggregator(Arrays.asList(ref(
+            "a", INTEGER)), INTEGER))),
+            Arrays.asList(named(span(ref("age", INTEGER), literal(10), "")))));
   }
 
   @SneakyThrows

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/SpanAggregationBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/SpanAggregationBuilderTest.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ *
+ */
+
+package org.opensearch.sql.opensearch.storage.script.aggregation.dsl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.sql.data.type.ExprCoreType.DATE;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
+import static org.opensearch.sql.expression.DSL.literal;
+import static org.opensearch.sql.expression.DSL.named;
+import static org.opensearch.sql.expression.DSL.ref;
+import static org.opensearch.sql.expression.DSL.span;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.expression.NamedExpression;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+public class SpanAggregationBuilderTest {
+  private final SpanAggregationBuilder aggregationBuilder = new SpanAggregationBuilder();
+
+  @Test
+  void fixed_interval_time_span() {
+    assertEquals(
+        "{\n"
+            + "  \"SpanExpression(field=timestamp, value=1, unit=H)\" : {\n"
+            + "    \"date_histogram\" : {\n"
+            + "      \"field\" : \"timestamp\",\n"
+            + "      \"fixed_interval\" : \"1h\",\n"
+            + "      \"offset\" : 0,\n"
+            + "      \"order\" : {\n"
+            + "        \"_key\" : \"asc\"\n"
+            + "      },\n"
+            + "      \"keyed\" : false,\n"
+            + "      \"min_doc_count\" : 0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(named(span(ref("timestamp", TIMESTAMP), literal(1), "h")))
+    );
+  }
+
+  @Test
+  void calendar_interval_time_span() {
+    assertEquals(
+        "{\n"
+            + "  \"SpanExpression(field=date, value=1, unit=W)\" : {\n"
+            + "    \"date_histogram\" : {\n"
+            + "      \"field\" : \"date\",\n"
+            + "      \"calendar_interval\" : \"1w\",\n"
+            + "      \"offset\" : 0,\n"
+            + "      \"order\" : {\n"
+            + "        \"_key\" : \"asc\"\n"
+            + "      },\n"
+            + "      \"keyed\" : false,\n"
+            + "      \"min_doc_count\" : 0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(named(span(ref("date", DATE), literal(1), "w")))
+    );
+  }
+
+  @Test
+  void general_span() {
+    assertEquals(
+        "{\n"
+            + "  \"SpanExpression(field=age, value=1, unit=NONE)\" : {\n"
+            + "    \"histogram\" : {\n"
+            + "      \"field\" : \"age\",\n"
+            + "      \"interval\" : 1.0,\n"
+            + "      \"offset\" : 0.0,\n"
+            + "      \"order\" : {\n"
+            + "        \"_key\" : \"asc\"\n"
+            + "      },\n"
+            + "      \"keyed\" : false,\n"
+            + "      \"min_doc_count\" : 0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(named(span(ref("age", INTEGER), literal(1), "")))
+    );
+  }
+
+  @Test
+  void invalid_unit() {
+    NamedExpression namedSpan = named(span(ref("age", INTEGER), literal(1), "invalid_unit"));
+    assertThrows(IllegalStateException.class, () -> buildQuery(namedSpan));
+  }
+
+  @SneakyThrows
+  private String buildQuery(NamedExpression namedExpression) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.readTree(
+        aggregationBuilder.build(namedExpression).toString())
+        .toPrettyString();
+  }
+
+}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -255,6 +255,16 @@ IFNULL:                             'IFNULL';
 NULLIF:                             'NULLIF';
 IF:                                 'IF';
 
+// SPAN KEYWORDS
+SPAN:                               'SPAN';
+MS:                                 'MS';
+S:                                  'S';
+M:                                  'M';
+H:                                  'H';
+W:                                  'W';
+Q:                                  'Q';
+Y:                                  'Y';
+
 
 // LITERALS AND VALUES
 //STRING_LITERAL:                     DQUOTA_STRING | SQUOTA_STRING | BQUOTA_STRING;

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -85,6 +85,7 @@ REGEXP:                             'REGEXP';
 DATETIME:                           'DATETIME';
 INTERVAL:                           'INTERVAL';
 MICROSECOND:                        'MICROSECOND';
+MILLISECOND:                        'MILLISECOND';
 SECOND:                             'SECOND';
 MINUTE:                             'MINUTE';
 HOUR:                               'HOUR';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -116,6 +116,11 @@ renameClasue
 
 byClause
     : BY fieldList
+    | BY spanClause
+    ;
+
+spanClause
+    : SPAN LT_PRTHS fieldExpression COMMA value=literalValue (unit=timespanUnit)? RT_PRTHS
     ;
 
 sortbyClause
@@ -314,6 +319,11 @@ intervalUnit
     : MICROSECOND | SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR | SECOND_MICROSECOND
     | MINUTE_MICROSECOND | MINUTE_SECOND | HOUR_MICROSECOND | HOUR_SECOND | HOUR_MINUTE | DAY_MICROSECOND
     | DAY_SECOND | DAY_MINUTE | DAY_HOUR | YEAR_MONTH
+    ;
+
+timespanUnit
+    : MS | S | M | H | D | W | Q | Y
+    | MICROSECOND | SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR
     ;
 
 

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -323,7 +323,7 @@ intervalUnit
 
 timespanUnit
     : MS | S | M | H | D | W | Q | Y
-    | MICROSECOND | SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR
+    | MILLISECOND | SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR
     ;
 
 

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -358,4 +358,5 @@ keywordsCanBeId
     | statsFunctionName
     | TIMESTAMP | DATE | TIME
     | FIRST | LAST
+    | timespanUnit
     ;

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -166,15 +166,15 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
       aggListBuilder.add(alias);
     }
 
-    List<UnresolvedExpression> groupList = ctx.byClause() == null ? Collections.emptyList() :
-        ctx.byClause() == null ? Collections.emptyList() : ctx.byClause().fieldList() != null
-            ? ctx.byClause()
-            .fieldList()
-            .fieldExpression()
-            .stream()
-            .map(groupCtx -> new Alias(getTextInQuery(groupCtx), visitExpression(groupCtx)))
-            .collect(Collectors.toList())
-            : Collections.singletonList(visitExpression(ctx.byClause().spanClause()));
+    List<UnresolvedExpression> groupList = ctx.byClause() == null ? Collections.emptyList()
+        : ctx.byClause().fieldList() != null
+        ? ctx.byClause()
+        .fieldList()
+        .fieldExpression()
+        .stream()
+        .map(groupCtx -> new Alias(getTextInQuery(groupCtx), visitExpression(groupCtx)))
+        .collect(Collectors.toList())
+        : Collections.singletonList(visitExpression(ctx.byClause().spanClause()));
 
     Aggregation aggregation = new Aggregation(
         aggListBuilder.build(),

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -167,12 +167,14 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     }
 
     List<UnresolvedExpression> groupList = ctx.byClause() == null ? Collections.emptyList() :
-        ctx.byClause()
+        ctx.byClause() == null ? Collections.emptyList() : ctx.byClause().fieldList() != null
+            ? ctx.byClause()
             .fieldList()
             .fieldExpression()
             .stream()
             .map(groupCtx -> new Alias(getTextInQuery(groupCtx), visitExpression(groupCtx)))
-            .collect(Collectors.toList());
+            .collect(Collectors.toList())
+            : Collections.singletonList(visitExpression(ctx.byClause().spanClause()));
 
     Aggregation aggregation = new Aggregation(
         aggListBuilder.build(),

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -51,6 +51,7 @@ import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalXor
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.ParentheticBinaryArithmeticContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.PercentileAggFunctionContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SortFieldContext;
+import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SpanClauseContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StatsFunctionCallContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StringLiteralContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TableSourceContext;
@@ -80,6 +81,8 @@ import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.Span;
+import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.Xor;
 import org.opensearch.sql.common.utils.StringUtils;
@@ -292,6 +295,12 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitBooleanLiteral(BooleanLiteralContext ctx) {
     return new Literal(Boolean.valueOf(ctx.getText()), DataType.BOOLEAN);
+  }
+
+  @Override
+  public UnresolvedExpression visitSpanClause(SpanClauseContext ctx) {
+    String unit = ctx.unit != null ? ctx.unit.getText() : "";
+    return new Span(visit(ctx.fieldExpression()), visit(ctx.value), SpanUnit.of(unit));
   }
 
   private QualifiedName visitIdentifiers(List<? extends ParserRuleContext> ctx) {

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -55,6 +55,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.rareTopN;
 import static org.opensearch.sql.ast.dsl.AstDSL.relation;
 import static org.opensearch.sql.ast.dsl.AstDSL.rename;
 import static org.opensearch.sql.ast.dsl.AstDSL.sort;
+import static org.opensearch.sql.ast.dsl.AstDSL.span;
 import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
 
 import org.junit.Ignore;
@@ -62,6 +63,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
 
@@ -282,6 +284,35 @@ public class AstBuilderTest {
             ),
             emptyList(),
             emptyList(),
+            defaultStatsArgs()
+        ));
+  }
+
+  @Test
+  public void testStatsCommandWithSpan() {
+    assertEqual("source=t | stats avg(price) by span(timestamp, 1h)",
+        agg(
+            relation("t"),
+            exprList(
+                alias("avg(price)", aggregate("avg", field("price")))
+            ),
+            emptyList(),
+            exprList(
+                span(field("timestamp"), intLiteral(1), SpanUnit.H)
+            ),
+            defaultStatsArgs()
+        ));
+
+    assertEqual("source=t | stats count(a) by span(age, 10)",
+        agg(
+            relation("t"),
+            exprList(
+                alias("count(a)", aggregate("count", field("a")))
+            ),
+            emptyList(),
+            exprList(
+                span(field("age"), intLiteral(10), SpanUnit.NONE)
+            ),
             defaultStatsArgs()
         ));
   }


### PR DESCRIPTION
### Description
The legacy engine has supported the date_histogram as an aggregation group option, but the new engine does not have this feature yet. This pull request adds the date histogram and also the numeric histogram (in other word the span aggregations) in the new query engine, and enable both SQL and PPL language with this functionality. Here follows a brief introduction of this implementation:

#### Syntax

1. PPL syntax: `span(field_name, interval_expr)`
The `interval_expr` is composite of a numeric value and optionally a time unit, for example `1w` (= 1 week), `1h` (= 1 hour) etc.. If no time unit is specified, the parser will take the unit as the natural unit 1.

In the PPL syntax, the span is enabled as a group (bucket) in the `stats` command in the by clause. For example, to aggregate the average of `taxful_total_price` by a monthly span of the `order_date` field:
```
# ppl query:
source=opensearch_dashboards_sample_data_ecommerce | stats avg(taxful_total_price) by span(order_date, 1M)

# result:
{
  "schema": [
    {
      "name": "avg(taxful_total_price)",
      "type": "double"
    },
    {
      "name": """Span(field=Field(field=order_date, fieldArgs=[]), value=1, unit=M)""",
      "type": "timestamp"
    }
  ],
  "datarows": [
    [
      74.53827711063859,
      "2021-07-01 00:00:00"
    ],
    [
      76.75837207300276,
      "2021-08-01 00:00:00"
    ]
  ],
  "total": 2,
  "size": 2
}
```

Here is another example, to count the doc number by a span of 1000 dollars of the `taxless_total_price` field:
```
# query
source=opensearch_dashboards_sample_data_ecommerce | stats count() by span(taxless_total_price, 1000)

# result
{
  "schema": [
    {
      "name": "count()",
      "type": "integer"
    },
    {
      "name": """Span(field=Field(field=taxless_total_price, fieldArgs=[]), value=1000, unit=NONE)""",
      "type": "float"
    }
  ],
  "datarows": [
    [
      4674,
      0.0
    ],
    [
      0,
      1000.0
    ],
    [
      1,
      2000.0
    ]
  ],
  "total": 3,
  "size": 3
}
```

2. SQL syntax


#### Span component query planning

#### Optimization and execution

#### Test

 
### Issues Resolved
#169 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

### Additional Check List
- [ ] Legacy engine compatibility
- [ ] Update user manual



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).