### PR TITLE
Integ Test Refactoring

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -28,7 +28,7 @@ jobs:
           - { os: windows-latest, java: 11, os_build_args: -x doctest  -PbuildPlatform=windows }
           - { os: macos-latest, java: 11}
           - { os: ubuntu-latest, java: 17 }
-          - { os: windows-latest, java: 17, os_build_args: -PbuildPlatform=windows }
+          - { os: windows-latest, java: 17, os_build_args: -x doctest -PbuildPlatform=windows }
           - { os: macos-latest, java: 17 }
     runs-on: ${{ matrix.entry.os }}
 

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -25,11 +25,11 @@ jobs:
       matrix:
         entry:
           - { os: ubuntu-latest, java: 11 }
-          - { os: windows-latest, java: 11, os_build_args: -x jacocoTestReport  -PbuildPlatform=windows }
-          - { os: macos-latest, java: 11, os_build_args: -x jacocoTestReport  }
+          - { os: windows-latest, java: 11, os_build_args: -x doctest  -PbuildPlatform=windows }
+          - { os: macos-latest, java: 11}
           - { os: ubuntu-latest, java: 17 }
-          - { os: windows-latest, java: 17, os_build_args: -x jacocoTestReport  -PbuildPlatform=windows }
-          - { os: macos-latest, java: 17, os_build_args: -x jacocoTestReport  }
+          - { os: windows-latest, java: 17, os_build_args: -PbuildPlatform=windows }
+          - { os: macos-latest, java: 17 }
     runs-on: ${{ matrix.entry.os }}
 
     steps:

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -25,10 +25,10 @@ jobs:
       matrix:
         entry:
           - { os: ubuntu-latest, java: 11 }
-          - { os: windows-latest, java: 11, os_build_args: -x doctest -x integTest -x jacocoTestReport  -PbuildPlatform=windows }
+          - { os: windows-latest, java: 11, os_build_args: -x doctest -x jacocoTestReport  -PbuildPlatform=windows }
           - { os: macos-latest, java: 11, os_build_args: -x doctest -x integTest -x jacocoTestReport  }
           - { os: ubuntu-latest, java: 17 }
-          - { os: windows-latest, java: 17, os_build_args: -x doctest -x integTest -x jacocoTestReport  -PbuildPlatform=windows }
+          - { os: windows-latest, java: 17, os_build_args: -x doctest -x jacocoTestReport  -PbuildPlatform=windows }
           - { os: macos-latest, java: 17, os_build_args: -x doctest -x integTest -x jacocoTestReport  }
     runs-on: ${{ matrix.entry.os }}
 

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -25,11 +25,11 @@ jobs:
       matrix:
         entry:
           - { os: ubuntu-latest, java: 11 }
-          - { os: windows-latest, java: 11, os_build_args: -x doctest -x jacocoTestReport  -PbuildPlatform=windows }
-          - { os: macos-latest, java: 11, os_build_args: -x doctest -x integTest -x jacocoTestReport  }
+          - { os: windows-latest, java: 11, os_build_args: -x jacocoTestReport  -PbuildPlatform=windows }
+          - { os: macos-latest, java: 11, os_build_args: -x jacocoTestReport  }
           - { os: ubuntu-latest, java: 17 }
-          - { os: windows-latest, java: 17, os_build_args: -x doctest -x jacocoTestReport  -PbuildPlatform=windows }
-          - { os: macos-latest, java: 17, os_build_args: -x doctest -x integTest -x jacocoTestReport  }
+          - { os: windows-latest, java: 17, os_build_args: -x jacocoTestReport  -PbuildPlatform=windows }
+          - { os: macos-latest, java: 17, os_build_args: -x jacocoTestReport  }
     runs-on: ${{ matrix.entry.os }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+*.http
 .settings/
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
@@ -33,7 +34,6 @@ gen/
 # git mergetool artifact
 *.orig
 gen
-*.tokens
 
 # Python
 */.venv

--- a/build-tools/sqlplugin-coverage.gradle
+++ b/build-tools/sqlplugin-coverage.gradle
@@ -16,6 +16,7 @@
  *  cluster is stopped and dump it to a file. Luckily our current security policy seems to allow this. This will also probably
  *  break if there are multiple nodes in the integTestCluster. But for now... it sorta works.
  */
+import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'jacoco'
 
 // Get gradle to generate the required jvm agent arg for us using a dummy tasks of type Test. Unfortunately Elastic's
@@ -45,7 +46,12 @@ integTest.runner {
 }
 
 testClusters.integTest {
-    jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}"
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        // Replacing build with absolute path to fix the error "error opening zip file or JAR manifest missing : /build/tmp/expandedArchives/..../jacocoagent.jar"
+        jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}".replace('build',"${buildDir}")
+    } else {
+        jvmArgs " ${dummyIntegTest.jacoco.getAsJvmArg()}".replace('javaagent:','javaagent:/')
+    }
     systemProperty 'com.sun.management.jmxremote', "true"
     systemProperty 'com.sun.management.jmxremote.authenticate', "false"
     systemProperty 'com.sun.management.jmxremote.port', "7777"

