### PR TITLE
Fix doctest not running issue

### DIFF
--- a/docs/category.json
+++ b/docs/category.json
@@ -7,7 +7,6 @@
     "user/admin/settings.rst"
   ],
   "ppl_cli": [
-    "user/ppl/cmd/ad.rst",
     "user/ppl/cmd/dedup.rst",
     "user/ppl/cmd/eval.rst",
     "user/ppl/cmd/fields.rst",

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -75,7 +75,7 @@ testClusters {
                 }
             }
         }))
-
+        plugin ':plugin'
         testDistribution = 'integ_test'
     }
 }


### PR DESCRIPTION
Signed-off-by: jackiehanyang <jkhanjob@gmail.com>

### Description
- Fix doctest not running issue. 
- Comment out `ad` in doctest running list as it takes more time to investigate. It looks like something is wrong in the doctest-cluster transport layer when ppl makes the call to ml-commons. Will take look into it. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).