### PR TITLE
Add Support For Legacy Syntax For Match Function In New Engine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/OpenSearchFunctions.java
@@ -27,7 +27,9 @@ public class OpenSearchFunctions {
    */
   public void register(BuiltinFunctionRepository repository) {
     repository.register(match_bool_prefix());
-    repository.register(match());
+    repository.register(match(BuiltinFunctionName.MATCH));
+    repository.register(match(BuiltinFunctionName.MATCHQUERY));
+    repository.register(match(BuiltinFunctionName.MATCH_QUERY));
     repository.register(multi_match());
     repository.register(simple_query_string());
     repository.register(query());
@@ -44,8 +46,8 @@ public class OpenSearchFunctions {
     return new RelevanceFunctionResolver(name, STRING);
   }
 
-  private static FunctionResolver match() {
-    FunctionName funcName = BuiltinFunctionName.MATCH.getName();
+  private static FunctionResolver match(BuiltinFunctionName match) {
+    FunctionName funcName = match.getName();
     return new RelevanceFunctionResolver(funcName, STRING);
   }
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2730,6 +2730,95 @@ Another example to show how to set custom values for the optional parameters::
     +------------+
 
 
+MATCHQUERY
+-----
+
+Description
+>>>>>>>>>>>
+
+``matchquery(field_expression, query_expression[, option=<option_value>]*)``
+
+The matchquery function maps to the match query used in search engine, to return the documents that match a provided text, number, date or boolean value with a given field. This is alternate syntax for the `match`_ function. Available parameters include:
+
+- analyzer
+- auto_generate_synonyms_phrase
+- fuzziness
+- max_expansions
+- prefix_length
+- fuzzy_transpositions
+- fuzzy_rewrite
+- lenient
+- operator
+- minimum_should_match
+- zero_terms_query
+- boost
+
+Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
+
+    os> SELECT lastname, address FROM accounts WHERE match(address, 'Street');
+    fetched rows / total rows = 2/2
+    +------------+--------------------+
+    | lastname   | address            |
+    |------------+--------------------|
+    | Bond       | 671 Bristol Street |
+    | Bates      | 789 Madison Street |
+    +------------+--------------------+
+
+Another example to show how to set custom values for the optional parameters::
+
+    os> SELECT lastname FROM accounts WHERE match(firstname, 'Hattie', operator='AND', boost=2.0);
+    fetched rows / total rows = 1/1
+    +------------+
+    | lastname   |
+    |------------|
+    | Bond       |
+    +------------+
+
+MATCH_QUERY
+-----
+
+Description
+>>>>>>>>>>>
+
+``match(field_expression, query_expression[, option=<option_value>]*)``
+
+The match function maps to the match query used in search engine, to return the documents that match a provided text, number, date or boolean value with a given field. This is alternate syntax for the `match`_ function.  Available parameters include:
+
+- analyzer
+- auto_generate_synonyms_phrase
+- fuzziness
+- max_expansions
+- prefix_length
+- fuzzy_transpositions
+- fuzzy_rewrite
+- lenient
+- operator
+- minimum_should_match
+- zero_terms_query
+- boost
+
+Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
+
+    os> SELECT lastname, address FROM accounts WHERE match(address, 'Street');
+    fetched rows / total rows = 2/2
+    +------------+--------------------+
+    | lastname   | address            |
+    |------------+--------------------|
+    | Bond       | 671 Bristol Street |
+    | Bates      | 789 Madison Street |
+    +------------+--------------------+
+
+Another example to show how to set custom values for the optional parameters::
+
+    os> SELECT lastname FROM accounts WHERE match(firstname, 'Hattie', operator='AND', boost=2.0);
+    fetched rows / total rows = 1/1
+    +------------+
+    | lastname   |
+    |------------|
+    | Bond       |
+    +------------+
+
+
 MATCH_PHRASE
 ------------
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2736,24 +2736,7 @@ MATCHQUERY
 Description
 >>>>>>>>>>>
 
-``matchquery(field_expression, query_expression[, option=<option_value>]*)``
-
-The matchquery function maps to the match query used in search engine, to return the documents that match a provided text, number, date or boolean value with a given field. This is alternate syntax for the `match`_ function. Available parameters include:
-
-- analyzer
-- auto_generate_synonyms_phrase
-- fuzziness
-- max_expansions
-- prefix_length
-- fuzzy_transpositions
-- fuzzy_rewrite
-- lenient
-- operator
-- minimum_should_match
-- zero_terms_query
-- boost
-
-For backwards compatibility, matchquery is supported and mapped to the match query.
+The matchquery function is a synonym for the `match`_ function.
 
 Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
 
@@ -2782,24 +2765,7 @@ MATCH_QUERY
 Description
 >>>>>>>>>>>
 
-``match_query(field_expression, query_expression[, option=<option_value>]*)``
-
-The match_query function maps to the match query used in search engine, to return the documents that match_query a provided text, number, date or boolean value with a given field. This is alternate syntax for the `match`_ function.  Available parameters include:
-
-- analyzer
-- auto_generate_synonyms_phrase
-- fuzziness
-- max_expansions
-- prefix_length
-- fuzzy_transpositions
-- fuzzy_rewrite
-- lenient
-- operator
-- minimum_should_match
-- zero_terms_query
-- boost
-
-For backwards compatibility, match_query is supported and mapped to the match query.
+The match_query function is a synonym for the `match`_ function.
 
 Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
 

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2755,7 +2755,7 @@ The matchquery function maps to the match query used in search engine, to return
 
 Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
 
-    os> SELECT lastname, address FROM accounts WHERE match(address, 'Street');
+    os> SELECT lastname, address FROM accounts WHERE matchquery(address, 'Street');
     fetched rows / total rows = 2/2
     +------------+--------------------+
     | lastname   | address            |
@@ -2766,7 +2766,7 @@ Example with only ``field`` and ``query`` expressions, and all other parameters 
 
 Another example to show how to set custom values for the optional parameters::
 
-    os> SELECT lastname FROM accounts WHERE match(firstname, 'Hattie', operator='AND', boost=2.0);
+    os> SELECT lastname FROM accounts WHERE matchquery(firstname, 'Hattie', operator='AND', boost=2.0);
     fetched rows / total rows = 1/1
     +------------+
     | lastname   |
@@ -2780,9 +2780,9 @@ MATCH_QUERY
 Description
 >>>>>>>>>>>
 
-``match(field_expression, query_expression[, option=<option_value>]*)``
+``match_query(field_expression, query_expression[, option=<option_value>]*)``
 
-The match function maps to the match query used in search engine, to return the documents that match a provided text, number, date or boolean value with a given field. This is alternate syntax for the `match`_ function.  Available parameters include:
+The match_query function maps to the match query used in search engine, to return the documents that match_query a provided text, number, date or boolean value with a given field. This is alternate syntax for the `match`_ function.  Available parameters include:
 
 - analyzer
 - auto_generate_synonyms_phrase
@@ -2799,7 +2799,7 @@ The match function maps to the match query used in search engine, to return the 
 
 Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
 
-    os> SELECT lastname, address FROM accounts WHERE match(address, 'Street');
+    os> SELECT lastname, address FROM accounts WHERE match_query(address, 'Street');
     fetched rows / total rows = 2/2
     +------------+--------------------+
     | lastname   | address            |
@@ -2810,7 +2810,7 @@ Example with only ``field`` and ``query`` expressions, and all other parameters 
 
 Another example to show how to set custom values for the optional parameters::
 
-    os> SELECT lastname FROM accounts WHERE match(firstname, 'Hattie', operator='AND', boost=2.0);
+    os> SELECT lastname FROM accounts WHERE match_query(firstname, 'Hattie', operator='AND', boost=2.0);
     fetched rows / total rows = 1/1
     +------------+
     | lastname   |

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2753,6 +2753,8 @@ The matchquery function maps to the match query used in search engine, to return
 - zero_terms_query
 - boost
 
+For backwards compatibility, matchquery is supported and mapped to the match query.
+
 Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
 
     os> SELECT lastname, address FROM accounts WHERE matchquery(address, 'Street');
@@ -2796,6 +2798,8 @@ The match_query function maps to the match query used in search engine, to retur
 - minimum_should_match
 - zero_terms_query
 - boost
+
+For backwards compatibility, match_query is supported and mapped to the match query.
 
 Example with only ``field`` and ``query`` expressions, and all other parameters are set default values::
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
@@ -35,4 +35,32 @@ public class MatchIT extends SQLIntegTestCase {
     verifySchema(result, schema("lastname", "text"));
     verifyDataRows(result, rows("Bates"));
   }
+
+  @Test
+  public void matchquery_in_where() throws IOException {
+    JSONObject result = executeJdbcRequest("SELECT firstname FROM " + TEST_INDEX_ACCOUNT + " WHERE matchquery(lastname, 'Bates')");
+    verifySchema(result, schema("firstname", "text"));
+    verifyDataRows(result, rows("Nanette"));
+  }
+
+  @Test
+  public void matchquery_in_having() throws IOException {
+    JSONObject result = executeJdbcRequest("SELECT lastname FROM " + TEST_INDEX_ACCOUNT + " HAVING matchquery(firstname, 'Nanette')");
+    verifySchema(result, schema("lastname", "text"));
+    verifyDataRows(result, rows("Bates"));
+  }
+
+  @Test
+  public void match_query_in_where() throws IOException {
+    JSONObject result = executeJdbcRequest("SELECT firstname FROM " + TEST_INDEX_ACCOUNT + " WHERE match_query(lastname, 'Bates')");
+    verifySchema(result, schema("firstname", "text"));
+    verifyDataRows(result, rows("Nanette"));
+  }
+
+  @Test
+  public void match_query_in_having() throws IOException {
+    JSONObject result = executeJdbcRequest("SELECT lastname FROM " + TEST_INDEX_ACCOUNT + " HAVING match_query(firstname, 'Nanette')");
+    verifySchema(result, schema("lastname", "text"));
+    verifyDataRows(result, rows("Bates"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
@@ -59,8 +59,24 @@ public class MatchIT extends SQLIntegTestCase {
 
   @Test
   public void match_query_in_having() throws IOException {
-    JSONObject result = executeJdbcRequest("SELECT lastname FROM " + TEST_INDEX_ACCOUNT + " HAVING match_query(firstname, 'Nanette')");
+    JSONObject result = executeJdbcRequest(
+        "SELECT lastname FROM " + TEST_INDEX_ACCOUNT + " HAVING match_query(firstname, 'Nanette')");
     verifySchema(result, schema("lastname", "text"));
     verifyDataRows(result, rows("Bates"));
+  }
+
+  @Test
+  public void alternate_syntaxes_return_the_same_results() throws IOException {
+    String query1 = "SELECT lastname FROM "
+        + TEST_INDEX_ACCOUNT + " HAVING match(firstname, 'Nanette')";
+    JSONObject result1 = executeJdbcRequest(query1);
+    String query2 = "SELECT lastname FROM "
+        + TEST_INDEX_ACCOUNT + " HAVING matchquery(firstname, 'Nanette')";
+    JSONObject result2 = executeJdbcRequest(query2);
+    String query3 = "SELECT lastname FROM "
+        + TEST_INDEX_ACCOUNT + " HAVING match_query(firstname, 'Nanette')";
+    JSONObject result3 = executeJdbcRequest(query3);
+    assertEquals(result1.getInt("total"), result2.getInt("total"));
+    assertEquals(result1.getInt("total"), result3.getInt("total"));
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
-import org.opensearch.sql.common.grok.Match;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/MatchQueryTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.common.grok.Match;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;
@@ -113,27 +114,21 @@ public class MatchQueryTest {
   @ParameterizedTest
   @MethodSource("generateValidData")
   public void test_valid_parameters(List<Expression> validArgs) {
-    for (FunctionName funcName : functionNames) {
-      Assertions.assertNotNull(matchQuery.build(new MatchExpression(validArgs, funcName)));
-    }
+    Assertions.assertNotNull(matchQuery.build(new MatchExpression(validArgs)));
   }
 
   @Test
   public void test_SyntaxCheckException_when_no_arguments() {
     List<Expression> arguments = List.of();
-    for (FunctionName funcName : functionNames) {
-      assertThrows(SyntaxCheckException.class,
-          () -> matchQuery.build(new MatchExpression(arguments, funcName)));
-    }
+    assertThrows(SyntaxCheckException.class,
+        () -> matchQuery.build(new MatchExpression(arguments)));
   }
 
   @Test
   public void test_SyntaxCheckException_when_one_argument() {
     List<Expression> arguments = List.of(namedArgument("field", "field_value"));
-    for (FunctionName funcName : functionNames) {
-      assertThrows(SyntaxCheckException.class,
-          () -> matchQuery.build(new MatchExpression(arguments, funcName)));
-    }
+    assertThrows(SyntaxCheckException.class,
+        () -> matchQuery.build(new MatchExpression(arguments)));
   }
 
   @Test
@@ -142,17 +137,89 @@ public class MatchQueryTest {
         namedArgument("field", "field_value"),
         namedArgument("query", "query_value"),
         namedArgument("unsupported", "unsupported_value"));
-    for (FunctionName funcName : functionNames) {
-      Assertions.assertThrows(SemanticCheckException.class,
-          () -> matchQuery.build(new MatchExpression(arguments, funcName)));
-    }
+    Assertions.assertThrows(SemanticCheckException.class,
+        () -> matchQuery.build(new MatchExpression(arguments)));
   }
+
+  @ParameterizedTest
+  @MethodSource("generateValidData")
+  public void test_valid_parameters_matchquery_syntax(List<Expression> validArgs) {
+    Assertions.assertNotNull(matchQuery.build(
+        new MatchExpression(validArgs, MatchQueryTest.this.matchQueryName)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_no_arguments_matchquery_syntax() {
+    List<Expression> arguments = List.of();
+    assertThrows(SyntaxCheckException.class,
+        () -> matchQuery.build(
+            new MatchExpression(arguments, MatchQueryTest.this.matchQueryName)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_one_argument_matchquery_syntax() {
+    List<Expression> arguments = List.of(namedArgument("field", "field_value"));
+    assertThrows(SyntaxCheckException.class,
+        () -> matchQuery.build(
+            new MatchExpression(arguments, MatchQueryTest.this.matchQueryName)));
+  }
+
+  @Test
+  public void test_SemanticCheckException_when_invalid_parameter_matchquery_syntax() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("unsupported", "unsupported_value"));
+    Assertions.assertThrows(SemanticCheckException.class,
+        () -> matchQuery.build(
+            new MatchExpression(arguments, MatchQueryTest.this.matchQueryName)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateValidData")
+  public void test_valid_parameters_match_query_syntax(List<Expression> validArgs) {
+    Assertions.assertNotNull(matchQuery.build(
+        new MatchExpression(validArgs, MatchQueryTest.this.matchQueryWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_no_arguments_match_query_syntax() {
+    List<Expression> arguments = List.of();
+    assertThrows(SyntaxCheckException.class,
+        () -> matchQuery.build(
+            new MatchExpression(arguments, MatchQueryTest.this.matchQueryWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_SyntaxCheckException_when_one_argument_match_query_syntax() {
+    List<Expression> arguments = List.of(namedArgument("field", "field_value"));
+    assertThrows(SyntaxCheckException.class,
+        () -> matchQuery.build(
+            new MatchExpression(arguments, MatchQueryTest.this.matchQueryWithUnderscoreName)));
+  }
+
+  @Test
+  public void test_SemanticCheckException_when_invalid_parameter_match_query_syntax() {
+    List<Expression> arguments = List.of(
+        namedArgument("field", "field_value"),
+        namedArgument("query", "query_value"),
+        namedArgument("unsupported", "unsupported_value"));
+    Assertions.assertThrows(SemanticCheckException.class,
+        () -> matchQuery.build(
+            new MatchExpression(arguments, MatchQueryTest.this.matchQueryWithUnderscoreName)));
+  }
+
 
   private NamedArgumentExpression namedArgument(String name, String value) {
     return DSL.namedArgument(name, DSL.literal(value));
   }
 
   private class MatchExpression extends FunctionExpression {
+
+    public MatchExpression(List<Expression> arguments) {
+      super(MatchQueryTest.this.matchName, arguments);
+    }
+
     public MatchExpression(List<Expression> arguments, FunctionName funcName) {
       super(funcName, arguments);
     }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -425,7 +425,8 @@ systemFunctionName
     ;
 
 singleFieldRelevanceFunctionName
-    : MATCH | MATCH_PHRASE | MATCHPHRASE
+    : MATCH | MATCHQUERY | MATCH_QUERY
+    | MATCH_PHRASE | MATCHPHRASE
     | MATCH_BOOL_PREFIX | MATCH_PHRASE_PREFIX
     ;
 
@@ -436,7 +437,7 @@ multiFieldRelevanceFunctionName
     ;
 
 legacyRelevanceFunctionName
-    : QUERY | MATCH_QUERY | MATCHQUERY
+    : QUERY 
     ;
 
 functionArgs

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -436,10 +436,6 @@ multiFieldRelevanceFunctionName
     | QUERY_STRING
     ;
 
-legacyRelevanceFunctionName
-    : QUERY 
-    ;
-
 functionArgs
     : (functionArg (COMMA functionArg)*)?
     ;

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -375,7 +375,28 @@ class SQLSyntaxParserTest {
     assertNotNull(parser.parse("SELECT * FROM test WHERE match(`column`, \"this is a test\")"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE match(`column`, 'this is a test')"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE match(column, 100500)"));
+  }
 
+  @Test
+  public void can_parse_matchquery_relevance_function() {
+    assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(column, \"this is a test\")"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(column, 'this is a test')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(`column`, \"this is a test\")"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(`column`, 'this is a test')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(column, 100500)"));
+  }
+
+  @Test
+  public void can_parse_match_query_relevance_function() {
+    assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(column, \"this is a test\")"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(column, 'this is a test')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(`column`, \"this is a test\")"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(`column`, 'this is a test')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(column, 100500)"));
+  }
+
+  @Test
+  public void can_parse_match_phrase_relevance_function() {
     assertNotNull(
             parser.parse("SELECT * FROM test WHERE match_phrase(column, \"this is a test\")"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE match_phrase(column, 'this is a test')"));

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -381,16 +381,19 @@ class SQLSyntaxParserTest {
   public void can_parse_matchquery_relevance_function() {
     assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(column, \"this is a test\")"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(column, 'this is a test')"));
-    assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(`column`, \"this is a test\")"));
+    assertNotNull(parser.parse(
+        "SELECT * FROM test WHERE matchquery(`column`, \"this is a test\")"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(`column`, 'this is a test')"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE matchquery(column, 100500)"));
   }
 
   @Test
   public void can_parse_match_query_relevance_function() {
-    assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(column, \"this is a test\")"));
+    assertNotNull(parser.parse(
+        "SELECT * FROM test WHERE match_query(column, \"this is a test\")"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(column, 'this is a test')"));
-    assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(`column`, \"this is a test\")"));
+    assertNotNull(parser.parse(
+        "SELECT * FROM test WHERE match_query(`column`, \"this is a test\")"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(`column`, 'this is a test')"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE match_query(column, 100500)"));
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -486,6 +486,38 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void relevanceMatchQuery() {
+    assertEquals(AstDSL.function("matchquery",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("matchquery('message', 'search query')")
+    );
+
+    assertEquals(AstDSL.function("matchquery",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query")),
+            unresolvedArg("analyzer", stringLiteral("keyword")),
+            unresolvedArg("operator", stringLiteral("AND"))),
+        buildExprAst("matchquery('message', 'search query', analyzer='keyword', operator='AND')"));
+  }
+
+  @Test
+  public void relevanceMatch_Query() {
+    assertEquals(AstDSL.function("match_query",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("match_query('message', 'search query')")
+    );
+
+    assertEquals(AstDSL.function("match_query",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query")),
+            unresolvedArg("analyzer", stringLiteral("keyword")),
+            unresolvedArg("operator", stringLiteral("AND"))),
+        buildExprAst("match_query('message', 'search query', analyzer='keyword', operator='AND')"));
+  }
+
+  @Test
   public void relevanceMulti_match() {
     assertEquals(AstDSL.function("multi_match",
             unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(


### PR DESCRIPTION
### Description
Adds `match_query` and `matchquery` as alternate syntax for `match` function which currently exists in OpenSearch.
This is being done to support legacy syntax.

Queries can be performed using the following syntax : 
```
matchquery(field, 'query')
match_query(field, 'query')
```
Example:
```
SELECT field FROM index WHERE matchquery(field, 'query');
SELECT field FROM index WHERE match_query(field, 'query');
```
These queries should return the same result as `match(field, 'query')`
 
### Issues Resolved
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).