### PR TITLE
Bump Jackson dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.2.0-SNAPSHOT")
+        spring_version = "5.3.22"
+        jackson_version = "2.13.3"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,8 +40,8 @@ repositories {
 
 dependencies {
     api group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    api group: 'org.springframework', name: 'spring-context', version: '5.3.22'
-    api group: 'org.springframework', name: 'spring-beans', version: '5.3.22'
+    api group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    api group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     api group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     api group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
@@ -49,7 +49,7 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.springframework', name: 'spring-test', version: '5.3.22'
+    testImplementation group: 'org.springframework', name: 'spring-test', version: "${spring_version}"
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.12.4'
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -53,9 +53,9 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.13.3'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.3'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
 }
 
 dependencies {

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     api project(':core')
     api group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "io.github.resilience4j:resilience4j-retry:1.5.0"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.3'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.3'
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_version}"
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     implementation group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -82,12 +82,12 @@ configurations.all {
     // conflict with spring-jcl
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 2.12.6, https://github.com/opensearch-project/sql/issues/424
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.13.3'
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.3'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
 }
 compileJava {
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
@@ -98,7 +98,7 @@ compileTestJava {
 }
 
 dependencies {
-    api group: 'org.springframework', name: 'spring-beans', version: '5.3.22'
+    api group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     api project(":ppl")
     api project(':legacy')
     api project(':opensearch')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     api group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     api group: 'org.json', name: 'json', version: '20180813'
-    implementation group: 'org.springframework', name: 'spring-context', version: '5.3.22'
-    implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.22'
+    implementation group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    implementation group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     api project(':common')
     api project(':core')

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -30,9 +30,9 @@ plugins {
 
 dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_version}"
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation project(':core')
     implementation project(':opensearch')
@@ -44,7 +44,7 @@ dependencies {
 }
 
 configurations.all {
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
 }
 
 test {

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_version}"
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_version}"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "2.13.3"
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     implementation "org.antlr:antlr4-runtime:4.7.1"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'org.json', name: 'json', version:'20180813'
-    implementation group: 'org.springframework', name: 'spring-context', version: '5.3.22'
-    implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.22'
+    implementation group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    implementation group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     implementation project(':common')
     implementation project(':core')
     api project(':protocol')


### PR DESCRIPTION
### Description
Bump Jackson dependency version and extract hardcoding version number to root Gradle script. Will back port this to 1.3 branch after merged.

Verify all Jackson dependencies upgraded to latest 2.13.3:

```
$ ./gradlew clean
$ ./gradlew assemble
$ unzip -l plugin/build/distributions/opensearch-sql-2.2.0.0-SNAPSHOT.zip | grep -E 'spring|jackson'
  1275108  08-04-2022 11:08   spring-context-5.3.22.jar
   382963  08-04-2022 11:08   spring-aop-5.3.22.jar
   699011  08-04-2022 11:08   spring-beans-5.3.22.jar
    75714  07-19-2022 13:34   jackson-annotations-2.13.3.jar
  1536542  07-19-2022 13:34   jackson-databind-2.13.3.jar
   289392  08-04-2022 11:08   spring-expression-5.3.22.jar
  1486059  08-04-2022 11:08   spring-core-5.3.22.jar
    24436  08-04-2022 11:08   spring-jcl-5.3.22.jar
```

Note that SQL JDBC only has one dependency and has no access to root script, so change the version in place.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).