### PR TITLE
Adds plan context for Scroll physical plan building

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
@@ -43,6 +43,9 @@ public class AnalysisContext {
     this(environment, new PlanContext());
   }
 
+  /**
+   * Constructor.
+   */
   public AnalysisContext(TypeEnvironment environment, PlanContext planContext) {
     this.environment = environment;
     this.namedParseExpressions = new ArrayList<>();

--- a/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.Getter;
 import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.planner.PlanContext;
 
 /**
  * The context used for Analyzer.
@@ -20,16 +21,32 @@ public class AnalysisContext {
    * Environment stack for symbol scope management.
    */
   private TypeEnvironment environment;
+
+  /**
+   * Context for physical plan building.
+   */
+  @Getter
+  private PlanContext planContext;
+
   @Getter
   private final List<NamedExpression> namedParseExpressions;
 
   public AnalysisContext() {
-    this(new TypeEnvironment(null));
+    this(new TypeEnvironment(null), new PlanContext());
+  }
+
+  public AnalysisContext(PlanContext planContext) {
+    this (new TypeEnvironment(null), planContext);
   }
 
   public AnalysisContext(TypeEnvironment environment) {
+    this(environment, new PlanContext());
+  }
+
+  public AnalysisContext(TypeEnvironment environment, PlanContext planContext) {
     this.environment = environment;
     this.namedParseExpressions = new ArrayList<>();
+    this.planContext = planContext;
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/planner/PlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/planner/PlanContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class PlanContext {
+  @Getter
+  @Setter
+  private IndexScanType indexScanType;
+
+  public PlanContext() {
+    this.indexScanType = IndexScanType.QUERY;
+  }
+
+  public enum IndexScanType {
+    /**
+     * default query request
+     */
+    QUERY,
+
+    /**
+     * scroll request
+     */
+    SCROLL
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/PlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/planner/PlanContext.java
@@ -8,6 +8,9 @@ package org.opensearch.sql.planner;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * PlanContext that stores context for physical plan generation.
+ */
 public class PlanContext {
   @Getter
   @Setter
@@ -19,12 +22,12 @@ public class PlanContext {
 
   public enum IndexScanType {
     /**
-     * default query request
+     * default query request.
      */
     QUERY,
 
     /**
-     * scroll request
+     * scroll request.
      */
     SCROLL
   }

--- a/core/src/main/java/org/opensearch/sql/planner/Planner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/Planner.java
@@ -48,7 +48,8 @@ public class Planner {
 
     Table table = storageEngine.getTable(tableName);
     return table.implement(
-        table.optimize(optimize(plan)));
+        table.optimize(optimize(plan)),
+        context);
   }
 
   private String findTableName(LogicalPlan plan) {

--- a/core/src/main/java/org/opensearch/sql/planner/Planner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/Planner.java
@@ -36,10 +36,11 @@ public class Planner {
    * translate logical plan to physical by default implementor.
    * TODO: for now just delegate entire logical plan to storage engine.
    *
-   * @param plan logical plan
+   * @param plan    logical plan
+   * @param context plan context
    * @return optimal physical plan
    */
-  public PhysicalPlan plan(LogicalPlan plan) {
+  public PhysicalPlan plan(LogicalPlan plan, PlanContext context) {
     String tableName = findTableName(plan);
     if (isNullOrEmpty(tableName)) {
       return plan.accept(new DefaultImplementor<>(), null);

--- a/core/src/main/java/org/opensearch/sql/storage/Table.java
+++ b/core/src/main/java/org/opensearch/sql/storage/Table.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.storage;
 
 import java.util.Map;
 import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 
@@ -24,10 +25,11 @@ public interface Table {
   /**
    * Implement a {@link LogicalPlan} by {@link PhysicalPlan} in storage engine.
    *
-   * @param plan logical plan
+   * @param plan    logical plan
+   * @param context plan context
    * @return physical plan
    */
-  PhysicalPlan implement(LogicalPlan plan);
+  PhysicalPlan implement(LogicalPlan plan, PlanContext context);
 
   /**
    * Optimize the {@link LogicalPlan} by storage engine rule.

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -21,6 +21,7 @@ import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.storage.StorageEngine;
@@ -47,7 +48,7 @@ public class AnalyzerTestBase {
           }
 
           @Override
-          public PhysicalPlan implement(LogicalPlan plan) {
+          public PhysicalPlan implement(LogicalPlan plan, PlanContext context) {
             throw new UnsupportedOperationException();
           }
         };

--- a/core/src/test/java/org/opensearch/sql/config/TestConfig.java
+++ b/core/src/test/java/org/opensearch/sql/config/TestConfig.java
@@ -17,6 +17,7 @@ import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.storage.StorageEngine;
@@ -69,7 +70,7 @@ public class TestConfig {
           }
 
           @Override
-          public PhysicalPlan implement(LogicalPlan plan) {
+          public PhysicalPlan implement(LogicalPlan plan, PlanContext context) {
             throw new UnsupportedOperationException();
           }
         };

--- a/core/src/test/java/org/opensearch/sql/planner/PlannerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/PlannerTest.java
@@ -127,7 +127,7 @@ public class PlannerTest extends PhysicalPlanTestBase {
     }
 
     @Override
-    public PhysicalPlan implement(LogicalPlan plan) {
+    public PhysicalPlan implement(LogicalPlan plan, PlanContext context) {
       return plan.accept(this, null);
     }
 

--- a/core/src/test/java/org/opensearch/sql/planner/PlannerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/PlannerTest.java
@@ -84,7 +84,8 @@ public class PlannerTest extends PhysicalPlanTestBase {
                 ImmutableList.of()
             ),
             ImmutableMap.of(DSL.ref("ivalue", INTEGER), DSL.ref("avg(response)", DOUBLE))
-        )
+        ),
+        new PlanContext()
     );
   }
 
@@ -105,16 +106,17 @@ public class PlannerTest extends PhysicalPlanTestBase {
             DSL.named("123", DSL.literal(123)),
             DSL.named("hello", DSL.literal("hello")),
             DSL.named("false", DSL.literal(false))
-        )
+        ),
+        new PlanContext()
     );
   }
 
-  protected void assertPhysicalPlan(PhysicalPlan expected, LogicalPlan logicalPlan) {
-    assertEquals(expected, analyze(logicalPlan));
+  protected void assertPhysicalPlan(PhysicalPlan expected, LogicalPlan logicalPlan, PlanContext planContext) {
+    assertEquals(expected, analyze(logicalPlan, planContext));
   }
 
-  protected PhysicalPlan analyze(LogicalPlan logicalPlan) {
-    return new Planner(storageEngine, optimizer).plan(logicalPlan);
+  protected PhysicalPlan analyze(LogicalPlan logicalPlan, PlanContext planContext) {
+    return new Planner(storageEngine, optimizer).plan(logicalPlan, planContext);
   }
 
   protected class MockTable extends LogicalPlanNodeVisitor<PhysicalPlan, Object> implements Table {

--- a/core/src/test/java/org/opensearch/sql/planner/PlannerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/PlannerTest.java
@@ -111,7 +111,9 @@ public class PlannerTest extends PhysicalPlanTestBase {
     );
   }
 
-  protected void assertPhysicalPlan(PhysicalPlan expected, LogicalPlan logicalPlan, PlanContext planContext) {
+  protected void assertPhysicalPlan(PhysicalPlan expected,
+                                    LogicalPlan logicalPlan,
+                                    PlanContext planContext) {
     assertEquals(expected, analyze(logicalPlan, planContext));
   }
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -30,6 +30,7 @@ import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.legacy.metrics.MetricName;
 import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.opensearch.security.SecurityAccess;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.protocol.response.QueryResult;
 import org.opensearch.sql.protocol.response.format.CsvResponseFormatter;
@@ -101,9 +102,12 @@ public class RestSQLQueryAction extends BaseRestHandler {
     try {
       // For now analyzing and planning stage may throw syntax exception as well
       // which hints the fallback to legacy code is necessary here.
+      PlanContext context = new PlanContext();
       plan = sqlService.plan(
-                sqlService.analyze(
-                    sqlService.parse(request.getQuery())));
+                 sqlService.analyze(
+                     sqlService.parse(request.getQuery()),
+                     context
+                 ), context);
     } catch (SyntaxCheckException e) {
       // When explain, print info log for what unsupported syntax is causing fallback to old engine
       if (request.isExplainRequest()) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -32,6 +32,7 @@ import org.opensearch.sql.opensearch.storage.script.filter.FilterQueryBuilder;
 import org.opensearch.sql.opensearch.storage.script.sort.SortQueryBuilder;
 import org.opensearch.sql.opensearch.storage.serialization.DefaultExpressionSerializer;
 import org.opensearch.sql.planner.DefaultImplementor;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalAD;
 import org.opensearch.sql.planner.logical.LogicalMLCommons;
 import org.opensearch.sql.planner.logical.LogicalPlan;
@@ -83,7 +84,7 @@ public class OpenSearchIndex implements Table {
    * TODO: Push down operations to index scan operator as much as possible in future.
    */
   @Override
-  public PhysicalPlan implement(LogicalPlan plan) {
+  public PhysicalPlan implement(LogicalPlan plan, PlanContext context) {
     OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client, settings, indexName,
         new OpenSearchExprValueFactory(getFieldTypes()));
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -85,7 +85,7 @@ public class OpenSearchIndex implements Table {
    */
   @Override
   public PhysicalPlan implement(LogicalPlan plan, PlanContext context) {
-    OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client, settings, indexName,
+    OpenSearchIndexScan indexScan = new OpenSearchIndexScan(client, settings, indexName, context,
         new OpenSearchExprValueFactory(getFieldTypes()));
 
     /*

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScan.java
@@ -9,8 +9,6 @@ package org.opensearch.sql.opensearch.storage;
 import static org.opensearch.search.sort.FieldSortBuilder.DOC_FIELD_NAME;
 import static org.opensearch.search.sort.SortOrder.ASC;
 
-import com.google.common.collect.Iterables;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -91,16 +89,13 @@ public class OpenSearchIndexScan extends TableScanOperator {
   public void open() {
     super.open();
     iterator = Collections.emptyIterator();
+    fetchNextBatch();
   }
 
   @Override
   public boolean hasNext() {
     if (!iterator.hasNext()) {
-      // Fetch next batch
-      OpenSearchResponse response = client.search(request);
-      if (!response.isEmpty()) {
-        iterator = response.iterator();
-      }
+      fetchNextBatch();
     }
     return iterator.hasNext();
   }
@@ -108,6 +103,13 @@ public class OpenSearchIndexScan extends TableScanOperator {
   @Override
   public ExprValue next() {
     return iterator.next();
+  }
+
+  private void fetchNextBatch() {
+    OpenSearchResponse response = client.search(request);
+    if (!response.isEmpty()) {
+      iterator = response.iterator();
+    }
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScan.java
@@ -36,6 +36,7 @@ import org.opensearch.sql.opensearch.request.OpenSearchQueryRequest;
 import org.opensearch.sql.opensearch.request.OpenSearchRequest;
 import org.opensearch.sql.opensearch.response.OpenSearchResponse;
 import org.opensearch.sql.opensearch.response.agg.OpenSearchAggregationResponseParser;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.storage.TableScanOperator;
 
 /**
@@ -62,16 +63,16 @@ public class OpenSearchIndexScan extends TableScanOperator {
    */
   public OpenSearchIndexScan(OpenSearchClient client,
                              Settings settings, String indexName,
-                             OpenSearchExprValueFactory exprValueFactory) {
-    this(client, settings, new OpenSearchRequest.IndexName(indexName), exprValueFactory);
+                             PlanContext context, OpenSearchExprValueFactory exprValueFactory) {
+    this(client, settings, new OpenSearchRequest.IndexName(indexName), context, exprValueFactory);
   }
 
   /**
    * Constructor.
    */
   public OpenSearchIndexScan(OpenSearchClient client,
-      Settings settings, OpenSearchRequest.IndexName indexName,
-      OpenSearchExprValueFactory exprValueFactory) {
+                             Settings settings, OpenSearchRequest.IndexName indexName,
+                             PlanContext context, OpenSearchExprValueFactory exprValueFactory) {
     this.client = client;
     this.request = new OpenSearchQueryRequest(indexName,
         settings.getSettingValue(Settings.Key.QUERY_SIZE_LIMIT), exprValueFactory);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndex.java
@@ -18,6 +18,7 @@ import org.opensearch.sql.opensearch.request.system.OpenSearchCatIndicesRequest;
 import org.opensearch.sql.opensearch.request.system.OpenSearchDescribeIndexRequest;
 import org.opensearch.sql.opensearch.request.system.OpenSearchSystemRequest;
 import org.opensearch.sql.planner.DefaultImplementor;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalRelation;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
@@ -44,7 +45,7 @@ public class OpenSearchSystemIndex implements Table {
   }
 
   @Override
-  public PhysicalPlan implement(LogicalPlan plan) {
+  public PhysicalPlan implement(LogicalPlan plan, PlanContext context) {
     return plan.accept(new OpenSearchSystemIndexDefaultImplementor(), null);
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngineTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngineTest.java
@@ -125,7 +125,7 @@ class OpenSearchExecutionEngineTest {
   void explainSuccessfully() {
     OpenSearchExecutionEngine executor = new OpenSearchExecutionEngine(client, protector);
     Settings settings = mock(Settings.class);
-    PlanContext context = mock(PlanContext.class);
+    PlanContext context = new PlanContext();
     when(settings.getSettingValue(QUERY_SIZE_LIMIT)).thenReturn(100);
     PhysicalPlan plan = new OpenSearchIndexScan(mock(OpenSearchClient.class),
         settings, "test", context, mock(OpenSearchExprValueFactory.class));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngineTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngineTest.java
@@ -40,6 +40,7 @@ import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.executor.protector.OpenSearchExecutionProtector;
 import org.opensearch.sql.opensearch.storage.OpenSearchIndexScan;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.storage.TableScanOperator;
 
@@ -124,9 +125,10 @@ class OpenSearchExecutionEngineTest {
   void explainSuccessfully() {
     OpenSearchExecutionEngine executor = new OpenSearchExecutionEngine(client, protector);
     Settings settings = mock(Settings.class);
+    PlanContext context = mock(PlanContext.class);
     when(settings.getSettingValue(QUERY_SIZE_LIMIT)).thenReturn(100);
     PhysicalPlan plan = new OpenSearchIndexScan(mock(OpenSearchClient.class),
-        settings, "test", mock(OpenSearchExprValueFactory.class));
+        settings, "test", context, mock(OpenSearchExprValueFactory.class));
 
     AtomicReference<ExplainResponse> result = new AtomicReference<>();
     executor.explain(plan, new ResponseListener<ExplainResponse>() {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
@@ -77,7 +77,6 @@ class OpenSearchExecutionProtectorTest {
   @Mock
   private OpenSearchSettings settings;
 
-  @Mock
   private PlanContext context;
 
   private OpenSearchExecutionProtector executionProtector;
@@ -85,6 +84,7 @@ class OpenSearchExecutionProtectorTest {
   @BeforeEach
   public void setup() {
     executionProtector = new OpenSearchExecutionProtector(resourceMonitor);
+    context = new PlanContext();
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
@@ -59,6 +58,7 @@ import org.opensearch.sql.opensearch.planner.physical.ADOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLCommonsOperator;
 import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
 import org.opensearch.sql.opensearch.storage.OpenSearchIndexScan;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlanDSL;
 
@@ -76,6 +76,9 @@ class OpenSearchExecutionProtectorTest {
 
   @Mock
   private OpenSearchSettings settings;
+
+  @Mock
+  private PlanContext context;
 
   private OpenSearchExecutionProtector executionProtector;
 
@@ -124,7 +127,7 @@ class OpenSearchExecutionProtectorTest {
                                                 filter(
                                                     resourceMonitor(
                                                         new OpenSearchIndexScan(
-                                                            client, settings, indexName,
+                                                            client, settings, indexName, context,
                                                             exprValueFactory)),
                                                     filterExpr),
                                                 aggregators,
@@ -152,7 +155,7 @@ class OpenSearchExecutionProtectorTest {
                                             PhysicalPlanDSL.agg(
                                                 filter(
                                                     new OpenSearchIndexScan(
-                                                        client, settings, indexName,
+                                                        client, settings, indexName, context,
                                                         exprValueFactory),
                                                     filterExpr),
                                                 aggregators,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScanTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScanTest.java
@@ -164,10 +164,8 @@ class OpenSearchIndexScanTest {
                   when(response.isEmpty()).thenReturn(false);
                   ExprValue[] searchHit = searchHitBatches[batchNum];
                   when(response.iterator()).thenReturn(Arrays.asList(searchHit).iterator());
-                } else if (batchNum == totalBatch) {
-                  when(response.isEmpty()).thenReturn(true);
                 } else {
-                  fail("Search request after empty response returned already");
+                  when(response.isEmpty()).thenReturn(true);
                 }
 
                 batchNum++;

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScanTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScanTest.java
@@ -50,8 +50,7 @@ class OpenSearchIndexScanTest {
   @Mock
   private Settings settings;
 
-  @Mock
-  private PlanContext context;
+  private PlanContext context = new PlanContext();
 
   private OpenSearchExprValueFactory exprValueFactory = new OpenSearchExprValueFactory(
       ImmutableMap.of("name", STRING, "department", STRING));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexTest.java
@@ -138,10 +138,11 @@ class OpenSearchIndexTest {
 
     String indexName = "test";
     LogicalPlan plan = relation(indexName);
+    PlanContext context = new PlanContext();
     Table index = new OpenSearchIndex(client, settings, indexName);
     assertEquals(
-        new OpenSearchIndexScan(client, settings, indexName, exprValueFactory),
-        index.implement(plan, new PlanContext()));
+        new OpenSearchIndexScan(client, settings, indexName, context, exprValueFactory),
+        index.implement(plan, context));
   }
 
   @Test
@@ -150,10 +151,11 @@ class OpenSearchIndexTest {
 
     String indexName = "test";
     LogicalPlan plan = relation(indexName);
+    PlanContext context = new PlanContext();
     Table index = new OpenSearchIndex(client, settings, indexName);
     assertEquals(
-        new OpenSearchIndexScan(client, settings, indexName, exprValueFactory),
-        index.implement(index.optimize(plan), new PlanContext()));
+        new OpenSearchIndexScan(client, settings, indexName, context, exprValueFactory),
+        index.implement(index.optimize(plan), context));
   }
 
   @Test
@@ -192,6 +194,7 @@ class OpenSearchIndexTest {
                 dedupeField),
             include);
 
+    PlanContext context = new PlanContext();
     Table index = new OpenSearchIndex(client, settings, indexName);
     assertEquals(
         PhysicalPlanDSL.project(
@@ -200,7 +203,7 @@ class OpenSearchIndexTest {
                     PhysicalPlanDSL.eval(
                         PhysicalPlanDSL.remove(
                             PhysicalPlanDSL.rename(
-                                new OpenSearchIndexScan(client, settings, indexName,
+                                new OpenSearchIndexScan(client, settings, indexName, context,
                                     exprValueFactory),
                                 mappings),
                             exclude),
@@ -208,7 +211,7 @@ class OpenSearchIndexTest {
                     sortField),
                 dedupeField),
             include),
-        index.implement(plan, new PlanContext()));
+        index.implement(plan, context));
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexTest.java
@@ -62,6 +62,7 @@ import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.mapping.IndexMapping;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalPlanDSL;
 import org.opensearch.sql.planner.physical.AggregationOperator;
@@ -140,7 +141,7 @@ class OpenSearchIndexTest {
     Table index = new OpenSearchIndex(client, settings, indexName);
     assertEquals(
         new OpenSearchIndexScan(client, settings, indexName, exprValueFactory),
-        index.implement(plan));
+        index.implement(plan, new PlanContext()));
   }
 
   @Test
@@ -152,7 +153,7 @@ class OpenSearchIndexTest {
     Table index = new OpenSearchIndex(client, settings, indexName);
     assertEquals(
         new OpenSearchIndexScan(client, settings, indexName, exprValueFactory),
-        index.implement(index.optimize(plan)));
+        index.implement(index.optimize(plan), new PlanContext()));
   }
 
   @Test
@@ -207,7 +208,7 @@ class OpenSearchIndexTest {
                     sortField),
                 dedupeField),
             include),
-        index.implement(plan));
+        index.implement(plan, new PlanContext()));
   }
 
   @Test
@@ -226,7 +227,8 @@ class OpenSearchIndexTest {
                 indexName,
                 filterExpr
             ),
-            named));
+            named),
+        new PlanContext());
 
     assertTrue(plan instanceof ProjectOperator);
     assertTrue(((ProjectOperator) plan).getInput() instanceof OpenSearchIndexScan);
@@ -252,7 +254,8 @@ class OpenSearchIndexTest {
                 aggregators,
                 groupByExprs
             ),
-            filterExpr));
+            filterExpr),
+        new PlanContext());
 
     assertTrue(plan instanceof FilterOperator);
   }
@@ -279,7 +282,8 @@ class OpenSearchIndexTest {
                 aggregators,
                 groupByExprs
             ),
-            filterExpr));
+            filterExpr),
+        new PlanContext());
 
     assertTrue(plan.getChild().get(0) instanceof OpenSearchIndexScan);
 
@@ -289,7 +293,8 @@ class OpenSearchIndexTest {
             indexName,
             filterExpr,
             aggregators,
-            groupByExprs));
+            groupByExprs),
+        new PlanContext());
     assertTrue(plan instanceof OpenSearchIndexScan);
   }
 
@@ -313,7 +318,8 @@ class OpenSearchIndexTest {
                 relation(indexName),
                 filterExpr), filterExpr),
             aggregators,
-            groupByExprs));
+            groupByExprs),
+        new PlanContext());
     assertTrue(plan instanceof AggregationOperator);
   }
 
