### PR TITLE
Upgrade sqlite to 3.32.3.3

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
 
     testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
-    testImplementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.28.0'
+    testImplementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.32.3.3'
     testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":filesystem")))


### PR DESCRIPTION
Signed-off-by: Andrew Carbonetto <andrewc@bitquilltech.com>

### Description
SQLITE is not supported with jdk 11 using sqlite-jdbc version '3.28.0' and can cause connection issues. SQLITE is used in our correctness tests by comparing SQL-Plugin results to H2 and SQLITE output.

See: https://youtrack.jetbrains.com/issue/DBE-12342

Upgrade to '3.32.3.3' should fix this problem.
 
### Issues Resolved
fixes #1282
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).