### PR TITLE
Bug Fix, disable html escape when formatting response

### DIFF
--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
@@ -17,11 +17,13 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class ErrorFormatter {
 
-  private static final Gson PRETTY_PRINT_GSON =
-      AccessController.doPrivileged(
-          (PrivilegedAction<Gson>) () -> new GsonBuilder().setPrettyPrinting().create());
+  private static final Gson PRETTY_PRINT_GSON = AccessController.doPrivileged(
+          (PrivilegedAction<Gson>) () -> new GsonBuilder()
+              .setPrettyPrinting()
+              .disableHtmlEscaping()
+              .create());
   private static final Gson GSON = AccessController.doPrivileged(
-      (PrivilegedAction<Gson>) () -> new GsonBuilder().create());
+      (PrivilegedAction<Gson>) () -> new GsonBuilder().disableHtmlEscaping().create());
 
   /**
    * Util method to format {@link Throwable} response to JSON string in compact printing.

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/ErrorFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/ErrorFormatterTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.protocol.response.format;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+class ErrorFormatterTest {
+
+  // https://www.javadoc.io/doc/com.google.code.gson/gson/2.7/com/google/gson/GsonBuilder.html#disableHtmlEscaping--
+  @Test
+  void htmlEscaping_should_disabled() {
+    assertEquals(
+        "{\n" + "  \"request\": \"index=test\"\n" + "}",
+        ErrorFormatter.prettyJsonify(ImmutableMap.of("request", "index=test")));
+    assertEquals(
+        "{\"request\":\"index=test\"}",
+        ErrorFormatter.compactJsonify(ImmutableMap.of("request", "index=test")));
+  }
+}


### PR DESCRIPTION
Signed-off-by: penghuo <penghuo@gmail.com>

### Description
Disable html escape when formatting response.
 
### Issues Resolved
Issue:
```
curl --request POST \
  --url http://localhost:9200/_plugins/_ppl/_explain \
  --header 'content-type: application/json' \
  --header 'user-agent: vscode-restclient' \
  --data '{"query": "source=test | fields long"}'
{
  "root": {
    "name": "ProjectOperator",
    "description": {
      "fields": "[long]"
    },
    "children": [
      {
        "name": "OpenSearchIndexScan",
        "description": {
          "request": "OpenSearchQueryRequest(indexName\u003dtest, sourceBuilder\u003d{\"from\":0,\"size\":200,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"long\"],\"excludes\":[]}}, searchDone\u003dfalse)"
        },
        "children": []
      }
    ]
  }
}
```

Expected
```
{
  "root": {
    "name": "ProjectOperator",
    "description": {
      "fields": "[long]"
    },
    "children": [
      {
        "name": "OpenSearchIndexScan",
        "description": {
          "request": "OpenSearchQueryRequest(indexName=test, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"long\"],\"excludes\":[]}}, searchDone=false)"
        },
        "children": []
      }
    ]
  }
}
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).