### PR TITLE
Support In clause in SQL and PPL

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -269,6 +269,11 @@ public class AstDSL {
     return new In(field, Arrays.asList(valueList));
   }
 
+  public static UnresolvedExpression in(
+      UnresolvedExpression field, List<UnresolvedExpression> valueList) {
+    return new In(field, valueList);
+  }
+
   public static UnresolvedExpression compare(
       String operator, UnresolvedExpression left, UnresolvedExpression right) {
     return new Compare(operator, left, right);

--- a/docs/category.json
+++ b/docs/category.json
@@ -21,7 +21,8 @@
     "user/ppl/functions/datetime.rst",
     "user/ppl/functions/string.rst",
     "user/ppl/functions/condition.rst",
-    "user/ppl/functions/relevance.rst"
+    "user/ppl/functions/relevance.rst",
+    "user/ppl/functions/expressions.rst"
   ],
   "sql_cli": [
     "user/dql/expressions.rst",

--- a/docs/user/dql/expressions.rst
+++ b/docs/user/dql/expressions.rst
@@ -128,7 +128,10 @@ Operators
 +----------------+----------------------------------------+
 | REGEXP         | String matches regular expression test |
 +----------------+----------------------------------------+
-
+| IN             | IN value list test                     |
++----------------+----------------------------------------+
+| NOT IN         | NOT IN value list test                 |
++----------------+----------------------------------------+
 
 Basic Comparison Operator
 -------------------------
@@ -182,6 +185,19 @@ expr REGEXP pattern. The expr is string value, pattern is supports regular expre
     |------------------------+------------------|
     | 1                      | 0                |
     +------------------------+------------------+
+
+IN value list test
+------------------
+
+Here is an example for IN value test::
+
+    os> SELECT 1 in (1, 2), 3 not in (1, 2);
+    fetched rows / total rows = 1/1
+    +---------------+-------------------+
+    | 1 in (1, 2)   | 3 not in (1, 2)   |
+    |---------------+-------------------|
+    | True          | True              |
+    +---------------+-------------------+
 
 Function Call
 =============

--- a/docs/user/ppl/functions/expressions.rst
+++ b/docs/user/ppl/functions/expressions.rst
@@ -1,0 +1,158 @@
+===========
+Expressions
+===========
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 3
+
+
+Introduction
+============
+
+Expressions, particularly value expressions, are those which return a scalar value. Expressions have different types and forms. For example, there are literal values as atom expression and arithmetic, predicate and function expression built on top of them. And also expressions can be used in different clauses, such as using arithmetic expression in ``Filter``, ``Stats`` command.
+
+Arithmetic Operators
+====================
+
+Description
+-----------
+
+Operators
+`````````
+
+Arithmetic expression is an expression formed by numeric literals and binary arithmetic operators as follows:
+
+1. ``+``: Add.
+2. ``-``: Subtract.
+3. ``*``: Multiply.
+4. ``/``: Divide. For integers, the result is an integer with fractional part discarded.
+5. ``%``: Modulo. This can be used with integers only with remainder of the division as result.
+
+Precedence
+``````````
+
+Parentheses can be used to control the precedence of arithmetic operators. Otherwise, operators of higher precedence is performed first.
+
+Type Conversion
+```````````````
+
+Implicit type conversion is performed when looking up operator signature. For example, an integer ``+`` a real number matches signature ``+(double,double)`` which results in a real number. This rule also applies to function call discussed below.
+
+Examples
+--------
+
+Here is an example for different type of arithmetic expressions::
+
+    os> source=accounts | where age > (25 + 5) | fields age ;
+    fetched rows / total rows = 3/3
+    +-------+
+    | age   |
+    |-------|
+    | 32    |
+    | 36    |
+    | 33    |
+    +-------+
+
+Predicate Operators
+===================
+
+Description
+-----------
+
+Predicate operator is an expression that evaluated to be ture. The MISSING and NULL value comparison has following the rule. MISSING value only equal to MISSING value and less than all the other values. NULL value equals to NULL value, large than MISSING value, but less than all the other values.
+
+Operators
+`````````
+
++----------------+----------------------------------------+
+| name           | description                            |
++----------------+----------------------------------------+
+| >              | Greater than operator                  |
++----------------+----------------------------------------+
+| >=             | Greater than or equal operator         |
++----------------+----------------------------------------+
+| <              | Less than operator                     |
++----------------+----------------------------------------+
+| !=             | Not equal operator                     |
++----------------+----------------------------------------+
+| <=             | Less than or equal operator            |
++----------------+----------------------------------------+
+| =              | Equal operator                         |
++----------------+----------------------------------------+
+| LIKE           | Simple Pattern matching                |
++----------------+----------------------------------------+
+| IN             | NULL value test                        |
++----------------+----------------------------------------+
+| AND            | AND operator                           |
++----------------+----------------------------------------+
+| OR             | OR operator                            |
++----------------+----------------------------------------+
+| XOR            | XOR operator                           |
++----------------+----------------------------------------+
+| NOT            | NOT NULL value test                    |
++----------------+----------------------------------------+
+
+Examples
+--------
+
+Basic Predicate Operator
+````````````````````````
+
+Here is an example for comparison operators::
+
+    os> source=accounts | where age > 33 | fields age ;
+    fetched rows / total rows = 1/1
+    +-------+
+    | age   |
+    |-------|
+    | 36    |
+    +-------+
+
+
+IN
+``
+
+IN operator test field in value lists::
+
+    os> source=accounts | where age in (32, 33) | fields age ;
+    fetched rows / total rows = 2/2
+    +-------+
+    | age   |
+    |-------|
+    | 32    |
+    | 33    |
+    +-------+
+
+
+OR
+``
+
+OR operator ::
+
+    os> source=accounts | where age = 32 OR age = 33 | fields age ;
+    fetched rows / total rows = 2/2
+    +-------+
+    | age   |
+    |-------|
+    | 32    |
+    | 33    |
+    +-------+
+
+
+NOT
+```
+
+NOT operator ::
+
+    os> source=accounts | where not age in (32, 33) | fields age ;
+    fetched rows / total rows = 2/2
+    +-------+
+    | age   |
+    |-------|
+    | 36    |
+    | 28    |
+    +-------+
+

--- a/docs/user/ppl/index.rst
+++ b/docs/user/ppl/index.rst
@@ -60,6 +60,8 @@ The query start with search command and then flowing a set of command delimited 
 
 * **Functions**
 
+  - `Expressions <functions/expressions.rst>`_
+
   - `Math Functions <functions/math.rst>`_
 
   - `Date and Time Functions <functions/datetime.rst>`_

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
-import org.antlr.v4.runtime.Token;
 import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.AllFields;
@@ -72,7 +71,6 @@ import org.opensearch.sql.ast.expression.UnresolvedArgument;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.Xor;
 import org.opensearch.sql.common.utils.StringUtils;
-import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser;
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParserBaseVisitor;
 import org.opensearch.sql.ppl.utils.ArgumentFactory;
 

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -10,7 +10,6 @@ import static java.util.Collections.emptyList;
 import static org.opensearch.sql.ast.dsl.AstDSL.agg;
 import static org.opensearch.sql.ast.dsl.AstDSL.aggregate;
 import static org.opensearch.sql.ast.dsl.AstDSL.alias;
-import static org.opensearch.sql.ast.dsl.AstDSL.allFields;
 import static org.opensearch.sql.ast.dsl.AstDSL.and;
 import static org.opensearch.sql.ast.dsl.AstDSL.argument;
 import static org.opensearch.sql.ast.dsl.AstDSL.booleanLiteral;

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -7,8 +7,13 @@
 package org.opensearch.sql.ppl.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.opensearch.sql.ast.dsl.AstDSL.field;
+import static org.opensearch.sql.ast.dsl.AstDSL.projectWithArg;
+import static org.opensearch.sql.ast.dsl.AstDSL.relation;
 
+import java.util.Collections;
 import org.junit.Test;
+import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
 import org.opensearch.sql.ppl.parser.AstBuilder;
 import org.opensearch.sql.ppl.parser.AstExpressionBuilder;
@@ -146,9 +151,20 @@ public class PPLQueryDataAnonymizerTest {
     );
   }
 
