### PR TITLE
Add JDK 17 support

### DIFF
--- a/.github/workflows/sql-jdbc-test-and-build-workflow.yml
+++ b/.github/workflows/sql-jdbc-test-and-build-workflow.yml
@@ -4,7 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-
+    strategy:
+      matrix:
+        java:
+          - 14
+          - 17
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -12,11 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    
-    - name: Set up JDK 1.14
+
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
-        java-version: 1.14
+        java-version: ${{ matrix.java }}
     
     - name: Build with Gradle
       run: ./gradlew build test shadowJar

--- a/.github/workflows/sql-jdbc-test-and-build-workflow.yml
+++ b/.github/workflows/sql-jdbc-test-and-build-workflow.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         java:
+          - 11
           - 14
           - 17
     runs-on: ubuntu-latest

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -12,6 +12,7 @@ jobs:
         java:
           - 11
           - 14
+          - 17
     runs-on: ubuntu-latest
 
     steps:

--- a/DEVELOPER_GUIDE.rst
+++ b/DEVELOPER_GUIDE.rst
@@ -17,7 +17,7 @@ Prerequisites
 JDK
 ---
 
-OpenSearch builds using Java 11 at a minimum. This means you must have a JDK 11 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 11 installation::
+OpenSearch builds using Java 11 at a minimum and supports JDK 11, 14 and 17. This means you must have a JDK of supported version installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK installation::
 
    $ echo $JAVA_HOME
    /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ compileTestJava {
 }
 
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.7"
 }
 jacocoTestReport {
     reports {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'nebula.ospackage' version "8.3.0"
     id 'java-library'
     id 'checkstyle'
-    id "io.freefair.lombok" version "5.0.0-rc4"
+    id "io.freefair.lombok" version "6.4.0"
     id 'jacoco'
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,8 +50,8 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
     testImplementation group: 'org.springframework', name: 'spring-test', version: '5.2.19.RELEASE'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.3.3'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.12.4'
 }
 
 test {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,9 +62,6 @@ test {
     }
 }
 
-jacoco {
-    toolVersion = "0.8.5"
-}
 jacocoTestReport {
     reports {
         html.enabled true

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     compileOnly group: 'javax.servlet', name: 'servlet-api', version:'2.5'
 
     testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version:'2.2'
-    testImplementation group: 'org.mockito', name: 'mockito-inline', version:'3.5.0'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version:'3.12.4'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: "org.opensearch.client", name: 'transport', version: "${opensearch_version}"
 

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -41,8 +41,8 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.5.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.5.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.12.4'
     testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     testImplementation group: 'org.opensearch.test', name: 'framework', version: "${opensearch_version}"
 }

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -55,9 +55,6 @@ test {
     }
 }
 
-jacoco {
-    toolVersion = "0.8.5"
-}
 jacocoTestReport {
     reports {
         html.enabled true

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -68,10 +68,6 @@ test {
     }
 }
 
-jacoco {
-    toolVersion = "0.8.5"
-}
-
 jacocoTestReport {
     reports {
         html.enabled true

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
 
 }
 

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -51,9 +51,6 @@ test {
     }
 }
 
-jacoco {
-    toolVersion = "0.8.5"
-}
 jacocoTestReport {
     reports {
         html.enabled true

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -39,8 +39,8 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.3.3'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.12.4'
 }
 
 test {

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -55,8 +55,8 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.3.3'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.12.4'
 }
 
 test {

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -67,10 +67,6 @@ test {
     }
 }
 
-jacoco {
-    toolVersion = "0.8.5"
-}
-
 jacocoTestReport {
     reports {
         html.enabled true


### PR DESCRIPTION
### Description

1. Add JDK 17 to CI/CD. To pass all SQL build, `lombok`, `mockito` and `jacoco` is upgraded to newer version accordingly. 
2. Add JDK 17 to SQL JDBC CI/CD as well.
3. Update developer guide doc to clarify the JDK version supported.

### Issues Resolved
https://github.com/opensearch-project/sql/issues/467
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).