### PR TITLE
Fix result order of parse with other run time fields

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ParseCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ParseCommandIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.ppl;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyOrder;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class ParseCommandIT extends PPLIntegTestCase {
+
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.BANK);
+  }
+
+  @Test
+  public void testParseCommand() throws IOException {
+    JSONObject result = executeQuery(
+        String.format("source=%s | parse email '.+@(?<host>.+)' | fields email, host",
+            TEST_INDEX_BANK));
+    verifyOrder(
+        result,
+        rows("amberduke@pyrami.com", "pyrami.com"),
+        rows("hattiebond@netagy.com", "netagy.com"),
+        rows("nanettebates@quility.com", "quility.com"),
+        rows("daleadams@boink.com", "boink.com"),
+        rows("elinorratliff@scentric.com", "scentric.com"),
+        rows("virginiaayala@filodyne.com", "filodyne.com"),
+        rows("dillardmcpherson@quailcom.com", "quailcom.com"));
+  }
+
+  @Test
+  public void testParseCommandReplaceOriginalField() throws IOException {
+    JSONObject result = executeQuery(
+        String.format("source=%s | parse email '.+@(?<email>.+)' | fields email", TEST_INDEX_BANK));
+    verifyOrder(
+        result,
+        rows("pyrami.com"),
+        rows("netagy.com"),
+        rows("quility.com"),
+        rows("boink.com"),
+        rows("scentric.com"),
+        rows("filodyne.com"),
+        rows("quailcom.com"));
+  }
+
+  @Test
+  public void testParseCommandWithOtherRunTimeFields() throws IOException {
+    JSONObject result = executeQuery(String.format("source=%s | parse email '.+@(?<host>.+)' | "
+        + "eval eval_result=1 | fields host, eval_result", TEST_INDEX_BANK));
+    verifyOrder(
+        result,
+        rows("pyrami.com", 1),
+        rows("netagy.com", 1),
+        rows("quility.com", 1),
+        rows("boink.com", 1),
+        rows("scentric.com", 1),
+        rows("filodyne.com", 1),
+        rows("quailcom.com", 1));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
ProjectOperator assumes derived fields comes at last, since they are generated at run time. it's incorrect since there could be other run time fields (e.g. `eval`, `AD`). This PR fixes it.

Maybe `parse` should not allow overwriting original fields so ProjectOperator doesn't have to maintain a separate named expression list and handle conflicts.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).