@@ -333,7 +339,8 @@ class OpenSearchIndexTest {
                 indexName,
                 Pair.of(Sort.SortOption.DEFAULT_ASC, sortExpr)
             ),
-            named));
+            named),
+        new PlanContext());
 
     assertTrue(plan instanceof ProjectOperator);
     assertTrue(((ProjectOperator) plan).getInput() instanceof OpenSearchIndexScan);
@@ -354,7 +361,8 @@ class OpenSearchIndexTest {
                 indexName,
                 1, 1, noProjects()
             ),
-            named));
+            named),
+        new PlanContext());
 
     assertTrue(plan instanceof ProjectOperator);
     assertTrue(((ProjectOperator) plan).getInput() instanceof OpenSearchIndexScan);
@@ -378,7 +386,8 @@ class OpenSearchIndexTest {
                 1, 1,
                 noProjects()
             ),
-            named));
+            named),
+        new PlanContext());
 
     assertTrue(plan instanceof ProjectOperator);
     assertTrue(((ProjectOperator) plan).getInput() instanceof OpenSearchIndexScan);
@@ -402,7 +411,7 @@ class OpenSearchIndexTest {
             ),
             named("intV", ref("intV", INTEGER))
         )
-    ));
+    ), new PlanContext());
 
     assertTrue(plan instanceof ProjectOperator);
     assertTrue(((ProjectOperator) plan).getInput() instanceof LimitOperator);
