### PR TITLE
Extract doctest from main CI workflow

### DIFF
--- a/.github/workflows/sql-doctest.yml
+++ b/.github/workflows/sql-doctest.yml
@@ -1,0 +1,27 @@
+name: SQL Doctest CI
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - '**/*.java'
+      - '**/*.g4'
+      - '!sql-jdbc/**'
+      - '**gradle*'
+      - '**/*.jar'
+      - '**/*.pom'
+      - 'doctest/**'
+      - 'docs/**'
+      - '.github/workflows/sql-doctest.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build with Gradle
+      run: ./gradlew :doctest:doctest

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -45,7 +45,7 @@ task stopOpenSearch(type: KillProcessTask)
 doctest.dependsOn startOpenSearch
 doctest.finalizedBy stopOpenSearch
 
-build.dependsOn doctest
+//build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 
 // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -45,7 +45,9 @@ task stopOpenSearch(type: KillProcessTask)
 doctest.dependsOn startOpenSearch
 doctest.finalizedBy stopOpenSearch
 
-//build.dependsOn doctest
+// Deactivate doctest in the main gradle workflow (./gradlew build), because doctest depends
+// on ML plugin and it ruins SQL plugin build if ML plugin is not available (not released)
+// build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 
 // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT


### PR DESCRIPTION
### Description
Doctest depends on ML plugin. If it is unavailable for download for the current version, doctest fails and this ruins all SQL plugin CI.
 
### Issues Resolved
Make SQL plugin CI independent on ML plugin.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).