### PR TITLE
[Backport 2.x] Add Minute_Of_Hour Function As An Alias Of Minute Function

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -358,6 +358,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.MINUTE_OF_DAY, expressions);
   }
 
+  public static FunctionExpression minute_of_hour(Expression... expressions) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.MINUTE_OF_HOUR, expressions);
+  }
+
   public static FunctionExpression month(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.MONTH, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -119,8 +119,9 @@ public class DateTimeFunction {
     repository.register(makedate());
     repository.register(maketime());
     repository.register(microsecond());
-    repository.register(minute());
+    repository.register(minute(BuiltinFunctionName.MINUTE));
     repository.register(minute_of_day());
+    repository.register(minute(BuiltinFunctionName.MINUTE_OF_HOUR));
     repository.register(month(BuiltinFunctionName.MONTH));
     repository.register(month(BuiltinFunctionName.MONTH_OF_YEAR));
     repository.register(monthName());
@@ -475,11 +476,12 @@ public class DateTimeFunction {
   /**
    * MINUTE(STRING/TIME/DATETIME/TIMESTAMP). return the minute value for time.
    */
-  private DefaultFunctionResolver minute() {
-    return define(BuiltinFunctionName.MINUTE.getName(),
+  private DefaultFunctionResolver minute(BuiltinFunctionName name) {
+    return define(name.getName(),
         impl(nullMissingHandling(DateTimeFunction::exprMinute), INTEGER, STRING),
         impl(nullMissingHandling(DateTimeFunction::exprMinute), INTEGER, TIME),
         impl(nullMissingHandling(DateTimeFunction::exprMinute), INTEGER, DATETIME),
+        impl(nullMissingHandling(DateTimeFunction::exprMinute), INTEGER, DATE),
         impl(nullMissingHandling(DateTimeFunction::exprMinute), INTEGER, TIMESTAMP)
     );
   }
@@ -1023,7 +1025,8 @@ public class DateTimeFunction {
    * @return ExprValue.
    */
   private ExprValue exprMinute(ExprValue time) {
-    return new ExprIntegerValue(time.timeValue().getMinute());
+    return new ExprIntegerValue(
+        (MINUTES.between(LocalTime.MIN, time.timeValue()) % 60));
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -79,6 +79,7 @@ public enum BuiltinFunctionName {
   MICROSECOND(FunctionName.of("microsecond")),
   MINUTE(FunctionName.of("minute")),
   MINUTE_OF_DAY(FunctionName.of("minute_of_day")),
+  MINUTE_OF_HOUR(FunctionName.of("minute_of_hour")),
   MONTH(FunctionName.of("month")),
   MONTH_OF_YEAR(FunctionName.of("month_of_year")),
   MONTHNAME(FunctionName.of("monthname")),

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -28,10 +28,15 @@ import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 import com.google.common.collect.ImmutableList;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Stream;
+
 import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.data.model.ExprDateValue;
@@ -46,6 +51,7 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ExpressionTestBase;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.env.Environment;
 
 @ExtendWith(MockitoExtension.class)

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1767,6 +1767,7 @@ Description
 >>>>>>>>>>>
 
 Usage: minute(time) returns the minute for time, in the range 0 to 59.
+The `minute_of_hour` function is provided as an alias.
 
 Argument type: STRING/TIME/DATETIME/TIMESTAMP
 
@@ -1774,13 +1775,13 @@ Return type: INTEGER
 
 Example::
 
-    os> SELECT MINUTE((TIME '01:02:03'))
+    os> SELECT MINUTE(time('01:02:03')), MINUTE_OF_HOUR(time('01:02:03'))
     fetched rows / total rows = 1/1
-    +-----------------------------+
-    | MINUTE((TIME '01:02:03'))   |
-    |-----------------------------|
-    | 2                           |
-    +-----------------------------+
+    +----------------------------+------------------------------------+
+    | MINUTE(time('01:02:03'))   | MINUTE_OF_HOUR(time('01:02:03'))   |
+    |----------------------------+------------------------------------|
+    | 2                          | 2                                  |
+    +----------------------------+------------------------------------+
 
 MINUTE_OF_DAY
 ------

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -391,6 +391,52 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testMinuteOfHour() throws IOException {
+    JSONObject result = executeQuery("select minute_of_hour(timestamp('2020-09-16 17:30:00'))");
+    verifySchema(result, schema(
+        "minute_of_hour(timestamp('2020-09-16 17:30:00'))", null, "integer"));
+    verifyDataRows(result, rows(30));
+
+    result = executeQuery("select minute_of_hour(time('17:30:00'))");
+    verifySchema(result, schema("minute_of_hour(time('17:30:00'))", null, "integer"));
+    verifyDataRows(result, rows(30));
+
+    result = executeQuery("select minute_of_hour('2020-09-16 17:30:00')");
+    verifySchema(result, schema("minute_of_hour('2020-09-16 17:30:00')", null, "integer"));
+    verifyDataRows(result, rows(30));
+
+    result = executeQuery("select minute_of_hour('17:30:00')");
+    verifySchema(result, schema("minute_of_hour('17:30:00')", null, "integer"));
+    verifyDataRows(result, rows(30));
+  }
+
+  @Test
+  public void testMinuteFunctionAliasesReturnTheSameResults() throws IOException {
+    JSONObject result1 = executeQuery("SELECT minute('11:30:00')");
+    JSONObject result2 = executeQuery("SELECT minute_of_hour('11:30:00')");
+    verifyDataRows(result1, rows(30));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT minute(datetime(CAST(time0 AS STRING))) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT minute_of_hour(datetime(CAST(time0 AS STRING))) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT minute(CAST(time0 AS STRING)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT minute_of_hour(CAST(time0 AS STRING)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+
+    result1 = executeQuery(String.format(
+        "SELECT minute(CAST(datetime0 AS timestamp)) FROM %s", TEST_INDEX_CALCS));
+    result2 = executeQuery(String.format(
+        "SELECT minute_of_hour(CAST(datetime0 AS timestamp)) FROM %s", TEST_INDEX_CALCS));
+    result1.getJSONArray("datarows").similar(result2.getJSONArray("datarows"));
+  }
+
+  @Test
   public void testMonth() throws IOException {
     JSONObject result = executeQuery("select month(date('2020-09-16'))");
     verifySchema(result, schema("month(date('2020-09-16'))", null, "integer"));

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -448,6 +448,7 @@ dateTimeFunctionName
     | MICROSECOND
     | MINUTE
     | MINUTE_OF_DAY
+    | MINUTE_OF_HOUR
     | MONTH
     | MONTHNAME
     | NOW

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -207,6 +207,15 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void can_parse_minute_functions() {
+    assertNotNull(parser.parse("SELECT minute('12:23:34')"));
+    assertNotNull(parser.parse("SELECT minute_of_hour('12:23:34')"));
+
+    assertNotNull(parser.parse("SELECT minute('2022-12-20 12:23:34')"));
+    assertNotNull(parser.parse("SELECT minute_of_hour('2022-12-20 12:23:34')"));
+  }
+
+  @Test
   public void can_parse_month_of_year_function() {
     assertNotNull(parser.parse("SELECT month('2022-11-18')"));
     assertNotNull(parser.parse("SELECT month_of_year('2022-11-18')"));


### PR DESCRIPTION
Backport https://github.com/opensearch-project/sql/commit/61e2374eace01945bb8b083c8b19859e5042e228 from https://github.com/opensearch-project/sql/pull/1230. Added imports causing checks to fail.