### PR TITLE
Support opensearch-sql:run and update developer_guide doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ gen
 /artifacts/
 /.pid.lock
 /.prom.pid.lock
+
+.java-version

--- a/DEVELOPER_GUIDE.rst
+++ b/DEVELOPER_GUIDE.rst
@@ -141,6 +141,8 @@ The plugin codebase is in standard layout of Gradle project::
    ├── core
    ├── doctest
    ├── opensearch
+   ├── filesystem
+   ├── prometheus
    ├── integ-test
    ├── legacy
    ├── plugin
@@ -159,6 +161,8 @@ Here are sub-folders (Gradle modules) for plugin source code:
 - ``ppl``: PPL language processor.
 - ``core``: core query engine.
 - ``opensearch``: OpenSearch storage engine.
+- ``prometheus``: Prometheus storage engine.
+- ``filesystem``: File System storage engine (in development).
 - ``protocol``: request/response protocol formatter.
 - ``common``: common util code.
 - ``integ-test``: integration and comparison test.

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -30,6 +30,7 @@ plugins {
 }
 
 apply plugin: 'opensearch.pluginzip'
+apply plugin: 'opensearch.rest-test'
 
 ext {
     projectSubstitutions = [:]
@@ -225,4 +226,20 @@ afterEvaluate {
             doLast { delete file("$buildDir/distributions/$archiveName") }
         }
     }
+}
+
+testClusters.integTest {
+    plugin(project.tasks.bundlePlugin.archiveFile)
+
+    // debug with command, ./gradlew opensearch-sql:run -DdebugJVM. --debug-jvm does not work with keystore.
+    if (System.getProperty("debugJVM") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
+    }
+
+    // add customized keystore
+    keystore 'plugins.query.federation.datasources.config', new File("$projectDir/src/test/resources/", 'datasources.json')
+}
+
+run {
+    useCluster testClusters.integTest
 }


### PR DESCRIPTION
### Description
1. Support  opensearch-sql:run
2. Update developer_guide doc. add prometheus and filesystem description.
3. Add .java-version to .gitignore
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).