### PR TITLE
[Release 1.3.5] Version increment and add `build.sh`

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -3,7 +3,7 @@ name: SQL Java CI
 on: [push, pull_request]
 
 env:
-  OPENSEARCH_VERSION: '1.3.4-SNAPSHOT'
+  OPENSEARCH_VERSION: '1.3.5-SNAPSHOT'
 
 jobs:
   build:

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 env: 
   PLUGIN_NAME: query-workbench-dashboards
   OPENSEARCH_VERSION: '1.3'
-  OPENSEARCH_PLUGIN_VERSION: 1.3.4.0
+  OPENSEARCH_PLUGIN_VERSION: 1.3.5.0
 
 jobs:
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.3.4-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.3.5-SNAPSHOT")
         spring_version = "5.3.22"
         jackson_version = "2.13.2"
         jackson_databind_version = "2.13.2.2"
@@ -143,4 +143,29 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
+}
+
+// updateVersion: Task to auto increment to the next development iteration
+task updateVersion {
+    onlyIf { System.getProperty('newVersion') }
+    doLast {
+        ext.newVersion = System.getProperty('newVersion')
+        println "Setting version to ${newVersion}."
+        // String tokenization to support -SNAPSHOT
+        ant.replaceregexp(file:'.github/workflows/sql-workbench-test-and-build-workflow.yml', match:'OPENSEARCH_PLUGIN_VERSION: \\d+.\\d+.\\d+.\\d+', replace:'OPENSEARCH_PLUGIN_VERSION: ' + newVersion.tokenize('-')[0] + '.0', flags:'g', byline:true)
+        ant.replaceregexp(match: opensearch_version.tokenize('-')[0]+'-SNAPSHOT', replace: newVersion.tokenize('-')[0]+'-SNAPSHOT', flags:'g', byline:true) {
+            fileset(dir: projectDir) {
+                     include(name: '.github/workflows/sql-test-and-build-workflow.yml')
+            }
+        }
+        ant.replaceregexp(file:'doctest/build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
+        ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
+        ant.replaceregexp(match:'"version": "\\d+.\\d+.\\d+.\\d+', replace:'"version": ' + '"' + newVersion.tokenize('-')[0] + '.0', flags:'g', byline:true) {
+            fileset(dir: projectDir) {
+                include(name: "workbench/package.json")
+                include(name: "workbench/opensearch_dashboards.json")
+            }
+        }
+        ant.replaceregexp(file:'workbench/opensearch_dashboards.json', match:'"opensearchDashboardsVersion": "\\d+.\\d+.\\d+', replace:'"opensearchDashboardsVersion": ' + '"' + newVersion.tokenize('-')[0], flags:'g', byline:true)
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -153,12 +153,12 @@ task updateVersion {
         println "Setting version to ${newVersion}."
         // String tokenization to support -SNAPSHOT
         ant.replaceregexp(file:'.github/workflows/sql-workbench-test-and-build-workflow.yml', match:'OPENSEARCH_PLUGIN_VERSION: \\d+.\\d+.\\d+.\\d+', replace:'OPENSEARCH_PLUGIN_VERSION: ' + newVersion.tokenize('-')[0] + '.0', flags:'g', byline:true)
-        ant.replaceregexp(match: opensearch_version.tokenize('-')[0]+'-SNAPSHOT', replace: newVersion.tokenize('-')[0]+'-SNAPSHOT', flags:'g', byline:true) {
+        ant.replaceregexp(match: opensearch_version.tokenize('-')[0], replace: newVersion.tokenize('-')[0], flags:'g', byline:true) {
             fileset(dir: projectDir) {
                      include(name: '.github/workflows/sql-test-and-build-workflow.yml')
+                     include(name: 'doctest/build.gradle')
             }
         }
-        ant.replaceregexp(file:'doctest/build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
         ant.replaceregexp(match:'"version": "\\d+.\\d+.\\d+.\\d+', replace:'"version": ' + '"' + newVersion.tokenize('-')[0] + '.0', flags:'g', byline:true) {
             fileset(dir: projectDir) {

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -48,7 +48,7 @@ doctest.finalizedBy stopOpenSearch
 build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 
-String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.4/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-1.3.4.0.zip'
+String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.5/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-1.3.5.0.zip'
 String mlCommonsPlugin = "ml-commons"
 
 testClusters {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:q:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ ! -z "$QUALIFIER" ]] && VERSION=$VERSION-$QUALIFIER
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mkdir -p $OUTPUT
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+
+echo "COPY ${distributions}/*.zip"
+mkdir -p $OUTPUT/plugins
+cp ${distributions}/*.zip ./$OUTPUT/plugins

--- a/workbench/opensearch_dashboards.json
+++ b/workbench/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "queryWorkbenchDashboards",
-  "version": "1.3.4.0",
-  "opensearchDashboardsVersion": "1.3.4",
+  "version": "1.3.5.0",
+  "opensearchDashboardsVersion": "1.3.5",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation"],

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-query-workbench",
-  "version": "1.3.4.0",
+  "version": "1.3.5.0",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Signed-off-by: prudhvigodithi <pgodithi@amazon.com>

### Description
Version increment 1.3.5
 
### Issues Resolved
Part of: https://github.com/opensearch-project/opensearch-build/issues/2348
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).