### PR TITLE
Add Day_Of_Year Function To OpenSearch

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -330,6 +330,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAYOFYEAR, expressions);
   }
 
+  public static FunctionExpression day_of_year(Expression... expressions) {
+    return compile(BuiltinFunctionName.DAY_OF_YEAR, expressions);
+  }
+
   public static FunctionExpression from_days(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.FROM_DAYS, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -331,7 +331,7 @@ public class DSL {
   }
 
   public static FunctionExpression day_of_year(Expression... expressions) {
-    return compile(BuiltinFunctionName.DAY_OF_YEAR, expressions);
+    return compile(FunctionProperties.None, BuiltinFunctionName.DAY_OF_YEAR, expressions);
   }
 
   public static FunctionExpression from_days(Expression... expressions) {

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -102,7 +102,8 @@ public class DateTimeFunction {
     repository.register(dayName());
     repository.register(dayOfMonth());
     repository.register(dayOfWeek());
-    repository.register(dayOfYear());
+    repository.register(dayOfYear(BuiltinFunctionName.DAYOFYEAR));
+    repository.register(dayOfYear(BuiltinFunctionName.DAY_OF_YEAR));
     repository.register(from_days());
     repository.register(from_unixtime());
     repository.register(hour());
@@ -359,8 +360,8 @@ public class DateTimeFunction {
    * DAYOFYEAR(STRING/DATE/DATETIME/TIMESTAMP).
    * return the day of the year for date (1-366).
    */
-  private DefaultFunctionResolver dayOfYear() {
-    return define(BuiltinFunctionName.DAYOFYEAR.getName(),
+  private DefaultFunctionResolver dayOfYear(BuiltinFunctionName dayOfYear) {
+    return define(dayOfYear.getName(),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfYear), INTEGER, TIMESTAMP),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -69,6 +69,7 @@ public enum BuiltinFunctionName {
   DAYOFMONTH(FunctionName.of("dayofmonth")),
   DAYOFWEEK(FunctionName.of("dayofweek")),
   DAYOFYEAR(FunctionName.of("dayofyear")),
+  DAY_OF_YEAR(FunctionName.of("day_of_year")),
   FROM_DAYS(FunctionName.of("from_days")),
   FROM_UNIXTIME(FunctionName.of("from_unixtime")),
   HOUR(FunctionName.of("hour")),

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1457,6 +1457,7 @@ Description
 >>>>>>>>>>>
 
 Usage:  dayofyear(date) returns the day of the year for date, in the range 1 to 366.
+The function `day_of_year`_ is also provided as an alias.
 
 Argument type: STRING/DATE/DATETIME/TIMESTAMP
 
@@ -1471,6 +1472,62 @@ Example::
     |---------------------------------|
     | 239                             |
     +---------------------------------+
+
+    os> SELECT DAYOFYEAR(DATETIME('2020-08-26 00:00:00'))
+    fetched rows / total rows = 1/1
+    +----------------------------------------------+
+    | DAYOFYEAR(DATETIME('2020-08-26 00:00:00'))   |
+    |----------------------------------------------|
+    | 239                                          |
+    +----------------------------------------------+
+
+    os> SELECT DAYOFYEAR(TIMESTAMP('2020-08-26 00:00:00'))
+    fetched rows / total rows = 1/1
+    +-----------------------------------------------+
+    | DAYOFYEAR(TIMESTAMP('2020-08-26 00:00:00'))   |
+    |-----------------------------------------------|
+    | 239                                           |
+    +-----------------------------------------------+
+
+
+DAY_OF_YEAR
+---------
+
+Description
+>>>>>>>>>>>
+
+This function is an alias to the `dayofyear`_ function
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    os> SELECT DAY_OF_YEAR(DATE('2020-08-26'))
+    fetched rows / total rows = 1/1
+    +-----------------------------------+
+    | DAY_OF_YEAR(DATE('2020-08-26'))   |
+    |-----------------------------------|
+    | 239                               |
+    +-----------------------------------+
+
+    os> SELECT DAY_OF_YEAR(DATETIME('2020-08-26 00:00:00'))
+    fetched rows / total rows = 1/1
+    +------------------------------------------------+
+    | DAY_OF_YEAR(DATETIME('2020-08-26 00:00:00'))   |
+    |------------------------------------------------|
+    | 239                                            |
+    +------------------------------------------------+
+
+    os> SELECT DAY_OF_YEAR(TIMESTAMP('2020-08-26 00:00:00'))
+    fetched rows / total rows = 1/1
+    +-------------------------------------------------+
+    | DAY_OF_YEAR(TIMESTAMP('2020-08-26 00:00:00'))   |
+    |-------------------------------------------------|
+    | 239                                             |
+    +-------------------------------------------------+
+
 
 
 FROM_DAYS

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -244,6 +244,7 @@ datetimeConstantLiteral
     : CURRENT_DATE
     | CURRENT_TIME
     | CURRENT_TIMESTAMP
+    | DAY_OF_YEAR
     | LOCALTIME
     | LOCALTIMESTAMP
     | UTC_TIMESTAMP

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -192,6 +192,12 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void can_parse_dayofyear_functions() {
+    assertNotNull(parser.parse("SELECT dayofyear('2022-11-18')"));
+    assertNotNull(parser.parse("SELECT day_of_year('2022-11-18')"));
+  }
+
+  @Test
   public void can_parse_multi_match_relevance_function() {
     assertNotNull(parser.parse(
         "SELECT id FROM test WHERE multi_match(['address'], 'query')"));


### PR DESCRIPTION
### Description
Adds the `day_of_year` function to the SQL plugin. It behaves like the `dayofyear` function which already exists in the new engine, and both are aligned with [MySQL](https://www.w3schools.com/sql/func_mysql_dayofyear.asp)

*Note: This function does not currently support the `TIME` type because adding support for this is currently blocked by [PR 1047](https://github.com/opensearch-project/sql/pull/1047). This will be accomplished in future work.
 
### Issues Resolved
#722 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).