### PR TITLE
Support ISO 8601 Format in Date Format.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
@@ -80,7 +80,7 @@ class DateTimeFormatterUtil {
 
   private static final Pattern pattern = Pattern.compile("%.");
   private static final Pattern CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN
-          = Pattern.compile("(?<!%)[a-zA-Z]+");
+          = Pattern.compile("(?<!%)[a-zA-Z&&[^ydmsMYDS]]+");
   private static final String MOD_LITERAL = "%";
 
   private DateTimeFormatterUtil() {

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
@@ -80,7 +80,7 @@ class DateTimeFormatterUtil {
 
   private static final Pattern pattern = Pattern.compile("%.");
   private static final Pattern CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN
-          = Pattern.compile("(?<!%)[a-zA-Z&&[^ydmshiHIMYDS]]+");
+          = Pattern.compile("(?<!%)[a-zA-Z&&[^aydmshiHIMYDSEL]]+");
   private static final String MOD_LITERAL = "%";
 
   private DateTimeFormatterUtil() {

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
@@ -80,7 +80,7 @@ class DateTimeFormatterUtil {
 
   private static final Pattern pattern = Pattern.compile("%.");
   private static final Pattern CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN
-          = Pattern.compile("(?<!%)[a-zA-Z&&[^ydmsMYDS]]+");
+          = Pattern.compile("(?<!%)[a-zA-Z&&[^ydmshiHIMYDS]]+");
   private static final String MOD_LITERAL = "%";
 
   private DateTimeFormatterUtil() {

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
@@ -79,6 +79,7 @@ class DateTimeFormatterUtil {
       .build();
 
   private static final Pattern pattern = Pattern.compile("%.");
+  private static final Pattern CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN = Pattern.compile("(?<!%)[a-zA-Z]+");
   private static final String MOD_LITERAL = "%";
 
   private DateTimeFormatterUtil() {
@@ -92,7 +93,14 @@ class DateTimeFormatterUtil {
    */
   static ExprValue getFormattedDate(ExprValue dateExpr, ExprValue formatExpr) {
     final LocalDateTime date = dateExpr.datetimeValue();
-    final Matcher matcher = pattern.matcher(formatExpr.stringValue());
+    final StringBuffer cleanFormat = new StringBuffer();
+    final Matcher m = CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN.matcher(formatExpr.stringValue());
+    while (m.find()) {
+      m.appendReplacement(cleanFormat,String.format("'%s'", m.group()));
+    }
+    m.appendTail(cleanFormat);
+
+    final Matcher matcher = pattern.matcher(cleanFormat.toString());
     final StringBuffer format = new StringBuffer();
     while (matcher.find()) {
       matcher.appendReplacement(format,

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
@@ -79,7 +79,8 @@ class DateTimeFormatterUtil {
       .build();
 
   private static final Pattern pattern = Pattern.compile("%.");
-  private static final Pattern CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN = Pattern.compile("(?<!%)[a-zA-Z]+");
+  private static final Pattern CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN
+          = Pattern.compile("(?<!%)[a-zA-Z]+");
   private static final String MOD_LITERAL = "%";
 
   private DateTimeFormatterUtil() {
@@ -94,7 +95,8 @@ class DateTimeFormatterUtil {
   static ExprValue getFormattedDate(ExprValue dateExpr, ExprValue formatExpr) {
     final LocalDateTime date = dateExpr.datetimeValue();
     final StringBuffer cleanFormat = new StringBuffer();
-    final Matcher m = CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN.matcher(formatExpr.stringValue());
+    final Matcher m = CHARACTERS_WITH_NO_MOD_LITERAL_BEHIND_PATTERN
+            .matcher(formatExpr.stringValue());
     while (m.find()) {
       m.appendReplacement(cleanFormat,String.format("'%s'", m.group()));
     }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -126,7 +126,15 @@ class DateTimeFunctionTest extends ExpressionTestBase {
       ),
       new DateFormatTester("1998-01-31 13:14:15.012345",
           ImmutableList.of("%Y-%m-%dT%TZ"),
-          ImmutableList.of("1998-01-31T13:14:15Z"))
+          ImmutableList.of("1998-01-31T13:14:15Z")
+      ),
+      new DateFormatTester("1998-01-31 13:14:15.012345",
+          ImmutableList.of("%Y-%m-%da %T a"),
+          ImmutableList.of("1998-01-31PM 13:14:15 PM")
+      ),
+      new DateFormatTester("1998-01-31 13:14:15.012345",
+          ImmutableList.of("%Y-%m-%db %T b"),
+          ImmutableList.of("1998-01-31b 13:14:15 b"))
   );
 
   @AllArgsConstructor

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -123,7 +123,10 @@ class DateTimeFunctionTest extends ExpressionTestBase {
       new DateFormatTester("2008-12-31",
           ImmutableList.of("%v","%V","%u","%U"),
           ImmutableList.of("53","52","53","52")
-      )
+      ),
+      new DateFormatTester("1998-01-31 13:14:15.012345",
+          ImmutableList.of("%Y-%m-%dT%TZ"),
+          ImmutableList.of("1998-01-31T13:14:15Z"))
   );
 
   @AllArgsConstructor

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1004,6 +1004,8 @@ Usage: date_format(date, format) formats the date argument using the specifiers 
      - A literal % character
    * - %x
      - x, for any “x” not listed above
+   * - x
+     - x, for any smallcase/uppercase alphabet except [aydmshiHIMYDSEL]
 
 Argument type: STRING/DATE/DATETIME/TIMESTAMP, STRING
 

--- a/docs/user/ppl/functions/datetime.rst
+++ b/docs/user/ppl/functions/datetime.rst
@@ -173,6 +173,8 @@ Usage: date_format(date, format) formats the date argument using the specifiers 
      - A literal % character
    * - %x
      - x, for any “x” not listed above
+   * - x
+     - x, for any smallcase/uppercase alphabet except [aydmshiHIMYDSEL]
 
 Argument type: STRING/DATE/DATETIME/TIMESTAMP, STRING
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
@@ -448,4 +448,19 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     String dateFormatted = "4 4 4 4 Saturday 6 1998 1998 1998 98";
     verifyDateFormat(date, "date", dateFormat, dateFormatted);
   }
+
+
+  @Test
+  public void testDateFormatISO8601() throws IOException {
+    String timestamp = "1998-01-31 13:14:15.012345";
+    String timestampFormat = "%Y-%m-%dT%TZ";
+    String timestampFormatted = "1998-01-31T13:14:15Z";
+    verifyDateFormat(timestamp, "timestamp", timestampFormat, timestampFormatted);
+
+    String date = "1998-01-31";
+    String dateFormat = "%Y-%m-%dT%TZ";
+    String dateFormatted = "1998-01-31T00:00:00Z";
+    verifyDateFormat(date, "date", dateFormat, dateFormatted);
+  }
+
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilderTest.java
@@ -94,6 +94,7 @@ class BucketAggregationBuilderTest {
             + "      \"lang\" : \"opensearch_query_expression\"\n"
             + "    },\n"
             + "    \"missing_bucket\" : true,\n"
+            + "    \"missing_order\" : \"first\",\n"
             + "    \"order\" : \"asc\"\n"
             + "  }\n"
             + "}",


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
Supported ISO 8601 Format in Date Format. IN order to solve this we are allowing all the alphabet characters with a '%' character behind to be replicated into the output format as is.
Eg: 
%Y-%m-%dT%TZ   --- 2022-01-15T11:12:29Z





 
### Issues Resolved
https://github.com/opensearch-project/sql/pull/434

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).