### PR TITLE
Fix truncate() function

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
@@ -501,7 +501,7 @@ public class MathematicalFunction {
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprLongValue(
                         BigDecimal.valueOf(x.integerValue()).setScale(y.integerValue(),
-                                x.integerValue() > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING)
+                                        RoundingMode.DOWN)
                                 .longValue())),
             LONG, INTEGER, INTEGER),
         FunctionDSL.impl(

--- a/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
@@ -500,26 +500,30 @@ public class MathematicalFunction {
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprLongValue(
-                    new BigDecimal(x.integerValue()).setScale(y.integerValue(),
-                        RoundingMode.DOWN).longValue())),
+                        BigDecimal.valueOf(x.integerValue()).setScale(y.integerValue(),
+                                x.integerValue() > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING)
+                                .longValue())),
             LONG, INTEGER, INTEGER),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprLongValue(
-                    new BigDecimal(x.integerValue()).setScale(y.integerValue(),
-                        RoundingMode.DOWN).longValue())),
+                        BigDecimal.valueOf(x.longValue()).setScale(y.integerValue(),
+                                x.longValue() > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING)
+                                .longValue())),
             LONG, LONG, INTEGER),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprDoubleValue(
-                    new BigDecimal(x.floatValue()).setScale(y.integerValue(),
-                        RoundingMode.DOWN).doubleValue())),
+                        BigDecimal.valueOf(x.floatValue()).setScale(y.integerValue(),
+                                x.floatValue() > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING)
+                                .doubleValue())),
             DOUBLE, FLOAT, INTEGER),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprDoubleValue(
-                    new BigDecimal(x.doubleValue()).setScale(y.integerValue(),
-                        RoundingMode.DOWN).doubleValue())),
+                        BigDecimal.valueOf(x.doubleValue()).setScale(y.integerValue(),
+                                x.doubleValue() > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING)
+                                .doubleValue())),
             DOUBLE, DOUBLE, INTEGER));
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
@@ -501,29 +501,25 @@ public class MathematicalFunction {
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprLongValue(
                         BigDecimal.valueOf(x.integerValue()).setScale(y.integerValue(),
-                                        RoundingMode.DOWN)
-                                .longValue())),
+                                        RoundingMode.DOWN).longValue())),
             LONG, INTEGER, INTEGER),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprLongValue(
                         BigDecimal.valueOf(x.longValue()).setScale(y.integerValue(),
-                                x.longValue() > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING)
-                                .longValue())),
+                                        RoundingMode.DOWN).longValue())),
             LONG, LONG, INTEGER),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprDoubleValue(
                         BigDecimal.valueOf(x.floatValue()).setScale(y.integerValue(),
-                                x.floatValue() > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING)
-                                .doubleValue())),
+                                        RoundingMode.DOWN).doubleValue())),
             DOUBLE, FLOAT, INTEGER),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (x, y) -> new ExprDoubleValue(
                         BigDecimal.valueOf(x.doubleValue()).setScale(y.integerValue(),
-                                x.doubleValue() > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING)
-                                .doubleValue())),
+                                        RoundingMode.DOWN).doubleValue())),
             DOUBLE, DOUBLE, INTEGER));
   }
 

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
@@ -192,12 +192,12 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     assertThat(
         ceil.valueOf(valueEnv()),
         allOf(hasType(INTEGER), hasValue((int) Math.ceil(value))));
-    assertEquals(String.format("ceil(%s)", value.toString()), ceil.toString());
+    assertEquals(String.format("ceil(%s)", value), ceil.toString());
 
     FunctionExpression ceiling = DSL.ceiling(DSL.literal(value));
     assertThat(
         ceiling.valueOf(valueEnv()), allOf(hasType(INTEGER), hasValue((int) Math.ceil(value))));