--- a/buildSrc/src/main/groovy/com/wiredforcode/spawn/KillProcessTask.groovy
+++ b/buildSrc/src/main/groovy/com/wiredforcode/spawn/KillProcessTask.groovy
@@ -1,5 +1,6 @@
 package com.wiredforcode.gradle.spawn
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.tasks.TaskAction
 
 class KillProcessTask extends DefaultSpawnTask {
@@ -12,7 +13,13 @@ class KillProcessTask extends DefaultSpawnTask {
         }
 
         def pid = pidFile.text
-        def process = "kill $pid".execute()
+        def killCommandLine
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            killCommandLine = Arrays.asList("taskkill", "/F", "/T", "/PID", "$pid")
+        } else {
+            killCommandLine = Arrays.asList("kill", "$pid")
+        }
+        def process = killCommandLine.execute()
 
         try {
             process.waitFor()

--- a/buildSrc/src/main/groovy/com/wiredforcode/spawn/SpawnProcessTask.groovy
+++ b/buildSrc/src/main/groovy/com/wiredforcode/spawn/SpawnProcessTask.groovy
@@ -95,9 +95,18 @@ class SpawnProcessTask extends DefaultSpawnTask {
     }
 
     private int extractPidFromProcess(Process process) {
-        def pidField = process.class.getDeclaredField('pid')
-        pidField.accessible = true
-
-        return pidField.getInt(process)
+        def pid
+        try {
+            // works since java 9
+            def pidMethod = process.class.getDeclaredMethod('pid')
+            pidMethod.setAccessible(true)
+            pid = pidMethod.invoke(process)
+        } catch (ignored) {
+            // fallback to UNIX-only implementation
+            def pidField = process.class.getDeclaredField('pid')
+            pidField.accessible = true
+            pid = pidField.getInt(process)
+        }
+        return pid
     }
 }

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -56,7 +56,12 @@ task startPrometheus(type: SpawnProcessTask) {
 
 //evaluationDependsOn(':')
 task startOpenSearch(type: SpawnProcessTask) {
-    command "${path}/gradlew -p ${plugin_path} runRestTestCluster"
+    if( getOSFamilyType() == "windows") {
+        command "${path}\\gradlew.bat -p ${plugin_path} runRestTestCluster"
+    }
+    else {
+        command "${path}/gradlew -p ${plugin_path} runRestTestCluster"
+    }
     ready 'started'
 }
 
@@ -94,12 +99,13 @@ task stopPrometheus() {
         }
     }
 }
-
-stopPrometheus.mustRunAfter startPrometheus
+if(getOSFamilyType() != "windows") {
+    stopPrometheus.mustRunAfter startPrometheus
+    startOpenSearch.dependsOn startPrometheus
+    stopOpenSearch.finalizedBy stopPrometheus
+}
 doctest.dependsOn startOpenSearch
-startOpenSearch.dependsOn startPrometheus
 doctest.finalizedBy stopOpenSearch
-stopOpenSearch.finalizedBy stopPrometheus
 check.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -152,9 +152,10 @@ stopPrometheus.mustRunAfter startPrometheus
 // Run PPL ITs and new, legacy and comparison SQL ITs with new SQL engine enabled
 integTest {
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
-    dependsOn startPrometheus
-    finalizedBy stopPrometheus
-
+    if(getOSFamilyType() != "windows") {
+        dependsOn startPrometheus
+        finalizedBy stopPrometheus
+    }
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)
 
@@ -179,9 +180,10 @@ integTest {
         }
     }
 