+  @Test
+  public void anonymizeFieldsNoArg() {
+    assertEquals("source=t | fields + f",
+        anonymize(projectWithArg(relation("t"), Collections.emptyList(), field("f")))
+    );
+  }
+
   private String anonymize(String query) {
     AstBuilder astBuilder = new AstBuilder(new AstExpressionBuilder(), query);
-    final PPLQueryDataAnonymizer anonymizer = new PPLQueryDataAnonymizer();
-    return anonymizer.anonymizeData(astBuilder.visit(parser.analyzeSyntax(query)));
+    return anonymize(astBuilder.visit(parser.analyzeSyntax(query)));
+  }
+
+  private String anonymize(UnresolvedPlan plan) {
+    final PPLQueryDataAnonymizer anonymize = new PPLQueryDataAnonymizer();
+    return anonymize.anonymizeData(plan);
   }
 }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -265,6 +265,7 @@ predicate
     | predicate IS nullNotnull                                      #isNullPredicate
     | left=predicate NOT? LIKE right=predicate                      #likePredicate
     | left=predicate REGEXP right=predicate                         #regexpPredicate
+    | predicate NOT? IN predicateList                               #inList
     ;
 
 expressionAtom
@@ -286,6 +287,10 @@ comparisonOperator
 
 nullNotnull
     : NOT? NULL_LITERAL
