### PR TITLE
Revert to windows 2019 for odbc CI

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -78,7 +78,7 @@ jobs:
     #    name: mac-test-results
     #    path: test-output
   build-windows32:
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         working-directory: sql-odbc
@@ -123,7 +123,7 @@ jobs:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
   build-windows64:
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         working-directory: sql-odbc


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Revert to previous windows version for now to unblock PRs
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).