### PR TITLE
Span expression should always be first in by list if exist

### DIFF
--- a/docs/user/ppl/cmd/stats.rst
+++ b/docs/user/ppl/cmd/stats.rst
@@ -39,7 +39,7 @@ stats <aggregation>... [by-clause]
 
 * by-clause: optional.
 
- * Syntax: by [field]... [span-expression].
+ * Syntax: by [span-expression,] [field,]...
  * Description: The by clause could be the fields and expressions like scalar functions and aggregation functions. Besides, the span clause can be used to split specific field into buckets in the same interval, the stats then does the aggregation by these span buckets.
  * Default: If no <by-clause> is specified, the stats command returns only one row, which is the aggregation over the entire result set.
 
@@ -372,7 +372,7 @@ The example gets the count of age by the interval of 10 years and group by gende
 
 PPL query::
 
-    os> source=accounts | stats count() as cnt by gender span(age, 5) as age_span
+    os> source=accounts | stats count() as cnt by span(age, 5) as age_span, gender
     fetched rows / total rows = 3/3
     +-------+------------+----------+
     | cnt   | age_span   | gender   |

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -101,7 +101,7 @@ byClause
 statsByClause
     : BY fieldList
     | BY bySpanClause
-    | BY fieldList bySpanClause
+    | BY bySpanClause COMMA fieldList
     ;
 
 bySpanClause

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -294,7 +294,7 @@ public class AstBuilderTest {
             defaultStatsArgs()
         ));
 
-    assertEqual("source=t | stats avg(price) by b span(timestamp, 1h)",
+    assertEqual("source=t | stats avg(price) by span(timestamp, 1h), b",
         agg(
             relation("t"),
             exprList(
@@ -306,7 +306,7 @@ public class AstBuilderTest {
             defaultStatsArgs()
         ));
 
-    assertEqual("source=t | stats avg(price) by f1, f2 span(timestamp, 1h)",
+    assertEqual("source=t | stats avg(price) by span(timestamp, 1h), f1, f2",
         agg(
             relation("t"),
             exprList(


### PR DESCRIPTION
Signed-off-by: penghuo <penghuo@gmail.com>

### Description
1.Span expression should always be first in by list if exist
2.Update [doc](https://github.com/penghuo/os-sql/blob/fix-span/docs/user/ppl/cmd/stats.rst). 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).