### PR TITLE
[Backport 2.x] Fix ArgumentCaptor can't capture varargs (#1320)

### DIFF
--- a/plugin/src/test/java/org/opensearch/sql/plugin/datasource/DataSourceMetaDataTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/datasource/DataSourceMetaDataTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
@@ -111,10 +112,10 @@ public class DataSourceMetaDataTest {
   }
 
   void verifyAddDataSourceWithMetadata(List<DataSourceMetadata> metadataList) {
-    ArgumentCaptor<DataSourceMetadata> metadataCaptor =
-        ArgumentCaptor.forClass(DataSourceMetadata.class);
+    ArgumentCaptor<DataSourceMetadata[]> metadataCaptor =
+        ArgumentCaptor.forClass(DataSourceMetadata[].class);
     verify(dataSourceService, times(1)).addDataSource(metadataCaptor.capture());
-    List<DataSourceMetadata> actualValues = metadataCaptor.getAllValues();
+    List<DataSourceMetadata> actualValues = Arrays.asList(metadataCaptor.getValue());
     assertEquals(metadataList.size(), actualValues.size());
     assertEquals(metadataList, actualValues);
   }


### PR DESCRIPTION
Signed-off-by: Peng Huo <penghuo@gmail.com>
(cherry picked from commit 513428be833d9937860f27206c40f0effbc48a18)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).