@@ -419,7 +428,8 @@ class OpenSearchIndexTest {
             indexScan(
                 indexName, projects(ref("intV", INTEGER))
             ),
-            named("i", ref("intV", INTEGER))));
+            named("i", ref("intV", INTEGER))),
+        new PlanContext());
 
     assertTrue(plan instanceof ProjectOperator);
     assertTrue(((ProjectOperator) plan).getInput() instanceof OpenSearchIndexScan);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndexTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.planner.physical.ProjectOperator;
 
@@ -58,12 +59,13 @@ class OpenSearchSystemIndexTest {
   void implement() {
     OpenSearchSystemIndex systemIndex = new OpenSearchSystemIndex(client, TABLE_INFO);
     NamedExpression projectExpr = named("TABLE_NAME", ref("TABLE_NAME", STRING));
+    PlanContext planContext = new PlanContext();
 
     final PhysicalPlan plan = systemIndex.implement(
         project(
             relation(TABLE_INFO),
             projectExpr
-        ));
+        ), planContext);
     assertTrue(plan instanceof ProjectOperator);
     assertTrue(plan.getChild().get(0) instanceof OpenSearchSystemIndexScan);
   }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
@@ -21,6 +21,7 @@ import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.Planner;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.optimizer.LogicalPlanOptimizer;
@@ -86,13 +87,15 @@ public class PPLService {
 
     LOG.info("[{}] Incoming request {}", LogUtils.getRequestId(), anonymizer.anonymizeData(ast));
 
+    PlanContext planContext = new PlanContext();
+
     // 2.Analyze abstract syntax to generate logical plan
     LogicalPlan logicalPlan = analyzer.analyze(UnresolvedPlanHelper.addSelectAll(ast),
-        new AnalysisContext());
+        new AnalysisContext(planContext));
 
     // 3.Generate optimal physical plan from logical plan
     return new Planner(storageEngine, LogicalPlanOptimizer.create(new DSL(repository)))
