### PR TITLE
Add limitation section in PPL docs

### DIFF
--- a/docs/user/ppl/cmd/dedup.rst
+++ b/docs/user/ppl/cmd/dedup.rst
@@ -111,4 +111,4 @@ PPL query::
 
 Limitation
 ==========
-The ``dedup`` command is not rewrite as OpenSearch DSL and executed on coordination node only.
+The ``dedup`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.

--- a/docs/user/ppl/cmd/dedup.rst
+++ b/docs/user/ppl/cmd/dedup.rst
@@ -109,3 +109,6 @@ PPL query::
     | 18               | M        |
     +------------------+----------+
 
+Limitation
+==========
+The ``dedup`` command is not rewrite as OpenSearch DSL and executed on coordination node only.

--- a/docs/user/ppl/cmd/eval.rst
+++ b/docs/user/ppl/cmd/eval.rst
@@ -78,4 +78,4 @@ PPL query::
 
 Limitation
 ==========
-The ``eval`` command is not rewrite as OpenSearch DSL and executed on coordination node only.
+The ``eval`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.

--- a/docs/user/ppl/cmd/eval.rst
+++ b/docs/user/ppl/cmd/eval.rst
@@ -75,3 +75,7 @@ PPL query::
     | 28    | 56          | 112     |
     | 33    | 66          | 132     |
     +-------+-------------+---------+
+
+Limitation
+==========
+The ``eval`` command is not rewrite as OpenSearch DSL and executed on coordination node only.

--- a/docs/user/ppl/cmd/head.rst
+++ b/docs/user/ppl/cmd/head.rst
@@ -61,3 +61,6 @@ PPL query::
     | Nanette       | 28        |
     +---------------+-----------+
 
+Limitation
+==========
+The ``head`` command is not rewrite as OpenSearch DSL and executed on coordination node only.

--- a/docs/user/ppl/cmd/head.rst
+++ b/docs/user/ppl/cmd/head.rst
@@ -63,4 +63,4 @@ PPL query::
 
 Limitation
 ==========
-The ``head`` command is not rewrite as OpenSearch DSL and executed on coordination node only.
+The ``head`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.

--- a/docs/user/ppl/cmd/rare.rst
+++ b/docs/user/ppl/cmd/rare.rst
@@ -75,4 +75,6 @@ PPL query::
     | M        | 29       |
     +----------+----------+
 
-
+Limitation
+==========
+The ``rare`` command is not rewrite as OpenSearch DSL and executed on coordination node only.

--- a/docs/user/ppl/cmd/rare.rst
+++ b/docs/user/ppl/cmd/rare.rst
@@ -77,4 +77,4 @@ PPL query::
 
 Limitation
 ==========
-The ``rare`` command is not rewrite as OpenSearch DSL and executed on coordination node only.
+The ``rare`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.

--- a/docs/user/ppl/cmd/rename.rst
+++ b/docs/user/ppl/cmd/rename.rst
@@ -61,4 +61,4 @@ PPL query::
 
 Limitation
 ==========
-The ``rename`` command is not rewrite as OpenSearch DSL and executed on coordination node only.
+The ``rename`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.

--- a/docs/user/ppl/cmd/rename.rst
+++ b/docs/user/ppl/cmd/rename.rst
@@ -59,3 +59,6 @@ PPL query::
     | 18   | null    |
     +------+---------+
 
+Limitation
+==========
+The ``rename`` command is not rewrite as OpenSearch DSL and executed on coordination node only.

--- a/docs/user/ppl/cmd/top.rst
+++ b/docs/user/ppl/cmd/top.rst
@@ -71,4 +71,6 @@ PPL query::
     | M        | 31       |
     +----------+----------+
 
-
+Limitation
+==========
+The ``top`` command is not rewrite as OpenSearch DSL and executed on coordination node only.

--- a/docs/user/ppl/cmd/top.rst
+++ b/docs/user/ppl/cmd/top.rst
@@ -73,4 +73,4 @@ PPL query::
 
 Limitation
 ==========
-The ``top`` command is not rewrite as OpenSearch DSL and executed on coordination node only.
+The ``top`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.


### PR DESCRIPTION
Signed-off-by: penghuo <penghuo@gmail.com>

### Description
Add limitation section in PPL docs for commands [dedup, eval, head, rare, rename, top] which are not rewritten to OpenSearch DSL and only executed on the coordination node.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).