### PR TITLE
Parse none type field as null instead of throw exception

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import lombok.Getter;
 import lombok.Setter;
@@ -130,7 +131,7 @@ public class OpenSearchExprValueFactory {
   public ExprValue construct(String jsonString) {
     try {
       return parse(new OpenSearchJsonContent(OBJECT_MAPPER.readTree(jsonString)), TOP_PATH,
-          STRUCT);
+          Optional.of(STRUCT));
     } catch (JsonProcessingException e) {
       throw new IllegalStateException(String.format("invalid json: %s.", jsonString), e);
     }
@@ -149,11 +150,12 @@ public class OpenSearchExprValueFactory {
     return parse(new ObjectContent(value), field, type(field));
   }
 
-  private ExprValue parse(Content content, String field, ExprType type) {
-    if (content.isNull()) {
+  private ExprValue parse(Content content, String field, Optional<ExprType> fieldType) {
+    if (content.isNull() || !fieldType.isPresent()) {
       return ExprNullValue.of();
     }
 
+    ExprType type = fieldType.get();
     if (type == STRUCT) {
       return parseStruct(content, field);
     } else if (type == ARRAY) {
@@ -169,12 +171,12 @@ public class OpenSearchExprValueFactory {
     }
   }
 
-  private ExprType type(String field) {
-    if (typeMapping.containsKey(field)) {
-      return typeMapping.get(field);
-    } else {
-      throw new IllegalStateException(String.format("No type found for field: %s.", field));
-    }
+  /**
+   * In OpenSearch, it is possible field doesn't have type definition in mapping.
+   * but has empty value. For example, {"empty_field": []}.
+   */
+  private Optional<ExprType> type(String field) {
+    return Optional.ofNullable(typeMapping.get(field));
   }
 
   /**
@@ -223,7 +225,7 @@ public class OpenSearchExprValueFactory {
    */
   private ExprValue parseArray(Content content, String prefix) {
     List<ExprValue> result = new ArrayList<>();
-    content.array().forEachRemaining(v -> result.add(parse(v, prefix, STRUCT)));
+    content.array().forEachRemaining(v -> result.add(parse(v, prefix, Optional.of(STRUCT))));
     return new ExprCollectionValue(result);
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -347,10 +347,10 @@ class OpenSearchExprValueFactoryTest {
   }
 
   @Test
-  public void noTypeFoundForMappingThrowException() {
-    IllegalStateException exception =
-        assertThrows(IllegalStateException.class, () -> tupleValue("{\"not_exist\":1}"));
-    assertEquals("No type found for field: not_exist.", exception.getMessage());
+  public void noTypeFoundForMapping() {
+    assertEquals(nullValue(), tupleValue("{\"not_exist\":[]}").get("not_exist"));
+    // Only for test coverage, It is impossible in OpenSearch.
+    assertEquals(nullValue(), tupleValue("{\"not_exist\":1}").get("not_exist"));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: penghuo <penghuo@gmail.com>

### Description
Parse none type field as null instead of throw exception.

```
POST /empty-test-00002/_doc/
{ "l1": 1, "l2":{"l2": []}}

POST {{baseUrl}}/_plugins/_sql
{
  "query": "select * from empty-test-00001"
}

# Response
{
  "schema": [
    {
      "name": "l1",
      "type": "long"
    },
    {
      "name": "l2",
      "type": "object"
    }
  ],
  "datarows": [
    [
      1,
      {}
    ]
  ],
  "total": 1,
  "size": 1,
  "status": 200
}
```
 
### Issues Resolved
#398
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).