### PR TITLE
Disable loading `ML-commons` plugin for doctests

### DIFF
--- a/docs/user/ppl/cmd/ad.rst
+++ b/docs/user/ppl/cmd/ad.rst
@@ -48,7 +48,7 @@ The example trains an RCF model and uses the model to detect anomalies in the ti
 
 PPL query::
 
-    os> source=nyc_taxi | fields value, timestamp | AD time_field='timestamp' | where value=10844.0
+    > source=nyc_taxi | fields value, timestamp | AD time_field='timestamp' | where value=10844.0
     fetched rows / total rows = 1/1
     +---------+---------------------+---------+-----------------+
     | value   | timestamp           | score   | anomaly_grade   |
@@ -63,7 +63,7 @@ The example trains an RCF model and uses the model to detect anomalies in the ti
 
 PPL query::
 
-    os> source=nyc_taxi | fields category, value, timestamp | AD time_field='timestamp' category_field='category' | where value=10844.0 or value=6526.0
+    > source=nyc_taxi | fields category, value, timestamp | AD time_field='timestamp' category_field='category' | where value=10844.0 or value=6526.0
     fetched rows / total rows = 2/2
     +------------+---------+---------------------+---------+-----------------+
     | category   | value   | timestamp           | score   | anomaly_grade   |
@@ -80,7 +80,7 @@ The example trains an RCF model and uses the model to detect anomalies in the no
 
 PPL query::
 
-    os> source=nyc_taxi | fields value | AD | where value=10844.0
+    > source=nyc_taxi | fields value | AD | where value=10844.0
     fetched rows / total rows = 1/1
     +---------+---------+-------------+
     | value   | score   | anomalous   |
@@ -95,7 +95,7 @@ The example trains an RCF model and uses the model to detect anomalies in the no
 
 PPL query::
 
-    os> source=nyc_taxi | fields category, value | AD category_field='category' | where value=10844.0 or value=6526.0
+    > source=nyc_taxi | fields category, value | AD category_field='category' | where value=10844.0 or value=6526.0
     fetched rows / total rows = 2/2
     +------------+---------+---------+-------------+
     | category   | value   | score   | anomalous   |

--- a/docs/user/ppl/cmd/kmeans.rst
+++ b/docs/user/ppl/cmd/kmeans.rst
@@ -30,7 +30,7 @@ The example shows how to classify three Iris species (Iris setosa, Iris virginic
 
 PPL query::
 
-    os> source=iris_data | fields sepal_length_in_cm, sepal_width_in_cm, petal_length_in_cm, petal_width_in_cm | kmeans centroids=3
+    > source=iris_data | fields sepal_length_in_cm, sepal_width_in_cm, petal_length_in_cm, petal_width_in_cm | kmeans centroids=3
     +--------------------+-------------------+--------------------+-------------------+-----------+
     | sepal_length_in_cm | sepal_width_in_cm | petal_length_in_cm | petal_width_in_cm | ClusterID |
     |--------------------+-------------------+--------------------+-------------------+-----------|

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -105,6 +105,8 @@ String mlCommonsPlugin = 'opensearch-ml'
 testClusters {
     docTestCluster {
         keystore 'plugins.query.federation.catalog.config', new File("$projectDir/catalog", 'catalog.json')
+        // Disable loading of `ML-commons` plugin, because it might be unavailable (not released yet).
+        /*
         plugin(provider(new Callable<RegularFile>(){
             @Override
             RegularFile call() throws Exception {
@@ -124,6 +126,7 @@ testClusters {
                 }
             }
         }))
+        */
         plugin ':opensearch-sql-plugin'
         testDistribution = 'integ_test'
     }


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
[temporary] Disable doctests which use `ML-common` plugin.
 
### Issues Resolved
https://github.com/opensearch-project/sql/pull/915#issuecomment-1294048850
Unblocks #999
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).