-        .plan(logicalPlan);
+        .plan(logicalPlan, planContext);
   }
 
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
@@ -24,6 +24,7 @@ import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponseNode;
 import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.ppl.config.PPLServiceConfig;
 import org.opensearch.sql.ppl.domain.PPLQueryRequest;
@@ -58,7 +59,7 @@ public class PPLServiceTest {
   @Before
   public void setUp() {
     when(table.getFieldTypes()).thenReturn(ImmutableMap.of("a", ExprCoreType.INTEGER));
-    when(table.implement(any())).thenReturn(plan);
+    when(table.implement(any(), new PlanContext())).thenReturn(plan);
     when(storageEngine.getTable(any())).thenReturn(table);
 
     context.registerBean(StorageEngine.class, () -> storageEngine);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
@@ -59,7 +59,7 @@ public class PPLServiceTest {
   @Before
   public void setUp() {
     when(table.getFieldTypes()).thenReturn(ImmutableMap.of("a", ExprCoreType.INTEGER));
-    when(table.implement(any(), new PlanContext())).thenReturn(plan);
+    when(table.implement(any(), any())).thenReturn(plan);
     when(storageEngine.getTable(any())).thenReturn(table);
 
     context.registerBean(StorageEngine.class, () -> storageEngine);


### PR DESCRIPTION
### Description
1. Adds plan context that can be modified during request handling and/or logical plan analysis. It is then used to help build the physical plan. Right now it has only one field, namely, IndexScanMode, `IndexScanType`, which decides whether to invoke a regular query request or a scroll request to OpenSearch.
Before:
`logical plan => physical plan`
After:
`(logical plan, plan context) => physical plan`
An example use case is to distinguish scrolling requests from regular query requests (#656) . Both of them can have the exact same query, and therefore, have the exact same logical plan. They differ only in the underlying index scan operator choice.
We can set the index scan type to SCROLL during request handling.
Another use case is to allow for some commands to request more data rows than `query.size_limit` and `index.max_result_window` (#703).

2. Pull opensearch index scan results in batches, rather than loading all at once.
 
### Issues Resolved
This is a building block for both #656 and #703 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).