### PR TITLE
Improve Error Reporting for New SQL Engine

### DIFF
--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -111,13 +111,13 @@ Result set::
 	}
 	Query failed on both V1 and V2 SQL parser engines. V2 SQL parser error following:
 	{
-      "error": {
-        "reason": "Invalid SQL query",
-        "details": "Failed to parse query due to offending symbol [DELETE] at: 'DELETE' <--- HERE... More details: Expecting tokens in {<EOF>, 'DESCRIBE', 'SELECT', 'SHOW', ';'}",
-        "type": "SyntaxCheckException"
-      },
-      "status": 400
-    }
+	  "error": {
+	    "reason": "Invalid SQL query",
+	    "details": "Failed to parse query due to offending symbol [DELETE] at: 'DELETE' <--- HERE... More details: Expecting tokens in {<EOF>, 'DESCRIBE', 'SELECT', 'SHOW', ';'}",
+	    "type": "SyntaxCheckException"
+	  },
+	  "status": 400
+	}
 
 plugins.sql.slowlog
 ============================

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -109,15 +109,6 @@ Result set::
 	  },
 	  "status" : 400
 	}
-	Query failed on both V1 and V2 SQL parser engines. V2 SQL parser error following:
-	{
-	  "error": {
-	    "reason": "Invalid SQL query",
-	    "details": "Failed to parse query due to offending symbol [DELETE] at: 'DELETE' <--- HERE... More details: Expecting tokens in {<EOF>, 'DESCRIBE', 'SELECT', 'SHOW', ';'}",
-	    "type": "SyntaxCheckException"
-	  },
-	  "status": 400
-	}
 
 plugins.sql.slowlog
 ============================

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -109,6 +109,15 @@ Result set::
 	  },
 	  "status" : 400
 	}
+	Query failed on both V1 and V2 SQL parser engines. V2 SQL parser error following:
+	{
+      "error": {
+        "reason": "Invalid SQL query",
+        "details": "Failed to parse query due to offending symbol [DELETE] at: 'DELETE' <--- HERE... More details: Expecting tokens in {<EOF>, 'DESCRIBE', 'SELECT', 'SHOW', ';'}",
+        "type": "SyntaxCheckException"
+      },
+      "status": 400
+    }
 
 plugins.sql.slowlog
 ============================
@@ -307,6 +316,15 @@ SQL query::
         "reason": "Invalid SQL query",
         "details": "DELETE clause is disabled by default and will be deprecated. Using the plugins.sql.delete.enabled setting to enable it",
         "type": "SQLFeatureDisabledException"
