### PR TITLE
Update com.fasterxml.jackson to 2.13.4 to match opensearch repo.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.4.0-SNAPSHOT")
         spring_version = "5.3.22"
-        jackson_version = "2.13.3"
+        jackson_version = "2.13.4"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION


### Description
`./gradlew compile` currently fails because sql plugin uses jackson 2.13.3, but opensearch snapshot it depends on is now on [2.13.4](https://github.com/opensearch-project/OpenSearch/pull/4556).

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: MaxKsyunz <maxk@bitquilltech.com>