### PR TITLE
Bug Fix, return default ID when log4j ThreadContext is empty

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/JdbcTestIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/JdbcTestIT.java
@@ -9,6 +9,7 @@ package org.opensearch.sql.legacy;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
+import java.io.IOException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
@@ -38,6 +39,26 @@ public class JdbcTestIT extends SQLIntegTestCase {
     assertThat(percentileRow.getDouble("50.0"), equalTo(33.5));
     assertThat(percentileRow.getDouble("75.0"), equalTo(36.5));
     assertThat(percentileRow.getDouble("99.9"), equalTo(39.0));
+  }
+
+  // https://github.com/opensearch-project/sql/issues/537
+  @Test
+  public void testSlowQuery() throws IOException {
+    // set slow log threshold = 0s
+    updateClusterSettings(new ClusterSetting(PERSISTENT, "plugins.sql.slowlog", "0"));
+
+    JSONObject response = executeJdbcRequest(
+        "SELECT percentiles(age, 25.0, 50.0, 75.0, 99.9) age_percentiles " +
+            "FROM opensearch-sql_test_index_people");
+
+    assertThat(response.getJSONArray("datarows").length(), equalTo(1));
+    JSONObject percentileRow = (JSONObject) response.query("/datarows/0/0");
+    assertThat(percentileRow.getDouble("25.0"), equalTo(31.5));
+    assertThat(percentileRow.getDouble("50.0"), equalTo(33.5));
+    assertThat(percentileRow.getDouble("75.0"), equalTo(36.5));
+    assertThat(percentileRow.getDouble("99.9"), equalTo(39.0));
+
+    wipeAllClusterSettings();
   }
 
   @Ignore("flaky test, trigger resource not enough exception. "

--- a/legacy/src/main/java/org/opensearch/sql/legacy/utils/LogUtils.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/utils/LogUtils.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.legacy.utils;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.logging.log4j.ThreadContext;
 
@@ -19,6 +20,8 @@ public class LogUtils {
      * The key of the request id in the context map
      */
     private static final String REQUEST_ID_KEY = "request_id";
+
+    private static final String EMPTY_ID = "ID";
 
     /**
      * Generates a random UUID and adds to the {@link ThreadContext} as the request id.
@@ -38,13 +41,7 @@ public class LogUtils {
      * @return the current request id from {@link ThreadContext}
      */
     public static String getRequestId() {
-
-        final String requestId = ThreadContext.get(REQUEST_ID_KEY);
-        if (requestId == null) {
-            throw new IllegalStateException("Request id not present in current context");
-        }
-
-        return requestId;
+        return Optional.ofNullable(ThreadContext.get(REQUEST_ID_KEY)).orElseGet(() -> EMPTY_ID);
     }
 
     /**

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/LogUtilsTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/LogUtilsTest.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.legacy.unittest.utils;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 
 import org.apache.logging.log4j.ThreadContext;
 import org.junit.After;
@@ -44,10 +45,9 @@ public class LogUtilsTest {
         Assert.assertThat(requestId2, not(equalTo(requestId)));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void getRequestId_doesNotExist() {
-
-        LogUtils.getRequestId();
+        assertEquals("ID", LogUtils.getRequestId());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: penghuo <penghuo@gmail.com>

### Description
Bug Fix, return default ID when log4j ThreadContext is empty.
 
### Issues Resolved
#537 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).