### PR TITLE
Remove checked-in ml-commons dependency

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -48,6 +48,9 @@ doctest.finalizedBy stopOpenSearch
 build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 
+String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.1/latest/linux/x64/builds/opensearch/plugins/opensearch-ml-1.3.1.0.zip'
+String mlCommonsPlugin = "ml-commons"
+
 testClusters {
     docTestCluster {
         plugin(provider(new Callable<RegularFile>(){
@@ -56,7 +59,15 @@ testClusters {
                 return new RegularFile() {
                     @Override
                     File getAsFile() {
-                        return fileTree("resources/ml-commons").getSingleFile()
+                        File dir = new File('./doctest/' + mlCommonsPlugin)
+                        if (!dir.exists()) {
+                            dir.mkdirs()
+                        }
+                        File f = new File(mlCommonsPlugin, dir)
+                        if (!f.exists()) {
+                            new URL(mlCommonsRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+                        }
+                        return fileTree(mlCommonsPlugin).getSingleFile()
                     }
                 }
             }


### PR DESCRIPTION
Signed-off-by: jackieyanghan <jkhanjob@gmail.com>

### Description
Remove checked-in ml-commons dependency used for doctest
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/495
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).