### PR TITLE
Added codecov for workbench

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429,999  "**/*.html" "**/*.md" "**/*.txt" --exclude "http://localhost*" "https://localhost" "https://odfe-node1:9200/" "https://community.tableau.com/docs/DOC-17978" ".*family.zzz" "https://pypi.python.org/pypi/opensearch-sql-cli/" "opensearch*" ".*@amazon.com" ".*email.com" "git@github.com" "http://timestamp.verisign.com/scripts/timstamp.dll"
+          args: --accept=200,403,429,999  "./**/*.html" "./**/*.md" "./**/*.txt" --exclude "http://localhost*" "https://localhost" "https://odfe-node1:9200/" "https://community.tableau.com/docs/DOC-17978" ".*family.zzz" "https://pypi.python.org/pypi/opensearch-sql-cli/" "opensearch*" ".*@amazon.com" ".*email.com" "git@github.com" "http://timestamp.verisign.com/scripts/timstamp.dll"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -2,6 +2,9 @@ name: SQL Java CI
 
 on: [push, pull_request]
 
+env:
+  OPENSEARCH_VERSION: '1.2.0-SNAPSHOT'
+
 jobs:
   build:
 
@@ -16,7 +19,7 @@ jobs:
         java-version: 1.14
     
     - name: Build with Gradle
-      run: ./gradlew build assemble -Dopensearch.version=1.2.0-SNAPSHOT
+      run: ./gradlew build assemble -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
 
     - name: Create Artifact Path
       run: |
@@ -27,6 +30,7 @@ jobs:
     - name: Upload SQL Coverage Report
       uses: codecov/codecov-action@v1
       with:
+        flags: sql-engine
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Artifacts

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
-          flags: sql-workbench
+          flags: query-workbench
           directory: ./OpenSearch-Dashboards/plugins/workbench
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -43,7 +43,14 @@ jobs:
       - name: Test
         run: |
           cd OpenSearch-Dashboards/plugins/workbench
-          yarn test:jest
+          yarn test:jest --coverage
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          flags: sql-workbench
+          directory: ./OpenSearch-Dashboards/plugins/workbench
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build Artifact
         run: |


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description
Uploading SQL workbench test coverage wasn't part of the build CI. 

### Issues Resolved
1. Added flags for sql engine and workbench to get separate code cov results.
2. Updated Link Checker
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).