### PR TITLE
Bump Checkstyle version to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,11 +127,11 @@ jacocoTestCoverageVerification {
 check.dependsOn jacocoTestCoverageVerification
 
 // TODO: fix code style in main and test source code
-subprojects {
+allprojects {
     apply plugin: 'checkstyle'
     checkstyle {
         configFile rootProject.file("config/checkstyle/google_checks.xml")
-        toolVersion "8.29"
+        toolVersion "10.3.2"
         configProperties = [
                 "org.checkstyle.google.suppressionfilter.config": rootProject.file("config/checkstyle/suppressions.xml")]
         ignoreFailures = false

--- a/config/checkstyle/google_checks.xml
+++ b/config/checkstyle/google_checks.xml
@@ -279,7 +279,7 @@
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -736,11 +736,11 @@ class AnalyzerTest extends AnalyzerTestBase {
   public void ad_batchRCF_relation() {
     Map<String, Literal> argumentMap =
             new HashMap<String, Literal>() {{
-        put("shingle_size", new Literal(8, DataType.INTEGER));
-      }};
+                put("shingle_size", new Literal(8, DataType.INTEGER));
+            }};
     assertAnalyzeEqual(
-            new LogicalAD(LogicalPlanDSL.relation("schema"), argumentMap),
-            new AD(AstDSL.relation("schema"), argumentMap)
+        new LogicalAD(LogicalPlanDSL.relation("schema"), argumentMap),
+        new AD(AstDSL.relation("schema"), argumentMap)
     );
   }
 

--- a/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
@@ -134,8 +134,8 @@ class LogicalPlanNodeVisitorTest {
               put("shingle_size", new Literal(8, DataType.INTEGER));
               put("time_decay", new Literal(0.0001, DataType.DOUBLE));
               put("time_field", new Literal(null, DataType.STRING));
-        }
-      });
+            }
+        });
     assertNull(ad.accept(new LogicalPlanNodeVisitor<Integer, Object>() {
     }, null));
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
@@ -71,7 +71,7 @@ public class ExpressionScript {
    * Evaluate on the doc generate by the doc provider.
    * @param docProvider doc provider.
    * @param evaluator evaluator
-   * @return
+   * @return expr value
    */
   public ExprValue execute(Supplier<Map<String, ScriptDocValues<?>>> docProvider,
                          BiFunction<Expression,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
@@ -263,12 +263,13 @@ class OpenSearchExecutionProtectorTest {
     MLCommonsOperator mlCommonsOperator =
             new MLCommonsOperator(
               values(emptyList()), "kmeans",
-                    new HashMap<String, Literal>() {{
-          put("centroids", new Literal(3, DataType.INTEGER));
-          put("iterations", new Literal(2, DataType.INTEGER));
-          put("distance_type", new Literal(null, DataType.STRING));
-        }
-      }, nodeClient);
+                new HashMap<String, Literal>() {{
+                  put("centroids", new Literal(3, DataType.INTEGER));
+                  put("iterations", new Literal(2, DataType.INTEGER));
+                  put("distance_type", new Literal(null, DataType.STRING));
+                }},
+                nodeClient
+            );
 
     assertEquals(executionProtector.doProtect(mlCommonsOperator),
             executionProtector.visitMLCommons(mlCommonsOperator, null));
@@ -279,13 +280,14 @@ class OpenSearchExecutionProtectorTest {
     NodeClient nodeClient = mock(NodeClient.class);
     ADOperator adOperator =
             new ADOperator(
-                    values(emptyList()),
-                    new HashMap<String, Literal>() {{
-          put("shingle_size", new Literal(8, DataType.INTEGER));
-          put("time_decay", new Literal(0.0001, DataType.DOUBLE));
-          put("time_field", new Literal(null, DataType.STRING));
-        }
-      }, nodeClient);
+                values(emptyList()),
+                new HashMap<String, Literal>() {{
+                  put("shingle_size", new Literal(8, DataType.INTEGER));
+                  put("time_decay", new Literal(0.0001, DataType.DOUBLE));
+                  put("time_field", new Literal(null, DataType.STRING));
+                }},
+                nodeClient
+            );
 
     assertEquals(executionProtector.doProtect(adOperator),
             executionProtector.visitAD(adOperator, null));

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java
@@ -24,6 +24,7 @@ public enum Format {
   private final String formatName;
 
   private static final Map<String, Format> ALL_FORMATS;
+
   static {
     ImmutableMap.Builder<String, Format> builder = new ImmutableMap.Builder<>();
     for (Format format : Format.values()) {


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description
1. Bump checkstyle from 8.28 to the latest version and fixed all violations.
2. Change `subprojects` to `allprojects` to enforce root project using same version as subproject (specified by `toolVersion`). Otherwise, the default Checkstyle version (8.37) defined by Gradle is in use.

```
$ ./gradlew dependencies :sql:dependencies :ppl:dependencies :core:dependencies :protocol:dependencies :opensearch-sql-plugin:dependencies :opensearch:dependencies :legacy:dependencies :common:dependencies | grep checkstyle
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2
checkstyle - The Checkstyle libraries to be used for this project.
\--- com.puppycrawl.tools:checkstyle:10.3.2

$ ./gradlew dependencies :sql:dependencies :ppl:dependencies :core:dependencies :protocol:dependencies :opensearch-sql-plugin:dependencies :opensearch:dependencies :legacy:dependencies :common:dependencies | grep guava | grep 28

```
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/431
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).