### PR TITLE
Add stream context and window trigger

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/streaming/StreamContext.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/StreamContext.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming;
+
+import lombok.Data;
+
+/**
+ * Stream context required by stream processing components and can be
+ * stored and restored between executions.
+ */
+@Data
+public class StreamContext {
+
+  /** Current watermark timestamp. */
+  private long watermark;
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTrigger.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTrigger.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.trigger;
+
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.planner.streaming.StreamContext;
+import org.opensearch.sql.planner.streaming.windowing.Window;
+
+/**
+ * After watermark window trigger fires window state output once watermark.
+ */
+@RequiredArgsConstructor
+public class AfterWatermarkWindowTrigger implements WindowTrigger {
+
+  /** Stream context. */
+  private final StreamContext context;
+
+  @Override
+  public TriggerResult trigger(Window window) {
+    if (window.maxTimestamp() <= context.getWatermark()) {
+      return TriggerResult.FIRE;
+    }
+    return TriggerResult.CONTINUE;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTrigger.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTrigger.java
@@ -10,12 +10,14 @@ import org.opensearch.sql.planner.streaming.StreamContext;
 import org.opensearch.sql.planner.streaming.windowing.Window;
 
 /**
- * After watermark window trigger fires window state output once watermark.
+ * After watermark window trigger fires window state output once a window is below watermark.
+ * Precisely speaking, after watermark means the window boundary (max timestamp) is equal to
+ * or less than the current watermark timestamp.
  */
 @RequiredArgsConstructor
 public class AfterWatermarkWindowTrigger implements WindowTrigger {
 
-  /** Stream context. */
+  /** Stream context that contains the current watermark. */
   private final StreamContext context;
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/TriggerResult.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/TriggerResult.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.trigger;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Result determined by a trigger for what should happen to the window.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum TriggerResult {
+
+  /** Continue without any operation. */
+  CONTINUE(false, false),
+
+  /** Fire and purge window state by default. */
+  FIRE(true, true);
+
+  /** If window should be fired to output. */
+  private final boolean fire;
+
+  /** If the window state should be discarded. */
+  private final boolean purge;
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/WindowTrigger.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/WindowTrigger.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.trigger;
+
+import org.opensearch.sql.planner.streaming.windowing.Window;
+
+/**
+ * A window trigger determines if the current window state should be evaluated to emit output.
+ */
+public interface WindowTrigger {
+
+  /**
+   * Return trigger result for a window.
+   *
+   * @param window given window
+   * @return trigger result
+   */
+  TriggerResult trigger(Window window);
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/WindowTrigger.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/windowing/trigger/WindowTrigger.java
@@ -9,6 +9,8 @@ import org.opensearch.sql.planner.streaming.windowing.Window;
 
 /**
  * A window trigger determines if the current window state should be evaluated to emit output.
+ * Typically, trigger strategy works with downstream Sink operator together to meet the semantic
+ * requirements. For example, per-event trigger can work with Sink for materialized view semantic.
  */
 public interface WindowTrigger {
 

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTriggerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/windowing/trigger/AfterWatermarkWindowTriggerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.windowing.trigger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.planner.streaming.StreamContext;
+import org.opensearch.sql.planner.streaming.windowing.Window;
+
+class AfterWatermarkWindowTriggerTest {
+
+  private final StreamContext context = new StreamContext();
+
+  private final AfterWatermarkWindowTrigger trigger = new AfterWatermarkWindowTrigger(context);
+
+  @Test
+  void shouldNotFireWindowAboveWatermark() {
+    context.setWatermark(999);
+    assertEquals(TriggerResult.CONTINUE, trigger.trigger(new Window(500, 1500)));
+    assertEquals(TriggerResult.CONTINUE, trigger.trigger(new Window(500, 1001)));
+    assertEquals(TriggerResult.CONTINUE, trigger.trigger(new Window(1000, 1500)));
+  }
+
+  @Test
+  void shouldFireWindowBelowWatermark() {
+    context.setWatermark(999);
+    assertEquals(TriggerResult.FIRE, trigger.trigger(new Window(500, 800)));
+    assertEquals(TriggerResult.FIRE, trigger.trigger(new Window(500, 1000)));
+  }
+}


### PR DESCRIPTION
### Description

As another main component for stream data windowing, this PR adds Window Trigger along with Stream Context.

#### Stream Context

A stream context holds useful context information for all stream processing components. It’s also easy to store and restore between executions by put all state in one place.

#### Window Trigger

A window trigger determines whether to trigger window state output (a window pane). Common trigger implementation includes:

* After Watermark: trigger if the window is below watermark.
* Count: trigger based on a counter. A special case is per-event trigger for materialized view semantics.
* Time: trigger when its time comes.

Note that window trigger is easy to be confused with watermark. Watermark is the way to reason about the completeness of window state. Window trigger upon user configuration can decide to trigger output no matter the window state is complete or not.

 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/951
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).