### PR TITLE
[1.3] Bump jackson to 2.13.2

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -52,8 +52,8 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.12.6'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.6'
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.13.2'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2'
 }
 
 dependencies {

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     compile project(':core')
     compile group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compile "io.github.resilience4j:resilience4j-retry:1.5.0"
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.6' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.12.6'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2' 
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
     compile group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     compile group: 'org.opensearch', name:'opensearch-ml-client', version: '1.3.2.0-SNAPSHOT'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -56,12 +56,12 @@ configurations.all {
     resolutionStrategy.force 'junit:junit:4.13.2'
     // conflict with spring-jcl
     exclude group: "commons-logging", module: "commons-logging"
-    // enforce 2.12.6, https://github.com/opensearch-project/sql/issues/424
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.12.6'
+    // enforce 2.13.2, https://www.mend.io/vulnerability-database/CVE-2020-36518
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.13.2'
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.6'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2'
 }
 
 dependencies {

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -30,9 +30,9 @@ plugins {
 
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.6' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.12.6'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2' 
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
     implementation 'com.google.code.gson:gson:2.8.9'
     compile project(':core')
     compile project(':opensearch')

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
bump jackson libraries for 1.3, it's already bumped in main

Build will fail until upstream OpenSearch is bumped as well
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).