### PR TITLE
Add any case of arguments in relevancy based functions to be allowed

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhrasePrefixQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhrasePrefixQuery.java
@@ -23,7 +23,7 @@ public class MatchPhrasePrefixQuery  extends RelevanceQuery<MatchPhrasePrefixQue
         .put("slop", (b, v) -> b.slop(Integer.parseInt(v.stringValue())))
         .put("max_expansions", (b, v) -> b.maxExpansions(Integer.parseInt(v.stringValue())))
         .put("zero_terms_query", (b, v) -> b.zeroTermsQuery(
-            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(v.stringValue())))
+            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(valueOfToUpper(v))))
         .put("boost", (b, v) -> b.boost(Float.parseFloat(v.stringValue())))
         .build());
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchPhraseQuery.java
@@ -34,7 +34,7 @@ public class MatchPhraseQuery extends RelevanceQuery<MatchPhraseQueryBuilder> {
         .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
         .put("slop", (b, v) -> b.slop(Integer.parseInt(v.stringValue())))
         .put("zero_terms_query", (b, v) -> b.zeroTermsQuery(
-            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(v.stringValue())))
+            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(valueOfToUpper(v))))
         .build());
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MatchQuery.java
@@ -24,7 +24,7 @@ public class MatchQuery extends RelevanceQuery<MatchQueryBuilder> {
         .put("analyzer", (b, v) -> b.analyzer(v.stringValue()))
         .put("auto_generate_synonyms_phrase_query",
             (b, v) -> b.autoGenerateSynonymsPhraseQuery(Boolean.parseBoolean(v.stringValue())))
-        .put("fuzziness", (b, v) -> b.fuzziness(v.stringValue()))
+        .put("fuzziness", (b, v) -> b.fuzziness(valueOfToUpper(v)))
         .put("max_expansions", (b, v) -> b.maxExpansions(Integer.parseInt(v.stringValue())))
         .put("prefix_length", (b, v) -> b.prefixLength(Integer.parseInt(v.stringValue())))
         .put("fuzzy_transpositions",
@@ -34,7 +34,7 @@ public class MatchQuery extends RelevanceQuery<MatchQueryBuilder> {
         .put("operator", (b, v) -> b.operator(Operator.fromString(v.stringValue())))
         .put("minimum_should_match", (b, v) -> b.minimumShouldMatch(v.stringValue()))
         .put("zero_terms_query", (b, v) -> b.zeroTermsQuery(
-            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(v.stringValue())))
+            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(valueOfToUpper(v))))
         .put("boost", (b, v) -> b.boost(Float.parseFloat(v.stringValue())))
         .build());
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiMatchQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiMatchQuery.java
@@ -41,7 +41,7 @@ public class MultiMatchQuery extends RelevanceQuery<MultiMatchQueryBuilder> {
         .put("type", (b, v) -> b.type(v.stringValue()))
         .put("slop", (b, v) -> b.slop(Integer.parseInt(v.stringValue())))
         .put("zero_terms_query", (b, v) -> b.zeroTermsQuery(
-            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(v.stringValue())))
+            org.opensearch.index.search.MatchQuery.ZeroTermsQuery.valueOf(valueOfToUpper(v))))
         .build());
   }
 
@@ -67,14 +67,15 @@ public class MultiMatchQuery extends RelevanceQuery<MultiMatchQueryBuilder> {
         .fields(fieldsAndWeights);
     while (iterator.hasNext()) {
       NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
-      if (!queryBuildActions.containsKey(arg.getArgName())) {
+      String argNormalized = arg.getArgName().toLowerCase();
+      if (!queryBuildActions.containsKey(argNormalized)) {
         throw new SemanticCheckException(
             String.format("Parameter %s is invalid for %s function.",
-                arg.getArgName(), queryBuilder.getWriteableName()));
+                argNormalized, queryBuilder.getWriteableName()));
       }
       (Objects.requireNonNull(
           queryBuildActions
-              .get(arg.getArgName())))
+              .get(argNormalized)))
           .apply(queryBuilder, arg.getValue().valueOf(null));
     }
     return queryBuilder;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/QueryStringQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/QueryStringQuery.java
