### PR TITLE
Fix back quoted alias of FROM subquery

### DIFF
--- a/docs/user/limitations/limitations.rst
+++ b/docs/user/limitations/limitations.rst
@@ -34,23 +34,6 @@ Aggregation over expression is not supported for now. You can only apply aggrega
 Here's a link to the Github issue - [Issue #288](https://github.com/opendistro-for-elasticsearch/sql/issues/288).
 
 
-Limitations on Subqueries
-=========================
-
-Subqueries in the FROM clause
------------------------------
-
-Subquery in the `FROM` clause in this format: `SELECT outer FROM (SELECT inner)` is supported only when the query is merged into one query. For example, the following query is supported::
-
-    SELECT t.f, t.d
-    FROM (
-        SELECT FlightNum as f, DestCountry as d
-        FROM opensearch_dashboards_sample_data_flights
-        WHERE OriginCountry = 'US') t
-
-But, if the outer query has `GROUP BY` or `ORDER BY`, then it's not supported.
-
-
 Limitations on JOINs
 ====================
 

--- a/integ-test/src/test/resources/correctness/bugfixes/550.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/550.txt
@@ -1,1 +1,2 @@
 SELECT ABS(`flights`.`AvgTicketPrice`) FROM (SELECT `AvgTicketPrice` FROM `opensearch_dashboards_sample_data_flights`) AS `flights` GROUP BY ABS(`flights`.`AvgTicketPrice`)
+SELECT `b`.`Origin`, `b`.`avgPrice` FROM (SELECT `a`.`Origin` AS `Origin`, AVG(`AvgTicketPrice`) AS `avgPrice` FROM (SELECT `Origin`, `AvgTicketPrice` FROM `opensearch_dashboards_sample_data_flights` WHERE `FlightDelay` = True) AS `a` GROUP BY `a`.`Origin`) AS `b` ORDER BY `b`.`avgPrice` DESC

--- a/integ-test/src/test/resources/correctness/bugfixes/550.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/550.txt
@@ -1,0 +1,1 @@
+SELECT ABS(`flights`.`AvgTicketPrice`) FROM (SELECT `AvgTicketPrice` FROM `opensearch_dashboards_sample_data_flights`) AS `flights` GROUP BY ABS(`flights`.`AvgTicketPrice`)

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
@@ -170,7 +170,8 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
 
   @Override
   public UnresolvedPlan visitSubqueryAsRelation(SubqueryAsRelationContext ctx) {
-    return new RelationSubquery(visit(ctx.subquery), ctx.alias().getText());
+    String subqueryAlias = StringUtils.unquoteIdentifier(ctx.alias().getText());
+    return new RelationSubquery(visit(ctx.subquery), subqueryAlias);
   }
 
   @Override

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -519,6 +519,27 @@ class AstBuilderTest extends AstBuilderTestBase {
   }
 
   @Test
