### PR TITLE
[Prometheus]Bug fix for less than and greater than operators on @time…

### DIFF
--- a/docs/user/ppl/admin/prometheus_connector.rst
+++ b/docs/user/ppl/admin/prometheus_connector.rst
@@ -111,6 +111,7 @@ Prometheus Connector Limitations
 * Only one aggregation is supported in stats command.
 * Span Expression is compulsory in stats command.
 * AVG, MAX, MIN, SUM, COUNT are the only aggregations supported in prometheus connector.
+* Where clause only supports EQUALS(=) operation on metric dimensions and Comparative(> , < , >= , <=) Operations on @timestamp attribute.
 
 Example queries
 ---------------

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/querybuilder/TimeRangeParametersResolver.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/querybuilder/TimeRangeParametersResolver.java
@@ -7,6 +7,8 @@
 
 package org.opensearch.sql.prometheus.storage.querybuilder;
 
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.TIMESTAMP;
+
 import java.util.Date;
 import lombok.NoArgsConstructor;
 import org.apache.commons.math3.util.Pair;
@@ -15,6 +17,7 @@ import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ExpressionNodeVisitor;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
 
 @NoArgsConstructor
 public class TimeRangeParametersResolver extends ExpressionNodeVisitor<Void, Object> {
@@ -53,10 +56,13 @@ public class TimeRangeParametersResolver extends ExpressionNodeVisitor<Void, Obj
 
   @Override
   public Void visitFunction(FunctionExpression func, Object context) {
-    if (func.getFunctionName().getFunctionName().contains("=")) {
+    if ((BuiltinFunctionName.LTE.getName().equals(func.getFunctionName())
+        || BuiltinFunctionName.GTE.getName().equals(func.getFunctionName())
+        || BuiltinFunctionName.LESS.getName().equals(func.getFunctionName())
+        || BuiltinFunctionName.GREATER.getName().equals(func.getFunctionName()))) {
       ReferenceExpression ref = (ReferenceExpression) func.getArguments().get(0);
       Expression rightExpr = func.getArguments().get(1);
-      if (ref.getAttr().equals("@timestamp")) {
+      if (ref.getAttr().equals(TIMESTAMP)) {
         ExprValue literalValue = rightExpr.valueOf();
         if (func.getFunctionName().getFunctionName().contains(">")) {
           startTime = literalValue.timestampValue().toEpochMilli() / 1000;
@@ -67,6 +73,8 @@ public class TimeRangeParametersResolver extends ExpressionNodeVisitor<Void, Obj
       }
     } else {
       func.getArguments()
+          .stream()
+          .filter(arg -> arg instanceof FunctionExpression)
           .forEach(arg -> visitFunction((FunctionExpression) arg, context));
     }
     return null;

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTableTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTableTest.java
@@ -696,7 +696,8 @@ class PrometheusMetricTableTest {
             DSL.equal(DSL.ref("handler", STRING), DSL.literal(stringValue("/ready/")))));
     RuntimeException exception
         = assertThrows(RuntimeException.class, () -> prometheusMetricTable.implement(plan));
-    assertEquals("Prometheus Catalog doesn't support or in where command.", exception.getMessage());
+    assertEquals("Prometheus Datasource doesn't support or in where command.",
+        exception.getMessage());
   }
 
   @Test
@@ -735,6 +736,66 @@ class PrometheusMetricTableTest {
         new PrometheusMetricTable(client, "prometheus_http_total_requests");
     LogicalPlan logicalPlan = project(indexScan("prometheus_http_total_requests",
         DSL.lte(DSL.ref("@timestamp", ExprCoreType.TIMESTAMP),
+            DSL.literal(
+                fromObjectValue(dateFormat.format(new Date(endTime)),
+                    ExprCoreType.TIMESTAMP)))
+    ), finalProjectList, null);
+    PhysicalPlan physicalPlan = prometheusMetricTable.implement(logicalPlan);
+    assertTrue(physicalPlan instanceof ProjectOperator);
+    assertTrue(((ProjectOperator) physicalPlan).getInput() instanceof PrometheusMetricScan);
+    PrometheusQueryRequest request
+        = ((PrometheusMetricScan) ((ProjectOperator) physicalPlan).getInput()).getRequest();
+    assertEquals((3600 / 250) + "s", request.getStep());
+    assertEquals("prometheus_http_total_requests",
+        request.getPromQl());
+    List<NamedExpression> projectList = ((ProjectOperator) physicalPlan).getProjectList();
+    List<String> outputFields
+        = projectList.stream().map(NamedExpression::getName).collect(Collectors.toList());
+    assertEquals(List.of(VALUE, TIMESTAMP), outputFields);
+  }
+
+
+  @Test
+  void testImplementWithRelationAndTimestampLTFilter() {
+    List<NamedExpression> finalProjectList = new ArrayList<>();
+    finalProjectList.add(DSL.named(VALUE, DSL.ref(VALUE, STRING)));
+    finalProjectList.add(DSL.named(TIMESTAMP, DSL.ref(TIMESTAMP, ExprCoreType.TIMESTAMP)));
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    Long endTime = new Date(System.currentTimeMillis()).getTime();
+    PrometheusMetricTable prometheusMetricTable =
+        new PrometheusMetricTable(client, "prometheus_http_total_requests");
+    LogicalPlan logicalPlan = project(indexScan("prometheus_http_total_requests",
+        DSL.less(DSL.ref("@timestamp", ExprCoreType.TIMESTAMP),
+            DSL.literal(
+                fromObjectValue(dateFormat.format(new Date(endTime)),
+                    ExprCoreType.TIMESTAMP)))
+    ), finalProjectList, null);
+    PhysicalPlan physicalPlan = prometheusMetricTable.implement(logicalPlan);
+    assertTrue(physicalPlan instanceof ProjectOperator);
+    assertTrue(((ProjectOperator) physicalPlan).getInput() instanceof PrometheusMetricScan);
+    PrometheusQueryRequest request
+        = ((PrometheusMetricScan) ((ProjectOperator) physicalPlan).getInput()).getRequest();
+    assertEquals((3600 / 250) + "s", request.getStep());
+    assertEquals("prometheus_http_total_requests",
+        request.getPromQl());
+    List<NamedExpression> projectList = ((ProjectOperator) physicalPlan).getProjectList();
+    List<String> outputFields
+        = projectList.stream().map(NamedExpression::getName).collect(Collectors.toList());
+    assertEquals(List.of(VALUE, TIMESTAMP), outputFields);
+  }
+
+
+  @Test
+  void testImplementWithRelationAndTimestampGTFilter() {
+    List<NamedExpression> finalProjectList = new ArrayList<>();
+    finalProjectList.add(DSL.named(VALUE, DSL.ref(VALUE, STRING)));
+    finalProjectList.add(DSL.named(TIMESTAMP, DSL.ref(TIMESTAMP, ExprCoreType.TIMESTAMP)));
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    Long endTime = new Date(System.currentTimeMillis()).getTime();
+    PrometheusMetricTable prometheusMetricTable =
+        new PrometheusMetricTable(client, "prometheus_http_total_requests");
+    LogicalPlan logicalPlan = project(indexScan("prometheus_http_total_requests",
+        DSL.greater(DSL.ref("@timestamp", ExprCoreType.TIMESTAMP),
             DSL.literal(
                 fromObjectValue(dateFormat.format(new Date(endTime)),
                     ExprCoreType.TIMESTAMP)))
@@ -803,4 +864,41 @@ class PrometheusMetricTableTest {
         prometheusQueryRequest.getPromQl());
 
   }
+
+  @Test
+  void testImplementPrometheusQueryWithFilterQuery() {
+
+    PrometheusMetricTable prometheusMetricTable =
+        new PrometheusMetricTable(client, "prometheus_http_total_requests");
+
+    // IndexScanAgg without Filter
+    PhysicalPlan plan = prometheusMetricTable.implement(
+            indexScan("prometheus_http_total_requests",
+            DSL.and(DSL.equal(DSL.ref("code", STRING), DSL.literal(stringValue("200"))),
+                DSL.equal(DSL.ref("handler", STRING), DSL.literal(stringValue("/ready/"))))));
+
+    assertTrue(plan instanceof PrometheusMetricScan);
+    PrometheusQueryRequest prometheusQueryRequest =
+        ((PrometheusMetricScan) plan).getRequest();
+    assertEquals(
+        "prometheus_http_total_requests{code=\"200\" , handler=\"/ready/\"}",
+        prometheusQueryRequest.getPromQl());
+  }
+
+  @Test
+  void testImplementPrometheusQueryWithUnsupportedFilterQuery() {
+
+    PrometheusMetricTable prometheusMetricTable =
+        new PrometheusMetricTable(client, "prometheus_http_total_requests");
+
+    RuntimeException exception = assertThrows(RuntimeException.class,
+        () -> prometheusMetricTable.implement(indexScan("prometheus_http_total_requests",
+            DSL.and(DSL.lte(DSL.ref("code", STRING), DSL.literal(stringValue("200"))),
+                DSL.equal(DSL.ref("handler", STRING), DSL.literal(stringValue("/ready/")))))));
+    assertEquals("Prometheus Datasource doesn't support <= in where command.",
+        exception.getMessage());
+  }
+
+
+
 }

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/querybuilders/TimeRangeParametersResolverTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/querybuilders/TimeRangeParametersResolverTest.java
@@ -1,0 +1,30 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.storage.querybuilders;
+
+import static org.opensearch.sql.data.model.ExprValueUtils.stringValue;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import org.apache.commons.math3.util.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.prometheus.storage.querybuilder.TimeRangeParametersResolver;
+
+public class TimeRangeParametersResolverTest {
+
+  @Test
+  void testTimeRangeParametersWithoutTimestampFilter() {
+    TimeRangeParametersResolver timeRangeParametersResolver = new TimeRangeParametersResolver();
+    Pair<Long, Long> result = timeRangeParametersResolver.resolve(
+        DSL.and(DSL.less(DSL.ref("code", STRING), DSL.literal(stringValue("200"))),
+            DSL.equal(DSL.ref("handler", STRING), DSL.literal(stringValue("/ready/")))));
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(3600, result.getSecond() - result.getFirst());
+  }
+}


### PR DESCRIPTION
[Prometheus Datasource]Bug fix for less than and greater than operators on @timestamp dimension.

Below command is not working with strict greater than command.

```
source = prometheus.process_resident_memory_bytes | where @timestamp > '2023-01-10 17:21:33.000000'  | sort + @timestamp | head 5
```
Without fix:
```
{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "Prometheus Catalog doesn't support > in where command.",
    "type": "RuntimeException"
  },
  "status": 503
}
```
With fix:
```
{
  "schema": [
    {
      "name": "instance",
      "type": "string"
    },
    {
      "name": "@timestamp",
      "type": "timestamp"
    },
    {
      "name": "@value",
      "type": "double"
    },
    {
      "name": "monitor",
      "type": "string"
    },
    {
      "name": "job",
      "type": "string"
    }
  ],
  "datarows": [
    [
      "localhost:8000",
      "2023-01-10 14:56:12",
      1.5208448E7,
      "prometheus",
      "prometheus"
    ],
    [
      "localhost:8000",
      "2023-01-10 14:56:26",
      1.5208448E7,
      "prometheus",
      "prometheus"
    ],
    [
      "localhost:8000",
      "2023-01-10 14:56:40",
      1.5208448E7,
      "prometheus",
      "prometheus"
    ],
    [
      "localhost:8000",
      "2023-01-10 14:56:54",
      1.5208448E7,
      "prometheus",
      "prometheus"
    ],
    [
      "localhost:8000",
      "2023-01-10 14:57:08",
      1.5208448E7,
      "prometheus",
      "prometheus"
    ]
  ],
  "total": 5,
  "size": 5
}
```




Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
Strict Greater than and Strict Less than are supposed to work on timerange. This PR fixes that issues.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).