### PR TITLE
Validate Field and Fields Parameters in Relevance Search Functions

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -5,10 +5,6 @@
 
 package org.opensearch.sql.expression.function;
 
-import static org.opensearch.sql.data.type.ExprCoreType.STRING;
-import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
-
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
@@ -48,46 +44,46 @@ public class OpenSearchFunctions {
 
   private static FunctionResolver match_bool_prefix() {
     FunctionName name = BuiltinFunctionName.MATCH_BOOL_PREFIX.getName();
-    return new RelevanceFunctionResolver(name, STRING);
+    return new RelevanceFunctionResolver(name);
   }
 
   private static FunctionResolver match(BuiltinFunctionName match) {
     FunctionName funcName = match.getName();
-    return new RelevanceFunctionResolver(funcName, STRING);
+    return new RelevanceFunctionResolver(funcName);
   }
 
   private static FunctionResolver match_phrase_prefix() {
     FunctionName funcName = BuiltinFunctionName.MATCH_PHRASE_PREFIX.getName();
-    return new RelevanceFunctionResolver(funcName, STRING);
+    return new RelevanceFunctionResolver(funcName);
   }
 
   private static FunctionResolver match_phrase(BuiltinFunctionName matchPhrase) {
     FunctionName funcName = matchPhrase.getName();
-    return new RelevanceFunctionResolver(funcName, STRING);
+    return new RelevanceFunctionResolver(funcName);
   }
 
   private static FunctionResolver multi_match(BuiltinFunctionName multiMatchName) {
-    return new RelevanceFunctionResolver(multiMatchName.getName(), STRUCT);
+    return new RelevanceFunctionResolver(multiMatchName.getName());
   }
 
   private static FunctionResolver simple_query_string() {
     FunctionName funcName = BuiltinFunctionName.SIMPLE_QUERY_STRING.getName();
-    return new RelevanceFunctionResolver(funcName, STRUCT);
+    return new RelevanceFunctionResolver(funcName);
   }
 
   private static FunctionResolver query() {
     FunctionName funcName = BuiltinFunctionName.QUERY.getName();
-    return new RelevanceFunctionResolver(funcName, STRING);
+    return new RelevanceFunctionResolver(funcName);
   }
 
   private static FunctionResolver query_string() {
     FunctionName funcName = BuiltinFunctionName.QUERY_STRING.getName();
-    return new RelevanceFunctionResolver(funcName, STRUCT);
+    return new RelevanceFunctionResolver(funcName);
   }
 
   private static FunctionResolver wildcard_query(BuiltinFunctionName wildcardQuery) {
     FunctionName funcName = wildcardQuery.getName();
-    return new RelevanceFunctionResolver(funcName, STRING);
+    return new RelevanceFunctionResolver(funcName);
   }
 
   public static class OpenSearchFunction extends FunctionExpression {

--- a/core/src/main/java/org/opensearch/sql/expression/function/RelevanceFunctionResolver.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/RelevanceFunctionResolver.java
@@ -20,9 +20,6 @@ public class RelevanceFunctionResolver
   @Getter
   private final FunctionName functionName;
 
-  @Getter
-  private final ExprType declaredFirstParamType;
-
   @Override
   public Pair<FunctionSignature, FunctionBuilder> resolve(FunctionSignature unresolvedSignature) {
     if (!unresolvedSignature.getFunctionName().equals(functionName)) {
@@ -30,14 +27,6 @@ public class RelevanceFunctionResolver
           functionName.getFunctionName(), unresolvedSignature.getFunctionName().getFunctionName()));
     }
     List<ExprType> paramTypes = unresolvedSignature.getParamTypeList();
-    ExprType providedFirstParamType = paramTypes.get(0);
-
-    // Check if the first parameter is of the specified type.
-    if (!declaredFirstParamType.equals(providedFirstParamType)) {
-      throw new SemanticCheckException(
-          getWrongParameterErrorMessage(0, providedFirstParamType, declaredFirstParamType));
-    }
-
     // Check if all but the first parameter are of type STRING.
     for (int i = 1; i < paramTypes.size(); i++) {
       ExprType paramType = paramTypes.get(i);

--- a/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
@@ -358,10 +358,10 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
   void match_bool_prefix_expression() {
     assertAnalyzeEqual(
         DSL.match_bool_prefix(
-            DSL.namedArgument("field", DSL.literal("fieldA")),
+            DSL.namedArgument("field", DSL.literal("field_value1")),
             DSL.namedArgument("query", DSL.literal("sample query"))),
         AstDSL.function("match_bool_prefix",
-            AstDSL.unresolvedArg("field", stringLiteral("fieldA")),
+            AstDSL.unresolvedArg("field", stringLiteral("field_value1")),
             AstDSL.unresolvedArg("query", stringLiteral("sample query"))));
   }
 
@@ -402,11 +402,11 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.multi_match(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field", ExprValueUtils.floatValue(1.F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F)))))),
             DSL.namedArgument("query", DSL.literal("sample query"))),
         AstDSL.function("multi_match",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(Map.of(
-                "field", 1.F))),
+                "field_value1", 1.F))),
             AstDSL.unresolvedArg("query", stringLiteral("sample query"))));
   }
 
