### PR TITLE
[2.x]Changes in DataSourceService and DataSourceMetadataStorage interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ gen
 /.prom.pid.lock
 
 .java-version
+.worktrees

--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -64,7 +64,6 @@ import org.opensearch.sql.ast.tree.Values;
 import org.opensearch.sql.data.model.ExprMissingValue;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.datasource.DataSourceService;
-import org.opensearch.sql.datasource.model.DataSource;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
@@ -135,7 +134,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitRelation(Relation node, AnalysisContext context) {
     QualifiedName qualifiedName = node.getTableQualifiedName();
-    Set<String> allowedDataSourceNames = dataSourceService.getMaskedDataSourceMetadataSet()
+    Set<String> allowedDataSourceNames = dataSourceService.getDataSourceMetadataSet()
         .stream()
         .map(DataSourceMetadata::getName)
         .collect(Collectors.toSet());
@@ -183,7 +182,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitTableFunction(TableFunction node, AnalysisContext context) {
     QualifiedName qualifiedName = node.getFunctionName();
-    Set<String> allowedDataSourceNames = dataSourceService.getMaskedDataSourceMetadataSet()
+    Set<String> allowedDataSourceNames = dataSourceService.getDataSourceMetadataSet()
         .stream()
         .map(DataSourceMetadata::getName)
         .collect(Collectors.toSet());

--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -65,6 +65,7 @@ import org.opensearch.sql.data.model.ExprMissingValue;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
@@ -134,9 +135,9 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitRelation(Relation node, AnalysisContext context) {
     QualifiedName qualifiedName = node.getTableQualifiedName();
-    Set<String> allowedDataSourceNames = dataSourceService.getDataSources()
+    Set<String> allowedDataSourceNames = dataSourceService.getMaskedDataSourceMetadataSet()
         .stream()
-        .map(DataSource::getName)
+        .map(DataSourceMetadata::getName)
         .collect(Collectors.toSet());
     DataSourceSchemaIdentifierNameResolver dataSourceSchemaIdentifierNameResolver
         = new DataSourceSchemaIdentifierNameResolver(qualifiedName.getParts(),
@@ -182,9 +183,9 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitTableFunction(TableFunction node, AnalysisContext context) {
     QualifiedName qualifiedName = node.getFunctionName();
-    Set<String> allowedDataSourceNames = dataSourceService.getDataSources()
+    Set<String> allowedDataSourceNames = dataSourceService.getMaskedDataSourceMetadataSet()
         .stream()
-        .map(DataSource::getName)
+        .map(DataSourceMetadata::getName)
         .collect(Collectors.toSet());
     DataSourceSchemaIdentifierNameResolver dataSourceSchemaIdentifierNameResolver
         = new DataSourceSchemaIdentifierNameResolver(qualifiedName.getParts(),

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceMetadataStorage.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceMetadataStorage.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.datasource;
+
+import java.util.List;
+import java.util.Optional;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+
+/**
+ * Interface for DataSourceMetadata Storage.
+ */
+public interface DataSourceMetadataStorage {
+
+  List<DataSourceMetadata> getDataSourceMetadata();
+
+  Optional<DataSourceMetadata> getDataSourceMetadata(String datasourceName);
+
+  void createDataSourceMetadata(DataSourceMetadata dataSourceMetadata);
+
+}

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceMetadataStorage.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceMetadataStorage.java
@@ -9,17 +9,56 @@ package org.opensearch.sql.datasource;
 
 import java.util.List;
 import java.util.Optional;
+import javax.xml.crypto.Data;
+import org.opensearch.sql.datasource.model.DataSource;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 
 /**
- * Interface for DataSourceMetadata Storage.
+ * Interface for DataSourceMetadata Storage
+ * which will be only used by DataSourceService for Storage.
  */
 public interface DataSourceMetadataStorage {
 
+  /**
+   * Returns all dataSource Metadata objects. The returned objects won't contain
+   * any of the credential info.
+   *
+   * @return list of {@link DataSourceMetadata}.
+   */
   List<DataSourceMetadata> getDataSourceMetadata();
 
+
+  /**
+   * Gets {@link DataSourceMetadata} corresponding to the
+   * datasourceName from underlying storage.
+   *
+   * @param datasourceName name of the {@link DataSource}.
+   */
   Optional<DataSourceMetadata> getDataSourceMetadata(String datasourceName);
 
+
+  /**
+   * Stores {@link DataSourceMetadata} in underlying storage.
+   *
+   * @param dataSourceMetadata {@link DataSourceMetadata}.
+   */
   void createDataSourceMetadata(DataSourceMetadata dataSourceMetadata);
+
+
+  /**
+   * Updates {@link DataSourceMetadata} in underlying storage.
+   *
+   * @param dataSourceMetadata {@link DataSourceMetadata}.
+   */
+  void updateDataSourceMetadata(DataSourceMetadata dataSourceMetadata);
+
+
+  /**
+   * Deletes {@link DataSourceMetadata} corresponding to the
+   * datasourceName from underlying storage.
+   *
+   * @param datasourceName name of the {@link DataSource}.
+   */
+  void deleteDataSourceMetadata(String datasourceName);
 
 }

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
@@ -19,7 +19,7 @@ public interface DataSourceService {
    *
    * @return set of {@link DataSource}.
    */
-  Set<DataSource> getDataSources();
+  Set<DataSourceMetadata> getMaskedDataSourceMetadataSet();
 
   /**
    * Returns {@link DataSource} with corresponding to the DataSource name.

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
@@ -15,26 +15,49 @@ import org.opensearch.sql.datasource.model.DataSourceMetadata;
 public interface DataSourceService {
 
   /**
-   * Returns all DataSource objects.
-   *
-   * @return set of {@link DataSource}.
-   */
-  Set<DataSourceMetadata> getMaskedDataSourceMetadataSet();
-
-  /**
-   * Returns {@link DataSource} with corresponding to the DataSource name.
+   * Returns {@link DataSource} corresponding to the DataSource name.
    *
    * @param dataSourceName Name of the {@link DataSource}.
    * @return {@link DataSource}.
    */
   DataSource getDataSource(String dataSourceName);
 
+
+  /**
+   * Returns all dataSource Metadata objects. The returned objects won't contain
+   * any of the credential info.
+   *
+   * @return set of {@link DataSourceMetadata}.
+   */
+  Set<DataSourceMetadata> getDataSourceMetadataSet();
+
   /**
    * Register {@link DataSource} defined by {@link DataSourceMetadata}.
    *
    * @param metadatas list of {@link DataSourceMetadata}.
    */
-  void addDataSource(DataSourceMetadata... metadatas);
+  void createDataSource(DataSourceMetadata... metadatas);
+
+  /**
+   * Updates {@link DataSource} corresponding to dataSourceMetadata.
+   *
+   * @param dataSourceMetadata {@link DataSourceMetadata}.
+   */
+  void updateDataSource(DataSourceMetadata dataSourceMetadata);
+
+
+  /**
+   * Deletes {@link DataSource} corresponding to the DataSource name.
+   *
+   * @param dataSourceName name of the {@link DataSource}.
+   */
+  void deleteDataSource(String dataSourceName);
+
+  /**
+   * This method is to bootstrap
+   * datasources during the startup of the plugin.
+   */
+  void bootstrapDataSources();
 
   /**
    * remove all the registered {@link DataSource}.

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceServiceImpl.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceServiceImpl.java
@@ -7,6 +7,8 @@ package org.opensearch.sql.datasource;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -45,8 +47,12 @@ public class DataSourceServiceImpl implements DataSourceService {
   }
 
   @Override
-  public Set<DataSource> getDataSources() {
-    return Set.copyOf(dataSourceMap.values());
+  public Set<DataSourceMetadata> getMaskedDataSourceMetadataSet() {
+    return dataSourceMap.values().stream()
+        .map(dataSource
+            -> new DataSourceMetadata(dataSource.getName(),
+            dataSource.getConnectorType(), ImmutableMap.of()))
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceServiceImpl.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceServiceImpl.java
@@ -47,7 +47,7 @@ public class DataSourceServiceImpl implements DataSourceService {
   }
 
   @Override
-  public Set<DataSourceMetadata> getMaskedDataSourceMetadataSet() {
+  public Set<DataSourceMetadata> getDataSourceMetadataSet() {
     return dataSourceMap.values().stream()
         .map(dataSource
             -> new DataSourceMetadata(dataSource.getName(),
@@ -65,13 +65,28 @@ public class DataSourceServiceImpl implements DataSourceService {
   }
 
   @Override
-  public void addDataSource(DataSourceMetadata... metadatas) {
+  public void createDataSource(DataSourceMetadata... metadatas) {
     for (DataSourceMetadata metadata : metadatas) {
       validateDataSourceMetaData(metadata);
       dataSourceMap.put(
           metadata.getName(),
           dataSourceFactoryMap.get(metadata.getConnector()).createDataSource(metadata));
     }
+  }
+
+  @Override
+  public void updateDataSource(DataSourceMetadata dataSourceMetadata) {
+    throw new UnsupportedOperationException("will be supported in future");
+  }
+
+  @Override
+  public void deleteDataSource(String dataSourceName) {
+    throw new UnsupportedOperationException("will be supported in future");
+  }
+
+  @Override
+  public void bootstrapDataSources() {
+    throw new UnsupportedOperationException("will be supported in future");
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceMetadata.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceMetadata.java
@@ -13,14 +13,19 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.opensearch.sql.datasource.DataSourceService;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @EqualsAndHashCode
 public class DataSourceMetadata {
 
@@ -39,10 +44,7 @@ public class DataSourceMetadata {
    * {@link DataSource} to {@link DataSourceService}.
    */
   public static DataSourceMetadata defaultOpenSearchDataSourceMetadata() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName(DEFAULT_DATASOURCE_NAME);
-    dataSourceMetadata.setConnector(DataSourceType.OPENSEARCH);
-    dataSourceMetadata.setProperties(ImmutableMap.of());
-    return dataSourceMetadata;
+    return new DataSourceMetadata(DEFAULT_DATASOURCE_NAME,
+        DataSourceType.OPENSEARCH, ImmutableMap.of());
   }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScan.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScan.java
@@ -18,7 +18,7 @@ import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.datasource.DataSourceService;
-import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.storage.TableScanOperator;
 
 /**
@@ -47,14 +47,15 @@ public class DataSourceTableScan extends TableScanOperator {
   @Override
   public void open() {
     List<ExprValue> exprValues = new ArrayList<>();
-    Set<DataSource> dataSources = dataSourceService.getDataSources();
-    for (DataSource dataSource : dataSources) {
+    Set<DataSourceMetadata> dataSourceMetadataSet
+        = dataSourceService.getMaskedDataSourceMetadataSet();
+    for (DataSourceMetadata dataSource : dataSourceMetadataSet) {
       exprValues.add(
           new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
               "DATASOURCE_NAME",
               ExprValueUtils.stringValue(dataSource.getName()),
               "CONNECTOR_TYPE",
-              ExprValueUtils.stringValue(dataSource.getConnectorType().name())))));
+              ExprValueUtils.stringValue(dataSource.getConnector().name())))));
     }
     iterator = exprValues.iterator();
   }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScan.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScan.java
@@ -48,14 +48,14 @@ public class DataSourceTableScan extends TableScanOperator {
   public void open() {
     List<ExprValue> exprValues = new ArrayList<>();
     Set<DataSourceMetadata> dataSourceMetadataSet
-        = dataSourceService.getMaskedDataSourceMetadataSet();
-    for (DataSourceMetadata dataSource : dataSourceMetadataSet) {
+        = dataSourceService.getDataSourceMetadataSet();
+    for (DataSourceMetadata dataSourceMetadata : dataSourceMetadataSet) {
       exprValues.add(
           new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(
               "DATASOURCE_NAME",
-              ExprValueUtils.stringValue(dataSource.getName()),
+              ExprValueUtils.stringValue(dataSourceMetadata.getName()),
               "CONNECTOR_TYPE",
-              ExprValueUtils.stringValue(dataSource.getConnector().name())))));
+              ExprValueUtils.stringValue(dataSourceMetadata.getConnector().name())))));
     }
     iterator = exprValues.iterator();
   }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -199,7 +199,7 @@ public class AnalyzerTestBase {
 
 
     @Override
-    public Set<DataSourceMetadata> getMaskedDataSourceMetadataSet() {
+    public Set<DataSourceMetadata> getDataSourceMetadataSet() {
       return ImmutableSet.of(new DataSourceMetadata(dataSource.getName(),
           dataSource.getConnectorType(), ImmutableMap.of()));
     }
@@ -210,8 +210,23 @@ public class AnalyzerTestBase {
     }
 
     @Override
-    public void addDataSource(DataSourceMetadata... metadatas) {
+    public void createDataSource(DataSourceMetadata... metadatas) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateDataSource(DataSourceMetadata dataSourceMetadata) {
+
+    }
+
+    @Override
+    public void deleteDataSource(String dataSourceName) {
+
+    }
+
+    @Override
+    public void bootstrapDataSources() {
+
     }
 
     @Override

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opensearch.sql.data.type.ExprCoreType.LONG;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Map;
@@ -198,8 +199,9 @@ public class AnalyzerTestBase {
 
 
     @Override
-    public Set<DataSource> getDataSources() {
-      return ImmutableSet.of(dataSource);
+    public Set<DataSourceMetadata> getMaskedDataSourceMetadataSet() {
+      return ImmutableSet.of(new DataSourceMetadata(dataSource.getName(),
+          dataSource.getConnectorType(), ImmutableMap.of()));
     }
 
     @Override

--- a/core/src/test/java/org/opensearch/sql/datasource/DataSourceServiceImplTest.java
+++ b/core/src/test/java/org/opensearch/sql/datasource/DataSourceServiceImplTest.java
@@ -81,19 +81,19 @@ class DataSourceServiceImplTest {
 
   @Test
   void getAddDataSourcesShouldSuccess() {
-    assertEquals(0, dataSourceService.getDataSources().size());
+    assertEquals(0, dataSourceService.getMaskedDataSourceMetadataSet().size());
 
     dataSourceService.addDataSource(metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
-    assertEquals(1, dataSourceService.getDataSources().size());
+    assertEquals(1, dataSourceService.getMaskedDataSourceMetadataSet().size());
   }
 
   @Test
   void noDataSourceExistAfterClear() {
     dataSourceService.addDataSource(metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
-    assertEquals(1, dataSourceService.getDataSources().size());
+    assertEquals(1, dataSourceService.getMaskedDataSourceMetadataSet().size());
 
     dataSourceService.clear();
-    assertEquals(0, dataSourceService.getDataSources().size());
+    assertEquals(0, dataSourceService.getMaskedDataSourceMetadataSet().size());
   }
 
   @Test
@@ -137,7 +137,7 @@ class DataSourceServiceImplTest {
   @Test
   void metaDataHasDuplicateNameShouldFail() {
     dataSourceService.addDataSource(metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
-    assertEquals(1, dataSourceService.getDataSources().size());
+    assertEquals(1, dataSourceService.getMaskedDataSourceMetadataSet().size());
 
     IllegalArgumentException exception =
         assertThrows(

--- a/core/src/test/java/org/opensearch/sql/datasource/DataSourceServiceImplTest.java
+++ b/core/src/test/java/org/opensearch/sql/datasource/DataSourceServiceImplTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.datasource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -65,7 +66,7 @@ class DataSourceServiceImplTest {
 
   @Test
   void getDataSourceSuccess() {
-    dataSourceService.addDataSource(DataSourceMetadata.defaultOpenSearchDataSourceMetadata());
+    dataSourceService.createDataSource(DataSourceMetadata.defaultOpenSearchDataSourceMetadata());
 
     assertEquals(
         new DataSource(DEFAULT_DATASOURCE_NAME, DataSourceType.OPENSEARCH, storageEngine),
@@ -81,19 +82,21 @@ class DataSourceServiceImplTest {
 
   @Test
   void getAddDataSourcesShouldSuccess() {
-    assertEquals(0, dataSourceService.getMaskedDataSourceMetadataSet().size());
+    assertEquals(0, dataSourceService.getDataSourceMetadataSet().size());
 
-    dataSourceService.addDataSource(metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
-    assertEquals(1, dataSourceService.getMaskedDataSourceMetadataSet().size());
+    dataSourceService.createDataSource(metadata(NAME,
+        DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    assertEquals(1, dataSourceService.getDataSourceMetadataSet().size());
   }
 
   @Test
   void noDataSourceExistAfterClear() {
-    dataSourceService.addDataSource(metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
-    assertEquals(1, dataSourceService.getMaskedDataSourceMetadataSet().size());
+    dataSourceService.createDataSource(metadata(NAME,
+        DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    assertEquals(1, dataSourceService.getDataSourceMetadataSet().size());
 
     dataSourceService.clear();
-    assertEquals(0, dataSourceService.getMaskedDataSourceMetadataSet().size());
+    assertEquals(0, dataSourceService.getDataSourceMetadataSet().size());
   }
 
   @Test
@@ -102,7 +105,7 @@ class DataSourceServiceImplTest {
         assertThrows(
             IllegalArgumentException.class,
             () ->
-                dataSourceService.addDataSource(
+                dataSourceService.createDataSource(
                     metadata(null, DataSourceType.OPENSEARCH, ImmutableMap.of())));
     assertEquals(
         "Missing Name Field from a DataSource. Name is a required parameter.",
@@ -115,7 +118,7 @@ class DataSourceServiceImplTest {
         assertThrows(
             IllegalArgumentException.class,
             () ->
-                dataSourceService.addDataSource(
+                dataSourceService.createDataSource(
                     metadata("prometheus.test", DataSourceType.OPENSEARCH, ImmutableMap.of())));
     assertEquals(
         "DataSource Name: prometheus.test contains illegal characters. "
@@ -128,7 +131,8 @@ class DataSourceServiceImplTest {
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> dataSourceService.addDataSource(metadata(NAME, DataSourceType.OPENSEARCH, null)));
+            () -> dataSourceService.createDataSource(metadata(NAME,
+                DataSourceType.OPENSEARCH, null)));
     assertEquals(
         "Missing properties field in catalog configuration. Properties are required parameters.",
         exception.getMessage());
@@ -136,16 +140,39 @@ class DataSourceServiceImplTest {
 
   @Test
   void metaDataHasDuplicateNameShouldFail() {
-    dataSourceService.addDataSource(metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
-    assertEquals(1, dataSourceService.getMaskedDataSourceMetadataSet().size());
+    dataSourceService.createDataSource(metadata(NAME,
+        DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    assertEquals(1, dataSourceService.getDataSourceMetadataSet().size());
 
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> dataSourceService.addDataSource(metadata(NAME, DataSourceType.OPENSEARCH, null)));
+            () -> dataSourceService.createDataSource(metadata(NAME,
+                DataSourceType.OPENSEARCH, null)));
     assertEquals(
         String.format("Datasource name should be unique, Duplicate datasource found %s.", NAME),
         exception.getMessage());
+  }
+
+  @Test
+  void testUpdateDatasource() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> dataSourceService.updateDataSource(new DataSourceMetadata()));
+  }
+
+  @Test
+  void testDeleteDatasource() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> dataSourceService.deleteDataSource(NAME));
+  }
+
+  @Test
+  void testLoadDatasource() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> dataSourceService.bootstrapDataSources());
   }
 
   DataSourceMetadata metadata(String name, DataSourceType type, Map<String, String> properties) {

--- a/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScanTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScanTest.java
@@ -16,6 +16,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.storage.StorageEngine;
 
@@ -54,7 +56,10 @@ public class DataSourceTableScanTest {
     Set<DataSource> dataSourceSet = new HashSet<>();
     dataSourceSet.add(new DataSource("prometheus", DataSourceType.PROMETHEUS, storageEngine));
     dataSourceSet.add(new DataSource("opensearch", DataSourceType.OPENSEARCH, storageEngine));
-    when(dataSourceService.getDataSources()).thenReturn(dataSourceSet);
+    Set<DataSourceMetadata> dataSourceMetadata = dataSourceSet.stream()
+        .map(dataSource -> new DataSourceMetadata(dataSource.getName(),
+        dataSource.getConnectorType(), ImmutableMap.of())).collect(Collectors.toSet());
+    when(dataSourceService.getMaskedDataSourceMetadataSet()).thenReturn(dataSourceMetadata);
 
     assertFalse(dataSourceTableScan.hasNext());
     dataSourceTableScan.open();

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
@@ -81,7 +81,7 @@ public class StandaloneIT extends PPLIntegTestCase {
         new ImmutableSet.Builder<DataSourceFactory>()
             .add(new OpenSearchDataSourceFactory(client, defaultSettings()))
             .build());
-    dataSourceService.addDataSource(defaultOpenSearchDataSourceMetadata());
+    dataSourceService.createDataSource(defaultOpenSearchDataSourceMetadata());
     context.registerBean(DataSourceService.class, () -> dataSourceService);
     context.register(StandaloneConfig.class);
     context.register(PPLServiceConfig.class);

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -167,7 +167,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin, Rel
                         new OpenSearchNodeClient(this.client), pluginSettings))
                 .add(new PrometheusStorageFactory())
                 .build());
-    dataSourceService.addDataSource(defaultOpenSearchDataSourceMetadata());
+    dataSourceService.createDataSource(defaultOpenSearchDataSourceMetadata());
     loadDataSources(dataSourceService, clusterService.getSettings());
     LocalClusterState.state().setClusterService(clusterService);
     LocalClusterState.state().setPluginSettings((OpenSearchSettings) pluginSettings);
@@ -221,7 +221,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin, Rel
   @Override
   public void reload(Settings settings) {
     dataSourceService.clear();
-    dataSourceService.addDataSource(defaultOpenSearchDataSourceMetadata());
+    dataSourceService.createDataSource(defaultOpenSearchDataSourceMetadata());
     loadDataSources(dataSourceService, settings);
   }
 
@@ -239,7 +239,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin, Rel
             try {
               List<DataSourceMetadata> metadataList =
                   objectMapper.readValue(inputStream, new TypeReference<>() {});
-              dataSourceService.addDataSource(metadataList.toArray(new DataSourceMetadata[0]));
+              dataSourceService.createDataSource(metadataList.toArray(new DataSourceMetadata[0]));
             } catch (IOException e) {
               LOG.error(
                   "DataSource Configuration File uploaded is malformed. Verify and re-upload.", e);

--- a/plugin/src/test/java/org/opensearch/sql/plugin/datasource/DataSourceMetaDataTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/datasource/DataSourceMetaDataTest.java
@@ -96,7 +96,7 @@ public class DataSourceMetaDataTest {
     Settings settings = getDataSourceSettings("malformed_datasources.json");
     loadConnectors(settings);
 
-    verify(dataSourceService, never()).addDataSource(any());
+    verify(dataSourceService, never()).createDataSource(any());
   }
 
   private Settings getDataSourceSettings(String filename) throws URISyntaxException, IOException {
@@ -114,7 +114,7 @@ public class DataSourceMetaDataTest {
   void verifyAddDataSourceWithMetadata(List<DataSourceMetadata> metadataList) {
     ArgumentCaptor<DataSourceMetadata[]> metadataCaptor =
         ArgumentCaptor.forClass(DataSourceMetadata[].class);
-    verify(dataSourceService, times(1)).addDataSource(metadataCaptor.capture());
+    verify(dataSourceService, times(1)).createDataSource(metadataCaptor.capture());
     List<DataSourceMetadata> actualValues = Arrays.asList(metadataCaptor.getValue());
     assertEquals(metadataList.size(), actualValues.size());
     assertEquals(metadataList, actualValues);


### PR DESCRIPTION
### Description

### Definitions
* **Datasource** : Datasource class holds basic datasource info(name, connector), storage engine and other objects created specific to a datasource.
* **DatasourceMetadata**:  DatasourceMetadata class carries all the metadata required for a datasource.
* **DatasourceService**: This class acts as interface for datasources and datasource metadata management.
* **DatasourceMetadataStorageService**: This class acts as interface for datasource metadata storage.

### usecases
* CRUD APIs for datasources.
* Analyzer class
    * Fully Qualified Name Resolution requires names of all datasources. [Queries GetAllDatasourceMetadata]
    * DataSourceTable class requires metadata(name, connector) of all datasources for show datasources command. [Queries GetAllDatasourceMetadata]
    * Requires storage engine to implement and execute queries. [Queries GetAllDatasourceMetadata]

### code flow for each usecase.

#### Datasource bootstrapping during plugin startup [Internal usecase for storage engine creation]
<img width="880" alt="Screen Shot 2023-03-06 at 5 56 34 PM" src="https://user-images.githubusercontent.com/99925918/223299687-09e4217e-35b0-421d-ae0a-ebe1d45b0462.png">

#### Create datasource [REST API]

<img width="1026" alt="Screen Shot 2023-03-06 at 6 09 58 PM" src="https://user-images.githubusercontent.com/99925918/223301346-3f519be7-f102-4f04-bb53-8b9929e600af.png">


#### Get datasource along with storage engine and other artifacts [Internal use case only]


<img width="851" alt="Screen Shot 2023-03-06 at 6 13 39 PM" src="https://user-images.githubusercontent.com/99925918/223301991-c368f57f-394f-42ef-8359-06cf7d52ba15.png">


#### Get datasource [REST API]

<img width="780" alt="Screen Shot 2023-03-06 at 6 21 26 PM" src="https://user-images.githubusercontent.com/99925918/223302968-4437ff38-0142-4247-943a-5173c0f37f02.png">



#### Delete datasource [REST API]

<img width="746" alt="Screen Shot 2023-03-06 at 6 21 44 PM" src="https://user-images.githubusercontent.com/99925918/223303105-0ea47e29-abe7-46ed-9f2c-90bd77162bab.png">



 
 
  
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).