### PR TITLE
Update junit version to 5.6.2

### DIFF
--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -42,6 +42,7 @@ test {
 configurations.all {
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0"
+    resolutionStrategy.force "org.junit.jupiter:junit-jupiter:5.6.2"
 }
 
 jacocoTestReport {


### PR DESCRIPTION
Signed-off-by: Rupal Mahajan <maharup@amazon.com>

### Description
Added junit to resolutions. 
junit 4.13 was identified at 
`prometheus/build.gradle > testCompileClasspath > com.squareup.okhttp3-mockwebserver@4.9.3 > junit-junit@4.13`
 
### Issues Resolved
CVE-2020-15250
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).