### PR TITLE
Table function for supporting prometheus query_range function

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -50,6 +50,7 @@ import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
+import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.Values;
 
 /**
@@ -90,6 +91,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitRelationSubquery(RelationSubquery node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitTableFunction(TableFunction node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -57,6 +57,7 @@ import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
+import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
 
@@ -85,6 +86,10 @@ public class AstDSL {
 
   public UnresolvedPlan relation(String tableName, String alias) {
     return new Relation(qualifiedName(tableName), alias);
+  }
+
+  public UnresolvedPlan tableFunction(List<String> functionName, UnresolvedExpression... args) {
+    return new TableFunction(new QualifiedName(functionName), Arrays.asList(args));
   }
 
   public static UnresolvedPlan project(UnresolvedPlan input, UnresolvedExpression... projectList) {

--- a/core/src/main/java/org/opensearch/sql/ast/tree/TableFunction.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/TableFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.Let;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+/**
+ * ASTNode for Table Function.
+ */
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class TableFunction extends UnresolvedPlan {
+
+  private final UnresolvedExpression functionName;
+
+  @Getter
+  private final List<UnresolvedExpression> arguments;
+
+  public QualifiedName getFunctionName() {
+    return (QualifiedName) functionName;
+  }
+
+  @Override
+  public List<UnresolvedPlan> getChild() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitTableFunction(this, context);
+  }
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    return null;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -118,7 +118,7 @@ public class DSL {
     return new NamedAggregator(name, aggregator);
   }
 
-  public NamedArgumentExpression namedArgument(String argName, Expression value) {
+  public static NamedArgumentExpression namedArgument(String argName, Expression value) {
     return new NamedArgumentExpression(argName, value);
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/TableFunctionImplementation.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/TableFunctionImplementation.java
@@ -1,0 +1,19 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.expression.function;
+
+import org.opensearch.sql.storage.Table;
+
+/**
+ * Interface for table function which returns Table when executed.
+ */
+public interface TableFunctionImplementation extends FunctionImplementation {
+
+  Table applyArguments();
+
+}

--- a/core/src/main/java/org/opensearch/sql/storage/StorageEngine.java
+++ b/core/src/main/java/org/opensearch/sql/storage/StorageEngine.java
@@ -6,6 +6,10 @@
 
 package org.opensearch.sql.storage;
 
+import java.util.Collection;
+import java.util.Collections;
+import org.opensearch.sql.expression.function.FunctionResolver;
+
 /**
  * Storage engine for different storage to provide data access API implementation.
  */
@@ -15,4 +19,14 @@ public interface StorageEngine {
    * Get {@link Table} from storage engine.
    */
   Table getTable(String name);
+
+  /**
+   * Get list of catalog related functions.
+   *
+   * @return FunctionResolvers of catalog functions.
+   */
+  default Collection<FunctionResolver> getFunctions() {
+    return Collections.emptyList();
+  }
+
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -22,6 +22,8 @@ import static org.opensearch.sql.ast.dsl.AstDSL.intLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.ast.dsl.AstDSL.relation;
 import static org.opensearch.sql.ast.dsl.AstDSL.span;
+import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.unresolvedArg;
 import static org.opensearch.sql.ast.tree.Sort.NullOrder;
 import static org.opensearch.sql.ast.tree.Sort.SortOption;
 import static org.opensearch.sql.ast.tree.Sort.SortOption.DEFAULT_ASC;
@@ -40,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -56,6 +59,7 @@ import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.AD;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.HighlightExpression;
@@ -64,6 +68,7 @@ import org.opensearch.sql.expression.window.WindowDefinition;
 import org.opensearch.sql.planner.logical.LogicalAD;
 import org.opensearch.sql.planner.logical.LogicalMLCommons;
 import org.opensearch.sql.planner.logical.LogicalPlanDSL;
+import org.opensearch.sql.planner.logical.LogicalRelation;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -925,9 +930,9 @@ class AnalyzerTest extends AnalyzerTestBase {
   @Test
   public void ad_batchRCF_relation() {
     Map<String, Literal> argumentMap =
-            new HashMap<String, Literal>() {{
-                put("shingle_size", new Literal(8, DataType.INTEGER));
-            }};
+        new HashMap<String, Literal>() {{
+            put("shingle_size", new Literal(8, DataType.INTEGER));
+          }};
     assertAnalyzeEqual(
         new LogicalAD(LogicalPlanDSL.relation("schema", table), argumentMap),
         new AD(AstDSL.relation("schema"), argumentMap)
@@ -947,4 +952,51 @@ class AnalyzerTest extends AnalyzerTestBase {
         new AD(AstDSL.relation("schema"), argumentMap)
     );
   }
+
+
+  @Test
+  public void table_function() {
+    assertAnalyzeEqual(new LogicalRelation("query_range", table),
+        AstDSL.tableFunction(List.of("prometheus", "query_range"),
+            unresolvedArg("query", stringLiteral("http_latency")),
+            unresolvedArg("starttime", intLiteral(12345)),
+            unresolvedArg("endtime", intLiteral(12345)),
+            unresolvedArg("step", intLiteral(14))));
+  }
+
+  @Test
+  public void table_function_with_no_catalog() {
+    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
+        () -> analyze(AstDSL.tableFunction(List.of("query_range"),
+            unresolvedArg("query", stringLiteral("http_latency")),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg(null, intLiteral(14)))));
+    assertEquals("unsupported function name: query_range",
+        exception.getMessage());
+  }
+
+  @Test
+  public void table_function_with_wrong_catalog() {
+    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
+        () -> analyze(AstDSL.tableFunction(Arrays.asList("prome", "query_range"),
+            unresolvedArg("query", stringLiteral("http_latency")),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg(null, intLiteral(14)))));
+    assertEquals("unsupported function name: prome.query_range", exception.getMessage());
+  }
+
+  @Test
+  public void table_function_with_wrong_table_function() {
+    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
+        () -> analyze(AstDSL.tableFunction(Arrays.asList("prometheus", "queryrange"),
+            unresolvedArg("query", stringLiteral("http_latency")),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg("", intLiteral(12345)),
+            unresolvedArg(null, intLiteral(14)))));
+    assertEquals("unsupported function name: queryrange", exception.getMessage());
+  }
+
+
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -7,13 +7,19 @@
 package org.opensearch.sql.analysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.swing.JTable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.analysis.symbol.Namespace;
 import org.opensearch.sql.analysis.symbol.Symbol;
 import org.opensearch.sql.analysis.symbol.SymbolTable;
+import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.catalog.CatalogService;
 import org.opensearch.sql.config.TestConfig;
@@ -24,6 +30,11 @@ import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.expression.function.TableFunctionImplementation;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.storage.StorageEngine;
@@ -115,9 +126,27 @@ public class AnalyzerTestBase {
 
   @Bean
   protected Analyzer analyzer(ExpressionAnalyzer expressionAnalyzer, CatalogService catalogService,
-                              StorageEngine storageEngine) {
+                      StorageEngine storageEngine, BuiltinFunctionRepository functionRepository,
+                      Table table) {
     catalogService.registerOpenSearchStorageEngine(storageEngine);
-    return new Analyzer(expressionAnalyzer, catalogService);
+    functionRepository.register("prometheus", new FunctionResolver() {
+
+      @Override
+      public Pair<FunctionSignature, FunctionBuilder> resolve(
+          FunctionSignature unresolvedSignature) {
+        FunctionName functionName = FunctionName.of("query_range");
+        FunctionSignature functionSignature =
+            new FunctionSignature(functionName, List.of(STRING, LONG, LONG, LONG));
+        return Pair.of(functionSignature,
+            args -> new TestTableFunctionImplementation(functionName, args, table));
+      }
+
+      @Override
+      public FunctionName getFunctionName() {
+        return FunctionName.of("query_range");
+      }
+    });
+    return new Analyzer(expressionAnalyzer, catalogService, functionRepository);
   }
 
   @Bean
@@ -160,6 +189,37 @@ public class AnalyzerTestBase {
     @Override
     public void registerOpenSearchStorageEngine(StorageEngine storageEngine) {
       this.storageEngine = storageEngine;
+    }
+  }
+
+  private class TestTableFunctionImplementation implements TableFunctionImplementation {
+
+    private FunctionName functionName;
+
+    private List<Expression> arguments;
+
+    private Table table;
+
+    public TestTableFunctionImplementation(FunctionName functionName, List<Expression> arguments,
+                                           Table table) {
+      this.functionName = functionName;
+      this.arguments = arguments;
+      this.table = table;
+    }
+
+    @Override
+    public FunctionName getFunctionName() {
+      return functionName;
+    }
+
+    @Override
+    public List<Expression> getArguments() {
+      return this.arguments;
+    }
+
+    @Override
+    public Table applyArguments() {
+      return table;
     }
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
@@ -6,11 +6,13 @@
 package org.opensearch.sql.expression.datetime;
 
 import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
+import static org.opensearch.sql.expression.function.BuiltinFunctionRepository.DEFAULT_NAMESPACE;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -45,7 +47,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   protected BuiltinFunctionRepository functionRepository;
 
   protected FunctionExpression maketime(Expression hour, Expression minute, Expression second) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("maketime"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("maketime"),
         List.of(DOUBLE, DOUBLE, DOUBLE)));
     return (FunctionExpression)func.apply(List.of(hour, minute, second));
   }
@@ -56,7 +59,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression makedate(Expression year, Expression dayOfYear) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("makedate"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("makedate"),
         List.of(DOUBLE, DOUBLE)));
     return (FunctionExpression)func.apply(List.of(year, dayOfYear));
   }
