### PR TITLE
Removed json-smart in the JDBC driver

### DIFF
--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -57,9 +57,8 @@ dependencies {
     testImplementation('org.junit-pioneer:junit-pioneer:0.3.0')
     testImplementation('org.eclipse.jetty:jetty-server:9.4.48.v20220622')
 
-    // Enforce wiremock to use latest guava and json-smart
+    // Enforce wiremock to use latest guava
     testImplementation('com.google.guava:guava:31.1-jre')
-    testImplementation('net.minidev:json-smart:2.4.8')
 
     testRuntimeOnly('org.slf4j:slf4j-simple:1.7.25') // capture WireMock logging
 }


### PR DESCRIPTION
Signed-off-by: Guian Gumpac <guiang@bitquilltech.com>

### Description
Removed json-smart in the jdbc driver as it introduces a CVE (CVE-2021-31684).
 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).