### PR TITLE
Backport Spring and jackson-databind version bump to 1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "1.3.4-SNAPSHOT")
         spring_version = "5.3.22"
+        jackson_version = "2.13.2"
+        jackson_databind_version = "2.13.2.2"
     }
 
     repositories {
@@ -123,6 +125,10 @@ subprojects {
         configProperties = [
                 "org.checkstyle.google.suppressionfilter.config": rootProject.file("config/checkstyle/suppressions.xml")]
         ignoreFailures = false
+    }
+
+    configurations.all {
+        resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
     }
 }
 checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "1.3.4-SNAPSHOT")
+        spring_version = "5.3.22"
     }
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,8 +40,8 @@ repositories {
 
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     compile group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
@@ -49,7 +49,7 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testCompile group: 'org.springframework', name: 'spring-test', version: '5.2.20.RELEASE'
+    testCompile group: 'org.springframework', name: 'spring-test', version: "${spring_version}"
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
     testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.3.3'
 }

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     compile project(':core')
     compile group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compile "io.github.resilience4j:resilience4j-retry:1.5.0"
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_databind_version}"
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     compile group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     compile group: 'org.opensearch', name:'opensearch-ml-client', version: '1.3.4.0-SNAPSHOT'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -62,7 +62,7 @@ configurations.all {
 }
 
 dependencies {
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile project(":ppl")
     compile project(':legacy')
     compile project(':opensearch')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     compile group: 'org.json', name: 'json', version: '20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     compile project(':common')
     compile project(':core')

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -30,9 +30,9 @@ plugins {
 
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson_version}"
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jackson_databind_version}"
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${jackson_version}"
     implementation 'com.google.code.gson:gson:2.8.9'
     compile project(':core')
     compile project(':opensearch')

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.6'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile group: 'org.json', name: 'json', version:'20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
+    compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile project(':common')
     compile project(':core')
     compile project(':protocol')


### PR DESCRIPTION
### Description
Backporting #751 and #756 to 1.x branch.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).