### PR TITLE
Add Support for Highlight Wildcard in SQL

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -313,7 +313,6 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
     for (UnresolvedExpression expr : node.getProjectList()) {
       HighlightAnalyzer highlightAnalyzer = new HighlightAnalyzer(expressionAnalyzer, child);
       child = highlightAnalyzer.analyze(expr, context);
-
     }
 
     List<NamedExpression> namedExpressions =

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -205,7 +205,7 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
   }
 
   @Override
-  public Expression visitHighlight(HighlightFunction node, AnalysisContext context) {
+  public Expression visitHighlightFunction(HighlightFunction node, AnalysisContext context) {
     Expression expr = node.getHighlightField().accept(this, context);
     return new HighlightExpression(expr);
   }

--- a/core/src/main/java/org/opensearch/sql/analysis/HighlightAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/HighlightAnalyzer.java
@@ -30,12 +30,13 @@ public class HighlightAnalyzer extends AbstractNodeVisitor<LogicalPlan, Analysis
 
   @Override
   public LogicalPlan visitAlias(Alias node, AnalysisContext context) {
-    if (!(node.getDelegated() instanceof HighlightFunction)) {
+    UnresolvedExpression delegated = node.getDelegated();
+    if (!(delegated instanceof HighlightFunction)) {
       return null;
     }
 
-    HighlightFunction unresolved = (HighlightFunction) node.getDelegated();
+    HighlightFunction unresolved = (HighlightFunction) delegated;
     Expression field = expressionAnalyzer.analyze(unresolved.getHighlightField(), context);
-    return new LogicalHighlight(child, field);
+    return new LogicalHighlight(child, field, unresolved.getArguments());
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -261,7 +261,7 @@ public abstract class AbstractNodeVisitor<T, C> {
     return visitChildren(node, context);
   }
 
-  public T visitHighlight(HighlightFunction node, C context) {
+  public T visitHighlightFunction(HighlightFunction node, C context) {
     return visitChildren(node, context);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -272,8 +272,9 @@ public class AstDSL {
     return new When(condition, result);
   }
 
-  public UnresolvedExpression highlight(UnresolvedExpression fieldName) {
-    return new HighlightFunction(fieldName);
+  public UnresolvedExpression highlight(UnresolvedExpression fieldName,
+      java.util.Map<String, Literal> arguments) {
+    return new HighlightFunction(fieldName, arguments);
   }
 
   public UnresolvedExpression window(UnresolvedExpression function,

--- a/core/src/main/java/org/opensearch/sql/ast/expression/HighlightFunction.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/HighlightFunction.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.ast.expression;
 
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -21,10 +22,11 @@ import org.opensearch.sql.ast.AbstractNodeVisitor;
 @ToString
 public class HighlightFunction extends UnresolvedExpression {
   private final UnresolvedExpression highlightField;
+  private final Map<String, Literal> arguments;
 
   @Override
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
-    return nodeVisitor.visitHighlight(this, context);
+    return nodeVisitor.visitHighlightFunction(this, context);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/expression/HighlightExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/HighlightExpression.java
@@ -5,10 +5,16 @@
 
 package org.opensearch.sql.expression;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.expression.env.Environment;
@@ -20,6 +26,7 @@ import org.opensearch.sql.expression.function.BuiltinFunctionName;
 @Getter
 public class HighlightExpression extends FunctionExpression {
   private final Expression highlightField;
+  private final ExprType type;
 
   /**
    * HighlightExpression Constructor.
@@ -28,6 +35,8 @@ public class HighlightExpression extends FunctionExpression {
   public HighlightExpression(Expression highlightField) {
     super(BuiltinFunctionName.HIGHLIGHT.getName(), List.of(highlightField));
     this.highlightField = highlightField;
+    this.type = this.highlightField.toString().contains("*")
+        ? ExprCoreType.STRUCT : ExprCoreType.ARRAY;
   }
 
   /**
@@ -37,21 +46,57 @@ public class HighlightExpression extends FunctionExpression {
    */
   @Override
   public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
-    String refName = "_highlight" + "." + StringUtils.unquoteText(getHighlightField().toString());
-    return valueEnv.resolve(DSL.ref(refName, ExprCoreType.STRING));
+    String refName = "_highlight";
+    // Not a wilcard expression
+    if (this.type == ExprCoreType.ARRAY) {
+      refName += "." + StringUtils.unquoteText(getHighlightField().toString());
+    }
+    ExprValue value = valueEnv.resolve(DSL.ref(refName, ExprCoreType.STRING));
+
+    // In the event of multiple returned highlights and wildcard being
+    // used in conjunction with other highlight calls, we need to ensure
+    // only wildcard regex matching is mapped to wildcard call.
+    if (this.type == ExprCoreType.STRUCT && value.type() == ExprCoreType.STRUCT) {
+      value = new ExprTupleValue(
+          new LinkedHashMap<String, ExprValue>(value.tupleValue()
+              .entrySet()
+              .stream()
+              .filter(s -> matchesHighlightRegex(s.getKey(),
+                  StringUtils.unquoteText(highlightField.toString())))
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> e.getValue()))));
+      if (value.tupleValue().isEmpty()) {
+        value = ExprValueUtils.missingValue();
+      }
+    }
+
+    return value;
   }
 
   /**
    * Get type for HighlightExpression.
-   * @return : String type.
+   * @return : Expression type.
    */
   @Override
   public ExprType type() {
-    return ExprCoreType.ARRAY;
+    return this.type;
   }
 
   @Override
   public <T, C> T accept(ExpressionNodeVisitor<T, C> visitor, C context) {
     return visitor.visitHighlight(this, context);
+  }
+
+  /**
+   * Check if field matches the wildcard pattern used in highlight query.
+   * @param field Highlight selected field for query
+   * @param pattern Wildcard regex to match field against
+   * @return True if field matches wildcard pattern
+   */
+  private boolean matchesHighlightRegex(String field, String pattern) {
+    Pattern p = Pattern.compile(pattern.replace("*", ".*"));
+    Matcher matcher = p.matcher(field);
+    return matcher.matches();
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -17,7 +17,6 @@ import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.HighlightExpression;
 import org.opensearch.sql.expression.NamedArgumentExpression;
 import org.opensearch.sql.expression.env.Environment;
 
@@ -37,15 +36,6 @@ public class OpenSearchFunctions {
     repository.register(match_phrase(BuiltinFunctionName.MATCH_PHRASE));
     repository.register(match_phrase(BuiltinFunctionName.MATCHPHRASE));
     repository.register(match_phrase_prefix());
-    repository.register(highlight());
-  }
-
-  private static FunctionResolver highlight() {
-    FunctionName functionName = BuiltinFunctionName.HIGHLIGHT.getName();
-    FunctionSignature functionSignature = new FunctionSignature(functionName, List.of(STRING));
-    FunctionBuilder functionBuilder = arguments -> new HighlightExpression(arguments.get(0));
-    return new DefaultFunctionResolver(functionName,
-        ImmutableMap.of(functionSignature, functionBuilder));
   }
 
   private static FunctionResolver match_bool_prefix() {

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalHighlight.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalHighlight.java
@@ -6,9 +6,11 @@
 package org.opensearch.sql.planner.logical;
 
 import java.util.Collections;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.expression.Expression;
 
 @EqualsAndHashCode(callSuper = true)
@@ -16,10 +18,16 @@ import org.opensearch.sql.expression.Expression;
 @ToString
 public class LogicalHighlight extends LogicalPlan {
   private final Expression highlightField;
+  private final Map<String, Literal> arguments;
 
-  public LogicalHighlight(LogicalPlan childPlan, Expression field) {
+  /**
+   * Constructor of LogicalHighlight.
+   */
+  public LogicalHighlight(LogicalPlan childPlan, Expression highlightField,
+      Map<String, Literal> arguments) {
     super(Collections.singletonList(childPlan));
-    highlightField = field;
+    this.highlightField = highlightField;
+    this.arguments = arguments;
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanDSL.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanDSL.java
@@ -63,8 +63,9 @@ public class LogicalPlanDSL {
     return new LogicalWindow(input, windowFunction, windowDefinition);
   }
 
-  public LogicalPlan highlight(LogicalPlan input, Expression field) {
-    return new LogicalHighlight(input, field);
+  public LogicalPlan highlight(LogicalPlan input, Expression field,
+      Map<String, Literal> arguments) {
+    return new LogicalHighlight(input, field, arguments);
   }
 
   public static LogicalPlan remove(LogicalPlan input, ReferenceExpression... fields) {

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -27,10 +27,12 @@ import static org.opensearch.sql.ast.tree.Sort.SortOption;
 import static org.opensearch.sql.ast.tree.Sort.SortOption.DEFAULT_ASC;
 import static org.opensearch.sql.ast.tree.Sort.SortOrder;
 import static org.opensearch.sql.data.model.ExprValueUtils.integerValue;
+import static org.opensearch.sql.data.type.ExprCoreType.ARRAY;
 import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.LONG;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -270,16 +272,41 @@ class AnalyzerTest extends AnalyzerTestBase {
 
   @Test
   public void project_highlight() {
+    Map<String, Literal> args = new HashMap<>();
+    args.put("pre_tags", new Literal("<mark>", DataType.STRING));
+    args.put("post_tags", new Literal("</mark>", DataType.STRING));
+
     assertAnalyzeEqual(
         LogicalPlanDSL.project(
             LogicalPlanDSL.highlight(LogicalPlanDSL.relation("schema", table),
-                DSL.literal("fieldA")),
-            DSL.named("highlight(fieldA)", new HighlightExpression(DSL.literal("fieldA")))
+                DSL.literal("fieldA"), args),
+            DSL.named("highlight(fieldA, pre_tags='<mark>', post_tags='</mark>')",
+                new HighlightExpression(DSL.literal("fieldA")))
         ),
         AstDSL.projectWithArg(
             AstDSL.relation("schema"),
             AstDSL.defaultFieldsArgs(),
-            AstDSL.alias("highlight(fieldA)", new HighlightFunction(AstDSL.stringLiteral("fieldA")))
+            AstDSL.alias("highlight(fieldA, pre_tags='<mark>', post_tags='</mark>')",
+                new HighlightFunction(AstDSL.stringLiteral("fieldA"), args))
+        )
+    );
+  }
+
+  @Test
+  public void project_highlight_wildcard() {
+    Map<String, Literal> args = new HashMap<>();
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.highlight(LogicalPlanDSL.relation("schema", table),
+                DSL.literal("*"), args),
+            DSL.named("highlight(*)",
+                new HighlightExpression(DSL.literal("*")))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.relation("schema"),
+            AstDSL.defaultFieldsArgs(),
+            AstDSL.alias("highlight(*)",
+                new HighlightFunction(AstDSL.stringLiteral("*"), args))
         )
     );
   }

--- a/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
@@ -8,7 +8,6 @@ package org.opensearch.sql.analysis;
 
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.sql.ast.dsl.AstDSL.field;
@@ -38,7 +37,6 @@ import org.opensearch.sql.analysis.symbol.Symbol;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.DataType;
-import org.opensearch.sql.ast.expression.HighlightFunction;
 import org.opensearch.sql.ast.expression.RelevanceFieldList;
 import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
@@ -50,7 +48,6 @@ import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.HighlightExpression;
 import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.expression.window.aggregation.AggregateWindowFunction;
@@ -590,12 +587,6 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         analyze(function("now")), analyze(function("now")));
     var referenceValue = analyze(function("now")).valueOf(null);
     assertTrue(values.stream().noneMatch(v -> v.valueOf(null) == referenceValue));
-  }
-
-  @Test
-  void highlight() {
-    assertAnalyzeEqual(new HighlightExpression(DSL.literal("fieldA")),
-        new HighlightFunction(stringLiteral("fieldA")));
   }
 
   protected Expression analyze(UnresolvedExpression unresolvedExpression) {

--- a/core/src/test/java/org/opensearch/sql/analysis/NamedExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/NamedExpressionAnalyzerTest.java
@@ -8,15 +8,14 @@ package org.opensearch.sql.analysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.HighlightFunction;
-import org.opensearch.sql.ast.expression.QualifiedName;
-import org.opensearch.sql.expression.DSL;
-import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.springframework.context.annotation.Configuration;
@@ -40,8 +39,10 @@ class NamedExpressionAnalyzerTest extends AnalyzerTestBase {
 
   @Test
   void visit_highlight() {
+    Map<String, Literal> args = new HashMap<>();
     Alias alias = AstDSL.alias("highlight(fieldA)",
-        new HighlightFunction(AstDSL.stringLiteral("fieldA")));
+        new HighlightFunction(
+            AstDSL.stringLiteral("fieldA"), args));
     NamedExpressionAnalyzer analyzer =
         new NamedExpressionAnalyzer(expressionAnalyzer);
 

--- a/core/src/test/java/org/opensearch/sql/expression/HighlightExpressionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/HighlightExpressionTest.java
@@ -6,17 +6,18 @@
 package org.opensearch.sql.expression;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.sql.data.type.ExprCoreType.ARRAY;
 import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.errorprone.annotations.DoNotCall;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.expression.env.Environment;
+
 
 public class HighlightExpressionTest extends ExpressionTestBase {
 
@@ -35,33 +36,73 @@ public class HighlightExpressionTest extends ExpressionTestBase {
   public void missing_highlight_test() {
     Environment<Expression, ExprValue> hlTuple = ExprValueUtils.tupleValue(
         ImmutableMap.of("_highlight.Title", "result value")).bindingTuples();
+
     HighlightExpression expr = new HighlightExpression(DSL.literal("invalid"));
     ExprValue resultVal = expr.valueOf(hlTuple);
 
     assertTrue(resultVal.isMissing());
   }
 
-  /**
-   * Enable me when '*' is supported in highlight.
-   */
-  @DoNotCall
+  @Test
+  public void missing_highlight_wildcard_test() {
+    ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
+    var hlBuilder = ImmutableMap.<String, ExprValue>builder();
+    hlBuilder.put("Title", ExprValueUtils.stringValue("first result value"));
+    hlBuilder.put("Body", ExprValueUtils.stringValue("secondary result value"));
+    builder.put("_highlight", ExprTupleValue.fromExprValueMap(hlBuilder.build()));
+
+    HighlightExpression hlExpr = new HighlightExpression(DSL.literal("invalid*"));
+    ExprValue resultVal = hlExpr.valueOf(
+        ExprTupleValue.fromExprValueMap(builder.build()).bindingTuples());
+
+    assertTrue(resultVal.isMissing());
+  }
+
+  @Test
   public void highlight_all_test() {
+    ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
+    var hlBuilder = ImmutableMap.<String, ExprValue>builder();
+    hlBuilder.put("Title", ExprValueUtils.stringValue("correct result value"));
+    hlBuilder.put("Body", ExprValueUtils.stringValue("secondary correct result value"));
+    builder.put("_highlight", ExprTupleValue.fromExprValueMap(hlBuilder.build()));
+
+    HighlightExpression hlExpr = new HighlightExpression(DSL.literal("T*"));
+    ExprValue resultVal = hlExpr.valueOf(
+        ExprTupleValue.fromExprValueMap(builder.build()).bindingTuples());
+
+    assertEquals(STRUCT, resultVal.type());
+    assertTrue(resultVal.tupleValue().containsValue(
+        ExprValueUtils.stringValue("correct result value")));
+    assertFalse(resultVal.tupleValue().containsValue(
+        ExprValueUtils.stringValue("secondary correct result value")));
+  }
+
+  @Test
+  public void do_nothing_with_missing_value() {
+    Environment<Expression, ExprValue> hlTuple = ExprValueUtils.tupleValue(
+        ImmutableMap.of("NonHighlightField", "ResultValue")).bindingTuples();
+    HighlightExpression expr = new HighlightExpression(DSL.literal("*"));
+    ExprValue resultVal = expr.valueOf(hlTuple);
+
+    assertTrue(resultVal.isMissing());
+  }
+
+  @Test
+  public void highlight_wildcard_test() {
     ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
     var hlBuilder = ImmutableMap.<String, ExprValue>builder();
     hlBuilder.put("Title", ExprValueUtils.stringValue("correct result value"));
     hlBuilder.put("Body", ExprValueUtils.stringValue("incorrect result value"));
     builder.put("_highlight", ExprTupleValue.fromExprValueMap(hlBuilder.build()));
 
-    HighlightExpression hlExpr = new HighlightExpression(DSL.literal("*"));
+    HighlightExpression hlExpr = new HighlightExpression(DSL.literal("T*"));
     ExprValue resultVal = hlExpr.valueOf(
         ExprTupleValue.fromExprValueMap(builder.build()).bindingTuples());
-    assertEquals(ARRAY, resultVal.type());
-    for (var field : resultVal.tupleValue().entrySet()) {
-      assertTrue(field.toString().contains(hlExpr.getHighlightField().toString()));
-    }
+
+    assertEquals(STRUCT, resultVal.type());
     assertTrue(resultVal.tupleValue().containsValue(
-        ExprValueUtils.stringValue("\"correct result value\"")));
-    assertTrue(resultVal.tupleValue().containsValue(
-        ExprValueUtils.stringValue("\"correct result value\"")));
+        ExprValueUtils.stringValue("correct result value")));
+    assertFalse(resultVal.tupleValue().containsValue(
+        ExprValueUtils.stringValue("incorrect result value")));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
@@ -13,6 +13,7 @@ import static org.opensearch.sql.expression.DSL.named;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
@@ -117,8 +118,9 @@ class LogicalPlanNodeVisitorTest {
     assertNull(rareTopN.accept(new LogicalPlanNodeVisitor<Integer, Object>() {
     }, null));
 
+    Map<String, Literal> args = new HashMap<>();
     LogicalPlan highlight = new LogicalHighlight(filter,
-        new LiteralExpression(ExprValueUtils.stringValue("fieldA")));
+        new LiteralExpression(ExprValueUtils.stringValue("fieldA")), args);
     assertNull(highlight.accept(new LogicalPlanNodeVisitor<Integer, Object>() {
     }, null));
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/HighlightFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/HighlightFunctionIT.java
@@ -5,14 +5,18 @@
 
 package org.opensearch.sql.sql;
 
+import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
-import com.google.errorprone.annotations.DoNotCall;
+import com.google.common.collect.ImmutableMap;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.legacy.TestsConstants;
+import java.util.List;
 
 public class HighlightFunctionIT extends SQLIntegTestCase {
 
@@ -25,57 +29,104 @@ public class HighlightFunctionIT extends SQLIntegTestCase {
   public void single_highlight_test() {
     String query = "SELECT Tags, highlight('Tags') FROM %s WHERE match(Tags, 'yeast') LIMIT 1";
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
+
     verifySchema(response, schema("Tags", null, "text"),
         schema("highlight('Tags')", null, "nested"));
     assertEquals(1, response.getInt("total"));
+
+    verifyDataRows(response,
+        rows("alcohol-level yeast home-brew champagne",
+            new JSONArray(List.of("alcohol-level <em>yeast</em> home-brew champagne"))));
   }
 
   @Test
-  public void accepts_unquoted_test() {
-    String query = "SELECT Tags, highlight(Tags) FROM %s WHERE match(Tags, 'yeast') LIMIT 1";
+  public void highlight_optional_arguments_test() {
+    String query = "SELECT highlight('Tags', pre_tags='<mark>', post_tags='</mark>') " +
+        "FROM %s WHERE match(Tags, 'yeast') LIMIT 1";
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
-    verifySchema(response, schema("Tags", null, "text"),
-        schema("highlight(Tags)", null, "nested"));
+
+    verifySchema(response, schema("highlight('Tags', pre_tags='<mark>', post_tags='</mark>')",
+            null, "nested"));
+
     assertEquals(1, response.getInt("total"));
+
+    verifyDataRows(response,
+        rows(new JSONArray(List.of("alcohol-level <mark>yeast</mark> home-brew champagne"))));
+  }
+
+  @Test
+  public void highlight_multiple_optional_arguments_test() {
+    String query = "SELECT highlight(Title), highlight(Body, pre_tags='<mark style=\\\"background-color: " +
+        "green;\\\">', post_tags='</mark>') FROM %s WHERE multi_match([Title, Body], 'IPA') LIMIT 1";
+    JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
+
+    verifySchema(response, schema("highlight(Title)", null, "nested"),
+        schema("highlight(Body, pre_tags='<mark style=\"background-color: green;\">', " +
+                "post_tags='</mark>')", null, "nested"));
+
+    assertEquals(1, response.getInt("total"));
+
+    verifyDataRows(response, rows(new JSONArray(List.of("What are the differences between an <em>IPA</em>" +
+            " and its variants?")),
+        new JSONArray(List.of("<p>I know what makes an <mark style=\"background-color: green;\">IPA</mark>" +
+                " an <mark style=" +
+            "\"background-color: green;\">IPA</mark>, but what are the unique characteristics of it's" +
+                " common variants?",
+            "To be specific, the ones I'm interested in are Double <mark style=\"background-color:" +
+                " green;\">IPA</mark> " +
+                "and Black <mark style=\"background-color: green;\">IPA</mark>, but general differences" +
+                " between"))));
   }
 
   @Test
   public void multiple_highlight_test() {
-    String query = "SELECT highlight(Title), highlight(Body) FROM %s WHERE MULTI_MATCH([Title, Body], 'hops') LIMIT 1";
+    String query = "SELECT highlight(Title), highlight(Tags) FROM %s WHERE MULTI_MATCH([Title, Tags], 'hops') LIMIT 1";
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
     verifySchema(response, schema("highlight(Title)", null, "nested"),
-        schema("highlight(Body)", null, "nested"));
+        schema("highlight(Tags)", null, "nested"));
     assertEquals(1, response.getInt("total"));
+
+    verifyDataRows(response,
+        rows( new JSONArray(List.of("What uses do <em>hops</em> have outside of brewing?")),
+            new JSONArray(List.of("<em>hops</em> history"))));
   }
 
-  // Enable me when * is supported
-  @DoNotCall
+  @Test
   public void wildcard_highlight_test() {
-    String query = "SELECT highlight('*itle') FROM %s WHERE MULTI_MATCH([Title, Body], 'hops') LIMIT 1";
+    String query = "SELECT highlight('*itle') FROM %s WHERE MULTI_MATCH([Title, Tags], 'hops') LIMIT 1";
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
-    verifySchema(response, schema("highlight('*itle')", null, "nested"));
+
+    verifySchema(response, schema("highlight('*itle')", null, "object"));
     assertEquals(1, response.getInt("total"));
+
+    verifyDataRows(response, rows(new JSONObject(ImmutableMap.of(
+        "Title", new JSONArray(List.of("What uses do <em>hops</em> have outside of brewing?"))))));
   }
 
-  // Enable me when * is supported
-  @DoNotCall
+  @Test
   public void wildcard_multi_field_highlight_test() {
     String query = "SELECT highlight('T*') FROM %s WHERE MULTI_MATCH([Title, Tags], 'hops') LIMIT 1";
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
-    verifySchema(response, schema("highlight('T*')", null, "nested"));
-    var resultMap = response.getJSONArray("datarows").getJSONArray(0).getJSONObject(0);
+
+    verifySchema(response, schema("highlight('T*')", null, "object"));
     assertEquals(1, response.getInt("total"));
-    assertTrue(resultMap.has("highlight(\"T*\").Title"));
-    assertTrue(resultMap.has("highlight(\"T*\").Tags"));
+
+    verifyDataRows(response, rows(new JSONObject(ImmutableMap.of(
+        "Title", new JSONArray(List.of("What uses do <em>hops</em> have outside of brewing?")),
+        "Tags", new JSONArray(List.of("<em>hops</em> history"))))));
   }
 
-  // Enable me when * is supported
-  @DoNotCall
+  @Test
   public void highlight_all_test() {
-    String query = "SELECT highlight('*') FROM %s WHERE MULTI_MATCH([Title, Body], 'hops') LIMIT 1";
+    String query = "SELECT highlight('*') FROM %s WHERE MULTI_MATCH([Title, Tags], 'hops') LIMIT 1";
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
-    verifySchema(response, schema("highlight('*')", null, "nested"));
+
+    verifySchema(response, schema("highlight('*')", null, "object"));
     assertEquals(1, response.getInt("total"));
+
+    verifyDataRows(response, rows(new JSONObject(ImmutableMap.of(
+        "Title", new JSONArray(List.of("What uses do <em>hops</em> have outside of brewing?")),
+        "Tags", new JSONArray(List.of("<em>hops</em> history"))))));
   }
 
   @Test
@@ -84,5 +135,15 @@ public class HighlightFunctionIT extends SQLIntegTestCase {
     JSONObject response = executeJdbcRequest(String.format(query, TestsConstants.TEST_INDEX_BEER));
     verifySchema(response, schema("highlight(Body)", null, "nested"));
     assertEquals(2, response.getInt("total"));
+
+    verifyDataRows(response, rows(new JSONArray(List.of("Boiling affects <em>hops</em>, by boiling" +
+            " off the aroma and extracting more of the organic acids that provide"))),
+
+        rows(new JSONArray(List.of("<p>Do <em>hops</em> have (or had in the past) any use outside of brewing beer?",
+            "when-was-the-first-beer-ever-brewed\">dating first modern beers</a> we have the first record" +
+                " of cultivating <em>hops</em>",
+            "predating the first record of use of <em>hops</em> in beer by nearly a century.",
+            "Could the <em>hops</em> have been cultivated for any other purpose than brewing, " +
+                "or can we safely assume if they"))));
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -207,7 +207,8 @@ public class OpenSearchIndex implements Table {
 
     @Override
     public PhysicalPlan visitHighlight(LogicalHighlight node, OpenSearchIndexScan context) {
-      context.getRequestBuilder().pushDownHighlight(node.getHighlightField().toString());
+      context.getRequestBuilder().pushDownHighlight(
+          StringUtils.unquoteText(node.getHighlightField().toString()), node.getArguments());
       return visitChild(node, context);
     }
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchDefaultImplementorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchDefaultImplementorTest.java
@@ -88,6 +88,6 @@ public class OpenSearchDefaultImplementorTest {
         new OpenSearchIndex.OpenSearchDefaultImplementor(indexScan, client);
 
     implementor.visitHighlight(node, indexScan);
-    verify(requestBuilder).pushDownHighlight(any());
+    verify(requestBuilder).pushDownHighlight(any(), any());
   }
 }

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -361,6 +361,8 @@ TIME_ZONE:                          'TIME_ZONE';
 TYPE:                               'TYPE';
 ZERO_TERMS_QUERY:                   'ZERO_TERMS_QUERY';
 HIGHLIGHT:                          'HIGHLIGHT';
+HIGHLIGHT_PRE_TAGS:                 'PRE_TAGS';
+HIGHLIGHT_POST_TAGS:                'POST_TAGS';
 
 // RELEVANCE FUNCTIONS
 MATCH_BOOL_PREFIX:                  'MATCH_BOOL_PREFIX';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -315,7 +315,7 @@ constantFunction
     ;
 
 highlightFunction
-    : HIGHLIGHT LR_BRACKET relevanceField RR_BRACKET
+    : HIGHLIGHT LR_BRACKET relevanceField (COMMA highlightArg)* RR_BRACKET
     ;
 
 scalarFunctionName
@@ -443,6 +443,10 @@ relevanceArg
     : relevanceArgName EQUAL_SYMBOL relevanceArgValue
     ;
 
+highlightArg
+    : highlightArgName EQUAL_SYMBOL highlightArgValue
+    ;
+
 relevanceArgName
     : ALLOW_LEADING_WILDCARD | ANALYZER | ANALYZE_WILDCARD | AUTO_GENERATE_SYNONYMS_PHRASE_QUERY
     | BOOST | CUTOFF_FREQUENCY | DEFAULT_FIELD | DEFAULT_OPERATOR | ENABLE_POSITION_INCREMENTS
@@ -451,6 +455,10 @@ relevanceArgName
     | MAX_EXPANSIONS | MINIMUM_SHOULD_MATCH | OPERATOR | PHRASE_SLOP | PREFIX_LENGTH
     | QUOTE_ANALYZER | QUOTE_FIELD_SUFFIX | REWRITE | SLOP | TIE_BREAKER | TIME_ZONE | TYPE
     | ZERO_TERMS_QUERY
+    ;
+
+highlightArgName
+    : HIGHLIGHT_POST_TAGS | HIGHLIGHT_PRE_TAGS
     ;
 
 relevanceFieldAndWeight
@@ -476,5 +484,9 @@ relevanceQuery
 relevanceArgValue
     : qualifiedName
     | constant
+    ;
+
+highlightArgValue
+    : stringLiteral
     ;
 

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -50,6 +50,7 @@ import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.WindowFunc
 import static org.opensearch.sql.sql.parser.ParserUtils.createSortOption;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -137,7 +138,15 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitHighlightFunctionCall(
       OpenSearchSQLParser.HighlightFunctionCallContext ctx) {
-    return new HighlightFunction(visit(ctx.highlightFunction().relevanceField()));
+    ImmutableMap.Builder<String, Literal> builder = ImmutableMap.builder();
+    ctx.highlightFunction().highlightArg().forEach(v -> builder.put(
+        v.highlightArgName().getText().toLowerCase(),
+        new Literal(StringUtils.unquoteText(v.highlightArgValue().getText()),
+            DataType.STRING))
+    );
+
+    return new HighlightFunction(visit(ctx.highlightFunction().relevanceField()),
+        builder.build());
   }
 
   @Override

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -33,7 +33,9 @@ import static org.opensearch.sql.utils.SystemIndexUtils.TABLE_INFO;
 import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
 import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.AllFields;
+import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
@@ -731,18 +735,36 @@ class AstBuilderTest {
 
   @Test
   public void can_build_qualified_name_highlight() {
+    Map<String, Literal> args = new HashMap<>();
     assertEquals(
         project(relation("test"),
-            alias("highlight(fieldA)", highlight(AstDSL.qualifiedName("fieldA")))),
+            alias("highlight(fieldA)",
+                highlight(AstDSL.qualifiedName("fieldA"), args))),
         buildAST("SELECT highlight(fieldA) FROM test")
     );
   }
 
   @Test
-  public void can_build_string_literal_highlight() {
+  public void can_build_qualified_highlight_with_arguments() {
+    Map<String, Literal> args = new HashMap<>();
+    args.put("pre_tags", new Literal("<mark>", DataType.STRING));
+    args.put("post_tags", new Literal("</mark>", DataType.STRING));
     assertEquals(
         project(relation("test"),
-            alias("highlight(\"fieldA\")", highlight(AstDSL.stringLiteral("fieldA")))),
+            alias("highlight(fieldA, pre_tags='<mark>', post_tags='</mark>')",
+                highlight(AstDSL.qualifiedName("fieldA"), args))),
+        buildAST("SELECT highlight(fieldA, pre_tags='<mark>', post_tags='</mark>') "
+            + "FROM test")
+    );
+  }
+
+  @Test
+  public void can_build_string_literal_highlight() {
+    Map<String, Literal> args = new HashMap<>();
+    assertEquals(
+        project(relation("test"),
+            alias("highlight(\"fieldA\")",
+                highlight(AstDSL.stringLiteral("fieldA"), args))),
         buildAST("SELECT highlight(\"fieldA\") FROM test")
     );
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -13,7 +13,6 @@ import static org.opensearch.sql.ast.dsl.AstDSL.booleanLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.caseWhen;
 import static org.opensearch.sql.ast.dsl.AstDSL.dateLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.doubleLiteral;
-import static org.opensearch.sql.ast.dsl.AstDSL.floatLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.function;
 import static org.opensearch.sql.ast.dsl.AstDSL.highlight;
 import static org.opensearch.sql.ast.dsl.AstDSL.intLiteral;
@@ -35,12 +34,14 @@ import static org.opensearch.sql.ast.tree.Sort.SortOrder.DESC;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.RelevanceFieldList;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.common.antlr.CaseInsensitiveCharStream;
@@ -311,16 +312,18 @@ class AstExpressionBuilderTest {
 
   @Test
   public void canBuildStringLiteralHighlightFunction() {
+    HashMap<String, Literal> args = new HashMap<>();
     assertEquals(
-        highlight(AstDSL.stringLiteral("fieldA")),
+        highlight(AstDSL.stringLiteral("fieldA"), args),
         buildExprAst("highlight(\"fieldA\")")
     );
   }
 
   @Test
   public void canBuildQualifiedNameHighlightFunction() {
+    HashMap<String, Literal> args = new HashMap<>();
     assertEquals(
-        highlight(AstDSL.qualifiedName("fieldA")),
+        highlight(AstDSL.qualifiedName("fieldA"), args),
         buildExprAst("highlight(fieldA)")
     );
   }


### PR DESCRIPTION
### Description
Add support for wildcard in SQL with optional arguments `pre_tags` and `post_tags`.
 
### Sample Query

`select highlight('Body'), highlight('T*') from beer where multi_match([Title, Body, Tags], 'taste');`

### Issues Resolved
Issue: [636](https://github.com/opensearch-project/sql/issues/636)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).