### PR TITLE
Update SQL CLI to use AWS session token.

### DIFF
--- a/sql-cli/src/opensearch_sql_cli/main.py
+++ b/sql-cli/src/opensearch_sql_cli/main.py
@@ -61,7 +61,7 @@ click.disable_unicode_literals_warning = True
     "use_aws_authentication",
     is_flag=True,
     default=False,
-    help="Use AWS sigV4 to connect to AWS ELasticsearch domain",
+    help="Use AWS sigV4 to connect to AWS OpenSearch domain",
 )
 @click.option(
     "-l",

--- a/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
+++ b/sql-cli/src/opensearch_sql_cli/opensearch_connection.py
@@ -58,7 +58,7 @@ class OpenSearchConnection:
         region = session.region_name
 
         if credentials is not None:
-            self.aws_auth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service)
+            self.aws_auth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
         else:
             click.secho(
                 message="Can not retrieve your AWS credentials, check your AWS config",


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

## Description
How to test:
### Prepare
#### 1. Create a cluster in the cloud and configure AWS_SIGv4 authentication for it
#### 2. Create authentication key pair - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` - that is your permanent keys
#### 3. Install AWSCLI:
`sudo apt-get install awscli`
or
`brew install awscli`
if this doesn't work, try
`pip3 install --upgrade awscli`
#### 4. Configure it
`awscli configure`
or if you installed it using `pip`
`python3 -m awscli configure`
Enter your access key, secret key and region
#### 5. Get the token
Run
`awscli sts get-session-token`
the output is like
```json
{
    "Credentials": {
        "AccessKeyId": "...",
        "SecretAccessKey": "...",
        "SessionToken": "...",
        "Expiration": "2022-10-15T04:31:24Z"
    }
}
```
Record your temporary keys and session token.
#### 6. Checkout my branch
#### 7. Configure environment
Follow the guide https://github.com/opensearch-project/sql/blob/2.x/sql-cli/development_guide.md#development-environment-set-up
### Test 1.
#### 1. Check credentials
Ensure that `~/.aws/credentials` contains `default` profile with your permanent keys, no session token yet there.
#### 2. Run SQL CLI
`opensearchsql --aws-auth https://<cluster>:443`
### Test 2.
#### 1. Record your new credentials
Run
`awscli configure`
and enter your temporary access and secret keys, or edit `~/.aws/credentials` manually, replace your permanent keys by temporary ones
#### 2. Add `session_token`
Add line
`aws_session_token = ...`
to `~/.aws/credentials`
#### 3. Verify session token authentication
`awscli es list-domain-names`
#### 4. Run SQL CLI
`opensearchsql --aws-auth https://<cluster>:443`
### Test 3.
#### 1. Unset credentials
Comment out (`#`) or delete all lines in `~/.aws/credentials` or move/delete the file
#### 2. Set credentials in env vars
run
```
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...
```
with your permanent keys
#### 3. Run SQL CLI
`opensearchsql --aws-auth https://<cluster>:443`
### Test 4.
#### 1. Unset credentials
Comment out (`#`) or delete all lines in `~/.aws/credentials` or move/delete the file
#### 2. Set credentials in env vars
run
```
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...
export AWS_SESSION_TOKEN=...
```
with your temporary keys and session token
#### 3. Run SQL CLI
`opensearchsql --aws-auth https://<cluster>:443`

## Notes
1. In case if you have different credentials set in `~/.aws/credentials` and in env vars, last one is used.
2. `default` profile is used only.

## Limitations
No option yet to specify `profile`, keys and token in command line. That is easy to add.


### Issues Resolved
fixes #854
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).