### PR TITLE
Fix manual CI workflow and add `name` option.

### DIFF
--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -2,6 +2,13 @@ name: SQL Plugin Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      name:
+        required: false
+        type: string
+
+run-name:
+  ${{ inputs.name == '' && format('{0} @ {1}', github.ref_name, github.sha) || inputs.name }}
 
 jobs:
   build:
@@ -64,10 +71,10 @@ jobs:
         
     - name: Verify test results
       run: |
-        if [[ -e failures.log ]]
+        if [[ -e report.log ]]
         then
           echo "## FAILED TESTS :facepalm::warning::bangbang:" >> $GITHUB_STEP_SUMMARY
-          cat failures.log >> $GITHUB_STEP_SUMMARY
+          cat report.log >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
 


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
* Fix manual CI workflow.
* Add `name` optional parameter; If not given `<branch name> @ <commit sha>` is used.
 
### Issues Resolved
Workflow ignored all test errors and reported always success. Workflow was introduced in #837.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).