-    assertEquals(String.format("ceiling(%s)", value.toString()), ceiling.toString());
+    assertEquals(String.format("ceiling(%s)", value), ceiling.toString());
   }
 
   /**
@@ -209,12 +209,12 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     FunctionExpression ceil = DSL.ceil(DSL.literal(value));
     assertThat(
         ceil.valueOf(valueEnv()), allOf(hasType(INTEGER), hasValue((int) Math.ceil(value))));
-    assertEquals(String.format("ceil(%s)", value.toString()), ceil.toString());
+    assertEquals(String.format("ceil(%s)", value), ceil.toString());
 
     FunctionExpression ceiling = DSL.ceiling(DSL.literal(value));
     assertThat(
         ceiling.valueOf(valueEnv()), allOf(hasType(INTEGER), hasValue((int) Math.ceil(value))));
-    assertEquals(String.format("ceiling(%s)", value.toString()), ceiling.toString());
+    assertEquals(String.format("ceiling(%s)", value), ceiling.toString());
   }
 
   /**
@@ -226,12 +226,12 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     FunctionExpression ceil = DSL.ceil(DSL.literal(value));
     assertThat(
         ceil.valueOf(valueEnv()), allOf(hasType(INTEGER), hasValue((int) Math.ceil(value))));
-    assertEquals(String.format("ceil(%s)", value.toString()), ceil.toString());
+    assertEquals(String.format("ceil(%s)", value), ceil.toString());
 
     FunctionExpression ceiling = DSL.ceiling(DSL.literal(value));
     assertThat(
         ceiling.valueOf(valueEnv()), allOf(hasType(INTEGER), hasValue((int) Math.ceil(value))));
-    assertEquals(String.format("ceiling(%s)", value.toString()), ceiling.toString());
+    assertEquals(String.format("ceiling(%s)", value), ceiling.toString());
   }
 
   /**
@@ -243,12 +243,12 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     FunctionExpression ceil = DSL.ceil(DSL.literal(value));
     assertThat(
         ceil.valueOf(valueEnv()), allOf(hasType(INTEGER), hasValue((int) Math.ceil(value))));
-    assertEquals(String.format("ceil(%s)", value.toString()), ceil.toString());
+    assertEquals(String.format("ceil(%s)", value), ceil.toString());
 
     FunctionExpression ceiling = DSL.ceiling(DSL.literal(value));
     assertThat(
         ceiling.valueOf(valueEnv()), allOf(hasType(INTEGER), hasValue((int) Math.ceil(value))));
-    assertEquals(String.format("ceiling(%s)", value.toString()), ceiling.toString());
+    assertEquals(String.format("ceiling(%s)", value), ceiling.toString());
   }
 
   /**
@@ -1721,12 +1721,13 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
    * Test truncate with integer value.
    */
   @ParameterizedTest(name = "truncate({0}, {1})")
-  @ValueSource(ints = {2, -2})
+  @ValueSource(ints = {2, -2, Integer.MAX_VALUE, Integer.MIN_VALUE})
   public void truncate_int_value(Integer value) {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(LONG),
-            hasValue(new BigDecimal(value).setScale(1, RoundingMode.DOWN).longValue())));
+              hasValue(BigDecimal.valueOf(value).setScale(1,
+                      value > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING).longValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 
@@ -1734,12 +1735,13 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
    * Test truncate with long value.
    */
   @ParameterizedTest(name = "truncate({0}, {1})")
-  @ValueSource(longs = {2L, -2L})
+  @ValueSource(longs = {2L, -2L, Long.MAX_VALUE, Long.MIN_VALUE})
   public void truncate_long_value(Long value) {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(LONG),
-            hasValue(new BigDecimal(value).setScale(1, RoundingMode.DOWN).longValue())));
+            hasValue(BigDecimal.valueOf(value).setScale(1,
+                    value > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING).longValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 
@@ -1747,12 +1749,13 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
    * Test truncate with float value.
    */
   @ParameterizedTest(name = "truncate({0}, {1})")
-  @ValueSource(floats = {2F, -2F})
+  @ValueSource(floats = {2F, -2F, Float.MAX_VALUE, Float.MIN_VALUE})
   public void truncate_float_value(Float value) {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(DOUBLE),
-            hasValue(new BigDecimal(value).setScale(1, RoundingMode.DOWN).doubleValue())));
+            hasValue(BigDecimal.valueOf(value).setScale(1,
+                    value > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING).doubleValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 
@@ -1760,12 +1763,16 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
    * Test truncate with double value.
    */
   @ParameterizedTest(name = "truncate({0}, {1})")
-  @ValueSource(doubles = {2D, -2D})
+  @ValueSource(doubles = {2D, -9.223372036854776e+18D, -2147483649.0D, -2147483648.0D,
+                          -32769.0D, -32768.0D, -34.84D, -2.0D, -1.2D, -1.0D, 0.0D, 1.0D,
+                          1.3D, 2.0D, 1004.3D, 32767.0D, 32768.0D, 2147483647.0D, 2147483648.0D,
+                          9.223372036854776e+18D, Double.MAX_VALUE, Double.MIN_VALUE})
   public void truncate_double_value(Double value) {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(DOUBLE),
-            hasValue(new BigDecimal(value).setScale(1, RoundingMode.DOWN).doubleValue())));
+            hasValue(BigDecimal.valueOf(value).setScale(1,
+                    value > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING).doubleValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
@@ -1726,7 +1726,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(LONG),
-              hasValue(BigDecimal.valueOf(value).setScale(1, RoundingMode.DOWN).longValue())));
+            hasValue(BigDecimal.valueOf(value).setScale(1, RoundingMode.DOWN).longValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 
@@ -1739,8 +1739,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(LONG),
-            hasValue(BigDecimal.valueOf(value).setScale(1,
-                    value > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING).longValue())));
+            hasValue(BigDecimal.valueOf(value).setScale(1, RoundingMode.DOWN).longValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 
@@ -1753,8 +1752,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(DOUBLE),
-            hasValue(BigDecimal.valueOf(value).setScale(1,
-                    value > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING).doubleValue())));
+            hasValue(BigDecimal.valueOf(value).setScale(1, RoundingMode.DOWN).doubleValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 
@@ -1770,8 +1768,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(DOUBLE),
-            hasValue(BigDecimal.valueOf(value).setScale(1,
-                    value > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING).doubleValue())));
+            hasValue(BigDecimal.valueOf(value).setScale(1, RoundingMode.DOWN).doubleValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
@@ -1726,8 +1726,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
     FunctionExpression truncate = DSL.truncate(DSL.literal(value), DSL.literal(1));
     assertThat(
         truncate.valueOf(valueEnv()), allOf(hasType(LONG),
-              hasValue(BigDecimal.valueOf(value).setScale(1,
-                      value > 0 ? RoundingMode.FLOOR : RoundingMode.CEILING).longValue())));
+              hasValue(BigDecimal.valueOf(value).setScale(1, RoundingMode.DOWN).longValue())));
     assertEquals(String.format("truncate(%s, 1)", value), truncate.toString());
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MathematicalFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MathematicalFunctionIT.java
@@ -142,6 +142,30 @@ public class MathematicalFunctionIT extends SQLIntegTestCase {
     result = executeQuery("select truncate(-56, -1)");
     verifySchema(result, schema("truncate(-56, -1)", null, "long"));
     verifyDataRows(result, rows(-50));
+
+    result = executeQuery("select truncate(33.33344, -1)");
+    verifySchema(result, schema("truncate(33.33344, -1)", null, "double"));
+    verifyDataRows(result, rows(30.0));
+
+    result = executeQuery("select truncate(33.33344, 2)");
+    verifySchema(result, schema("truncate(33.33344, 2)", null, "double"));
+    verifyDataRows(result, rows(33.33));
+
+    result = executeQuery("select truncate(33.33344, 100)");
+    verifySchema(result, schema("truncate(33.33344, 100)", null, "double"));
+    verifyDataRows(result, rows(33.33344));
+
+    result = executeQuery("select truncate(33.33344, 0)");
+    verifySchema(result, schema("truncate(33.33344, 0)", null, "double"));
+    verifyDataRows(result, rows(33.0));
+
+    result = executeQuery("select truncate(33.33344, 4)");
+    verifySchema(result, schema("truncate(33.33344, 4)", null, "double"));
+    verifyDataRows(result, rows(33.3334));
+
+    result = executeQuery(String.format("select truncate(%s, 6)", Math.PI));
+    verifySchema(result, schema(String.format("truncate(%s, 6)", Math.PI), null, "double"));
+    verifyDataRows(result, rows(3.141592));
   }
 
   @Test


