### PR TITLE
Bump log4j to 2.16 and plugin to 1.2.2

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -3,7 +3,7 @@ name: SQL Java CI
 on: [push, pull_request]
 
 env:
-  OPENSEARCH_VERSION: '1.2.1-SNAPSHOT'
+  OPENSEARCH_VERSION: '1.2.2-SNAPSHOT'
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.2.1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.2-SNAPSHOT")
     }
 
     repositories {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.16.0'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -212,7 +212,7 @@ String bwcFilePath = "src/test/resources/bwc/"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2", "1.2.1-SNAPSHOT"]
+            versions = ["7.10.2", "1.2.2-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -212,7 +212,7 @@ String bwcFilePath = "src/test/resources/bwc/"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["7.10.2", "1.2.2-SNAPSHOT"]
+            versions = ["7.10.2", opensearch_version]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testCompile group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     testCompile group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-    testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+    testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.16.0'
     testCompile project(':plugin')
     testCompile project(':legacy')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile group: 'org.json', name: 'json', version: '20180813'
     compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
     compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.16.0'
     compile project(':common')
     compile project(':core')
     compile project(':protocol')

--- a/release-notes/opensearch-sql.release-notes-1.2.2.0.md
+++ b/release-notes/opensearch-sql.release-notes-1.2.2.0.md
@@ -1,0 +1,6 @@
+### Version 1.2.2.0 Release Notes
+Compatible with OpenSearch and OpenSearch Dashboards Version 1.2.2
+
+### Bug fixes
+
+* Bump log4j to 2.16 and plugin to 1.2.2 ([#338](https://github.com/opensearch-project/sql/pull/338))


### PR DESCRIPTION
### Description
Bump log4j to 2.16 and plugin to 1.2.2
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).