### PR TITLE
Fix sql offending symbol due to keyword as an ID

### DIFF
--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -86,7 +86,7 @@ showDescribePattern
     ;
 
 compatibleID
-    : (MODULE | ID)+?
+    : (MODULE | ID | keywordsCanBeId)+?
     ;
 
 //    Select Statement's Details


### PR DESCRIPTION
### Description
This PR allows SQL to parse pattern matching query correctly for identifiers that contain keywords.
 
### Issues Resolved
#650 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).