### PR TITLE
Fixed StringIndexOutOfBoundsException issue of left and right text functions

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
@@ -286,12 +286,18 @@ public class TextFunction {
   }
 
   private static ExprValue exprRight(ExprValue str, ExprValue len) {
-    return new ExprStringValue(str.stringValue().substring(
-            str.stringValue().length() - len.integerValue()));
+    if (len.integerValue() <= 0) {
+      return new ExprStringValue("");
+    }
+    String stringValue = str.stringValue();
+    int left = Math.max(stringValue.length() - len.integerValue(), 0);
+    return new ExprStringValue(str.stringValue().substring(left));
   }
 
   private static ExprValue exprLeft(ExprValue expr, ExprValue length) {
-    return new ExprStringValue(expr.stringValue().substring(0, length.integerValue()));
+    String stringValue = expr.stringValue();
+    int right = length.integerValue();
+    return new ExprStringValue(stringValue.substring(0, Math.min(right, stringValue.length())));
   }
 
   private static ExprValue exprAscii(ExprValue expr) {

--- a/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
@@ -291,6 +291,18 @@ public class TextFunctionTest extends ExpressionTestBase {
     assertEquals(STRING, expression.type());
     assertEquals("rbar", eval(expression).stringValue());
 
+    expression = dsl.right(DSL.literal("foo"), DSL.literal(10));
+    assertEquals(STRING, expression.type());
+    assertEquals("foo", eval(expression).value());
+
+    expression = dsl.right(DSL.literal("foo"), DSL.literal(0));
+    assertEquals(STRING, expression.type());
+    assertEquals("", eval(expression).value());
+
+    expression = dsl.right(DSL.literal(""), DSL.literal(10));
+    assertEquals(STRING, expression.type());
+    assertEquals("", eval(expression).value());
+
     when(nullRef.type()).thenReturn(STRING);
     when(missingRef.type()).thenReturn(INTEGER);
     assertEquals(missingValue(), eval(dsl.right(nullRef, missingRef)));
@@ -307,6 +319,18 @@ public class TextFunctionTest extends ExpressionTestBase {
         DSL.literal(new ExprIntegerValue(5)));
     assertEquals(STRING, expression.type());
     assertEquals("hello", eval(expression).stringValue());
+
+    expression = dsl.left(DSL.literal("hello"), DSL.literal(10));
+    assertEquals(STRING, expression.type());
+    assertEquals("hello", eval(expression).value());
+
+    expression = dsl.left(DSL.literal("hello"), DSL.literal(0));
+    assertEquals(STRING, expression.type());
+    assertEquals("", eval(expression).value());
+
+    expression = dsl.left(DSL.literal(""), DSL.literal(10));
+    assertEquals(STRING, expression.type());
+    assertEquals("", eval(expression).value());
 
     when(nullRef.type()).thenReturn(STRING);
     when(missingRef.type()).thenReturn(INTEGER);

--- a/integ-test/src/test/resources/correctness/expressions/text_functions.txt
+++ b/integ-test/src/test/resources/correctness/expressions/text_functions.txt
@@ -1,5 +1,11 @@
 RIGHT('Hello World', 5) as column
+RIGHT('Hello World', 20) as column
+RIGHT('Hello World', 0) as column
+RIGHT('', 5) as column
 LEFT('Hello World', 5) as column
+LEFT('Hello World', 20) as column
+LEFT('Hello World', 0) as column
+LEFT('', 5) as column
 ASCII('hello') as column
 LOCATE('world', 'helloworld') as column
 LOCATE('world', 'hello') as column


### PR DESCRIPTION
Signed-off-by: Chloe Zhang <chloezh1102@gmail.com>

### Description
- Fixed string index out of bound issue in left and right functions
- Added unit test cases
- Added comparison test cases
 
### Issues Resolved
#266 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).