### PR TITLE
Adding docs related to catalog.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ gen
 
 /artifacts/
 /.pid.lock
+/.prom.pid.lock

--- a/docs/user/ppl/admin/catalog.rst
+++ b/docs/user/ppl/admin/catalog.rst
@@ -1,0 +1,86 @@
+.. highlight:: sh
+
+=================
+Catalog Settings
+=================
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 1
+
+Introduction
+============
+
+The concept of ``catalog`` is introduced to support the federation of SQL/PPL query engine to multiple data sources.
+This helps PPL users to leverage data from multiple data sources and derive correlation and insights.
+Catalog definition provides the information to connect to a datasource and also gives a name to them to refer in PPL commands.
+
+
+Definitions of catalog and connector
+====================================
+* Connector is a component that adapts the query engine to a datasource. For example, Prometheus connector would adapt and help execute the queries to run on Prometheus data source. connector name is enough in the catalog definition json.
+* Catalog is a construct to define how to connect to a datasource and which connector to adapt by query engine.
+
+Example Prometheus Catalog Definition ::
+
+    [{
+        "name" : "prometheus",
+        "connector": "prometheus",
+        "uri" : "http://localhost:9090",
+        "authentication" : {
+            "type" : "basicauth",
+            "username" : "admin",
+            "password" : "admin"
+        }
+    }]
+Catalog configuration Restrictions.
+
+* ``name``, ``uri``, ``connector`` are required fields in the catalog configuration.
+* All the catalog names should be unique.
+* Catalog names should match with the regex of an identifier[``[@*A-Za-z]+?[*a-zA-Z_\-0-9]*``].
+* ``prometheus`` is the only connector allowed.
+
+Configuring catalog in OpenSearch
+====================================
+
+* Catalogs are configured in opensearch keystore as secure settings under ``plugins.query.federation.catalog.config`` key as they contain credential info.
+* A json file containing array of catalog configurations should be injected into keystore with the above mentioned key. sample json file can be seen in the above section.
+
+
+[**To be run on all the nodes in the cluster**] Command to add catalog.json file to OpenSearch Keystore ::
+
+    >> bin/opensearch-keystore add-file plugins.query.federation.catalog.config catalog.json
+
+Catalogs can be configured during opensearch start up or can be updated while the opensearch is running.
+If we update catalog configuration during runtime, the following api should be triggered to update the query engine with the latest changes.
+
+[**Required only if we update keystore settings during runtime**] Secure Settings refresh api::
+
+    >> curl --request POST \
+      --url http://{{opensearch-domain}}:9200/_nodes/reload_secure_settings \
+      --data '{"secure_settings_password":"{{keystore-password}}"}'
+
+
+Using a catalog in PPL command
+====================================
+Catalog is referred in source command as show in the code block below.
+Based on the abstraction designed by the connector,
+one can refer the corresponding entity as table in the source command.
+For example in prometheus connector, each metric is abstracted as a table.
+so we can refer a metric and apply stats over it in the following way.
+
+Example source command with prometheus catalog ::
+
+    >> source = prometheus.prometheus_http_requests_total | stats avg(@value) by job;
+
+
+Limitations of catalog
+====================================
+* Catalog settings are global and all PPL users are allowed to fetch data from all the defined catalogs.
+* In each catalog, PPL users can access all the data available with the credentials provided in the catalog definition.
+* With the current release, Basic and AWSSigV4 are the only authentication mechanisms supported with the underlying data sources.
+
+
+

--- a/docs/user/ppl/index.rst
+++ b/docs/user/ppl/index.rst
@@ -34,6 +34,8 @@ The query start with search command and then flowing a set of command delimited 
 
   - `Monitoring <admin/monitoring.rst>`_
 
+  - `Catalog Settings <admin/catalog.rst>`_
+
 * **Commands**
 
   - `Syntax <cmd/syntax.rst>`_

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -9,6 +9,7 @@ import org.opensearch.gradle.testclusters.RunTask
 plugins {
     id 'base'
     id 'com.wiredforcode.spawn'
+    id "de.undercouch.download" version "5.3.0"
 }
 
 apply plugin: 'opensearch.testclusters'
@@ -25,6 +26,27 @@ task bootstrap(type: Exec) {
     commandLine 'sh', "$projectDir/bootstrap.sh"
 }
 
+task startPrometheus(type: SpawnProcessTask) {
+    doFirst {
+        download.run {
+            src 'https://github.com/prometheus/prometheus/releases/download/v2.39.1/prometheus-2.39.1.linux-amd64.tar.gz'
+            dest new File("$projectDir/bin", 'prometheus.tar.gz')
+        }
+        copy {
+            from tarTree("$projectDir/bin/prometheus.tar.gz")
+            into "$projectDir/bin"
+        }
+        copy {
+            from "$projectDir/bin/prometheus.yml"
+            into "$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus"
+        }
+    }
+    command "$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus --storage.tsdb.path=$projectDir/bin/prometheus-2.39.1.linux-amd64/data --config.file=$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus.yml"
+    ready 'TSDB started'
+    pidLockFileName '.prom.pid.lock'
+}
+
+
 //evaluationDependsOn(':')
 task startOpenSearch(type: SpawnProcessTask) {
     command "${path}/gradlew -p ${plugin_path} runRestTestCluster"
@@ -40,11 +62,30 @@ task doctest(type: Exec, dependsOn: ['bootstrap']) {
     }
 }
 
-task stopOpenSearch(type: KillProcessTask)
+task stopOpenSearch(type: KillProcessTask) {
+
+    finalizedBy {
+        def pidFile = new File(path, ".prom.pid.lock")
+        if(!pidFile.exists()) {
+            logger.quiet "No Prometheus server running!"
+            return
+        }
+
+        def pid = pidFile.text
+        def process = "kill $pid".execute()
+
+        try {
+            process.waitFor()
+        } finally {
+            pidFile.delete()
+        }
+        println("Killed Prometheus")
+    }
+}
 
 doctest.dependsOn startOpenSearch
+startOpenSearch.dependsOn startPrometheus
 doctest.finalizedBy stopOpenSearch
-
 build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 
@@ -60,6 +101,7 @@ String mlCommonsPlugin = 'opensearch-ml'
 
 testClusters {
     docTestCluster {
+        keystore 'plugins.query.federation.catalog.config', new File("$projectDir/catalog", 'catalog.json')
         plugin(provider(new Callable<RegularFile>(){
             @Override
             RegularFile call() throws Exception {

--- a/doctest/catalog/catalog.json
+++ b/doctest/catalog/catalog.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name" : "prometheus",
+    "connector": "prometheus",
+    "uri" : "http://localhost:9090"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Vamsi Manohar <reddyvam@amazon.com>

### Description
Documentation for catalog and added prometheus connector in doctest cluster.

One can view the page here: https://github.com/vamsi-amazon/sql/blob/docs-prometheus/docs/user/ppl/admin/catalog.rst
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/939
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).