### PR TITLE
Fix IT according to OpenSearch changes.

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PluginIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PluginIT.java
@@ -418,7 +418,7 @@ public class PluginIT extends SQLIntegTestCase {
 
     actual = new JSONObject(TestUtils.getResponseBody(response));
     assertThat(actual.getInt("status"), equalTo(400));
-    assertThat(actual.query("/error/type"), equalTo("illegal_argument_exception"));
+    assertThat(actual.query("/error/type"), equalTo("settings_exception"));
     assertThat(
         actual.query("/error/reason"),
         equalTo("transient setting [plugins.sql.query.state.city], not recognized")


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>

### Description
Request:
```
curl -s -XPUT http://localhost:9200/_plugins/_query/settings -H 'Content-Type: application/json' -d '{ "transient" : { "plugins.sql.query.state.city" : 200 }}'
```
Response was changed. Recently it was
```json
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "transient setting [plugins.sql.query.state.city], not recognized"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "transient setting [plugins.sql.query.state.city], not recognized"
  },
  "status": 400
}
```
Tonight it was changed to
```json
{
  "error": {
    "root_cause": [
      {
        "type": "settings_exception",
        "reason": "transient setting [plugins.sql.query.state.city], not recognized"
      }
    ],
    "type": "settings_exception",
    "reason": "transient setting [plugins.sql.query.state.city], not recognized"
  },
  "status": 400
}
```

### Issues Resolved
Fix failing IT.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).