### PR TITLE
Using jackson and jackson_databind version defined in OpenSearch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ plugins {
     id 'jacoco'
 }
 
+// import versions defined in https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java#L94
+// versions https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/version.properties
+apply plugin: 'opensearch.java'
+
 // Repository on root level is for dependencies that project code depends on. And this block must be placed after plugins{}
 repositories {
     mavenLocal()

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -53,9 +53,9 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.13.2'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 }
 
 dependencies {

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     api project(':core')
     api group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "io.github.resilience4j:resilience4j-retry:1.5.0"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
     implementation group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -57,12 +57,12 @@ configurations.all {
     // conflict with spring-jcl
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 2.12.6, https://github.com/opensearch-project/sql/issues/424
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.13.2'
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 }
 
 dependencies {

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -30,9 +30,9 @@ plugins {
 
 dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation project(':core')
     implementation project(':opensearch')
@@ -44,7 +44,7 @@ dependencies {
 }
 
 configurations.all {
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 }
 
 test {


### PR DESCRIPTION
Signed-off-by: Peng Huo <penghuo@gmail.com>
(cherry picked from commit 5073215f813bad5fdad0d5d37a20c7cb100296fd)

Related to https://github.com/opensearch-project/sql/pull/1169
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).