### PR TITLE
Remove rc1 qualifier for 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         if (buildVersionQualifier) {
@@ -44,11 +44,6 @@ repositories {
     mavenLocal()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
-}
-
-ext {
-    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-    buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
 }
 
 allprojects {

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -50,8 +50,12 @@ clean.dependsOn(cleanBootstrap)
 
 // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
 String opensearch_no_snapshot = opensearch_version.replace("-SNAPSHOT","")
-String opensearch_build = opensearch_no_snapshot.tokenize('-')[0] + '.0-' + opensearch_no_snapshot.tokenize('-')[1]
-String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot + '/2500/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-' + opensearch_build +'.zip'
+String[] version_tokens = opensearch_no_snapshot.tokenize('-')
+String opensearch_build = version_tokens[0] + '.0'
+if (version_tokens.length > 1) {
+    opensearch_build += "-" + version_tokens[1]
+}
+String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot + '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-' + opensearch_build +'.zip'
 String mlCommonsPlugin = "ml-commons"
 
 testClusters {

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -49,14 +49,14 @@ build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 
 // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
-String opensearch_no_snapshot = opensearch_version.replace("-SNAPSHOT","")
+String opensearch_no_snapshot = opensearch_version.replace('-SNAPSHOT', '')
 String[] version_tokens = opensearch_no_snapshot.tokenize('-')
 String opensearch_build = version_tokens[0] + '.0'
 if (version_tokens.length > 1) {
-    opensearch_build += "-" + version_tokens[1]
+    opensearch_build += '-' + version_tokens[1]
 }
-String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot + '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-' + opensearch_build +'.zip'
-String mlCommonsPlugin = "ml-commons"
+String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot + '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-' + opensearch_build + '.zip'
+String mlCommonsPlugin = 'opensearch-ml'
 
 testClusters {
     docTestCluster {
@@ -70,9 +70,9 @@ testClusters {
                         if (!dir.exists()) {
                             dir.mkdirs()
                         }
-                        File f = new File(dir, mlCommonsPlugin)
+                        File f = new File(dir, mlCommonsPlugin + '-' + opensearch_build + '.zip')
                         if (!f.exists()) {
-                            new URL(mlCommonsRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins }}
+                            new URL(mlCommonsRemoteFile).withInputStream{ ins -> f.withOutputStream{ it << ins } }
                         }
                         return fileTree(mlCommonsPlugin).getSingleFile()
                     }

--- a/doctest/opensearch-ml/.gitignore
+++ b/doctest/opensearch-ml/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/workbench/opensearch_dashboards.json
+++ b/workbench/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "queryWorkbenchDashboards",
-  "version": "2.0.0.0-rc1",
+  "version": "2.0.0.0",
   "opensearchDashboardsVersion": "2.0.0",
   "server": true,
   "ui": true,

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-query-workbench",
-  "version": "2.0.0.0-rc1",
+  "version": "2.0.0.0",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
closes #597 
CI will fail until ml-commons 2.0 is ready
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).