### PR TITLE
Jackson-databind bump to 2.12.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ checkstyleMain.ignoreFailures = false
 checkstyleTest.ignoreFailures = true
 
 configurations.all {
+    resolutionStrategy.force 'junit:junit:4.13.2'
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,5 +36,5 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
 
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -51,8 +51,8 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4'
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.12.6'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.6'
 }
 
 dependencies {

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -47,6 +47,7 @@ validateNebulaPom.enabled = false
 loggerUsageCheck.enabled = false
 
 configurations.all {
+    resolutionStrategy.force 'junit:junit:4.13.2'
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -103,7 +103,7 @@ dependencies {
 
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version:'2.2'
     testCompile group: 'org.mockito', name: 'mockito-inline', version:'3.5.0'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
     testCompile group: "org.opensearch.client", name: 'transport', version: "${opensearch_version}"
 
 }

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compile "io.github.resilience4j:resilience4j-retry:1.5.0"
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.4'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.11.4'
     compile group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     compile project(':core')
     compile group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compile "io.github.resilience4j:resilience4j-retry:1.5.0"
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5' 
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.6' 
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.11.4'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.12.6'
     compile group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -53,6 +53,7 @@ dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
 
 configurations.all {
+    resolutionStrategy.force 'junit:junit:4.13.2'
     // conflict with spring-jcl
     exclude group: "commons-logging", module: "commons-logging"
     resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -59,7 +59,7 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.6'
 }
 
 dependencies {

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compile project(':core')
     compile project(':protocol')
 
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
 

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -30,9 +30,9 @@ plugins {
 
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5' 
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.6' 
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.11.4'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.12.6'
     implementation 'com.google.code.gson:gson:2.8.9'
     compile project(':core')
     compile project(':opensearch')

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -31,7 +31,7 @@ plugins {
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.4'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.11.4'
     implementation 'com.google.code.gson:gson:2.8.9'
     compile project(':core')

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')


### PR DESCRIPTION
### Description
Bumping up version for Jackson libraries to 2.12.6
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).