### PR TITLE
PoC fetch all

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.Getter;
 import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.planner.PlanContext;
 
 /**
  * The context used for Analyzer.
@@ -23,13 +24,28 @@ public class AnalysisContext {
   @Getter
   private final List<NamedExpression> namedParseExpressions;
 
+  /**
+   * Context for physical plan building.
+   */
+  @Getter
+  private PlanContext planContext;
+
   public AnalysisContext() {
-    this(new TypeEnvironment(null));
+    this(new TypeEnvironment(null), new PlanContext());
+  }
+
+  public AnalysisContext(PlanContext planContext) {
+    this(new TypeEnvironment(null), planContext);
   }
 
   public AnalysisContext(TypeEnvironment environment) {
+    this(environment, new PlanContext());
+  }
+
+  public AnalysisContext(TypeEnvironment environment, PlanContext planContext) {
     this.environment = environment;
     this.namedParseExpressions = new ArrayList<>();
+    this.planContext = planContext;
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/ast/tree/RareTopN.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/RareTopN.java
@@ -54,7 +54,8 @@ public class RareTopN extends UnresolvedPlan {
 
   public enum CommandType {
     TOP,
-    RARE
+    RARE,
+    TOPOFALL
   }
 }
 

--- a/core/src/main/java/org/opensearch/sql/planner/IndexScanType.java
+++ b/core/src/main/java/org/opensearch/sql/planner/IndexScanType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.planner;
+
+/**
+ * Enum representing supported index scan modes
+ */
+public enum IndexScanType {
+
+  /**
+   * default regular request
+   */
+  DEFAULT,
+
+  /**
+   * scroll request
+   */
+  SCROLL,
+
+  /**
+   * fetch all data
+   */
+  FETCH_ALL
+}

--- a/core/src/main/java/org/opensearch/sql/planner/PlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/planner/PlanContext.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.planner;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class PlanContext {
+  @Getter
+  @Setter
+  private IndexScanType indexScanType;
+
+  public PlanContext() {
+    this.indexScanType = IndexScanType.DEFAULT;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/Planner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/Planner.java
@@ -10,6 +10,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalPlanNodeVisitor;
 import org.opensearch.sql.planner.logical.LogicalRelation;
@@ -40,6 +41,10 @@ public class Planner {
    * @return optimal physical plan
    */
   public PhysicalPlan plan(LogicalPlan plan) {
+    return plan(plan, new PlanContext());
+  }
+
+  public PhysicalPlan plan(LogicalPlan plan, PlanContext context) {
     String tableName = findTableName(plan);
     if (isNullOrEmpty(tableName)) {
       return plan.accept(new DefaultImplementor<>(), null);
@@ -47,7 +52,8 @@ public class Planner {
 
     Table table = storageEngine.getTable(tableName);
     return table.implement(
-        table.optimize(optimize(plan)));
+        table.optimize(optimize(plan)),
+        context);
   }
 
   private String findTableName(LogicalPlan plan) {

--- a/core/src/main/java/org/opensearch/sql/storage/Table.java
+++ b/core/src/main/java/org/opensearch/sql/storage/Table.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.storage;
 
 import java.util.Map;
 import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 
@@ -28,6 +29,7 @@ public interface Table {
    * @return physical plan
    */
   PhysicalPlan implement(LogicalPlan plan);
+  PhysicalPlan implement(LogicalPlan plan, PlanContext context);
 
   /**
    * Optimize the {@link LogicalPlan} by storage engine rule.

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -32,6 +32,7 @@ import org.opensearch.sql.opensearch.storage.script.filter.FilterQueryBuilder;
 import org.opensearch.sql.opensearch.storage.script.sort.SortQueryBuilder;
 import org.opensearch.sql.opensearch.storage.serialization.DefaultExpressionSerializer;
 import org.opensearch.sql.planner.DefaultImplementor;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalAD;
 import org.opensearch.sql.planner.logical.LogicalMLCommons;
 import org.opensearch.sql.planner.logical.LogicalPlan;
@@ -84,7 +85,12 @@ public class OpenSearchIndex implements Table {
    */
   @Override
   public PhysicalPlan implement(LogicalPlan plan) {
-    OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client, settings, indexName,
+    return implement(plan, new PlanContext());
+  }
+
+  @Override
+  public PhysicalPlan implement(LogicalPlan plan, PlanContext context) {
+    OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client, settings, indexName, context,
         new OpenSearchExprValueFactory(getFieldTypes()));
 
     /*

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndex.java
@@ -11,6 +11,7 @@ import static org.opensearch.sql.utils.SystemIndexUtils.systemTable;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
@@ -18,6 +19,7 @@ import org.opensearch.sql.opensearch.request.system.OpenSearchCatIndicesRequest;
 import org.opensearch.sql.opensearch.request.system.OpenSearchDescribeIndexRequest;
 import org.opensearch.sql.opensearch.request.system.OpenSearchSystemRequest;
 import org.opensearch.sql.planner.DefaultImplementor;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalRelation;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
@@ -46,6 +48,12 @@ public class OpenSearchSystemIndex implements Table {
   @Override
   public PhysicalPlan implement(LogicalPlan plan) {
     return plan.accept(new OpenSearchSystemIndexDefaultImplementor(), null);
+  }
+
+  @Override
+  public PhysicalPlan implement(LogicalPlan plan, PlanContext context) {
+    // context is of no use for system index scan
+    return implement(plan);
   }
 
   @VisibleForTesting

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -26,6 +26,7 @@ RARE:                               'RARE';
 PARSE:                              'PARSE';
 KMEANS:                             'KMEANS';
 AD:                                 'AD';
+TOPOFALL:                           'TOPOFALL';
 
 // COMMAND ASSIST KEYWORDS
 AS:                                 'AS';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -25,7 +25,7 @@ pplCommands
 
 commands
     : whereCommand | fieldsCommand | renameCommand | statsCommand | dedupCommand | sortCommand | evalCommand | headCommand
-    | topCommand | rareCommand | parseCommand | kmeansCommand | adCommand;
+    | topCommand | rareCommand | parseCommand | kmeansCommand | adCommand | topOfAllCommand;
 
 searchCommand
     : (SEARCH)? fromClause                                          #searchFrom
@@ -81,6 +81,13 @@ headCommand
     (FROM from=integerLiteral)?
     ;
     
+topOfAllCommand
+    : TOPOFALL
+    (number=integerLiteral)?
+    fieldList
+    (byClause)?
+    ;
+
 topCommand
     : TOP
     (number=integerLiteral)?

--- a/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
@@ -21,6 +21,7 @@ import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.Planner;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.optimizer.LogicalPlanOptimizer;
@@ -87,12 +88,13 @@ public class PPLService {
     LOG.info("[{}] Incoming request {}", LogUtils.getRequestId(), anonymizer.anonymizeData(ast));
 
     // 2.Analyze abstract syntax to generate logical plan
+    PlanContext planContext = new PlanContext();
     LogicalPlan logicalPlan = analyzer.analyze(UnresolvedPlanHelper.addSelectAll(ast),
-        new AnalysisContext());
+        new AnalysisContext(planContext));
 
     // 3.Generate optimal physical plan from logical plan
     return new Planner(storageEngine, LogicalPlanOptimizer.create(new DSL(repository)))
-        .plan(logicalPlan);
+        .plan(logicalPlan, planContext);
   }
 
 }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -23,6 +23,7 @@ import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SortComman
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StatsCommandContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TableSourceClauseContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TopCommandContext;
+import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TopOfAllCommandContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.WhereCommandContext;
 import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
@@ -288,6 +289,18 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
         getGroupByList(ctx.byClause());
     return new RareTopN(
         CommandType.TOP,
+        ArgumentFactory.getArgumentList(ctx),
+        getFieldList(ctx.fieldList()),
+        groupList
+    );
+  }
+
+  @Override
+  public UnresolvedPlan visitTopOfAllCommand(TopOfAllCommandContext ctx) {
+    List<UnresolvedExpression> groupList = ctx.byClause() == null ? Collections.emptyList() :
+        getGroupByList(ctx.byClause());
+    return new RareTopN(
+        CommandType.TOPOFALL,
         ArgumentFactory.getArgumentList(ctx),
         getFieldList(ctx.fieldList()),
         groupList

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/ArgumentFactory.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/ArgumentFactory.java
@@ -15,6 +15,7 @@ import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.RareComman
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SortFieldContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StatsCommandContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TopCommandContext;
+import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TopOfAllCommandContext;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -117,6 +118,14 @@ public class ArgumentFactory {
    * @return the list of arguments fetched from the top command
    */
   public static List<Argument> getArgumentList(TopCommandContext ctx) {
+    return Collections.singletonList(
+        ctx.number != null
+            ? new Argument("noOfResults", getArgumentValue(ctx.number))
+            : new Argument("noOfResults", new Literal(10, DataType.INTEGER))
+    );
+  }
+
+  public static List<Argument> getArgumentList(TopOfAllCommandContext ctx) {
     return Collections.singletonList(
         ctx.number != null
             ? new Argument("noOfResults", getArgumentValue(ctx.number))


### PR DESCRIPTION
### Description
PoC for using PlanContext during LogicalPlan generation `Analyzer.analyze(...)` to decide whether to 1) fetch all data using scrolling, or 2) fetch data via regular request bounded by the query size limit.
This is useful for ML commands.

I added a `topOfAll` command in this PR that's purely for demo purpose. It's almost identical to the `top` command, except that `top` returns the top results of the first 200 rows, while `topOfAll` returns the top results of all rows.

Sample queries using the opensearch_dashboards_sample_data_flights:
1. Get top Origin of the first 200 (default query size limit) rows => “Licenciado Benito Juarez International Airport”
2. Get top Origin of all rows => “Mariscal Sucre International Airport”
3. number of rows with Origin = “Licenciado Benito Juarez International Airport”: 134
4. number of rows with Origin = “Mariscal Sucre International Airport”: 285

```
❯ curl -XPOST https://localhost:9200/_plugins/_ppl -u 'admin:admin' -k -H 'Content-Type: application/json' -d '{
"query": "source=opensearch_dashboards_sample_data_flights | top 1 Origin"
}'

{
  "schema": [
    {
      "name": "Origin",
      "type": "string"
    }
  ],
  "datarows": [
    [
      "Licenciado Benito Juarez International Airport"
    ]
  ],
  "total": 1,
  "size": 1
}
❯ curl -XPOST https://localhost:9200/_plugins/_ppl -u 'admin:admin' -k -H 'Content-Type: application/json' -d '{
"query": "source=opensearch_dashboards_sample_data_flights | topOfAll 1 Origin"
}'

{
  "schema": [
    {
      "name": "Origin",
      "type": "string"
    }
  ],
  "datarows": [
    [
      "Mariscal Sucre International Airport"
    ]
  ],
  "total": 1,
  "size": 1
}
❯ curl -XPOST https://localhost:9200/_plugins/_ppl -u 'admin:admin' -k -H 'Content-Type: application/json' -d '{
"query": "source=opensearch_dashboards_sample_data_flights Origin=\"Licenciado Benito Juarez International Airport\"| stats count()"
}'

{
  "schema": [
    {
      "name": "count()",
      "type": "integer"
    }
  ],
  "datarows": [
    [
      134
    ]
  ],
  "total": 1,
  "size": 1
}
❯ curl -XPOST https://localhost:9200/_plugins/_ppl -u 'admin:admin' -k -H 'Content-Type: application/json' -d '{
"query": "source=opensearch_dashboards_sample_data_flights Origin=\"Mariscal Sucre International Airport\"| stats count()"
}'

{
  "schema": [
    {
      "name": "count()",
      "type": "integer"
    }
  ],
  "datarows": [
    [
      285
    ]
  ],
  "total": 1,
  "size": 1
}
```

Explain (for OpenSearchIndexScan, one uses OpenSearchQueryRequest, while the other uses OpenSearchScrollRequest):
```
❯ curl -XPOST https://localhost:9200/_plugins/_ppl/_explain -u 'admin:admin' -k -H 'Content-Type: application/json' -d '{"query": "source=opensearch_dashboards_sample_data_flights | top 1 Origin"}'

{
  "root": {
    "name": "ProjectOperator",
    "description": {
      "fields": "[Origin]"
    },
    "children": [
      {
        "name": "RareTopNOperator",
        "description": {
          "commandType": "TOP",
          "noOfResults": 1,
          "fields": "[Origin]",
          "groupBy": "[]"
        },
        "children": [
          {
            "name": "OpenSearchIndexScan",
            "description": {
              "request": "OpenSearchQueryRequest(indexName=opensearch_dashboards_sample_data_flights, sourceBuilder={\"from\":0,\"size\":200,\"timeout\":\"1m\"}, searchDone=false)"
            },
            "children": []
          }
        ]
      }
    ]
  }
}
❯ curl -XPOST https://localhost:9200/_plugins/_ppl/_explain -u 'admin:admin' -k -H 'Content-Type: application/json' -d '{"query": "source=opensearch_dashboards_sample_data_flights | topOfAll 1 Origin"}'

{
  "root": {
    "name": "ProjectOperator",
    "description": {
      "fields": "[Origin]"
    },
    "children": [
      {
        "name": "RareTopNOperator",
        "description": {
          "commandType": "TOP",
          "noOfResults": 1,
          "fields": "[Origin]",
          "groupBy": "[]"
        },
        "children": [
          {
            "name": "OpenSearchIndexScan",
            "description": {
              "request": "OpenSearchScrollRequest(indexName=opensearch_dashboards_sample_data_flights, scrollId=null, sourceBuilder={})"
            },
            "children": []
          }
        ]
      }
    ]
  }
}
```
 
### Issues Resolved
#656 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).