@@ -66,7 +70,7 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression unixTimeStampExpr() {
-    var func = functionRepository.resolve(
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
         new FunctionSignature(new FunctionName("unix_timestamp"), List.of()));
     return (FunctionExpression)func.apply(List.of());
   }
@@ -76,7 +80,8 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression unixTimeStampOf(Expression value) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("unix_timestamp"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("unix_timestamp"),
         List.of(value.type())));
     return (FunctionExpression)func.apply(List.of(value));
   }
@@ -98,13 +103,15 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected FunctionExpression fromUnixTime(Expression value) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("from_unixtime"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("from_unixtime"),
         List.of(value.type())));
     return (FunctionExpression)func.apply(List.of(value));
   }
 
   protected FunctionExpression fromUnixTime(Expression value, Expression format) {
-    var func = functionRepository.resolve(new FunctionSignature(new FunctionName("from_unixtime"),
+    var func = functionRepository.resolve(Collections.singletonList(DEFAULT_NAMESPACE),
+        new FunctionSignature(new FunctionName("from_unixtime"),
         List.of(value.type(), format.type())));
     return (FunctionExpression)func.apply(List.of(value, format));
   }

--- a/core/src/test/java/org/opensearch/sql/storage/StorageEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/storage/StorageEngineTest.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.storage;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StorageEngineTest {
+
+
+  @Test
+  void testFunctionsMethod() {
+    StorageEngine k = new StorageEngine() {
+      @Override
+      public Table getTable(String name) {
+        return null;
+      }
+    };
+    Assertions.assertEquals(Collections.emptyList(), k.getFunctions());
+  }
+
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     api project(":ppl")
     api project(':legacy')
     api project(':opensearch')
+    api project(':prometheus')
 }
 
 test {

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -181,7 +181,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin, Rel
 
   @Override
   public void reload(Settings settings) {
-    CatalogServiceImpl.getInstance().loadConnectors(clusterService.getSettings());
+    CatalogServiceImpl.getInstance().loadConnectors(settings);
     CatalogServiceImpl.getInstance().registerOpenSearchStorageEngine(openSearchStorageEngine());
   }
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/catalog/CatalogServiceImpl.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/catalog/CatalogServiceImpl.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,6 +28,9 @@ import org.opensearch.sql.catalog.CatalogService;
 import org.opensearch.sql.catalog.model.CatalogMetadata;
 import org.opensearch.sql.catalog.model.ConnectorType;
 import org.opensearch.sql.opensearch.security.SecurityAccess;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.client.PrometheusClientImpl;
+import org.opensearch.sql.prometheus.storage.PrometheusStorageEngine;
 import org.opensearch.sql.storage.StorageEngine;
 
 /**
@@ -113,7 +118,11 @@ public class CatalogServiceImpl implements CatalogService {
     ConnectorType connector = catalog.getConnector();
     switch (connector) {
       case PROMETHEUS:
-        storageEngine = null;
+        PrometheusClient
+            prometheusClient =
+            new PrometheusClientImpl(new OkHttpClient(),
+                new URI(catalog.getUri()));
+        storageEngine = new PrometheusStorageEngine(prometheusClient);
         break;
       default:
         LOG.info(

--- a/plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugin/src/main/plugin-metadata/plugin-security.policy
@@ -11,4 +11,6 @@ grant {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "getClassLoader";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+  permission java.net.NetPermission "getProxySelector";
+  permission java.net.SocketPermission "*", "accept,connect,resolve";
 };

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -147,6 +147,8 @@ adParameter
 fromClause
     : SOURCE EQUAL tableSourceClause
     | INDEX EQUAL tableSourceClause
+    | SOURCE EQUAL tableFunction
+    | INDEX EQUAL tableFunction
     ;
 
 tableSourceClause
@@ -273,6 +275,10 @@ tableSource
     | ID_DATE_SUFFIX
     ;
 
+tableFunction
+    : qualifiedName LT_PRTHS functionArgs RT_PRTHS
+    ;
+
 /** fields */
 fieldList
     : fieldExpression (COMMA fieldExpression)*
@@ -342,7 +348,7 @@ functionArgs
     ;
 
 functionArg
-    : valueExpression
+    : (ident EQUAL)? valueExpression
     ;
 
 relevanceArg

--- a/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
@@ -86,7 +86,7 @@ public class PPLService {
         anonymizer.anonymizeData(ast));
     // 2.Analyze abstract syntax to generate logical plan
     LogicalPlan logicalPlan =
-        new Analyzer(new ExpressionAnalyzer(repository), catalogService).analyze(
+        new Analyzer(new ExpressionAnalyzer(repository), catalogService, repository).analyze(
             UnresolvedPlanHelper.addSelectAll(ast),
             new AnalysisContext());
 

--- a/ppl/src/main/java/org/opensearch/sql/ppl/config/PPLServiceConfig.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/config/PPLServiceConfig.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.ppl.config;
 
 import org.opensearch.sql.catalog.CatalogService;
+import org.opensearch.sql.catalog.model.ConnectorType;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
@@ -38,6 +39,10 @@ public class PPLServiceConfig {
    */
   @Bean
   public PPLService pplService() {
+    catalogService.getCatalogs()
+        .forEach(catalog -> catalogService.getStorageEngine(catalog)
+            .getFunctions()
+            .forEach(functionResolver -> functionRepository.register(catalog, functionResolver)));
     return new PPLService(new PPLSyntaxParser(), executionEngine,
             functionRepository, catalogService);
   }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -39,6 +39,7 @@ import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
+import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
@@ -76,6 +77,16 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
   @Override
   public String visitRelation(Relation node, String context) {
     return StringUtils.format("source=%s", node.getTableName());
+  }
+
+  @Override
+  public String visitTableFunction(TableFunction node, String context) {
+    String arguments =
+        node.getArguments().stream()
+            .map(unresolvedExpression
+                -> this.expressionAnalyzer.analyze(unresolvedExpression, context))
+            .collect(Collectors.joining(","));
+    return StringUtils.format("source=%s(%s)", node.getFunctionName().toString(), arguments);
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/PPLServiceTest.java
@@ -8,11 +8,14 @@ package org.opensearch.sql.ppl;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +30,12 @@ import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponseNode;
 import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.expression.function.FunctionSignature;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.ppl.config.PPLServiceConfig;
 import org.opensearch.sql.ppl.domain.PPLQueryRequest;
@@ -50,6 +59,12 @@ public class PPLServiceTest {
   private CatalogService catalogService;
 
   @Mock
+  private BuiltinFunctionRepository functionRepository;
+
+  @Mock
+  private DSL dsl;
+
+  @Mock
   private Table table;
 
   @Mock
@@ -57,6 +72,9 @@ public class PPLServiceTest {
 
   @Mock
   private ExecutionEngine.Schema schema;
+
+  @Mock
+  private FunctionResolver functionResolver;
 
   /**
    * Setup the test context.
@@ -66,6 +84,9 @@ public class PPLServiceTest {
     when(table.getFieldTypes()).thenReturn(ImmutableMap.of("a", ExprCoreType.INTEGER));
     when(table.implement(any())).thenReturn(plan);
     when(storageEngine.getTable(any())).thenReturn(table);
+    when(catalogService.getCatalogs()).thenReturn(Set.of("prometheus"));
+    when(catalogService.getStorageEngine("prometheus")).thenReturn(storageEngine);
+    when(storageEngine.getFunctions()).thenReturn(Collections.singleton(functionResolver));
 
     context.registerBean(StorageEngine.class, () -> storageEngine);
     context.registerBean(ExecutionEngine.class, () -> executionEngine);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -38,9 +38,12 @@ import static org.opensearch.sql.ast.dsl.AstDSL.rename;
 import static org.opensearch.sql.ast.dsl.AstDSL.sort;
 import static org.opensearch.sql.ast.dsl.AstDSL.span;
 import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.tableFunction;
+import static org.opensearch.sql.ast.dsl.AstDSL.unresolvedArg;
 import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,6 +94,29 @@ public class AstBuilderTest {
     assertEqual("search source = http_requests_total.test",
         relation(qualifiedName("http_requests_total","test"))
     );
+  }
+
+  @Test
+  public void testSearchWithPrometheusQueryRangeWithPositionedArguments() {
+    assertEqual("search source = prometheus.query_range(\"test{code='200'}\",1234, 12345, 3)",
+        tableFunction(Arrays.asList("prometheus", "query_range"),
+            unresolvedArg(null, stringLiteral("test{code='200'}")),
+            unresolvedArg(null, intLiteral(1234)),
+            unresolvedArg(null, intLiteral(12345)),
+            unresolvedArg(null, intLiteral(3))
+    ));
+  }
+
+  @Test
+  public void testSearchWithPrometheusQueryRangeWithNamedArguments() {
+    assertEqual("search source = prometheus.query_range(query = \"test{code='200'}\", "
+            + "starttime = 1234, step=3, endtime=12345)",
+        tableFunction(Arrays.asList("prometheus", "query_range"),
+            unresolvedArg("query", stringLiteral("test{code='200'}")),
+            unresolvedArg("starttime", intLiteral(1234)),
+            unresolvedArg("step", intLiteral(3)),
+            unresolvedArg("endtime", intLiteral(12345))
+        ));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -39,6 +39,13 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testTableFunctionCommand() {
+    assertEquals("source=prometheus.query_range(***,***,***,***)",
+        anonymize("source=prometheus.query_range('afsd',123,123,3)")
+    );
+  }
+
+  @Test
   public void testPrometheusPPLCommand() {
     assertEquals("source=prometheus.http_requests_process",
         anonymize("source=prometheus.http_requests_process")

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/implementation/QueryRangeFunctionImplementation.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/implementation/QueryRangeFunctionImplementation.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.functions.implementation;
+
+import static org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver.ENDTIME;
+import static org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver.QUERY;
+import static org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver.STARTTIME;
+import static org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver.STEP;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.TableFunctionImplementation;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+import org.opensearch.sql.prometheus.storage.PrometheusMetricTable;
+import org.opensearch.sql.storage.Table;
+
+public class QueryRangeFunctionImplementation extends FunctionExpression implements
+    TableFunctionImplementation {
+
+  private final FunctionName functionName;
+  private final List<Expression> arguments;
+  private final PrometheusClient prometheusClient;
+
+  /**
+   * Required argument constructor.
+   *
+   * @param functionName name of the function
+   * @param arguments    a list of expressions
+   */
+  public QueryRangeFunctionImplementation(FunctionName functionName, List<Expression> arguments,
+                                          PrometheusClient prometheusClient) {
+    super(functionName, arguments);
+    this.functionName = functionName;
+    this.arguments = arguments;
+    this.prometheusClient = prometheusClient;
+  }
+
+  @Override
+  public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+    throw new UnsupportedOperationException(String.format(
+        "Prometheus defined function [%s] is only "
+            + "supported in SOURCE clause with prometheus connector catalog",
+        functionName));
+  }
+
+  @Override
+  public ExprType type() {
+    return ExprCoreType.STRUCT;
+  }
+
+  @Override
+  public String toString() {
+    List<String> args = arguments.stream()
+        .map(arg -> String.format("%s=%s", ((NamedArgumentExpression) arg)
+            .getArgName(), ((NamedArgumentExpression) arg).getValue().toString()))
+        .collect(Collectors.toList());
+    return String.format("%s(%s)", functionName, String.join(", ", args));
+  }
+
+  @Override
+  public Table applyArguments() {
+    return new PrometheusMetricTable(prometheusClient, buildQueryFromQueryRangeFunction(arguments));
+  }
+
+  private PrometheusQueryRequest buildQueryFromQueryRangeFunction(List<Expression> arguments) {
+
+    PrometheusQueryRequest prometheusQueryRequest = new PrometheusQueryRequest();
+    arguments.forEach(arg -> {
+      String argName = ((NamedArgumentExpression) arg).getArgName();
+      Expression argValue = ((NamedArgumentExpression) arg).getValue();
+      ExprValue literalValue = argValue.valueOf(null);
+      switch (argName) {
+        case QUERY:
+          prometheusQueryRequest
+              .getPromQl().append((String) literalValue.value());
+          break;
+        case STARTTIME:
+          prometheusQueryRequest.setStartTime(((Number) literalValue.value()).longValue());
+          break;
+        case ENDTIME:
+          prometheusQueryRequest.setEndTime(((Number) literalValue.value()).longValue());
+          break;
+        case STEP:
+          prometheusQueryRequest.setStep(literalValue.value().toString());
+          break;
+        default:
+          throw new ExpressionEvaluationException(
+              String.format("Invalid Function Argument:%s", argName));
+      }
+    });
+    return prometheusQueryRequest;
+  }
+
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/resolver/QueryRangeTableFunctionResolver.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/resolver/QueryRangeTableFunctionResolver.java
@@ -1,0 +1,98 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.functions.resolver;
+
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.implementation.QueryRangeFunctionImplementation;
+
+@RequiredArgsConstructor
+public class QueryRangeTableFunctionResolver implements FunctionResolver {
+
+  private final PrometheusClient prometheusClient;
+
+  public static final String QUERY_RANGE = "query_range";
+  public static final String QUERY = "query";
+  public static final String STARTTIME = "starttime";
+  public static final String ENDTIME = "endtime";
+  public static final String STEP = "step";
+
+  @Override
+  public Pair<FunctionSignature, FunctionBuilder> resolve(FunctionSignature unresolvedSignature) {
+    FunctionName functionName = FunctionName.of(QUERY_RANGE);
+    FunctionSignature functionSignature =
+        new FunctionSignature(functionName, List.of(STRING, LONG, LONG, LONG));
+    final List<String> argumentNames = List.of(QUERY, STARTTIME, ENDTIME, STEP);
+
+    FunctionBuilder functionBuilder = arguments -> {
+      Boolean argumentsPassedByName = arguments.stream()
+          .noneMatch(arg -> StringUtils.isEmpty(((NamedArgumentExpression) arg).getArgName()));
+      Boolean argumentsPassedByPosition = arguments.stream()
+          .allMatch(arg -> StringUtils.isEmpty(((NamedArgumentExpression) arg).getArgName()));
+      if (!(argumentsPassedByName || argumentsPassedByPosition)) {
+        throw new SemanticCheckException("Arguments should be either passed by name or position");
+      }
+
+      if (arguments.size() != argumentNames.size()) {
+        throw new SemanticCheckException(
+            generateErrorMessageForMissingArguments(argumentsPassedByPosition, arguments,
+                argumentNames));
+      }
+
+      if (argumentsPassedByPosition) {
+        List<Expression> namedArguments = new ArrayList<>();
+        for (int i = 0; i < arguments.size(); i++) {
+          namedArguments.add(new NamedArgumentExpression(argumentNames.get(i),
+              ((NamedArgumentExpression) arguments.get(i)).getValue()));
+        }
+        return new QueryRangeFunctionImplementation(functionName, namedArguments, prometheusClient);
+      }
+      return new QueryRangeFunctionImplementation(functionName, arguments, prometheusClient);
+    };
+    return Pair.of(functionSignature, functionBuilder);
+  }
+
+  private String generateErrorMessageForMissingArguments(Boolean argumentsPassedByPosition,
+                                                         List<Expression> arguments,
+                                                         List<String> argumentNames) {
+    if (argumentsPassedByPosition) {
+      return String.format("Missing arguments:[%s]",
+          String.join(",", argumentNames.subList(arguments.size(), argumentNames.size())));
+    } else {
+      Set<String> requiredArguments = new HashSet<>(argumentNames);
+      Set<String> providedArguments =
+          arguments.stream().map(expression -> ((NamedArgumentExpression) expression).getArgName())
+              .collect(Collectors.toSet());
+      requiredArguments.removeAll(providedArguments);
+      return String.format("Missing arguments:[%s]", String.join(",", requiredArguments));
+    }
+  }
+
+  @Override
+  public FunctionName getFunctionName() {
+    return FunctionName.of(QUERY_RANGE);
+  }
+
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/request/PrometheusQueryRequest.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/request/PrometheusQueryRequest.java
@@ -6,6 +6,7 @@
 
 package org.opensearch.sql.prometheus.request;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,6 +19,7 @@ import org.opensearch.common.unit.TimeValue;
 @EqualsAndHashCode
 @Getter
 @ToString
+@AllArgsConstructor
 public class PrometheusQueryRequest {
 
   public static final TimeValue DEFAULT_QUERY_TIMEOUT = TimeValue.timeValueMinutes(1L);

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricScan.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricScan.java
@@ -11,6 +11,7 @@ import java.security.PrivilegedAction;
 import java.util.Iterator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,8 +33,9 @@ public class PrometheusMetricScan extends TableScanOperator {
 
   @EqualsAndHashCode.Include
   @Getter
+  @Setter
   @ToString.Include
-  private final PrometheusQueryRequest request;
+  private PrometheusQueryRequest request;
 
   private Iterator<ExprValue> iterator;
 

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTable.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTable.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.prometheus.storage;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.request.PrometheusDescribeMetricRequest;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+import org.opensearch.sql.prometheus.storage.implementor.PrometheusDefaultImplementor;
+import org.opensearch.sql.storage.Table;
+
+/**
+ * Prometheus table (metric) implementation.
+ */
+public class PrometheusMetricTable implements Table {
+
+  private final PrometheusClient prometheusClient;
+
+  @Getter
+  private final Optional<String> metricName;
+
+  @Getter
+  private final Optional<PrometheusQueryRequest> prometheusQueryRequest;
+
+
+  /**
+   * The cached mapping of field and type in index.
+   */
+  private Map<String, ExprType> cachedFieldTypes = null;
+
+  /**
+   * Constructor only with metric name.
+   */
+  public PrometheusMetricTable(PrometheusClient prometheusService, @Nonnull String metricName) {
+    this.prometheusClient = prometheusService;
+    this.metricName = Optional.of(metricName);
+    this.prometheusQueryRequest = Optional.empty();
+  }
+
+  /**
+   * Constructor for entire promQl Request.
+   */
+  public PrometheusMetricTable(PrometheusClient prometheusService,
+                               @Nonnull PrometheusQueryRequest prometheusQueryRequest) {
+    this.prometheusClient = prometheusService;
+    this.metricName = Optional.empty();
+    this.prometheusQueryRequest = Optional.of(prometheusQueryRequest);
+  }
+
+  @Override
+  public Map<String, ExprType> getFieldTypes() {
+    if (cachedFieldTypes == null) {
+      cachedFieldTypes =
+          new PrometheusDescribeMetricRequest(prometheusClient,
+              metricName.orElse(null)).getFieldTypes();
+    }
+    return cachedFieldTypes;
+  }
+
+  @Override
+  public PhysicalPlan implement(LogicalPlan plan) {
+    PrometheusMetricScan metricScan =
+        new PrometheusMetricScan(prometheusClient);
+    prometheusQueryRequest.ifPresent(metricScan::setRequest);
+    return plan.accept(new PrometheusDefaultImplementor(), metricScan);
+  }
+
+  @Override
+  public LogicalPlan optimize(LogicalPlan plan) {
+    return plan;
+  }
+
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngine.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngine.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.storage;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver;
+import org.opensearch.sql.storage.StorageEngine;
+import org.opensearch.sql.storage.Table;
+
+
+/**
+ * Prometheus storage engine implementation.
+ */
+public class PrometheusStorageEngine implements StorageEngine {
+
+  private final PrometheusClient prometheusClient;
+
+  public PrometheusStorageEngine(PrometheusClient prometheusClient) {
+    this.prometheusClient = prometheusClient;
+  }
+
+  @Override
+  public Table getTable(String name) {
+    return null;
+  }
+
+  @Override
+  public Collection<FunctionResolver> getFunctions() {
+    return Collections.singletonList(new QueryRangeTableFunctionResolver(prometheusClient));
+  }
+
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/implementor/PrometheusDefaultImplementor.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/implementor/PrometheusDefaultImplementor.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.storage.implementor;
+
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.METRIC;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.TIMESTAMP;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.VALUE;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.planner.DefaultImplementor;
+import org.opensearch.sql.planner.logical.LogicalProject;
+import org.opensearch.sql.planner.logical.LogicalRelation;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+import org.opensearch.sql.planner.physical.ProjectOperator;
+import org.opensearch.sql.prometheus.storage.PrometheusMetricScan;
+
+/**
+ * Default Implementor of Logical plan for prometheus.
+ */
+@RequiredArgsConstructor
+public class PrometheusDefaultImplementor
+    extends DefaultImplementor<PrometheusMetricScan> {
+
+  @Override
+  public PhysicalPlan visitRelation(LogicalRelation node,
+                                    PrometheusMetricScan context) {
+    return context;
+  }
+
+  // Since getFieldTypes include labels
+  // we are explicitly specifying the output column names;
+  @Override
+  public PhysicalPlan visitProject(LogicalProject node, PrometheusMetricScan context) {
+    List<NamedExpression> finalProjectList = new ArrayList<>();
+    finalProjectList.add(
+        new NamedExpression(METRIC, new ReferenceExpression(METRIC, ExprCoreType.STRING)));
+    finalProjectList.add(
+        new NamedExpression(TIMESTAMP,
+            new ReferenceExpression(TIMESTAMP, ExprCoreType.TIMESTAMP)));
+    finalProjectList.add(
+        new NamedExpression(VALUE, new ReferenceExpression(VALUE, ExprCoreType.DOUBLE)));
+    return new ProjectOperator(visitChild(node, context), finalProjectList,
+        node.getNamedParseExpressions());
+  }
+
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeFunctionImplementationTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeFunctionImplementationTest.java
@@ -1,0 +1,95 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.implementation.QueryRangeFunctionImplementation;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+import org.opensearch.sql.prometheus.storage.PrometheusMetricTable;
+
+
+@ExtendWith(MockitoExtension.class)
+class QueryRangeFunctionImplementationTest {
+
+  @Mock
+  private PrometheusClient client;
+
+
+  @Test
+  void testValueOfAndTypeAndToString() {
+    FunctionName functionName = new FunctionName("query_range");
+    List<Expression> namedArgumentExpressionList
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("starttime", DSL.literal(12345)),
+        DSL.namedArgument("endtime", DSL.literal(12345)),
+        DSL.namedArgument("step", DSL.literal(14)));
+    QueryRangeFunctionImplementation queryRangeFunctionImplementation
+        = new QueryRangeFunctionImplementation(functionName, namedArgumentExpressionList, client);
+    UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+        () -> queryRangeFunctionImplementation.valueOf(null));
+    assertEquals("Prometheus defined function [query_range] is only "
+        + "supported in SOURCE clause with prometheus connector catalog", exception.getMessage());
+    assertEquals("query_range(query=\"http_latency\", starttime=12345, endtime=12345, step=14)",
+        queryRangeFunctionImplementation.toString());
+    assertEquals(ExprCoreType.STRUCT, queryRangeFunctionImplementation.type());
+  }
+
+  @Test
+  void testApplyArguments() {
+    FunctionName functionName = new FunctionName("query_range");
+    List<Expression> namedArgumentExpressionList
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("starttime", DSL.literal(12345)),
+        DSL.namedArgument("endtime", DSL.literal(1234)),
+        DSL.namedArgument("step", DSL.literal(14)));
+    QueryRangeFunctionImplementation queryRangeFunctionImplementation
+        = new QueryRangeFunctionImplementation(functionName, namedArgumentExpressionList, client);
+    PrometheusMetricTable prometheusMetricTable
+        = (PrometheusMetricTable) queryRangeFunctionImplementation.applyArguments();
+    assertFalse(prometheusMetricTable.getMetricName().isPresent());
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    PrometheusQueryRequest prometheusQueryRequest
+        = prometheusMetricTable.getPrometheusQueryRequest().get();
+    assertEquals("http_latency", prometheusQueryRequest.getPromQl().toString());
+    assertEquals(12345, prometheusQueryRequest.getStartTime());
+    assertEquals(1234, prometheusQueryRequest.getEndTime());
+    assertEquals("14", prometheusQueryRequest.getStep());
+  }
+
+  @Test
+  void testApplyArgumentsException() {
+    FunctionName functionName = new FunctionName("query_range");
+    List<Expression> namedArgumentExpressionList
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("starttime", DSL.literal(12345)),
+        DSL.namedArgument("end_time", DSL.literal(1234)),
+        DSL.namedArgument("step", DSL.literal(14)));
+    QueryRangeFunctionImplementation queryRangeFunctionImplementation
+        = new QueryRangeFunctionImplementation(functionName, namedArgumentExpressionList, client);
+    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
+        () -> queryRangeFunctionImplementation.applyArguments());
+    assertEquals("Invalid Function Argument:end_time", exception.getMessage());
+  }
+
+
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeTableFunctionResolverTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeTableFunctionResolverTest.java
@@ -1,0 +1,214 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.expression.function.TableFunctionImplementation;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.implementation.QueryRangeFunctionImplementation;
+import org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+import org.opensearch.sql.prometheus.storage.PrometheusMetricTable;
+
+@ExtendWith(MockitoExtension.class)
+class QueryRangeTableFunctionResolverTest {
+
+  @Mock
+  private PrometheusClient client;
+
+  @Test
+  void testResolve() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("starttime", DSL.literal(12345)),
+        DSL.namedArgument("endtime", DSL.literal(12345)),
+        DSL.namedArgument("step", DSL.literal(14)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    FunctionBuilder functionBuilder = resolution.getValue();
+    TableFunctionImplementation functionImplementation
+        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+    assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
+    PrometheusMetricTable prometheusMetricTable
+        = (PrometheusMetricTable) functionImplementation.applyArguments();
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    PrometheusQueryRequest prometheusQueryRequest =
+        prometheusMetricTable.getPrometheusQueryRequest()
+            .get();
+    assertEquals("http_latency", prometheusQueryRequest.getPromQl().toString());
+    assertEquals(12345L, prometheusQueryRequest.getStartTime());
+    assertEquals(12345L, prometheusQueryRequest.getEndTime());
+    assertEquals("14", prometheusQueryRequest.getStep());
+  }
+
+  @Test
+  void testArgumentsPassedByPosition() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument(null, DSL.literal("http_latency")),
+        DSL.namedArgument(null, DSL.literal(12345)),
+        DSL.namedArgument(null, DSL.literal(12345)),
+        DSL.namedArgument(null, DSL.literal(14)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    FunctionBuilder functionBuilder = resolution.getValue();
+    TableFunctionImplementation functionImplementation
+        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+    assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
+    PrometheusMetricTable prometheusMetricTable
+        = (PrometheusMetricTable) functionImplementation.applyArguments();
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    PrometheusQueryRequest prometheusQueryRequest =
+        prometheusMetricTable.getPrometheusQueryRequest()
+            .get();
+    assertEquals("http_latency", prometheusQueryRequest.getPromQl().toString());
+    assertEquals(12345L, prometheusQueryRequest.getStartTime());
+    assertEquals(12345L, prometheusQueryRequest.getEndTime());
+    assertEquals("14", prometheusQueryRequest.getStep());
+  }
+
+
+  @Test
+  void testArgumentsPassedByNameWithDifferentOrder() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("endtime", DSL.literal(12345)),
+        DSL.namedArgument("step", DSL.literal(14)),
+        DSL.namedArgument("starttime", DSL.literal(12345)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    FunctionBuilder functionBuilder = resolution.getValue();
+    TableFunctionImplementation functionImplementation
+        = (TableFunctionImplementation) functionBuilder.apply(expressions);
+    assertTrue(functionImplementation instanceof QueryRangeFunctionImplementation);
+    PrometheusMetricTable prometheusMetricTable
+        = (PrometheusMetricTable) functionImplementation.applyArguments();
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    PrometheusQueryRequest prometheusQueryRequest =
+        prometheusMetricTable.getPrometheusQueryRequest()
+            .get();
+    assertEquals("http_latency", prometheusQueryRequest.getPromQl().toString());
+    assertEquals(12345L, prometheusQueryRequest.getStartTime());
+    assertEquals(12345L, prometheusQueryRequest.getEndTime());
+    assertEquals("14", prometheusQueryRequest.getStep());
+  }
+
+  @Test
+  void testMixedArgumentTypes() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument(null, DSL.literal(12345)),
+        DSL.namedArgument(null, DSL.literal(12345)),
+        DSL.namedArgument(null, DSL.literal(14)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    SemanticCheckException exception = assertThrows(SemanticCheckException.class,
+        () -> resolution.getValue().apply(expressions));
+
+    assertEquals("Arguments should be either passed by name or position", exception.getMessage());
+  }
+
+  @Test
+  void testWrongArgumentsSizeWhenPassedByName() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument("query", DSL.literal("http_latency")),
+        DSL.namedArgument("step", DSL.literal(12345)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    SemanticCheckException exception = assertThrows(SemanticCheckException.class,
+        () -> resolution.getValue().apply(expressions));
+
+    assertEquals("Missing arguments:[endtime,starttime]", exception.getMessage());
+  }
+
+  @Test
+  void testWrongArgumentsSizeWhenPassedByPosition() {
+    QueryRangeTableFunctionResolver queryRangeTableFunctionResolver
+        = new QueryRangeTableFunctionResolver(client);
+    FunctionName functionName = FunctionName.of("query_range");
+    List<Expression> expressions
+        = List.of(DSL.namedArgument(null, DSL.literal("http_latency")),
+        DSL.namedArgument(null, DSL.literal(12345)));
+    FunctionSignature functionSignature = new FunctionSignature(functionName, expressions
+        .stream().map(Expression::type).collect(Collectors.toList()));
+    Pair<FunctionSignature, FunctionBuilder> resolution
+        = queryRangeTableFunctionResolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, queryRangeTableFunctionResolver.getFunctionName());
+    assertEquals(List.of(STRING, LONG, LONG, LONG), resolution.getKey().getParamTypeList());
+    SemanticCheckException exception = assertThrows(SemanticCheckException.class,
+        () -> resolution.getValue().apply(expressions));
+
+    assertEquals("Missing arguments:[endtime,step]", exception.getMessage());
+  }
+
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTableTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTableTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.prometheus.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.planner.logical.LogicalPlanDSL.project;
+import static org.opensearch.sql.planner.logical.LogicalPlanDSL.relation;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.METRIC;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.TIMESTAMP;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.VALUE;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+import org.opensearch.sql.planner.physical.ProjectOperator;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.constants.TestConstants;
+import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
+
+@ExtendWith(MockitoExtension.class)
+class PrometheusMetricTableTest {
+
+  @Mock
+  private PrometheusClient client;
+
+  @Test
+  @SneakyThrows
+  void getFieldTypesFromMetric() {
+    when(client.getLabels(TestConstants.METRIC_NAME)).thenReturn(List.of("label1", "label2"));
+    PrometheusMetricTable prometheusMetricTable
+        = new PrometheusMetricTable(client, TestConstants.METRIC_NAME);
+    Map<String, ExprType> expectedFieldTypes = new HashMap<>();
+    expectedFieldTypes.put("label1", ExprCoreType.STRING);
+    expectedFieldTypes.put("label2", ExprCoreType.STRING);
+    expectedFieldTypes.put(VALUE, ExprCoreType.DOUBLE);
+    expectedFieldTypes.put(TIMESTAMP, ExprCoreType.TIMESTAMP);
+    expectedFieldTypes.put(METRIC, ExprCoreType.STRING);
+
+    Map<String, ExprType> fieldTypes = prometheusMetricTable.getFieldTypes();
+
+    assertEquals(expectedFieldTypes, fieldTypes);
+    verify(client, times(1)).getLabels(TestConstants.METRIC_NAME);
+    assertFalse(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    assertTrue(prometheusMetricTable.getMetricName().isPresent());
+    fieldTypes = prometheusMetricTable.getFieldTypes();
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  @SneakyThrows
+  void getFieldTypesFromPrometheusQueryRequest() {
+    PrometheusMetricTable prometheusMetricTable
+        = new PrometheusMetricTable(client, new PrometheusQueryRequest());
+    Map<String, ExprType> expectedFieldTypes = new HashMap<>();
+    expectedFieldTypes.put(VALUE, ExprCoreType.DOUBLE);
+    expectedFieldTypes.put(TIMESTAMP, ExprCoreType.TIMESTAMP);
+    expectedFieldTypes.put(METRIC, ExprCoreType.STRING);
+
+    Map<String, ExprType> fieldTypes = prometheusMetricTable.getFieldTypes();
+
+    assertEquals(expectedFieldTypes, fieldTypes);
+    verifyNoMoreInteractions(client);
+    assertTrue(prometheusMetricTable.getPrometheusQueryRequest().isPresent());
+    assertFalse(prometheusMetricTable.getMetricName().isPresent());
+  }
+
+  @Test
+  void testImplement() {
+    PrometheusQueryRequest prometheusQueryRequest = new PrometheusQueryRequest();
+    PrometheusMetricTable prometheusMetricTable =
+        new PrometheusMetricTable(client, prometheusQueryRequest);
+    List<NamedExpression> finalProjectList = new ArrayList<>();
+    finalProjectList.add(
+        new NamedExpression(METRIC, new ReferenceExpression(METRIC, ExprCoreType.STRING)));
+    PhysicalPlan plan = prometheusMetricTable.implement(
+        project(relation("query_range", prometheusMetricTable),
+            finalProjectList, null));
+
+
+    assertTrue(plan instanceof ProjectOperator);
+    List<NamedExpression> projectList = ((ProjectOperator) plan).getProjectList();
+    List<String> outputFields
+        = projectList.stream().map(NamedExpression::getName).collect(Collectors.toList());
+    assertEquals(List.of(METRIC, TIMESTAMP, VALUE), outputFields);
+    assertTrue(((ProjectOperator) plan).getInput() instanceof PrometheusMetricScan);
+    PrometheusMetricScan prometheusMetricScan =
+        (PrometheusMetricScan) ((ProjectOperator) plan).getInput();
+    assertEquals(prometheusQueryRequest, prometheusMetricScan.getRequest());
+  }
+
+  @Test
+  void testOptimize() {
+    PrometheusQueryRequest prometheusQueryRequest = new PrometheusQueryRequest();
+    PrometheusMetricTable prometheusMetricTable =
+        new PrometheusMetricTable(client, prometheusQueryRequest);
+    List<NamedExpression> finalProjectList = new ArrayList<>();
+    finalProjectList.add(
+        new NamedExpression(METRIC, new ReferenceExpression(METRIC, ExprCoreType.STRING)));
+    LogicalPlan inputPlan = project(relation("query_range", prometheusMetricTable),
+        finalProjectList, null);
+    LogicalPlan optimizedPlan = prometheusMetricTable.optimize(
+        inputPlan);
+    assertEquals(inputPlan, optimizedPlan);
+  }
+
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngineTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageEngineTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.prometheus.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.functions.resolver.QueryRangeTableFunctionResolver;
+import org.opensearch.sql.storage.Table;
+
+@ExtendWith(MockitoExtension.class)
+class PrometheusStorageEngineTest {
+
+  @Mock
+  private PrometheusClient client;
+
+  @Test
+  public void getTable() {
+    PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
+    Table table = engine.getTable("test");
+    assertNull(table);
+  }
+
+  @Test
+  public void getFunctions() {
+    PrometheusStorageEngine engine = new PrometheusStorageEngine(client);
+    Collection<FunctionResolver> functionResolverCollection = engine.getFunctions();
+    assertNotNull(functionResolverCollection);
+    assertEquals(1, functionResolverCollection.size());
+    assertTrue(
+        functionResolverCollection.iterator().next() instanceof QueryRangeTableFunctionResolver);
+  }
+
+}

--- a/sql/src/main/java/org/opensearch/sql/sql/config/SQLServiceConfig.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/config/SQLServiceConfig.java
@@ -14,7 +14,6 @@ import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.sql.SQLService;
 import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
-import org.opensearch.sql.storage.StorageEngine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +37,8 @@ public class SQLServiceConfig {
 
   @Bean
   public Analyzer analyzer() {
-    return new Analyzer(new ExpressionAnalyzer(functionRepository), catalogService);
+    return new Analyzer(new ExpressionAnalyzer(functionRepository), catalogService,
+        functionRepository);
   }
 
   /**


### PR DESCRIPTION
### Description
* This CR includes changes for initial implementation of table functions targeting prometheus API.
* Table functions are functions which return tables as output. Table functions can be defined for any of the connector and will be pushed down.
* New `query_range` table function is defined to support pass through promQL query directly to prometheus.

These functions can be called either with named parameters or positioned parameters.

Example queries for query_range.
Named parameters query.
``source = prometheus.query_range(query="promQL", start=123, end=145, step=45)``

Positioned parameters query.
``source = prometheus.query_range("promQL", 123, 145, 45)``
 
 ### Issues Related:
* https://github.com/opensearch-project/sql/issues/623

### Check List
- [x ] New functionality includes testing.
  - [x ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).