### PR TITLE
Version Bump: springframework and jackson

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,8 +40,8 @@ repositories {
 
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.19.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.19.RELEASE'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     compile group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
@@ -49,7 +49,7 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testCompile group: 'org.springframework', name: 'spring-test', version: '5.2.5.RELEASE'
+    testCompile group: 'org.springframework', name: 'spring-test', version: '5.2.19.RELEASE'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
     testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.3.3'
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -56,7 +56,8 @@ configurations.all {
     resolutionStrategy.force 'junit:junit:4.13.2'
     // conflict with spring-jcl
     exclude group: "commons-logging", module: "commons-logging"
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
+    // enforce 2.12.6, https://github.com/opensearch-project/sql/issues/424
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.12.6'
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
@@ -64,7 +65,7 @@ configurations.all {
 }
 
 dependencies {
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.19.RELEASE'
     compile project(":ppl")
     compile project(':legacy')
     compile project(':opensearch')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     compile group: 'org.json', name: 'json', version: '20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.19.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.19.RELEASE'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     compile project(':common')
     compile project(':core')

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile group: 'org.json', name: 'json', version:'20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.19.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.19.RELEASE'
     compile project(':common')
     compile project(':core')
     compile project(':protocol')


### PR DESCRIPTION
### Description
Version Bump
* springframework 5.2.5 -> 5.2.19
* jackson 2.10.5 -> 2.12.6
 
### Issues Resolved
* #424
* #426
* #428

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).