### PR TITLE
Added Correctness Tests For Date And Time Functions

### DIFF
--- a/integ-test/src/test/resources/correctness/expressions/date_and_time_functions.txt
+++ b/integ-test/src/test/resources/correctness/expressions/date_and_time_functions.txt
@@ -1,0 +1,13 @@
+DATE '2001-05-07'
+TIME '12:30:00'
+TIMESTAMP '2001-05-07 12:30:00'
+SECOND(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+MINUTE(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+HOUR(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+DAY_OF_MONTH(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+DAY_OF_YEAR(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+MONTH(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+QUARTER(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+YEAR(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+DAYNAME(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights
+MONTHNAME(timestamp) AS COLUMN FROM opensearch_dashboards_sample_data_flights


### PR DESCRIPTION
Signed-off-by: Matthew Wells <matthew.wells@improving.com>

### Description
Wrote correctness tests for date and time functions, some tests were not including due to them failing.

All string functions that have no been included in the test is because they either aren't implemented in OpenSearch, or they aren't implemented in H2 and SQLite. Because of the small number of string functions in SQLite and the fact that all correctness tests need to pass against at least one database all functions are taken from the overlap of functions between OpenSearch and H2. All functions that are implemented in both OpenSearch and H2 that do not pass have their specific reasons for failure mentioned below.

- TIME does not work when adding milliseconds because of a [bug](https://github.com/opensearch-project/sql-jdbc/issues/16)
- DAY_OF_WEEK() on H2 returns a value 1 higher than on OpenSearch
- WEEK() on H2 returns a value 1 higher than on OpenSearch
- CURRENT_WEEK() on H2 returns a value that is sometimes 1 higher than on OpenSearch due to a difference in timezone
- CURRENT_TIME() on H2 returns a `TIME WITH TIME ZONE` whereas OpenSearch returns a `TIME` as well as a different time due to different timezone
- CURRENT_TIMESTAMP() on H2 returns a `TIME WITH TIME ZONE` whereas OpenSearch returns a `TIME` as well as a different time and sometimes date due to different timezone
- DATEDIFF() on OpenSearch takes in two `DATE` parameters and returns the difference in days while H2 takes in a third parameter for time period to be returned
 
### Issue
https://github.com/opensearch-project/sql/issues/722
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).