### PR TITLE
Suppress CI failures not related to testing/building

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -70,6 +70,7 @@ jobs:
     - name: Upload test reports
       if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
       uses: actions/upload-artifact@v2
+      continue-on-error: true
       with:
         name: test-reports
         path: |


### PR DESCRIPTION
### Description
The proposed fix suppresses errors from the uploading step. [ref](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)
 
### Issues Resolved
Sometimes CI fails to upload test reports and marks that entire workflow had failed.
Example:
https://github.com/Bit-Quill/opensearch-project-sql/actions/runs/3681582096/jobs/6228417004#step:8:19

Seen only in `SQL Java CI`, I guess it is caused by big amount of files and/or big total zip size.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).