### PR TITLE
Bump log4j to 2.17

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.0'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     testCompile group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     testCompile group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-    testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.16.0'
+    testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.0'
     testCompile project(':plugin')
     testCompile project(':legacy')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     compile group: 'org.json', name: 'json', version: '20180813'
     compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
     compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.0'
     compile project(':common')
     compile project(':core')
     compile project(':protocol')

--- a/release-notes/opensearch-sql.release-notes-1.2.3.0.md
+++ b/release-notes/opensearch-sql.release-notes-1.2.3.0.md
@@ -1,0 +1,6 @@
+### Version 1.2.3.0 Release Notes
+Compatible with OpenSearch and OpenSearch Dashboards Version 1.2.3
+
+### Bug fixes
+
+* Bump log4j to 2.17 and plugin to 1.2.3 ([#345](https://github.com/opensearch-project/sql/pull/345))

--- a/release-notes/opensearch-sql.release-notes-1.2.3.0.md
+++ b/release-notes/opensearch-sql.release-notes-1.2.3.0.md
@@ -1,5 +1,5 @@
 ### Version 1.2.3.0 Release Notes
-Compatible with OpenSearch and OpenSearch Dashboards Version 1.2.3
+Compatible with OpenSearch Version 1.2.3 and OpenSearch Dashboards Version 1.2.x
 
 ### Bug fixes
 


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description
Bumped up log4j to 2.17 
 
### Issues Resolved
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105
https://github.com/opensearch-project/opensearch-build/issues/1365
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).