### PR TITLE
Change master node timeout to new API

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestQuerySettingsAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestQuerySettingsAction.java
@@ -79,8 +79,8 @@ public class RestQuerySettingsAction extends BaseRestHandler {
         Requests.clusterUpdateSettingsRequest();
     clusterUpdateSettingsRequest.timeout(request.paramAsTime(
         "timeout", clusterUpdateSettingsRequest.timeout()));
-    clusterUpdateSettingsRequest.masterNodeTimeout(request.paramAsTime(
-        "master_timeout", clusterUpdateSettingsRequest.masterNodeTimeout()));
+    clusterUpdateSettingsRequest.clusterManagerNodeTimeout(request.paramAsTime(
+        "master_timeout", clusterUpdateSettingsRequest.clusterManagerNodeTimeout()));
     Map<String, Object> source;
     try (XContentParser parser = request.contentParser()) {
       source = parser.map();

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestQuerySettingsAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestQuerySettingsAction.java
@@ -80,7 +80,7 @@ public class RestQuerySettingsAction extends BaseRestHandler {
     clusterUpdateSettingsRequest.timeout(request.paramAsTime(
         "timeout", clusterUpdateSettingsRequest.timeout()));
     clusterUpdateSettingsRequest.clusterManagerNodeTimeout(request.paramAsTime(
-        "master_timeout", clusterUpdateSettingsRequest.clusterManagerNodeTimeout()));
+        "cluster_manager_timeout", clusterUpdateSettingsRequest.clusterManagerNodeTimeout()));
     Map<String, Object> source;
     try (XContentParser parser = request.contentParser()) {
       source = parser.map();


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description
Change `masterNodeTimeout` to new API `clusterManagerNodeTimeout`.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/463
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).