+  public void can_build_from_subquery_with_backquoted_alias() {
+    assertEquals(
+        project(
+            relationSubquery(
+                project(
+                    relation("test"),
+                    alias("firstname", qualifiedName("firstname"), "firstName")),
+                "a"),
+            alias("a.firstName", qualifiedName("a", "firstName"))
+        ),
+        buildAST(
+            "SELECT a.firstName "
+                + "FROM ( "
+                + " SELECT `firstname` AS `firstName` "
+                + " FROM `test` "
+                + ") AS `a`"
+        )
+    );
+  }
+
+  @Test
   public void can_build_show_all_tables() {
     assertEquals(
         project(


### PR DESCRIPTION
### Description

Previously, FROM subquery alias was not unquoted in AST layer. This caused back quoted symbol name pushed to symbol table and thus fall back to legacy subquery logic due to semantic exception. 

#### Example

Take ```SELECT `a`.`name` FROM (...) AS `a` ``` for example. In AST node, alias name of `RelationSubquery` is still ``` `a` ``` and then Analyzer push ``` `a` ``` to symbol table. When resolving `a` in `a.name`, semantic exception is thrown because there is ``` `a` ``` instead of `a` in symbol table. Please check the comments in https://github.com/opensearch-project/sql/issues/550 below for more details.
 
#### Testing

The comparison test seems broken due to failed OpenSearch address resolving. I made local changes and ran it manually. Need to send separate PR to fix the comparison test framework.

```
$ ./gradlew :integ-test:comparisonTest -Dqueries=bugfixes/550.txt

...
{
  "summary": {
    "total": 2,
    "failure": 0,
    "success": 2
  },
  "tests": [
    {
      "result": "Success",
      "id": 1,
      "sql": "SELECT ABS(`flights`.`AvgTicketPrice`) FROM (SELECT `AvgTicketPrice` FROM `opensearch_dashboards_sample_data_flights`) AS `flights` GROUP BY ABS(`flights`.`AvgTicketPrice`)"
    },
    {
      "result": "Success",
      "id": 2,
      "sql": "SELECT `b`.`Origin`, `b`.`avgPrice` FROM (SELECT `a`.`Origin` AS `Origin`, AVG(`AvgTicketPrice`) AS `avgPrice` FROM (SELECT `Origin`, `AvgTicketPrice` FROM `opensearch_dashboards_sample_data_flights` WHERE `FlightDelay` = True) AS `a` GROUP BY `a`.`Origin`) AS `b` ORDER BY `b`.`avgPrice` DESC"
    }
  ]
}
```

#### Documentation

I don't see the limitation mentioned in our doc any more. Even very complex and nested subquery as below can be supported now. So I updated the doc to remove the limitation statement.

```
POST _plugins/_sql
{
  "query": """
    SELECT b.Origin, b.avgPrice
    FROM (
      SELECT
        a.Origin AS Origin,
        AVG(AvgTicketPrice) AS avgPrice
      FROM (
        SELECT Origin, AvgTicketPrice
        FROM opensearch_dashboards_sample_data_flights
        WHERE FlightDelay = True
      ) AS a
      GROUP BY a.Origin
    ) AS b
    ORDER BY b.avgPrice DESC
  """
}

{
  "schema": [
    {
      "name": "Origin",
      "type": "keyword"
    },
    {
      "name": "avgPrice",
      "type": "double"
    }
  ],
  "datarows": [
    [
      "Charles de Gaulle International Airport",
      999.1396484375
    ],
    [
      "Huntsville International Carl T Jones Field",
      993.1741333007812
    ],
    [
      "Minneapolis-St Paul International/Wold-Chamberlain Airport",
      952.474853515625
    ],
...

Explain output:
{
  "root": {
    "name": "ProjectOperator",
    "description": {
      "fields": "[Origin, avgPrice]"
    },
    "children": [
      {
        "name": "SortOperator",
        "description": {
          "sortList": {
            "avgPrice": {
              "sortOrder": "DESC",
              "nullOrder": "NULL_LAST"
            }
          }
        },
        "children": [
          {
            "name": "ProjectOperator",
            "description": {
              "fields": "[Origin, avgPrice]"
            },
            "children": [
              {
                "name": "AggregationOperator",
                "description": {
                  "aggregators": "[AVG(AvgTicketPrice)]",
                  "groupBy": "[Origin]"
                },
                "children": [
                  {
                    "name": "ProjectOperator",
                    "description": {
                      "fields": "[Origin, AvgTicketPrice]"
                    },
                    "children": [
                      {
                        "name": "OpenSearchIndexScan",
                        "description": {
                          "request": """OpenSearchQueryRequest(indexName=opensearch_dashboards_sample_data_flights, sourceBuilder={"from":0,"size":200,"timeout":"1m","query":{"term":{"FlightDelay":{"value":true,"boost":1.0}}},"_source":{"includes":["Origin","AvgTicketPrice"],"excludes":[]},"sort":[{"_doc":{"order":"asc"}}]}, searchDone=false)"""
                        },
                        "children": []
                      }
                    ]
                  }
                ]
              }
            ]
          }
        ]
      }
    ]
  }
}
```

### Issues Resolved

+ Root cause analysis: https://github.com/opensearch-project/sql/issues/550
+ Issues probably related:
    + https://github.com/opensearch-project/sql/issues/304
    + https://github.com/opensearch-project/sql/issues/342
    + https://github.com/opensearch-project/sql/issues/347
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).