### PR TITLE
Add valueOf() to Expression

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -184,7 +184,7 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
     }
 
     var value = visitFunction(node, context);
-    value = DSL.literal(value.valueOf(null));
+    value = DSL.literal(value.valueOf());
     context.getConstantFunctionValues().put(valueName, value);
     return value;
   }

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -102,7 +102,7 @@ public class DSL {
       return (NamedExpression) expression;
     }
     if (expression instanceof ParseExpression) {
-      return named(((ParseExpression) expression).getIdentifier().valueOf(null).stringValue(),
+      return named(((ParseExpression) expression).getIdentifier().valueOf().stringValue(),
           expression);
     }
     return named(expression.toString(), expression);

--- a/core/src/main/java/org/opensearch/sql/expression/Expression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/Expression.java
@@ -17,6 +17,13 @@ import org.opensearch.sql.expression.env.Environment;
 public interface Expression extends Serializable {
 
   /**
+   * Evaluate the value of expression that does not depend on value environment.
+   */
+  default ExprValue valueOf() {
+    return valueOf(null);
+  }
+
+  /**
    * Evaluate the value of expression in the value environment.
    */
   ExprValue valueOf(Environment<Expression, ExprValue> valueEnv);

--- a/core/src/main/java/org/opensearch/sql/expression/aggregation/TakeAggregator.java
+++ b/core/src/main/java/org/opensearch/sql/expression/aggregation/TakeAggregator.java
@@ -29,7 +29,7 @@ public class TakeAggregator extends Aggregator<TakeAggregator.TakeState> {
 
   @Override
   public TakeState create() {
-    return new TakeState(getArguments().get(1).valueOf(null).integerValue());
+    return new TakeState(getArguments().get(1).valueOf().integerValue());
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/expression/parse/GrokExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/parse/GrokExpression.java
@@ -45,7 +45,7 @@ public class GrokExpression extends ParseExpression {
    */
   public GrokExpression(Expression sourceField, Expression pattern, Expression identifier) {
     super("grok", sourceField, pattern, identifier);
-    this.grok = grokCompiler.compile(pattern.valueOf(null).stringValue());
+    this.grok = grokCompiler.compile(pattern.valueOf().stringValue());
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/expression/parse/ParseExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/parse/ParseExpression.java
@@ -48,7 +48,7 @@ public abstract class ParseExpression extends FunctionExpression {
     this.sourceField = sourceField;
     this.pattern = pattern;
     this.identifier = identifier;
-    this.identifierStr = identifier.valueOf(null).stringValue();
+    this.identifierStr = identifier.valueOf().stringValue();
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/expression/parse/PatternsExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/parse/PatternsExpression.java
@@ -44,7 +44,7 @@ public class PatternsExpression extends ParseExpression {
    */
   public PatternsExpression(Expression sourceField, Expression pattern, Expression identifier) {
     super("patterns", sourceField, pattern, identifier);
-    String patternStr = pattern.valueOf(null).stringValue();
+    String patternStr = pattern.valueOf().stringValue();
     useCustomPattern = !patternStr.isEmpty();
     if (useCustomPattern) {
       this.pattern = Pattern.compile(patternStr);

--- a/core/src/main/java/org/opensearch/sql/expression/parse/RegexExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/parse/RegexExpression.java
@@ -40,7 +40,7 @@ public class RegexExpression extends ParseExpression {
    */
   public RegexExpression(Expression sourceField, Expression pattern, Expression identifier) {
     super("regex", sourceField, pattern, identifier);
-    this.regexPattern = Pattern.compile(pattern.valueOf(null).stringValue());
+    this.regexPattern = Pattern.compile(pattern.valueOf().stringValue());
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/planner/physical/ValuesOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/ValuesOperator.java
@@ -58,7 +58,7 @@ public class ValuesOperator extends PhysicalPlan {
   @Override
   public ExprValue next() {
     List<ExprValue> values = valuesIterator.next().stream()
-                                           .map(expr -> expr.valueOf(null))
+                                           .map(expr -> expr.valueOf())
                                            .collect(Collectors.toList());
     return new ExprCollectionValue(values);
   }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
@@ -49,7 +49,7 @@ public abstract class Rounding<T> {
    * Create Rounding instance.
    */
   public static Rounding<?> createRounding(SpanExpression span) {
-    ExprValue interval = span.getValue().valueOf(null);
+    ExprValue interval = span.getValue().valueOf();
     ExprType type = span.type();
 
     if (LONG.isCompatible(type)) {

--- a/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
@@ -583,7 +583,7 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
     var values = List.of(analyze(AstDSL.constantFunction("now")),
         analyze(AstDSL.constantFunction("now")), analyze(AstDSL.constantFunction("now")));
     assertTrue(values.stream().allMatch(v ->
-        v.valueOf(null) == analyze(AstDSL.constantFunction("now")).valueOf(null)));
+        v.valueOf() == analyze(AstDSL.constantFunction("now")).valueOf()));
   }
 
   @Test
@@ -593,8 +593,8 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
     // different values
     var values = List.of(analyze(function("sysdate")), analyze(function("sysdate")),
         analyze(function("sysdate")), analyze(function("sysdate")));
-    var referenceValue = analyze(function("sysdate")).valueOf(null);
-    assertTrue(values.stream().noneMatch(v -> v.valueOf(null) == referenceValue));
+    var referenceValue = analyze(function("sysdate")).valueOf();
+    assertTrue(values.stream().noneMatch(v -> v.valueOf() == referenceValue));
   }
 
   @Test
@@ -602,8 +602,8 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
     // // We can call `now()` as a function, in that case nothing should be cached
     var values = List.of(analyze(function("now")), analyze(function("now")),
         analyze(function("now")), analyze(function("now")));
-    var referenceValue = analyze(function("now")).valueOf(null);
-    assertTrue(values.stream().noneMatch(v -> v.valueOf(null) == referenceValue));
+    var referenceValue = analyze(function("now")).valueOf();
+    assertTrue(values.stream().noneMatch(v -> v.valueOf() == referenceValue));
   }
 
   protected Expression analyze(UnresolvedExpression unresolvedExpression) {

--- a/core/src/test/java/org/opensearch/sql/expression/NamedExpressionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/NamedExpressionTest.java
@@ -59,7 +59,7 @@ class NamedExpressionTest extends ExpressionTestBase {
             DSL.literal("group"));
     NamedExpression named = DSL.named(parse);
     assertEquals(parse, named.getDelegated());
-    assertEquals(parse.getIdentifier().valueOf(null).stringValue(), named.getName());
+    assertEquals(parse.getIdentifier().valueOf().stringValue(), named.getName());
   }
 
 }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -831,7 +831,7 @@ class DateTimeFunctionTest extends ExpressionTestBase {
 
     expr = dsl.time(dsl.date(DSL.literal("2020-01-02")));
     assertEquals(TIME, expr.type());
-    assertEquals(new ExprTimeValue("00:00:00"), expr.valueOf(null));
+    assertEquals(new ExprTimeValue("00:00:00"), expr.valueOf());
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
@@ -66,19 +66,19 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected LocalDateTime fromUnixTime(Long value) {
-    return fromUnixTime(DSL.literal(value)).valueOf(null).datetimeValue();
+    return fromUnixTime(DSL.literal(value)).valueOf().datetimeValue();
   }
 
   protected LocalDateTime fromUnixTime(Double value) {
-    return fromUnixTime(DSL.literal(value)).valueOf(null).datetimeValue();
+    return fromUnixTime(DSL.literal(value)).valueOf().datetimeValue();
   }
 
   protected String fromUnixTime(Long value, String format) {
-    return fromUnixTime(DSL.literal(value), DSL.literal(format)).valueOf(null).stringValue();
+    return fromUnixTime(DSL.literal(value), DSL.literal(format)).valueOf().stringValue();
   }
 
   protected String fromUnixTime(Double value, String format) {
-    return fromUnixTime(DSL.literal(value), DSL.literal(format)).valueOf(null).stringValue();
+    return fromUnixTime(DSL.literal(value), DSL.literal(format)).valueOf().stringValue();
   }
 
   protected FunctionExpression makedate(Expression year, Expression dayOfYear) {
@@ -89,7 +89,7 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected LocalDate makedate(Double year, Double dayOfYear) {
-    return makedate(DSL.literal(year), DSL.literal(dayOfYear)).valueOf(null).dateValue();
+    return makedate(DSL.literal(year), DSL.literal(dayOfYear)).valueOf().dateValue();
   }
 
   protected FunctionExpression maketime(Expression hour, Expression minute, Expression second) {
@@ -101,7 +101,7 @@ public class DateTimeTestBase extends ExpressionTestBase {
 
   protected LocalTime maketime(Double hour, Double minute, Double second) {
     return maketime(DSL.literal(hour), DSL.literal(minute), DSL.literal(second))
-        .valueOf(null).timeValue();
+        .valueOf().timeValue();
   }
 
   protected FunctionExpression period_add(Expression period, Expression months) {
@@ -112,7 +112,7 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected Integer period_add(Integer period, Integer months) {
-    return period_add(DSL.literal(period), DSL.literal(months)).valueOf(null).integerValue();
+    return period_add(DSL.literal(period), DSL.literal(months)).valueOf().integerValue();
   }
 
   protected FunctionExpression period_diff(Expression first, Expression second) {
@@ -123,7 +123,7 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected Integer period_diff(Integer first, Integer second) {
-    return period_diff(DSL.literal(first), DSL.literal(second)).valueOf(null).integerValue();
+    return period_diff(DSL.literal(first), DSL.literal(second)).valueOf().integerValue();
   }
 
   protected FunctionExpression unixTimeStampExpr() {
@@ -133,7 +133,7 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected Long unixTimeStamp() {
-    return unixTimeStampExpr().valueOf(null).longValue();
+    return unixTimeStampExpr().valueOf().longValue();
   }
 
   protected FunctionExpression unixTimeStampOf(Expression value) {
@@ -144,18 +144,18 @@ public class DateTimeTestBase extends ExpressionTestBase {
   }
 
   protected Double unixTimeStampOf(Double value) {
-    return unixTimeStampOf(DSL.literal(value)).valueOf(null).doubleValue();
+    return unixTimeStampOf(DSL.literal(value)).valueOf().doubleValue();
   }
 
   protected Double unixTimeStampOf(LocalDate value) {
-    return unixTimeStampOf(DSL.literal(new ExprDateValue(value))).valueOf(null).doubleValue();
+    return unixTimeStampOf(DSL.literal(new ExprDateValue(value))).valueOf().doubleValue();
   }
 
   protected Double unixTimeStampOf(LocalDateTime value) {
-    return unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value))).valueOf(null).doubleValue();
+    return unixTimeStampOf(DSL.literal(new ExprDatetimeValue(value))).valueOf().doubleValue();
   }
 
   protected Double unixTimeStampOf(Instant value) {
-    return unixTimeStampOf(DSL.literal(new ExprTimestampValue(value))).valueOf(null).doubleValue();
+    return unixTimeStampOf(DSL.literal(new ExprTimestampValue(value))).valueOf().doubleValue();
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/FromUnixTimeTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/FromUnixTimeTest.java
@@ -132,54 +132,54 @@ public class FromUnixTimeTest extends DateTimeTestBase {
   @Test
   public void checkInvalidFormat() {
     assertEquals(new ExprStringValue("q"),
-        fromUnixTime(DSL.literal(0L), DSL.literal("%q")).valueOf(null));
+        fromUnixTime(DSL.literal(0L), DSL.literal("%q")).valueOf());
     assertEquals(new ExprStringValue(""),
-        fromUnixTime(DSL.literal(0L), DSL.literal("")).valueOf(null));
+        fromUnixTime(DSL.literal(0L), DSL.literal("")).valueOf());
   }
 
   @Test
   public void checkValueOutsideOfTheRangeWithoutFormat() {
-    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(-1L)).valueOf(null));
-    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(-1.5d)).valueOf(null));
-    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(32536771200L)).valueOf(null));
-    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(32536771200d)).valueOf(null));
+    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(-1L)).valueOf());
+    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(-1.5d)).valueOf());
+    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(32536771200L)).valueOf());
+    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(32536771200d)).valueOf());
   }
 
   @Test
   public void checkInsideTheRangeWithoutFormat() {
-    assertNotEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(32536771199L)).valueOf(null));
-    assertNotEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(32536771199d)).valueOf(null));
+    assertNotEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(32536771199L)).valueOf());
+    assertNotEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(32536771199d)).valueOf());
   }
 
   @Test
   public void checkValueOutsideOfTheRangeWithFormat() {
     assertEquals(ExprNullValue.of(),
-        fromUnixTime(DSL.literal(32536771200L), DSL.literal("%d")).valueOf(null));
+        fromUnixTime(DSL.literal(32536771200L), DSL.literal("%d")).valueOf());
     assertEquals(ExprNullValue.of(),
-        fromUnixTime(DSL.literal(32536771200d), DSL.literal("%d")).valueOf(null));
+        fromUnixTime(DSL.literal(32536771200d), DSL.literal("%d")).valueOf());
   }
 
   @Test
   public void checkInsideTheRangeWithFormat() {
     assertNotEquals(ExprNullValue.of(),
-        fromUnixTime(DSL.literal(32536771199L), DSL.literal("%d")).valueOf(null));
+        fromUnixTime(DSL.literal(32536771199L), DSL.literal("%d")).valueOf());
     assertNotEquals(ExprNullValue.of(),
-        fromUnixTime(DSL.literal(32536771199d), DSL.literal("%d")).valueOf(null));
+        fromUnixTime(DSL.literal(32536771199d), DSL.literal("%d")).valueOf());
   }
 
   @Test
   public void checkNullOrNegativeValues() {
-    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(ExprNullValue.of())).valueOf(null));
+    assertEquals(ExprNullValue.of(), fromUnixTime(DSL.literal(ExprNullValue.of())).valueOf());
     assertEquals(ExprNullValue.of(),
-        fromUnixTime(DSL.literal(-1L), DSL.literal("%d")).valueOf(null));
+        fromUnixTime(DSL.literal(-1L), DSL.literal("%d")).valueOf());
     assertEquals(ExprNullValue.of(),
-        fromUnixTime(DSL.literal(-1.5d), DSL.literal("%d")).valueOf(null));
+        fromUnixTime(DSL.literal(-1.5d), DSL.literal("%d")).valueOf());
     assertEquals(ExprNullValue.of(),
-        fromUnixTime(DSL.literal(42L), DSL.literal(ExprNullValue.of())).valueOf(null));
+        fromUnixTime(DSL.literal(42L), DSL.literal(ExprNullValue.of())).valueOf());
     assertEquals(ExprNullValue.of(),
-        fromUnixTime(DSL.literal(ExprNullValue.of()), DSL.literal("%d")).valueOf(null));
+        fromUnixTime(DSL.literal(ExprNullValue.of()), DSL.literal("%d")).valueOf());
     assertEquals(ExprNullValue.of(),
         fromUnixTime(DSL.literal(ExprNullValue.of()), DSL.literal(ExprNullValue.of()))
-            .valueOf(null));
+            .valueOf());
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/NowLikeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/NowLikeFunctionTest.java
@@ -60,9 +60,9 @@ public class NowLikeFunctionTest extends ExpressionTestBase {
 
   private Temporal extractValue(FunctionExpression func) {
     switch ((ExprCoreType)func.type()) {
-      case DATE: return func.valueOf(null).dateValue();
-      case DATETIME: return func.valueOf(null).datetimeValue();
-      case TIME: return func.valueOf(null).timeValue();
+      case DATE: return func.valueOf().dateValue();
+      case DATETIME: return func.valueOf().datetimeValue();
+      case TIME: return func.valueOf().timeValue();
       // unreachable code
       default: throw new IllegalArgumentException(String.format("%s", func.type()));
     }
@@ -105,7 +105,7 @@ public class NowLikeFunctionTest extends ExpressionTestBase {
 
       for (var wrongFspValue: List.of(-1, 10)) {
         var exception = assertThrows(IllegalArgumentException.class,
-            () -> function.apply(new Expression[]{DSL.literal(wrongFspValue)}).valueOf(null));
+            () -> function.apply(new Expression[]{DSL.literal(wrongFspValue)}).valueOf());
         assertEquals(String.format("Invalid `fsp` value: %d, allowed 0 to 6", wrongFspValue),
             exception.getMessage());
       }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/PeriodFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/PeriodFunctionsTest.java
@@ -96,8 +96,8 @@ public class PeriodFunctionsTest extends DateTimeTestBase {
   @ParameterizedTest
   @MethodSource("getInvalidTestData")
   public void period_add_returns_null_on_invalid_input(int period) {
-    assertNull(period_add(DSL.literal(period), DSL.literal(1)).valueOf(null).value());
-    assertNull(period_diff(DSL.literal(period), DSL.literal(1)).valueOf(null).value());
-    assertNull(period_diff(DSL.literal(1), DSL.literal(period)).valueOf(null).value());
+    assertNull(period_add(DSL.literal(period), DSL.literal(1)).valueOf().value());
+    assertNull(period_diff(DSL.literal(period), DSL.literal(1)).valueOf().value());
+    assertNull(period_diff(DSL.literal(1), DSL.literal(period)).valueOf().value());
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/UnixTimeStampTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/UnixTimeStampTest.java
@@ -229,7 +229,7 @@ public class UnixTimeStampTest extends DateTimeTestBase {
   @MethodSource("getInvalidDoubleSamples")
   public void checkInvalidDoubleCausesNull(Double value) {
     assertEquals(ExprNullValue.of(),
-        unixTimeStampOf(DSL.literal(new ExprDoubleValue(value))).valueOf(null),
+        unixTimeStampOf(DSL.literal(new ExprDoubleValue(value))).valueOf(),
         new DecimalFormat("0.#").format(value));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/ArithmeticFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/ArithmeticFunctionTest.java
@@ -71,7 +71,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     FunctionExpression expression = dsl.add(literal(op1), literal(op2));
     ExprType expectedType = WideningTypeRule.max(op1.type(), op2.type());
     assertEquals(expectedType, expression.type());
-    assertValueEqual(BuiltinFunctionName.ADD, expectedType, op1, op2, expression.valueOf(null));
+    assertValueEqual(BuiltinFunctionName.ADD, expectedType, op1, op2, expression.valueOf());
     assertEquals(String.format("+(%s, %s)", op1.toString(), op2.toString()), expression.toString());
   }
 
@@ -147,7 +147,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     ExprType expectedType = WideningTypeRule.max(op1.type(), op2.type());
     assertEquals(expectedType, expression.type());
     assertValueEqual(BuiltinFunctionName.SUBTRACT, expectedType, op1, op2,
-        expression.valueOf(null));
+        expression.valueOf());
     assertEquals(String.format("-(%s, %s)", op1.toString(), op2.toString()),
         expression.toString());
   }
@@ -159,7 +159,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     ExprType expectedType = WideningTypeRule.max(op1.type(), op2.type());
     assertEquals(expectedType, expression.type());
     assertValueEqual(BuiltinFunctionName.MULTIPLY, expectedType, op1, op2,
-        expression.valueOf(null));
+        expression.valueOf());
     assertEquals(String.format("*(%s, %s)", op1.toString(), op2.toString()),
         expression.toString());
   }
@@ -170,7 +170,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     FunctionExpression expression = dsl.divide(literal(op1), literal(op2));
     ExprType expectedType = WideningTypeRule.max(op1.type(), op2.type());
     assertEquals(expectedType, expression.type());
-    assertValueEqual(BuiltinFunctionName.DIVIDE, expectedType, op1, op2, expression.valueOf(null));
+    assertValueEqual(BuiltinFunctionName.DIVIDE, expectedType, op1, op2, expression.valueOf());
     assertEquals(String.format("/(%s, %s)", op1.toString(), op2.toString()),
         expression.toString());
 
@@ -187,7 +187,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     FunctionExpression expression = dsl.module(literal(op1), literal(op2));
     ExprType expectedType = WideningTypeRule.max(op1.type(), op2.type());
     assertEquals(expectedType, expression.type());
-    assertValueEqual(BuiltinFunctionName.MODULES, expectedType, op1, op2, expression.valueOf(null));
+    assertValueEqual(BuiltinFunctionName.MODULES, expectedType, op1, op2, expression.valueOf());
     assertEquals(String.format("%%(%s, %s)", op1.toString(), op2.toString()),
         expression.toString());
 

--- a/core/src/test/java/org/opensearch/sql/expression/operator/convert/TypeCastOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/convert/TypeCastOperatorTest.java
@@ -81,7 +81,7 @@ class TypeCastOperatorTest {
   void castToString(ExprValue value) {
     FunctionExpression expression = dsl.castString(DSL.literal(value));
     assertEquals(STRING, expression.type());
-    assertEquals(new ExprStringValue(value.value().toString()), expression.valueOf(null));
+    assertEquals(new ExprStringValue(value.value().toString()), expression.valueOf());
   }
 
   @ParameterizedTest(name = "castToByte({0})")
@@ -89,7 +89,7 @@ class TypeCastOperatorTest {
   void castToByte(ExprValue value) {
     FunctionExpression expression = dsl.castByte(DSL.literal(value));
     assertEquals(BYTE, expression.type());
-    assertEquals(new ExprByteValue(value.byteValue()), expression.valueOf(null));
+    assertEquals(new ExprByteValue(value.byteValue()), expression.valueOf());
   }
 
   @ParameterizedTest(name = "castToShort({0})")
@@ -97,7 +97,7 @@ class TypeCastOperatorTest {
   void castToShort(ExprValue value) {
     FunctionExpression expression = dsl.castShort(DSL.literal(value));
     assertEquals(SHORT, expression.type());
-    assertEquals(new ExprShortValue(value.shortValue()), expression.valueOf(null));
+    assertEquals(new ExprShortValue(value.shortValue()), expression.valueOf());
   }
 
   @ParameterizedTest(name = "castToInt({0})")
@@ -105,67 +105,67 @@ class TypeCastOperatorTest {
   void castToInt(ExprValue value) {
     FunctionExpression expression = dsl.castInt(DSL.literal(value));
     assertEquals(INTEGER, expression.type());
-    assertEquals(new ExprIntegerValue(value.integerValue()), expression.valueOf(null));
+    assertEquals(new ExprIntegerValue(value.integerValue()), expression.valueOf());
   }
 
   @Test
   void castStringToByte() {
     FunctionExpression expression = dsl.castByte(DSL.literal("100"));
     assertEquals(BYTE, expression.type());
-    assertEquals(new ExprByteValue(100), expression.valueOf(null));
+    assertEquals(new ExprByteValue(100), expression.valueOf());
   }
 
   @Test
   void castStringToShort() {
     FunctionExpression expression = dsl.castShort(DSL.literal("100"));
     assertEquals(SHORT, expression.type());
-    assertEquals(new ExprShortValue(100), expression.valueOf(null));
+    assertEquals(new ExprShortValue(100), expression.valueOf());
   }
 
   @Test
   void castStringToInt() {
     FunctionExpression expression = dsl.castInt(DSL.literal("100"));
     assertEquals(INTEGER, expression.type());
-    assertEquals(new ExprIntegerValue(100), expression.valueOf(null));
+    assertEquals(new ExprIntegerValue(100), expression.valueOf());
   }
 
   @Test
   void castStringToIntException() {
     FunctionExpression expression = dsl.castInt(DSL.literal("invalid"));
-    assertThrows(RuntimeException.class, () -> expression.valueOf(null));
+    assertThrows(RuntimeException.class, () -> expression.valueOf());
   }
 
   @Test
   void castBooleanToByte() {
     FunctionExpression expression = dsl.castByte(DSL.literal(true));
     assertEquals(BYTE, expression.type());
-    assertEquals(new ExprByteValue(1), expression.valueOf(null));
+    assertEquals(new ExprByteValue(1), expression.valueOf());
 
     expression = dsl.castByte(DSL.literal(false));
     assertEquals(BYTE, expression.type());
-    assertEquals(new ExprByteValue(0), expression.valueOf(null));
+    assertEquals(new ExprByteValue(0), expression.valueOf());
   }
 
   @Test
   void castBooleanToShort() {
     FunctionExpression expression = dsl.castShort(DSL.literal(true));
     assertEquals(SHORT, expression.type());
-    assertEquals(new ExprShortValue(1), expression.valueOf(null));
+    assertEquals(new ExprShortValue(1), expression.valueOf());
 
     expression = dsl.castShort(DSL.literal(false));
     assertEquals(SHORT, expression.type());
-    assertEquals(new ExprShortValue(0), expression.valueOf(null));
+    assertEquals(new ExprShortValue(0), expression.valueOf());
   }
 
   @Test
   void castBooleanToInt() {
     FunctionExpression expression = dsl.castInt(DSL.literal(true));
     assertEquals(INTEGER, expression.type());
-    assertEquals(new ExprIntegerValue(1), expression.valueOf(null));
+    assertEquals(new ExprIntegerValue(1), expression.valueOf());
 
     expression = dsl.castInt(DSL.literal(false));
     assertEquals(INTEGER, expression.type());
-    assertEquals(new ExprIntegerValue(0), expression.valueOf(null));
+    assertEquals(new ExprIntegerValue(0), expression.valueOf());
   }
 
   @ParameterizedTest(name = "castToLong({0})")
@@ -173,31 +173,31 @@ class TypeCastOperatorTest {
   void castToLong(ExprValue value) {
     FunctionExpression expression = dsl.castLong(DSL.literal(value));
     assertEquals(LONG, expression.type());
-    assertEquals(new ExprLongValue(value.longValue()), expression.valueOf(null));
+    assertEquals(new ExprLongValue(value.longValue()), expression.valueOf());
   }
 
   @Test
   void castStringToLong() {
     FunctionExpression expression = dsl.castLong(DSL.literal("100"));
     assertEquals(LONG, expression.type());
-    assertEquals(new ExprLongValue(100), expression.valueOf(null));
+    assertEquals(new ExprLongValue(100), expression.valueOf());
   }
 
   @Test
   void castStringToLongException() {
     FunctionExpression expression = dsl.castLong(DSL.literal("invalid"));
-    assertThrows(RuntimeException.class, () -> expression.valueOf(null));
+    assertThrows(RuntimeException.class, () -> expression.valueOf());
   }
 
   @Test
   void castBooleanToLong() {
     FunctionExpression expression = dsl.castLong(DSL.literal(true));
     assertEquals(LONG, expression.type());
-    assertEquals(new ExprLongValue(1), expression.valueOf(null));
+    assertEquals(new ExprLongValue(1), expression.valueOf());
 
     expression = dsl.castLong(DSL.literal(false));
     assertEquals(LONG, expression.type());
-    assertEquals(new ExprLongValue(0), expression.valueOf(null));
+    assertEquals(new ExprLongValue(0), expression.valueOf());
   }
 
   @ParameterizedTest(name = "castToFloat({0})")
@@ -205,31 +205,31 @@ class TypeCastOperatorTest {
   void castToFloat(ExprValue value) {
     FunctionExpression expression = dsl.castFloat(DSL.literal(value));
     assertEquals(FLOAT, expression.type());
-    assertEquals(new ExprFloatValue(value.floatValue()), expression.valueOf(null));
+    assertEquals(new ExprFloatValue(value.floatValue()), expression.valueOf());
   }
 
   @Test
   void castStringToFloat() {
     FunctionExpression expression = dsl.castFloat(DSL.literal("100.0"));
     assertEquals(FLOAT, expression.type());
-    assertEquals(new ExprFloatValue(100.0), expression.valueOf(null));
+    assertEquals(new ExprFloatValue(100.0), expression.valueOf());
   }
 
   @Test
   void castStringToFloatException() {
     FunctionExpression expression = dsl.castFloat(DSL.literal("invalid"));
-    assertThrows(RuntimeException.class, () -> expression.valueOf(null));
+    assertThrows(RuntimeException.class, () -> expression.valueOf());
   }
 
   @Test
   void castBooleanToFloat() {
     FunctionExpression expression = dsl.castFloat(DSL.literal(true));
     assertEquals(FLOAT, expression.type());
-    assertEquals(new ExprFloatValue(1), expression.valueOf(null));
+    assertEquals(new ExprFloatValue(1), expression.valueOf());
 
     expression = dsl.castFloat(DSL.literal(false));
     assertEquals(FLOAT, expression.type());
-    assertEquals(new ExprFloatValue(0), expression.valueOf(null));
+    assertEquals(new ExprFloatValue(0), expression.valueOf());
   }
 
   @ParameterizedTest(name = "castToDouble({0})")
@@ -237,31 +237,31 @@ class TypeCastOperatorTest {
   void castToDouble(ExprValue value) {
     FunctionExpression expression = dsl.castDouble(DSL.literal(value));
     assertEquals(DOUBLE, expression.type());
-    assertEquals(new ExprDoubleValue(value.doubleValue()), expression.valueOf(null));
+    assertEquals(new ExprDoubleValue(value.doubleValue()), expression.valueOf());
   }
 
   @Test
   void castStringToDouble() {
     FunctionExpression expression = dsl.castDouble(DSL.literal("100.0"));
     assertEquals(DOUBLE, expression.type());
-    assertEquals(new ExprDoubleValue(100), expression.valueOf(null));
+    assertEquals(new ExprDoubleValue(100), expression.valueOf());
   }
 
   @Test
   void castStringToDoubleException() {
     FunctionExpression expression = dsl.castDouble(DSL.literal("invalid"));
-    assertThrows(RuntimeException.class, () -> expression.valueOf(null));
+    assertThrows(RuntimeException.class, () -> expression.valueOf());
   }
 
   @Test
   void castBooleanToDouble() {
     FunctionExpression expression = dsl.castDouble(DSL.literal(true));
     assertEquals(DOUBLE, expression.type());
-    assertEquals(new ExprDoubleValue(1), expression.valueOf(null));
+    assertEquals(new ExprDoubleValue(1), expression.valueOf());
 
     expression = dsl.castDouble(DSL.literal(false));
     assertEquals(DOUBLE, expression.type());
-    assertEquals(new ExprDoubleValue(0), expression.valueOf(null));
+    assertEquals(new ExprDoubleValue(0), expression.valueOf());
   }
 
   @ParameterizedTest(name = "castToBoolean({0})")
@@ -269,96 +269,96 @@ class TypeCastOperatorTest {
   void castToBoolean(ExprValue value) {
     FunctionExpression expression = dsl.castBoolean(DSL.literal(value));
     assertEquals(BOOLEAN, expression.type());
-    assertEquals(ExprBooleanValue.of(true), expression.valueOf(null));
+    assertEquals(ExprBooleanValue.of(true), expression.valueOf());
   }
 
   @Test
   void castZeroToBoolean() {
     FunctionExpression expression = dsl.castBoolean(DSL.literal(0));
     assertEquals(BOOLEAN, expression.type());
-    assertEquals(ExprBooleanValue.of(false), expression.valueOf(null));
+    assertEquals(ExprBooleanValue.of(false), expression.valueOf());
   }
 
   @Test
   void castStringToBoolean() {
     FunctionExpression expression = dsl.castBoolean(DSL.literal("True"));
     assertEquals(BOOLEAN, expression.type());
-    assertEquals(ExprBooleanValue.of(true), expression.valueOf(null));
+    assertEquals(ExprBooleanValue.of(true), expression.valueOf());
   }
 
   @Test
   void castBooleanToBoolean() {
     FunctionExpression expression = dsl.castBoolean(DSL.literal(true));
     assertEquals(BOOLEAN, expression.type());
-    assertEquals(ExprBooleanValue.of(true), expression.valueOf(null));
+    assertEquals(ExprBooleanValue.of(true), expression.valueOf());
   }
 
   @Test
   void castToDate() {
     FunctionExpression expression = dsl.castDate(DSL.literal("2012-08-07"));
     assertEquals(DATE, expression.type());
-    assertEquals(new ExprDateValue("2012-08-07"), expression.valueOf(null));
+    assertEquals(new ExprDateValue("2012-08-07"), expression.valueOf());
 
     expression = dsl.castDate(DSL.literal(new ExprDatetimeValue("2012-08-07 01:01:01")));
     assertEquals(DATE, expression.type());
-    assertEquals(new ExprDateValue("2012-08-07"), expression.valueOf(null));
+    assertEquals(new ExprDateValue("2012-08-07"), expression.valueOf());
 
     expression = dsl.castDate(DSL.literal(new ExprTimestampValue("2012-08-07 01:01:01")));
     assertEquals(DATE, expression.type());
-    assertEquals(new ExprDateValue("2012-08-07"), expression.valueOf(null));
+    assertEquals(new ExprDateValue("2012-08-07"), expression.valueOf());
 
     expression = dsl.castDate(DSL.literal(new ExprDateValue("2012-08-07")));
     assertEquals(DATE, expression.type());
-    assertEquals(new ExprDateValue("2012-08-07"), expression.valueOf(null));
+    assertEquals(new ExprDateValue("2012-08-07"), expression.valueOf());
   }
 
   @Test
   void castToTime() {
     FunctionExpression expression = dsl.castTime(DSL.literal("01:01:01"));
     assertEquals(TIME, expression.type());
-    assertEquals(new ExprTimeValue("01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprTimeValue("01:01:01"), expression.valueOf());
 
     expression = dsl.castTime(DSL.literal(new ExprDatetimeValue("2012-08-07 01:01:01")));
     assertEquals(TIME, expression.type());
-    assertEquals(new ExprTimeValue("01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprTimeValue("01:01:01"), expression.valueOf());
 
     expression = dsl.castTime(DSL.literal(new ExprTimestampValue("2012-08-07 01:01:01")));
     assertEquals(TIME, expression.type());
-    assertEquals(new ExprTimeValue("01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprTimeValue("01:01:01"), expression.valueOf());
 
     expression = dsl.castTime(DSL.literal(new ExprTimeValue("01:01:01")));
     assertEquals(TIME, expression.type());
-    assertEquals(new ExprTimeValue("01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprTimeValue("01:01:01"), expression.valueOf());
   }
 
   @Test
   void castToTimestamp() {
     FunctionExpression expression = dsl.castTimestamp(DSL.literal("2012-08-07 01:01:01"));
     assertEquals(TIMESTAMP, expression.type());
-    assertEquals(new ExprTimestampValue("2012-08-07 01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprTimestampValue("2012-08-07 01:01:01"), expression.valueOf());
 
     expression = dsl.castTimestamp(DSL.literal(new ExprDatetimeValue("2012-08-07 01:01:01")));
     assertEquals(TIMESTAMP, expression.type());
-    assertEquals(new ExprTimestampValue("2012-08-07 01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprTimestampValue("2012-08-07 01:01:01"), expression.valueOf());
 
     expression = dsl.castTimestamp(DSL.literal(new ExprTimestampValue("2012-08-07 01:01:01")));
     assertEquals(TIMESTAMP, expression.type());
-    assertEquals(new ExprTimestampValue("2012-08-07 01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprTimestampValue("2012-08-07 01:01:01"), expression.valueOf());
   }
 
   @Test
   void castToDatetime() {
     FunctionExpression expression = dsl.castDatetime(DSL.literal("2012-08-07 01:01:01"));
     assertEquals(DATETIME, expression.type());
-    assertEquals(new ExprDatetimeValue("2012-08-07 01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprDatetimeValue("2012-08-07 01:01:01"), expression.valueOf());
 
     expression = dsl.castDatetime(DSL.literal(new ExprTimestampValue("2012-08-07 01:01:01")));
     assertEquals(DATETIME, expression.type());
-    assertEquals(new ExprDatetimeValue("2012-08-07 01:01:01"), expression.valueOf(null));
+    assertEquals(new ExprDatetimeValue("2012-08-07 01:01:01"), expression.valueOf());
 
     expression = dsl.castDatetime(DSL.literal(new ExprDateValue("2012-08-07")));
     assertEquals(DATETIME, expression.type());
-    assertEquals(new ExprDatetimeValue("2012-08-07 00:00:00"), expression.valueOf(null));
+    assertEquals(new ExprDatetimeValue("2012-08-07 00:00:00"), expression.valueOf());
   }
 
 }

--- a/core/src/test/java/org/opensearch/sql/expression/system/SystemFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/system/SystemFunctionsTest.java
@@ -88,6 +88,6 @@ public class SystemFunctionsTest {
   }
 
   private String typeofGetValue(ExprValue input) {
-    return dsl.typeof(DSL.literal(input)).valueOf(null).stringValue();
+    return dsl.typeof(DSL.literal(input)).valueOf().stringValue();
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilder.java
@@ -55,7 +55,7 @@ public class BucketAggregationBuilder {
       return buildHistogram(
           expr.getNameOrAlias(),
           spanExpr.getField().toString(),
-          spanExpr.getValue().valueOf(null).doubleValue(),
+          spanExpr.getValue().valueOf().doubleValue(),
           spanExpr.getUnit(),
           missingOrder);
     } else {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
@@ -215,7 +215,7 @@ public class MetricAggregationBuilder
                                                       MetricParser parser) {
     String fieldName = ((ReferenceExpression) expression).getAttr();
     builder.fetchSource(fieldName, null);
-    builder.size(size.valueOf(null).integerValue());
+    builder.size(size.valueOf().integerValue());
     builder.from(0);
     if (condition != null) {
       return Pair.of(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -95,7 +95,7 @@ public abstract class LuceneQuery {
     ReferenceExpression ref = (ReferenceExpression) func.getArguments().get(0);
     Expression expr = func.getArguments().get(1);
     ExprValue literalValue = expr instanceof LiteralExpression ? expr
-        .valueOf(null) : cast((FunctionExpression) expr);
+        .valueOf() : cast((FunctionExpression) expr);
     return doBuild(ref.getAttr(), ref.type(), literalValue);
   }
 
@@ -111,101 +111,101 @@ public abstract class LuceneQuery {
       .<FunctionName, Function<LiteralExpression, ExprValue>>builder()
       .put(BuiltinFunctionName.CAST_TO_STRING.getName(), expr -> {
         if (!expr.type().equals(ExprCoreType.STRING)) {
-          return new ExprStringValue(String.valueOf(expr.valueOf(null).value()));
+          return new ExprStringValue(String.valueOf(expr.valueOf().value()));
         } else {
-          return expr.valueOf(null);
+          return expr.valueOf();
         }
       })
       .put(BuiltinFunctionName.CAST_TO_BYTE.getName(), expr -> {
         if (ExprCoreType.numberTypes().contains(expr.type())) {
-          return new ExprByteValue(expr.valueOf(null).byteValue());
+          return new ExprByteValue(expr.valueOf().byteValue());
         } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
-          return new ExprByteValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+          return new ExprByteValue(expr.valueOf().booleanValue() ? 1 : 0);
         } else {
-          return new ExprByteValue(Byte.valueOf(expr.valueOf(null).stringValue()));
+          return new ExprByteValue(Byte.valueOf(expr.valueOf().stringValue()));
         }
       })
       .put(BuiltinFunctionName.CAST_TO_SHORT.getName(), expr -> {
         if (ExprCoreType.numberTypes().contains(expr.type())) {
-          return new ExprShortValue(expr.valueOf(null).shortValue());
+          return new ExprShortValue(expr.valueOf().shortValue());
         } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
-          return new ExprShortValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+          return new ExprShortValue(expr.valueOf().booleanValue() ? 1 : 0);
         } else {
-          return new ExprShortValue(Short.valueOf(expr.valueOf(null).stringValue()));
+          return new ExprShortValue(Short.valueOf(expr.valueOf().stringValue()));
         }
       })
       .put(BuiltinFunctionName.CAST_TO_INT.getName(), expr -> {
         if (ExprCoreType.numberTypes().contains(expr.type())) {
-          return new ExprIntegerValue(expr.valueOf(null).integerValue());
+          return new ExprIntegerValue(expr.valueOf().integerValue());
         } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
-          return new ExprIntegerValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+          return new ExprIntegerValue(expr.valueOf().booleanValue() ? 1 : 0);
         } else {
-          return new ExprIntegerValue(Integer.valueOf(expr.valueOf(null).stringValue()));
+          return new ExprIntegerValue(Integer.valueOf(expr.valueOf().stringValue()));
         }
       })
       .put(BuiltinFunctionName.CAST_TO_LONG.getName(), expr -> {
         if (ExprCoreType.numberTypes().contains(expr.type())) {
-          return new ExprLongValue(expr.valueOf(null).longValue());
+          return new ExprLongValue(expr.valueOf().longValue());
         } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
-          return new ExprLongValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+          return new ExprLongValue(expr.valueOf().booleanValue() ? 1 : 0);
         } else {
-          return new ExprLongValue(Long.valueOf(expr.valueOf(null).stringValue()));
+          return new ExprLongValue(Long.valueOf(expr.valueOf().stringValue()));
         }
       })
       .put(BuiltinFunctionName.CAST_TO_FLOAT.getName(), expr -> {
         if (ExprCoreType.numberTypes().contains(expr.type())) {
-          return new ExprFloatValue(expr.valueOf(null).floatValue());
+          return new ExprFloatValue(expr.valueOf().floatValue());
         } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
-          return new ExprFloatValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+          return new ExprFloatValue(expr.valueOf().booleanValue() ? 1 : 0);
         } else {
-          return new ExprFloatValue(Float.valueOf(expr.valueOf(null).stringValue()));
+          return new ExprFloatValue(Float.valueOf(expr.valueOf().stringValue()));
         }
       })
       .put(BuiltinFunctionName.CAST_TO_DOUBLE.getName(), expr -> {
         if (ExprCoreType.numberTypes().contains(expr.type())) {
-          return new ExprDoubleValue(expr.valueOf(null).doubleValue());
+          return new ExprDoubleValue(expr.valueOf().doubleValue());
         } else if (expr.type().equals(ExprCoreType.BOOLEAN)) {
-          return new ExprDoubleValue(expr.valueOf(null).booleanValue() ? 1 : 0);
+          return new ExprDoubleValue(expr.valueOf().booleanValue() ? 1 : 0);
         } else {
-          return new ExprDoubleValue(Double.valueOf(expr.valueOf(null).stringValue()));
+          return new ExprDoubleValue(Double.valueOf(expr.valueOf().stringValue()));
         }
       })
       .put(BuiltinFunctionName.CAST_TO_BOOLEAN.getName(), expr -> {
         if (ExprCoreType.numberTypes().contains(expr.type())) {
-          return expr.valueOf(null).doubleValue() != 0
+          return expr.valueOf().doubleValue() != 0
               ? ExprBooleanValue.of(true) : ExprBooleanValue.of(false);
         } else if (expr.type().equals(ExprCoreType.STRING)) {
-          return ExprBooleanValue.of(Boolean.valueOf(expr.valueOf(null).stringValue()));
+          return ExprBooleanValue.of(Boolean.valueOf(expr.valueOf().stringValue()));
         } else {
-          return expr.valueOf(null);
+          return expr.valueOf();
         }
       })
       .put(BuiltinFunctionName.CAST_TO_DATE.getName(), expr -> {
         if (expr.type().equals(ExprCoreType.STRING)) {
-          return new ExprDateValue(expr.valueOf(null).stringValue());
+          return new ExprDateValue(expr.valueOf().stringValue());
         } else {
-          return new ExprDateValue(expr.valueOf(null).dateValue());
+          return new ExprDateValue(expr.valueOf().dateValue());
         }
       })
       .put(BuiltinFunctionName.CAST_TO_TIME.getName(), expr -> {
         if (expr.type().equals(ExprCoreType.STRING)) {
-          return new ExprTimeValue(expr.valueOf(null).stringValue());
+          return new ExprTimeValue(expr.valueOf().stringValue());
         } else {
-          return new ExprTimeValue(expr.valueOf(null).timeValue());
+          return new ExprTimeValue(expr.valueOf().timeValue());
         }
       })
       .put(BuiltinFunctionName.CAST_TO_DATETIME.getName(), expr -> {
         if (expr.type().equals(ExprCoreType.STRING)) {
-          return new ExprDatetimeValue(expr.valueOf(null).stringValue());
+          return new ExprDatetimeValue(expr.valueOf().stringValue());
         } else {
-          return new ExprDatetimeValue(expr.valueOf(null).datetimeValue());
+          return new ExprDatetimeValue(expr.valueOf().datetimeValue());
         }
       })
       .put(BuiltinFunctionName.CAST_TO_TIMESTAMP.getName(), expr -> {
         if (expr.type().equals(ExprCoreType.STRING)) {
-          return new ExprTimestampValue(expr.valueOf(null).stringValue());
+          return new ExprTimestampValue(expr.valueOf().stringValue());
         } else {
-          return new ExprTimestampValue(expr.valueOf(null).timestampValue());
+          return new ExprTimestampValue(expr.valueOf().timestampValue());
         }
       })
       .build();

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/MultiFieldQuery.java
@@ -37,13 +37,13 @@ abstract class MultiFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T>
 
     var fieldsAndWeights = fields
         .getValue()
-        .valueOf(null)
+        .valueOf()
         .tupleValue()
         .entrySet()
         .stream()
         .collect(ImmutableMap.toImmutableMap(e -> e.getKey(), e -> e.getValue().floatValue()));
 
-    return createBuilder(fieldsAndWeights, query.getValue().valueOf(null).stringValue());
+    return createBuilder(fieldsAndWeights, query.getValue().valueOf().stringValue());
   }
 
   protected abstract  T createBuilder(ImmutableMap<String, Float> fields, String query);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/NoFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/NoFieldQuery.java
@@ -65,7 +65,7 @@ abstract class NoFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T> {
     var query = arguments.stream().filter(a -> a.getArgName().equalsIgnoreCase("query")).findFirst()
         .orElseThrow(() -> new SemanticCheckException("'query' parameter is missing"));
 
-    return createBuilder(query.getValue().valueOf(null).stringValue());
+    return createBuilder(query.getValue().valueOf().stringValue());
   }
 
   protected abstract T createBuilder(String query);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
@@ -66,7 +66,7 @@ public abstract class RelevanceQuery<T extends QueryBuilder> extends LuceneQuery
       (Objects.requireNonNull(
           queryBuildActions
               .get(argNormalized)))
-          .apply(queryBuilder, arg.getValue().valueOf(null));
+          .apply(queryBuilder, arg.getValue().valueOf());
     }
 
     return queryBuilder;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQuery.java
@@ -36,8 +36,8 @@ abstract class SingleFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T
         .orElseThrow(() -> new SemanticCheckException("'query' parameter is missing"));
 
     return createBuilder(
-        field.getValue().valueOf(null).stringValue(),
-        query.getValue().valueOf(null).stringValue());
+        field.getValue().valueOf().stringValue(),
+        query.getValue().valueOf().stringValue());
   }
 
   protected abstract T createBuilder(String field, String query);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeRecognitionTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeRecognitionTest.java
@@ -42,6 +42,6 @@ public class OpenSearchDataTypeRecognitionTest {
   }
 
   private String typeofGetValue(ExprValue input) {
-    return dsl.typeof(DSL.literal(input)).valueOf(null).stringValue();
+    return dsl.typeof(DSL.literal(input)).valueOf().stringValue();
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -1188,7 +1188,7 @@ class FilterQueryBuilderTest {
             + "      \"boost\" : 1.0\n"
             + "    }\n"
             + "  }\n"
-            + "}", castToInteger(expr.valueOf(null).value())),
+            + "}", castToInteger(expr.valueOf().value())),
         buildQuery(dsl.equal(ref("byte_value", BYTE), dsl.castByte(expr))));
   }
 
@@ -1203,7 +1203,7 @@ class FilterQueryBuilderTest {
             + "      \"boost\" : 1.0\n"
             + "    }\n"
             + "  }\n"
-            + "}", castToInteger(expr.valueOf(null).value())),
+            + "}", castToInteger(expr.valueOf().value())),
         buildQuery(dsl.equal(ref("short_value", SHORT), dsl.castShort(expr))));
   }
 
@@ -1218,7 +1218,7 @@ class FilterQueryBuilderTest {
             + "      \"boost\" : 1.0\n"
             + "    }\n"
             + "  }\n"
-            + "}", castToInteger(expr.valueOf(null).value())),
+            + "}", castToInteger(expr.valueOf().value())),
         buildQuery(dsl.equal(ref("integer_value", INTEGER), dsl.castInt(expr))));
   }
 
@@ -1233,7 +1233,7 @@ class FilterQueryBuilderTest {
             + "      \"boost\" : 1.0\n"
             + "    }\n"
             + "  }\n"
-            + "}", castToInteger(expr.valueOf(null).value())),
+            + "}", castToInteger(expr.valueOf().value())),
         buildQuery(dsl.equal(ref("long_value", LONG), dsl.castLong(expr))));
   }
 
@@ -1248,7 +1248,7 @@ class FilterQueryBuilderTest {
             + "      \"boost\" : 1.0\n"
             + "    }\n"
             + "  }\n"
-            + "}", castToFloat(expr.valueOf(null).value())),
+            + "}", castToFloat(expr.valueOf().value())),
         buildQuery(dsl.equal(ref("float_value", FLOAT), dsl.castFloat(expr))));
   }
 
@@ -1257,8 +1257,8 @@ class FilterQueryBuilderTest {
   void cast_to_double_in_filter(LiteralExpression expr) {
     // double values affected by floating point imprecision, so we can't compare them in json
     // (Double)(Float)3.14 -> 3.14000010490417
-    assertEquals(castToFloat(expr.valueOf(null).value()),
-        dsl.castDouble(expr).valueOf(null).doubleValue(), 0.00001);
+    assertEquals(castToFloat(expr.valueOf().value()),
+        dsl.castDouble(expr).valueOf().doubleValue(), 0.00001);
 
     assertJsonEquals(String.format(
         "{\n"
@@ -1268,7 +1268,7 @@ class FilterQueryBuilderTest {
             + "      \"boost\" : 1.0\n"
             + "    }\n"
             + "  }\n"
-            + "}", dsl.castDouble(expr).valueOf(null).doubleValue()),
+            + "}", dsl.castDouble(expr).valueOf().doubleValue()),
         buildQuery(dsl.equal(ref("double_value", DOUBLE), dsl.castDouble(expr))));
   }
 

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/implementation/QueryRangeFunctionImplementation.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/functions/implementation/QueryRangeFunctionImplementation.java
@@ -83,7 +83,7 @@ public class QueryRangeFunctionImplementation extends FunctionExpression impleme
     arguments.forEach(arg -> {
       String argName = ((NamedArgumentExpression) arg).getArgName();
       Expression argValue = ((NamedArgumentExpression) arg).getValue();
-      ExprValue literalValue = argValue.valueOf(null);
+      ExprValue literalValue = argValue.valueOf();
       switch (argName) {
         case QUERY:
           prometheusQueryRequest

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/querybuilder/TimeRangeParametersResolver.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/querybuilder/TimeRangeParametersResolver.java
@@ -57,7 +57,7 @@ public class TimeRangeParametersResolver extends ExpressionNodeVisitor<Void, Obj
       ReferenceExpression ref = (ReferenceExpression) func.getArguments().get(0);
       Expression rightExpr = func.getArguments().get(1);
       if (ref.getAttr().equals("@timestamp")) {
-        ExprValue literalValue = rightExpr.valueOf(null);
+        ExprValue literalValue = rightExpr.valueOf();
         if (func.getFunctionName().getFunctionName().contains(">")) {
           startTime = literalValue.timestampValue().toEpochMilli() / 1000;
         }

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeFunctionImplementationTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/QueryRangeFunctionImplementationTest.java
@@ -48,7 +48,7 @@ class QueryRangeFunctionImplementationTest {
     QueryRangeFunctionImplementation queryRangeFunctionImplementation
         = new QueryRangeFunctionImplementation(functionName, namedArgumentExpressionList, client);
     UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
-        () -> queryRangeFunctionImplementation.valueOf(null));
+        () -> queryRangeFunctionImplementation.valueOf());
     assertEquals("Prometheus defined function [query_range] is only "
         + "supported in SOURCE clause with prometheus connector catalog", exception.getMessage());
     assertEquals("query_range(query=\"http_latency\", starttime=12345, endtime=12345, step=14)",


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Minor change to use `valueOf()` instead of `valueOf(null)`
 
### Issues Resolved
closes #976 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).