### PR TITLE
Add reverse() string function to V2

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -486,6 +486,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.REPLACE, expressions);
   }
 
+  public static FunctionExpression reverse(Expression... expressions) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.REVERSE, expressions);
+  }
+
   public static FunctionExpression and(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.AND, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -167,6 +167,7 @@ public enum BuiltinFunctionName {
   POSITION(FunctionName.of("position")),
   REGEXP(FunctionName.of("regexp")),
   REPLACE(FunctionName.of("replace")),
+  REVERSE(FunctionName.of("reverse")),
   RIGHT(FunctionName.of("right")),
   RTRIM(FunctionName.of("rtrim")),
   STRCMP(FunctionName.of("strcmp")),

--- a/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/text/TextFunction.java
@@ -49,6 +49,7 @@ public class TextFunction {
     repository.register(ltrim());
     repository.register(position());
     repository.register(replace());
+    repository.register(reverse());
     repository.register(right());
     repository.register(rtrim());
     repository.register(strcmp());
@@ -268,6 +269,17 @@ public class TextFunction {
         impl(nullMissingHandling(TextFunction::exprReplace), STRING, STRING, STRING, STRING));
   }
 
+  /**
+   * REVERSE(str) returns reversed string of the string supplied as an argument
+   * Returns NULL if the argument is NULL.
+   * Supports the following signature:
+   * (STRING) -> STRING
+   */
+  private DefaultFunctionResolver reverse() {
+    return define(BuiltinFunctionName.REVERSE.getName(),
+        impl(nullMissingHandling(TextFunction::exprReverse), STRING, STRING));
+  }
+
   private static ExprValue exprSubstrStart(ExprValue exprValue, ExprValue start) {
     int startIdx = start.integerValue();
     if (startIdx == 0) {
@@ -330,6 +342,10 @@ public class TextFunction {
 
   private static ExprValue exprReplace(ExprValue str, ExprValue from, ExprValue to) {
     return new ExprStringValue(str.stringValue().replaceAll(from.stringValue(), to.stringValue()));
+  }
+
+  private static ExprValue exprReverse(ExprValue str) {
+    return new ExprStringValue(new StringBuilder(str.stringValue()).reverse().toString());
   }
 }
 

--- a/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/text/TextFunctionTest.java
@@ -412,6 +412,18 @@ public class TextFunctionTest extends ExpressionTestBase {
     assertEquals(missingValue(), eval(DSL.replace(missingRef, DSL.literal("a"), DSL.literal("b"))));
   }
 
+  @Test
+  void reverse() {
+    FunctionExpression expression = DSL.reverse(DSL.literal("abcde"));
+    assertEquals(STRING, expression.type());
+    assertEquals("edcba", eval(expression).stringValue());
+
+    when(nullRef.type()).thenReturn(STRING);
+    assertEquals(nullValue(), eval(DSL.reverse(nullRef)));
+    when(missingRef.type()).thenReturn(STRING);
+    assertEquals(missingValue(), eval(DSL.reverse(missingRef)));
+  }
+
   void testConcatString(List<String> strings) {
     String expected = null;
     if (strings.stream().noneMatch(Objects::isNull)) {

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2468,6 +2468,29 @@ Example::
     +--------------------------------------------------+
 
 
+REVERSE
+-------
+
+Description
+>>>>>>>>>>>
+
+Usage: REVERSE(str) returns reversed string of the string supplied as an argument. Returns NULL if the argument is NULL.
+
+Argument type: STRING
+
+Return type: STRING
+
+Example::
+
+    os> SELECT REVERSE('abcde'), REVERSE(null)
+    fetched rows / total rows = 1/1
+    +--------------------+-----------------+
+    | REVERSE('abcde')   | REVERSE(null)   |
+    |--------------------+-----------------|
+    | edcba              | null            |
+    +--------------------+-----------------+
+
+
 RIGHT
 -----
 

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -175,6 +175,29 @@ Example::
     +-------------------------------------+---------------------------------------+
 
 
+REVERSE
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: REVERSE(str) returns reversed string of the string supplied as an argument.
+
+Argument type: STRING
+
+Return type: STRING
+
+Example::
+
+    os> source=people | eval `REVERSE('abcde')` = REVERSE('abcde') | fields `REVERSE('abcde')`
+    fetched rows / total rows = 1/1
+    +--------------------+
+    | REVERSE('abcde')   |
+    |--------------------|
+    | edcba              |
+    +--------------------+
+
+
 RIGHT
 -----
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/TextFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/TextFunctionIT.java
@@ -139,4 +139,9 @@ public class TextFunctionIT extends PPLIntegTestCase {
   public void testReplace() throws IOException {
     verifyQuery("replace", "", ", 'world', ' opensearch'", "hello", " opensearch", "hello opensearch");
   }
+
+  @Test
+  public void testReverse() throws IOException {
+    verifyQuery("reverse", "", "", "olleh", "dlrow", "dlrowolleh");
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/TextFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/TextFunctionIT.java
@@ -41,10 +41,24 @@ public class TextFunctionIT extends SQLIntegTestCase {
     verifyDataRows(result, rows(output));
   }
 
+  void verifyQueryWithNullOutput(String query, String type) throws IOException {
+    JSONObject result = executeQuery("select 'test null'," + query);
+    verifySchema(result, schema(query, null, type),
+            schema("'test null'", null, type));
+    verifyDataRows(result, rows("test null", null));
+  }
+
   @Test
   public void testRegexp() throws IOException {
     verifyQuery("'a' regexp 'b'", "integer", 0);
     verifyQuery("'a' regexp '.*'", "integer", 1);
+  }
+
+  @Test
+  public void testReverse() throws IOException {
+    verifyQuery("reverse('hello')", "keyword", "olleh");
+    verifyQuery("reverse('')", "keyword", "");
+    verifyQueryWithNullOutput("reverse(null)", "keyword");
   }
 
   @Test

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -290,6 +290,7 @@ LEFT:                               'LEFT';
 ASCII:                              'ASCII';
 LOCATE:                             'LOCATE';
 REPLACE:                            'REPLACE';
+REVERSE:                            'REVERSE';
 CAST:                               'CAST';
 
 // BOOL FUNCTIONS

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -487,7 +487,7 @@ systemFunctionBase
 
 textFunctionBase
     : SUBSTR | SUBSTRING | TRIM | LTRIM | RTRIM | LOWER | UPPER | CONCAT | CONCAT_WS | LENGTH | STRCMP
-    | RIGHT | LEFT | ASCII | LOCATE | REPLACE
+    | RIGHT | LEFT | ASCII | LOCATE | REPLACE | REVERSE
     ;
 
 positionFunctionName

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -243,6 +243,7 @@ REPLACE:                            'REPLACE';
 RINT:                               'RINT';
 ROUND:                              'ROUND';
 RTRIM:                              'RTRIM';
+REVERSE:                            'REVERSE';
 SIGN:                               'SIGN';
 SIGNUM:                             'SIGNUM';
 SIN:                                'SIN';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -454,7 +454,7 @@ dateTimeFunctionName
 textFunctionName
     : SUBSTR | SUBSTRING | TRIM | LTRIM | RTRIM | LOWER | UPPER
     | CONCAT | CONCAT_WS | SUBSTR | LENGTH | STRCMP | RIGHT | LEFT
-    | ASCII | LOCATE | REPLACE
+    | ASCII | LOCATE | REPLACE | REVERSE
     ;
 
 flowControlFunctionName


### PR DESCRIPTION
* Add reverse() string function to V2

Signed-off-by: Margarit Hakobyan <margarith@bitquilltech.com>

### Description
Usage: REVERSE(str) returns reversed string of the string supplied as an argument. Returns NULL if the argument is NULL.

Argument type: STRING

Return type: STRING

Example::

    os> SELECT REVERSE('abcde')
    fetched rows / total rows = 1/1
    +--------------------+
    | REVERSE('abcde')   |
    |--------------------|
    | edcba              |
    +--------------------+

Example::

    os> source=people | eval `REVERSE('abcde')` = REVERSE('abcde') | fields `REVERSE('abcde')`
    fetched rows / total rows = 1/1
    +--------------------+
    | REVERSE('abcde')   |
    |--------------------|
    | edcba              |
    +--------------------+
 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).