### PR TITLE
Bump version to 1.3.7

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -3,7 +3,7 @@ name: SQL Java CI
 on: [push, pull_request]
 
 env:
-  OPENSEARCH_VERSION: '1.3.6-SNAPSHOT'
+  OPENSEARCH_VERSION: '1.3.7-SNAPSHOT'
 
 jobs:
   build:

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 env: 
   PLUGIN_NAME: query-workbench-dashboards
   OPENSEARCH_VERSION: '1.3'
-  OPENSEARCH_PLUGIN_VERSION: 1.3.6.0
+  OPENSEARCH_PLUGIN_VERSION: 1.3.7.0
 
 jobs:
 

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ subprojects {
     apply plugin: 'checkstyle'
     checkstyle {
         configFile rootProject.file("config/checkstyle/google_checks.xml")
-        toolVersion "10.3.2"
+        toolVersion "8.29"
         configProperties = [
                 "org.checkstyle.google.suppressionfilter.config": rootProject.file("config/checkstyle/suppressions.xml")]
         ignoreFailures = false

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ subprojects {
     apply plugin: 'checkstyle'
     checkstyle {
         configFile rootProject.file("config/checkstyle/google_checks.xml")
-        toolVersion "8.29"
+        toolVersion "10.3.2"
         configProperties = [
                 "org.checkstyle.google.suppressionfilter.config": rootProject.file("config/checkstyle/suppressions.xml")]
         ignoreFailures = false

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.3.6-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.3.7-SNAPSHOT")
         spring_version = "5.3.22"
         jackson_version = "2.13.4"
         jackson_databind_version = "2.13.4.2"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         opensearch_version = System.getProperty("opensearch.version", "1.3.6-SNAPSHOT")
         spring_version = "5.3.22"
         jackson_version = "2.13.4"
-        jackson_databind_version = "2.13.4"
+        jackson_databind_version = "2.13.4.2"
     }
 
     repositories {

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -45,7 +45,9 @@ task stopOpenSearch(type: KillProcessTask)
 doctest.dependsOn startOpenSearch
 doctest.finalizedBy stopOpenSearch
 
-build.dependsOn doctest
+// disable doctest for 1.3.x in case no opensearch-ml-1.3.7 snapshot.
+// https://github.com/opensearch-project/sql/issues/942
+// build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 
 String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.6/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-1.3.6.0.zip'

--- a/workbench/opensearch_dashboards.json
+++ b/workbench/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "queryWorkbenchDashboards",
-  "version": "1.3.6.0",
-  "opensearchDashboardsVersion": "1.3.6",
+  "version": "1.3.7.0",
+  "opensearchDashboardsVersion": "1.3.7",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation"],

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-query-workbench",
-  "version": "1.3.6.0",
+  "version": "1.3.7.0",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description
* Bump version to 1.3.7.
* Bump jackson-databind to 2.13.4.2.
* Disable doctest for ml-commons. 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).