### PR TITLE
Bump workbench to 1.3.1

### DIFF
--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -4,8 +4,8 @@ on: [pull_request, push]
 
 env: 
   PLUGIN_NAME: query-workbench-dashboards
-  OPENSEARCH_VERSION: '1.x'
-  OPENSEARCH_PLUGIN_VERSION: 1.3.0.0
+  OPENSEARCH_VERSION: '1.3'
+  OPENSEARCH_PLUGIN_VERSION: 1.3.1.0
 
 jobs:
 

--- a/workbench/opensearch_dashboards.json
+++ b/workbench/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "queryWorkbenchDashboards",
-  "version": "1.3.0.0",
-  "opensearchDashboardsVersion": "1.3.0",
+  "version": "1.3.1.0",
+  "opensearchDashboardsVersion": "1.3.1",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation"],

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,14 +1,10 @@
 {
   "name": "opensearch-query-workbench",
-  "version": "1.3.0.0",
+  "version": "1.3.1.0",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/sql/tree/main/workbench",
-  "opensearchDashboards": {
-    "version": "1.3.0",
-    "templateVersion": "1.0.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/opensearch-project/sql/tree/main/workbench"

--- a/workbench/yarn.lock
+++ b/workbench/yarn.lock
@@ -2297,10 +2297,10 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-semver-regex@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.3.tgz#b2bcc6f97f63269f286994e297e229b6245d0dc3"
-  integrity sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==
+semver-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
+  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
 semver@7.x:
   version "7.3.4"


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Bump dashboards plugin to 1.3.1
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).