### PR TITLE
Allow literal in aggregation (#203)

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/AggregationBuilderHelper.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/AggregationBuilderHelper.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.opensearch.script.Script;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.storage.script.ScriptUtils;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
@@ -38,7 +39,8 @@ public class AggregationBuilderHelper {
     if (expression instanceof ReferenceExpression) {
       String fieldName = ((ReferenceExpression) expression).getAttr();
       return fieldBuilder.apply(ScriptUtils.convertTextToKeyword(fieldName, expression.type()));
-    } else if (expression instanceof FunctionExpression) {
+    } else if (expression instanceof FunctionExpression
+        || expression instanceof LiteralExpression) {
       return scriptBuilder.apply(new Script(
           DEFAULT_SCRIPT_TYPE, EXPRESSION_LANG_NAME, serializer.serialize(expression),
           emptyMap()));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilderTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.expression.DSL.literal;
 import static org.opensearch.sql.expression.DSL.named;
 import static org.opensearch.sql.expression.DSL.ref;
 import static org.opensearch.sql.opensearch.data.type.OpenSearchDataType.OPENSEARCH_TEXT_KEYWORD;
@@ -66,6 +67,27 @@ class BucketAggregationBuilderTest {
         buildQuery(
             Arrays.asList(
                 asc(named("age", ref("age", INTEGER))))));
+  }
+
+  @Test
+  void should_build_bucket_with_literal() {
+    var literal = literal(1);
+    when(serializer.serialize(literal)).thenReturn("mock-serialize");
+    assertEquals(
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"script\" : {\n"
+            + "      \"source\" : \"mock-serialize\",\n"
+            + "      \"lang\" : \"opensearch_query_expression\"\n"
+            + "    },\n"
+            + "    \"missing_bucket\" : true,\n"
+            + "    \"missing_order\" : \"first\",\n"
+            + "    \"order\" : \"asc\"\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            Arrays.asList(
+                asc(named(literal)))));
   }
 
   @Test


### PR DESCRIPTION
* Support constant in aggregation.

Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>

### Description
* Minor fix for aggregation
* Fix and reactivate some aggregation integration tests
 
### Issues Resolved
Fix query like
```sql
select 1 from <any table> GROUP BY 1
```
Query is pretty useless, but fix is pretty simple though.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).