-    if(getOSFamilyType() != "linux" && getOSFamilyType()!="darwin") {
-        exclude 'org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java'
-        exclude 'org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java'
+    if(getOSFamilyType() == "windows") {
+        exclude 'org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.class'
+        exclude 'org/opensearch/sql/ppl/ShowDataSourcesCommandIT.class'
+        exclude 'org/opensearch/sql/ppl/InformationSchemaCommandIT.class'
     }
 
     exclude 'org/opensearch/sql/doctest/**/*IT.class'

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -22,7 +22,6 @@
  * under the License.
  */
 
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.opensearch.gradle.test.RestIntegTestTask
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -178,6 +177,11 @@ integTest {
         filter {
             excludeTestsMatching "org.opensearch.sql.bwc.*IT"
         }
+    }
+
+    if(getOSFamilyType() != "linux" && getOSFamilyType()!="darwin") {
+        exclude 'org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java'
+        exclude 'org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java'
     }
 
     exclude 'org/opensearch/sql/doctest/**/*IT.class'

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/CsvFormatIT.java
@@ -24,12 +24,12 @@ public class CsvFormatIT extends PPLIntegTestCase {
     String result = executeCsvQuery(
         String.format(Locale.ROOT, "source=%s | fields firstname, lastname", TEST_INDEX_BANK_CSV_SANITIZE));
     assertEquals(
-        "firstname,lastname" + System.lineSeparator()
-            + "'+Amber JOHnny,Duke Willmington+"+ System.lineSeparator()
-            + "'-Hattie,Bond-"+System.lineSeparator()
-            + "'=Nanette,Bates="+System.lineSeparator()
-            + "'@Dale,Adams@"+System.lineSeparator()
-            + "\",Elinor\",\"Ratliff,,,\""+System.lineSeparator(),
+        "firstname,lastname%n"
+            + "'+Amber JOHnny,Duke Willmington+%n"
+            + "'-Hattie,Bond-%n"
+            + "'=Nanette,Bates=%n"
+            + "'@Dale,Adams@%n"
+            + "\",Elinor\",\"Ratliff,,,\"%n",
         result);
   }
 
@@ -38,12 +38,12 @@ public class CsvFormatIT extends PPLIntegTestCase {
     String result = executeCsvQuery(
         String.format(Locale.ROOT, "source=%s | fields firstname, lastname", TEST_INDEX_BANK_CSV_SANITIZE), false);
     assertEquals(
-        "firstname,lastname" + System.lineSeparator()
-            + "+Amber JOHnny,Duke Willmington+" + System.lineSeparator()
-            + "-Hattie,Bond-" + System.lineSeparator()
-            + "=Nanette,Bates="+ System.lineSeparator()
-            + "@Dale,Adams@" + System.lineSeparator()
-            + "\",Elinor\",\"Ratliff,,,\"" + System.lineSeparator(),
+        "firstname,lastname%n"
+            + "+Amber JOHnny,Duke Willmington+%n"
+            + "-Hattie,Bond-%n"
+            + "=Nanette,Bates=%n"
+            + "@Dale,Adams@%n"
+            + "\",Elinor\",\"Ratliff,,,\"%n",
         result);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/CsvFormatIT.java
@@ -11,6 +11,7 @@ import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_CSV_SANIT
 import java.io.IOException;
 import java.util.Locale;
 import org.junit.Test;
+import org.opensearch.sql.common.utils.StringUtils;
 
 public class CsvFormatIT extends PPLIntegTestCase {
 
@@ -23,13 +24,13 @@ public class CsvFormatIT extends PPLIntegTestCase {
   public void sanitizeTest() throws IOException {
     String result = executeCsvQuery(
         String.format(Locale.ROOT, "source=%s | fields firstname, lastname", TEST_INDEX_BANK_CSV_SANITIZE));
-    assertEquals(
+    assertEquals(StringUtils.format(
         "firstname,lastname%n"
             + "'+Amber JOHnny,Duke Willmington+%n"
             + "'-Hattie,Bond-%n"
             + "'=Nanette,Bates=%n"
             + "'@Dale,Adams@%n"
-            + "\",Elinor\",\"Ratliff,,,\"%n",
+            + "\",Elinor\",\"Ratliff,,,\"%n"),
         result);
   }
 
@@ -37,13 +38,13 @@ public class CsvFormatIT extends PPLIntegTestCase {
   public void escapeSanitizeTest() throws IOException {
     String result = executeCsvQuery(
         String.format(Locale.ROOT, "source=%s | fields firstname, lastname", TEST_INDEX_BANK_CSV_SANITIZE), false);
-    assertEquals(
+    assertEquals(StringUtils.format(
         "firstname,lastname%n"
             + "+Amber JOHnny,Duke Willmington+%n"
             + "-Hattie,Bond-%n"
             + "=Nanette,Bates=%n"
             + "@Dale,Adams@%n"
-            + "\",Elinor\",\"Ratliff,,,\"%n",
+            + "\",Elinor\",\"Ratliff,,,\"%n"),
         result);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/CsvFormatIT.java
@@ -24,12 +24,12 @@ public class CsvFormatIT extends PPLIntegTestCase {
     String result = executeCsvQuery(
         String.format(Locale.ROOT, "source=%s | fields firstname, lastname", TEST_INDEX_BANK_CSV_SANITIZE));
     assertEquals(
-        "firstname,lastname\n"
-            + "'+Amber JOHnny,Duke Willmington+\n"
-            + "'-Hattie,Bond-\n"
-            + "'=Nanette,Bates=\n"
-            + "'@Dale,Adams@\n"
-            + "\",Elinor\",\"Ratliff,,,\"\n",
+        "firstname,lastname" + System.lineSeparator()
+            + "'+Amber JOHnny,Duke Willmington+"+ System.lineSeparator()
+            + "'-Hattie,Bond-"+System.lineSeparator()
+            + "'=Nanette,Bates="+System.lineSeparator()
+            + "'@Dale,Adams@"+System.lineSeparator()
+            + "\",Elinor\",\"Ratliff,,,\""+System.lineSeparator(),
         result);
   }
 
@@ -38,12 +38,12 @@ public class CsvFormatIT extends PPLIntegTestCase {
     String result = executeCsvQuery(
         String.format(Locale.ROOT, "source=%s | fields firstname, lastname", TEST_INDEX_BANK_CSV_SANITIZE), false);
     assertEquals(
-        "firstname,lastname\n"
-            + "+Amber JOHnny,Duke Willmington+\n"
-            + "-Hattie,Bond-\n"
-            + "=Nanette,Bates=\n"
-            + "@Dale,Adams@\n"
-            + "\",Elinor\",\"Ratliff,,,\"\n",
+        "firstname,lastname" + System.lineSeparator()
+            + "+Amber JOHnny,Duke Willmington+" + System.lineSeparator()
+            + "-Hattie,Bond-" + System.lineSeparator()
+            + "=Nanette,Bates="+ System.lineSeparator()
+            + "@Dale,Adams@" + System.lineSeparator()
+            + "\",Elinor\",\"Ratliff,,,\"" + System.lineSeparator(),
         result);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DescribeCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DescribeCommandIT.java
@@ -6,18 +6,16 @@
 
 package org.opensearch.sql.ppl;
 
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DOG;
+import static org.opensearch.sql.util.MatcherUtils.columnName;
+import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+
+import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.ResponseException;
-
-import java.io.IOException;
-
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DOG;
-import static org.opensearch.sql.util.MatcherUtils.columnName;
-import static org.opensearch.sql.util.MatcherUtils.rows;
-import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
-import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
 public class DescribeCommandIT extends PPLIntegTestCase {
 
@@ -87,26 +85,5 @@ public class DescribeCommandIT extends PPLIntegTestCase {
       assertTrue(e.getMessage().contains("RuntimeException"));
       assertTrue(e.getMessage().contains("Failed to parse query due to offending symbol"));
     }
-  }
-
-  @Test
-  public void testDescribeCommandWithPrometheusCatalog() throws IOException {
-    JSONObject result = executeQuery("describe  my_prometheus.prometheus_http_requests_total");
-    verifyColumn(
-        result,
-        columnName("TABLE_CATALOG"),
-        columnName("TABLE_SCHEMA"),
-        columnName("TABLE_NAME"),
-        columnName("COLUMN_NAME"),
-        columnName("DATA_TYPE")
-    );
-    verifyDataRows(result,
-        rows("my_prometheus", "default", "prometheus_http_requests_total", "handler", "keyword"),
-        rows("my_prometheus", "default", "prometheus_http_requests_total", "code", "keyword"),
-        rows("my_prometheus", "default", "prometheus_http_requests_total", "instance", "keyword"),
-        rows("my_prometheus", "default", "prometheus_http_requests_total", "@value", "double"),
-        rows("my_prometheus", "default", "prometheus_http_requests_total", "@timestamp",
-            "timestamp"),
-        rows("my_prometheus", "default", "prometheus_http_requests_total", "job", "keyword"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
@@ -71,4 +71,27 @@ public class InformationSchemaCommandIT extends PPLIntegTestCase {
             "counter", "", "Counter of HTTP requests."));
   }
 
+
+  // Moved this IT from DescribeCommandIT to segregate Datasource Integ Tests.
+  @Test
+  public void testDescribeCommandWithPrometheusCatalog() throws IOException {
+    JSONObject result = executeQuery("describe  my_prometheus.prometheus_http_requests_total");
+    verifyColumn(
+        result,
+        columnName("TABLE_CATALOG"),
+        columnName("TABLE_SCHEMA"),
+        columnName("TABLE_NAME"),
+        columnName("COLUMN_NAME"),
+        columnName("DATA_TYPE")
+    );
+    verifyDataRows(result,
+        rows("my_prometheus", "default", "prometheus_http_requests_total", "handler", "keyword"),
+        rows("my_prometheus", "default", "prometheus_http_requests_total", "code", "keyword"),
+        rows("my_prometheus", "default", "prometheus_http_requests_total", "instance", "keyword"),
+        rows("my_prometheus", "default", "prometheus_http_requests_total", "@value", "double"),
+        rows("my_prometheus", "default", "prometheus_http_requests_total", "@timestamp",
+            "timestamp"),
+        rows("my_prometheus", "default", "prometheus_http_requests_total", "job", "keyword"));
+  }
+
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
@@ -25,12 +25,12 @@ public class CsvFormatIT extends SQLIntegTestCase {
     String result = executeQuery(
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_CSV_SANITIZE), "csv");
     assertEquals(
-        "firstname,lastname\n"
-            + "'+Amber JOHnny,Duke Willmington+\n"
-            + "'-Hattie,Bond-\n"
-            + "'=Nanette,Bates=\n"
-            + "'@Dale,Adams@\n"
-            + "\",Elinor\",\"Ratliff,,,\"\n",
+        "firstname,lastname" + System.lineSeparator()
+            + "'+Amber JOHnny,Duke Willmington+" + System.lineSeparator()
+            + "'-Hattie,Bond-" + System.lineSeparator()
+            + "'=Nanette,Bates=" + System.lineSeparator()
+            + "'@Dale,Adams@" + System.lineSeparator()
+            + "\",Elinor\",\"Ratliff,,,\"" + System.lineSeparator(),
         result);
   }
 
@@ -40,12 +40,12 @@ public class CsvFormatIT extends SQLIntegTestCase {
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_CSV_SANITIZE),
         "csv&sanitize=false");
     assertEquals(
-        "firstname,lastname\n"
-            + "+Amber JOHnny,Duke Willmington+\n"
-            + "-Hattie,Bond-\n"
-            + "=Nanette,Bates=\n"
-            + "@Dale,Adams@\n"
-            + "\",Elinor\",\"Ratliff,,,\"\n",
+        "firstname,lastname" + System.lineSeparator()
+            + "+Amber JOHnny,Duke Willmington+" + System.lineSeparator()
+            + "-Hattie,Bond-" + System.lineSeparator()
+            + "=Nanette,Bates=" + System.lineSeparator()
+            + "@Dale,Adams@" + System.lineSeparator()
+            + "\",Elinor\",\"Ratliff,,,\"" + System.lineSeparator(),
         result);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
@@ -11,6 +11,7 @@ import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_CSV_SANIT
 import java.io.IOException;
 import java.util.Locale;
 import org.junit.Test;
+import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
 public class CsvFormatIT extends SQLIntegTestCase {
@@ -24,13 +25,13 @@ public class CsvFormatIT extends SQLIntegTestCase {
   public void sanitizeTest() {
     String result = executeQuery(
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_CSV_SANITIZE), "csv");
-    assertEquals(
+    assertEquals(StringUtils.format(
         "firstname,lastname%n"
             + "'+Amber JOHnny,Duke Willmington+%n"
             + "'-Hattie,Bond-%n"
             + "'=Nanette,Bates=%n"
             + "'@Dale,Adams@%n"
-            + "\",Elinor\",\"Ratliff,,,\"%n",
+            + "\",Elinor\",\"Ratliff,,,\"%n"),
         result);
   }
 
@@ -39,13 +40,13 @@ public class CsvFormatIT extends SQLIntegTestCase {
     String result = executeQuery(
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_CSV_SANITIZE),
         "csv&sanitize=false");
-    assertEquals(
+    assertEquals(StringUtils.format(
         "firstname,lastname%n"
             + "+Amber JOHnny,Duke Willmington+%n"
             + "-Hattie,Bond-%n"
             + "=Nanette,Bates=%n"
             + "@Dale,Adams@%n"
-            + "\",Elinor\",\"Ratliff,,,\"%n",
+            + "\",Elinor\",\"Ratliff,,,\"%n"),
         result);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
@@ -25,12 +25,12 @@ public class CsvFormatIT extends SQLIntegTestCase {
     String result = executeQuery(
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_CSV_SANITIZE), "csv");
     assertEquals(
-        "firstname,lastname" + System.lineSeparator()
-            + "'+Amber JOHnny,Duke Willmington+" + System.lineSeparator()
-            + "'-Hattie,Bond-" + System.lineSeparator()
-            + "'=Nanette,Bates=" + System.lineSeparator()
-            + "'@Dale,Adams@" + System.lineSeparator()
-            + "\",Elinor\",\"Ratliff,,,\"" + System.lineSeparator(),
+        "firstname,lastname%n"
+            + "'+Amber JOHnny,Duke Willmington+%n"
+            + "'-Hattie,Bond-%n"
+            + "'=Nanette,Bates=%n"
+            + "'@Dale,Adams@%n"
+            + "\",Elinor\",\"Ratliff,,,\"%n",
         result);
   }
 
@@ -40,12 +40,12 @@ public class CsvFormatIT extends SQLIntegTestCase {
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_CSV_SANITIZE),
         "csv&sanitize=false");
     assertEquals(
-        "firstname,lastname" + System.lineSeparator()
-            + "+Amber JOHnny,Duke Willmington+" + System.lineSeparator()
-            + "-Hattie,Bond-" + System.lineSeparator()
-            + "=Nanette,Bates=" + System.lineSeparator()
-            + "@Dale,Adams@" + System.lineSeparator()
-            + "\",Elinor\",\"Ratliff,,,\"" + System.lineSeparator(),
+        "firstname,lastname%n"
+            + "+Amber JOHnny,Duke Willmington+%n"
+            + "-Hattie,Bond-%n"
+            + "=Nanette,Bates=%n"
+            + "@Dale,Adams@%n"
+            + "\",Elinor\",\"Ratliff,,,\"%n",
         result);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -11,6 +11,7 @@ import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_RAW_SANIT
 import java.io.IOException;
 import java.util.Locale;
 import org.junit.Test;
+import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
 public class RawFormatIT extends SQLIntegTestCase {
@@ -24,13 +25,13 @@ public class RawFormatIT extends SQLIntegTestCase {
   public void rawFormatWithPipeFieldTest() {
     String result = executeQuery(
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE), "raw");
-    assertEquals(
+    assertEquals(StringUtils.format(
         "firstname|lastname%n"
             + "+Amber JOHnny|Duke Willmington+%n"
             + "-Hattie|Bond-%n"
             + "=Nanette|Bates=%n"
             + "@Dale|Adams@%n"
-            + "@Elinor|\"Ratliff|||\"%n",
+            + "@Elinor|\"Ratliff|||\"%n"),
         result);
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -25,12 +25,12 @@ public class RawFormatIT extends SQLIntegTestCase {
     String result = executeQuery(
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE), "raw");
     assertEquals(
-        "firstname|lastname\n"
-            + "+Amber JOHnny|Duke Willmington+\n"
-            + "-Hattie|Bond-\n"
-            + "=Nanette|Bates=\n"
-            + "@Dale|Adams@\n"
-            + "@Elinor|\"Ratliff|||\"\n",
+        "firstname|lastname" + System.lineSeparator()
+            + "+Amber JOHnny|Duke Willmington+" + System.lineSeparator()
+            + "-Hattie|Bond-" + System.lineSeparator()
+            + "=Nanette|Bates=" + System.lineSeparator()
+            + "@Dale|Adams@" + System.lineSeparator()
+            + "@Elinor|\"Ratliff|||\"" + System.lineSeparator(),
         result);
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -25,12 +25,12 @@ public class RawFormatIT extends SQLIntegTestCase {
     String result = executeQuery(
         String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE), "raw");
     assertEquals(
-        "firstname|lastname" + System.lineSeparator()
-            + "+Amber JOHnny|Duke Willmington+" + System.lineSeparator()
-            + "-Hattie|Bond-" + System.lineSeparator()
-            + "=Nanette|Bates=" + System.lineSeparator()
-            + "@Dale|Adams@" + System.lineSeparator()
-            + "@Elinor|\"Ratliff|||\"" + System.lineSeparator(),
+        "firstname|lastname%n"
+            + "+Amber JOHnny|Duke Willmington+%n"
+            + "-Hattie|Bond-%n"
+            + "=Nanette|Bates=%n"
+            + "@Dale|Adams@%n"
+            + "@Elinor|\"Ratliff|||\"%n",
         result);
   }
 

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -96,7 +96,8 @@ USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
 PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 
 OS="`uname`"
-
+##Cygwin or MinGW packages should be preinstalled in the windows.
+## This command doesn't work without bash
 if [ $OS != "WindowsNT" ]
 then
 	OPENSEARCH_HOME=`ps -ef | grep -o "[o]pensearch.path.home=\S\+" | cut -d= -f2- | head -n1`

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -96,9 +96,9 @@ USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
 PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 
 OS="`uname`"
-##Cygwin or MinGW packages should be preinstalled in the windows.
-## This command doesn't work without bash
-## https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
+#Cygwin or MinGW packages should be preinstalled in the windows.
+#This command doesn't work without bash
+#https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
 #Operating System	uname -s
 #Mac OS X	Darwin
 #Cygwin 32-bit (Win-XP)	CYGWIN_NT-5.1
@@ -110,7 +110,7 @@ OS="`uname`"
 #Interix (Services for UNIX)	Interix
 #MSYS	MSYS_NT-6.1
 #MSYS2	MSYS_NT-10.0-17763
-if [[ $OS =~ CYGWIN*|MINGW*|MINGW32*|MSYS* ]]
+if ! [[ $OS =~ CYGWIN*|MINGW*|MINGW32*|MSYS* ]]
 then
 	OPENSEARCH_HOME=`ps -ef | grep -o "[o]pensearch.path.home=\S\+" | cut -d= -f2- | head -n1`
 	curl -SL https://raw.githubusercontent.com/opensearch-project/sql/main/integ-test/src/test/resources/datasource/datasources.json -o "$OPENSEARCH_HOME"/datasources.json

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -98,7 +98,19 @@ PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 OS="`uname`"
 ##Cygwin or MinGW packages should be preinstalled in the windows.
 ## This command doesn't work without bash
-if [ $OS != "WindowsNT" ]
+## https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
+#Operating System	uname -s
+#Mac OS X	Darwin
+#Cygwin 32-bit (Win-XP)	CYGWIN_NT-5.1
+#Cygwin 32-bit (Win-7 32-bit)	CYGWIN_NT-6.1
+#Cygwin 32-bit (Win-7 64-bit)	CYGWIN_NT-6.1-WOW64
+#Cygwin 64-bit (Win-7 64-bit)	CYGWIN_NT-6.1
+#MinGW (Windows 7 32-bit)	MINGW32_NT-6.1
+#MinGW (Windows 10 64-bit)	MINGW64_NT-10.0
+#Interix (Services for UNIX)	Interix
+#MSYS	MSYS_NT-6.1
+#MSYS2	MSYS_NT-10.0-17763
+if [[ $OS =~ CYGWIN*|MINGW*|MINGW32*|MSYS* ]]
 then
 	OPENSEARCH_HOME=`ps -ef | grep -o "[o]pensearch.path.home=\S\+" | cut -d= -f2- | head -n1`
 	curl -SL https://raw.githubusercontent.com/opensearch-project/sql/main/integ-test/src/test/resources/datasource/datasources.json -o "$OPENSEARCH_HOME"/datasources.json


### PR DESCRIPTION
### Description
Refactored to skip integ tests with datasources and prometheus in windows platform.

Changes Included:
* Changed release integ tests script to perform datasource creation action only in case of non-windows OS types.
* Changed integ test task to exclude `org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.class`
`org/opensearch/sql/ppl/ShowDataSourcesCommandIT.class`, `org/opensearch/sql/ppl/InformationSchemaCommandIT.class` in case of non-windows OS Types.
* Fixed Integ Tests failures in windows platform due to line separators.
* Added support for windows in SpawnGradleTask and KillGradleTask. This is required for doctests. Even after fixing this doctests are still failing in windows due to bootstrap.sh. We can tackle doctests fix in a separate issue.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).