### PR DESCRIPTION
* Fix truncate() function

Signed-off-by: Margarit Hakobyan <margarith@bitquilltech.com>
Signed-off-by: Margarit Hakobyan <margarit.hakobyan@improving.com>

### Description
Fixes `truncate()` returning incorrect results for some input data issue.
Example of a query result after the proposed fix:

    opensearchsql> SELECT ddouble.key, ddouble.val, TRUNCATE(ddouble.val, 1) AS `EXPR$2` FROM ddouble;                                                    
    fetched rows / total rows = 20/20
    +----------------------------+------------------------+------------------------+
    | key                        | val                    | EXPR$2                 |
    |----------------------------+------------------------+------------------------|
    | null                       | null                   | null                   |
    | 001: min long              | -9.223372036854776e+18 | -9.223372036854776e+18 |
    | 002: min int minus one     | -2147483649.0          | -2147483649.0          |
    | 003: min int               | -2147483648.0          | -2147483648.0          |
    | 004: min short minus one   | -32769.0               | -32769.0               |
    | 005: min short             | -32768.0               | -32768.0               |
    | 006: pgtest float8 value 2 | -34.84                 | -34.8                  |
    | 007: -two                  | -2.0                   | -2.0                   |
    | 008: -1.2                  | -1.2                   | -1.2                   |
    | 009: -one                  | -1.0                   | -1.0                   |
    | 010: zero                  | 0.0                    | 0.0                    |
    | 011: one                   | 1.0                    | 1.0                    |
    | 012: 1.3                   | 1.3                    | 1.3                    |
    | 013: two                   | 2.0                    | 2.0                    |
    | 014: pgtest float8 value 1 | 1004.3                 | 1004.3                 |
    | 015: max short             | 32767.0                | 32767.0                |
    | 016: max short plus one    | 32768.0                | 32768.0                |
    | 017: max int               | 2147483647.0           | 2147483647.0           |
    | 018: max int plus one      | 2147483648.0           | 2147483648.0           |
    | 019: max long              | 9.223372036854776e+18  | 9.223372036854776e+18  |
    +----------------------------+------------------------+------------------------+
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1043
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).