### PR TITLE
Update Jackson to 2.14.1 and fix dependency resolution issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.4.0-SNAPSHOT")
         spring_version = "5.3.22"
-        jackson_version = "2.14.0"
-        jackson_databind_version = "2.14.0"
+        jackson_version = "2.14.1"
+        jackson_databind_version = "2.14.1"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -66,6 +66,8 @@ configurations.all {
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jackson_version}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -89,6 +89,8 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jackson_version}"
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jackson_version}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${jackson_databind_version}"
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
The distribution builds [1] are failing with:

```
Execution failed for task ':opensearch-sql-plugin:compileJava'.
> Could not resolve all dependencies for configuration ':opensearch-sql-plugin:compileClasspath'.
   > Conflict(s) found for the following module(s):
       - com.fasterxml.jackson.dataformat:jackson-dataformat-smile between versions 2.14.1 and 2.13.4
       - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml between versions 2.14.1 and 2.13.4
     Run with:
         --scan or
         :opensearch-sql-plugin:dependencyInsight --configuration compileClasspath --dependency com.fasterxml.jackson.dataformat:jackson-dataformat-smile
     to get more insight on how to solve the conflict.
```

[1]  https://build.ci.opensearch.org/job/distribution-build-opensearch/6673/console
 
### Issues Resolved
Closes https://github.com/opensearch-project/sql/issues/1148
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).