### PR TITLE
Fix arithmetic operator precedence

### DIFF
--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -254,11 +254,15 @@ comparisonExpression
     ;
 
 valueExpression
-    : left=valueExpression binaryOperator right=valueExpression     #binaryArithmetic
-    | LT_PRTHS left=valueExpression binaryOperator
-    right=valueExpression RT_PRTHS                                  #parentheticBinaryArithmetic
+    : left=valueExpression
+        binaryOperator=(STAR | DIVIDE | MODULE)
+            right=valueExpression                                   #binaryArithmetic
+    | left=valueExpression
+        binaryOperator=(PLUS | MINUS)
+            right=valueExpression                                   #binaryArithmetic
     | primaryExpression                                             #valueExpressionDefault
     | positionFunction                                              #positionFunctionCall
+    | LT_PRTHS valueExpression RT_PRTHS                             #parentheticValueExpr
     ;
 
 primaryExpression
@@ -497,10 +501,6 @@ positionFunctionName
 /** operators */
 comparisonOperator
     : EQUAL | NOT_EQUAL | LESS | NOT_LESS | GREATER | NOT_GREATER | REGEXP
-    ;
-
-binaryOperator
-    : PLUS | MINUS | STAR | DIVIDE | MODULE
     ;
 
 

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -33,7 +33,7 @@ import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalNot
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalOrContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalXorContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.MultiFieldRelevanceFunctionContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.ParentheticBinaryArithmeticContext;
+import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.ParentheticValueExprContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.PercentileAggFunctionContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SingleFieldRelevanceFunctionContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SortFieldContext;
@@ -154,18 +154,14 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitBinaryArithmetic(BinaryArithmeticContext ctx) {
     return new Function(
-        ctx.binaryOperator().getText(),
+        ctx.binaryOperator.getText(),
         Arrays.asList(visit(ctx.left), visit(ctx.right))
     );
   }
 
   @Override
-  public UnresolvedExpression visitParentheticBinaryArithmetic(
-      ParentheticBinaryArithmeticContext ctx) {
-    return new Function(
-        ctx.binaryOperator().getText(),
-        Arrays.asList(visit(ctx.left), visit(ctx.right))
-    );
+  public UnresolvedExpression visitParentheticValueExpr(ParentheticValueExprContext ctx) {
+    return visit(ctx.valueExpression()); // Discard parenthesis around
   }
 
   /**

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -227,6 +227,30 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
   }
 
   @Test
+  public void testBinaryOperationExprWithParentheses() {
+    assertEqual("source = t | where a = (1 + 2) * 3",
+        filter(
+            relation("t"),
+            compare("=",
+                field("a"),
+                function("*",
+                    function("+", intLiteral(1), intLiteral(2)),
+                    intLiteral(3)))));
+  }
+
+  @Test
+  public void testBinaryOperationExprPrecedence() {
+    assertEqual("source = t | where a = 1 + 2 * 3",
+        filter(
+            relation("t"),
+            compare("=",
+                field("a"),
+                function("+",
+                    intLiteral(1),
+                    function("*", intLiteral(2), intLiteral(3))))));
+  }
+
+  @Test
   public void testCompareExpr() {
     assertEqual("source=t a='b'",
         filter(

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -292,10 +292,12 @@ expressionAtom
     | columnName                                                    #fullColumnNameExpressionAtom
     | functionCall                                                  #functionCallExpressionAtom
     | LR_BRACKET expression RR_BRACKET                              #nestedExpressionAtom
-    | left=expressionAtom mathOperator=(STAR | DIVIDE | MODULE)
-        right=expressionAtom                                        #mathExpressionAtom
-    | left=expressionAtom mathOperator=(PLUS | MINUS)
-        right=expressionAtom                                        #mathExpressionAtom
+    | left=expressionAtom
+        mathOperator=(STAR | DIVIDE | MODULE)
+            right=expressionAtom                                    #mathExpressionAtom
+    | left=expressionAtom
+        mathOperator=(PLUS | MINUS)
+            right=expressionAtom                                    #mathExpressionAtom
     ;
 
 comparisonOperator

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -292,11 +292,10 @@ expressionAtom
     | columnName                                                    #fullColumnNameExpressionAtom
     | functionCall                                                  #functionCallExpressionAtom
     | LR_BRACKET expression RR_BRACKET                              #nestedExpressionAtom
-    | left=expressionAtom mathOperator right=expressionAtom         #mathExpressionAtom
-    ;
-
-mathOperator
-    : PLUS | MINUS | STAR | DIVIDE | MODULE
+    | left=expressionAtom mathOperator=(STAR | DIVIDE | MODULE)
+        right=expressionAtom                                        #mathExpressionAtom
+    | left=expressionAtom mathOperator=(PLUS | MINUS)
+        right=expressionAtom                                        #mathExpressionAtom
     ;
 
 comparisonOperator

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -120,7 +120,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitMathExpressionAtom(MathExpressionAtomContext ctx) {
     return new Function(
-        ctx.mathOperator().getText(),
+        ctx.mathOperator.getText(),
         Arrays.asList(visit(ctx.left), visit(ctx.right))
     );
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -154,7 +154,7 @@ class AstExpressionBuilderTest {
   }
 
   @Test
-  public void canBuildArithmeticExpressionWithPrecedence() {
+  public void canBuildArithmeticExpressionPrecedence() {
     assertEquals(
         function("+",
             intLiteral(1),

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -154,6 +154,17 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void canBuildArithmeticExpressionWithPrecedence() {
+    assertEquals(
+        function("+",
+            intLiteral(1),
+            function("*",
+                intLiteral(2), intLiteral(3))),
+        buildExprAst("1 + 2 * 3")
+    );
+  }
+
+  @Test
   public void canBuildFunctionWithoutArguments() {
     assertEquals(
         function("PI"),


### PR DESCRIPTION
### Description

This PR fixed arithmetic operator precedence reported in the issue below. I tried to reorder operator in `mathOperator` rule (Reference: https://github.com/antlr/grammars-v4/blob/master/sql/mysql/Positive-Technologies/MySqlParser.g4#L2598). However, reordering operator inside `mathOperator` rule didn't work at all.

Finally, I split the `mathExpressionAtom` rule and order them by precedence (Reference: https://github.com/crate/crate/blob/master/libs/sql-parser/src/main/antlr/SqlBaseParser.g4#L299).
 
### Issues Resolved

https://github.com/opensearch-project/sql/issues/293
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).