### PR TITLE
Change master nomenclature

### DIFF
--- a/.github/workflows/sql-cli-release-workflow.yml
+++ b/.github/workflows/sql-cli-release-workflow.yml
@@ -1,5 +1,5 @@
 name: Release SQL CLI Artifacts
-# This workflows is triggered on creating tags to master
+# This workflows is triggered on creating tags to main
 on:
   push:
     tags:

--- a/.github/workflows/sql-jdbc-release-workflow.yml
+++ b/.github/workflows/sql-jdbc-release-workflow.yml
@@ -1,5 +1,5 @@
 name: Build and Release SQL-JDBC
-# This workflow is triggered on creating tags to master or an opensearch release branch
+# This workflow is triggered on creating tags to main or an opensearch release branch
 on:
   push:
     tags:

--- a/.github/workflows/sql-release-workflow.yml
+++ b/.github/workflows/sql-release-workflow.yml
@@ -1,5 +1,5 @@
 name: Release SQL Artifacts
-# This workflow is triggered on creating tags to master or an opensearch release branch
+# This workflow is triggered on creating tags to main or an opensearch release branch
 on:
   push:
     tags:

--- a/DEVELOPER_GUIDE.rst
+++ b/DEVELOPER_GUIDE.rst
@@ -46,16 +46,16 @@ Now you can check out the code from your forked GitHub repository and create a n
    $ git clone git@github.com:<your_account>/sql.git
    $ git checkout -b <branch_name>
 
-If there is update in master or you want to keep the forked repository long living, you can sync it by following the instructions: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork. Basically you just need to pull latest changes from upstream master once you add it for the first time::
+If there is update in main or you want to keep the forked repository long living, you can sync it by following the instructions: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork. Basically you just need to pull latest changes from upstream main once you add it for the first time::
 
-   #Merge to your local master
+   #Merge to your local main
    $ git fetch upstream
-   $ git checkout master
-   $ git merge upstream/master
+   $ git checkout main
+   $ git merge upstream/main
 
    #Merge to your branch if any
    $ git checkout <branch_name>
-   $ git merge master
+   $ git merge main
 
 After getting the source code as well as OpenSearch and OpenSearch Dashboards, your workspace layout may look like this::
 
@@ -181,7 +181,7 @@ Note that other related project code has already merged into this single reposit
 Code Convention
 ---------------
 
-We’re integrated Checkstyle plugin into Gradle build: https://github.com/opensearch-project/sql/blob/master/config/checkstyle/google_checks.xml. So any violation will fail the build. You need to identify the offending code from Gradle error message and fix them and rerun the Gradle build. Here are the highlight of some Checkstyle rules:
+We’re integrated Checkstyle plugin into Gradle build: https://github.com/opensearch-project/sql/blob/main/config/checkstyle/google_checks.xml. So any violation will fail the build. You need to identify the offending code from Gradle error message and fix them and rerun the Gradle build. Here are the highlight of some Checkstyle rules:
 
 * 2 spaces indentation.
 * No line starts with tab character in source file.

--- a/docs/attributions.md
+++ b/docs/attributions.md
@@ -22,7 +22,7 @@ Apart from the problems we identified earlier, we made significant improvement i
 
 1. *Integration Test*: We migrated all integrate tests to standard OpenSearch IT framework which spins up in-memory cluster for testing. Now all test cases treat plugin code as blackbox and verify functionality from externally.
 2. *New JDBC Driver*: We developed our own JDBC driver without any dependency on Elasticsearch proprietary code.
