### PR TITLE
Fix index not found reported as server error bug

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PPLPluginIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PPLPluginIT.java
@@ -58,6 +58,14 @@ public class PPLPluginIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testQueryEndpointShouldFailWithNonExistIndex() throws IOException {
+    exceptionRule.expect(ResponseException.class);
+    exceptionRule.expect(hasProperty("response", statusCode(400)));
+
+    client().performRequest(makePPLRequest("search source=non_exist_index"));
+  }
+
+  @Test
   public void sqlEnableSettingsTest() throws IOException {
     String query =
         String.format("search source=%s firstname='Hattie' | fields firstname", TEST_INDEX_BANK);


### PR DESCRIPTION
### Description

`IndexNotFoundException` thrown from OpenSearch get index mapping API is treated as server error. This caused breaking behavior as reported in issue below. More importantly, this may cause false alarm if monitoring logic on SQL plugin.

#### Root Cause

Due to security concern, we switched from OpenSearch's `ClusterService.getIndexMapping()` to our current `OpenSearchNodeClient.getIndexMapping()`. OpenSearchNodeClient captures every exception thrown from underlying OpenSearch API, including `IndexNotFoundException`, and wrap it by `IllegalStateException`. On the high level, `isClientError()` determines if this is a client error on IllegalStateException instead of the IndexNotFoundException wrapped inside.

#### Quick Fix

1. Capture IndexNotFoundException individually and re-throw it directly to fix the issue
2. Add IT in PPLPluginIT because no better place in SQL IT. Confirmed it can reproduce the issue without the fix
3. Clean up the unused `resolver` field and `mockNodeClient()` handy
 
### Issues Resolved

https://github.com/opensearch-project/sql/issues/851
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).