### PR TITLE
Add WeekOfYear Function To OpenSearch

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -419,6 +419,11 @@ public class DSL {
     return compile(functionProperties, BuiltinFunctionName.WEEK, expressions);
   }
 
+  public static FunctionExpression weekofyear(
+      FunctionProperties functionProperties, Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.WEEKOFYEAR, expressions);
+  }
+
   public static FunctionExpression week_of_year(
       FunctionProperties functionProperties, Expression... expressions) {
     return compile(functionProperties, BuiltinFunctionName.WEEK_OF_YEAR, expressions);

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -163,6 +163,7 @@ public class DateTimeFunction {
     repository.register(to_days());
     repository.register(unix_timestamp());
     repository.register(week(BuiltinFunctionName.WEEK));
+    repository.register(week(BuiltinFunctionName.WEEKOFYEAR));
     repository.register(week(BuiltinFunctionName.WEEK_OF_YEAR));
     repository.register(year());
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -105,6 +105,7 @@ public enum BuiltinFunctionName {
   UTC_TIMESTAMP(FunctionName.of("utc_timestamp")),
   UNIX_TIMESTAMP(FunctionName.of("unix_timestamp")),
   WEEK(FunctionName.of("week")),
+  WEEKOFYEAR(FunctionName.of("weekofyear")),
   WEEK_OF_YEAR(FunctionName.of("week_of_year")),
   YEAR(FunctionName.of("year")),
   // `now`-like functions

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2476,7 +2476,7 @@ Description
 
 Usage: week(date[, mode]) returns the week number for date. If the mode argument is omitted, the default mode 0 is used.
 If an argument of type `TIME` is given, the function will use the current date.
-The function `week_of_year` is also provided as an alias.
+The functions `weekofyear` and `week_of_year` is also provided as an alias.
 
 .. list-table:: The following table describes how the mode argument works.
    :widths: 25 50 25 75
@@ -2534,7 +2534,7 @@ Example::
     +----------------------------+-------------------------------+
 
 WEEK_OF_YEAR
-----
+------------
 
 Description
 >>>>>>>>>>>
@@ -2555,6 +2555,30 @@ Example::
     |------------------------------------+---------------------------------------|
     | 7                                  | 8                                     |
     +------------------------------------+---------------------------------------+
+
+
+WEEKOFYEAR
+----------
+
+Description
+>>>>>>>>>>>
+
+The weekofyear function is a synonym for the `week`_ function.
+If an argument of type `TIME` is given, the function will use the current date.
+
+Argument type: DATE/DATETIME/TIME/TIMESTAMP/STRING
+
+Return type: INTEGER
+
+Example::
+
+    os> SELECT WEEKOFYEAR(DATE('2008-02-20')), WEEKOFYEAR(DATE('2008-02-20'), 1)
+    fetched rows / total rows = 1/1
+    +----------------------------------+-------------------------------------+
+    | WEEKOFYEAR(DATE('2008-02-20'))   | WEEKOFYEAR(DATE('2008-02-20'), 1)   |
+    |----------------------------------+-------------------------------------|
+    | 7                                | 8                                   |
+    +----------------------------------+-------------------------------------+
 
 
 YEAR

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -327,6 +327,7 @@ TERMS:                              'TERMS';
 TOPHITS:                            'TOPHITS';
 TYPEOF:                             'TYPEOF';
 WEEK_OF_YEAR:                       'WEEK_OF_YEAR';
+WEEKOFYEAR:                         'WEEKOFYEAR';
 WILDCARDQUERY:                      'WILDCARDQUERY';
 WILDCARD_QUERY:                     'WILDCARD_QUERY';
 

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -466,6 +466,7 @@ dateTimeFunctionName
     | UNIX_TIMESTAMP
     | WEEK
     | WEEK_OF_YEAR
+    | WEEKOFYEAR
     | YEAR
     ;
 


### PR DESCRIPTION
### Description
Adds the `WeekOfYear` function to the SQL plugin. It behaves like the `week` function which already exists in the new engine, and both are aligned with [MySQL](https://www.w3schools.com/sql/func_mysql_week.asp). It has been added as an alias.
 
### Issues Resolved
[722 ](https://github.com/opensearch-project/sql/issues/722)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).