### PR TITLE
Add how to setup aws credentials for ODBC Tableau

### DIFF
--- a/sql-odbc/docs/user/tableau_support.md
+++ b/sql-odbc/docs/user/tableau_support.md
@@ -31,7 +31,7 @@ Click on **Download** option for downloading `opensearch_sql_odbc.taco` file.
 <img src="img/tableau_select_connector.png" width=600>
 
 * Enter **Server** & **Port** value. 
-* Select required authentication option. For **AWS_SIGV4** authentication, select **Integrated Authentication** and enter value for **Region**.
+* Select required authentication option. For **AWS_SIGV4** authentication, select **Integrated Authentication** and enter value for **Region**. To setup aws access key id and secret key, create ~/.aws/credentials with [AWS CLI](https://aws.amazon.com/cli/) and use `opensearchodbc` as the profile name.
 * Use **Additional Options** section for specifying options like **FetchSize**, **ResponseTimeout**. Use `;` to separate values. For example,
 
 ```


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
ODBC ignores the default profile (#328), so adding instructions on which profile name to use.
This can be reverted after https://github.com/opensearch-project/sql/issues/328 is resolved
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).