### PR TITLE
TDVT Add ISDATE back as a Tableau function

### DIFF
--- a/bi-connectors/TableauConnector/opensearch_sql_jdbc/dialect.tdd
+++ b/bi-connectors/TableauConnector/opensearch_sql_jdbc/dialect.tdd
@@ -378,9 +378,6 @@
             <argument type='localstr' />
             <argument type='str' />
         </remove-function>
-        <remove-function name='ISDATE'>
-            <argument type='str' />
-        </remove-function>
 
         <remove-function name='USEC_TO_TIMESTAMP'>
             <argument type='int' />


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
The test case `ISDATE("2015-01-01")` passes but `ISDATE("data")` fails because of the issue below.
This function will work as expected when https://github.com/opensearch-project/sql/issues/580 is fixed.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).