+      },
+      "status": 400
+    }
+    Query failed on both V1 and V2 SQL parser engines. V2 SQL parser error following:
+    {
+      "error": {
+        "reason": "Invalid SQL query",
+        "details": "Failed to parse query due to offending symbol [DELETE] at: 'DELETE' <--- HERE... More details: Expecting tokens in {<EOF>, 'DESCRIBE', 'SELECT', 'SHOW', ';'}",
+        "type": "SyntaxCheckException"
       },
       "status": 400
     }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -121,6 +121,8 @@ public class RestSQLQueryAction extends BaseRestHandler {
    */
   public RestChannelConsumer prepareRequest(SQLQueryRequest request, NodeClient nodeClient) {
     if (!request.isSupported()) {
+      setErrorStr("Query request is not supported. Either unsupported fields present," +
+          " the request is not a cursor request, or response format can't be supported.");
       return NOT_SUPPORTED_YET;
     }
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -71,7 +71,7 @@ public class RestSQLQueryAction extends BaseRestHandler {
    * This member variable and it's usage can be deleted once the
    * legacy SQL engine is deprecated.
    */
-  private String ErrorStr;
+  private String errorStr;
 
   /**
    * Constructor of RestSQLQueryAction.
@@ -98,19 +98,19 @@ public class RestSQLQueryAction extends BaseRestHandler {
   }
 
   /**
-   * Setter for ErrorStr member variable.
+   * Setter for errorStr member variable.
    * @param error : String error value to set member variable.
    */
   public void setErrorStr(String error) {
-    ErrorStr = error;
+    errorStr = error;
   }
 
   /**
-   * Getter for ErrorStr member variable.
-   * @return : ErrorStr member variable.
+   * Getter for errorStr member variable.
+   * @return : errorStr member variable.
    */
   public String getErrorStr() {
-    return ErrorStr;
+    return errorStr;
   }
 
   /**
@@ -139,7 +139,7 @@ public class RestSQLQueryAction extends BaseRestHandler {
       }
 
       /**
-       * Setting ErrorStr member variable is used to aggregate error messages when both legacy and new SQL engines fail.
+       * Setting errorStr member variable is used to aggregate error messages when both legacy and new SQL engines fail.
        * This implementation can be removed when the legacy SQL engine is deprecated.
        */
       setErrorStr(ErrorMessageFactory.createErrorMessage(e, isClientError(e) ? BAD_REQUEST.getStatus() : SERVICE_UNAVAILABLE.getStatus()).toString());

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -17,6 +17,9 @@ import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.node.NodeClient;
@@ -71,6 +74,8 @@ public class RestSQLQueryAction extends BaseRestHandler {
    * This member variable and it's usage can be deleted once the
    * legacy SQL engine is deprecated.
    */
+  @Setter
+  @Getter
   private String errorStr;
 
   /**
@@ -98,22 +103,6 @@ public class RestSQLQueryAction extends BaseRestHandler {
   }
 
   /**
-   * Setter for errorStr member variable.
-   * @param error : String error value to set member variable.
-   */
-  public void setErrorStr(String error) {
-    errorStr = error;
-  }
-
-  /**
-   * Getter for errorStr member variable.
-   * @return : errorStr member variable.
-   */
-  public String getErrorStr() {
-    return errorStr;
-  }
-
-  /**
    * Prepare REST channel consumer for a SQL query request.
    * @param request     SQL request
    * @param nodeClient  node client
@@ -121,8 +110,8 @@ public class RestSQLQueryAction extends BaseRestHandler {
    */
   public RestChannelConsumer prepareRequest(SQLQueryRequest request, NodeClient nodeClient) {
     if (!request.isSupported()) {
-      setErrorStr("Query request is not supported. Either unsupported fields present," +
-          " the request is not a cursor request, or response format can't be supported.");
+      setErrorStr("Query request is not supported. Either unsupported fields are present," +
+          " the request is not a cursor request, or the response format is not supported.");
       return NOT_SUPPORTED_YET;
     }
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -64,6 +64,13 @@ public class RestSQLQueryAction extends BaseRestHandler {
    * Settings required by been initialization.
    */
   private final Settings pluginSettings;
+
+  /**
+   * Captured error message to aggregate diagnostics
+   * for both legacy and new SQL engines.
+   * This member variable and it's usage can be deleted once the
+   * legacy SQL engine is deprecated.
+   */
   private String ErrorStr;
 
   /**
@@ -90,10 +97,18 @@ public class RestSQLQueryAction extends BaseRestHandler {
     throw new UnsupportedOperationException("New SQL handler is not ready yet");
   }
 
+  /**
+   * Setter for ErrorStr member variable.
+   * @param error : String error value to set member variable.
+   */
   public void setErrorStr(String error) {
     ErrorStr = error;
   }
 
+  /**
+   * Getter for ErrorStr member variable.
+   * @return : ErrorStr member variable.
+   */
   public String getErrorStr() {
     return ErrorStr;
   }
@@ -122,6 +137,11 @@ public class RestSQLQueryAction extends BaseRestHandler {
       if (request.isExplainRequest()) {
         LOG.info("Request is falling back to old SQL engine due to: " + e.getMessage());
       }
+
+      /**
+       * Setting ErrorStr member variable is used to aggregate error messages when both legacy and new SQL engines fail.
+       * This implementation can be removed when the legacy SQL engine is deprecated.
+       */
       setErrorStr(ErrorMessageFactory.createErrorMessage(e, isClientError(e) ? BAD_REQUEST.getStatus() : SERVICE_UNAVAILABLE.getStatus()).toString());
       return NOT_SUPPORTED_YET;
     }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -134,6 +134,7 @@ public class RestSqlAction extends BaseRestHandler {
         Metrics.getInstance().getNumericalMetric(MetricName.REQ_COUNT_TOTAL).increment();
 
         LogUtils.addRequestId();
+        newSqlQueryHandler.setErrorStr("");
 
         try {
             if (!isSQLFeatureEnabled()) {

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -197,6 +197,14 @@ public class RestSqlAction extends BaseRestHandler {
      * @param e : Caught exception.
      */
     private static void logAndPublishMetrics(final Exception e) {
+        if (isClientError(e)) {
+            LOG.error(LogUtils.getRequestId() + " Client side error during query execution", QueryDataAnonymizer.anonymizeData(e.getMessage()));
+            Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_CUS).increment();
+        } else {
+            LOG.error(LogUtils.getRequestId() + " Server side error during query execution", QueryDataAnonymizer.anonymizeData(e.getMessage()));
+            Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
+        }
+
         /**
          * Use PrintWriter to copy the stack trace for logging. This is used to anonymize
          * log messages, and can be reverted to the simpler implementation when
@@ -205,13 +213,6 @@ public class RestSqlAction extends BaseRestHandler {
         StringWriter sw = new StringWriter();
         e.printStackTrace(new PrintWriter(sw));
         String stackTrace = sw.toString();
-        if (isClientError(e)) {
-            LOG.error(LogUtils.getRequestId() + " Client side error during query execution", QueryDataAnonymizer.anonymizeData(e.getMessage()));
-            Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_CUS).increment();
-        } else {
-            LOG.error(LogUtils.getRequestId() + " Server side error during query execution", QueryDataAnonymizer.anonymizeData(e.getMessage()));
-            Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
-        }
         LOG.error(stackTrace);
     }
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -258,12 +258,14 @@ public class RestSqlAction extends BaseRestHandler {
      * @param channel : Rest channel to sent response through.
      * @param e : Exception caught when attempting query.
      * @param status : Status for rest request made.
-     * @param newSqlEngineError : Error message for new SQL engine. Can be removed when old SQL engine is deprecated.
+     * @param v2SqlEngineError : Error message for new SQL engine. Can be removed when old SQL engine is deprecated.
      */
-    private void reportError(final RestChannel channel, final Exception e, final RestStatus status, String newSqlEngineError) {
-        sendResponse(channel, ErrorMessageFactory.createErrorMessage(e, status.getStatus()).toString() + (newSqlEngineError.isEmpty()
-            ? "" : "\nQuery failed both legacy and new SQL engines, see error message below for new SQL engine error.\n"
-            + newSqlEngineError), status);
+    private void reportError(final RestChannel channel, final Exception e, final RestStatus status, String v2SqlEngineError) {
+        String errorMsg = ErrorMessageFactory.createErrorMessage(e, status.getStatus()).toString();
+        errorMsg += v2SqlEngineError.isEmpty() ? "" :
+            "\nQuery failed on both V1 and V2 SQL parser engines. V2 SQL parser error following: \n"
+            + v2SqlEngineError;
+        sendResponse(channel, errorMsg, status);
     }
 
     private boolean isSQLFeatureEnabled() {

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -253,10 +253,17 @@ public class RestSqlAction extends BaseRestHandler {
         channel.sendResponse(new BytesRestResponse(status, message));
     }
 
-    private void reportError(final RestChannel channel, final Exception e, final RestStatus status, String otherError) {
-        sendResponse(channel, ErrorMessageFactory.createErrorMessage(e, status.getStatus()).toString() + (otherError.isEmpty()
+    /**
+     * Report Error message to user.
+     * @param channel : Rest channel to sent response through.
+     * @param e : Exception caught when attempting query.
+     * @param status : Status for rest request made.
+     * @param newSqlEngineError : Error message for new SQL engine. Can be removed when old SQL engine is deprecated.
+     */
+    private void reportError(final RestChannel channel, final Exception e, final RestStatus status, String newSqlEngineError) {
+        sendResponse(channel, ErrorMessageFactory.createErrorMessage(e, status.getStatus()).toString() + (newSqlEngineError.isEmpty()
             ? "" : "\nQuery failed both legacy and new SQL engines, see error message below for new SQL engine error.\n"
-            + otherError), status);
+            + newSqlEngineError), status);
     }
 
     private boolean isSQLFeatureEnabled() {

--- a/legacy/src/main/java/org/opensearch/sql/legacy/utils/QueryDataAnonymizer.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/utils/QueryDataAnonymizer.java
@@ -26,7 +26,8 @@ public class QueryDataAnonymizer {
      * Sensitive data includes index names, column names etc.,
      * which in druid parser are parsed to SQLIdentifierExpr instances
      * @param query entire sql query string
-     * @return sql query string with all identifiers replaced with "***"
+     * @return sql query string with all identifiers replaced with "***" on success
+     * and failure string otherwise to ensure no non-anonymized data is logged in production.
      */
     public static String anonymizeData(String query) {
         String resultQuery;
@@ -38,7 +39,8 @@ public class QueryDataAnonymizer {
                     .replaceAll("false", "boolean_literal")
                     .replaceAll("[\\n][\\t]+", " ");
         } catch (Exception e) {
-            LOG.warn("Caught an exception when anonymizing sensitive data");
+            LOG.warn("Caught an exception when anonymizing sensitive data.");
+            LOG.debug("String {} failed anonymization.", query);
             resultQuery = "Failed to anonymize data.";
         }
         return resultQuery;

--- a/legacy/src/main/java/org/opensearch/sql/legacy/utils/QueryDataAnonymizer.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/utils/QueryDataAnonymizer.java
@@ -39,7 +39,7 @@ public class QueryDataAnonymizer {
                     .replaceAll("[\\n][\\t]+", " ");
         } catch (Exception e) {
             LOG.warn("Caught an exception when anonymizing sensitive data");
-            resultQuery = query;
+            resultQuery = "Failed to anonymize data.";
         }
         return resultQuery;
     }


### PR DESCRIPTION
### Description
When a query fails both legacy and new SQL engines, only the legacy engine error is reported to the user. On failure in both the legacy and new SQL engines, error messages from both should be reported to the end user. To avoid logging un-anonymized data, the anonymizer now returns a failure to anonymize string.

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).