### PR TITLE
[Backport main] Bump jackson to 2.14.0 (#1058)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,8 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         spring_version = "5.3.22"
-        jackson_version = "2.13.4"
+        jackson_version = "2.14.0"
+        jackson_databind_version = "2.14.0"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>
(cherry picked from commit 5a1adb236f5589dfd10aa17783f13684b70a3c51)
Signed-off-by: Yury-Fridlyand <yuryf@bitquilltech.com>

### Description
Backport #1058 to `main`.
 
### Issues Resolved
Fixes #1065
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).