@@ -59,7 +59,7 @@ public class QueryStringQuery extends RelevanceQuery<QueryStringQueryBuilder> {
         .put("phrase_slop", (b, v) -> b.phraseSlop(Integer.parseInt(v.stringValue())))
         .put("quote_field_suffix", (b, v) -> b.quoteFieldSuffix(v.stringValue()))
         .put("rewrite", (b, v) -> b.rewrite(v.stringValue()))
-        .put("type", (b, v) -> b.type(MultiMatchQueryBuilder.Type.parse(v.stringValue(),
+        .put("type", (b, v) -> b.type(MultiMatchQueryBuilder.Type.parse(valueOfToLower(v),
             LoggingDeprecationHandler.INSTANCE)))
         .put("tie_breaker", (b, v) -> b.tieBreaker(Float.parseFloat(v.stringValue())))
         .put("time_zone", (b, v) -> b.timeZone(v.stringValue()))
@@ -93,14 +93,15 @@ public class QueryStringQuery extends RelevanceQuery<QueryStringQueryBuilder> {
         .fields(fieldsAndWeights);
     while (iterator.hasNext()) {
       NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
-      if (!queryBuildActions.containsKey(arg.getArgName())) {
+      String argNormalized = arg.getArgName().toLowerCase();
+      if (!queryBuildActions.containsKey(argNormalized)) {
         throw new SemanticCheckException(
             String.format("Parameter %s is invalid for %s function.",
-                arg.getArgName(), queryBuilder.getWriteableName()));
+                argNormalized, queryBuilder.getWriteableName()));
       }
       (Objects.requireNonNull(
           queryBuildActions
-              .get(arg.getArgName())))
+              .get(argNormalized)))
           .apply(queryBuilder, arg.getValue().valueOf(null));
     }
     return queryBuilder;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
@@ -46,14 +46,15 @@ public abstract class RelevanceQuery<T extends QueryBuilder> extends LuceneQuery
     Iterator<Expression> iterator = arguments.listIterator(2);
     while (iterator.hasNext()) {
       NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
-      if (!queryBuildActions.containsKey(arg.getArgName())) {
+      String argNormalized = arg.getArgName().toLowerCase();
+      if (!queryBuildActions.containsKey(argNormalized)) {
         throw new SemanticCheckException(
             String.format("Parameter %s is invalid for %s function.",
-                arg.getArgName(), queryBuilder.getWriteableName()));
+                argNormalized, queryBuilder.getWriteableName()));
       }
       (Objects.requireNonNull(
           queryBuildActions
-              .get(arg.getArgName())))
+              .get(argNormalized)))
           .apply(queryBuilder, arg.getValue().valueOf(null));
     }
     return queryBuilder;
@@ -69,5 +70,13 @@ public abstract class RelevanceQuery<T extends QueryBuilder> extends LuceneQuery
   public interface QueryBuilderStep<T extends QueryBuilder> extends
       BiFunction<T, ExprValue, T> {
 
+  }
+
+  public static String valueOfToUpper(ExprValue v) {
+    return v.stringValue().toUpperCase();
+  }
+
+  public static String valueOfToLower(ExprValue v) {
+    return v.stringValue().toLowerCase();
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SimpleQueryStringQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SimpleQueryStringQuery.java
@@ -32,7 +32,7 @@ public class SimpleQueryStringQuery extends RelevanceQuery<SimpleQueryStringBuil
             b.autoGenerateSynonymsPhraseQuery(Boolean.parseBoolean(v.stringValue())))
         .put("boost", (b, v) -> b.boost(Float.parseFloat(v.stringValue())))
         .put("default_operator", (b, v) -> b.defaultOperator(Operator.fromString(v.stringValue())))
