### PR TITLE
add groupId to pluginzip publication

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -55,6 +55,7 @@ publishing {
             pom {
                 name = 'opensearch-sql'
                 description = 'OpenSearch SQL'
+                group = "org.opensearch.plugin"
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'


### PR DESCRIPTION
Signed-off-by: Peng Huo <penghuo@gmail.com>

### Description
Added groupId as org.opensearch.plugin in pluginZip publication
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2521
https://github.com/opensearch-project/sql/issues/790
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).