### PR TITLE
Bump jackson-databind version 1.13.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "1.3.4-SNAPSHOT")
         spring_version = "5.3.22"
+        jackson_version = "2.13.2"
+        jackson_databind_version = "2.13.2.2"
     }
 
     repositories {
@@ -123,6 +125,10 @@ subprojects {
         configProperties = [
                 "org.checkstyle.google.suppressionfilter.config": rootProject.file("config/checkstyle/suppressions.xml")]
         ignoreFailures = false
+    }
+
+    configurations.all {
+        resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
     }
 }
 checkstyle {

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     compile project(':core')
     compile group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compile "io.github.resilience4j:resilience4j-retry:1.5.0"
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_databind_version}"
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     compile group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     compile group: 'org.opensearch', name:'opensearch-ml-client', version: '1.3.4.0-SNAPSHOT'

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -30,9 +30,9 @@ plugins {
 
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_databind_version}"
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     implementation 'com.google.code.gson:gson:2.8.9'
     compile project(':core')
     compile project(':opensearch')

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')


### PR DESCRIPTION
### Description
Back porting https://github.com/opensearch-project/sql/pull/745 to 1.3 branch. Change jackson-databind version to 1.13.2.2 to match jackson introduced in OpenSearch core's: https://github.com/opensearch-project/OpenSearch/blob/1.3/buildSrc/version.properties#L13
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).