### PR TITLE
[Backport 2.x] Add Alternate Syntax For Match_Query And Other Functions

### DIFF
--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -3044,6 +3044,16 @@ Another example to show how to set custom values for the optional parameters::
     | Bond       |
     +------------+
 
+    The matchquery function also supports an alternative syntax::
+
+    os> SELECT firstname FROM accounts WHERE firstname = matchquery('Hattie');
+    fetched rows / total rows = 1/1
+    +-------------+
+    | firstname   |
+    |-------------|
+    | Hattie      |
+    +-------------+
+
 MATCH_QUERY
 -----
 
@@ -3072,6 +3082,16 @@ Another example to show how to set custom values for the optional parameters::
     |------------|
     | Bond       |
     +------------+
+
+The match_query function also supports an alternative syntax::
+
+    os> SELECT firstname FROM accounts WHERE firstname = match_query('Hattie');
+    fetched rows / total rows = 1/1
+    +-------------+
+    | firstname   |
+    |-------------|
+    | Hattie      |
+    +-------------+
 
 
 MATCH_PHRASE
@@ -3112,6 +3132,23 @@ Another example to show how to set custom values for the optional parameters::
     | Alan Alexander Milne | Winnie-the-Pooh          |
     +----------------------+--------------------------+
 
+The match_phrase function also supports an alternative syntax::
+
+    os> SELECT firstname FROM accounts WHERE firstname = match_phrase('Hattie');
+    fetched rows / total rows = 1/1
+    +-------------+
+    | firstname   |
+    |-------------|
+    | Hattie      |
+    +-------------+
+
+    os> SELECT firstname FROM accounts WHERE firstname = matchphrase('Hattie');
+    fetched rows / total rows = 1/1
+    +-------------+
+    | firstname   |
+    |-------------|
+    | Hattie      |
+    +-------------+
 
 MATCH_BOOL_PREFIX
 -----
@@ -3254,6 +3291,24 @@ Another example to show how to set custom values for the optional parameters::
     |------+--------------------------+----------------------|
     | 1    | The House at Pooh Corner | Alan Alexander Milne |
     +------+--------------------------+----------------------+
