### PR TITLE
Restricted catalog name to [a-zA-Z0-9_-] characters

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/model/CatalogName.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/model/CatalogName.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.analysis.model;
+
+import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+public class CatalogName {
+
+  public static final String DEFAULT_CATALOG_NAME = ".opensearch";
+  private String name = DEFAULT_CATALOG_NAME;
+
+  /**
+   * Capture only if there are more parts in the name.
+   *
+   * @param parts           parts.
+   * @param allowedCatalogs allowedCatalogs.
+   * @return remaining parts.
+   */
+  List<String> capture(List<String> parts, Set<String> allowedCatalogs) {
+    if (parts.size() > 1 && allowedCatalogs.contains(parts.get(0))) {
+      name = parts.get(0);
+      return parts.subList(1, parts.size());
+    } else {
+      return parts;
+    }
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/analysis/model/CatalogSchemaIdentifierName.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/model/CatalogSchemaIdentifierName.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.analysis.model;
+
+import java.util.List;
+import java.util.Set;
+import lombok.EqualsAndHashCode;
+
+public class CatalogSchemaIdentifierName {
+  private final CatalogName catalogName;
+  private final SchemaName schemaName;
+  private final String identifierName;
+
+  private static final String DOT = ".";
+
+  /**
+   * Data model for capturing catalog, schema and identifier from
+   * fully qualifiedName. In the current state, it is used to capture
+   * CatalogSchemaTable name and CatalogSchemaFunction in case of table
+   * functions.
+   *
+   * @param parts parts of qualifiedName.
+   * @param allowedCatalogs allowedCatalogs.
+   */
+  public CatalogSchemaIdentifierName(List<String> parts, Set<String> allowedCatalogs) {
+    catalogName = new CatalogName();
+    schemaName = new SchemaName();
+    List<String> remainingParts = schemaName.capture(catalogName.capture(parts, allowedCatalogs));
+    identifierName = String.join(DOT, remainingParts);
+  }
+
+  public String getIdentifierName() {
+    return identifierName;
+  }
+
+  public String getCatalogName() {
+    return catalogName.getName();
+  }
+
+  public String getSchemaName() {
+    return schemaName.getName();
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/analysis/model/SchemaName.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/model/SchemaName.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.analysis.model;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class SchemaName {
+
+  public static final String DEFAULT_SCHEMA_NAME = "default";
+  public static final String INFORMATION_SCHEMA_NAME = "information_schema";
+  private String name = DEFAULT_SCHEMA_NAME;
+
+  /**
+   * Capture only if there are more parts in the name.
+   *
+   * @param parts parts.
+   * @return remaining parts.
+   */
+  List<String> capture(List<String> parts) {
+    if (parts.size() > 1
+        && (DEFAULT_SCHEMA_NAME.equals(parts.get(0))
+        || INFORMATION_SCHEMA_NAME.contains(parts.get(0)))) {
+      name = parts.get(0);
+      return parts.subList(1, parts.size());
+    } else {
+      return parts;
+    }
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.ast.dsl;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.expression.AggregateFunction;
@@ -71,6 +72,11 @@ public class AstDSL {
 
   public UnresolvedPlan relation(String tableName) {
     return new Relation(qualifiedName(tableName));
+  }
+
+  public UnresolvedPlan relation(List<String> tableNames) {
+    return new Relation(
+        tableNames.stream().map(AstDSL::qualifiedName).collect(Collectors.toList()));
   }
 
   public UnresolvedPlan relation(QualifiedName tableName) {

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Relation.java
@@ -45,45 +45,12 @@ public class Relation extends UnresolvedPlan {
   private String alias;
 
   /**
-   * Get original table name. Unwrap and get name if table name expression
-   * is actually an Alias.
-   * In case of federated queries we are assuming single table.
+   * Return table name.
    *
    * @return table name
    */
   public String getTableName() {
-    if (tableName.size() == 1 && ((QualifiedName) tableName.get(0)).first().isPresent()) {
-      return ((QualifiedName) tableName.get(0)).rest().toString();
-    }
-    return tableName.stream()
-        .map(UnresolvedExpression::toString)
-        .collect(Collectors.joining(COMMA));
-  }
-
-  /**
-   * Get Catalog Name if present. Since in the initial phase we would be supporting single table
-   * federation queries, we are making an assumption of one table.
-   *
-   * @return catalog name
-   */
-  public String getCatalogName() {
-    if (tableName.size() == 1) {
-      if (tableName.get(0) instanceof QualifiedName) {
-        return ((QualifiedName) tableName.get(0)).first().orElse(null);
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Return full qualified table name with catalog.
-   *
-   * @return fully qualified table name with catalog.
-   */
-  public String getFullyQualifiedTableNameWithCatalog() {
-    return tableName.stream()
-        .map(UnresolvedExpression::toString)
-        .collect(Collectors.joining(COMMA));
+    return getTableQualifiedName().toString();
   }
 
   /**
@@ -93,6 +60,32 @@ public class Relation extends UnresolvedPlan {
    */
   public String getTableNameOrAlias() {
     return (alias == null) ? getTableName() : alias;
+  }
+
+  /**
+   * Return alias.
+   *
+   * @return alias.
+   */
+  public String getAlias() {
+    return alias;
+  }
+
+  /**
+   * Get Qualified name preservs parts of the user given identifiers.
+   * This can later be utilized to determine Catalog,Schema and Table Name during
+   * Analyzer stage. So Passing QualifiedName directly to Analyzer Stage.
+   *
+   * @return TableQualifiedName.
+   */
+  public QualifiedName getTableQualifiedName() {
+    if (tableName.size() == 1) {
+      return (QualifiedName) tableName.get(0);
+    } else {
+      return new QualifiedName(tableName.stream()
+          .map(UnresolvedExpression::toString)
+          .collect(Collectors.joining(COMMA)));
+    }
   }
 
   @Override

--- a/core/src/test/java/org/opensearch/sql/analysis/model/CatalogSchemaIdentifierNameTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/model/CatalogSchemaIdentifierNameTest.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.analysis.model;
+
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CatalogSchemaIdentifierNameTest {
+
+  @Test
+  void testFullyQualifiedName() {
+    CatalogSchemaIdentifierName catalogSchemaIdentifierName = new CatalogSchemaIdentifierName(
+        Arrays.asList("prom", "information_schema", "tables"), Collections.singleton("prom"));
+    Assertions.assertEquals("information_schema", catalogSchemaIdentifierName.getSchemaName());
+    Assertions.assertEquals("prom", catalogSchemaIdentifierName.getCatalogName());
+    Assertions.assertEquals("tables", catalogSchemaIdentifierName.getIdentifierName());
+  }
+
+}

--- a/plugin/src/test/java/org/opensearch/sql/plugin/catalog/CatalogServiceImplTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/catalog/CatalogServiceImplTest.java
@@ -59,16 +59,20 @@ public class CatalogServiceImplTest {
   @Test
   public void testLoadConnectorsWithMissingName() {
     Settings settings = getCatalogSettings("catalog_missing_name.json");
-    Assert.assertThrows(IllegalArgumentException.class,
+    IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
         () -> CatalogServiceImpl.getInstance().loadConnectors(settings));
+    Assert.assertEquals("Missing Name Field from a catalog. Name is a required parameter.",
+        exception.getMessage());
   }
 
   @SneakyThrows
   @Test
   public void testLoadConnectorsWithDuplicateCatalogNames() {
     Settings settings = getCatalogSettings("duplicate_catalog_names.json");
-    Assert.assertThrows(IllegalArgumentException.class,
+    IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
         () -> CatalogServiceImpl.getInstance().loadConnectors(settings));
+    Assert.assertEquals("Catalogs with same name are not allowed.",
+        exception.getMessage());
   }
 
   @SneakyThrows
@@ -92,6 +96,15 @@ public class CatalogServiceImplTest {
     Assert.assertEquals(storageEngine, CatalogServiceImpl.getInstance().getStorageEngine(null));
   }
 
+  @SneakyThrows
+  @Test
+  public void testLoadConnectorsWithIllegalCatalogNames() {
+    Settings settings = getCatalogSettings("illegal_catalog_name.json");
+    IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+        () -> CatalogServiceImpl.getInstance().loadConnectors(settings));
+    Assert.assertEquals("Catalog Name: prometheus.test contains illegal characters."
+        + " Allowed characters: a-zA-Z0-9_-*@ ", exception.getMessage());
+  }
 
   private Settings getCatalogSettings(String filename) throws URISyntaxException, IOException {
     MockSecureSettings mockSecureSettings = new MockSecureSettings();

--- a/plugin/src/test/resources/duplicate_catalog_names.json
+++ b/plugin/src/test/resources/duplicate_catalog_names.json
@@ -1,5 +1,6 @@
 [
   {
+    "name" : "prometheus",
     "connector": "prometheus",
     "uri" : "http://localhost:9090",
     "authentication" : {
@@ -9,6 +10,7 @@
     }
   },
   {
+    "name" : "prometheus",
     "connector": "prometheus",
     "uri" : "http://localhost:9219",
     "authentication" : {

--- a/plugin/src/test/resources/illegal_catalog_name.json
+++ b/plugin/src/test/resources/illegal_catalog_name.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name" : "prometheus.test",
+    "connector": "prometheus",
+    "uri" : "http://localhost:9090",
+    "authentication" : {
+      "type" : "basicauth",
+      "username" : "admin",
+      "password" : "password"
+    }
+  }
+]

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -75,7 +75,7 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
 
   @Override
   public String visitRelation(Relation node, String context) {
-    return StringUtils.format("source=%s", node.getFullyQualifiedTableNameWithCatalog());
+    return StringUtils.format("source=%s", node.getTableName());
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -75,7 +75,7 @@ public class AstBuilderTest {
   @Test
   public void testPrometheusSearchCommand() {
     assertEqual("search source = prometheus.http_requests_total",
-        relation(qualifiedName("http_requests_total"))
+        relation(qualifiedName("prometheus", "http_requests_total"))
     );
   }
 
@@ -89,7 +89,7 @@ public class AstBuilderTest {
   @Test
   public void testSearchCommandWithDotInIndexName() {
     assertEqual("search source = http_requests_total.test",
-        relation("test")
+        relation(qualifiedName("http_requests_total","test"))
     );
   }
 


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
Restricting catalog name to [a-zA-Z0-9_-] characters.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/619
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
Will raise document PR separately.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).