### PR TITLE
In memory execution for queries with span and patterns expressions

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusCatalogCommandsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusCatalogCommandsIT.java
@@ -155,4 +155,22 @@ public class PrometheusCatalogCommandsIT extends PPLIntegTestCase {
     }
   }
 
+  @Test
+  @SneakyThrows
+  public void testMetricSumAggregationCommandWithOutSpan() {
+    JSONObject response =
+        executeQuery("source=my_prometheus.prometheus_http_requests_total | stats sum(@value) by handler, job");
+    verifySchema(response,
+        schema("sum(@value)",  "double"),
+        schema("handler", "string"),
+        schema("job", "string"));
+    Assertions.assertTrue(response.getInt("size") > 0);
+    Assertions.assertEquals(3, response.getJSONArray("datarows").getJSONArray(0).length());
+    JSONArray firstRow = response.getJSONArray("datarows").getJSONArray(0);
+    for (int i = 0; i < firstRow.length(); i++) {
+      Assertions.assertNotNull(firstRow.get(i));
+      Assertions.assertTrue(StringUtils.isNotEmpty(firstRow.get(i).toString()));
+    }
+  }
+
 }

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/planner/logical/rules/MergeAggAndIndexScan.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/planner/logical/rules/MergeAggAndIndexScan.java
@@ -14,6 +14,8 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import org.opensearch.sql.expression.parse.PatternsExpression;
+import org.opensearch.sql.expression.span.SpanExpression;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.optimizer.Rule;
@@ -37,6 +39,12 @@ public class MergeAggAndIndexScan implements Rule<LogicalAggregation> {
   public MergeAggAndIndexScan() {
     this.capture = Capture.newCapture();
     this.pattern = typeOf(LogicalAggregation.class)
+        .matching(logicalAggregation -> logicalAggregation.getGroupByList()
+            .stream()
+            .noneMatch(expression -> expression.getDelegated() instanceof PatternsExpression))
+        .matching(logicalAggregation -> logicalAggregation.getGroupByList()
+            .stream()
+            .anyMatch(expression -> expression.getDelegated() instanceof SpanExpression))
         .with(source().matching(typeOf(PrometheusLogicalMetricScan.class)
             .capturedAs(capture)));
   }

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/planner/logical/rules/MergeAggAndRelation.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/planner/logical/rules/MergeAggAndRelation.java
@@ -14,6 +14,8 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import org.opensearch.sql.expression.parse.PatternsExpression;
+import org.opensearch.sql.expression.span.SpanExpression;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalRelation;
@@ -37,6 +39,12 @@ public class MergeAggAndRelation implements Rule<LogicalAggregation> {
   public MergeAggAndRelation() {
     this.relationCapture = Capture.newCapture();
     this.pattern = typeOf(LogicalAggregation.class)
+        .matching(logicalAggregation -> logicalAggregation.getGroupByList()
+            .stream()
+            .noneMatch(expression -> expression.getDelegated() instanceof PatternsExpression))
+        .matching(logicalAggregation -> logicalAggregation.getGroupByList()
+            .stream()
+            .anyMatch(expression -> expression.getDelegated() instanceof SpanExpression))
         .with(source().matching(typeOf(LogicalRelation.class).capturedAs(relationCapture)));
   }
 

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/planner/logical/PrometheusLogicOptimizerTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/planner/logical/PrometheusLogicOptimizerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.config.ExpressionConfig;
 import org.opensearch.sql.planner.logical.LogicalPlan;
@@ -62,7 +63,9 @@ public class PrometheusLogicOptimizerTest {
             indexScanAgg("prometheus_http_total_requests", ImmutableList
                     .of(DSL.named("AVG(@value)",
                         dsl.avg(DSL.ref("@value", INTEGER)))),
-                ImmutableList.of(DSL.named("code", DSL.ref("code", STRING)))),
+                ImmutableList.of(DSL.named("code", DSL.ref("code", STRING)),
+                    DSL.named(DSL.span(DSL.ref("@timestamp", ExprCoreType.TIMESTAMP),
+                        DSL.literal(40), "s")))),
             DSL.named("AVG(intV)", DSL.ref("AVG(intV)", DOUBLE))),
         optimize(
             project(
@@ -72,7 +75,10 @@ public class PrometheusLogicOptimizerTest {
                         .of(DSL.named("AVG(@value)",
                             dsl.avg(DSL.ref("@value", INTEGER)))),
                     ImmutableList.of(DSL.named("code",
-                        DSL.ref("code", STRING)))),
+                        DSL.ref("code", STRING)),
+                        DSL.named(DSL.span(DSL.ref("@timestamp", ExprCoreType.TIMESTAMP),
+                            DSL.literal(40), "s"))
+                        )),
                 DSL.named("AVG(intV)", DSL.ref("AVG(intV)", DOUBLE)))
         )
     );
