### PR TITLE
Trigger build on pull request synchronize action.

### DIFF
--- a/.github/workflows/bi-connectors.yml
+++ b/.github/workflows/bi-connectors.yml
@@ -2,7 +2,6 @@ name: Build connectors for BI tools
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
     paths:
       - 'bi-connectors/PowerBIConnector/**'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - '[1-9]+.[0-9x]+'
-    types: [opened, reopened]
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -2,7 +2,6 @@ name: Release Drafter
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
     branches:
       - 'main'

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -2,7 +2,6 @@ name: Link Checker
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
     branches:
       - 'main'

--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -2,7 +2,6 @@ name: SQL CLI Test and Build
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/sql-jdbc-test-and-build-workflow.yml
+++ b/.github/workflows/sql-jdbc-test-and-build-workflow.yml
@@ -2,7 +2,6 @@ name: SQL JDBC Java CI
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -2,7 +2,6 @@ name: OpenSearch ODBC Driver
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -2,7 +2,6 @@ name: SQL Java CI
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -2,7 +2,6 @@ name: SQL Workbench Test and Build
 
 on:
   pull_request:
-    types: [opened, reopened]
   push:
     branches-ignore:
       - 'dependabot/**'


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
Build is not getting triggered on updating PR with new commits.
Removed types under pull_request. This would default to opened, reopened, synchronize.
Ref for synchronize def: https://frontside.com/blog/2020-05-26-github-actions-pull_request/
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).