### PR TITLE
Add security policy for ml-commons library

### DIFF
--- a/plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugin/src/main/plugin-metadata/plugin-security.policy
@@ -8,9 +8,10 @@ grant {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "defineClass";
-  permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "getClassLoader";
-  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.net.NetPermission "getProxySelector";
   permission java.net.SocketPermission "*", "accept,connect,resolve";
+
+  // ml-commons client
+  permission java.lang.RuntimePermission "setContextClassLoader";
 };


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
ml-commons requires `setContextClassLoader` to run, ref: https://github.com/opensearch-project/neural-search/blob/d8b24bf5f71c7e8cba5988d6bd18462002802cf7/src/main/plugin-metadata/plugin-security.policy

error: 
```
java.lang.ExceptionInInitializerError
        at org.opensearch.ml.common.output.MLOutput.fromStream(MLOutput.java:35)
        at org.opensearch.ml.common.transport.MLTaskResponse.<init>(MLTaskResponse.java:38)
        at org.opensearch.ml.common.transport.MLTaskResponse.fromActionResponse(MLTaskResponse.java:55)
        at org.opensearch.ml.client.MachineLearningNodeClient.lambda$getMlPredictionTaskResponseActionListener$8(MachineLearningNodeClient.java:148)
        at org.opensearch.ml.client.MachineLearningNodeClient.lambda$wrapActionListener$9(MachineLearningNodeClient.java:156)
        at org.opensearch.action.ActionListener$1.onResponse(ActionListener.java:80)
        at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:113)
        at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:107)
        at org.opensearch.action.ActionListener$5.onResponse(ActionListener.java:266)
        at org.opensearch.ml.task.MLTrainAndPredictTaskRunner.trainAndPredict(MLTrainAndPredictTaskRunner.java:140)
        at org.opensearch.ml.task.MLTrainAndPredictTaskRunner.lambda$executeTask$2(MLTrainAndPredictTaskRunner.java:115)
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:747)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
        at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "setContextClassLoader")
        at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
        at java.base/java.security.AccessController.checkPermission(AccessController.java:1036)
        at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:408)
        at java.base/java.lang.Thread.setContextClassLoader(Thread.java:1514)
        at org.opensearch.ml.common.MLCommonsClassLoader.loadClassMapping(MLCommonsClassLoader.java:55)
        at org.opensearch.ml.common.MLCommonsClassLoader.lambda$static$0(MLCommonsClassLoader.java:37)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:554)
        at org.opensearch.ml.common.MLCommonsClassLoader.<clinit>(MLCommonsClassLoader.java:36)
        ... 15 more
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).