+
+The multi_match function also supports an alternative syntax::
+
+    os> SELECT firstname FROM accounts WHERE firstname = multi_match('Hattie');
+    fetched rows / total rows = 1/1
+    +-------------+
+    | firstname   |
+    |-------------|
+    | Hattie      |
+    +-------------+
+
+    os> SELECT firstname FROM accounts WHERE firstname = multimatch('Hattie');
+    fetched rows / total rows = 1/1
+    +-------------+
+    | firstname   |
+    |-------------|
+    | Hattie      |
+    +-------------+
 
 SIMPLE_QUERY_STRING
 -------------------

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/MethodQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/MethodQueryIT.java
@@ -54,7 +54,7 @@ public class MethodQueryIT extends SQLIntegTestCase {
         "select address from %s where address= matchQuery('880 Holmes Lane') limit 3",
         TestsConstants.TEST_INDEX_ACCOUNT));
     Assert.assertThat(result,
-        containsString("{\"match\":{\"address\":{\"query\":\"880 Holmes Lane\""));
+        containsString("{\\\"match\\\":{\\\"address\\\":{\\\"query\\\":\\\"880 Holmes Lane\\\""));
   }
 
   /**

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchIT.java
@@ -103,7 +103,7 @@ public class MatchIT extends SQLIntegTestCase {
   }
 
   @Test
-  public void alternate_syntaxes_return_the_same_results() throws IOException {
+  public void match_aliases_return_the_same_results() throws IOException {
     String query1 = "SELECT lastname FROM "
         + TEST_INDEX_ACCOUNT + " HAVING match(firstname, 'Nanette')";
     JSONObject result1 = executeJdbcRequest(query1);
@@ -112,6 +112,37 @@ public class MatchIT extends SQLIntegTestCase {
     JSONObject result2 = executeJdbcRequest(query2);
     String query3 = "SELECT lastname FROM "
         + TEST_INDEX_ACCOUNT + " HAVING match_query(firstname, 'Nanette')";
+    JSONObject result3 = executeJdbcRequest(query3);
+    assertEquals(result1.getInt("total"), result2.getInt("total"));
+    assertEquals(result1.getInt("total"), result3.getInt("total"));
+  }
+
+  @Test
+  public void match_query_alternate_syntax() throws IOException {
+    JSONObject result = executeJdbcRequest(
+        "SELECT lastname FROM " + TEST_INDEX_ACCOUNT + " WHERE lastname = match_query('Bates')");
+    verifySchema(result, schema("lastname", "text"));
+    verifyDataRows(result, rows("Bates"));
+  }
+
+  @Test
+  public void matchquery_alternate_syntax() throws IOException {
+    JSONObject result = executeJdbcRequest(
+        "SELECT lastname FROM " + TEST_INDEX_ACCOUNT + " WHERE lastname = matchquery('Bates')");
+    verifySchema(result, schema("lastname", "text"));
+    verifyDataRows(result, rows("Bates"));
+  }
+
+  @Test
+  public void match_alternate_syntaxes_return_the_same_results() throws IOException {
+    String query1 = "SELECT * FROM "
+        + TEST_INDEX_ACCOUNT + " WHERE match(firstname, 'Nanette')";
+    JSONObject result1 = executeJdbcRequest(query1);
+    String query2 = "SELECT * FROM "
+        + TEST_INDEX_ACCOUNT + " WHERE firstname = match_query('Nanette')";
+    JSONObject result2 = executeJdbcRequest(query2);
+    String query3 = "SELECT * FROM "
+        + TEST_INDEX_ACCOUNT + " WHERE firstname = matchquery('Nanette')";
     JSONObject result3 = executeJdbcRequest(query3);
     assertEquals(result1.getInt("total"), result2.getInt("total"));
     assertEquals(result1.getInt("total"), result3.getInt("total"));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhraseIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MatchPhraseIT.java
@@ -51,10 +51,36 @@ public class MatchPhraseIT extends SQLIntegTestCase {
   }
 
   @Test
-  public void test_alternate_syntax_for_match_phrase_returns_same_result() throws IOException {
+  public void test_aliases_for_match_phrase_returns_same_result() throws IOException {
     String query1 = "SELECT phrase FROM %s WHERE matchphrase(phrase, 'quick fox')";
     String query2 = "SELECT phrase FROM %s WHERE match_phrase(phrase, 'quick fox')";
     String query3 = "SELECT phrase FROM %s WHERE matchphrasequery(phrase, 'quick fox')";
+    JSONObject result1 = executeJdbcRequest(String.format(query1, TEST_INDEX_PHRASE));
+    JSONObject result2 = executeJdbcRequest(String.format(query2, TEST_INDEX_PHRASE));
+    JSONObject result3 = executeJdbcRequest(String.format(query3, TEST_INDEX_PHRASE));
+    assertTrue(result1.similar(result2));
+    assertTrue(result1.similar(result3));
+  }
+
+  @Test
+  public void match_phrase_alternate_syntax() throws IOException {
+    String query = "SELECT phrase FROM %s WHERE phrase = match_phrase('quick fox')";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_PHRASE));
+    verifyDataRows(result, rows("quick fox"), rows("quick fox here"));
+  }
+
+  @Test
+  public void matchphrase_alternate_syntax() throws IOException {
+    String query = "SELECT phrase FROM %s WHERE phrase = matchphrase('quick fox')";
+    JSONObject result = executeJdbcRequest(String.format(query, TEST_INDEX_PHRASE));
+    verifyDataRows(result, rows("quick fox"), rows("quick fox here"));
+  }
+
+  @Test
+  public void match_phrase_alternate_syntaxes_return_the_same_results() throws IOException {
+    String query1 = "SELECT phrase FROM %s WHERE matchphrase(phrase, 'quick fox')";
+    String query2 = "SELECT phrase FROM %s WHERE phrase = matchphrase('quick fox')";
+    String query3 = "SELECT phrase FROM %s WHERE phrase = match_phrase('quick fox')";
     JSONObject result1 = executeJdbcRequest(String.format(query1, TEST_INDEX_PHRASE));
     JSONObject result2 = executeJdbcRequest(String.format(query2, TEST_INDEX_PHRASE));
     JSONObject result3 = executeJdbcRequest(String.format(query3, TEST_INDEX_PHRASE));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MultiMatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MultiMatchIT.java
@@ -124,4 +124,35 @@ public class MultiMatchIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest(query);
     assertEquals(2, result.getInt("total"));
   }
+
+  @Test
+  public void multi_match_alternate_syntax() throws IOException {
+    String query = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE CreationDate = multi_match('2014-01-22');";
+    var result = new JSONObject(executeQuery(query, "jdbc"));
+    assertEquals(8, result.getInt("total"));
+  }
+
+  @Test
+  public void multimatch_alternate_syntax() throws IOException {
+    String query = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE CreationDate = multimatch('2014-01-22');";
+    var result = new JSONObject(executeQuery(query, "jdbc"));
+    assertEquals(8, result.getInt("total"));
+  }
+
+  @Test
+  public void multi_match_alternate_syntaxes_return_the_same_results() throws IOException {
+    String query1 = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE multi_match(['CreationDate'], '2014-01-22');";
+    String query2 = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE CreationDate = multi_match('2014-01-22');";
+    String query3 = "SELECT Id FROM " + TEST_INDEX_BEER
+        + " WHERE CreationDate = multimatch('2014-01-22');";
+    var result1 = new JSONObject(executeQuery(query1, "jdbc"));
+    var result2 = new JSONObject(executeQuery(query2, "jdbc"));
+    var result3 = new JSONObject(executeQuery(query3, "jdbc"));
+    assertEquals(result1.getInt("total"), result2.getInt("total"));
+    assertEquals(result1.getInt("total"), result3.getInt("total"));
+  }
 }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -328,6 +328,10 @@ positionFunction
     : POSITION LR_BRACKET functionArg IN functionArg RR_BRACKET
     ;
 
+matchQueryAltSyntaxFunction
+    : field=relevanceField EQUAL_SYMBOL MATCH_QUERY LR_BRACKET query=relevanceQuery RR_BRACKET
+    ;
+
 scalarFunctionName
     : mathematicalFunctionName
     | dateTimeFunctionName
@@ -345,7 +349,8 @@ specificFunction
     ;
 
 relevanceFunction
-    : noFieldRelevanceFunction | singleFieldRelevanceFunction | multiFieldRelevanceFunction
+    : noFieldRelevanceFunction | singleFieldRelevanceFunction | multiFieldRelevanceFunction | altSingleFieldRelevanceFunction | altMultiFieldRelevanceFunction
+
     ;
 
 noFieldRelevanceFunction
@@ -365,6 +370,14 @@ multiFieldRelevanceFunction
         COMMA query=relevanceQuery (COMMA relevanceArg)* RR_BRACKET
     | multiFieldRelevanceFunctionName LR_BRACKET
         alternateMultiMatchQuery  COMMA alternateMultiMatchField (COMMA relevanceArg)* RR_BRACKET
+    ;
+
+altSingleFieldRelevanceFunction
+    : field=relevanceField EQUAL_SYMBOL altSyntaxFunctionName=altSingleFieldRelevanceFunctionName LR_BRACKET query=relevanceQuery (COMMA relevanceArg)* RR_BRACKET
+    ;
+
+altMultiFieldRelevanceFunction
+    : field=relevanceField EQUAL_SYMBOL altSyntaxFunctionName=altMultiFieldRelevanceFunctionName LR_BRACKET query=relevanceQuery (COMMA relevanceArg)* RR_BRACKET
     ;
 
 convertedDataType
@@ -485,6 +498,18 @@ multiFieldRelevanceFunctionName
     | MULTIMATCHQUERY
     | SIMPLE_QUERY_STRING
     | QUERY_STRING
+    ;
+
+altSingleFieldRelevanceFunctionName
+    : MATCH_QUERY
+    | MATCHQUERY
+    | MATCH_PHRASE
+    | MATCHPHRASE
+    ;
+
+altMultiFieldRelevanceFunctionName
+    : MULTI_MATCH
+    | MULTIMATCH
     ;
 
 functionArgs

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -16,8 +16,9 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.LIKE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.NOT_LIKE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.POSITION;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.REGEXP;
+import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AltMultiFieldRelevanceFunctionContext;
+import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AltSingleFieldRelevanceFunctionContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AlternateMultiMatchFieldContext;
-import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AlternateMultiMatchQueryContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.BetweenPredicateContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.BinaryComparisonPredicateContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.BooleanContext;
@@ -96,6 +97,7 @@ import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AlternateMultiMatchQueryContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AndExpressionContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.ColumnNameContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.IdentContext;
@@ -435,7 +437,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
 
   @Override
   public UnresolvedExpression visitAltSingleFieldRelevanceFunction(
-      OpenSearchSQLParser.AltSingleFieldRelevanceFunctionContext ctx) {
+      AltSingleFieldRelevanceFunctionContext ctx) {
     return new Function(
         ctx.altSyntaxFunctionName.getText().toLowerCase(),
         altSingleFieldRelevanceFunctionArguments(ctx));
@@ -464,7 +466,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
 
   @Override
   public UnresolvedExpression visitAltMultiFieldRelevanceFunction(
-      OpenSearchSQLParser.AltMultiFieldRelevanceFunctionContext ctx) {
+      AltMultiFieldRelevanceFunctionContext ctx) {
     return new Function(
         ctx.altSyntaxFunctionName.getText().toLowerCase(),
         altMultiFieldRelevanceFunctionArguments(ctx));
@@ -527,12 +529,12 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
 
 
   private List<UnresolvedExpression> altSingleFieldRelevanceFunctionArguments(
-      OpenSearchSQLParser.AltSingleFieldRelevanceFunctionContext ctx) {
+      AltSingleFieldRelevanceFunctionContext ctx) {
     // all the arguments are defaulted to string values
     // to skip environment resolving and function signature resolving
     ImmutableList.Builder<UnresolvedExpression> builder = ImmutableList.builder();
     builder.add(new UnresolvedArgument("field",
-        new Literal(StringUtils.unquoteText(ctx.field.getText()), DataType.STRING)));
+        new QualifiedName(StringUtils.unquoteText(ctx.field.getText()))));
     builder.add(new UnresolvedArgument("query",
         new Literal(StringUtils.unquoteText(ctx.query.getText()), DataType.STRING)));
     fillRelevanceArgs(ctx.relevanceArg(), builder);
@@ -595,7 +597,7 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   }
 
   private List<UnresolvedExpression> altMultiFieldRelevanceFunctionArguments(
-      OpenSearchSQLParser.AltMultiFieldRelevanceFunctionContext ctx) {
+      AltMultiFieldRelevanceFunctionContext ctx) {
     // all the arguments are defaulted to string values
     // to skip environment resolving and function signature resolving
     var map = new HashMap<String, Float>();

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -509,6 +509,30 @@ class SQLSyntaxParserTest {
     );
   }
 
+  @Test
+  public void canParseMatchQueryAlternateSyntax() {
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = matchquery('query')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = matchquery(\"query\")"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = match_query('query')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = match_query(\"query\")"));
+  }
+
+  @Test
+  public void canParseMatchPhraseAlternateSyntax() {
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = match_phrase('query')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = match_phrase(\"query\")"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = matchphrase('query')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = matchphrase(\"query\")"));
+  }
+
+  @Test
+  public void canParseMultiMatchAlternateSyntax() {
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = multi_match('query')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = multi_match(\"query\")"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = multimatch('query')"));
+    assertNotNull(parser.parse("SELECT * FROM test WHERE Field = multimatch(\"query\")"));
+  }
+
   private static Stream<String> matchPhraseQueryComplexQueries() {
     return Stream.of(
         "SELECT * FROM t WHERE matchphrasequery(c, 3)",

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -573,6 +573,87 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void relevanceMatchQueryAltSyntax() {
+    assertEquals(AstDSL.function("match_query",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("message = match_query('search query')")
+    );
+
+    assertEquals(AstDSL.function("match_query",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("message = match_query(\"search query\")")
+    );
+
+    assertEquals(AstDSL.function("matchquery",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("message = matchquery('search query')")
+    );
+
+    assertEquals(AstDSL.function("matchquery",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("message = matchquery(\"search query\")")
+    );
+  }
+
+  @Test
+  public void relevanceMatchPhraseAltSyntax() {
+    assertEquals(AstDSL.function("match_phrase",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("message = match_phrase('search query')")
+    );
+
+    assertEquals(AstDSL.function("match_phrase",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("message = match_phrase(\"search query\")")
+    );
+
+    assertEquals(AstDSL.function("matchphrase",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("message = matchphrase('search query')")
+    );
+
+    assertEquals(AstDSL.function("matchphrase",
+            unresolvedArg("field", stringLiteral("message")),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("message = matchphrase(\"search query\")")
+    );
+  }
+
+  @Test
+  public void relevanceMultiMatchAltSyntax() {
+    assertEquals(AstDSL.function("multi_match",
+            unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of("field1", 1.F))),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("field1 = multi_match('search query')")
+    );
+
+    assertEquals(AstDSL.function("multi_match",
+            unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of("field1", 1.F))),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("field1 = multi_match(\"search query\")")
+    );
+
+    assertEquals(AstDSL.function("multimatch",
+            unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of("field1", 1.F))),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("field1 = multimatch('search query')")
+    );
+
+    assertEquals(AstDSL.function("multimatch",
+            unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of("field1", 1.F))),
+            unresolvedArg("query", stringLiteral("search query"))),
+        buildExprAst("field1 = multimatch(\"search query\")")
+    );
+  }
+
+  @Test
   public void relevanceMulti_match() {
     assertEquals(AstDSL.function("multi_match",
             unresolvedArg("fields", new RelevanceFieldList(ImmutableMap.of(

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -576,26 +576,26 @@ class AstExpressionBuilderTest {
   public void relevanceMatchQueryAltSyntax() {
     assertEquals(AstDSL.function("match_query",
             unresolvedArg("field", stringLiteral("message")),
-            unresolvedArg("query", stringLiteral("search query"))),
-        buildExprAst("message = match_query('search query')")
+            unresolvedArg("query", stringLiteral("search query"))).toString(),
+        buildExprAst("message = match_query('search query')").toString()
     );
 
     assertEquals(AstDSL.function("match_query",
             unresolvedArg("field", stringLiteral("message")),
-            unresolvedArg("query", stringLiteral("search query"))),
-        buildExprAst("message = match_query(\"search query\")")
+            unresolvedArg("query", stringLiteral("search query"))).toString(),
+        buildExprAst("message = match_query(\"search query\")").toString()
     );
 
     assertEquals(AstDSL.function("matchquery",
             unresolvedArg("field", stringLiteral("message")),
-            unresolvedArg("query", stringLiteral("search query"))),
-        buildExprAst("message = matchquery('search query')")
+            unresolvedArg("query", stringLiteral("search query"))).toString(),
+        buildExprAst("message = matchquery('search query')").toString()
     );
 
     assertEquals(AstDSL.function("matchquery",
             unresolvedArg("field", stringLiteral("message")),
-            unresolvedArg("query", stringLiteral("search query"))),
-        buildExprAst("message = matchquery(\"search query\")")
+            unresolvedArg("query", stringLiteral("search query"))).toString(),
+        buildExprAst("message = matchquery(\"search query\")").toString()
     );
   }
 
@@ -603,26 +603,26 @@ class AstExpressionBuilderTest {
   public void relevanceMatchPhraseAltSyntax() {
     assertEquals(AstDSL.function("match_phrase",
             unresolvedArg("field", stringLiteral("message")),
-            unresolvedArg("query", stringLiteral("search query"))),
-        buildExprAst("message = match_phrase('search query')")
+            unresolvedArg("query", stringLiteral("search query"))).toString(),
+        buildExprAst("message = match_phrase('search query')").toString()
     );
 
     assertEquals(AstDSL.function("match_phrase",
             unresolvedArg("field", stringLiteral("message")),
-            unresolvedArg("query", stringLiteral("search query"))),
-        buildExprAst("message = match_phrase(\"search query\")")
+            unresolvedArg("query", stringLiteral("search query"))).toString(),
+        buildExprAst("message = match_phrase(\"search query\")").toString()
     );
 
     assertEquals(AstDSL.function("matchphrase",
             unresolvedArg("field", stringLiteral("message")),
-            unresolvedArg("query", stringLiteral("search query"))),
-        buildExprAst("message = matchphrase('search query')")
+            unresolvedArg("query", stringLiteral("search query"))).toString(),
+        buildExprAst("message = matchphrase('search query')").toString()
     );
 
     assertEquals(AstDSL.function("matchphrase",
             unresolvedArg("field", stringLiteral("message")),
-            unresolvedArg("query", stringLiteral("search query"))),
-        buildExprAst("message = matchphrase(\"search query\")")
+            unresolvedArg("query", stringLiteral("search query"))).toString(),
+        buildExprAst("message = matchphrase(\"search query\")").toString()
     );
   }
 


### PR DESCRIPTION
Backport https://github.com/opensearch-project/sql/commit/b919ba023a48f0d73a58c94a79354b6ffe291384 from https://github.com/opensearch-project/sql/pull/1166. Backport aae57a0bdc995bd53bd88eb812d329761c4333a6 from #1241