### PR TITLE
Integ tests fix for arm64.[Failure in starting up prometheus server]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,39 @@ buildscript {
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
+        prometheus_binary_version = "2.37.2"
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
         }
         if (isSnapshot) {
             // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT (opensearch_build)
             opensearch_build += "-SNAPSHOT"
+        }
+        getArchType = {
+            if (System.getProperty("os.arch").startsWith("x") || System.getProperty("os.arch").startsWith("amd")) {
+                return "amd64"
+            }
+            else {
+                return "arm64"
+            }
+        }
+        getOSFamilyType = {
+            def os = org.gradle.internal.os.OperatingSystem.current();
+            if (os.isMacOsX()) {
+                return "darwin"
+            }
+            else if(os.isLinux()){
+                return "linux"
+            }
+            else if(os.isWindows()) {
+                return "windows"
+            }
+            else {
+                return os.getFamilyName().toString()
+            }
+        }
+        getPrometheusBinaryLocation = { ->
+            return "https://github.com/prometheus/prometheus/releases/download/v${prometheus_binary_version}/prometheus-${prometheus_binary_version}."+ getOSFamilyType() + "-" + getArchType() + ".tar.gz"
         }
     }
 

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -29,19 +29,21 @@ task bootstrap(type: Exec) {
 task startPrometheus(type: SpawnProcessTask) {
     doFirst {
         download.run {
-            src 'https://github.com/prometheus/prometheus/releases/download/v2.39.1/prometheus-2.39.1.linux-amd64.tar.gz'
+            src getPrometheusBinaryLocation()
             dest new File("$projectDir/bin", 'prometheus.tar.gz')
         }
         copy {
             from tarTree("$projectDir/bin/prometheus.tar.gz")
             into "$projectDir/bin"
         }
-        copy {
-            from "$projectDir/bin/prometheus.yml"
-            into "$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus"
+        file("$projectDir/bin").eachDir {
+            if (it.name.startsWith("prometheus-")) {
+                println "Renaming folder : " + it.name.toString()
+                println it.renameTo("$projectDir/bin/prometheus")
+            }
         }
     }
-    command "$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus --storage.tsdb.path=$projectDir/bin/prometheus-2.39.1.linux-amd64/data --config.file=$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus.yml"
+    command "$projectDir/bin/prometheus/prometheus --storage.tsdb.path=$projectDir/bin/prometheus/data --config.file=$projectDir/bin/prometheus/prometheus.yml"
     ready 'TSDB started'
     pidLockFileName '.prom.pid.lock'
 }
@@ -80,6 +82,8 @@ task stopPrometheus() {
             process.waitFor()
         } finally {
             pidFile.delete()
+            file("$projectDir/bin/prometheus").deleteDir()
+            file("$projectDir/bin/prometheus.tar.gz").delete()
         }
     }
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -27,6 +27,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 import java.util.concurrent.Callable
+import org.gradle.internal.os.OperatingSystem
 
 plugins {
     id "de.undercouch.download" version "5.3.0"
@@ -37,6 +38,9 @@ apply plugin: 'opensearch.rest-test'
 apply plugin: 'java'
 apply plugin: 'io.freefair.lombok'
 apply plugin: 'com.wiredforcode.spawn'
+
+
+
 
 repositories {
     mavenCentral()
@@ -113,27 +117,36 @@ testClusters.integTest {
     plugin ":opensearch-sql-plugin"
     keystore 'plugins.query.federation.datasources.config', new File("$projectDir/src/test/resources/catalog/", 'catalog.json')
 }
+
 task startPrometheus(type: SpawnProcessTask) {
     mustRunAfter ':doctest:doctest'
+
     doFirst {
         download.run {
-            src 'https://github.com/prometheus/prometheus/releases/download/v2.39.1/prometheus-2.39.1.linux-amd64.tar.gz'
+            src getPrometheusBinaryLocation()
             dest new File("$projectDir/bin", 'prometheus.tar.gz')
         }
         copy {
             from tarTree("$projectDir/bin/prometheus.tar.gz")
             into "$projectDir/bin"
         }
-        copy {
-            from "$projectDir/bin/prometheus.yml"
-            into "$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus"
+        file("$projectDir/bin").eachDir {
+            if (it.name.startsWith("prometheus-")) {
+                println "Renaming folder : " + it.name.toString()
+                println it.renameTo("$projectDir/bin/prometheus")
+            }
         }
     }
-    command "$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus --storage.tsdb.path=$projectDir/bin/prometheus-2.39.1.linux-amd64/data --config.file=$projectDir/bin/prometheus-2.39.1.linux-amd64/prometheus.yml"
+    command "$projectDir/bin/prometheus/prometheus --storage.tsdb.path=$projectDir/bin/prometheus/data --config.file=$projectDir/bin/prometheus/prometheus.yml"
     ready 'TSDB started'
 }
 
-task stopPrometheus(type: KillProcessTask)
+task stopPrometheus(type: KillProcessTask) {
+    doLast {
+        file("$projectDir/bin/prometheus").deleteDir()
+        file("$projectDir/bin/prometheus.tar.gz").delete()
+    }
+}
 
 stopPrometheus.mustRunAfter startPrometheus
 


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
This is to fix integration test errors for arm64 archetype.
RCA: using wrong binary to start prometheus server for integ tests.
https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/3242/pipeline/131

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).