### PR TITLE
Add watermark generator

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGenerator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGenerator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.watermark;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Watermark generator that generates watermark with bounded out-of-order latency.
+ */
+@RequiredArgsConstructor
+public class BoundedOutOfOrderWatermarkGenerator implements WatermarkGenerator {
+
+  /** The maximum out-of-order allowed. */
+  private final long maxOutOfOrderAllowed;
+
+  /** The maximum timestamp seen so far. */
+  private long maxTimestamp;
+
+  @Override
+  public long generate(long timestamp) {
+    maxTimestamp = Math.max(maxTimestamp, timestamp);
+    return (maxTimestamp - maxOutOfOrderAllowed - 1);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGenerator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGenerator.java
@@ -8,15 +8,15 @@ package org.opensearch.sql.planner.streaming.watermark;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Watermark generator that generates watermark with bounded out-of-order latency.
+ * Watermark generator that generates watermark with bounded out-of-order delay.
  */
 @RequiredArgsConstructor
 public class BoundedOutOfOrderWatermarkGenerator implements WatermarkGenerator {
 
-  /** The maximum out-of-order allowed. */
+  /** The maximum out-of-order allowed in millisecond. */
   private final long maxOutOfOrderAllowed;
 
-  /** The maximum timestamp seen so far. */
+  /** The maximum timestamp seen so far in millisecond. */
   private long maxTimestamp;
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/WatermarkGenerator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/WatermarkGenerator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.watermark;
+
+/**
+ * A watermark generator generates watermark timestamp based on some strategy.
+ */
+public interface WatermarkGenerator {
+
+  /**
+   * Generate watermark timestamp on the given event timestamp.
+   *
+   * @param timestamp event timestamp.
+   * @return watermark timestamp
+   */
+  long generate(long timestamp);
+
+}

--- a/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/WatermarkGenerator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/streaming/watermark/WatermarkGenerator.java
@@ -6,15 +6,16 @@
 package org.opensearch.sql.planner.streaming.watermark;
 
 /**
- * A watermark generator generates watermark timestamp based on some strategy.
+ * A watermark generator generates watermark timestamp based on some strategy which is defined
+ * in implementation class.
  */
 public interface WatermarkGenerator {
 
   /**
    * Generate watermark timestamp on the given event timestamp.
    *
-   * @param timestamp event timestamp.
-   * @return watermark timestamp
+   * @param timestamp event timestamp in millisecond
+   * @return watermark timestamp in millisecond
    */
   long generate(long timestamp);
 

--- a/core/src/test/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGeneratorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/streaming/watermark/BoundedOutOfOrderWatermarkGeneratorTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.streaming.watermark;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class BoundedOutOfOrderWatermarkGeneratorTest {
+
+  @Test
+  void shouldAdvanceWatermarkIfLaterEvent() {
+    BoundedOutOfOrderWatermarkGenerator generator = new BoundedOutOfOrderWatermarkGenerator(100);
+    assertEquals(899, generator.generate(1000));
+    assertEquals(1899, generator.generate(2000));
+  }
+
+  @Test
+  void shouldNotChangeWatermarkByLateEvent() {
+    BoundedOutOfOrderWatermarkGenerator generator = new BoundedOutOfOrderWatermarkGenerator(100);
+    assertEquals(899, generator.generate(1000));
+    assertEquals(899, generator.generate(500));
+    assertEquals(899, generator.generate(700));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Chen Dai <daichen@amazon.com>

### Description

Watermark is a monotonically increasing timestamp of the oldest work not yet completed. The work can be any grouping operation, such as aggregate or join, that accumulate stream events to a table and maintain the state. In other words, watermark is the way of how we reason about the completeness of accumulated window state.

There are several aspects of watermark implementation, including watermark generation, watermark emit frequency and watermark propagation. This PR is focused on the watermark generation which has no dependency on how we integrate with query plan later.

What's covered in this PR is the common generate strategy: *Bounded Out-Of-Order Watermark Generator* which allows a fixed delay for disordered data.
 
### Issues Resolved

https://github.com/opensearch-project/sql/issues/953
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).