### PR TITLE
Fix doctest and add AD to doctest

### DIFF
--- a/docs/category.json
+++ b/docs/category.json
@@ -8,6 +8,7 @@
   ],
   "ppl_cli": [
     "user/ppl/cmd/ad.rst",
+    "user/ppl/cmd/kmeans.rst",
     "user/ppl/cmd/dedup.rst",
     "user/ppl/cmd/eval.rst",
     "user/ppl/cmd/fields.rst",

--- a/docs/user/ppl/cmd/ad.rst
+++ b/docs/user/ppl/cmd/ad.rst
@@ -46,7 +46,7 @@ The example trains an RCF model and uses the model to detect anomalies in the ti
 
 PPL query::
 
-    os> source=nyc_taxi | fields value, timestamp | AD time_field='timestamp' | where value=10844.0'
+    os> source=nyc_taxi | fields value, timestamp | AD time_field='timestamp' | where value=10844.0
     +----------+---------------+-------+---------------+
     | value    | timestamp     | score | anomaly_grade |
     |----------+---------------+-------+---------------|
@@ -61,7 +61,7 @@ The example trains an RCF model and uses the model to detect anomalies in the no
 
 PPL query::
 
-    os> source=nyc_taxi | fields value | AD | where value=10844.0'
+    os> source=nyc_taxi | fields value | AD | where value=10844.0
     +----------+--------+-----------+
     | value    | score  | anomalous |
     |----------+--------+-----------|

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -75,7 +75,7 @@ testClusters {
                 }
             }
         }))
-
+        plugin ':plugin'
         testDistribution = 'integ_test'
     }
 }


### PR DESCRIPTION
### Description
enable doctest and add AD to doctest

@jackiehanyang kmeans doc uses `iris_data`, could you add it like the [nyc_taxi.json](https://github.com/opensearch-project/sql/blob/0888b3bf50c4c3e138b700c879828c5eb8e9a500/doctest/test_data/nyc_taxi.json) one? And ad.rst doctest failed, could you also take a look?
 
cc @ylwu-amzn 

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).