### PR TITLE
change plugin folder name to opensearch-sql-plugin

### DIFF
--- a/DEVELOPER_GUIDE.rst
+++ b/DEVELOPER_GUIDE.rst
@@ -34,7 +34,7 @@ OpenSearch & OpenSearch Dashboards
 
 For convenience, we recommend installing `OpenSearch <https://www.opensearch.org/downloads.html>`_ and `OpenSearch Dashboards <https://www.opensearch.org/downloads.html>`_ on your local machine. You can download the open source ZIP for each and extract them to a folder.
 
-If you just want to have a quick look, you can also get an OpenSearch running with plugin installed by ``./gradlew :plugin:run``.
+If you just want to have a quick look, you can also get an OpenSearch running with plugin installed by ``./gradlew :opensearch-sql-plugin:run``.
 
 OpenSearch Dashboards is optional, but makes it easier to test your queries. Alternately, you can use curl from the terminal to run queries against the plugin.
 

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -79,7 +79,7 @@ testClusters {
                 }
             }
         }))
-        plugin ':plugin'
+        plugin ':opensearch-sql-plugin'
         testDistribution = 'integ_test'
     }
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
-    testImplementation project(':plugin')
+    testImplementation project(':opensearch-sql-plugin')
     testImplementation project(':legacy')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
@@ -98,12 +98,12 @@ testClusters.all {
 }
 
 testClusters.integTest {
-    plugin ":plugin"
+    plugin ":opensearch-sql-plugin"
 }
 
 // Run PPL ITs and new, legacy and comparison SQL ITs with new SQL engine enabled
 integTest {
-    dependsOn ':plugin:bundlePlugin'
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
 
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)
@@ -147,7 +147,7 @@ integTest {
 
 
 task comparisonTest(type: RestIntegTestTask) {
-    dependsOn ':plugin:bundlePlugin'
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
 
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,8 @@
 
 rootProject.name = 'opensearch-sql'
 
-include 'plugin'
+include 'opensearch-sql-plugin'
+project(':opensearch-sql-plugin').projectDir = file('plugin')
 include 'ppl'
 include 'integ-test'
 include 'common'


### PR DESCRIPTION
Signed-off-by: Kavitha Conjeevaram Mohan <mohakavi@amazon.com>

### Description
Providing alias for plugin folder name and changing the plugin name in respective files too.
this PR ports #662 to main
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).