### PR TITLE
Fix CI workflows on `1.x`

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -34,9 +34,8 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v1
       with:
-        distribution: 'temurin'
         java-version: ${{ matrix.java }}
     
     - name: Build with Gradle

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -26,27 +26,28 @@ jobs:
         with:
           repository: opensearch-project/Opensearch-Dashboards
           ref: ${{ env.OPENSEARCH_VERSION }}
-          path: sql/OpenSearch-Dashboards
+          path: OpenSearch-Dashboards
 
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '10.24.1'
+          node-version-file: "../OpenSearch-Dashboards/.nvmrc"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Move Workbench to Plugins Dir
         run: |
-          mv workbench OpenSearch-Dashboards/plugins
+          mv workbench ../OpenSearch-Dashboards/plugins
 
       - name: OpenSearch Dashboards Plugin Bootstrap
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 60
           max_attempts: 3
-          command: cd OpenSearch-Dashboards/plugins/workbench; yarn osd bootstrap
+          command: cd ../OpenSearch-Dashboards/plugins/workbench; yarn osd bootstrap
 
       - name: Test
         run: |
-          cd OpenSearch-Dashboards/plugins/workbench
+          cd ../OpenSearch-Dashboards/plugins/workbench
           yarn test:jest --coverage
 
       - name: Upload coverage
@@ -54,12 +55,12 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           flags: query-workbench
-          directory: ./OpenSearch-Dashboards/plugins/workbench
+          directory: ./../OpenSearch-Dashboards/plugins/workbench
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build Artifact
         run: |
-          cd OpenSearch-Dashboards/plugins/workbench
+          cd ../OpenSearch-Dashboards/plugins/workbench
           yarn build
           mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OPENSEARCH_PLUGIN_VERSION }}.zip
 
@@ -68,4 +69,4 @@ jobs:
         uses: actions/upload-artifact@v1 # can't update to v3 because upload fails
         with:
           name: workbench
-          path: OpenSearch-Dashboards/plugins/workbench/build
+          path: ../OpenSearch-Dashboards/plugins/workbench/build

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -42,10 +42,6 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1"
   },
-  "engines": {
-    "node": "10.24.1",
-    "yarn": "^1.21.1"
-  },
   "resolutions": {
     "**/@types/node": "10.12.27",
     "@types/react": "16.3.14",


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
* Fix java installation for SQL plugin workflow;
* Backport workbench CI fixes from #588 and #704.

See most recent workflow runs in https://github.com/Bit-Quill/opensearch-project-sql/actions?query=branch%3Adev-fix-ci-1.x

### Issues Resolved
Fix failing CI workflows: https://github.com/opensearch-project/sql/actions/workflows/sql-test-and-build-workflow.yml?query=branch%3A1.x
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).