### PR TITLE
Move PiTest to a new workflow.

### DIFF
--- a/.github/workflows/sql-pitest.yml
+++ b/.github/workflows/sql-pitest.yml
@@ -1,0 +1,42 @@
+name: SQL Plugin PiTest
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        required: false
+        type: string
+
+run-name:
+  ${{ inputs.name == '' && format('{0} @ {1}', github.ref_name, github.sha) || inputs.name }}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java:
+          - 11
+          - 17
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+
+    - name: PiTest with Gradle
+      run: |
+        ./gradlew --continue :core:pitest :opensearch:pitest
+
+    - name: Upload test reports
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-reports
+        path: |
+          core/build/reports/**
+          opensearch/build/reports/**

--- a/.github/workflows/sql-pitest.yml
+++ b/.github/workflows/sql-pitest.yml
@@ -36,7 +36,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: test-reports
+        name: test-reports-${{ matrix.entry.java }}
         path: |
           core/build/reports/**
           opensearch/build/reports/**

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -44,12 +44,6 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew --continue build ${{ matrix.entry.os_build_args }}
 
-    - name: PiTest with Gradle
-      run: |
-        ./gradlew :core:pitest
-        ./gradlew :opensearch:pitest
-     
-
     - name: Run backward compatibility tests
       if: ${{ matrix.entry.os == 'ubuntu-latest' }}
       run: ./scripts/bwctest.sh
@@ -63,12 +57,14 @@ jobs:
     - name: Upload SQL Coverage Report
       if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
       uses: codecov/codecov-action@v3
+      continue-on-error: true
       with:
         flags: sql-engine
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
+      continue-on-error: true
       with:
         name: opensearch-sql-${{ matrix.entry.os }}
         path: opensearch-sql-builds
@@ -89,3 +85,5 @@ jobs:
           protocol/build/reports/**
           legacy/build/reports/**
           plugin/build/reports/**
+          doctest/build/testclusters/docTestCluster-0/logs/*
+          integ-test/build/testclusters/*/logs/*

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/upload-artifact@v2
       continue-on-error: true
       with:
-        name: opensearch-sql-${{ matrix.entry.os }}
+        name: opensearch-sql-${{ matrix.entry.os }}-${{ matrix.entry.java }}
         path: opensearch-sql-builds
 
     - name: Upload test reports
@@ -74,7 +74,7 @@ jobs:
       uses: actions/upload-artifact@v2
       continue-on-error: true
       with:
-        name: test-reports
+        name: test-reports-${{ matrix.entry.os }}-${{ matrix.entry.java }}
         path: |
           sql/build/reports/**
           ppl/build/reports/**

--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -93,3 +93,5 @@ jobs:
           protocol/build/reports/**
           legacy/build/reports/**
           plugin/build/reports/**
+          doctest/build/testclusters/docTestCluster-0/logs/*
+          integ-test/build/testclusters/*/logs/*

--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -82,7 +82,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: test-reports
+        name: test-reports-${{ matrix.entry.java }}
         path: |
           sql/build/reports/**
           ppl/build/reports/**


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>

### Description
* Move PiTest to a new workflow. Triggerable on demand
* Minor fixes in the build workflow:
  * Upload doctest and integtest cluster logs
  * Suppress uploading failures
  * Keep reports and artifact from all jobs (now CI stores only them from first or last job only)
 
### Issues Resolved
Make main CI workflow faster.
![image](https://user-images.githubusercontent.com/88679692/213326073-d2d19f38-9336-4a36-823b-88bff9494a77.png)
See #1204 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).