### PR TITLE
Fixed result parsing error for boolean type

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
@@ -63,7 +63,13 @@ public class ObjectContent implements Content {
 
   @Override
   public Boolean booleanValue() {
-    return (Boolean) value;
+    if (value instanceof String) {
+      return Boolean.valueOf((String) value);
+    } else if (value instanceof Number) {
+      return ((Number) value).intValue() != 0;
+    } else {
+      return (Boolean) value;
+    }
   }
 
   @Override

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -154,6 +154,9 @@ class OpenSearchExprValueFactoryTest {
   public void constructBoolean() {
     assertEquals(booleanValue(true), tupleValue("{\"boolV\":true}").get("boolV"));
     assertEquals(booleanValue(true), constructFromObject("boolV", true));
+    assertEquals(booleanValue(true), constructFromObject("boolV", "true"));
+    assertEquals(booleanValue(true), constructFromObject("boolV", 1));
+    assertEquals(booleanValue(false), constructFromObject("boolV", 0));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Chloe Zhang <chloezh1102@gmail.com>

### Description
```
POST _plugins/_sql
{
  "query": "SELECT (CASE WHEN bool0 THEN TRUE WHEN NOT bool0 THEN FALSE ELSE NULL END) AS a FROM boolean_test GROUP BY a"
}

# result:
{
  "schema": [
    {
      "name": "(CASE WHEN bool0 THEN TRUE WHEN NOT bool0 THEN FALSE ELSE NULL END)",
      "alias": "a",
      "type": "boolean"
    }
  ],
  "datarows": [
    [
      null
    ],
    [
      false
    ],
    [
      true
    ]
  ],
  "total": 3,
  "size": 3,
  "status": 200
}
```
 
### Issues Resolved
#276 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).