### PR TITLE
Add Month_Of_Year Function To OpenSearch

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -350,6 +350,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.MONTH, expressions);
   }
 
+  public static FunctionExpression month_of_year(Expression... expressions) {
+    return compile(BuiltinFunctionName.MONTH_OF_YEAR, expressions);
+  }
+
   public static FunctionExpression monthname(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.MONTHNAME, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -351,7 +351,7 @@ public class DSL {
   }
 
   public static FunctionExpression month_of_year(Expression... expressions) {
-    return compile(BuiltinFunctionName.MONTH_OF_YEAR, expressions);
+    return compile(FunctionProperties.None, BuiltinFunctionName.MONTH_OF_YEAR, expressions);
   }
 
   public static FunctionExpression monthname(Expression... expressions) {

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -112,7 +112,8 @@ public class DateTimeFunction {
     repository.register(maketime());
     repository.register(microsecond());
     repository.register(minute());
-    repository.register(month());
+    repository.register(month(BuiltinFunctionName.MONTH));
+    repository.register(month(BuiltinFunctionName.MONTH_OF_YEAR));
     repository.register(monthName());
     repository.register(now());
     repository.register(period_add());
@@ -432,8 +433,8 @@ public class DateTimeFunction {
   /**
    * MONTH(STRING/DATE/DATETIME/TIMESTAMP). return the month for date (1-12).
    */
-  private DefaultFunctionResolver month() {
-    return define(BuiltinFunctionName.MONTH.getName(),
+  private DefaultFunctionResolver month(BuiltinFunctionName month) {
+    return define(month.getName(),
         impl(nullMissingHandling(DateTimeFunction::exprMonth), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprMonth), INTEGER, DATETIME),
         impl(nullMissingHandling(DateTimeFunction::exprMonth), INTEGER, TIMESTAMP),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -77,6 +77,7 @@ public enum BuiltinFunctionName {
   MICROSECOND(FunctionName.of("microsecond")),
   MINUTE(FunctionName.of("minute")),
   MONTH(FunctionName.of("month")),
+  MONTH_OF_YEAR(FunctionName.of("month_of_year")),
   MONTHNAME(FunctionName.of("monthname")),
   PERIOD_ADD(FunctionName.of("period_add")),
   PERIOD_DIFF(FunctionName.of("period_diff")),

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1713,6 +1713,7 @@ Description
 >>>>>>>>>>>
 
 Usage: month(date) returns the month for date, in the range 1 to 12 for January to December. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
+The function month_of_year is also provided as an alias
 
 Argument type: STRING/DATE/DATETIME/TIMESTAMP
 
@@ -1727,6 +1728,15 @@ Example::
     |-----------------------------|
     | 8                           |
     +-----------------------------+
+
+
+    os> SELECT MONTH_OF_YEAR(DATE('2020-08-26'))
+    fetched rows / total rows = 1/1
+    +-------------------------------------+
+    | MONTH_OF_YEAR(DATE('2020-08-26'))   |
+    |-------------------------------------|
+    | 8                                   |
+    +-------------------------------------+
 
 
 MONTHNAME

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_PEOPLE2;
 import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 import static org.opensearch.sql.util.MatcherUtils.rows;
@@ -49,6 +50,7 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
     super.init();
     loadIndex(Index.BANK);
     loadIndex(Index.PEOPLE2);
+    loadIndex(Index.CALCS);
   }
 
   @Test
@@ -320,6 +322,57 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
     result = executeQuery("select month('2020-09-16')");
     verifySchema(result, schema("month('2020-09-16')", null, "integer"));
     verifyDataRows(result, rows(9));
+  }
+
+  @Test
+  public void testMonthOfYearTypes() throws IOException {
+    JSONObject result = executeQuery("select month_of_year(date('2020-09-16'))");
+    verifySchema(result, schema("month_of_year(date('2020-09-16'))", null, "integer"));
+    verifyDataRows(result, rows(9));
+
+    result = executeQuery("select month_of_year(datetime('2020-09-16 00:00:00'))");
+    verifySchema(result, schema("month_of_year(datetime('2020-09-16 00:00:00'))", null, "integer"));
+    verifyDataRows(result, rows(9));
+
+    result = executeQuery("select month_of_year(timestamp('2020-09-16 00:00:00'))");
+    verifySchema(result, schema("month_of_year(timestamp('2020-09-16 00:00:00'))", null, "integer"));
+    verifyDataRows(result, rows(9));
+
+    result = executeQuery("select month_of_year('2020-09-16')");
+    verifySchema(result, schema("month_of_year('2020-09-16')", null, "integer"));
+    verifyDataRows(result, rows(9));
+  }
+
+  @Test
+  public void testMonthAlternateSyntaxesReturnTheSameResults() throws IOException {
+    JSONObject result1 = executeQuery("SELECT month(date('2022-11-22'))");
+    JSONObject result2 = executeQuery("SELECT month_of_year(date('2022-11-22'))");
+    verifyDataRows(result1, rows(11));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT month(CAST(date0 AS date)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT month_of_year(CAST(date0 AS date)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT month(datetime(CAST(time0 AS STRING))) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT month_of_year(datetime(CAST(time0 AS STRING))) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT month(CAST(time0 AS STRING)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT month_of_year(CAST(time0 AS STRING)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT month(CAST(datetime0 AS timestamp)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT month_of_year(CAST(datetime0 AS timestamp)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
   }
 
   @Test

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -246,6 +246,7 @@ datetimeConstantLiteral
     | CURRENT_TIMESTAMP
     | LOCALTIME
     | LOCALTIMESTAMP
+    | MONTH_OF_YEAR
     | UTC_TIMESTAMP
     | UTC_DATE
     | UTC_TIME

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -192,6 +192,22 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void can_parse_month_of_year_function() {
+    assertNotNull(parser.parse("SELECT month('2022-11-18')"));
+    assertNotNull(parser.parse("SELECT month_of_year('2022-11-18')"));
+
+    assertNotNull(parser.parse("SELECT month(date('2022-11-18'))"));
+    assertNotNull(parser.parse("SELECT month_of_year(date('2022-11-18'))"));
+
+    assertNotNull(parser.parse("SELECT month(datetime('2022-11-18 00:00:00'))"));
+    assertNotNull(parser.parse("SELECT month_of_year(datetime('2022-11-18 00:00:00'))"));
+
+    assertNotNull(parser.parse("SELECT month(timestamp('2022-11-18 00:00:00'))"));
+    assertNotNull(parser.parse("SELECT month_of_year(timestamp('2022-11-18 00:00:00'))"));
+
+  }
+
+  @Test
   public void can_parse_multi_match_relevance_function() {
     assertNotNull(parser.parse(
         "SELECT id FROM test WHERE multi_match(['address'], 'query')"));


### PR DESCRIPTION
### Description
Adds the `month_of_year` function to the SQL plugin. It behaves like the `month` function which already exists in the new engine, and both are aligned with [MySQL](https://www.w3schools.com/sql/func_mysql_month.asp)

*Note: This function does not currently support the `TIME` type because adding support for this is currently blocked by [PR 1047](https://github.com/opensearch-project/sql/pull/1047). This will be accomplished in future work.
 
### Issues Resolved
#722 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).