### PR TITLE
Removign JDK14 from CI

### DIFF
--- a/.github/workflows/sql-jdbc-test-and-build-workflow.yml
+++ b/.github/workflows/sql-jdbc-test-and-build-workflow.yml
@@ -8,7 +8,6 @@ jobs:
       matrix:
         java:
           - 11
-          - 14
           - 17
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -8,7 +8,6 @@ jobs:
       matrix:
         java:
           - 11
-          - 14
           - 17
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
Removing JDK14 from CI as we will be only supporting Java LTS versions(11&17) from 2.0 release.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).