@@ -89,7 +95,50 @@ public class PrometheusLogicOptimizerTest {
                 ImmutableList
                     .of(DSL.named("AVG(@value)",
                         dsl.avg(DSL.ref("@value", INTEGER)))),
-                ImmutableList.of(DSL.named("job", DSL.ref("job", STRING)))),
+                ImmutableList.of(DSL.named("job", DSL.ref("job", STRING)),
+                    DSL.named(DSL.span(DSL.ref("@timestamp", ExprCoreType.TIMESTAMP),
+                        DSL.literal(40), "s")))),
+            DSL.named("AVG(@value)", DSL.ref("AVG(@value)", DOUBLE))),
+        optimize(
+            project(
+                aggregation(
+                    filter(
+                        relation("prometheus_http_total_requests", table),
+                        dsl.and(
+                            dsl.equal(DSL.ref("code", STRING),
+                                DSL.literal(stringValue("200"))),
+                            dsl.equal(DSL.ref("handler", STRING),
+                                DSL.literal(stringValue("/ready/"))))
+                    ),
+                    ImmutableList
+                        .of(DSL.named("AVG(@value)",
+                            dsl.avg(DSL.ref("@value", INTEGER)))),
+                    ImmutableList.of(DSL.named("job",
+                        DSL.ref("job", STRING)),
+                        DSL.named(DSL.span(DSL.ref("@timestamp", ExprCoreType.TIMESTAMP),
+                            DSL.literal(40), "s")))),
+                DSL.named("AVG(@value)", DSL.ref("AVG(@value)", DOUBLE)))
+        )
+    );
+  }
+
+
+  @Test
+  void aggregation_merge_filter_relation_with_patterns_expression() {
+    assertEquals(
+        project(
+            aggregation(
+                indexScan("prometheus_http_total_requests",
+                    dsl.and(
+                        dsl.equal(DSL.ref("code", STRING),
+                            DSL.literal(stringValue("200"))),
+                        dsl.equal(DSL.ref("handler", STRING),
+                            DSL.literal(stringValue("/ready/"))))),
+                ImmutableList
+                    .of(DSL.named("AVG(@value)",
+                        dsl.avg(DSL.ref("@value", INTEGER)))),
+                ImmutableList.of(DSL.named("job",
+                    DSL.ref("job", STRING)))),
             DSL.named("AVG(@value)", DSL.ref("AVG(@value)", DOUBLE))),
         optimize(
             project(
@@ -107,6 +156,52 @@ public class PrometheusLogicOptimizerTest {
                             dsl.avg(DSL.ref("@value", INTEGER)))),
                     ImmutableList.of(DSL.named("job",
                         DSL.ref("job", STRING)))),
+                DSL.named("AVG(@value)", DSL.ref("AVG(@value)", DOUBLE)))
+        )
+    );
+  }
+
+  @Test
+  void aggregation_merge_filter_relation_without_span_expression() {
+    assertEquals(
+        project(
+            aggregation(
+                indexScan("prometheus_http_total_requests",
+                    dsl.and(
+                        dsl.equal(DSL.ref("code", STRING),
+                            DSL.literal(stringValue("200"))),
+                        dsl.equal(DSL.ref("handler", STRING),
+                            DSL.literal(stringValue("/ready/"))))),
+                ImmutableList
+                    .of(DSL.named("AVG(@value)",
+                        dsl.avg(DSL.ref("@value", INTEGER)))),
+                ImmutableList.of(DSL.named("job",
+                        DSL.ref("job", STRING)),
+                    DSL.named("custom_field",
+                        DSL.patterns(DSL.ref("string_value", STRING),
+                            DSL.literal("custom_pattern"),
+                            DSL.literal("custom_field"))))),
+            DSL.named("AVG(@value)", DSL.ref("AVG(@value)", DOUBLE))),
+        optimize(
+            project(
+                aggregation(
+                    filter(
+                        relation("prometheus_http_total_requests", table),
+                        dsl.and(
+                            dsl.equal(DSL.ref("code", STRING),
+                                DSL.literal(stringValue("200"))),
+                            dsl.equal(DSL.ref("handler", STRING),
+                                DSL.literal(stringValue("/ready/"))))
+                    ),
+                    ImmutableList
+                        .of(DSL.named("AVG(@value)",
+                            dsl.avg(DSL.ref("@value", INTEGER)))),
+                    ImmutableList.of(DSL.named("job",
+                        DSL.ref("job", STRING)),
+                        DSL.named("custom_field",
+                            DSL.patterns(DSL.ref("string_value", STRING),
+                                DSL.literal("custom_pattern"),
+                                DSL.literal("custom_field"))))),
                 DSL.named("AVG(@value)", DSL.ref("AVG(@value)", DOUBLE)))
         )
     );


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
Instead of failing requests without span and patterns expressions, don't push down the aggregations to prometheus rather calculate them in memory.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).