### PR TITLE
Add Second_Of_Minute Function As An Alias Of The Second Function

### DIFF
--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -831,6 +831,60 @@ class DateTimeFunctionTest extends ExpressionTestBase {
     assertEquals("second(DATETIME '2020-08-17 01:02:03')", expression.toString());
   }
 
+  public void testSecondOfMinute(FunctionExpression dateExpression, int second, String testExpr) {
+    assertEquals(INTEGER, dateExpression.type());
+    assertEquals(integerValue(second), eval(dateExpression));
+    assertEquals(testExpr, dateExpression.toString());
+  }
+
+  @Test
+  public void secondOfMinute() {
+    lenient().when(nullRef.valueOf(env)).thenReturn(nullValue());
+    lenient().when(missingRef.valueOf(env)).thenReturn(missingValue());
+
+    FunctionExpression expression1 = DSL.second_of_minute(DSL.literal(new ExprTimeValue("01:02:03")));
+    FunctionExpression expression2 = DSL.second_of_minute(DSL.literal("01:02:03"));
+    FunctionExpression expression3 = DSL.second_of_minute(DSL.literal("2020-08-17 01:02:03"));
+    FunctionExpression expression4 = DSL.second_of_minute(DSL.literal(new ExprTimestampValue("2020-08-17 01:02:03")));
+    FunctionExpression expression5 = DSL.second_of_minute(DSL.literal(new ExprDatetimeValue("2020-08-17 01:02:03")));
+
+    assertAll(
+        () -> testSecondOfMinute(expression1, 3, "second_of_minute(TIME '01:02:03')"),
+        () -> testSecondOfMinute(expression2, 3, "second_of_minute(\"01:02:03\")"),
+        () -> testSecondOfMinute(expression3, 3, "second_of_minute(\"2020-08-17 01:02:03\")"),
+        () -> testSecondOfMinute(
+            expression4, 3, "second_of_minute(TIMESTAMP '2020-08-17 01:02:03')"),
+        () -> testSecondOfMinute(
+            expression5, 3, "second_of_minute(DATETIME '2020-08-17 01:02:03')")
+    );
+  }
+
+  public void testInvalidSecondOfMinute(String time) {
+    FunctionExpression expression = DSL.second_of_minute(DSL.literal(new ExprTimeValue(time)));
+    eval(expression);
+  }
+
+  @Test
+  public void secondOfMinuteInvalidArguments() {
+    when(nullRef.type()).thenReturn(TIME);
+    when(missingRef.type()).thenReturn(TIME);
+    assertEquals(nullValue(), eval(DSL.second_of_minute(nullRef)));
+    assertEquals(missingValue(), eval(DSL.second_of_minute(missingRef)));
+
+    //Invalid Seconds
+    assertThrows(SemanticCheckException.class, () -> testInvalidSecondOfMinute("12:23:61"));
+
+    //Invalid Minutes
+    assertThrows(SemanticCheckException.class, () -> testInvalidSecondOfMinute("12:61:34"));
+
+    //Invalid Hours
+    assertThrows(SemanticCheckException.class, () -> testInvalidSecondOfMinute("25:23:34"));
+
+    //incorrect format
+    assertThrows(SemanticCheckException.class, () -> testInvalidSecondOfMinute("asdfasdf"));
+  }
+
+
   @Test
   public void subdate() {
     FunctionExpression expr = DSL.subdate(DSL.date(DSL.literal("2020-08-26")), DSL.literal(7));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -468,6 +468,57 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testSecondOfMinute() throws IOException {
+    JSONObject result = executeQuery("select second_of_minute(timestamp('2020-09-16 17:30:00'))");
+    verifySchema(result, schema("second_of_minute(timestamp('2020-09-16 17:30:00'))", null, "integer"));
+    verifyDataRows(result, rows(0));
+
+    result = executeQuery("select second_of_minute(time('17:30:00'))");
+    verifySchema(result, schema("second_of_minute(time('17:30:00'))", null, "integer"));
+    verifyDataRows(result, rows(0));
+
+    result = executeQuery("select second_of_minute('2020-09-16 17:30:00')");
+    verifySchema(result, schema("second_of_minute('2020-09-16 17:30:00')", null, "integer"));
+    verifyDataRows(result, rows(0));
+
+    result = executeQuery("select second_of_minute('17:30:00')");
+    verifySchema(result, schema("second_of_minute('17:30:00')", null, "integer"));
+    verifyDataRows(result, rows(0));
+  }
+
+  @Test
+  public void testSecondFunctionAliasesReturnTheSameResults() throws IOException {
+    JSONObject result1 = executeQuery("SELECT second(date('2022-11-22 12:23:34'))");
+    JSONObject result2 = executeQuery("SELECT second_of_minute(date('2022-11-22 12:23:34'))");
+    verifyDataRows(result1, rows(34));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT second(CAST(date0 AS date)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT second_of_minute(CAST(date0 AS date)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT second(datetime(CAST(time0 AS STRING))) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT second_of_minute(datetime(CAST(time0 AS STRING))) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT second(CAST(time0 AS STRING)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT second_of_minute(CAST(time0 AS STRING)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT second(CAST(datetime0 AS timestamp)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT second_of_minute(CAST(datetime0 AS timestamp)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+  }
+
+  @Test
   public void testSubDate() throws IOException {
     JSONObject result =
         executeQuery("select subdate(timestamp('2020-09-16 17:30:00'), interval 1 day)");

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -266,6 +266,14 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void can_parse_second_functions() {
+    assertNotNull(parser.parse("SELECT second('12:23:34')"));
+    assertNotNull(parser.parse("SELECT second_of_minute('2022-11-18')"));
+    assertNotNull(parser.parse("SELECT second('2022-11-18 12:23:34')"));
+    assertNotNull(parser.parse("SELECT second_of_minute('2022-11-18 12:23:34')"));
+  }
+
+  @Test
   public void can_parse_simple_query_string_relevance_function() {
     assertNotNull(parser.parse(
         "SELECT id FROM test WHERE simple_query_string(['address'], 'query')"));


### PR DESCRIPTION
Signed-off-by: GabeFernandez310 <gabrielf@bitquilltech.com>

### Description
Adds support for the `second_of_minute` function as an alias for the `second` function which currently exists in opensearch

### Issues Resolved
[#722](https://github.com/opensearch-project/sql/issues/722)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).