### PR TITLE
Fix bwc build issue with jdk17

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -189,8 +189,8 @@ task compileJdbc(type: Exec) {
 String bwcVersion = "1.13.2.0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"
-String bwcOpenDistroPlugin = "opendistro-sql-1.13.2.0.zip"
-String bwcRemoteFile = 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro-sql-1.13.2.0.zip'
+String bwcOpenDistroPlugin = "opendistro-sql-" + bwcVersion + ".zip"
+String bwcRemoteFile = 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/' + bwcOpenDistroPlugin
 
 2.times { i ->
     testClusters {
@@ -208,7 +208,7 @@ String bwcRemoteFile = 'https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elastics
                             if (!dir.exists()) {
                                 dir.mkdirs()
                             }
-                            File f = new File(bwcOpenDistroPlugin, dir)
+                            File f = new File(dir, bwcOpenDistroPlugin)
                             if (!f.exists()) {
                                 new URL(bwcRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
                             }


### PR DESCRIPTION
Signed-off-by: penghuo <penghuo@gmail.com>

### Description
Java 17 bwc test failed, because of
`Could not find matching constructor for: java.io.File(String, File)`

https://github.com/opensearch-project/sql/runs/5725756591?check_suite_focus=true
 
### Issues Resolved
None
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).