### PR TITLE
Treating ExpressionEvaluationException as Client Error.

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -35,6 +35,7 @@ import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.legacy.antlr.OpenSearchLegacySqlAnalyzer;
 import org.opensearch.sql.legacy.antlr.SqlAnalysisConfig;
@@ -244,7 +245,8 @@ public class RestSqlAction extends BaseRestHandler {
             || e instanceof VerificationException
             || e instanceof SqlAnalysisException
             || e instanceof SyntaxCheckException
-            || e instanceof SemanticCheckException;
+            || e instanceof SemanticCheckException
+            || e instanceof ExpressionEvaluationException;
     }
 
     private void sendResponse(final RestChannel channel, final String message, final RestStatus status) {


### PR DESCRIPTION
Treating ExpressionEvaluationException as Client Error.

### Description
[Describe what this change achieves]
In SQL query interface, we are wrongly treating ExpressionEvaluationException as back end error instead of client error. Included ExpressionEvaluationException in the list of client errors.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/423
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).