### PR TITLE
Fix EqualsAndHashCode Annotation Warning Messages

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/physical/AggregationOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/AggregationOperator.java
@@ -25,7 +25,7 @@ import org.opensearch.sql.storage.bindingtuple.BindingTuple;
  * Group the all the input {@link BindingTuple} by {@link AggregationOperator#groupByExprList},
  * calculate the aggregation result by using {@link AggregationOperator#aggregatorList}.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @ToString
 public class AggregationOperator extends PhysicalPlan {
   @Getter

--- a/core/src/main/java/org/opensearch/sql/planner/physical/DedupeOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/DedupeOperator.java
@@ -26,7 +26,7 @@ import org.opensearch.sql.storage.bindingtuple.BindingTuple;
  * DedupeOperator#dedupeList} The result order follow the input order.
  */
 @Getter
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class DedupeOperator extends PhysicalPlan {
   @Getter
   private final PhysicalPlan input;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/FilterOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/FilterOperator.java
@@ -21,7 +21,7 @@ import org.opensearch.sql.storage.bindingtuple.BindingTuple;
  * The Filter operator only return the results that evaluated to true.
  * The NULL and MISSING are handled by the logic defined in {@link BinaryPredicateOperator}.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @ToString
 @RequiredArgsConstructor
 public class FilterOperator extends PhysicalPlan {

--- a/core/src/main/java/org/opensearch/sql/planner/physical/LimitOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/LimitOperator.java
@@ -28,7 +28,7 @@ import org.opensearch.sql.data.model.ExprValue;
 @RequiredArgsConstructor
 @Getter
 @ToString
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class LimitOperator extends PhysicalPlan {
   private final PhysicalPlan input;
   private final Integer limit;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/ProjectOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/ProjectOperator.java
@@ -26,7 +26,7 @@ import org.opensearch.sql.expression.ParseExpression;
  * Project the fields specified in {@link ProjectOperator#projectList} from input.
  */
 @ToString
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @RequiredArgsConstructor
 public class ProjectOperator extends PhysicalPlan {
   @Getter

--- a/core/src/main/java/org/opensearch/sql/planner/physical/RareTopNOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/RareTopNOperator.java
@@ -33,7 +33,7 @@ import org.opensearch.sql.storage.bindingtuple.BindingTuple;
  * Calculate the rare result by using the {@link RareTopNOperator#fieldExprList}.
  */
 @ToString
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class RareTopNOperator extends PhysicalPlan {
 
   @Getter

--- a/core/src/main/java/org/opensearch/sql/planner/physical/RemoveOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/RemoveOperator.java
@@ -28,7 +28,7 @@ import org.opensearch.sql.expression.ReferenceExpression;
  * Remove the fields specified in {@link RemoveOperator#removeList} from input.
  */
 @ToString
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class RemoveOperator extends PhysicalPlan {
   @Getter
   private final PhysicalPlan input;

--- a/core/src/main/java/org/opensearch/sql/planner/physical/RenameOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/RenameOperator.java
@@ -28,7 +28,7 @@ import org.opensearch.sql.storage.bindingtuple.BindingTuple;
  * The mapping maintain the relation between source and target.
  * it means BindingTuple.resolve(target) = BindingTuple.resolve(source).
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @ToString
 public class RenameOperator extends PhysicalPlan {
   @Getter

--- a/core/src/main/java/org/opensearch/sql/planner/physical/SortOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/SortOperator.java
@@ -32,7 +32,7 @@ import org.opensearch.sql.planner.physical.SortOperator.Sorter.SorterBuilder;
  * The count indicate how many sorted result should been return.
  */
 @ToString
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class SortOperator extends PhysicalPlan {
   @Getter
   private final PhysicalPlan input;


### PR DESCRIPTION
### Description
Fix warning messages in GitHub actions associated with EqualsAndHashCode annotations.

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).