### PR TITLE
Add conversion support for datetime as per https://github.com/kylepbi…

### DIFF
--- a/sql-jdbc/src/main/java/org/opensearch/jdbc/ResultSetImpl.java
+++ b/sql-jdbc/src/main/java/org/opensearch/jdbc/ResultSetImpl.java
@@ -595,8 +595,11 @@ public class ResultSetImpl implements ResultSet, JdbcWrapper, LoggingSource {
     }
 
     protected <T> T getObjectX(int columnIndex, Class<T> javaClass, Map<String, Object> conversionParams) throws SQLException {
-        Object value = getColumn(columnIndex);
-        TypeConverter tc = TypeConverters.getInstance(getColumnMetaData(columnIndex).getOpenSearchType().getJdbcType());
+        final Object value = getColumn(columnIndex);
+        final TypeConverter tc = TypeConverters.getInstance(getColumnMetaData(columnIndex).getOpenSearchType().getJdbcType());
+        if (null == tc) {
+            throw new SQLException("Conversion from " + getColumnMetaData(columnIndex).getOpenSearchType() + " not supported.");
+        }
         return tc.convert(value, javaClass, conversionParams);
     }
 

--- a/sql-jdbc/src/main/java/org/opensearch/jdbc/types/OpenSearchType.java
+++ b/sql-jdbc/src/main/java/org/opensearch/jdbc/types/OpenSearchType.java
@@ -85,6 +85,7 @@ public enum OpenSearchType {
     OBJECT(JDBCType.STRUCT, null, 0, 0, false),
     DATE(JDBCType.DATE, Date.class, 24, 24, false),
     TIME(JDBCType.TIME, Time.class, 24, 24, false),
+    DATETIME(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
     TIMESTAMP(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
     BINARY(JDBCType.VARBINARY, String.class, Integer.MAX_VALUE, 0, false),
     NULL(JDBCType.NULL, null, 0, 0, false),


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
Previously datetime types would result in an NPE on retrieval, as the conversion would be unsupported. Map datetime to timestamp to support it. Copied from https://github.com/opensearch-project/sql/pull/255. Created this PR to include --signoff
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/252
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).