### PR TITLE
Add category_field to AD command in PPL

### DIFF
--- a/core/src/main/java/org/opensearch/sql/utils/MLCommonsConstants.java
+++ b/core/src/main/java/org/opensearch/sql/utils/MLCommonsConstants.java
@@ -9,7 +9,7 @@ public class MLCommonsConstants {
   public static final String OUTPUT_AFTER = "output_after";
   public static final String TIME_DECAY = "time_decay";
   public static final String ANOMALY_RATE = "anomaly_rate";
-  public static final String AGG_FIELD = "agg_field";
+  public static final String CATEGORY_FIELD = "category_field";
   public static final String TIME_FIELD = "time_field";
   public static final String DATE_FORMAT = "date_format";
   public static final String TIME_ZONE = "time_zone";

--- a/core/src/main/java/org/opensearch/sql/utils/MLCommonsConstants.java
+++ b/core/src/main/java/org/opensearch/sql/utils/MLCommonsConstants.java
@@ -9,6 +9,7 @@ public class MLCommonsConstants {
   public static final String OUTPUT_AFTER = "output_after";
   public static final String TIME_DECAY = "time_decay";
   public static final String ANOMALY_RATE = "anomaly_rate";
+  public static final String AGG_FIELD = "agg_field";
   public static final String TIME_FIELD = "time_field";
   public static final String DATE_FORMAT = "date_format";
   public static final String TIME_ZONE = "time_zone";

--- a/docs/category.json
+++ b/docs/category.json
@@ -7,6 +7,7 @@
     "user/admin/settings.rst"
   ],
   "ppl_cli": [
+    "user/ppl/cmd/ad.rst",
     "user/ppl/cmd/dedup.rst",
     "user/ppl/cmd/describe.rst",
     "user/ppl/cmd/eval.rst",

--- a/docs/user/ppl/cmd/ad.rst
+++ b/docs/user/ppl/cmd/ad.rst
@@ -41,32 +41,65 @@ ad <number_of_trees> <sample_size> <output_after> <training_data_size> <anomaly_
 * anomaly_score_threshold(double): optional. The threshold of anomaly score. The default value is 1.0.
 * category_field(string): optional. It specifies the category field used to group inputs. Each category will be independently predicted.
 
-Example1: Detecting events in New York City from taxi ridership data with time-series data
-==========================================================================================
+Example 1: Detecting events in New York City from taxi ridership data with time-series data
+===========================================================================================
 
 The example trains an RCF model and uses the model to detect anomalies in the time-series ridership data.
 
 PPL query::
 
-    os> source=nyc_taxi | fields value, timestamp | AD time_field='timestamp' | where value=10844.0'
-    +----------+---------------+-------+---------------+
-    | value    | timestamp     | score | anomaly_grade |
-    |----------+---------------+-------+---------------|
-    | 10844.0  | 1404172800000 | 0.0   |  0.0          |
-    +----------+---------------+-------+---------------+
+    os> source=nyc_taxi | fields value, timestamp | AD time_field='timestamp' | where value=10844.0
+    fetched rows / total rows = 1/1
+    +---------+---------------------+---------+-----------------+
+    | value   | timestamp           | score   | anomaly_grade   |
+    |---------+---------------------+---------+-----------------|
+    | 10844.0 | 2014-07-01 00:00:00 | 0.0     | 0.0             |
+    +---------+---------------------+---------+-----------------+
+
+Example 2: Detecting events in New York City from taxi ridership data with time-series data independently with each category
+============================================================================================================================
+
+The example trains an RCF model and uses the model to detect anomalies in the time-series ridership data with multiple category values.
+
+PPL query::
+
+    os> source=nyc_taxi | fields category, value, timestamp | AD time_field='timestamp' category_field='category' | where value=10844.0 or value=6526.0
+    fetched rows / total rows = 2/2
+    +------------+---------+---------------------+---------+-----------------+
+    | category   | value   | timestamp           | score   | anomaly_grade   |
+    |------------+---------+---------------------+---------+-----------------|
+    | night      | 10844.0 | 2014-07-01 00:00:00 | 0.0     | 0.0             |
+    | day        | 6526.0  | 2014-07-01 06:00:00 | 0.0     | 0.0             |
+    +------------+---------+---------------------+---------+-----------------+
 
 
-Example2: Detecting events in New York City from taxi ridership data with non-time-series data
-==============================================================================================
+Example 3: Detecting events in New York City from taxi ridership data with non-time-series data
+===============================================================================================
 
 The example trains an RCF model and uses the model to detect anomalies in the non-time-series ridership data.
 
 PPL query::
 
-    os> source=nyc_taxi | fields value | AD | where value=10844.0'
-    +----------+--------+-----------+
-    | value    | score  | anomalous |
-    |----------+--------+-----------|
-    | 10844.0  | 0.0    | false     |
-    +----------+--------+-----------+
+    os> source=nyc_taxi | fields value | AD | where value=10844.0
+    fetched rows / total rows = 1/1
+    +---------+---------+-------------+
+    | value   | score   | anomalous   |
+    |---------+---------+-------------|
+    | 10844.0 | 0.0     | False       |
+    +---------+---------+-------------+
 
+Example 4: Detecting events in New York City from taxi ridership data with non-time-series data independently with each category
+================================================================================================================================
+
+The example trains an RCF model and uses the model to detect anomalies in the non-time-series ridership data with multiple category values.
+
+PPL query::
+
+    os> source=nyc_taxi | fields category, value | AD category_field='category' | where value=10844.0 or value=6526.0
+    fetched rows / total rows = 2/2
+    +------------+---------+---------+-------------+
+    | category   | value   | score   | anomalous   |
+    |------------+---------+---------+-------------|
+    | night      | 10844.0 | 0.0     | False       |
+    | day        | 6526.0  | 0.0     | False       |
+    +------------+---------+---------+-------------+

--- a/docs/user/ppl/cmd/ad.rst
+++ b/docs/user/ppl/cmd/ad.rst
@@ -24,9 +24,10 @@ ad <number_of_trees> <shingle_size> <sample_size> <output_after> <time_decay> <a
 * output_after(integer): optional. The number of points required by stream samplers before results are returned. The default value is 32.
 * time_decay(double): optional. The decay factor used by stream samplers in this forest. The default value is 0.0001.
 * anomaly_rate(double): optional. The anomaly rate. The default value is 0.005.
-* time_field(string): mandatory. It specifies the time filed for RCF to use as time-series data.
+* time_field(string): mandatory. It specifies the time field for RCF to use as time-series data.
 * date_format(string): optional. It's used for formatting time_field field. The default formatting is "yyyy-MM-dd HH:mm:ss".
 * time_zone(string): optional. It's used for setting time zone for time_field filed. The default time zone is UTC.
+* category_field(string): optional. It specifies the category field used to group inputs. Each category will be independently predicted.
 
 
 Batch RCF for Non-time-series Data Command Syntax
@@ -38,6 +39,7 @@ ad <number_of_trees> <sample_size> <output_after> <training_data_size> <anomaly_
 * output_after(integer): optional. The number of points required by stream samplers before results are returned. The default value is 32.
 * training_data_size(integer): optional. The default value is the size of your training data set.
 * anomaly_score_threshold(double): optional. The threshold of anomaly score. The default value is 1.0.
+* category_field(string): optional. It specifies the category field used to group inputs. Each category will be independently predicted.
 
 Example1: Detecting events in New York City from taxi ridership data with time-series data
 ==========================================================================================

--- a/doctest/test_data/nyc_taxi.json
+++ b/doctest/test_data/nyc_taxi.json
@@ -1,1946 +1,973 @@
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 00:00:00","value":10844,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 00:30:00","value":8127,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 01:00:00","value":6210,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 01:30:00","value":4656,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 02:00:00","value":3820,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 02:30:00","value":2873,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 03:00:00","value":2369,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 03:30:00","value":2064,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 04:00:00","value":2221,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 04:30:00","value":2158,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 05:00:00","value":2515,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 05:30:00","value":4364,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 06:00:00","value":6526,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 06:30:00","value":11039,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 07:00:00","value":13857,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 07:30:00","value":15865,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 08:00:00","value":17920,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 08:30:00","value":20346,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 09:00:00","value":19539,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 09:30:00","value":20107,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 10:00:00","value":18984,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 10:30:00","value":17720,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 11:00:00","value":17249,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 11:30:00","value":18463,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 12:00:00","value":18908,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 12:30:00","value":18886,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 13:00:00","value":18178,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 13:30:00","value":19459,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 14:00:00","value":19546,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 14:30:00","value":20591,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 15:00:00","value":19380,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 15:30:00","value":18544,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 16:00:00","value":16228,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 16:30:00","value":15013,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 17:00:00","value":17203,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 17:30:00","value":19525,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 18:00:00","value":22966,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 18:30:00","value":27598,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 19:00:00","value":26827,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 19:30:00","value":24904,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 20:00:00","value":22875,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 20:30:00","value":20394,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 21:00:00","value":23401,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 21:30:00","value":24439,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 22:00:00","value":23318,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 22:30:00","value":21733,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 23:00:00","value":20104,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-01 23:30:00","value":16111,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 00:00:00","value":13370,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 00:30:00","value":9945,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 01:00:00","value":7571,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 01:30:00","value":5917,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 02:00:00","value":4820,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 02:30:00","value":3634,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 03:00:00","value":2993,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 03:30:00","value":2535,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 04:00:00","value":2570,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 04:30:00","value":2485,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 05:00:00","value":2868,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 05:30:00","value":4482,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 06:00:00","value":6788,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 06:30:00","value":11078,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 07:00:00","value":13729,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 07:30:00","value":16700,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 08:00:00","value":19156,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 08:30:00","value":19953,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 09:00:00","value":19502,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 09:30:00","value":18994,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 10:00:00","value":17311,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 10:30:00","value":17904,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 11:00:00","value":17133,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 11:30:00","value":18589,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 12:00:00","value":19134,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 12:30:00","value":19259,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 13:00:00","value":18667,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 13:30:00","value":19078,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 14:00:00","value":18546,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 14:30:00","value":18593,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 15:00:00","value":17967,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 15:30:00","value":16624,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 16:00:00","value":14634,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 16:30:00","value":13888,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 17:00:00","value":17430,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 17:30:00","value":21919,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 18:00:00","value":23633,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 18:30:00","value":24512,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 19:00:00","value":24887,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 19:30:00","value":26872,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 20:00:00","value":22009,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 20:30:00","value":18259,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 21:00:00","value":20844,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 21:30:00","value":22576,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 22:00:00","value":22401,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 22:30:00","value":19056,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 23:00:00","value":17518,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-02 23:30:00","value":15307,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 00:00:00","value":12646,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 00:30:00","value":10562,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 01:00:00","value":8416,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 01:30:00","value":7098,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 02:00:00","value":5826,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 02:30:00","value":4383,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 03:00:00","value":3270,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 03:30:00","value":2948,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 04:00:00","value":3146,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 04:30:00","value":3077,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 05:00:00","value":3000,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 05:30:00","value":4592,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 06:00:00","value":6486,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 06:30:00","value":10113,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 07:00:00","value":12240,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 07:30:00","value":14574,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 08:00:00","value":16778,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 08:30:00","value":18910,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 09:00:00","value":18350,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 09:30:00","value":17218,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 10:00:00","value":16097,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 10:30:00","value":16409,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 11:00:00","value":15893,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 11:30:00","value":16778,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 12:00:00","value":17604,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 12:30:00","value":18665,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 13:00:00","value":19045,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 13:30:00","value":19261,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 14:00:00","value":19363,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 14:30:00","value":19078,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 15:00:00","value":18193,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 15:30:00","value":16635,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 16:00:00","value":14615,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 16:30:00","value":13759,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 17:00:00","value":17008,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 17:30:00","value":19595,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 18:00:00","value":21328,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 18:30:00","value":22661,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 19:00:00","value":29985,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 19:30:00","value":21501,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 20:00:00","value":22684,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 20:30:00","value":22188,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 21:00:00","value":22663,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 21:30:00","value":19573,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 22:00:00","value":17136,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 22:30:00","value":16606,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 23:00:00","value":16166,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-03 23:30:00","value":16020,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 00:00:00","value":15591,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 00:30:00","value":14395,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 01:00:00","value":12535,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 01:30:00","value":11341,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 02:00:00","value":9980,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 02:30:00","value":8404,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 03:00:00","value":7200,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 03:30:00","value":6578,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 04:00:00","value":5657,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 04:30:00","value":4474,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 05:00:00","value":3459,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 05:30:00","value":3276,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 06:00:00","value":3595,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 06:30:00","value":4240,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 07:00:00","value":4828,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 07:30:00","value":4926,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 08:00:00","value":5165,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 08:30:00","value":5776,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 09:00:00","value":7338,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 09:30:00","value":7839,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 10:00:00","value":8623,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 10:30:00","value":9731,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 11:00:00","value":11024,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 11:30:00","value":13231,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 12:00:00","value":13613,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 12:30:00","value":13737,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 13:00:00","value":15574,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 13:30:00","value":14226,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 14:00:00","value":18480,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 14:30:00","value":18265,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 15:00:00","value":16575,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 15:30:00","value":16417,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 16:00:00","value":14703,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 16:30:00","value":13469,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 17:00:00","value":12105,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 17:30:00","value":11676,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 18:00:00","value":15487,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 18:30:00","value":15077,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 19:00:00","value":14999,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 19:30:00","value":14487,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 20:00:00","value":14415,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 20:30:00","value":13796,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 21:00:00","value":14036,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 21:30:00","value":14021,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 22:00:00","value":15593,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 22:30:00","value":16589,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 23:00:00","value":17984,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-04 23:30:00","value":18035,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 00:00:00","value":17576,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 00:30:00","value":16189,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 01:00:00","value":14441,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 01:30:00","value":12535,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 02:00:00","value":11006,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 02:30:00","value":9151,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 03:00:00","value":8010,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 03:30:00","value":7096,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 04:00:00","value":6407,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 04:30:00","value":4421,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 05:00:00","value":3126,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 05:30:00","value":2514,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 06:00:00","value":2550,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 06:30:00","value":3148,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 07:00:00","value":3658,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 07:30:00","value":4345,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 08:00:00","value":4682,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 08:30:00","value":6248,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 09:00:00","value":7454,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 09:30:00","value":9010,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 10:00:00","value":10280,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 10:30:00","value":11488,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 11:00:00","value":11595,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 11:30:00","value":13098,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 12:00:00","value":12623,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 12:30:00","value":13031,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 13:00:00","value":13263,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 13:30:00","value":13349,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 14:00:00","value":13822,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 14:30:00","value":13716,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 15:00:00","value":13919,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 15:30:00","value":14203,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 16:00:00","value":13179,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 16:30:00","value":13708,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 17:00:00","value":13897,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 17:30:00","value":14740,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 18:00:00","value":14575,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 18:30:00","value":16085,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 19:00:00","value":18182,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 19:30:00","value":16861,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 20:00:00","value":14140,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 20:30:00","value":14477,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 21:00:00","value":15293,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 21:30:00","value":15457,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 22:00:00","value":16048,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 22:30:00","value":17477,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 23:00:00","value":16391,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-05 23:30:00","value":17006,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 00:00:00","value":15427,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 00:30:00","value":14615,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 01:00:00","value":13124,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 01:30:00","value":12222,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 02:00:00","value":11134,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 02:30:00","value":9145,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 03:00:00","value":8624,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 03:30:00","value":7885,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 04:00:00","value":7167,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 04:30:00","value":4805,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 05:00:00","value":3103,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 05:30:00","value":2671,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 06:00:00","value":2510,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 06:30:00","value":2917,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 07:00:00","value":3189,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 07:30:00","value":4107,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 08:00:00","value":4122,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 08:30:00","value":5654,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 09:00:00","value":6360,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 09:30:00","value":8406,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 10:00:00","value":9372,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 10:30:00","value":11067,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 11:00:00","value":11595,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 11:30:00","value":12909,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 12:00:00","value":13715,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 12:30:00","value":13648,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 13:00:00","value":14296,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 13:30:00","value":14798,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 14:00:00","value":15473,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 14:30:00","value":16032,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 15:00:00","value":14661,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 15:30:00","value":14836,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 16:00:00","value":13700,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 16:30:00","value":14565,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 17:00:00","value":15392,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 17:30:00","value":16866,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 18:00:00","value":16893,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 18:30:00","value":16877,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 19:00:00","value":17025,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 19:30:00","value":15884,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 20:00:00","value":14487,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 20:30:00","value":14159,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 21:00:00","value":16135,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 21:30:00","value":16165,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 22:00:00","value":14025,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 22:30:00","value":13970,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 23:00:00","value":13198,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-06 23:30:00","value":11355,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 00:00:00","value":8675,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 00:30:00","value":7180,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 01:00:00","value":5178,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 01:30:00","value":3658,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 02:00:00","value":3181,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 02:30:00","value":2402,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 03:00:00","value":1944,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 03:30:00","value":1877,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 04:00:00","value":2257,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 04:30:00","value":2280,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 05:00:00","value":2575,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 05:30:00","value":4174,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 06:00:00","value":6346,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 06:30:00","value":10594,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 07:00:00","value":12632,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 07:30:00","value":14893,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 08:00:00","value":16470,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 08:30:00","value":18998,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 09:00:00","value":17792,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 09:30:00","value":16396,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 10:00:00","value":14128,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 10:30:00","value":14161,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 11:00:00","value":14154,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 11:30:00","value":15074,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 12:00:00","value":15188,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 12:30:00","value":15483,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 13:00:00","value":15338,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 13:30:00","value":16242,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 14:00:00","value":16579,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 14:30:00","value":16885,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 15:00:00","value":16824,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 15:30:00","value":16238,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 16:00:00","value":15702,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 16:30:00","value":15132,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 17:00:00","value":17500,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 17:30:00","value":19167,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 18:00:00","value":21398,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 18:30:00","value":22382,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 19:00:00","value":22270,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 19:30:00","value":20575,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 20:00:00","value":18824,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 20:30:00","value":17909,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 21:00:00","value":19707,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 21:30:00","value":19066,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 22:00:00","value":17755,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 22:30:00","value":16583,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 23:00:00","value":14955,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-07 23:30:00","value":11849,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 00:00:00","value":9292,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 00:30:00","value":8110,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 01:00:00","value":7352,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 01:30:00","value":5049,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 02:00:00","value":3451,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 02:30:00","value":2465,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 03:00:00","value":2125,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 03:30:00","value":1877,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 04:00:00","value":2069,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 04:30:00","value":2080,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 05:00:00","value":2375,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 05:30:00","value":4303,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 06:00:00","value":6537,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 06:30:00","value":11331,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 07:00:00","value":13565,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 07:30:00","value":16455,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 08:00:00","value":18310,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 08:30:00","value":20288,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 09:00:00","value":19564,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 09:30:00","value":19380,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 10:00:00","value":16507,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 10:30:00","value":16939,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 11:00:00","value":16113,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 11:30:00","value":17537,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 12:00:00","value":18120,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 12:30:00","value":18038,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 13:00:00","value":17870,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 13:30:00","value":18427,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 14:00:00","value":18971,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 14:30:00","value":19071,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 15:00:00","value":18646,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 15:30:00","value":18229,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 16:00:00","value":15977,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 16:30:00","value":15026,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 17:00:00","value":17398,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 17:30:00","value":20865,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 18:00:00","value":23875,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 18:30:00","value":25290,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 19:00:00","value":25510,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 19:30:00","value":24535,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 20:00:00","value":21922,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 20:30:00","value":20113,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 21:00:00","value":22079,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 21:30:00","value":23111,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 22:00:00","value":25209,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 22:30:00","value":21978,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 23:00:00","value":18320,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-08 23:30:00","value":14881,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 00:00:00","value":12053,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 00:30:00","value":9409,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 01:00:00","value":7740,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 01:30:00","value":5528,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 02:00:00","value":4667,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 02:30:00","value":3242,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 03:00:00","value":2678,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 03:30:00","value":2370,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 04:00:00","value":2475,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 04:30:00","value":2304,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 05:00:00","value":2491,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 05:30:00","value":4117,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 06:00:00","value":6435,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 06:30:00","value":11067,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 07:00:00","value":13384,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 07:30:00","value":17194,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 08:00:00","value":18510,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 08:30:00","value":20464,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 09:00:00","value":19777,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 09:30:00","value":18928,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 10:00:00","value":17243,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 10:30:00","value":17490,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 11:00:00","value":16558,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 11:30:00","value":17830,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 12:00:00","value":18203,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 12:30:00","value":18126,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 13:00:00","value":18122,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 13:30:00","value":18488,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 14:00:00","value":18487,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 14:30:00","value":18542,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 15:00:00","value":18240,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 15:30:00","value":17393,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 16:00:00","value":15175,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 16:30:00","value":15360,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 17:00:00","value":17103,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 17:30:00","value":19561,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 18:00:00","value":22262,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 18:30:00","value":24725,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 19:00:00","value":25995,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 19:30:00","value":26319,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 20:00:00","value":24995,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 20:30:00","value":20534,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 21:00:00","value":23458,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 21:30:00","value":24681,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 22:00:00","value":23955,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 22:30:00","value":23655,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 23:00:00","value":21896,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-09 23:30:00","value":19338,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 00:00:00","value":15185,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 00:30:00","value":11459,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 01:00:00","value":8847,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 01:30:00","value":6580,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 02:00:00","value":5247,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 02:30:00","value":4127,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 03:00:00","value":3440,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 03:30:00","value":2957,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 04:00:00","value":2779,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 04:30:00","value":2532,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 05:00:00","value":2718,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 05:30:00","value":4449,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 06:00:00","value":6601,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 06:30:00","value":11202,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 07:00:00","value":13934,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 07:30:00","value":17176,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 08:00:00","value":19057,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 08:30:00","value":21112,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 09:00:00","value":19882,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 09:30:00","value":19024,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 10:00:00","value":16989,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 10:30:00","value":16979,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 11:00:00","value":16381,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 11:30:00","value":17815,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 12:00:00","value":18029,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 12:30:00","value":17495,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 13:00:00","value":17075,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 13:30:00","value":18234,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 14:00:00","value":18091,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 14:30:00","value":18495,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 15:00:00","value":17523,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 15:30:00","value":16714,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 16:00:00","value":14735,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 16:30:00","value":13610,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 17:00:00","value":16290,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 17:30:00","value":19152,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 18:00:00","value":21865,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 18:30:00","value":24347,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 19:00:00","value":26186,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 19:30:00","value":25852,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 20:00:00","value":23995,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 20:30:00","value":21664,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 21:00:00","value":25027,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 21:30:00","value":25431,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 22:00:00","value":25643,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 22:30:00","value":24654,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 23:00:00","value":23154,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-10 23:30:00","value":21863,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 00:00:00","value":20051,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 00:30:00","value":16122,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 01:00:00","value":13107,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 01:30:00","value":10506,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 02:00:00","value":8444,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 02:30:00","value":6876,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 03:00:00","value":5375,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 03:30:00","value":4366,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 04:00:00","value":4183,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 04:30:00","value":3249,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 05:00:00","value":3134,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 05:30:00","value":4620,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 06:00:00","value":6725,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 06:30:00","value":10651,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 07:00:00","value":12952,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 07:30:00","value":15808,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 08:00:00","value":17565,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 08:30:00","value":19784,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 09:00:00","value":19699,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 09:30:00","value":18663,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 10:00:00","value":16509,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 10:30:00","value":16600,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 11:00:00","value":15636,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 11:30:00","value":17434,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 12:00:00","value":17668,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 12:30:00","value":17124,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 13:00:00","value":17124,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 13:30:00","value":17489,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 14:00:00","value":18371,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 14:30:00","value":18381,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 15:00:00","value":17898,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 15:30:00","value":16350,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 16:00:00","value":14688,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 16:30:00","value":14227,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 17:00:00","value":16924,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 17:30:00","value":19952,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 18:00:00","value":22665,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 18:30:00","value":23465,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 19:00:00","value":25111,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 19:30:00","value":23984,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 20:00:00","value":21701,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 20:30:00","value":20592,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 21:00:00","value":22630,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 21:30:00","value":22854,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 22:00:00","value":23892,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 22:30:00","value":24959,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 23:00:00","value":26039,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-11 23:30:00","value":26873,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 00:00:00","value":25871,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 00:30:00","value":24874,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 01:00:00","value":23243,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 01:30:00","value":21674,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 02:00:00","value":19221,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 02:30:00","value":16140,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 03:00:00","value":13371,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 03:30:00","value":12041,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 04:00:00","value":10301,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 04:30:00","value":6472,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 05:00:00","value":4507,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 05:30:00","value":3682,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 06:00:00","value":3422,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 06:30:00","value":4554,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 07:00:00","value":5347,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 07:30:00","value":6853,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 08:00:00","value":7107,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 08:30:00","value":9463,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 09:00:00","value":11022,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 09:30:00","value":13393,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 10:00:00","value":13567,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 10:30:00","value":15452,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 11:00:00","value":15525,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 11:30:00","value":17165,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 12:00:00","value":17263,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 12:30:00","value":18418,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 13:00:00","value":18578,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 13:30:00","value":18762,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 14:00:00","value":18076,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 14:30:00","value":18604,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 15:00:00","value":18580,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 15:30:00","value":19306,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 16:00:00","value":18140,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 16:30:00","value":17455,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 17:00:00","value":18980,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 17:30:00","value":21152,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 18:00:00","value":22483,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 18:30:00","value":22534,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 19:00:00","value":22801,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 19:30:00","value":22117,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 20:00:00","value":19864,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 20:30:00","value":19494,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 21:00:00","value":20607,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 21:30:00","value":20627,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 22:00:00","value":21706,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 22:30:00","value":24243,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 23:00:00","value":25204,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-12 23:30:00","value":25752,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 00:00:00","value":25792,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 00:30:00","value":25033,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 01:00:00","value":23935,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 01:30:00","value":21440,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 02:00:00","value":19468,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 02:30:00","value":16622,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 03:00:00","value":14485,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 03:30:00","value":12974,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 04:00:00","value":11191,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 04:30:00","value":6911,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 05:00:00","value":4410,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 05:30:00","value":3467,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 06:00:00","value":3429,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 06:30:00","value":3599,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 07:00:00","value":3575,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 07:30:00","value":4557,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 08:00:00","value":5243,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 08:30:00","value":6588,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 09:00:00","value":8009,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 09:30:00","value":10743,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 10:00:00","value":13524,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 10:30:00","value":16179,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 11:00:00","value":14905,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 11:30:00","value":16916,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 12:00:00","value":17082,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 12:30:00","value":18606,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 13:00:00","value":18935,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 13:30:00","value":20175,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 14:00:00","value":22219,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 14:30:00","value":22868,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 15:00:00","value":20375,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 15:30:00","value":18489,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 16:00:00","value":16187,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 16:30:00","value":14015,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 17:00:00","value":14261,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 17:30:00","value":20081,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 18:00:00","value":21503,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 18:30:00","value":19850,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 19:00:00","value":18383,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 19:30:00","value":17640,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 20:00:00","value":16225,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 20:30:00","value":15566,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 21:00:00","value":17088,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 21:30:00","value":16968,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 22:00:00","value":15271,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 22:30:00","value":14141,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 23:00:00","value":12851,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-13 23:30:00","value":13877,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 00:00:00","value":12484,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 00:30:00","value":9037,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 01:00:00","value":7393,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 01:30:00","value":5176,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 02:00:00","value":3479,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 02:30:00","value":2755,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 03:00:00","value":2027,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 03:30:00","value":1769,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 04:00:00","value":2091,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 04:30:00","value":2553,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 05:00:00","value":2853,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 05:30:00","value":4835,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 06:00:00","value":6603,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 06:30:00","value":11230,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 07:00:00","value":13395,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 07:30:00","value":15650,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 08:00:00","value":17601,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 08:30:00","value":18818,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 09:00:00","value":18515,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 09:30:00","value":16972,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 10:00:00","value":15316,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 10:30:00","value":16003,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 11:00:00","value":14818,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 11:30:00","value":15610,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 12:00:00","value":16536,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 12:30:00","value":16153,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 13:00:00","value":15548,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 13:30:00","value":16500,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 14:00:00","value":16726,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 14:30:00","value":16838,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 15:00:00","value":16550,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 15:30:00","value":16621,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 16:00:00","value":15657,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 16:30:00","value":15334,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 17:00:00","value":17584,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 17:30:00","value":20903,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 18:00:00","value":21968,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 18:30:00","value":26945,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 19:00:00","value":24416,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 19:30:00","value":22401,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 20:00:00","value":23549,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 20:30:00","value":21498,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 21:00:00","value":23114,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 21:30:00","value":23341,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 22:00:00","value":22141,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 22:30:00","value":19110,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 23:00:00","value":16682,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-14 23:30:00","value":12631,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 00:00:00","value":10089,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 00:30:00","value":8553,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 01:00:00","value":6416,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 01:30:00","value":4694,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 02:00:00","value":3933,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 02:30:00","value":2833,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 03:00:00","value":2089,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 03:30:00","value":1896,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 04:00:00","value":2055,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 04:30:00","value":2031,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 05:00:00","value":2449,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 05:30:00","value":4360,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 06:00:00","value":7036,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 06:30:00","value":11730,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 07:00:00","value":14387,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 07:30:00","value":17505,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 08:00:00","value":19091,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 08:30:00","value":21057,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 09:00:00","value":20050,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 09:30:00","value":18637,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 10:00:00","value":17555,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 10:30:00","value":17595,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 11:00:00","value":16312,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 11:30:00","value":18232,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 12:00:00","value":18446,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 12:30:00","value":18204,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 13:00:00","value":17607,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 13:30:00","value":18945,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 14:00:00","value":22208,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 14:30:00","value":21574,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 15:00:00","value":17299,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 15:30:00","value":15515,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 16:00:00","value":13246,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 16:30:00","value":12328,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 17:00:00","value":15342,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 17:30:00","value":18730,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 18:00:00","value":23412,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 18:30:00","value":26340,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 19:00:00","value":27167,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 19:30:00","value":26279,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 20:00:00","value":23392,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 20:30:00","value":21571,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 21:00:00","value":23477,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 21:30:00","value":22612,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 22:00:00","value":21389,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 22:30:00","value":19575,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 23:00:00","value":18165,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-15 23:30:00","value":14923,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 00:00:00","value":11815,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 00:30:00","value":9024,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 01:00:00","value":7363,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 01:30:00","value":5812,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 02:00:00","value":4559,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 02:30:00","value":3673,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 03:00:00","value":2830,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 03:30:00","value":2374,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 04:00:00","value":2556,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 04:30:00","value":2456,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 05:00:00","value":2486,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 05:30:00","value":4451,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 06:00:00","value":6723,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 06:30:00","value":12501,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 07:00:00","value":14763,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 07:30:00","value":18127,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 08:00:00","value":20393,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 08:30:00","value":20753,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 09:00:00","value":20124,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 09:30:00","value":19253,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 10:00:00","value":17981,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 10:30:00","value":17720,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 11:00:00","value":16525,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 11:30:00","value":18153,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 12:00:00","value":18558,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 12:30:00","value":17652,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 13:00:00","value":17292,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 13:30:00","value":17551,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 14:00:00","value":17951,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 14:30:00","value":17909,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 15:00:00","value":17442,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 15:30:00","value":16533,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 16:00:00","value":14776,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 16:30:00","value":13462,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 17:00:00","value":16363,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 17:30:00","value":19310,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 18:00:00","value":22346,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 18:30:00","value":24408,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 19:00:00","value":26225,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 19:30:00","value":25423,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 20:00:00","value":23811,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 20:30:00","value":22028,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 21:00:00","value":24290,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 21:30:00","value":24835,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 22:00:00","value":24269,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 22:30:00","value":23526,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 23:00:00","value":21968,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-16 23:30:00","value":20137,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 00:00:00","value":16928,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 00:30:00","value":12753,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 01:00:00","value":10087,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 01:30:00","value":7881,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 02:00:00","value":6006,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 02:30:00","value":4382,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 03:00:00","value":3676,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 03:30:00","value":3214,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 04:00:00","value":3205,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 04:30:00","value":2849,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 05:00:00","value":2887,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 05:30:00","value":5039,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 06:00:00","value":7132,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 06:30:00","value":12095,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 07:00:00","value":14558,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 07:30:00","value":17298,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 08:00:00","value":19124,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 08:30:00","value":20407,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 09:00:00","value":19379,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 09:30:00","value":18867,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 10:00:00","value":17662,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 10:30:00","value":17447,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 11:00:00","value":16579,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 11:30:00","value":18340,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 12:00:00","value":18760,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 12:30:00","value":18457,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 13:00:00","value":17608,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 13:30:00","value":18913,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 14:00:00","value":19122,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 14:30:00","value":19547,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 15:00:00","value":17267,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 15:30:00","value":15916,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 16:00:00","value":13836,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 16:30:00","value":11985,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 17:00:00","value":14313,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 17:30:00","value":17988,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 18:00:00","value":21181,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 18:30:00","value":23539,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 19:00:00","value":24714,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 19:30:00","value":25079,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 20:00:00","value":23032,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 20:30:00","value":21168,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 21:00:00","value":25514,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 21:30:00","value":26286,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 22:00:00","value":25650,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 22:30:00","value":24850,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 23:00:00","value":23869,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-17 23:30:00","value":22913,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 00:00:00","value":20850,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 00:30:00","value":16734,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 01:00:00","value":14106,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 01:30:00","value":11587,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 02:00:00","value":8951,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 02:30:00","value":7199,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 03:00:00","value":6051,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 03:30:00","value":4693,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 04:00:00","value":4507,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 04:30:00","value":3791,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 05:00:00","value":3586,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 05:30:00","value":4918,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 06:00:00","value":7039,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 06:30:00","value":11262,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 07:00:00","value":13725,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 07:30:00","value":15899,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 08:00:00","value":17329,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 08:30:00","value":19757,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 09:00:00","value":19341,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 09:30:00","value":17660,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 10:00:00","value":16532,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 10:30:00","value":16354,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 11:00:00","value":16054,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 11:30:00","value":17326,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 12:00:00","value":17463,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 12:30:00","value":17091,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 13:00:00","value":16668,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 13:30:00","value":17096,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 14:00:00","value":17811,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 14:30:00","value":17980,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 15:00:00","value":17080,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 15:30:00","value":15185,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 16:00:00","value":13538,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 16:30:00","value":12704,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 17:00:00","value":15019,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 17:30:00","value":18778,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 18:00:00","value":21583,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 18:30:00","value":23834,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 19:00:00","value":25123,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 19:30:00","value":24762,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 20:00:00","value":22761,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 20:30:00","value":22227,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 21:00:00","value":23985,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 21:30:00","value":23788,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 22:00:00","value":23855,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 22:30:00","value":26040,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 23:00:00","value":25863,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-18 23:30:00","value":25851,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 00:00:00","value":26100,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 00:30:00","value":24625,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 01:00:00","value":22657,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 01:30:00","value":20289,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 02:00:00","value":18524,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 02:30:00","value":15943,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 03:00:00","value":13179,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 03:30:00","value":12423,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 04:00:00","value":10478,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 04:30:00","value":6556,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 05:00:00","value":4561,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 05:30:00","value":3513,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 06:00:00","value":3607,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 06:30:00","value":4781,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 07:00:00","value":5423,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 07:30:00","value":6669,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 08:00:00","value":7064,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 08:30:00","value":9363,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 09:00:00","value":10874,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 09:30:00","value":13255,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 10:00:00","value":13164,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 10:30:00","value":15159,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 11:00:00","value":16030,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 11:30:00","value":18256,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 12:00:00","value":17751,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 12:30:00","value":17675,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 13:00:00","value":18557,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 13:30:00","value":18389,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 14:00:00","value":17538,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 14:30:00","value":17506,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 15:00:00","value":17580,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 15:30:00","value":18027,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 16:00:00","value":16959,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 16:30:00","value":17066,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 17:00:00","value":18155,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 17:30:00","value":20610,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 18:00:00","value":20793,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 18:30:00","value":21584,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 19:00:00","value":23493,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 19:30:00","value":22555,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 20:00:00","value":20183,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 20:30:00","value":20441,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 21:00:00","value":21555,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 21:30:00","value":22406,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 22:00:00","value":22512,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 22:30:00","value":24667,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 23:00:00","value":25424,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-19 23:30:00","value":25852,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 00:00:00","value":25137,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 00:30:00","value":24099,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 01:00:00","value":23058,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 01:30:00","value":20786,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 02:00:00","value":19217,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 02:30:00","value":16329,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 03:00:00","value":14293,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 03:30:00","value":13193,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 04:00:00","value":11166,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 04:30:00","value":7518,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 05:00:00","value":4877,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 05:30:00","value":3639,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 06:00:00","value":3412,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 06:30:00","value":3827,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 07:00:00","value":3922,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 07:30:00","value":5241,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 08:00:00","value":5601,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 08:30:00","value":7147,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 09:00:00","value":8425,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 09:30:00","value":10951,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 10:00:00","value":11800,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 10:30:00","value":13936,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 11:00:00","value":14835,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 11:30:00","value":16412,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 12:00:00","value":16763,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 12:30:00","value":17613,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 13:00:00","value":17439,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 13:30:00","value":17921,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 14:00:00","value":18605,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 14:30:00","value":18113,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 15:00:00","value":17579,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 15:30:00","value":16927,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 16:00:00","value":16526,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 16:30:00","value":16956,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 17:00:00","value":17381,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 17:30:00","value":19232,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 18:00:00","value":19127,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 18:30:00","value":19404,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 19:00:00","value":18812,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 19:30:00","value":18253,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 20:00:00","value":16497,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 20:30:00","value":16681,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 21:00:00","value":17334,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 21:30:00","value":17674,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 22:00:00","value":16469,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 22:30:00","value":15128,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 23:00:00","value":13973,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-20 23:30:00","value":12040,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 00:00:00","value":9494,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 00:30:00","value":6963,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 01:00:00","value":5611,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 01:30:00","value":4140,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 02:00:00","value":3370,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 02:30:00","value":2625,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 03:00:00","value":2093,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 03:30:00","value":1854,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 04:00:00","value":2482,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 04:30:00","value":2529,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 05:00:00","value":2968,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 05:30:00","value":4540,"anomaly_type":"EXPECTED"}
-{ "index" : { "_index" : "nyc_taxi" } }
-{"timestamp":"2014-07-21 06:00:00","value":6868,"anomaly_type":"EXPECTED"}
+{"timestamp":"2014-07-01 00:00:00","value":10844,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 00:30:00","value":8127,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 01:00:00","value":6210,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 01:30:00","value":4656,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 02:00:00","value":3820,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 02:30:00","value":2873,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 03:00:00","value":2369,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 03:30:00","value":2064,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 04:00:00","value":2221,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 04:30:00","value":2158,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 05:00:00","value":2515,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 05:30:00","value":4364,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 06:00:00","value":6526,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 06:30:00","value":11039,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 07:00:00","value":13857,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 07:30:00","value":15865,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 08:00:00","value":17920,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 08:30:00","value":20346,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 09:00:00","value":19539,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 09:30:00","value":20107,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 10:00:00","value":18984,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 10:30:00","value":17720,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 11:00:00","value":17249,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 11:30:00","value":18463,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 12:00:00","value":18908,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 12:30:00","value":18886,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 13:00:00","value":18178,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 13:30:00","value":19459,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 14:00:00","value":19546,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 14:30:00","value":20591,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 15:00:00","value":19380,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 15:30:00","value":18544,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 16:00:00","value":16228,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 16:30:00","value":15013,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 17:00:00","value":17203,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 17:30:00","value":19525,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 18:00:00","value":22966,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 18:30:00","value":27598,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 19:00:00","value":26827,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 19:30:00","value":24904,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-01 20:00:00","value":22875,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 20:30:00","value":20394,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 21:00:00","value":23401,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 21:30:00","value":24439,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 22:00:00","value":23318,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 22:30:00","value":21733,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 23:00:00","value":20104,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-01 23:30:00","value":16111,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 00:00:00","value":13370,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 00:30:00","value":9945,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 01:00:00","value":7571,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 01:30:00","value":5917,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 02:00:00","value":4820,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 02:30:00","value":3634,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 03:00:00","value":2993,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 03:30:00","value":2535,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 04:00:00","value":2570,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 04:30:00","value":2485,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 05:00:00","value":2868,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 05:30:00","value":4482,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 06:00:00","value":6788,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 06:30:00","value":11078,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 07:00:00","value":13729,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 07:30:00","value":16700,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 08:00:00","value":19156,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 08:30:00","value":19953,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 09:00:00","value":19502,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 09:30:00","value":18994,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 10:00:00","value":17311,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 10:30:00","value":17904,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 11:00:00","value":17133,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 11:30:00","value":18589,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 12:00:00","value":19134,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 12:30:00","value":19259,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 13:00:00","value":18667,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 13:30:00","value":19078,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 14:00:00","value":18546,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 14:30:00","value":18593,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 15:00:00","value":17967,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 15:30:00","value":16624,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 16:00:00","value":14634,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 16:30:00","value":13888,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 17:00:00","value":17430,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 17:30:00","value":21919,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 18:00:00","value":23633,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 18:30:00","value":24512,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 19:00:00","value":24887,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 19:30:00","value":26872,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-02 20:00:00","value":22009,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 20:30:00","value":18259,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 21:00:00","value":20844,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 21:30:00","value":22576,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 22:00:00","value":22401,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 22:30:00","value":19056,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 23:00:00","value":17518,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-02 23:30:00","value":15307,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 00:00:00","value":12646,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 00:30:00","value":10562,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 01:00:00","value":8416,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 01:30:00","value":7098,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 02:00:00","value":5826,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 02:30:00","value":4383,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 03:00:00","value":3270,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 03:30:00","value":2948,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 04:00:00","value":3146,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 04:30:00","value":3077,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 05:00:00","value":3000,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 05:30:00","value":4592,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 06:00:00","value":6486,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 06:30:00","value":10113,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 07:00:00","value":12240,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 07:30:00","value":14574,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 08:00:00","value":16778,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 08:30:00","value":18910,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 09:00:00","value":18350,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 09:30:00","value":17218,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 10:00:00","value":16097,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 10:30:00","value":16409,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 11:00:00","value":15893,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 11:30:00","value":16778,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 12:00:00","value":17604,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 12:30:00","value":18665,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 13:00:00","value":19045,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 13:30:00","value":19261,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 14:00:00","value":19363,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 14:30:00","value":19078,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 15:00:00","value":18193,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 15:30:00","value":16635,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 16:00:00","value":14615,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 16:30:00","value":13759,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 17:00:00","value":17008,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 17:30:00","value":19595,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 18:00:00","value":21328,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 18:30:00","value":22661,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 19:00:00","value":29985,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 19:30:00","value":21501,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-03 20:00:00","value":22684,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 20:30:00","value":22188,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 21:00:00","value":22663,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 21:30:00","value":19573,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 22:00:00","value":17136,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 22:30:00","value":16606,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 23:00:00","value":16166,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-03 23:30:00","value":16020,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 00:00:00","value":15591,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 00:30:00","value":14395,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 01:00:00","value":12535,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 01:30:00","value":11341,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 02:00:00","value":9980,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 02:30:00","value":8404,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 03:00:00","value":7200,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 03:30:00","value":6578,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 04:00:00","value":5657,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 04:30:00","value":4474,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 05:00:00","value":3459,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 05:30:00","value":3276,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 06:00:00","value":3595,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 06:30:00","value":4240,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 07:00:00","value":4828,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 07:30:00","value":4926,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 08:00:00","value":5165,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 08:30:00","value":5776,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 09:00:00","value":7338,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 09:30:00","value":7839,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 10:00:00","value":8623,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 10:30:00","value":9731,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 11:00:00","value":11024,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 11:30:00","value":13231,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 12:00:00","value":13613,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 12:30:00","value":13737,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 13:00:00","value":15574,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 13:30:00","value":14226,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 14:00:00","value":18480,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 14:30:00","value":18265,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 15:00:00","value":16575,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 15:30:00","value":16417,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 16:00:00","value":14703,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 16:30:00","value":13469,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 17:00:00","value":12105,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 17:30:00","value":11676,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 18:00:00","value":15487,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 18:30:00","value":15077,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 19:00:00","value":14999,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 19:30:00","value":14487,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-04 20:00:00","value":14415,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 20:30:00","value":13796,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 21:00:00","value":14036,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 21:30:00","value":14021,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 22:00:00","value":15593,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 22:30:00","value":16589,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 23:00:00","value":17984,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-04 23:30:00","value":18035,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 00:00:00","value":17576,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 00:30:00","value":16189,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 01:00:00","value":14441,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 01:30:00","value":12535,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 02:00:00","value":11006,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 02:30:00","value":9151,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 03:00:00","value":8010,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 03:30:00","value":7096,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 04:00:00","value":6407,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 04:30:00","value":4421,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 05:00:00","value":3126,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 05:30:00","value":2514,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 06:00:00","value":2550,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 06:30:00","value":3148,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 07:00:00","value":3658,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 07:30:00","value":4345,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 08:00:00","value":4682,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 08:30:00","value":6248,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 09:00:00","value":7454,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 09:30:00","value":9010,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 10:00:00","value":10280,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 10:30:00","value":11488,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 11:00:00","value":11595,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 11:30:00","value":13098,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 12:00:00","value":12623,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 12:30:00","value":13031,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 13:00:00","value":13263,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 13:30:00","value":13349,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 14:00:00","value":13822,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 14:30:00","value":13716,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 15:00:00","value":13919,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 15:30:00","value":14203,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 16:00:00","value":13179,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 16:30:00","value":13708,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 17:00:00","value":13897,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 17:30:00","value":14740,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 18:00:00","value":14575,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 18:30:00","value":16085,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 19:00:00","value":18182,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 19:30:00","value":16861,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-05 20:00:00","value":14140,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 20:30:00","value":14477,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 21:00:00","value":15293,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 21:30:00","value":15457,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 22:00:00","value":16048,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 22:30:00","value":17477,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 23:00:00","value":16391,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-05 23:30:00","value":17006,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 00:00:00","value":15427,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 00:30:00","value":14615,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 01:00:00","value":13124,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 01:30:00","value":12222,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 02:00:00","value":11134,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 02:30:00","value":9145,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 03:00:00","value":8624,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 03:30:00","value":7885,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 04:00:00","value":7167,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 04:30:00","value":4805,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 05:00:00","value":3103,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 05:30:00","value":2671,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 06:00:00","value":2510,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 06:30:00","value":2917,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 07:00:00","value":3189,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 07:30:00","value":4107,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 08:00:00","value":4122,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 08:30:00","value":5654,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 09:00:00","value":6360,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 09:30:00","value":8406,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 10:00:00","value":9372,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 10:30:00","value":11067,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 11:00:00","value":11595,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 11:30:00","value":12909,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 12:00:00","value":13715,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 12:30:00","value":13648,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 13:00:00","value":14296,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 13:30:00","value":14798,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 14:00:00","value":15473,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 14:30:00","value":16032,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 15:00:00","value":14661,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 15:30:00","value":14836,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 16:00:00","value":13700,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 16:30:00","value":14565,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 17:00:00","value":15392,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 17:30:00","value":16866,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 18:00:00","value":16893,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 18:30:00","value":16877,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 19:00:00","value":17025,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 19:30:00","value":15884,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-06 20:00:00","value":14487,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 20:30:00","value":14159,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 21:00:00","value":16135,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 21:30:00","value":16165,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 22:00:00","value":14025,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 22:30:00","value":13970,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 23:00:00","value":13198,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-06 23:30:00","value":11355,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 00:00:00","value":8675,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 00:30:00","value":7180,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 01:00:00","value":5178,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 01:30:00","value":3658,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 02:00:00","value":3181,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 02:30:00","value":2402,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 03:00:00","value":1944,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 03:30:00","value":1877,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 04:00:00","value":2257,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 04:30:00","value":2280,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 05:00:00","value":2575,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 05:30:00","value":4174,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 06:00:00","value":6346,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 06:30:00","value":10594,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 07:00:00","value":12632,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 07:30:00","value":14893,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 08:00:00","value":16470,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 08:30:00","value":18998,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 09:00:00","value":17792,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 09:30:00","value":16396,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 10:00:00","value":14128,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 10:30:00","value":14161,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 11:00:00","value":14154,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 11:30:00","value":15074,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 12:00:00","value":15188,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 12:30:00","value":15483,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 13:00:00","value":15338,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 13:30:00","value":16242,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 14:00:00","value":16579,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 14:30:00","value":16885,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 15:00:00","value":16824,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 15:30:00","value":16238,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 16:00:00","value":15702,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 16:30:00","value":15132,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 17:00:00","value":17500,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 17:30:00","value":19167,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 18:00:00","value":21398,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 18:30:00","value":22382,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 19:00:00","value":22270,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 19:30:00","value":20575,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-07 20:00:00","value":18824,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 20:30:00","value":17909,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 21:00:00","value":19707,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 21:30:00","value":19066,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 22:00:00","value":17755,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 22:30:00","value":16583,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 23:00:00","value":14955,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-07 23:30:00","value":11849,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 00:00:00","value":9292,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 00:30:00","value":8110,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 01:00:00","value":7352,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 01:30:00","value":5049,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 02:00:00","value":3451,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 02:30:00","value":2465,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 03:00:00","value":2125,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 03:30:00","value":1877,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 04:00:00","value":2069,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 04:30:00","value":2080,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 05:00:00","value":2375,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 05:30:00","value":4303,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 06:00:00","value":6537,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 06:30:00","value":11331,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 07:00:00","value":13565,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 07:30:00","value":16455,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 08:00:00","value":18310,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 08:30:00","value":20288,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 09:00:00","value":19564,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 09:30:00","value":19380,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 10:00:00","value":16507,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 10:30:00","value":16939,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 11:00:00","value":16113,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 11:30:00","value":17537,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 12:00:00","value":18120,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 12:30:00","value":18038,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 13:00:00","value":17870,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 13:30:00","value":18427,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 14:00:00","value":18971,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 14:30:00","value":19071,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 15:00:00","value":18646,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 15:30:00","value":18229,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 16:00:00","value":15977,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 16:30:00","value":15026,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 17:00:00","value":17398,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 17:30:00","value":20865,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 18:00:00","value":23875,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 18:30:00","value":25290,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 19:00:00","value":25510,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 19:30:00","value":24535,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-08 20:00:00","value":21922,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 20:30:00","value":20113,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 21:00:00","value":22079,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 21:30:00","value":23111,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 22:00:00","value":25209,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 22:30:00","value":21978,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 23:00:00","value":18320,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-08 23:30:00","value":14881,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 00:00:00","value":12053,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 00:30:00","value":9409,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 01:00:00","value":7740,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 01:30:00","value":5528,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 02:00:00","value":4667,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 02:30:00","value":3242,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 03:00:00","value":2678,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 03:30:00","value":2370,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 04:00:00","value":2475,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 04:30:00","value":2304,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 05:00:00","value":2491,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 05:30:00","value":4117,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 06:00:00","value":6435,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 06:30:00","value":11067,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 07:00:00","value":13384,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 07:30:00","value":17194,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 08:00:00","value":18510,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 08:30:00","value":20464,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 09:00:00","value":19777,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 09:30:00","value":18928,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 10:00:00","value":17243,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 10:30:00","value":17490,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 11:00:00","value":16558,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 11:30:00","value":17830,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 12:00:00","value":18203,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 12:30:00","value":18126,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 13:00:00","value":18122,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 13:30:00","value":18488,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 14:00:00","value":18487,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 14:30:00","value":18542,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 15:00:00","value":18240,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 15:30:00","value":17393,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 16:00:00","value":15175,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 16:30:00","value":15360,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 17:00:00","value":17103,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 17:30:00","value":19561,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 18:00:00","value":22262,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 18:30:00","value":24725,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 19:00:00","value":25995,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 19:30:00","value":26319,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-09 20:00:00","value":24995,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 20:30:00","value":20534,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 21:00:00","value":23458,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 21:30:00","value":24681,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 22:00:00","value":23955,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 22:30:00","value":23655,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 23:00:00","value":21896,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-09 23:30:00","value":19338,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 00:00:00","value":15185,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 00:30:00","value":11459,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 01:00:00","value":8847,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 01:30:00","value":6580,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 02:00:00","value":5247,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 02:30:00","value":4127,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 03:00:00","value":3440,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 03:30:00","value":2957,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 04:00:00","value":2779,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 04:30:00","value":2532,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 05:00:00","value":2718,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 05:30:00","value":4449,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 06:00:00","value":6601,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 06:30:00","value":11202,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 07:00:00","value":13934,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 07:30:00","value":17176,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 08:00:00","value":19057,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 08:30:00","value":21112,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 09:00:00","value":19882,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 09:30:00","value":19024,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 10:00:00","value":16989,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 10:30:00","value":16979,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 11:00:00","value":16381,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 11:30:00","value":17815,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 12:00:00","value":18029,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 12:30:00","value":17495,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 13:00:00","value":17075,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 13:30:00","value":18234,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 14:00:00","value":18091,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 14:30:00","value":18495,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 15:00:00","value":17523,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 15:30:00","value":16714,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 16:00:00","value":14735,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 16:30:00","value":13610,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 17:00:00","value":16290,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 17:30:00","value":19152,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 18:00:00","value":21865,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 18:30:00","value":24347,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 19:00:00","value":26186,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 19:30:00","value":25852,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-10 20:00:00","value":23995,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 20:30:00","value":21664,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 21:00:00","value":25027,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 21:30:00","value":25431,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 22:00:00","value":25643,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 22:30:00","value":24654,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 23:00:00","value":23154,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-10 23:30:00","value":21863,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 00:00:00","value":20051,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 00:30:00","value":16122,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 01:00:00","value":13107,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 01:30:00","value":10506,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 02:00:00","value":8444,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 02:30:00","value":6876,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 03:00:00","value":5375,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 03:30:00","value":4366,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 04:00:00","value":4183,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 04:30:00","value":3249,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 05:00:00","value":3134,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 05:30:00","value":4620,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 06:00:00","value":6725,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 06:30:00","value":10651,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 07:00:00","value":12952,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 07:30:00","value":15808,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 08:00:00","value":17565,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 08:30:00","value":19784,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 09:00:00","value":19699,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 09:30:00","value":18663,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 10:00:00","value":16509,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 10:30:00","value":16600,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 11:00:00","value":15636,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 11:30:00","value":17434,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 12:00:00","value":17668,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 12:30:00","value":17124,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 13:00:00","value":17124,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 13:30:00","value":17489,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 14:00:00","value":18371,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 14:30:00","value":18381,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 15:00:00","value":17898,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 15:30:00","value":16350,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 16:00:00","value":14688,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 16:30:00","value":14227,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 17:00:00","value":16924,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 17:30:00","value":19952,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 18:00:00","value":22665,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 18:30:00","value":23465,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 19:00:00","value":25111,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 19:30:00","value":23984,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-11 20:00:00","value":21701,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 20:30:00","value":20592,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 21:00:00","value":22630,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 21:30:00","value":22854,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 22:00:00","value":23892,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 22:30:00","value":24959,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 23:00:00","value":26039,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-11 23:30:00","value":26873,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 00:00:00","value":25871,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 00:30:00","value":24874,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 01:00:00","value":23243,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 01:30:00","value":21674,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 02:00:00","value":19221,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 02:30:00","value":16140,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 03:00:00","value":13371,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 03:30:00","value":12041,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 04:00:00","value":10301,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 04:30:00","value":6472,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 05:00:00","value":4507,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 05:30:00","value":3682,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 06:00:00","value":3422,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 06:30:00","value":4554,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 07:00:00","value":5347,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 07:30:00","value":6853,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 08:00:00","value":7107,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 08:30:00","value":9463,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 09:00:00","value":11022,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 09:30:00","value":13393,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 10:00:00","value":13567,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 10:30:00","value":15452,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 11:00:00","value":15525,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 11:30:00","value":17165,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 12:00:00","value":17263,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 12:30:00","value":18418,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 13:00:00","value":18578,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 13:30:00","value":18762,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 14:00:00","value":18076,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 14:30:00","value":18604,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 15:00:00","value":18580,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 15:30:00","value":19306,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 16:00:00","value":18140,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 16:30:00","value":17455,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 17:00:00","value":18980,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 17:30:00","value":21152,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 18:00:00","value":22483,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 18:30:00","value":22534,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 19:00:00","value":22801,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 19:30:00","value":22117,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-12 20:00:00","value":19864,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 20:30:00","value":19494,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 21:00:00","value":20607,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 21:30:00","value":20627,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 22:00:00","value":21706,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 22:30:00","value":24243,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 23:00:00","value":25204,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-12 23:30:00","value":25752,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 00:00:00","value":25792,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 00:30:00","value":25033,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 01:00:00","value":23935,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 01:30:00","value":21440,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 02:00:00","value":19468,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 02:30:00","value":16622,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 03:00:00","value":14485,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 03:30:00","value":12974,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 04:00:00","value":11191,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 04:30:00","value":6911,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 05:00:00","value":4410,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 05:30:00","value":3467,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 06:00:00","value":3429,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 06:30:00","value":3599,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 07:00:00","value":3575,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 07:30:00","value":4557,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 08:00:00","value":5243,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 08:30:00","value":6588,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 09:00:00","value":8009,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 09:30:00","value":10743,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 10:00:00","value":13524,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 10:30:00","value":16179,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 11:00:00","value":14905,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 11:30:00","value":16916,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 12:00:00","value":17082,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 12:30:00","value":18606,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 13:00:00","value":18935,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 13:30:00","value":20175,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 14:00:00","value":22219,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 14:30:00","value":22868,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 15:00:00","value":20375,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 15:30:00","value":18489,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 16:00:00","value":16187,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 16:30:00","value":14015,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 17:00:00","value":14261,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 17:30:00","value":20081,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 18:00:00","value":21503,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 18:30:00","value":19850,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 19:00:00","value":18383,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 19:30:00","value":17640,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-13 20:00:00","value":16225,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 20:30:00","value":15566,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 21:00:00","value":17088,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 21:30:00","value":16968,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 22:00:00","value":15271,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 22:30:00","value":14141,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 23:00:00","value":12851,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-13 23:30:00","value":13877,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 00:00:00","value":12484,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 00:30:00","value":9037,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 01:00:00","value":7393,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 01:30:00","value":5176,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 02:00:00","value":3479,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 02:30:00","value":2755,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 03:00:00","value":2027,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 03:30:00","value":1769,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 04:00:00","value":2091,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 04:30:00","value":2553,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 05:00:00","value":2853,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 05:30:00","value":4835,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 06:00:00","value":6603,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 06:30:00","value":11230,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 07:00:00","value":13395,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 07:30:00","value":15650,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 08:00:00","value":17601,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 08:30:00","value":18818,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 09:00:00","value":18515,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 09:30:00","value":16972,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 10:00:00","value":15316,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 10:30:00","value":16003,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 11:00:00","value":14818,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 11:30:00","value":15610,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 12:00:00","value":16536,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 12:30:00","value":16153,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 13:00:00","value":15548,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 13:30:00","value":16500,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 14:00:00","value":16726,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 14:30:00","value":16838,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 15:00:00","value":16550,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 15:30:00","value":16621,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 16:00:00","value":15657,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 16:30:00","value":15334,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 17:00:00","value":17584,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 17:30:00","value":20903,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 18:00:00","value":21968,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 18:30:00","value":26945,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 19:00:00","value":24416,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 19:30:00","value":22401,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-14 20:00:00","value":23549,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 20:30:00","value":21498,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 21:00:00","value":23114,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 21:30:00","value":23341,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 22:00:00","value":22141,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 22:30:00","value":19110,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 23:00:00","value":16682,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-14 23:30:00","value":12631,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 00:00:00","value":10089,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 00:30:00","value":8553,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 01:00:00","value":6416,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 01:30:00","value":4694,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 02:00:00","value":3933,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 02:30:00","value":2833,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 03:00:00","value":2089,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 03:30:00","value":1896,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 04:00:00","value":2055,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 04:30:00","value":2031,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 05:00:00","value":2449,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 05:30:00","value":4360,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 06:00:00","value":7036,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 06:30:00","value":11730,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 07:00:00","value":14387,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 07:30:00","value":17505,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 08:00:00","value":19091,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 08:30:00","value":21057,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 09:00:00","value":20050,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 09:30:00","value":18637,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 10:00:00","value":17555,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 10:30:00","value":17595,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 11:00:00","value":16312,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 11:30:00","value":18232,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 12:00:00","value":18446,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 12:30:00","value":18204,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 13:00:00","value":17607,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 13:30:00","value":18945,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 14:00:00","value":22208,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 14:30:00","value":21574,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 15:00:00","value":17299,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 15:30:00","value":15515,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 16:00:00","value":13246,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 16:30:00","value":12328,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 17:00:00","value":15342,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 17:30:00","value":18730,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 18:00:00","value":23412,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 18:30:00","value":26340,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 19:00:00","value":27167,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 19:30:00","value":26279,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-15 20:00:00","value":23392,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 20:30:00","value":21571,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 21:00:00","value":23477,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 21:30:00","value":22612,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 22:00:00","value":21389,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 22:30:00","value":19575,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 23:00:00","value":18165,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-15 23:30:00","value":14923,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 00:00:00","value":11815,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 00:30:00","value":9024,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 01:00:00","value":7363,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 01:30:00","value":5812,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 02:00:00","value":4559,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 02:30:00","value":3673,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 03:00:00","value":2830,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 03:30:00","value":2374,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 04:00:00","value":2556,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 04:30:00","value":2456,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 05:00:00","value":2486,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 05:30:00","value":4451,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 06:00:00","value":6723,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 06:30:00","value":12501,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 07:00:00","value":14763,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 07:30:00","value":18127,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 08:00:00","value":20393,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 08:30:00","value":20753,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 09:00:00","value":20124,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 09:30:00","value":19253,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 10:00:00","value":17981,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 10:30:00","value":17720,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 11:00:00","value":16525,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 11:30:00","value":18153,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 12:00:00","value":18558,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 12:30:00","value":17652,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 13:00:00","value":17292,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 13:30:00","value":17551,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 14:00:00","value":17951,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 14:30:00","value":17909,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 15:00:00","value":17442,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 15:30:00","value":16533,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 16:00:00","value":14776,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 16:30:00","value":13462,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 17:00:00","value":16363,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 17:30:00","value":19310,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 18:00:00","value":22346,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 18:30:00","value":24408,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 19:00:00","value":26225,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 19:30:00","value":25423,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-16 20:00:00","value":23811,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 20:30:00","value":22028,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 21:00:00","value":24290,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 21:30:00","value":24835,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 22:00:00","value":24269,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 22:30:00","value":23526,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 23:00:00","value":21968,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-16 23:30:00","value":20137,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 00:00:00","value":16928,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 00:30:00","value":12753,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 01:00:00","value":10087,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 01:30:00","value":7881,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 02:00:00","value":6006,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 02:30:00","value":4382,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 03:00:00","value":3676,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 03:30:00","value":3214,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 04:00:00","value":3205,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 04:30:00","value":2849,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 05:00:00","value":2887,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 05:30:00","value":5039,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 06:00:00","value":7132,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 06:30:00","value":12095,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 07:00:00","value":14558,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 07:30:00","value":17298,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 08:00:00","value":19124,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 08:30:00","value":20407,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 09:00:00","value":19379,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 09:30:00","value":18867,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 10:00:00","value":17662,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 10:30:00","value":17447,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 11:00:00","value":16579,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 11:30:00","value":18340,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 12:00:00","value":18760,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 12:30:00","value":18457,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 13:00:00","value":17608,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 13:30:00","value":18913,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 14:00:00","value":19122,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 14:30:00","value":19547,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 15:00:00","value":17267,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 15:30:00","value":15916,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 16:00:00","value":13836,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 16:30:00","value":11985,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 17:00:00","value":14313,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 17:30:00","value":17988,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 18:00:00","value":21181,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 18:30:00","value":23539,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 19:00:00","value":24714,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 19:30:00","value":25079,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-17 20:00:00","value":23032,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 20:30:00","value":21168,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 21:00:00","value":25514,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 21:30:00","value":26286,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 22:00:00","value":25650,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 22:30:00","value":24850,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 23:00:00","value":23869,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-17 23:30:00","value":22913,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 00:00:00","value":20850,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 00:30:00","value":16734,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 01:00:00","value":14106,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 01:30:00","value":11587,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 02:00:00","value":8951,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 02:30:00","value":7199,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 03:00:00","value":6051,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 03:30:00","value":4693,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 04:00:00","value":4507,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 04:30:00","value":3791,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 05:00:00","value":3586,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 05:30:00","value":4918,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 06:00:00","value":7039,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 06:30:00","value":11262,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 07:00:00","value":13725,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 07:30:00","value":15899,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 08:00:00","value":17329,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 08:30:00","value":19757,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 09:00:00","value":19341,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 09:30:00","value":17660,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 10:00:00","value":16532,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 10:30:00","value":16354,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 11:00:00","value":16054,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 11:30:00","value":17326,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 12:00:00","value":17463,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 12:30:00","value":17091,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 13:00:00","value":16668,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 13:30:00","value":17096,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 14:00:00","value":17811,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 14:30:00","value":17980,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 15:00:00","value":17080,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 15:30:00","value":15185,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 16:00:00","value":13538,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 16:30:00","value":12704,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 17:00:00","value":15019,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 17:30:00","value":18778,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 18:00:00","value":21583,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 18:30:00","value":23834,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 19:00:00","value":25123,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 19:30:00","value":24762,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-18 20:00:00","value":22761,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 20:30:00","value":22227,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 21:00:00","value":23985,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 21:30:00","value":23788,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 22:00:00","value":23855,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 22:30:00","value":26040,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 23:00:00","value":25863,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-18 23:30:00","value":25851,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 00:00:00","value":26100,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 00:30:00","value":24625,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 01:00:00","value":22657,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 01:30:00","value":20289,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 02:00:00","value":18524,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 02:30:00","value":15943,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 03:00:00","value":13179,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 03:30:00","value":12423,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 04:00:00","value":10478,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 04:30:00","value":6556,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 05:00:00","value":4561,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 05:30:00","value":3513,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 06:00:00","value":3607,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 06:30:00","value":4781,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 07:00:00","value":5423,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 07:30:00","value":6669,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 08:00:00","value":7064,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 08:30:00","value":9363,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 09:00:00","value":10874,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 09:30:00","value":13255,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 10:00:00","value":13164,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 10:30:00","value":15159,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 11:00:00","value":16030,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 11:30:00","value":18256,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 12:00:00","value":17751,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 12:30:00","value":17675,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 13:00:00","value":18557,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 13:30:00","value":18389,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 14:00:00","value":17538,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 14:30:00","value":17506,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 15:00:00","value":17580,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 15:30:00","value":18027,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 16:00:00","value":16959,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 16:30:00","value":17066,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 17:00:00","value":18155,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 17:30:00","value":20610,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 18:00:00","value":20793,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 18:30:00","value":21584,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 19:00:00","value":23493,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 19:30:00","value":22555,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-19 20:00:00","value":20183,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 20:30:00","value":20441,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 21:00:00","value":21555,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 21:30:00","value":22406,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 22:00:00","value":22512,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 22:30:00","value":24667,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 23:00:00","value":25424,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-19 23:30:00","value":25852,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 00:00:00","value":25137,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 00:30:00","value":24099,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 01:00:00","value":23058,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 01:30:00","value":20786,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 02:00:00","value":19217,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 02:30:00","value":16329,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 03:00:00","value":14293,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 03:30:00","value":13193,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 04:00:00","value":11166,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 04:30:00","value":7518,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 05:00:00","value":4877,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 05:30:00","value":3639,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 06:00:00","value":3412,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 06:30:00","value":3827,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 07:00:00","value":3922,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 07:30:00","value":5241,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 08:00:00","value":5601,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 08:30:00","value":7147,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 09:00:00","value":8425,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 09:30:00","value":10951,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 10:00:00","value":11800,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 10:30:00","value":13936,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 11:00:00","value":14835,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 11:30:00","value":16412,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 12:00:00","value":16763,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 12:30:00","value":17613,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 13:00:00","value":17439,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 13:30:00","value":17921,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 14:00:00","value":18605,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 14:30:00","value":18113,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 15:00:00","value":17579,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 15:30:00","value":16927,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 16:00:00","value":16526,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 16:30:00","value":16956,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 17:00:00","value":17381,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 17:30:00","value":19232,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 18:00:00","value":19127,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 18:30:00","value":19404,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 19:00:00","value":18812,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 19:30:00","value":18253,"anomaly_type":"EXPECTED","category":"day"}
+{"timestamp":"2014-07-20 20:00:00","value":16497,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 20:30:00","value":16681,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 21:00:00","value":17334,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 21:30:00","value":17674,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 22:00:00","value":16469,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 22:30:00","value":15128,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 23:00:00","value":13973,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-20 23:30:00","value":12040,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 00:00:00","value":9494,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 00:30:00","value":6963,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 01:00:00","value":5611,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 01:30:00","value":4140,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 02:00:00","value":3370,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 02:30:00","value":2625,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 03:00:00","value":2093,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 03:30:00","value":1854,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 04:00:00","value":2482,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 04:30:00","value":2529,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 05:00:00","value":2968,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 05:30:00","value":4540,"anomaly_type":"EXPECTED","category":"night"}
+{"timestamp":"2014-07-21 06:00:00","value":6868,"anomaly_type":"EXPECTED","category":"day"}

--- a/doctest/test_mapping/nyc_taxi.json
+++ b/doctest/test_mapping/nyc_taxi.json
@@ -4,6 +4,9 @@
       "anomaly_type": {
         "type": "keyword"
       },
+      "category": {
+        "type": "keyword"
+      },
       "timestamp": {
         "type": "date",
         "format": "yyyy-MM-dd HH:mm:ss"

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/ADOperator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/ADOperator.java
@@ -6,7 +6,7 @@
 
 package org.opensearch.sql.opensearch.planner.physical;
 
-import static org.opensearch.sql.utils.MLCommonsConstants.AGG_FIELD;
+import static org.opensearch.sql.utils.MLCommonsConstants.CATEGORY_FIELD;
 import static org.opensearch.sql.utils.MLCommonsConstants.ANOMALY_RATE;
 import static org.opensearch.sql.utils.MLCommonsConstants.ANOMALY_SCORE_THRESHOLD;
 import static org.opensearch.sql.utils.MLCommonsConstants.DATE_FORMAT;
@@ -66,10 +66,10 @@ public class ADOperator extends MLCommonsOperatorActions {
   @Override
   public void open() {
     super.open();
-    String aggField =
-        arguments.containsKey(AGG_FIELD) ? (String) arguments.get(AGG_FIELD).getValue() : null;
+    String categoryField = arguments.containsKey(CATEGORY_FIELD)
+        ? (String) arguments.get(CATEGORY_FIELD).getValue() : null;
     List<Pair<DataFrame, DataFrame>>
-        inputDataFrames = generateAggregatedInputDataset(input, aggField);
+        inputDataFrames = generateAggregatedInputDataset(input, categoryField);
     MLAlgoParams mlAlgoParams = convertArgumentToMLParameter(arguments);
 
     List<MLPredictionOutput> predictionResults = inputDataFrames.stream()

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/ADOperator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/ADOperator.java
@@ -6,9 +6,9 @@
 
 package org.opensearch.sql.opensearch.planner.physical;
 
-import static org.opensearch.sql.utils.MLCommonsConstants.CATEGORY_FIELD;
 import static org.opensearch.sql.utils.MLCommonsConstants.ANOMALY_RATE;
 import static org.opensearch.sql.utils.MLCommonsConstants.ANOMALY_SCORE_THRESHOLD;
+import static org.opensearch.sql.utils.MLCommonsConstants.CATEGORY_FIELD;
 import static org.opensearch.sql.utils.MLCommonsConstants.DATE_FORMAT;
 import static org.opensearch.sql.utils.MLCommonsConstants.NUMBER_OF_TREES;
 import static org.opensearch.sql.utils.MLCommonsConstants.OUTPUT_AFTER;
@@ -69,7 +69,7 @@ public class ADOperator extends MLCommonsOperatorActions {
     String categoryField = arguments.containsKey(CATEGORY_FIELD)
         ? (String) arguments.get(CATEGORY_FIELD).getValue() : null;
     List<Pair<DataFrame, DataFrame>>
-        inputDataFrames = generateAggregatedInputDataset(input, categoryField);
+        inputDataFrames = generateCategorizedInputDataset(input, categoryField);
     MLAlgoParams mlAlgoParams = convertArgumentToMLParameter(arguments);
 
     List<MLPredictionOutput> predictionResults = inputDataFrames.stream()
@@ -126,53 +126,53 @@ public class ADOperator extends MLCommonsOperatorActions {
     if (arguments.get(TIME_FIELD) == null) {
       rcfType = FunctionName.BATCH_RCF;
       return BatchRCFParams.builder()
-              .numberOfTrees(arguments.containsKey(NUMBER_OF_TREES)
-                      ? ((Integer) arguments.get(NUMBER_OF_TREES).getValue())
-                      : null)
-              .sampleSize(arguments.containsKey(SAMPLE_SIZE)
-                      ? ((Integer) arguments.get(SAMPLE_SIZE).getValue())
-                      : null)
-              .outputAfter(arguments.containsKey(OUTPUT_AFTER)
-                      ? ((Integer) arguments.get(OUTPUT_AFTER).getValue())
-                      : null)
-              .trainingDataSize(arguments.containsKey(TRAINING_DATA_SIZE)
-                      ? ((Integer) arguments.get(TRAINING_DATA_SIZE).getValue())
-                      : null)
-              .anomalyScoreThreshold(arguments.containsKey(ANOMALY_SCORE_THRESHOLD)
-                      ? ((Double) arguments.get(ANOMALY_SCORE_THRESHOLD).getValue())
-                      : null)
-              .build();
+          .numberOfTrees(arguments.containsKey(NUMBER_OF_TREES)
+              ? ((Integer) arguments.get(NUMBER_OF_TREES).getValue())
+              : null)
+          .sampleSize(arguments.containsKey(SAMPLE_SIZE)
+              ? ((Integer) arguments.get(SAMPLE_SIZE).getValue())
+              : null)
+          .outputAfter(arguments.containsKey(OUTPUT_AFTER)
+              ? ((Integer) arguments.get(OUTPUT_AFTER).getValue())
+              : null)
+          .trainingDataSize(arguments.containsKey(TRAINING_DATA_SIZE)
+              ? ((Integer) arguments.get(TRAINING_DATA_SIZE).getValue())
+              : null)
+          .anomalyScoreThreshold(arguments.containsKey(ANOMALY_SCORE_THRESHOLD)
+              ? ((Double) arguments.get(ANOMALY_SCORE_THRESHOLD).getValue())
+              : null)
+          .build();
     }
     rcfType = FunctionName.FIT_RCF;
     return FitRCFParams.builder()
-            .numberOfTrees(arguments.containsKey(NUMBER_OF_TREES)
-                    ? ((Integer) arguments.get(NUMBER_OF_TREES).getValue())
-                    : null)
-            .shingleSize(arguments.containsKey(SHINGLE_SIZE)
-                    ? ((Integer) arguments.get(SHINGLE_SIZE).getValue())
-                    : null)
-            .sampleSize(arguments.containsKey(SAMPLE_SIZE)
-                    ? ((Integer) arguments.get(SAMPLE_SIZE).getValue())
-                    : null)
-            .outputAfter(arguments.containsKey(OUTPUT_AFTER)
-                    ? ((Integer) arguments.get(OUTPUT_AFTER).getValue())
-                    : null)
-            .timeDecay(arguments.containsKey(TIME_DECAY)
-                    ? ((Double) arguments.get(TIME_DECAY).getValue())
-                    : null)
-            .anomalyRate(arguments.containsKey(ANOMALY_RATE)
-                    ? ((Double) arguments.get(ANOMALY_RATE).getValue())
-                    : null)
-            .timeField(arguments.containsKey(TIME_FIELD)
-                    ? ((String) arguments.get(TIME_FIELD).getValue())
-                    : null)
-            .dateFormat(arguments.containsKey(DATE_FORMAT)
-                    ? ((String) arguments.get(DATE_FORMAT).getValue())
-                    : "yyyy-MM-dd HH:mm:ss")
-            .timeZone(arguments.containsKey(TIME_ZONE)
-                    ? ((String) arguments.get(TIME_ZONE).getValue())
-                    : null)
-            .build();
+        .numberOfTrees(arguments.containsKey(NUMBER_OF_TREES)
+            ? ((Integer) arguments.get(NUMBER_OF_TREES).getValue())
+            : null)
+        .shingleSize(arguments.containsKey(SHINGLE_SIZE)
+            ? ((Integer) arguments.get(SHINGLE_SIZE).getValue())
+            : null)
+        .sampleSize(arguments.containsKey(SAMPLE_SIZE)
+            ? ((Integer) arguments.get(SAMPLE_SIZE).getValue())
+            : null)
+        .outputAfter(arguments.containsKey(OUTPUT_AFTER)
+            ? ((Integer) arguments.get(OUTPUT_AFTER).getValue())
+            : null)
+        .timeDecay(arguments.containsKey(TIME_DECAY)
+            ? ((Double) arguments.get(TIME_DECAY).getValue())
+            : null)
+        .anomalyRate(arguments.containsKey(ANOMALY_RATE)
+            ? ((Double) arguments.get(ANOMALY_RATE).getValue())
+            : null)
+        .timeField(arguments.containsKey(TIME_FIELD)
+            ? ((String) arguments.get(TIME_FIELD).getValue())
+            : null)
+        .dateFormat(arguments.containsKey(DATE_FORMAT)
+            ? ((String) arguments.get(DATE_FORMAT).getValue())
+            : "yyyy-MM-dd HH:mm:ss")
+        .timeZone(arguments.containsKey(TIME_ZONE)
+            ? ((String) arguments.get(TIME_ZONE).getValue())
+            : null)
+        .build();
   }
 
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/MLCommonsOperatorActions.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/MLCommonsOperatorActions.java
@@ -7,12 +7,17 @@
 package org.opensearch.sql.opensearch.planner.physical;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
@@ -58,6 +63,55 @@ public abstract class MLCommonsOperatorActions extends PhysicalPlan {
     }
 
     return DataFrameBuilder.load(inputData);
+  }
+
+  /**
+   * Generate ml-commons request input dataset per each aggregated value on a given field.
+   * Each aggregated value of aggField will be a {@link DataFrame} pair, where the left one
+   * contains all fields for building response, and the right one contains all fields except
+   * the aggregated field for ml prediction.
+   * This is a temporary solution before ml-commons supports 2 dimensional input.
+   *
+   * @param input physical input
+   * @param aggField String, the field should be aggregated on
+   * @return list of ml-commons dataframe pairs
+   */
+  protected List<Pair<DataFrame, DataFrame>> generateAggregatedInputDataset(PhysicalPlan input,
+                                                                      String aggField) {
+    if (aggField == null) {
+      DataFrame dataFrame = generateInputDataset(input);
+      return Collections.singletonList(new ImmutablePair<>(dataFrame, dataFrame));
+    }
+
+    Map<ExprValue, Pair<List<Map<String, Object>>, List<Map<String, Object>>>> inputMap =
+        new HashMap<>();
+    while (input.hasNext()) {
+      Map<String, ExprValue> tupleValue = input.next().tupleValue();
+      ExprValue aggValue = tupleValue.get(aggField);
+      Pair<List<Map<String, Object>>, List<Map<String, Object>>> inputDataPair =
+          inputMap.computeIfAbsent(aggValue,
+              k -> new ImmutablePair<>(new LinkedList<>(), new LinkedList<>()));
+      List<Map<String, Object>> inputData = inputDataPair.getLeft();
+      List<Map<String, Object>> filteredInputData = inputDataPair.getRight();
+
+      ImmutableMap.Builder<String, Object> inputDataBuilder = ImmutableMap.builder();
+      ImmutableMap.Builder<String, Object> filteredInputDataBuilder = ImmutableMap.builder();
+      tupleValue.forEach((key, value) -> {
+        inputDataBuilder.put(key, value.value());
+        // aggField should not be included for ml prediction
+        if (!Objects.equals(aggField, key)) {
+          filteredInputDataBuilder.put(key, value.value());
+        }
+      });
+
+      inputData.add(inputDataBuilder.build());
+      filteredInputData.add(filteredInputDataBuilder.build());
+    }
+
+    return inputMap.values().stream()
+        .map(inputDataPair -> new ImmutablePair<>(DataFrameBuilder.load(inputDataPair.getLeft()),
+            DataFrameBuilder.load(inputDataPair.getRight())))
+        .collect(Collectors.toList());
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/MLCommonsOperatorActions.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/MLCommonsOperatorActions.java
@@ -13,12 +13,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.client.node.NodeClient;
@@ -78,8 +74,8 @@ public abstract class MLCommonsOperatorActions extends PhysicalPlan {
    * @param categoryField String, the field should be aggregated on
    * @return list of ml-commons dataframe pairs
    */
-  protected List<Pair<DataFrame, DataFrame>> generateAggregatedInputDataset(PhysicalPlan input,
-                                                                      String categoryField) {
+  protected List<Pair<DataFrame, DataFrame>> generateCategorizedInputDataset(PhysicalPlan input,
+                                                                             String categoryField) {
     if (categoryField == null) {
       DataFrame dataFrame = generateInputDataset(input);
       return Collections.singletonList(new ImmutablePair<>(dataFrame, dataFrame));
@@ -102,7 +98,7 @@ public abstract class MLCommonsOperatorActions extends PhysicalPlan {
         .map(inputData -> {
           // categoryField should be excluded for ml-commons predictions
           List<Map<String, Object>> filteredInputData = inputData.stream().map(
-                  row -> row.entrySet().stream().filter(entry -> !entry.getKey().equals(categoryField))
+                  row -> row.entrySet().stream().filter(e -> !e.getKey().equals(categoryField))
                       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
               .collect(Collectors.toList());
           return new ImmutablePair<>(DataFrameBuilder.load(inputData),

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/MLCommonsOperatorActions.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/MLCommonsOperatorActions.java
@@ -14,8 +14,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.client.node.NodeClient;
@@ -66,52 +69,45 @@ public abstract class MLCommonsOperatorActions extends PhysicalPlan {
   }
 
   /**
-   * Generate ml-commons request input dataset per each aggregated value on a given field.
-   * Each aggregated value of aggField will be a {@link DataFrame} pair, where the left one
-   * contains all fields for building response, and the right one contains all fields except
-   * the aggregated field for ml prediction.
-   * This is a temporary solution before ml-commons supports 2 dimensional input.
+   * Generate ml-commons request input dataset per each category based on a given category field.
+   * Each category value will be a {@link DataFrame} pair, where the left one contains all fields
+   * for building response, and the right one contains all fields except the aggregated field for
+   * ml prediction. This is a temporary solution before ml-commons supports 2 dimensional input.
    *
    * @param input physical input
-   * @param aggField String, the field should be aggregated on
+   * @param categoryField String, the field should be aggregated on
    * @return list of ml-commons dataframe pairs
    */
   protected List<Pair<DataFrame, DataFrame>> generateAggregatedInputDataset(PhysicalPlan input,
-                                                                      String aggField) {
-    if (aggField == null) {
+                                                                      String categoryField) {
+    if (categoryField == null) {
       DataFrame dataFrame = generateInputDataset(input);
       return Collections.singletonList(new ImmutablePair<>(dataFrame, dataFrame));
     }
 
-    Map<ExprValue, Pair<List<Map<String, Object>>, List<Map<String, Object>>>> inputMap =
-        new HashMap<>();
+    Map<ExprValue, List<Map<String, Object>>> inputMap = new HashMap<>();
     while (input.hasNext()) {
       Map<String, ExprValue> tupleValue = input.next().tupleValue();
-      ExprValue aggValue = tupleValue.get(aggField);
-      Pair<List<Map<String, Object>>, List<Map<String, Object>>> inputDataPair =
-          inputMap.computeIfAbsent(aggValue,
-              k -> new ImmutablePair<>(new LinkedList<>(), new LinkedList<>()));
-      List<Map<String, Object>> inputData = inputDataPair.getLeft();
-      List<Map<String, Object>> filteredInputData = inputDataPair.getRight();
-
-      ImmutableMap.Builder<String, Object> inputDataBuilder = ImmutableMap.builder();
-      ImmutableMap.Builder<String, Object> filteredInputDataBuilder = ImmutableMap.builder();
-      tupleValue.forEach((key, value) -> {
-        inputDataBuilder.put(key, value.value());
-        // aggField should not be included for ml prediction
-        if (!Objects.equals(aggField, key)) {
-          filteredInputDataBuilder.put(key, value.value());
+      ExprValue categoryValue = tupleValue.get(categoryField);
+      List<Map<String, Object>> inputData =
+          inputMap.computeIfAbsent(categoryValue, k -> new LinkedList<>());
+      inputData.add(new HashMap<String, Object>() {
+        {
+          tupleValue.forEach((key, value) -> put(key, value.value()));
         }
       });
-
-      inputData.add(inputDataBuilder.build());
-      filteredInputData.add(filteredInputDataBuilder.build());
     }
 
     return inputMap.values().stream()
-        .map(inputDataPair -> new ImmutablePair<>(DataFrameBuilder.load(inputDataPair.getLeft()),
-            DataFrameBuilder.load(inputDataPair.getRight())))
-        .collect(Collectors.toList());
+        .map(inputData -> {
+          // categoryField should be excluded for ml-commons predictions
+          List<Map<String, Object>> filteredInputData = inputData.stream().map(
+                  row -> row.entrySet().stream().filter(entry -> !entry.getKey().equals(categoryField))
+                      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+              .collect(Collectors.toList());
+          return new ImmutablePair<>(DataFrameBuilder.load(inputData),
+              DataFrameBuilder.load(filteredInputData));
+        }).collect(Collectors.toList());
   }
 
   /**

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -69,6 +69,7 @@ SAMPLE_SIZE:                        'SAMPLE_SIZE';
 OUTPUT_AFTER:                       'OUTPUT_AFTER';
 TIME_DECAY:                         'TIME_DECAY';
 ANOMALY_RATE:                       'ANOMALY_RATE';
+AGG_FIELD:                          'AGG_FIELD';
 TIME_FIELD:                         'TIME_FIELD';
 TIME_ZONE:                          'TIME_ZONE';
 TRAINING_DATA_SIZE:                 'TRAINING_DATA_SIZE';

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -69,7 +69,7 @@ SAMPLE_SIZE:                        'SAMPLE_SIZE';
 OUTPUT_AFTER:                       'OUTPUT_AFTER';
 TIME_DECAY:                         'TIME_DECAY';
 ANOMALY_RATE:                       'ANOMALY_RATE';
-AGG_FIELD:                          'AGG_FIELD';
+CATEGORY_FIELD:                     'CATEGORY_FIELD';
 TIME_FIELD:                         'TIME_FIELD';
 TIME_ZONE:                          'TIME_ZONE';
 TRAINING_DATA_SIZE:                 'TRAINING_DATA_SIZE';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -141,6 +141,7 @@ adParameter
     | (OUTPUT_AFTER EQUAL output_after=integerLiteral)
     | (TIME_DECAY EQUAL time_decay=decimalLiteral)
     | (ANOMALY_RATE EQUAL anomaly_rate=decimalLiteral)
+    | (AGG_FIELD EQUAL agg_field=stringLiteral)
     | (TIME_FIELD EQUAL time_field=stringLiteral)
     | (DATE_FORMAT EQUAL date_format=stringLiteral)
     | (TIME_ZONE EQUAL time_zone=stringLiteral)

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -141,7 +141,7 @@ adParameter
     | (OUTPUT_AFTER EQUAL output_after=integerLiteral)
     | (TIME_DECAY EQUAL time_decay=decimalLiteral)
     | (ANOMALY_RATE EQUAL anomaly_rate=decimalLiteral)
-    | (AGG_FIELD EQUAL agg_field=stringLiteral)
+    | (CATEGORY_FIELD EQUAL category_field=stringLiteral)
     | (TIME_FIELD EQUAL time_field=stringLiteral)
     | (DATE_FORMAT EQUAL date_format=stringLiteral)
     | (TIME_ZONE EQUAL time_zone=stringLiteral)


### PR DESCRIPTION
### Description
Add `category_field` to `AD` command. PPL will group inputs by category, and each group will be sent to AD for predictions separately. This is a temporary solution before ml-commons supports 2 dimensional data.

Enabled doctest for AD (which was disabled by #575)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).