@@ -416,12 +416,12 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.multi_match(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field", ExprValueUtils.floatValue(1.F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F)))))),
             DSL.namedArgument("query", DSL.literal("sample query")),
             DSL.namedArgument("analyzer", DSL.literal("keyword"))),
         AstDSL.function("multi_match",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(Map.of(
-                "field", 1.F))),
+                "field_value1", 1.F))),
             AstDSL.unresolvedArg("query", stringLiteral("sample query")),
             AstDSL.unresolvedArg("analyzer", stringLiteral("keyword"))));
   }
@@ -432,12 +432,12 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.multi_match(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field1", ExprValueUtils.floatValue(1.F),
-                    "field2", ExprValueUtils.floatValue(.3F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F),
+                    "field_value2", ExprValueUtils.floatValue(.3F)))))),
             DSL.namedArgument("query", DSL.literal("sample query"))),
         AstDSL.function("multi_match",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(
-                "field1", 1.F, "field2", .3F))),
+                "field_value1", 1.F, "field_value2", .3F))),
             AstDSL.unresolvedArg("query", stringLiteral("sample query"))));
   }
 
@@ -447,11 +447,11 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.simple_query_string(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field", ExprValueUtils.floatValue(1.F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F)))))),
             DSL.namedArgument("query", DSL.literal("sample query"))),
         AstDSL.function("simple_query_string",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(Map.of(
-                "field", 1.F))),
+                "field_value1", 1.F))),
             AstDSL.unresolvedArg("query", stringLiteral("sample query"))));
   }
 
@@ -461,12 +461,12 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.simple_query_string(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field", ExprValueUtils.floatValue(1.F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F)))))),
             DSL.namedArgument("query", DSL.literal("sample query")),
             DSL.namedArgument("analyzer", DSL.literal("keyword"))),
         AstDSL.function("simple_query_string",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(Map.of(
-                "field", 1.F))),
+                "field_value1", 1.F))),
             AstDSL.unresolvedArg("query", stringLiteral("sample query")),
             AstDSL.unresolvedArg("analyzer", stringLiteral("keyword"))));
   }
@@ -477,12 +477,12 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.simple_query_string(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field1", ExprValueUtils.floatValue(1.F),
-                    "field2", ExprValueUtils.floatValue(.3F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F),
+                    "field_value2", ExprValueUtils.floatValue(.3F)))))),
             DSL.namedArgument("query", DSL.literal("sample query"))),
         AstDSL.function("simple_query_string",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(
-                "field1", 1.F, "field2", .3F))),
+                "field_value1", 1.F, "field_value2", .3F))),
             AstDSL.unresolvedArg("query", stringLiteral("sample query"))));
   }
 
@@ -501,11 +501,11 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.query_string(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field", ExprValueUtils.floatValue(1.F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F)))))),
             DSL.namedArgument("query", DSL.literal("query_value"))),
         AstDSL.function("query_string",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(Map.of(
-                "field", 1.F))),
+                "field_value1", 1.F))),
             AstDSL.unresolvedArg("query", stringLiteral("query_value"))));
   }
 
@@ -515,12 +515,12 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.query_string(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field", ExprValueUtils.floatValue(1.F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F)))))),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("escape", DSL.literal("false"))),
         AstDSL.function("query_string",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(Map.of(
-                "field", 1.F))),
+                "field_value1", 1.F))),
             AstDSL.unresolvedArg("query", stringLiteral("query_value")),
             AstDSL.unresolvedArg("escape", stringLiteral("false"))));
   }
@@ -531,12 +531,12 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
         DSL.query_string(
             DSL.namedArgument("fields", DSL.literal(
                 new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
-                    "field1", ExprValueUtils.floatValue(1.F),
-                    "field2", ExprValueUtils.floatValue(.3F)))))),
+                    "field_value1", ExprValueUtils.floatValue(1.F),
+                    "field_value2", ExprValueUtils.floatValue(.3F)))))),
             DSL.namedArgument("query", DSL.literal("query_value"))),
         AstDSL.function("query_string",
             AstDSL.unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(
-                "field1", 1.F, "field2", .3F))),
+                "field_value1", 1.F, "field_value2", .3F))),
             AstDSL.unresolvedArg("query", stringLiteral("query_value"))));
   }
 