+    ;
+
+predicateList
+    : '(' predicate (COMMA predicate)* ')'
     ;
 
 functionCall

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -238,6 +238,15 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   }
 
   @Override
+  public UnresolvedExpression visitInList(OpenSearchSQLParser.InListContext ctx) {
+    UnresolvedExpression field = visit(ctx.predicate());
+    List<UnresolvedExpression> inLists =
+        ctx.predicateList().predicate().stream().map(this::visit).collect(Collectors.toList());
+    UnresolvedExpression in = AstDSL.in(field, inLists);
+    return ctx.NOT() != null ? AstDSL.not(in) : in;
+  }
+
+  @Override
   public UnresolvedExpression visitAndExpression(AndExpressionContext ctx) {
     return new And(visit(ctx.left), visit(ctx.right));
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -444,6 +444,23 @@ class AstExpressionBuilderTest {
         buildExprAst("match(message, 'search query', analyzer='keyword', operator='AND')"));
   }
 
+  @Test
+  public void canBuildInClause() {
+    assertEquals(
+        AstDSL.in(qualifiedName("age"), AstDSL.intLiteral(20), AstDSL.intLiteral(30)),
+        buildExprAst("age in (20, 30)"));
+
+    assertEquals(
+        AstDSL.not(AstDSL.in(qualifiedName("age"), AstDSL.intLiteral(20), AstDSL.intLiteral(30))),
+        buildExprAst("age not in (20, 30)"));
+
+    assertEquals(
+        AstDSL.in(qualifiedName("age"),
+            AstDSL.function("abs", AstDSL.intLiteral(20)),
+            AstDSL.function("abs", AstDSL.intLiteral(30))),
+        buildExprAst("age in (abs(20), abs(30))"));
+  }
+
   private Node buildExprAst(String expr) {
     OpenSearchSQLLexer lexer = new OpenSearchSQLLexer(new CaseInsensitiveCharStream(expr));
     OpenSearchSQLParser parser = new OpenSearchSQLParser(new CommonTokenStream(lexer));


### PR DESCRIPTION
### Description
1. Support In clause in [SQL](https://github.com/penghuo/os-sql/blob/issue-308/docs/user/dql/expressions.rst#in-value-list-test).
2. Support In clause in [PPL](https://github.com/penghuo/os-sql/blob/issue-308/docs/user/ppl/functions/expressions.rst#in).

### Issues Resolved
#308 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).