### PR TITLE
Optimized type converting in DSL filters

### DIFF
--- a/core/src/main/java/org/opensearch/sql/data/model/ExprTimestampValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprTimestampValue.java
@@ -56,7 +56,7 @@ public class ExprTimestampValue extends AbstractExprValue {
   /**
    * todo. only support timestamp in format yyyy-MM-dd HH:mm:ss.
    */
-  private static final DateTimeFormatter FORMATTER_WITNOUT_NANO = DateTimeFormatter
+  private static final DateTimeFormatter FORMATTER_WITHOUT_NANO = DateTimeFormatter
       .ofPattern("yyyy-MM-dd HH:mm:ss");
   private final Instant timestamp;
 
@@ -92,7 +92,7 @@ public class ExprTimestampValue extends AbstractExprValue {
 
   @Override
   public String value() {
-    return timestamp.getNano() == 0 ? FORMATTER_WITNOUT_NANO.withZone(ZONE)
+    return timestamp.getNano() == 0 ? FORMATTER_WITHOUT_NANO.withZone(ZONE)
         .format(timestamp.truncatedTo(ChronoUnit.SECONDS))
         : FORMATTER_VARIABLE_MICROS.withZone(ZONE).format(timestamp);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/operator/convert/TypeCastOperator.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/convert/TypeCastOperator.java
@@ -101,9 +101,9 @@ public class TypeCastOperator {
   private static FunctionResolver castToByte() {
     return FunctionDSL.define(BuiltinFunctionName.CAST_TO_BYTE.getName(),
         impl(nullMissingHandling(
-            (v) -> new ExprByteValue(Short.valueOf(v.stringValue()))), BYTE, STRING),
+            (v) -> new ExprByteValue(Byte.valueOf(v.stringValue()))), BYTE, STRING),
         impl(nullMissingHandling(
-            (v) -> new ExprByteValue(v.shortValue())), BYTE, DOUBLE),
+            (v) -> new ExprByteValue(v.byteValue())), BYTE, DOUBLE),
         impl(nullMissingHandling(
             (v) -> new ExprByteValue(v.booleanValue() ? 1 : 0)), BYTE, BOOLEAN)
     );

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -95,8 +95,8 @@ public abstract class LuceneQuery {
 
   private boolean literalExpressionWrappedByCast(FunctionExpression func) {
     if (func.getArguments().get(1) instanceof FunctionExpression) {
-      FunctionExpression castFunction = (FunctionExpression) func.getArguments().get(1);
-      return castFunction.getArguments().get(0) instanceof LiteralExpression;
+      return castMap.containsKey(((FunctionExpression) func.getArguments().get(1))
+          .getFunctionName());
     }
     return false;
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -29,14 +29,32 @@ package org.opensearch.sql.opensearch.storage.script.filter.lucene;
 
 import static org.opensearch.sql.opensearch.data.type.OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.function.Function;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.sql.data.model.ExprBooleanValue;
+import org.opensearch.sql.data.model.ExprByteValue;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprDoubleValue;
+import org.opensearch.sql.data.model.ExprFloatValue;
+import org.opensearch.sql.data.model.ExprIntegerValue;
+import org.opensearch.sql.data.model.ExprLongValue;
+import org.opensearch.sql.data.model.ExprShortValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.NamedArgumentExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.expression.function.FunctionName;
 
 /**
  * Lucene query abstraction that builds Lucene query from function expression.
@@ -55,7 +73,8 @@ public abstract class LuceneQuery {
   public boolean canSupport(FunctionExpression func) {
     return (func.getArguments().size() == 2)
         && (func.getArguments().get(0) instanceof ReferenceExpression)
-        && (func.getArguments().get(1) instanceof LiteralExpression)
+        && (func.getArguments().get(1) instanceof LiteralExpression
+        || literalExpressionWrappedByCast(func))
         || isMultiParameterQuery(func);
   }
 
@@ -74,17 +93,139 @@ public abstract class LuceneQuery {
     return true;
   }
 
+  private boolean literalExpressionWrappedByCast(FunctionExpression func) {
+    if (func.getArguments().get(1) instanceof FunctionExpression) {
+      FunctionExpression castFunction = (FunctionExpression) func.getArguments().get(1);
+      return castFunction.getArguments().get(0) instanceof LiteralExpression;
+    }
+    return false;
+  }
+
   /**
    * Build Lucene query from function expression.
+   * The cast function is converted to literal expressions before generating DSL.
    *
    * @param func  function
    * @return      query
    */
   public QueryBuilder build(FunctionExpression func) {
     ReferenceExpression ref = (ReferenceExpression) func.getArguments().get(0);
-    LiteralExpression literal = (LiteralExpression) func.getArguments().get(1);
-    return doBuild(ref.getAttr(), ref.type(), literal.valueOf(null));
+    Expression expr = func.getArguments().get(1);
+    ExprValue literalValue = expr instanceof LiteralExpression ? expr
+        .valueOf(null) : cast((FunctionExpression) expr);
+    return doBuild(ref.getAttr(), ref.type(), literalValue);
   }
+
+  private ExprValue cast(FunctionExpression castFunction) {
+    return castMap.get(castFunction.getFunctionName()).apply(
+        (LiteralExpression) castFunction.getArguments().get(0));
+  }
+
+  /**
+   * Type converting map.
+   */
+  private final Map<FunctionName, Function<LiteralExpression, ExprValue>> castMap = ImmutableMap
+      .<FunctionName, Function<LiteralExpression, ExprValue>>builder()
+      .put(BuiltinFunctionName.CAST_TO_STRING.getName(), expr -> {
+        if (!expr.type().equals(ExprCoreType.STRING)) {
+          return new ExprStringValue(String.valueOf(expr.valueOf(null).value()));
+        } else {
+          return expr.valueOf(null);
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_BYTE.getName(), expr -> {
+        if (ExprCoreType.numberTypes().contains(expr.type())) {
+          return new ExprByteValue(expr.valueOf(null).byteValue());
+        } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
+          return new ExprByteValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+        } else {
+          return new ExprByteValue(Byte.valueOf(expr.valueOf(null).stringValue()));
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_SHORT.getName(), expr -> {
+        if (ExprCoreType.numberTypes().contains(expr.type())) {
+          return new ExprShortValue(expr.valueOf(null).shortValue());
+        } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
+          return new ExprShortValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+        } else {
+          return new ExprShortValue(Short.valueOf(expr.valueOf(null).stringValue()));
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_INT.getName(), expr -> {
+        if (ExprCoreType.numberTypes().contains(expr.type())) {
+          return new ExprIntegerValue(expr.valueOf(null).integerValue());
+        } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
+          return new ExprIntegerValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+        } else {
+          return new ExprIntegerValue(Integer.valueOf(expr.valueOf(null).stringValue()));
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_LONG.getName(), expr -> {
+        if (ExprCoreType.numberTypes().contains(expr.type())) {
+          return new ExprLongValue(expr.valueOf(null).longValue());
+        } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
+          return new ExprLongValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+        } else {
+          return new ExprLongValue(Long.valueOf(expr.valueOf(null).stringValue()));
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_FLOAT.getName(), expr -> {
+        if (ExprCoreType.numberTypes().contains(expr.type())) {
+          return new ExprFloatValue(expr.valueOf(null).floatValue());
+        } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
+          return new ExprFloatValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+        } else {
+          return new ExprFloatValue(Float.valueOf(expr.valueOf(null).stringValue()));
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_DOUBLE.getName(), expr -> {
+        if (ExprCoreType.numberTypes().contains(expr.type())) {
+          return new ExprDoubleValue(expr.valueOf(null).doubleValue());
+        } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
+          return new ExprDoubleValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+        } else {
+          return new ExprDoubleValue(Double.valueOf(expr.valueOf(null).stringValue()));
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_BOOLEAN.getName(), expr -> {
+        if (ExprCoreType.numberTypes().contains(expr.type())) {
+          return expr.valueOf(null).doubleValue() == 1
+              ? ExprBooleanValue.of(true) : ExprBooleanValue.of(false);
+        } else if (expr.type().equals(ExprCoreType.STRING)) {
+          return ExprBooleanValue.of(Boolean.valueOf(expr.valueOf(null).stringValue()));
+        } else {
+          return expr.valueOf(null);
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_DATE.getName(), expr -> {
+        if (expr.type().equals(ExprCoreType.STRING)) {
+          return new ExprDateValue(expr.valueOf(null).stringValue());
+        } else {
+          return new ExprDateValue(expr.valueOf(null).dateValue());
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_TIME.getName(), expr -> {
+        if (expr.type().equals(ExprCoreType.STRING)) {
+          return new ExprTimeValue(expr.valueOf(null).stringValue());
+        } else {
+          return new ExprTimeValue(expr.valueOf(null).timeValue());
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_DATETIME.getName(), expr -> {
+        if (expr.type().equals(ExprCoreType.STRING)) {
+          return new ExprDatetimeValue(expr.valueOf(null).stringValue());
+        } else {
+          return new ExprDatetimeValue(expr.valueOf(null).datetimeValue());
+        }
+      })
+      .put(BuiltinFunctionName.CAST_TO_TIMESTAMP.getName(), expr -> {
+        if (expr.type().equals(ExprCoreType.STRING)) {
+          return new ExprTimestampValue(expr.valueOf(null).stringValue());
+        } else {
+          return new ExprTimestampValue(expr.valueOf(null).timestampValue());
+        }
+      })
+      .build();
 
   /**
    * Build method that subclass implements by default which is to build query

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -100,7 +100,7 @@ public abstract class LuceneQuery {
     if (func.getArguments().get(1) instanceof FunctionExpression) {
       FunctionExpression expr = (FunctionExpression) func.getArguments().get(1);
       return castMap.containsKey(expr.getFunctionName())
-          && func.getArguments().get(0) instanceof LiteralExpression;
+          && expr.getArguments().get(0) instanceof LiteralExpression;
     }
     return false;
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -93,10 +93,14 @@ public abstract class LuceneQuery {
     return true;
   }
 
+  /**
+   * Check if the second argument of the function is a literal expression wrapped by cast function.
+   */
   private boolean literalExpressionWrappedByCast(FunctionExpression func) {
     if (func.getArguments().get(1) instanceof FunctionExpression) {
-      return castMap.containsKey(((FunctionExpression) func.getArguments().get(1))
-          .getFunctionName());
+      FunctionExpression expr = (FunctionExpression) func.getArguments().get(1);
+      return castMap.containsKey(expr.getFunctionName())
+          && func.getArguments().get(0) instanceof LiteralExpression;
     }
     return false;
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/RangeQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/RangeQuery.java
@@ -32,6 +32,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 
 /**
@@ -51,7 +52,7 @@ public class RangeQuery extends LuceneQuery {
 
   @Override
   protected QueryBuilder doBuild(String fieldName, ExprType fieldType, ExprValue literal) {
-    Object value = literal.value();
+    Object value = value(literal);
 
     RangeQueryBuilder query = QueryBuilders.rangeQuery(fieldName);
     switch (comparison) {
@@ -65,6 +66,14 @@ public class RangeQuery extends LuceneQuery {
         return query.gte(value);
       default:
         throw new IllegalStateException("Comparison is supported by range query: " + comparison);
+    }
+  }
+
+  private Object value(ExprValue literal) {
+    if (literal.type().equals(ExprCoreType.TIMESTAMP)) {
+      return literal.timestampValue().toEpochMilli();
+    } else {
+      return literal.value();
     }
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/TermQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/TermQuery.java
@@ -30,6 +30,7 @@ package org.opensearch.sql.opensearch.storage.script.filter.lucene;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 
 /**
@@ -40,7 +41,15 @@ public class TermQuery extends LuceneQuery {
   @Override
   protected QueryBuilder doBuild(String fieldName, ExprType fieldType, ExprValue literal) {
     fieldName = convertTextToKeyword(fieldName, fieldType);
-    return QueryBuilders.termQuery(fieldName, literal.value());
+    return QueryBuilders.termQuery(fieldName, value(literal));
+  }
+
+  private Object value(ExprValue literal) {
+    if (literal.type().equals(ExprCoreType.TIMESTAMP)) {
+      return literal.timestampValue().toEpochMilli();
+    } else {
+      return literal.value();
+    }
   }
 
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -656,7 +656,43 @@ class FilterQueryBuilderTest {
             + "    }\n"
             + "  }\n"
             + "}",
-        buildQuery(dsl.greater(ref("timestamp_value", TIMESTAMP), literal("2021-11-08 17:00:00"))));
+        buildQuery(dsl.greater(ref("timestamp_value", TIMESTAMP), dsl.castTimestamp(literal("2021-11-08 17:00:00")))));
+  }
+
+  @Test
+  void non_literal_in_cast_should_build_script() {
+    mockToStringSerializer();
+    assertJsonEquals(
+        "{\n"
+            + "  \"script\" : {\n"
+            + "    \"script\" : {\n"
+            + "      \"source\" : \"=(string_value, cast_to_string(+(1, 0)))\",\n"
+            + "      \"lang\" : \"opensearch_query_expression\"\n"
+            + "    },\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.equal(ref("string_value", STRING), dsl.castString(dsl
+            .add(literal(1), literal(0)))))
+    );
+  }
+
+  @Test
+  void non_cast_nested_function_should_build_script() {
+    mockToStringSerializer();
+    assertJsonEquals(
+        "{\n"
+            + "  \"script\" : {\n"
+            + "    \"script\" : {\n"
+            + "      \"source\" : \"=(integer_value, abs(+(1, 0)))\",\n"
+            + "      \"lang\" : \"opensearch_query_expression\"\n"
+            + "    },\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.equal(ref("integer_value", INTEGER), dsl.abs(dsl
+            .add(literal(1), literal(0)))))
+    );
   }
 
   private static void assertJsonEquals(String expected, String actual) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -31,27 +31,46 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static org.opensearch.sql.data.type.ExprCoreType.BYTE;
+import static org.opensearch.sql.data.type.ExprCoreType.DATE;
+import static org.opensearch.sql.data.type.ExprCoreType.DATETIME;
+import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
+import static org.opensearch.sql.data.type.ExprCoreType.FLOAT;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.data.type.ExprCoreType.SHORT;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.data.type.ExprCoreType.TIME;
+import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 import static org.opensearch.sql.expression.DSL.literal;
 import static org.opensearch.sql.expression.DSL.ref;
 import static org.opensearch.sql.opensearch.data.type.OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
+import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
 
@@ -60,6 +79,21 @@ import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
 class FilterQueryBuilderTest {
 
   private final DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+
+  private static Stream<LiteralExpression> numericCastSource() {
+    return Stream.of(literal((byte) 1), literal((short) 1), literal(
+        1), literal(1L), literal(1F), literal(1D), literal(true), literal("1"));
+  }
+
+  private static Stream<LiteralExpression> booleanTrueCastSource() {
+    return Stream.of(literal((byte) 1), literal((short) 1), literal(
+        1), literal(1L), literal(1F), literal(1D), literal(true), literal("true"));
+  }
+
+  private static Stream<LiteralExpression> booleanFalseCastSource() {
+    return Stream.of(literal((byte) 0), literal((short) 0), literal(
+        0), literal(0L), literal(0F), literal(0D), literal(false), literal("false"));
+  }
 
   @Mock
   private ExpressionSerializer serializer;
@@ -350,6 +384,279 @@ class FilterQueryBuilderTest {
         dsl.namedArgument("invalid_parameter", literal("invalid_value")));
     assertThrows(SemanticCheckException.class, () -> buildQuery(expr),
         "Parameter invalid_parameter is invalid for match function.");
+  }
+
+  @Test
+  void cast_to_string_in_filter() {
+    String json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"string_value\" : {\n"
+        + "      \"value\" : \"1\",\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("string_value", STRING), dsl.castString(literal(1)))));
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("string_value", STRING), dsl.castString(literal("1")))));
+  }
+
+  @ParameterizedTest(name = "castByte({0})")
+  @MethodSource({"numericCastSource"})
+  void cast_to_byte_in_filter(LiteralExpression expr) {
+    assertJsonEquals(
+        "{\n"
+            + "  \"term\" : {\n"
+            + "    \"byte_value\" : {\n"
+            + "      \"value\" : 1,\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.equal(ref("byte_value", BYTE), dsl.castByte(expr))));
+  }
+
+  @ParameterizedTest(name = "castShort({0})")
+  @MethodSource({"numericCastSource"})
+  void cast_to_short_in_filter(LiteralExpression expr) {
+    assertJsonEquals(
+        "{\n"
+            + "  \"term\" : {\n"
+            + "    \"short_value\" : {\n"
+            + "      \"value\" : 1,\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.equal(ref("short_value", SHORT), dsl.castShort(expr))));
+  }
+
+  @ParameterizedTest(name = "castInt({0})")
+  @MethodSource({"numericCastSource"})
+  void cast_to_int_in_filter(LiteralExpression expr) {
+    assertJsonEquals(
+        "{\n"
+            + "  \"term\" : {\n"
+            + "    \"integer_value\" : {\n"
+            + "      \"value\" : 1,\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.equal(ref("integer_value", INTEGER), dsl.castInt(expr))));
+  }
+
+  @ParameterizedTest(name = "castLong({0})")
+  @MethodSource({"numericCastSource"})
+  void cast_to_long_in_filter(LiteralExpression expr) {
+    assertJsonEquals(
+        "{\n"
+            + "  \"term\" : {\n"
+            + "    \"long_value\" : {\n"
+            + "      \"value\" : 1,\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.equal(ref("long_value", LONG), dsl.castLong(expr))));
+  }
+
+  @ParameterizedTest(name = "castFloat({0})")
+  @MethodSource({"numericCastSource"})
+  void cast_to_float_in_filter(LiteralExpression expr) {
+    assertJsonEquals(
+        "{\n"
+            + "  \"term\" : {\n"
+            + "    \"float_value\" : {\n"
+            + "      \"value\" : 1.0,\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.equal(ref("float_value", FLOAT), dsl.castFloat(expr))));
+  }
+
+  @ParameterizedTest(name = "castDouble({0})")
+  @MethodSource({"numericCastSource"})
+  void cast_to_double_in_filter(LiteralExpression expr) {
+    assertJsonEquals(
+        "{\n"
+            + "  \"term\" : {\n"
+            + "    \"double_value\" : {\n"
+            + "      \"value\" : 1.0,\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.equal(ref("double_value", DOUBLE), dsl.castDouble(expr))));
+  }
+
+  @ParameterizedTest(name = "castBooleanTrue({0})")
+  @MethodSource({"booleanTrueCastSource"})
+  void cast_to_boolean_true_in_filter(LiteralExpression expr) {
+    String json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"boolean_value\" : {\n"
+        + "      \"value\" : true,\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+
+    assertJsonEquals(
+        json, buildQuery(dsl.equal(ref("boolean_value", BOOLEAN), dsl.castBoolean(expr))));
+  }
+
+  @ParameterizedTest(name = "castBooleanFalse({0})")
+  @MethodSource({"booleanFalseCastSource"})
+  void cast_to_boolean_false_in_filter(LiteralExpression expr) {
+    String json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"boolean_value\" : {\n"
+        + "      \"value\" : false,\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+
+    assertJsonEquals(
+        json, buildQuery(dsl.equal(ref("boolean_value", BOOLEAN), dsl.castBoolean(expr))));
+  }
+
+  @Test
+  void cast_from_boolean() {
+    Expression booleanExpr = literal(false);
+    String json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"my_value\" : {\n"
+        + "      \"value\" : 0,\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("my_value", BYTE), dsl.castByte(booleanExpr))));
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("my_value", SHORT), dsl.castShort(booleanExpr))));
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("my_value", INTEGER), dsl.castInt(booleanExpr))));
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("my_value", LONG), dsl.castLong(booleanExpr))));
+
+    json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"my_value\" : {\n"
+        + "      \"value\" : 0.0,\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("my_value", FLOAT), dsl.castFloat(booleanExpr))));
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("my_value", DOUBLE), dsl.castDouble(booleanExpr))));
+
+    json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"my_value\" : {\n"
+        + "      \"value\" : \"false\",\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+    assertJsonEquals(json, buildQuery(
+        dsl.equal(ref("my_value", STRING), dsl.castString(booleanExpr))));
+  }
+
+  @Test
+  void cast_to_date_in_filter() {
+    String json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"date_value\" : {\n"
+        + "      \"value\" : \"2021-11-08\",\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+
+    assertJsonEquals(json, buildQuery(dsl.equal(
+        ref("date_value", DATE), dsl.castDate(literal("2021-11-08")))));
+    assertJsonEquals(json, buildQuery(dsl.equal(
+        ref("date_value", DATE), dsl.castDate(literal(new ExprDateValue("2021-11-08"))))));
+    assertJsonEquals(json, buildQuery(dsl.equal(ref(
+        "date_value", DATE), dsl.castDate(literal(new ExprDatetimeValue("2021-11-08 17:00:00"))))));
+  }
+
+  @Test
+  void cast_to_time_in_filter() {
+    String json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"time_value\" : {\n"
+        + "      \"value\" : \"17:00:00\",\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+
+    assertJsonEquals(json, buildQuery(dsl.equal(
+        ref("time_value", TIME), dsl.castTime(literal("17:00:00")))));
+    assertJsonEquals(json, buildQuery(dsl.equal(
+        ref("time_value", TIME), dsl.castTime(literal(new ExprTimeValue("17:00:00"))))));
+    assertJsonEquals(json, buildQuery(dsl.equal(ref("time_value", TIME), dsl
+        .castTime(literal(new ExprTimestampValue("2021-11-08 17:00:00"))))));
+  }
+
+  @Test
+  void cast_to_datetime_in_filter() {
+    String json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"datetime_value\" : {\n"
+        + "      \"value\" : \"2021-11-08 17:00:00\",\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+
+    assertJsonEquals(json, buildQuery(dsl.equal(ref("datetime_value", DATETIME), dsl
+        .castDatetime(literal("2021-11-08 17:00:00")))));
+    assertJsonEquals(json, buildQuery(dsl.equal(ref("datetime_value", DATETIME), dsl
+        .castDatetime(literal(new ExprTimestampValue("2021-11-08 17:00:00"))))));
+  }
+
+  @Test
+  void cast_to_timestamp_in_filter() {
+    String json = "{\n"
+        + "  \"term\" : {\n"
+        + "    \"timestamp_value\" : {\n"
+        + "      \"value\" : 1636390800000,\n"
+        + "      \"boost\" : 1.0\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+
+    assertJsonEquals(json, buildQuery(dsl.equal(ref("timestamp_value", TIMESTAMP), dsl
+        .castTimestamp(literal("2021-11-08 17:00:00")))));
+    assertJsonEquals(json, buildQuery(dsl.equal(ref("timestamp_value", TIMESTAMP), dsl
+        .castTimestamp(literal(new ExprTimestampValue("2021-11-08 17:00:00"))))));
+  }
+
+  @Test
+  void cast_in_range_query() {
+    assertJsonEquals(
+        "{\n"
+            + "  \"range\" : {\n"
+            + "    \"timestamp_value\" : {\n"
+            + "      \"from\" : 1636390800000,\n"
+            + "      \"to\" : null,"
+            + "      \"include_lower\" : false,"
+            + "      \"include_upper\" : true,"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(dsl.greater(ref("timestamp_value", TIMESTAMP), literal("2021-11-08 17:00:00"))));
   }
 
   private static void assertJsonEquals(String expected, String actual) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -656,7 +656,8 @@ class FilterQueryBuilderTest {
             + "    }\n"
             + "  }\n"
             + "}",
-        buildQuery(dsl.greater(ref("timestamp_value", TIMESTAMP), dsl.castTimestamp(literal("2021-11-08 17:00:00")))));
+        buildQuery(dsl.greater(ref("timestamp_value", TIMESTAMP), dsl
+            .castTimestamp(literal("2021-11-08 17:00:00")))));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Chloe Zhang <chloezh1102@gmail.com>

### Description
By default the non literal expressions in a query are converted to scripts before put into the DSL queries to enable users to do calculations over columns in the query engine. But The scripts usually cause low efficiency as a trade-off. We would prefer pushing as much as possible of the query out of the script and directly into fields if possible. 

This PR is to optimize the following scenario:

For filters that contains castings, for example:
```
SELECT FlightNum FROM opensearch_dashboards_sample_data_flights WHERE timestamp > '2021-01-01 00:00:00' 
```
There is an implicit cast in WHERE clause, `timestamp > '2021-01-01 00:00:00' ` casts the string '2021-01-01 00:00:00' to timestamp type implicitly before translate the entire filter expression to DSL, this is equivalent to
```
SELECT FlightNum FROM opensearch_dashboards_sample_data_flights WHERE timestamp > cast('2021-01-01 00:00:00' as timestamp)
```
The DSL query looks like, where the script is not readable because it is already serialized: 
```
{
  "from":0,
  "size":200,
  "timeout":"1m",
  "query":{
    "script":{
      "script":{
"source":"rO0ABXNyADRvcmcub3BlbnNlYXJjaC5zcWwuZXhwcmVzc2lvbi5mdW5jdGlvbi5GdW5jdGlvbkRTTCQzwaDcqkK/macCAARMAA12YWwkYXJndW1lbnRzdAAQTGphdmEvdXRpbC9MaXN0O0wADHZhbCRmdW5jdGlvbnQAP0xvcmcvb3BlbnNlYXJjaC9zcWwvZXhwcmVzc2lvbi9mdW5jdGlvbi9TZXJpYWxpemFibGVCaUZ1bmN0aW9uO0wAEHZhbCRmdW5jdGlvbk5hbWV0ADVMb3JnL29wZW5zZWFyY2gvc3FsL2V4cHJlc3Npb24vZnVuY3Rpb24vRnVuY3Rpb25OYW1lO0wADnZhbCRyZXR1cm5UeXBldAAnTG9yZy9vcGVuc2VhcmNoL3NxbC9kYXRhL3R5cGUvRXhwclR5cGU7eHIAMG9yZy5vcGVuc2VhcmNoLnNxbC5leHByZXNzaW9uLkZ1bmN0aW9uRXhwcmVzc2lvbrIqMNPcdWp7AgACTAAJYXJndW1lbnRzcQB+AAFMAAxmdW5jdGlvbk5hbWVxAH4AA3hwc3IAE2phdmEudXRpbC5BcnJheUxpc3R4gdIdmcdhnQMAAUkABHNpemV4cAAAAAJ3BAAAAAJzcgAxb3JnLm9wZW5zZWFyY2guc3FsLmV4cHJlc3Npb24uUmVmZXJlbmNlRXhwcmVzc2lvbvgA7SvFa8yQAgADTAAEYXR0cnQAEkxqYXZhL2xhbmcvU3RyaW5nO0wABXBhdGhzcQB+AAFMAAR0eXBlcQB+AAR4cHQACXRpbWVzdGFtcHNyABpqYXZhLnV0aWwuQXJyYXlzJEFycmF5TGlzdNmkPL7NiAbSAgABWwABYXQAE1tMamF2YS9sYW5nL09iamVjdDt4cHVyABNbTGphdmEubGFuZy5TdHJpbmc7rdJW5+kde0cCAAB4cAAAAAFxAH4ADH5yAClvcmcub3BlbnNlYXJjaC5zcWwuZGF0YS50eXBlLkV4cHJDb3JlVHlwZQAAAAAAAAAAEgAAeHIADmphdmEubGFuZy5FbnVtAAAAAAAAAAASAAB4cHQACVRJTUVTVEFNUHNyADRvcmcub3BlbnNlYXJjaC5zcWwuZXhwcmVzc2lvbi5mdW5jdGlvbi5GdW5jdGlvbkRTTCQy7+eYHhdeXG4CAARMAA12YWwkYXJndW1lbnRzcQB+AAFMAAx2YWwkZnVuY3Rpb250AD1Mb3JnL29wZW5zZWFyY2gvc3FsL2V4cHJlc3Npb24vZnVuY3Rpb24vU2VyaWFsaXphYmxlRnVuY3Rpb247TAAQdmFsJGZ1bmN0aW9uTmFtZXEAfgADTAAOdmFsJHJldHVyblR5cGVxAH4ABHhxAH4ABXNxAH4ABwAAAAF3BAAAAAFzcgAvb3JnLm9wZW5zZWFyY2guc3FsLmV4cHJlc3Npb24uTGl0ZXJhbEV4cHJlc3Npb25FQi3wjMeCJAIAAUwACWV4cHJWYWx1ZXQAKUxvcmcvb3BlbnNlYXJjaC9zcWwvZGF0YS9tb2RlbC9FeHByVmFsdWU7eHBzcgAtb3JnLm9wZW5zZWFyY2guc3FsLmRhdGEubW9kZWwuRXhwclN0cmluZ1ZhbHVlwrjb4hN19GwCAAFMAAV2YWx1ZXEAfgAKeHIAL29yZy5vcGVuc2VhcmNoLnNxbC5kYXRhLm1vZGVsLkFic3RyYWN0RXhwclZhbHVl5d/SeNHJxJQCAAB4cHQAEzIwMjEtMDEtMDEgMDA6MDA6MDB4c3IAM29yZy5vcGVuc2VhcmNoLnNxbC5leHByZXNzaW9uLmZ1bmN0aW9uLkZ1bmN0aW9uTmFtZQuoOE3O9meXAgABTAAMZnVuY3Rpb25OYW1lcQB+AAp4cHQAEWNhc3RfdG9fdGltZXN0YW1wcQB+ABlzcgAhamF2YS5sYW5nLmludm9rZS5TZXJpYWxpemVkTGFtYmRhb2HQlCwpNoUCAApJAA5pbXBsTWV0aG9kS2luZFsADGNhcHR1cmVkQXJnc3EAfgAOTAAOY2FwdHVyaW5nQ2xhc3N0ABFMamF2YS9sYW5nL0NsYXNzO0wAGGZ1bmN0aW9uYWxJbnRlcmZhY2VDbGFzc3EAfgAKTAAdZnVuY3Rpb25hbEludGVyZmFjZU1ldGhvZE5hbWVxAH4ACkwAImZ1bmN0aW9uYWxJbnRlcmZhY2VNZXRob2RTaWduYXR1cmVxAH4ACkwACWltcGxDbGFzc3EAfgAKTAAOaW1wbE1ldGhvZE5hbWVxAH4ACkwAE2ltcGxNZXRob2RTaWduYXR1cmVxAH4ACkwAFmluc3RhbnRpYXRlZE1ldGhvZFR5cGVxAH4ACnhwAAAABnVyABNbTGphdmEubGFuZy5PYmplY3Q7kM5YnxBzKWwCAAB4cAAAAAFzcQB+ACQAAAAGdXEAfgAnAAAAAHZyAD9vcmcub3BlbnNlYXJjaC5zcWwuZXhwcmVzc2lvbi5vcGVyYXRvci5jb252ZXJ0LlR5cGVDYXN0T3BlcmF0b3IAAAAAAAAAAAAAAHhwdAA7b3JnL29wZW5zZWFyY2gvc3FsL2V4cHJlc3Npb24vZnVuY3Rpb24vU2VyaWFsaXphYmxlRnVuY3Rpb250AAVhcHBseXQAJihMamF2YS9sYW5nL09iamVjdDspTGphdmEvbGFuZy9PYmplY3Q7dAA/b3JnL29wZW5zZWFyY2gvc3FsL2V4cHJlc3Npb24vb3BlcmF0b3IvY29udmVydC9UeXBlQ2FzdE9wZXJhdG9ydAAhbGFtYmRhJGNhc3RUb1RpbWVzdGFtcCQ4Nzc4ODA3NyQxdABUKExvcmcvb3BlbnNlYXJjaC9zcWwvZGF0YS9tb2RlbC9FeHByVmFsdWU7KUxvcmcvb3BlbnNlYXJjaC9zcWwvZGF0YS9tb2RlbC9FeHByVmFsdWU7cQB+ADJ2cgAyb3JnLm9wZW5zZWFyY2guc3FsLmV4cHJlc3Npb24uZnVuY3Rpb24uRnVuY3Rpb25EU0wAAAAAAAAAAAAAAHhwcQB+AC1xAH4ALnEAfgAvdAAyb3JnL29wZW5zZWFyY2gvc3FsL2V4cHJlc3Npb24vZnVuY3Rpb24vRnVuY3Rpb25EU0x0ACVsYW1iZGEkbnVsbE1pc3NpbmdIYW5kbGluZyQ4NzgwNjljOCQxdACRKExvcmcvb3BlbnNlYXJjaC9zcWwvZXhwcmVzc2lvbi9mdW5jdGlvbi9TZXJpYWxpemFibGVGdW5jdGlvbjtMb3JnL29wZW5zZWFyY2gvc3FsL2RhdGEvbW9kZWwvRXhwclZhbHVlOylMb3JnL29wZW5zZWFyY2gvc3FsL2RhdGEvbW9kZWwvRXhwclZhbHVlO3EAfgAycQB+ACJxAH4AFHhzcQB+ACF0AAE+cQB+AAhzcQB+ACQAAAAGdXEAfgAnAAAAAXNxAH4AJAAAAAZ1cQB+ACcAAAAAdnIASG9yZy5vcGVuc2VhcmNoLnNxbC5leHByZXNzaW9uLm9wZXJhdG9yLnByZWRpY2F0ZS5CaW5hcnlQcmVkaWNhdGVPcGVyYXRvcgAAAAAAAAAAAAAAeHB0AD1vcmcvb3BlbnNlYXJjaC9zcWwvZXhwcmVzc2lvbi9mdW5jdGlvbi9TZXJpYWxpemFibGVCaUZ1bmN0aW9ucQB+AC50ADgoTGphdmEvbGFuZy9PYmplY3Q7TGphdmEvbGFuZy9PYmplY3Q7KUxqYXZhL2xhbmcvT2JqZWN0O3QASG9yZy9vcGVuc2VhcmNoL3NxbC9leHByZXNzaW9uL29wZXJhdG9yL3ByZWRpY2F0ZS9CaW5hcnlQcmVkaWNhdGVPcGVyYXRvcnQAGWxhbWJkYSRncmVhdGVyJGEwMWNlNDMwJDF0AH0oTG9yZy9vcGVuc2VhcmNoL3NxbC9kYXRhL21vZGVsL0V4cHJWYWx1ZTtMb3JnL29wZW5zZWFyY2gvc3FsL2RhdGEvbW9kZWwvRXhwclZhbHVlOylMb3JnL29wZW5zZWFyY2gvc3FsL2RhdGEvbW9kZWwvRXhwclZhbHVlO3EAfgBEcQB+ADRxAH4AQHEAfgAucQB+AEFxAH4ANXQAJWxhbWJkYSRudWxsTWlzc2luZ0hhbmRsaW5nJGE1MDA1MjgxJDF0ALwoTG9yZy9vcGVuc2VhcmNoL3NxbC9leHByZXNzaW9uL2Z1bmN0aW9uL1NlcmlhbGl6YWJsZUJpRnVuY3Rpb247TG9yZy9vcGVuc2VhcmNoL3NxbC9kYXRhL21vZGVsL0V4cHJWYWx1ZTtMb3JnL29wZW5zZWFyY2gvc3FsL2RhdGEvbW9kZWwvRXhwclZhbHVlOylMb3JnL29wZW5zZWFyY2gvc3FsL2RhdGEvbW9kZWwvRXhwclZhbHVlO3EAfgBEcQB+ADh+cQB+ABJ0AAdCT09MRUFO",
        "lang":"opensearch_query_expression"
      },
      "boost":1.0
    }
  },
  "_source":{
    "includes":[
      "FlightDelay"
    ],
    "excludes":[
      
    ]
  },
  "sort":[
    {
      "_doc":{
        "order":"asc"
      }
    }
  ]
}
```

----

This PR is to disable the scripting for the literal expressions that are simply wrapped by the cast functions, like the example above. Thus the DSL will then become:
```
{
  "from":0,
  "size":200,
  "timeout":"1m",
  "query":{
    "range":{
      "timestamp":{
        "from":1609459200000,
        "to":null,
        "include_lower":false,
        "include_upper":true,
        "boost":1.0
      }
    }
  },
  "_source":{
    "includes":[
      "FlightDelay"
    ],
    "excludes":[
      
    ]
  },
  "sort":[
    {
      "_doc":{
        "order":"asc"
      }
    }
  ]
}
```

Another example:
```
SELECT FlightNum FROM opensearch_dashboards_sample_data_flights WHERE FlightDelay = true

# DSL:
{
  "from":0,
  "size":200,
  "timeout":"1m",
  "query":{
    "term":{
      "FlightDelay":{
        "value":true,
        "boost":1.0
      }
    }
  },
  "_source":{
    "includes":[
      "FlightNum"
    ],
    "excludes":[
      
    ]
  },
  "sort":[
    {
      "_doc":{
        "order":"asc"
      }
    }
  ]
}
```

 
### Issues Resolved
#263 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).