### PR TITLE
Bump Spring version in 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "1.3.4-SNAPSHOT")
+        spring_version = "5.3.22"
     }
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,8 +40,8 @@ repositories {
 
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     compile group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
@@ -49,7 +49,7 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testCompile group: 'org.springframework', name: 'spring-test', version: '5.2.20.RELEASE'
+    testCompile group: 'org.springframework', name: 'spring-test', version: "${spring_version}"
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
     testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.3.3'
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -62,7 +62,7 @@ configurations.all {
 }
 
 dependencies {
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile project(":ppl")
     compile project(':legacy')
     compile project(':opensearch')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     compile group: 'org.json', name: 'json', version: '20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     compile project(':common')
     compile project(':core')

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile group: 'org.json', name: 'json', version:'20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile project(':common')
     compile project(':core')
     compile project(':protocol')


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description
Back porting https://github.com/opensearch-project/sql/pull/745 to OpenSearch 1.3. The Github action is failing due to Jackson which will be version bumped in separate PR.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).