-        .put("flags", (b, v) -> b.flags(Arrays.stream(v.stringValue().split("\\|"))
+        .put("flags", (b, v) -> b.flags(Arrays.stream(valueOfToUpper(v).split("\\|"))
             .map(SimpleQueryStringFlag::valueOf)
             .toArray(SimpleQueryStringFlag[]::new)))
         .put("fuzzy_max_expansions", (b, v) ->
@@ -69,14 +69,15 @@ public class SimpleQueryStringQuery extends RelevanceQuery<SimpleQueryStringBuil
         .fields(fieldsAndWeights);
     while (iterator.hasNext()) {
       NamedArgumentExpression arg = (NamedArgumentExpression) iterator.next();
-      if (!queryBuildActions.containsKey(arg.getArgName())) {
+      String argNormalized = arg.getArgName().toLowerCase();
+      if (!queryBuildActions.containsKey(argNormalized)) {
         throw new SemanticCheckException(
             String.format("Parameter %s is invalid for %s function.",
-                arg.getArgName(), queryBuilder.getWriteableName()));
+                argNormalized, queryBuilder.getWriteableName()));
       }
       (Objects.requireNonNull(
           queryBuildActions
-              .get(arg.getArgName())))
+              .get(argNormalized)))
           .apply(queryBuilder, arg.getValue().valueOf(null));
     }
     return queryBuilder;

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -851,7 +851,7 @@ class FilterQueryBuilderTest {
         dsl.namedArgument("query", literal("search query")),
         dsl.namedArgument("zero_terms_query", literal("meow")));
     var msg = assertThrows(IllegalArgumentException.class, () -> buildQuery(expr)).getMessage();
