### PR TITLE
Change alpha1 to rc1 for first 2.0 release

### DIFF
--- a/workbench/opensearch_dashboards.json
+++ b/workbench/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "queryWorkbenchDashboards",
-  "version": "2.0.0.0-alpha1",
+  "version": "2.0.0.0-rc1",
   "opensearchDashboardsVersion": "2.0.0",
   "server": true,
   "ui": true,

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-query-workbench",
-  "version": "2.0.0.0-alpha1",
+  "version": "2.0.0.0-rc1",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
rc1 will be used instead of alpha1, will send another PR to update for opensearch plugins when core is ready
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).