### PR TITLE
Update build to use public Maven repo

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -14,18 +14,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.14
-
-    # Publish OpenSearch to local Maven repo for now
-    - name: Checkout OpenSearch
-      uses: actions/checkout@v2
-      with:
-        repository: 'opensearch-project/OpenSearch'
-        path: OpenSearch
-        ref: '1.1'
-
-    - name: Build OpenSearch
-      working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal
     
     - name: Build with Gradle
       run: ./gradlew build assemble -Dopensearch.version=1.1.0-SNAPSHOT

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         jcenter()
     }
@@ -51,6 +52,7 @@ plugins {
 // Repository on root level is for dependencies that project code depends on. And this block must be placed after plugins{}
 repositories {
     mavenLocal()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
 }
 
@@ -72,6 +74,7 @@ allprojects {
 subprojects {
     repositories {
         mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
     }
 }


### PR DESCRIPTION
Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>

### Description
Updates build to use public [Maven repo](https://aws.oss.sonatype.org/content/repositories/snapshots) for snapshot builds.
 
### Issues Resolved
#219 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).