### PR TITLE
Changed the ODBC mac installer build platform to MacOS 10.15 from latest

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:    
   build-mac:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     defaults:
       run:
         working-directory: sql-odbc

--- a/.github/workflows/sql-odbc-release-workflow.yml
+++ b/.github/workflows/sql-odbc-release-workflow.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-mac:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     defaults:
       run:
         working-directory: sql-odbc


### PR DESCRIPTION
Signed-off-by: chloe-zh <chloezh1102@gmail.com>

### Description
The ODBC build fails but the build on macos 10.15 and earlier is working fine.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).