### PR TITLE
[2.4] Bump jackson to 2.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.4.0-SNAPSHOT")
         spring_version = "5.3.22"
-        jackson_version = "2.13.4"
-        jackson_databind_version = "2.13.4.2"
+        jackson_version = "2.14.0"
+        jackson_databind_version = "2.14.0"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
bump to be consistent with core 2.4 branch: https://github.com/opensearch-project/OpenSearch/commit/7c184ab77c14fd73e76df9c2cea7f610fba21f39
 
### Issues Resolved
closes https://github.com/opensearch-project/sql/issues/1057
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).