### PR TITLE
Add time window and window assigner

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/Window.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/Window.java
@@ -13,8 +13,10 @@ import lombok.Data;
 @Data
 public class Window {
 
+  /** Start timestamp (inclusive) of the time window. */
   private final long startTime;
 
+  /** End timestamp (exclusive) of the time window. */
   private final long endTime;
 
   /**

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/Window.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/Window.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing;
+
+import lombok.Data;
+
+/**
+ * A time window is a window of time interval with inclusive start time and exclusive end time.
+ */
+@Data
+public class Window {
+
+  private final long startTime;
+
+  private final long endTime;
+
+  /**
+   * Return the maximum timestamp (inclusive) of the window.
+   */
+  public long maxTimestamp() {
+    return endTime - 1;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/SlidingWindowAssigner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/SlidingWindowAssigner.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.assigner;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.opensearch.sql.planner.streaming.windowing.Window;
+
+/**
+ * A sliding window assigner assigns multiple overlapped window per event timestamp.
+ * The overlap size is determined by the given slide interval.
+ */
+public class SlidingWindowAssigner implements WindowAssigner {
+
+  /** Window size in millisecond. */
+  private final long windowSize;
+
+  /** Slide size in millisecond. */
+  private final long slideSize;
+
+  /**
+   * Create sliding window assigner with the given window and slide size.
+   */
+  public SlidingWindowAssigner(long windowSize, long slideSize) {
+    Preconditions.checkArgument(windowSize > 0,
+        "Window size [%s] must be positive number", windowSize);
+    Preconditions.checkArgument(slideSize > 0,
+        "Slide size [%s] must be positive number", slideSize);
+    this.windowSize = windowSize;
+    this.slideSize = slideSize;
+  }
+
+  @Override
+  public List<Window> assign(long timestamp) {
+    List<Window> windows = new ArrayList<>();
+
+    // Assign window from the last start time to first until given timestamp outside current window
+    long startTime = timestamp - timestamp % slideSize;
+    for (Window win = window(startTime); win.maxTimestamp() >= timestamp; win = window(startTime)) {
+      windows.add(win);
+      startTime -= slideSize;
+    }
+
+    // Reverse the window list for easy read and test
+    Collections.reverse(windows);
+    return windows;
+  }
+
+  private Window window(long startTime) {
+    return new Window(startTime, startTime + windowSize);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssigner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssigner.java
@@ -9,10 +9,10 @@ import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import org.opensearch.sql.planner.streaming.windowing.Window;
+import org.opensearch.sql.utils.DateTimeUtils;
 
 /**
- * A tumbling window assigner assigns a single window per event timestamp
- * without overlap.
+ * A tumbling window assigner assigns a single window per event timestamp without overlap.
  */
 public class TumblingWindowAssigner implements WindowAssigner {
 
@@ -21,6 +21,8 @@ public class TumblingWindowAssigner implements WindowAssigner {
 
   /**
    * Create tumbling window assigner with the given window size.
+   *
+   * @param windowSize window size in millisecond
    */
   public TumblingWindowAssigner(long windowSize) {
     Preconditions.checkArgument(windowSize > 0,
@@ -30,7 +32,7 @@ public class TumblingWindowAssigner implements WindowAssigner {
 
   @Override
   public List<Window> assign(long timestamp) {
-    long startTime = timestamp - timestamp % windowSize;
+    long startTime = DateTimeUtils.getWindowStartTime(timestamp, windowSize);
     return Collections.singletonList(new Window(startTime, startTime + windowSize));
   }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssigner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssigner.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.assigner;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.planner.streaming.windowing.Window;
+
+/**
+ * A tumbling window assigner assigns a single window per event timestamp
+ * without overlap.
+ */
+@RequiredArgsConstructor
+public class TumblingWindowAssigner implements WindowAssigner {
+
+  /** Window size in millisecond. */
+  private final long windowSize;
+
+  @Override
+  public List<Window> assign(long timestamp) {
+    long startTime = timestamp - timestamp % windowSize;
+    return Collections.singletonList(new Window(startTime, startTime + windowSize));
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssigner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssigner.java
@@ -5,20 +5,28 @@
 
 package org.opensearch.sql.planner.streaming.windowing.assigner;
 
+import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.planner.streaming.windowing.Window;
 
 /**
  * A tumbling window assigner assigns a single window per event timestamp
  * without overlap.
  */
-@RequiredArgsConstructor
 public class TumblingWindowAssigner implements WindowAssigner {
 
   /** Window size in millisecond. */
   private final long windowSize;
+
+  /**
+   * Create tumbling window assigner with the given window size.
+   */
+  public TumblingWindowAssigner(long windowSize) {
+    Preconditions.checkArgument(windowSize > 0,
+        "Window size [%s] must be positive number", windowSize);
+    this.windowSize = windowSize;
+  }
 
   @Override
   public List<Window> assign(long timestamp) {

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/WindowAssigner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/assigner/WindowAssigner.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.assigner;
+
+import java.util.List;
+import org.opensearch.sql.planner.streaming.windowing.Window;
+
+/**
+ * A window assigner assigns zero or more window to an event timestamp
+ * based on different windowing approach.
+ */
+public interface WindowAssigner {
+
+  /**
+   * Return window(s) assigned to the timestamp.
+   * @param timestamp given event timestamp
+   * @return windows assigned
+   */
+  List<Window> assign(long timestamp);
+
+}

--- a/core/src/main/java/org/opensearch/sql/utils/DateTimeUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/DateTimeUtils.java
@@ -85,6 +85,16 @@ public class DateTimeUtils {
     return initDateTime.plusYears(yearToAdd).toInstant().toEpochMilli();
   }
 
+  /**
+   * Get window start time which aligns with the given size.
+   *
+   * @param timestamp event timestamp
+   * @param size defines a window's start time to align with
+   * @return start timestamp of the window
+   */
+  public long getWindowStartTime(long timestamp, long size) {
+    return timestamp - timestamp % size;
+  }
 
   /**
    * isValidMySqlTimeZoneId for timezones which match timezone the range set by MySQL.

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/WindowTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/WindowTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class WindowTest {
+
+  @Test
+  void test() {
+    Window window = new Window(1000, 2000);
+    assertEquals(1000, window.getStartTime());
+    assertEquals(2000, window.getEndTime());
+    assertEquals(1999, window.maxTimestamp());
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/SlidingWindowAssignerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/SlidingWindowAssignerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.assigner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.planner.streaming.windowing.Window;
+
+class SlidingWindowAssignerTest {
+
+  @Test
+  void testAssignWindows() {
+    long windowSize = 1000;
+    long slideSize = 500;
+    SlidingWindowAssigner assigner = new SlidingWindowAssigner(windowSize, slideSize);
+
+    assertEquals(
+        List.of(
+            new Window(0, 1000),
+            new Window(500, 1500)),
+        assigner.assign(500));
+
+    assertEquals(
+        List.of(
+            new Window(0, 1000),
+            new Window(500, 1500)),
+        assigner.assign(999));
+
+    assertEquals(
+        List.of(
+            new Window(500, 1500),
+            new Window(1000, 2000)),
+        assigner.assign(1000));
+  }
+
+  @Test
+  void testConstructWithIllegalArguments() {
+    IllegalArgumentException error1 = assertThrows(IllegalArgumentException.class,
+        () -> new SlidingWindowAssigner(-1, 100));
+    assertEquals("Window size [-1] must be positive number", error1.getMessage());
+
+    IllegalArgumentException error2 = assertThrows(IllegalArgumentException.class,
+        () -> new SlidingWindowAssigner(1000, 0));
+    assertEquals("Slide size [0] must be positive number", error2.getMessage());
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssignerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssignerTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.assigner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.planner.streaming.windowing.Window;
+
+class TumblingWindowAssignerTest {
+
+  @Test
+  void testAssign() {
+    long windowSize = 1000;
+    TumblingWindowAssigner assigner = new TumblingWindowAssigner(windowSize);
+
+    assertEquals(
+        Collections.singletonList(new Window(0, windowSize)),
+        assigner.assign(500));
+    assertEquals(
+        Collections.singletonList(new Window(1000, 1000 + windowSize)),
+        assigner.assign(1999));
+    assertEquals(
+        Collections.singletonList(new Window(2000, 2000 + windowSize)),
+        assigner.assign(2000));
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssignerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/assigner/TumblingWindowAssignerTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.planner.streaming.windowing.assigner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -14,18 +15,25 @@ import org.opensearch.sql.planner.streaming.windowing.Window;
 class TumblingWindowAssignerTest {
 
   @Test
-  void testAssign() {
+  void testAssignWindow() {
     long windowSize = 1000;
     TumblingWindowAssigner assigner = new TumblingWindowAssigner(windowSize);
 
     assertEquals(
-        Collections.singletonList(new Window(0, windowSize)),
+        Collections.singletonList(new Window(0, 1000)),
         assigner.assign(500));
     assertEquals(
-        Collections.singletonList(new Window(1000, 1000 + windowSize)),
+        Collections.singletonList(new Window(1000, 2000)),
         assigner.assign(1999));
     assertEquals(
-        Collections.singletonList(new Window(2000, 2000 + windowSize)),
+        Collections.singletonList(new Window(2000, 3000)),
         assigner.assign(2000));
+  }
+
+  @Test
+  void testConstructWithIllegalWindowSize() {
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+        () -> new TumblingWindowAssigner(-1));
+    assertEquals("Window size [-1] must be positive number", error.getMessage());
   }
 }


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description
Add window and window assigner interface along with tumbling and sliding window assigner implementation. This PR is only focus on core `WindowAssigner` interface. The future tasks in https://github.com/opensearch-project/sql/issues/954 will integrate it and other new windowing components with query plan operator.

#### Window

A Window is a time interval which has start timestamp and end timestamp. For convenience, the end timestamp is exclusive and thus the window boundary is actually `[startTime, endTime-1]`.

#### Window Assigner

A WindowAssigner identifies which window(s) the event belong. This is the first step and foundation of handling unbounded streaming data. As follows, an event may be assigned to a single window or multiple windows according to the windowing function. Here are a few example for common windowing approach.

Tumble window is fixed size without any overlap and start timestamp is aligned by mod window size.

![stream-processing-Tumbling-window](https://user-images.githubusercontent.com/46505291/197604240-c6302650-da37-4db6-a7ee-fee4b40424ff.jpg)

Sliding window is fixed size but overlapped by slide size. The algorithm is referencing https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingEventTimeWindows.java#L70

![stream-processing-Sliding-window](https://user-images.githubusercontent.com/46505291/197604271-97272fe8-fa7d-4c26-90eb-ea0e83b9c062.jpg)

Session windowing dynamic sized and defined by a given gap duration. It is useful for event representing user activity by analyzing user behavior within a session. Note that session window may cause window merging which will be supported in future as needed.

![stream-processing-Session-window](https://user-images.githubusercontent.com/46505291/197604305-a4939011-44a4-446b-990b-b83b87fc7dec.jpg)
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/951
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).