### PR TITLE
Upgrade to log4j 2.17.1.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testCompile group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     testCompile group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-    testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.0'
+    testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     testCompile project(':plugin')
     testCompile project(':legacy')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile group: 'org.json', name: 'json', version: '20180813'
     compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
     compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     compile project(':common')
     compile project(':core')
     compile project(':protocol')


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Upgrade to log4j 2.17.1.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).