### PR TITLE
Add Forum link in SQL plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ Besides basic filtering and aggregation, OpenSearch SQL also supports complex qu
 
 Recently we have been actively improving our query engine primarily for better correctness and extensibility. Behind the scene, the new enhanced engine has already supported both SQL and Piped Processing Language. Please find more details in [SQL Engine V2 - Release Notes](./docs/dev/NewSQLEngine.md).
 
-## Documentation & Forum
+## Documentation
 
 Please refer to the [SQL Language Reference Manual](./docs/user/index.rst), [Piped Processing Language (PPL) Reference Manual](./docs/user/ppl/index.rst) and [Technical Documentation](https://opensearch.org/docs/latest/search-plugins/sql/index/) for detailed information on installing and configuring plugin.
+
+## Forum
 
 For additional help with the plugin, including questions about opening an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/plugins/sql/8).
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ Besides basic filtering and aggregation, OpenSearch SQL also supports complex qu
 
 Recently we have been actively improving our query engine primarily for better correctness and extensibility. Behind the scene, the new enhanced engine has already supported both SQL and Piped Processing Language. Please find more details in [SQL Engine V2 - Release Notes](./docs/dev/NewSQLEngine.md).
 
-## Documentation
+## Documentation & Forum
 
 Please refer to the [SQL Language Reference Manual](./docs/user/index.rst), [Piped Processing Language (PPL) Reference Manual](./docs/user/ppl/index.rst) and [Technical Documentation](https://opensearch.org/docs/latest/search-plugins/sql/index/) for detailed information on installing and configuring plugin.
+
+For additional help with the plugin, including questions about opening an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/plugins/sql/8).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - [Code Summary](#code-summary)
 - [Highlights](#highlights)
 - [Documentation](#documentation)
+- [OpenSearch Forum](#forum)
 - [Contributing](#contributing)
 - [Attribution](#attribution)
 - [Code of Conduct](#code-of-conduct)
@@ -129,7 +130,7 @@ Please refer to the [SQL Language Reference Manual](./docs/user/index.rst), [Pip
 
 ## Forum
 
-For additional help with the plugin, including questions about opening an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/plugins/sql/8).
+For additional help with the plugin, including questions about opening an issue, visit the OpenSearch [Forum](https://forum.opensearch.org/c/plugins/sql/8).
 
 ## Contributing
 


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Added Forum header section that includes verbiage and a link to the OpenSearch Forum page for the SQL plugin.
 
### Issues Resolved
This more closely corresponds to the information found in the README.md file in all of the other plugins bundled with OpenSearch.

This fixes the issue for the SQL plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).