### PR TITLE
Fix unit test in PowerBI connector.

### DIFF
--- a/bi-connectors/PowerBIConnector/src/OpenSearchProject.query.pq
+++ b/bi-connectors/PowerBIConnector/src/OpenSearchProject.query.pq
@@ -7,13 +7,14 @@ shared MyExtension.UnitTest =
     Host = "localhost",
     Port = 9200,
     UseSSL = false,
+    HostnameVerification = false,
 
     facts =
     {        
         Fact("Connection Test",  
              7,                                    
              let
-                Source = OpenSearch.Contents(Host, Port, UseSSL),
+                Source = OpenSearchProject.Contents(Host, Port, UseSSL, HostnameVerification),
                 no_of_columns = Table.ColumnCount(Source)
              in
                 no_of_columns                
@@ -22,7 +23,7 @@ shared MyExtension.UnitTest =
             #table(type table [bool0 = logical],
                 { {null}, {false}, {true} }),
             let
-                Source = OpenSearch.Contents(Host, Port, UseSSL),
+                Source = OpenSearchProject.Contents(Host, Port, UseSSL, HostnameVerification),
                 calcs_null_null = Source{[Item="calcs",Schema=null,Catalog=null]}[Data],
                 grouped = Table.Group(calcs_null_null, {"bool0"}, {})
             in


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
Last time we updated PowerBI connector, we missed to update embedded unit tests.
These tests may be executed by a developer only. To run tests you need to install `PowerQuerySDK for Visual Studio`, open `mproj` file (`bi-connectors/PowerBIConnector/src/OpenSearchProject.mproj`) with Visual Studio and run it.
 
### Issues Resolved
#### Before
![image](https://user-images.githubusercontent.com/88679692/188252196-07ad5fb8-a8ba-469c-99c6-a29cc719c0c8.png)
![image](https://user-images.githubusercontent.com/88679692/188252197-0d1ae6e7-807d-406f-b3c4-3b31d26050ac.png)
#### After
![image](https://user-images.githubusercontent.com/88679692/188252203-4b33edeb-1b11-40d6-8907-9796e98dacdf.png)
![image](https://user-images.githubusercontent.com/88679692/188252210-8e8ab946-bc2f-495a-b674-8ad8c3008f01.png)

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).