-    assertEquals("No enum constant org.opensearch.index.search.MatchQuery.ZeroTermsQuery.meow",
+    assertEquals("No enum constant org.opensearch.index.search.MatchQuery.ZeroTermsQuery.MEOW",
           msg);
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhrasePrefixQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhrasePrefixQueryTest.java
@@ -94,6 +94,15 @@ public class MatchPhrasePrefixQueryTest {
     Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
 
+  @Test
+  public void test_zero_terms_query_parameter_lower_case() {
+    List<Expression> arguments = List.of(
+        dsl.namedArgument("field", "t1"),
+        dsl.namedArgument("query", "t2"),
+        dsl.namedArgument("zero_terms_query", "all")
+    );
+    Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
+  }
 
   @Test
   public void test_boost_parameter() {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhraseQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhraseQueryTest.java
@@ -99,6 +99,16 @@ public class MatchPhraseQueryTest {
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
 
+  @Test
+  public void test_zero_terms_query_parameter_lower_case() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "t1"),
+        namedArgument("query", "t2"),
+        namedArgument("zero_terms_query", "all")
+    );
+    Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
+  }
+
   private class MatchPhraseExpression extends FunctionExpression {
     public MatchPhraseExpression(List<Expression> arguments) {
       super(MatchPhraseQueryTest.this.matchPhrase, arguments);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -99,6 +99,11 @@ public class MatchQueryTest {
         List.of(
             dsl.namedArgument("field", DSL.literal("field_value")),
             dsl.namedArgument("query", DSL.literal("query_value")),
+            dsl.namedArgument("zero_terms_query", DSL.literal("none"))
+        ),
+        List.of(
+            dsl.namedArgument("field", DSL.literal("field_value")),
+            dsl.namedArgument("query", DSL.literal("query_value")),
             dsl.namedArgument("boost", DSL.literal("1"))
         )
     );

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MultiMatchTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MultiMatchTest.java
@@ -120,6 +120,11 @@ class MultiMatchTest {
             dsl.namedArgument("fields", fields_value),
             dsl.namedArgument("query", query_value),
             dsl.namedArgument("zero_terms_query", DSL.literal("ALL"))
+        ),
+        List.of(
+            dsl.namedArgument("fields", fields_value),
+            dsl.namedArgument("query", query_value),
+            dsl.namedArgument("zero_terms_query", DSL.literal("all"))
         )
       );
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/QueryStringTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/QueryStringTest.java
@@ -54,6 +54,7 @@ class QueryStringTest {
         dsl.namedArgument("auto_generate_synonyms_phrase_query", DSL.literal("true")),
         dsl.namedArgument("boost", DSL.literal("1")),
         dsl.namedArgument("default_operator", DSL.literal("AND")),
+        dsl.namedArgument("default_operator", DSL.literal("and")),
         dsl.namedArgument("enable_position_increments", DSL.literal("true")),
         dsl.namedArgument("escape", DSL.literal("false")),
         dsl.namedArgument("fuzziness", DSL.literal("1")),
@@ -70,7 +71,12 @@ class QueryStringTest {
         dsl.namedArgument("rewrite", DSL.literal("constant_score")),
         dsl.namedArgument("type", DSL.literal("best_fields")),
         dsl.namedArgument("tie_breaker", DSL.literal("0.3")),
-        dsl.namedArgument("time_zone", DSL.literal("Canada/Pacific"))
+        dsl.namedArgument("time_zone", DSL.literal("Canada/Pacific")),
+        dsl.namedArgument("ANALYZER", DSL.literal("standard")),
+        dsl.namedArgument("ANALYZE_wildcard", DSL.literal("true")),
+        dsl.namedArgument("Allow_Leading_wildcard", DSL.literal("true")),
+        dsl.namedArgument("Auto_Generate_Synonyms_Phrase_Query", DSL.literal("true")),
+        dsl.namedArgument("Boost", DSL.literal("1"))
     ).stream().map(arg -> List.of(field, query, arg));
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/RangeQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/RangeQueryTest.java
@@ -20,7 +20,7 @@ class RangeQueryTest {
 
   @Test
   void should_throw_exception_for_unsupported_comparison() {
-    // Note that since we do switch check on enum comparison, this should'be impossible
+    // Note that since we do switch check on enum comparison, this should be impossible
     assertThrows(IllegalStateException.class, () ->
         new RangeQuery(Comparison.BETWEEN)
             .doBuild("name", STRING, ExprValueUtils.stringValue("John")));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/SimpleQueryStringTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/SimpleQueryStringTest.java
@@ -84,6 +84,16 @@ class SimpleQueryStringTest {
         List.of(
             dsl.namedArgument("fields", fields_value),
             dsl.namedArgument("query", query_value),
+            dsl.namedArgument("flags", DSL.literal("PREFIX|not|AND"))
+        ),
+        List.of(
+            dsl.namedArgument("fields", fields_value),
+            dsl.namedArgument("query", query_value),
+            dsl.namedArgument("flags", DSL.literal("not|and"))
+        ),
+        List.of(
+            dsl.namedArgument("fields", fields_value),
+            dsl.namedArgument("query", query_value),
             dsl.namedArgument("fuzzy_max_expansions", DSL.literal("42"))
         ),
         List.of(
@@ -109,6 +119,11 @@ class SimpleQueryStringTest {
         List.of(
             dsl.namedArgument("fields", fields_value),
             dsl.namedArgument("query", query_value),
+            dsl.namedArgument("default_operator", DSL.literal("and"))
+        ),
+        List.of(
+            dsl.namedArgument("fields", fields_value),
+            dsl.namedArgument("query", query_value),
             dsl.namedArgument("minimum_should_match", DSL.literal("4"))
         ),
         List.of(
@@ -120,6 +135,20 @@ class SimpleQueryStringTest {
             dsl.namedArgument("fields", fields_value),
             dsl.namedArgument("query", query_value),
             dsl.namedArgument("boost", DSL.literal("1"))
+        ),
+        List.of(
+            dsl.namedArgument("FIELDS", fields_value),
+            dsl.namedArgument("QUERY", query_value)
+        ),
+        List.of(
+            dsl.namedArgument("FIELDS", fields_value),
+            dsl.namedArgument("query", query_value),
+            dsl.namedArgument("ANALYZE_wildcard", DSL.literal("true"))
+        ),
+        List.of(
+            dsl.namedArgument("fields", fields_value),
+            dsl.namedArgument("query", query_value),
+            dsl.namedArgument("analyZER", DSL.literal("standard"))
         )
       );
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQueryBuildTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQueryBuildTest.java
@@ -72,7 +72,7 @@ class RelevanceQueryBuildTest {
 
     SemanticCheckException exception =
         assertThrows(SemanticCheckException.class, () -> query.build(expr));
-    assertEquals("Parameter wrongArg is invalid for mock_query function.", exception.getMessage());
+    assertEquals("Parameter wrongarg is invalid for mock_query function.", exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
### Description
Allows for any case on argument name for relevancy based function (Match Phrase Prefix, Simple Query String,  Match Bool Prefix, Match, Multi-Match, Query String, Relevance, Simple Query String). 
e.g. 
`AnalyZer` can work instead of just `analyzer`
`Zero_Terms_Query` can work instead of just `zero_terms_query`
`BOOst` can work instead of just `boost`

Allows for `zero_term_query` arguments to be of any case.
e.g.
`All` can work instead of `ALL`
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).