@@ -572,7 +572,7 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
   public void match_phrase_prefix_all_params() {
     assertAnalyzeEqual(
         DSL.match_phrase_prefix(
-            DSL.namedArgument("field", "test"),
+            DSL.namedArgument("field", "field_value1"),
             DSL.namedArgument("query", "search query"),
             DSL.namedArgument("slop", "3"),
             DSL.namedArgument("boost", "1.5"),
@@ -581,7 +581,7 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
             DSL.namedArgument("zero_terms_query", "NONE")
             ),
         AstDSL.function("match_phrase_prefix",
-          unresolvedArg("field", stringLiteral("test")),
+          unresolvedArg("field", stringLiteral("field_value1")),
           unresolvedArg("query", stringLiteral("search query")),
           unresolvedArg("slop", stringLiteral("3")),
           unresolvedArg("boost", stringLiteral("1.5")),

--- a/core/src/test/java/org/opensearch/sql/config/TestConfig.java
+++ b/core/src/test/java/org/opensearch/sql/config/TestConfig.java
@@ -57,6 +57,8 @@ public class TestConfig {
       .put("struct_value", ExprCoreType.STRUCT)
       .put("array_value", ExprCoreType.ARRAY)
       .put("timestamp_value", ExprCoreType.TIMESTAMP)
+      .put("field_value1", ExprCoreType.STRING)
+      .put("field_value2", ExprCoreType.STRING)
       .build();
 
   @Bean

--- a/core/src/test/java/org/opensearch/sql/expression/function/RelevanceFunctionResolverTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/RelevanceFunctionResolverTest.java
@@ -24,7 +24,7 @@ class RelevanceFunctionResolverTest {
 
   @BeforeEach
   void setUp() {
-    resolver = new RelevanceFunctionResolver(sampleFuncName, STRING);
+    resolver = new RelevanceFunctionResolver(sampleFuncName);
   }
 
   @Test
@@ -41,15 +41,6 @@ class RelevanceFunctionResolverTest {
     Exception exception = assertThrows(SemanticCheckException.class,
         () -> resolver.resolve(sig));
     assertEquals("Expected 'sample_function' but got 'wrong_func'",
-        exception.getMessage());
-  }
-
-  @Test
-  void resolve_invalid_first_param_type_test() {
-    var sig = new FunctionSignature(sampleFuncName, List.of(INTEGER));
-    Exception exception = assertThrows(SemanticCheckException.class,
-        () -> resolver.resolve(sig));
-    assertEquals("Expected type STRING instead of INTEGER for parameter #1",
         exception.getMessage());
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQuery.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 
 /**
  * Base class to represent builder class for relevance queries like match_query, match_bool_prefix,
@@ -36,7 +37,7 @@ abstract class SingleFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T
         .orElseThrow(() -> new SemanticCheckException("'query' parameter is missing"));
 
     return createBuilder(
-        field.getValue().valueOf().stringValue(),
+        ((ReferenceExpression)field.getValue()).getAttr(),
         query.getValue().valueOf().stringValue());
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -53,6 +53,7 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -313,7 +314,8 @@ class FilterQueryBuilderTest {
             + "}",
         buildQuery(
             DSL.match(
-                DSL.namedArgument("field", literal("message")),
+                DSL.namedArgument("field",
+                    new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
                 DSL.namedArgument("query", literal("search query")))));
   }
 
@@ -341,7 +343,8 @@ class FilterQueryBuilderTest {
             + "}",
         buildQuery(
             DSL.match(
-                DSL.namedArgument("field", literal("message")),
+                DSL.namedArgument("field",
+                    new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
                 DSL.namedArgument("query", literal("search query")),
                 DSL.namedArgument("operator", literal("AND")),
                 DSL.namedArgument("analyzer", literal("keyword")),
@@ -360,7 +363,8 @@ class FilterQueryBuilderTest {
   @Test
   void match_invalid_parameter() {
     FunctionExpression expr = DSL.match(
-        DSL.namedArgument("field", literal("message")),
+        DSL.namedArgument("field",
+            new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", literal("search query")),
         DSL.namedArgument("invalid_parameter", literal("invalid_value")));
     var msg = assertThrows(SemanticCheckException.class, () -> buildQuery(expr)).getMessage();
@@ -433,7 +437,8 @@ class FilterQueryBuilderTest {
             + "}",
         buildQuery(
             DSL.match_phrase(
-                DSL.namedArgument("field", literal("message")),
+                DSL.namedArgument("field",
+                    new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
                 DSL.namedArgument("query", literal("search query")))));
   }
 
@@ -625,8 +630,9 @@ class FilterQueryBuilderTest {
             + "}",
         buildQuery(
             DSL.match_phrase(
+                DSL.namedArgument("field",
+                    new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
                 DSL.namedArgument("boost", literal("1.2")),
-                DSL.namedArgument("field", literal("message")),
                 DSL.namedArgument("query", literal("search query")),
                 DSL.namedArgument("analyzer", literal("keyword")),
                 DSL.namedArgument("slop", literal("2")),
@@ -636,7 +642,8 @@ class FilterQueryBuilderTest {
   @Test
   void wildcard_query_invalid_parameter() {
     FunctionExpression expr = DSL.wildcard_query(
-        DSL.namedArgument("field", literal("field")),
+        DSL.namedArgument("field",
+            new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", literal("search query*")),
         DSL.namedArgument("invalid_parameter", literal("invalid_value")));
     assertThrows(SemanticCheckException.class, () -> buildQuery(expr),
@@ -655,7 +662,8 @@ class FilterQueryBuilderTest {
         + "  }\n"
         + "}",
         buildQuery(DSL.wildcard_query(
-            DSL.namedArgument("field", literal("field")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", literal("search query%")))));
 
     assertJsonEquals("{\n"
@@ -667,7 +675,8 @@ class FilterQueryBuilderTest {
         + "  }\n"
         + "}",
         buildQuery(DSL.wildcard_query(
-            DSL.namedArgument("field", literal("field")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", literal("search query_")))));
   }
 
@@ -682,7 +691,8 @@ class FilterQueryBuilderTest {
         + "  }\n"
         + "}",
         buildQuery(DSL.wildcard_query(
-            DSL.namedArgument("field", literal("field")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", literal("search query\\%")))));
 
     assertJsonEquals("{\n"
@@ -694,7 +704,8 @@ class FilterQueryBuilderTest {
         + "  }\n"
         + "}",
         buildQuery(DSL.wildcard_query(
-            DSL.namedArgument("field", literal("field")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", literal("search query\\_")))));
 
     assertJsonEquals("{\n"
@@ -706,7 +717,8 @@ class FilterQueryBuilderTest {
         + "  }\n"
         + "}",
         buildQuery(DSL.wildcard_query(
-            DSL.namedArgument("field", literal("field")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", literal("search query\\*")))));
 
     assertJsonEquals("{\n"
@@ -718,7 +730,8 @@ class FilterQueryBuilderTest {
         + "  }\n"
         + "}",
         buildQuery(DSL.wildcard_query(
-            DSL.namedArgument("field", literal("field")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", literal("search query\\?")))));
   }
 
@@ -733,7 +746,8 @@ class FilterQueryBuilderTest {
         + "  }\n"
         + "}",
         buildQuery(DSL.wildcard_query(
-            DSL.namedArgument("field", literal("field")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", literal("search query*")))));
   }
 
@@ -750,7 +764,8 @@ class FilterQueryBuilderTest {
         + "  }\n"
         + "}",
         buildQuery(DSL.wildcard_query(
-            DSL.namedArgument("field", literal("field")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field", OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", literal("search query*")),
             DSL.namedArgument("boost", literal("0.6")),
             DSL.namedArgument("case_insensitive", literal("true")),
@@ -1088,7 +1103,8 @@ class FilterQueryBuilderTest {
   @Test
   void match_phrase_invalid_parameter() {
     FunctionExpression expr = DSL.match_phrase(
-        DSL.namedArgument("field", literal("message")),
+        DSL.namedArgument("field",
+            new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", literal("search query")),
         DSL.namedArgument("invalid_parameter", literal("invalid_value")));
     var msg = assertThrows(SemanticCheckException.class, () -> buildQuery(expr)).getMessage();
@@ -1097,7 +1113,8 @@ class FilterQueryBuilderTest {
 
   @Test
   void relevancy_func_invalid_arg_values() {
-    final var field = DSL.namedArgument("field", literal("message"));
+    final var field = DSL.namedArgument("field",
+        new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD));
     final var fields = DSL.namedArgument("fields", DSL.literal(
         new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
             "field1", ExprValueUtils.floatValue(1.F),
@@ -1175,16 +1192,9 @@ class FilterQueryBuilderTest {
             + "}",
         buildQuery(
             DSL.match_bool_prefix(
-                DSL.namedArgument("field", literal("message")),
+                DSL.namedArgument("field",
+                    new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
                 DSL.namedArgument("query", literal("search query")))));
-  }
-
-  @Test
-  void multi_match_missing_fields() {
-    var msg = assertThrows(SemanticCheckException.class, () ->
-        DSL.multi_match(
-            DSL.namedArgument("query", literal("search query")))).getMessage();
-    assertEquals("Expected type STRUCT instead of STRING for parameter #1", msg);
   }
 
   @Test
@@ -1227,7 +1237,8 @@ class FilterQueryBuilderTest {
             + "}",
         buildQuery(
             DSL.match_phrase_prefix(
-                DSL.namedArgument("field", literal("message")),
+                DSL.namedArgument("field",
+                    new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
                 DSL.namedArgument("query", literal("search query")))));
   }
 
@@ -1248,7 +1259,8 @@ class FilterQueryBuilderTest {
             + "}",
         buildQuery(
             DSL.match_phrase_prefix(
-                DSL.namedArgument("field", literal("message")),
+                DSL.namedArgument("field",
+                    new ReferenceExpression("message", OPENSEARCH_TEXT_KEYWORD)),
                 DSL.namedArgument("query", literal("search query")),
                 DSL.namedArgument("boost", literal("1.2")),
                 DSL.namedArgument("max_expansions", literal("42")),

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchBoolPrefixQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchBoolPrefixQueryTest.java
@@ -23,8 +23,10 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchBoolPrefixQuery;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -33,7 +35,8 @@ public class MatchBoolPrefixQueryTest {
   private final FunctionName matchBoolPrefix = FunctionName.of("match_bool_prefix");
 
   static Stream<List<Expression>> generateValidData() {
-    NamedArgumentExpression field = DSL.namedArgument("field", DSL.literal("field_value"));
+    NamedArgumentExpression field = DSL.namedArgument("field",
+        new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD));
     NamedArgumentExpression query = DSL.namedArgument("query", DSL.literal("query_value"));
     return List.of(
             DSL.namedArgument("fuzziness", DSL.literal("AUTO")),
@@ -58,7 +61,8 @@ public class MatchBoolPrefixQueryTest {
   @Test
   public void test_valid_when_two_arguments() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "field_value"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "query_value"));
     Assertions.assertNotNull(matchBoolPrefixQuery.build(new MatchExpression(arguments)));
   }
@@ -80,7 +84,8 @@ public class MatchBoolPrefixQueryTest {
   @Test
   public void test_SemanticCheckException_when_invalid_argument() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "field_value"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "query_value"),
         DSL.namedArgument("unsupported", "unsupported_value"));
     Assertions.assertThrows(SemanticCheckException.class,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhrasePrefixQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhrasePrefixQueryTest.java
@@ -20,8 +20,10 @@ import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchPhrasePrefixQuery;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -39,7 +41,8 @@ public class MatchPhrasePrefixQueryTest  {
 
   @Test
   public void test_SyntaxCheckException_when_one_argument() {
-    List<Expression> arguments = List.of(DSL.namedArgument("field", "test"));
+    List<Expression> arguments = List.of(DSL.namedArgument("field",
+        new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)));
     assertThrows(SyntaxCheckException.class,
         () -> matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -47,7 +50,8 @@ public class MatchPhrasePrefixQueryTest  {
   @Test
   public void test_SyntaxCheckException_when_invalid_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "test2"),
         DSL.namedArgument("unsupported", "3"));
     Assertions.assertThrows(SemanticCheckException.class,
@@ -57,7 +61,8 @@ public class MatchPhrasePrefixQueryTest  {
   @Test
   public void test_analyzer_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("analyzer", "standard")
     );
@@ -67,7 +72,8 @@ public class MatchPhrasePrefixQueryTest  {
   @Test
   public void build_succeeds_with_two_arguments() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "test2"));
     Assertions.assertNotNull(matchPhrasePrefixQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -75,7 +81,8 @@ public class MatchPhrasePrefixQueryTest  {
   @Test
   public void test_slop_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("slop", "2")
     );
@@ -85,7 +92,8 @@ public class MatchPhrasePrefixQueryTest  {
   @Test
   public void test_zero_terms_query_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("zero_terms_query", "ALL")
     );
@@ -95,7 +103,8 @@ public class MatchPhrasePrefixQueryTest  {
   @Test
   public void test_zero_terms_query_parameter_lower_case() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("zero_terms_query", "all")
     );
@@ -105,7 +114,8 @@ public class MatchPhrasePrefixQueryTest  {
   @Test
   public void test_boost_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("boost", "0.1")
     );

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhraseQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchPhraseQueryTest.java
@@ -20,8 +20,10 @@ import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchPhraseQuery;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -41,7 +43,8 @@ public class MatchPhraseQueryTest {
 
   @Test
   public void test_SyntaxCheckException_when_one_argument() {
-    List<Expression> arguments = List.of(DSL.namedArgument("field", "test"));
+    List<Expression> arguments = List.of(DSL.namedArgument("field",
+        new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)));
     assertThrows(SyntaxCheckException.class,
         () -> matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -49,7 +52,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_SyntaxCheckException_when_invalid_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "test2"),
         DSL.namedArgument("unsupported", "3"));
     Assertions.assertThrows(SemanticCheckException.class,
@@ -59,7 +63,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_analyzer_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("analyzer", "standard")
     );
@@ -69,7 +74,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void build_succeeds_with_two_arguments() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "test2"));
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(arguments)));
   }
@@ -77,7 +83,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_slop_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("slop", "2")
     );
@@ -87,7 +94,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_zero_terms_query_parameter() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("zero_terms_query", "ALL")
     );
@@ -97,7 +105,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_zero_terms_query_parameter_lower_case() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("zero_terms_query", "all")
     );
@@ -114,7 +123,8 @@ public class MatchPhraseQueryTest {
 
   @Test
   public void test_SyntaxCheckException_when_one_argument_match_phrase_syntax() {
-    List<Expression> arguments = List.of(DSL.namedArgument("field", "test"));
+    List<Expression> arguments = List.of(DSL.namedArgument("field",
+        new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)));
     assertThrows(SyntaxCheckException.class,
         () -> matchPhraseQuery.build(new MatchPhraseExpression(
             arguments, matchPhraseWithUnderscoreName)));
@@ -124,7 +134,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_SyntaxCheckException_when_invalid_parameter_match_phrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "test2"),
         DSL.namedArgument("unsupported", "3"));
     Assertions.assertThrows(SemanticCheckException.class,
@@ -135,7 +146,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_analyzer_parameter_match_phrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("analyzer", "standard")
     );
@@ -146,7 +158,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void build_succeeds_with_two_arguments_match_phrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "test2"));
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
         arguments, matchPhraseWithUnderscoreName)));
@@ -155,7 +168,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_slop_parameter_match_phrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("slop", "2")
     );
@@ -166,7 +180,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_zero_terms_query_parameter_match_phrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("zero_terms_query", "ALL")
     );
@@ -177,7 +192,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_zero_terms_query_parameter_lower_case_match_phrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("zero_terms_query", "all")
     );
@@ -195,7 +211,8 @@ public class MatchPhraseQueryTest {
 
   @Test
   public void test_SyntaxCheckException_when_one_argument_matchphrase_syntax() {
-    List<Expression> arguments = List.of(DSL.namedArgument("field", "test"));
+    List<Expression> arguments = List.of(DSL.namedArgument("field",
+        new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)));
     assertThrows(SyntaxCheckException.class,
         () -> matchPhraseQuery.build(new MatchPhraseExpression(
             arguments, matchPhraseQueryName)));
@@ -205,7 +222,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_SyntaxCheckException_when_invalid_parameter_matchphrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "test2"),
         DSL.namedArgument("unsupported", "3"));
     Assertions.assertThrows(SemanticCheckException.class,
@@ -216,7 +234,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_analyzer_parameter_matchphrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("analyzer", "standard")
     );
@@ -227,7 +246,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void build_succeeds_with_two_arguments_matchphrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "test"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("test", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "test2"));
     Assertions.assertNotNull(matchPhraseQuery.build(new MatchPhraseExpression(
         arguments, matchPhraseQueryName)));
@@ -236,7 +256,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_slop_parameter_matchphrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("slop", "2")
     );
@@ -247,7 +268,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_zero_terms_query_parameter_matchphrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("zero_terms_query", "ALL")
     );
@@ -258,7 +280,8 @@ public class MatchPhraseQueryTest {
   @Test
   public void test_zero_terms_query_parameter_lower_case_matchphrase_syntax() {
     List<Expression> arguments = List.of(
-        DSL.namedArgument("field", "t1"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("t1", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         DSL.namedArgument("query", "t2"),
         DSL.namedArgument("zero_terms_query", "all")
     );

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -23,8 +23,10 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.MatchQuery;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -39,71 +41,85 @@ public class MatchQueryTest {
   static Stream<List<Expression>> generateValidData() {
     return Stream.of(
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("analyzer", DSL.literal("standard"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("auto_generate_synonyms_phrase_query", DSL.literal("true"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("fuzziness", DSL.literal("AUTO"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("max_expansions", DSL.literal("50"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("prefix_length", DSL.literal("0"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("fuzzy_transpositions", DSL.literal("true"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("fuzzy_rewrite", DSL.literal("constant_score"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("lenient", DSL.literal("false"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("operator", DSL.literal("OR"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("minimum_should_match", DSL.literal("3"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("zero_terms_query", DSL.literal("NONE"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("zero_terms_query", DSL.literal("none"))
         ),
         List.of(
-            DSL.namedArgument("field", DSL.literal("field_value")),
+            DSL.namedArgument("field",
+                new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             DSL.namedArgument("query", DSL.literal("query_value")),
             DSL.namedArgument("boost", DSL.literal("1"))
         )
@@ -133,7 +149,8 @@ public class MatchQueryTest {
   @Test
   public void test_SemanticCheckException_when_invalid_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         namedArgument("query", "query_value"),
         namedArgument("unsupported", "unsupported_value"));
     Assertions.assertThrows(SemanticCheckException.class,
@@ -166,7 +183,8 @@ public class MatchQueryTest {
   @Test
   public void test_SemanticCheckException_when_invalid_parameter_matchquery_syntax() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         namedArgument("query", "query_value"),
         namedArgument("unsupported", "unsupported_value"));
     Assertions.assertThrows(SemanticCheckException.class,
@@ -200,7 +218,8 @@ public class MatchQueryTest {
   @Test
   public void test_SemanticCheckException_when_invalid_parameter_match_query_syntax() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "field_value"),
+        DSL.namedArgument("field",
+            new ReferenceExpression("field_value", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         namedArgument("query", "query_value"),
         namedArgument("unsupported", "unsupported_value"));
     Assertions.assertThrows(SemanticCheckException.class,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/WildcardQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/WildcardQueryTest.java
@@ -22,8 +22,10 @@ import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.relevance.WildcardQuery;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -34,7 +36,8 @@ class WildcardQueryTest {
   static Stream<List<Expression>> generateValidData() {
     return Stream.of(
         List.of(
-            namedArgument("field", "title"),
+            namedArgument("field",
+                new ReferenceExpression("title", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
             namedArgument("query", "query_value*"),
             namedArgument("boost", "0.7"),
             namedArgument("case_insensitive", "false"),
@@ -59,7 +62,8 @@ class WildcardQueryTest {
 
   @Test
   public void test_SyntaxCheckException_when_one_argument() {
-    List<Expression> arguments = List.of(namedArgument("field", "title"));
+    List<Expression> arguments = List.of(namedArgument("field",
+        new ReferenceExpression("title", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)));
     assertThrows(SyntaxCheckException.class,
         () -> wildcardQueryQuery.build(new WildcardQueryExpression(arguments)));
   }
@@ -67,7 +71,8 @@ class WildcardQueryTest {
   @Test
   public void test_SemanticCheckException_when_invalid_parameter() {
     List<Expression> arguments = List.of(
-        namedArgument("field", "title"),
+        namedArgument("field",
+            new ReferenceExpression("title", OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
         namedArgument("query", "query_value*"),
         namedArgument("unsupported", "unsupported_value"));
     Assertions.assertThrows(SemanticCheckException.class,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/SingleFieldQueryTest.java
@@ -19,6 +19,8 @@ import org.mockito.Mockito;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 
 class SingleFieldQueryTest {
   SingleFieldQuery query;
@@ -35,12 +37,26 @@ class SingleFieldQueryTest {
   }
 
   @Test
-  void createQueryBuilderTest() {
+  void createQueryBuilderTestTypeTextKeyword() {
     String sampleQuery = "sample query";
     String sampleField = "fieldA";
 
     query.createQueryBuilder(List.of(DSL.namedArgument("field",
-            new LiteralExpression(ExprValueUtils.stringValue(sampleField))),
+            new ReferenceExpression(sampleField, OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD)),
+        DSL.namedArgument("query",
+            new LiteralExpression(ExprValueUtils.stringValue(sampleQuery)))));
+
+    verify(query).createBuilder(eq(sampleField),
+        eq(sampleQuery));
+  }
+
+  @Test
+  void createQueryBuilderTestTypeText() {
+    String sampleQuery = "sample query";
+    String sampleField = "fieldA";
+
+    query.createQueryBuilder(List.of(DSL.namedArgument("field",
+            new ReferenceExpression(sampleField, OpenSearchDataType.OPENSEARCH_TEXT)),
         DSL.namedArgument("query",
             new LiteralExpression(ExprValueUtils.stringValue(sampleQuery)))));
 

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -372,7 +372,7 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     // to skip environment resolving and function signature resolving
     ImmutableList.Builder<UnresolvedExpression> builder = ImmutableList.builder();
     builder.add(new UnresolvedArgument("field",
-        new Literal(StringUtils.unquoteText(ctx.field.getText()), DataType.STRING)));
+        new QualifiedName(StringUtils.unquoteText(ctx.field.getText()))));
     builder.add(new UnresolvedArgument("query",
         new Literal(StringUtils.unquoteText(ctx.query.getText()), DataType.STRING)));
     ctx.relevanceArg().forEach(v -> builder.add(new UnresolvedArgument(

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -705,7 +705,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
             relation("test"),
             function(
                 "match",
-                unresolvedArg("field", stringLiteral("message")),
+                unresolvedArg("field", qualifiedName("message")),
                 unresolvedArg("query", stringLiteral("test query")),
                 unresolvedArg("analyzer", stringLiteral("keyword"))
             )

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -475,7 +475,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
     // to skip environment resolving and function signature resolving
     ImmutableList.Builder<UnresolvedExpression> builder = ImmutableList.builder();
     builder.add(new UnresolvedArgument("field",
-        new Literal(StringUtils.unquoteText(ctx.field.getText()), DataType.STRING)));
+        new QualifiedName(StringUtils.unquoteText(ctx.field.getText()))));
     builder.add(new UnresolvedArgument("query",
         new Literal(StringUtils.unquoteText(ctx.query.getText()), DataType.STRING)));
     fillRelevanceArgs(ctx.relevanceArg(), builder);

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -463,7 +463,7 @@ class AstExpressionBuilderTest {
   public void matchPhraseQueryAllParameters() {
     assertEquals(
         AstDSL.function("matchphrasequery",
-            unresolvedArg("field", stringLiteral("test")),
+            unresolvedArg("field", qualifiedName("test")),
             unresolvedArg("query", stringLiteral("search query")),
             unresolvedArg("slop", stringLiteral("3")),
             unresolvedArg("analyzer", stringLiteral("standard")),
@@ -479,7 +479,7 @@ class AstExpressionBuilderTest {
   public void matchPhrasePrefixAllParameters() {
     assertEquals(
         AstDSL.function("match_phrase_prefix",
-          unresolvedArg("field", stringLiteral("test")),
+          unresolvedArg("field", qualifiedName("test")),
           unresolvedArg("query", stringLiteral("search query")),
           unresolvedArg("slop", stringLiteral("3")),
           unresolvedArg("boost", stringLiteral("1.5")),
@@ -496,13 +496,13 @@ class AstExpressionBuilderTest {
   @Test
   public void relevanceMatch() {
     assertEquals(AstDSL.function("match",
-        unresolvedArg("field", stringLiteral("message")),
+        unresolvedArg("field", qualifiedName("message")),
         unresolvedArg("query", stringLiteral("search query"))),
         buildExprAst("match('message', 'search query')")
     );
 
     assertEquals(AstDSL.function("match",
-        unresolvedArg("field", stringLiteral("message")),
+        unresolvedArg("field", qualifiedName("message")),
         unresolvedArg("query", stringLiteral("search query")),
         unresolvedArg("analyzer", stringLiteral("keyword")),
         unresolvedArg("operator", stringLiteral("AND"))),
@@ -512,13 +512,13 @@ class AstExpressionBuilderTest {
   @Test
   public void relevanceMatchQuery() {
     assertEquals(AstDSL.function("matchquery",
-            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("field", qualifiedName("message")),
             unresolvedArg("query", stringLiteral("search query"))),
         buildExprAst("matchquery('message', 'search query')")
     );
 
     assertEquals(AstDSL.function("matchquery",
-            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("field", qualifiedName("message")),
             unresolvedArg("query", stringLiteral("search query")),
             unresolvedArg("analyzer", stringLiteral("keyword")),
             unresolvedArg("operator", stringLiteral("AND"))),
@@ -528,13 +528,13 @@ class AstExpressionBuilderTest {
   @Test
   public void relevanceMatch_Query() {
     assertEquals(AstDSL.function("match_query",
-            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("field", qualifiedName("message")),
             unresolvedArg("query", stringLiteral("search query"))),
         buildExprAst("match_query('message', 'search query')")
     );
 
     assertEquals(AstDSL.function("match_query",
-            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("field", qualifiedName("message")),
             unresolvedArg("query", stringLiteral("search query")),
             unresolvedArg("analyzer", stringLiteral("keyword")),
             unresolvedArg("operator", stringLiteral("AND"))),
@@ -640,7 +640,7 @@ class AstExpressionBuilderTest {
   @Test
   public void relevanceWildcard_query() {
     assertEquals(AstDSL.function("wildcard_query",
-            unresolvedArg("field", stringLiteral("field")),
+            unresolvedArg("field", qualifiedName("field")),
             unresolvedArg("query", stringLiteral("search query*")),
             unresolvedArg("boost", stringLiteral("1.5")),
             unresolvedArg("case_insensitive", stringLiteral("true")),


### PR DESCRIPTION
### Description
Relevance functions that query fields should act similar to how a `SELECT` query works. If a field is queried that does not exist, a `SemanticCheckException` should be thrown.

### Example Queryies
`SELECT * FROM stackexchange_beer WHERE query_string([invalid], 'beer');`
```
{'reason': 'Invalid SQL query', 'details': "can't resolve Symbol(namespace=FIELD_NAME, name=invalid) in type env", 'type': 'SemanticCheckException'}
```
`SELECT * FROM stackexchange_beer WHERE match(invalid, 'beer');`
```
{'reason': 'Invalid SQL query', 'details': "can't resolve Symbol(namespace=FIELD_NAME, name=invalid) in type env", 'type': 'SemanticCheckException'}
```
 
### Issues Resolved
[Issue: 613](https://github.com/opensearch-project/sql/issues/613)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).