-    [sql-jdbc](https://github.com/opensearch-project/sql/tree/master/sql-jdbc)
+    [sql-jdbc](https://github.com/opensearch-project/sql/tree/main/sql-jdbc)
 3. *Better Hash JOIN*: Block Hash Join implementation with circuit break mechanism protect your OpenSearch memory. Performance testing showed our implementation is 1.5 ~ 2x better than old hash join in terms of throughput and latency and much lower error rate under heavy pressure.
 4. *Query Planner*: Logical and physical planner was added to support JOIN query in efficient and extendible way.
 5. *PartiQL Compatibility*: we are partially compatible with PartiQL specification which allows for query involved in nested JSON documents.

--- a/docs/dev/Architecture.md
+++ b/docs/dev/Architecture.md
@@ -3,7 +3,7 @@
 ---
 ## 1.Overview
 
-The OpenSearch SQL (OD-SQL) project is developed based on NLPChina project (https://github.com/NLPchina/elasticsearch-sql) which has been deprecated now ([attributions](https://github.com/opensearch-project/sql/blob/master/docs/attributions.md)). Over the one year in development, a lot of features have been added to the OD-SQL project on top of the existing older NLPChina project. The purpose of this document is to explain the OD-SQL current architecture going ahead.
+The OpenSearch SQL (OD-SQL) project is developed based on NLPChina project (https://github.com/NLPchina/elasticsearch-sql) which has been deprecated now ([attributions](https://github.com/opensearch-project/sql/blob/main/docs/attributions.md)). Over the one year in development, a lot of features have been added to the OD-SQL project on top of the existing older NLPChina project. The purpose of this document is to explain the OD-SQL current architecture going ahead.
 
 ---
 ## 2.High Level View

--- a/docs/dev/Doctest.md
+++ b/docs/dev/Doctest.md
@@ -98,7 +98,7 @@ The reason we are not using OpenSearch test framework, is due to the difficulty 
     1. bootstrap
     2. StartOpenSearch
         1. ` ./gradlew run`
-        2. https://github.com/elastic/elasticsearch/blob/master/TESTING.asciidoc#running-elasticsearch-from-a-checkout
+        2. https://github.com/elastic/elasticsearch/blob/main/TESTING.asciidoc#running-elasticsearch-from-a-checkout
     3. doctest
     4. StopOpenSearch
 4. Integrate Doctest to project gradle build, which means `./gradlew build` will also run `doctest`

--- a/docs/presentations/20201116-sql-demo.md
+++ b/docs/presentations/20201116-sql-demo.md
@@ -108,7 +108,7 @@ Contribution: https://github.com/opendistro-for-elasticsearch/sql/blob/develop/d
 1. SQL reference manual
     1. https://opendistro.github.io/for-elasticsearch-docs/docs/sql/
     2. https://github.com/opendistro-for-elasticsearch/sql/blob/develop/docs/user/index.rst
-2. Setting for enabling new SQL engine: https://github.com/opendistro-for-elasticsearch/sql/blob/master/docs/user/admin/settings.rst#opendistro-sql-engine-new-enabled
+2. Setting for enabling new SQL engine: https://github.com/opensearch-project/sql/blob/main/docs/user/admin/settings.rst#opendistrosqlenginenewenabled
 
 ### (II) Demo Cluster Setup
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -94,7 +94,6 @@ tasks.withType(licenseHeaders.class) {
 forbiddenApis.ignoreFailures = true
 // TODO: fix forbidden code patterns
 // introduced by OpenSearch plugin
-// see https://github.com/elastic/elasticsearch/blob/master/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ForbiddenPatternsTask.java
 forbiddenPatterns {
     setEnabled(false)
 }

--- a/sql-cli/README.md
+++ b/sql-cli/README.md
@@ -88,13 +88,13 @@ You can also configure the following connection properties:
     * Amazon OpenSearch Service domain with [Fine Grained Access Control](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac.html) enabled
 * `--aws-auth`: Turns on AWS sigV4 authentication to connect to an Amazon Elasticsearch Service endpoint. Use with the AWS CLI (`aws configure`) to retrieve the local AWS configuration to authenticate and connect.
 
-For a list of all available configurations, see [clirc](https://github.com/opensearch-project/sql/blob/master/sql-cli/src/opensearch_sql_cli/conf/clirc).
+For a list of all available configurations, see [clirc](https://github.com/opensearch-project/sql/blob/main/sql-cli/src/opensearch_sql_cli/conf/clirc).
 
 
 
 ## Using the CLI
 
-1. Save the sample [accounts test data](https://github.com/opensearch-project/sql/blob/master/integ-test/src/test/resources/accounts.json) file.
+1. Save the sample [accounts test data](https://github.com/opensearch-project/sql/blob/main/integ-test/src/test/resources/accounts.json) file.
 2. Index the sample data.
 
     ```

--- a/sql-jdbc/docs/tableau.md
+++ b/sql-jdbc/docs/tableau.md
@@ -4,7 +4,7 @@
 
 * Download and install [Tableau Desktop](https://www.tableau.com/en-ca/products/desktop/download).
 * Install and configure [OpenSearch](https://docs-beta.opensearch.org/opensearch/install/index/).
-* Download the [OpenSearch JDBC Driver](https://github.com/opensearch-project/sql/blob/master/sql-jdbc/README.md#download-and-installation).
+* Download the [OpenSearch JDBC Driver](https://github.com/opensearch-project/sql/blob/main/sql-jdbc/README.md#download-and-installation).
 
 ## Setup
 
@@ -47,7 +47,7 @@ For futher details check [using a .tdc file with Tableau](https://kb.tableau.com
  ### Connection information
 
 You will need:
-* [JDBC connection string](https://github.com/opensearch-project/sql/blob/master/sql-jdbc/README.md#connection-url-and-other-settings) to enter in the URL field when you connect.
+* [JDBC connection string](https://github.com/opensearch-project/sql/blob/main/sql-jdbc/README.md#connection-url-and-other-settings) to enter in the URL field when you connect.
 
   Sample connection string for connecting to localhost: `jdbc:opensearch://localhost:9200`.
 

--- a/sql-odbc/THIRD-PARTY
+++ b/sql-odbc/THIRD-PARTY
@@ -4,7 +4,7 @@
 ** Visual Leak Detector -- https://github.com/KindDragon/vld
 ** PostgreSQL v12.0 -- https://www.postgresql.org/ftp/source/v12.0/
 ** Googletest -- https://github.com/google/googletest
-** StableCoder - code-coverage.cmake -- https://github.com/StableCoder/cmake-scripts/blob/master/code-coverage.cmake
+** StableCoder - code-coverage.cmake -- https://github.com/StableCoder/cmake-scripts/blob/main/code-coverage.cmake
 
 Apache License
 

--- a/sql-odbc/docs/dev/run_tests.md
+++ b/sql-odbc/docs/dev/run_tests.md
@@ -87,7 +87,7 @@ The **Test Runner** has been tried and tested with [Python3.7.6](https://www.pyt
 
 ### Run with Coverage (Mac only)
 
-(using a CMake script provided by George Cave (StableCoder) under the Apache 2.0 license, found [here](https://github.com/StableCoder/cmake-scripts/blob/master/code-coverage.cmake))
+(using a CMake script provided by George Cave (StableCoder) under the Apache 2.0 license, found [here](https://github.com/StableCoder/cmake-scripts/blob/main/code-coverage.cmake))
 
 #### Requirements
 * `llvm-cov` in your PATH environment variable

--- a/workbench/CONTRIBUTING.md
+++ b/workbench/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description
Change master nomenclature: Change `master` (mostly Github link) to `main` in docs and comments.

The only code using master nomenclature is in OpenSearch API call which doesn't seem have alternative clusterManager class or method:

```
RestQuerySettingsAction:
    final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest =
        Requests.clusterUpdateSettingsRequest();
    clusterUpdateSettingsRequest.timeout(request.paramAsTime(
        "timeout", clusterUpdateSettingsRequest.timeout()));
    clusterUpdateSettingsRequest.masterNodeTimeout(request.paramAsTime(
        "master_timeout", clusterUpdateSettingsRequest.masterNodeTimeout()));
```

The following `master` in doc link are also not changed due to `main` branch missing:

```
./plugin/src/main/java/org/opensearch/sql/plugin/rest/RestQuerySettingsAction.java:82:    clusterUpdateSettingsRequest.masterNodeTimeout(request.paramAsTime(
./plugin/src/main/java/org/opensearch/sql/plugin/rest/RestQuerySettingsAction.java:83:        "master_timeout", clusterUpdateSettingsRequest.masterNodeTimeout()));
./bi-connectors/PowerBIConnector/OdbcConstants.pqm:1:// values from https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
./docs/dev/Doctest.md:141:**Reference: [CrateDB Implementation](https://github.com/crate/crate/blob/master/blackbox/test_docs.py)**
./docs/dev/Doctest.md:145:    * https://github.com/crate/crate/blob/master/docs/general/dql/selects.rst
./workbench/test/polyfills/mutationObserver.js:9:// https://github.com/aurelia/pal-nodejs/blob/master/src/polyfills/mutation-observer.ts
./workbench/release-notes/sql-workbench.release-notes-1.7.0.0.md:28:- Initial merge from development branches to master ([#31](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/31))
./sql-odbc/libraries/rabbit/README:3:https://github.com/mashiro/rabbit/tree/master
./sql-odbc/src/sqlodbc/opensearch_types.h:214:    CONNECTION_AWAITING_RESPONSE, /* Waiting for a response from the postmaster.
./.github/workflows/link-checker.yml:17:        uses: lycheeverse/lychee-action@master
./sql-cli/src/opensearch_sql_cli/opensearch_style.py:61:        # https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/prompt_toolkit/styles/defaults.py
```

PR reference:
+ https://github.com/opensearch-project/asynchronous-search/pull/116/files
+ https://github.com/opensearch-project/cross-cluster-replication/pull/355/files
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/463
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).