### PR TITLE
Added function to cast string to int

### DIFF
--- a/bi-connectors/TableauConnector/opensearch_sql_jdbc/dialect.tdd
+++ b/bi-connectors/TableauConnector/opensearch_sql_jdbc/dialect.tdd
@@ -33,28 +33,33 @@
             <argument type='datetime' />
         </function>
         <function group='cast' name='STR' return-type='str'>
-            <formula>CAST(%1 as string)</formula>
+            <formula>CAST(%1 AS STRING)</formula>
             <argument type='real' />
         </function>
         <function group='cast' name='STR' return-type='str'>
-            <formula>CAST(%1 as string)</formula>
+            <formula>CAST(%1 AS STRING)</formula>
             <argument type='int' />
         </function>
         <function group='cast' name='STR' return-type='str'>
-            <formula>CAST(%1 as string)</formula>
+            <formula>CAST(%1 AS STRING)</formula>
             <argument type='date' />
         </function>
         <function group='cast' name='STR' return-type='str'>
-            <formula>CAST(%1 as string)</formula>
+            <formula>CAST(%1 AS STRING)</formula>
             <argument type='bool' />
         </function>
         <function group='cast' name='INT' return-type='int'>
-            <formula>CAST(%1 as int)</formula>
+            <formula>CAST(%1 AS INT)</formula>
             <argument type='real' />
         </function>
         <function group='cast' name='INT' return-type='int'>
-            <formula>CAST(%1 as int)</formula>
+            <formula>CAST(%1 AS INT)</formula>
             <argument type='bool' />
+        </function>
+        <function group='cast' name='INT' return-type='int'>
+            <!-- Casting to double covers the case where the string is not an integer. Casting a string double to int fails -->
+            <formula>CAST(CAST(%1 AS DOUBLE) AS INT)</formula>
+            <argument type='str' />
         </function>
 
         <function group='logical' name='IFNULL' return-type='datetime'>


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
Added function to cast string to int. The generated query will cast to DOUBLE before casting to INT to cover the case of "2.1".
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/554
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).