### PR TITLE
Add `WEEKDAY` Function to SQL Plugin

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -439,6 +439,11 @@ public class DSL {
     return compile(functionProperties, BuiltinFunctionName.WEEK, expressions);
   }
 
+  public static FunctionExpression weekday(FunctionProperties functionProperties,
+                                           Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.WEEKDAY, expressions);
+  }
+
   public static FunctionExpression weekofyear(
       FunctionProperties functionProperties, Expression... expressions) {
     return compile(functionProperties, BuiltinFunctionName.WEEKOFYEAR, expressions);

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -195,6 +195,7 @@ public class DateTimeFunction {
     repository.register(week(BuiltinFunctionName.WEEK));
     repository.register(week(BuiltinFunctionName.WEEKOFYEAR));
     repository.register(week(BuiltinFunctionName.WEEK_OF_YEAR));
+    repository.register(weekday());
     repository.register(year());
   }
 
@@ -885,6 +886,19 @@ public class DateTimeFunction {
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, DATETIME, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, TIMESTAMP, INTEGER),
         impl(nullMissingHandling(DateTimeFunction::exprWeek), INTEGER, STRING, INTEGER)
+    );
+  }
+
+  private DefaultFunctionResolver weekday() {
+    return define(BuiltinFunctionName.WEEKDAY.getName(),
+        implWithProperties(nullMissingHandlingWithProperties(
+            (functionProperties, arg) -> new ExprIntegerValue(
+                formatNow(functionProperties.getQueryStartClock()).getDayOfWeek().getValue() - 1)),
+            INTEGER, TIME),
+        impl(nullMissingHandling(DateTimeFunction::exprWeekday), INTEGER, DATE),
+        impl(nullMissingHandling(DateTimeFunction::exprWeekday), INTEGER, DATETIME),
+        impl(nullMissingHandling(DateTimeFunction::exprWeekday), INTEGER, TIMESTAMP),
+        impl(nullMissingHandling(DateTimeFunction::exprWeekday), INTEGER, STRING)
     );
   }
 
@@ -1635,6 +1649,16 @@ public class DateTimeFunction {
   private ExprValue exprWeek(ExprValue date, ExprValue mode) {
     return new ExprIntegerValue(
         CalendarLookup.getWeekNumber(mode.integerValue(), date.dateValue()));
+  }
+
+  /**
+   * Weekday implementation for ExprValue.
+   *
+   * @param date ExprValue of Date/Datetime/String/Timstamp type.
+   * @return ExprValue.
+   */
+  private ExprValue exprWeekday(ExprValue date) {
+    return new ExprIntegerValue(date.dateValue().getDayOfWeek().getValue() - 1);
   }
 
   private ExprValue unixTimeStamp(Clock clock) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -109,6 +109,7 @@ public enum BuiltinFunctionName {
   UTC_TIMESTAMP(FunctionName.of("utc_timestamp")),
   UNIX_TIMESTAMP(FunctionName.of("unix_timestamp")),
   WEEK(FunctionName.of("week")),
+  WEEKDAY(FunctionName.of("weekday")),
   WEEKOFYEAR(FunctionName.of("weekofyear")),
   WEEK_OF_YEAR(FunctionName.of("week_of_year")),
   YEAR(FunctionName.of("year")),

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/WeekdayTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/WeekdayTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.expression.datetime;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.sql.data.model.ExprValueUtils.integerValue;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ExpressionTestBase;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
+
+
+class WeekdayTest extends ExpressionTestBase {
+
+  private void weekdayQuery(
+      FunctionExpression dateExpression,
+      int dayOfWeek,
+      String testExpr) {
+
+    assertAll(
+        () -> assertEquals(INTEGER, dateExpression.type()),
+        () -> assertEquals(integerValue(dayOfWeek), eval(dateExpression)),
+        () -> assertEquals(testExpr, dateExpression.toString())
+    );
+  }
+
+  private static Stream<Arguments> getTestDataForWeekday() {
+    return Stream.of(
+        Arguments.of(
+            DSL.literal(new ExprDateValue("2020-08-07")),
+            4,
+            "weekday(DATE '2020-08-07')"),
+        Arguments.of(
+            DSL.literal(new ExprDateValue("2020-08-09")),
+            6,
+            "weekday(DATE '2020-08-09')"),
+        Arguments.of(
+            DSL.literal("2020-08-09"),
+            6,
+            "weekday(\"2020-08-09\")"),
+        Arguments.of(
+            DSL.literal("2020-08-09 01:02:03"),
+            6,
+            "weekday(\"2020-08-09 01:02:03\")")
+    );
+  }
+
+  @MethodSource("getTestDataForWeekday")
+  @ParameterizedTest
+  public void weekday(LiteralExpression arg, int expectedInt, String expectedString) {
+    FunctionExpression expression = DSL.weekday(
+        functionProperties,
+        arg);
+
+    weekdayQuery(expression, expectedInt, expectedString);
+  }
+
+  @Test
+  public void testWeekdayWithTimeType() {
+    FunctionExpression expression = DSL.weekday(
+        functionProperties, DSL.literal(new ExprTimeValue("12:23:34")));
+
+    assertAll(
+        () -> assertEquals(INTEGER, eval(expression).type()),
+        () -> assertEquals((
+                LocalDate.now(
+                    functionProperties.getQueryStartClock()).getDayOfWeek().getValue() - 1),
+            eval(expression).integerValue()),
+        () -> assertEquals("weekday(TIME '12:23:34')", expression.toString())
+    );
+  }
+
+  private void testInvalidWeekday(String date) {
+    FunctionExpression expression = DSL.weekday(
+        functionProperties, DSL.literal(new ExprDateValue(date)));
+    eval(expression);
+  }
+
+  @Test
+  public void weekdayLeapYear() {
+    assertAll(
+        //Feb. 29 of a leap year
+        () -> weekdayQuery(DSL.weekday(
+            functionProperties,
+            DSL.literal("2020-02-29")), 5, "weekday(\"2020-02-29\")"),
+        //day after Feb. 29 of a leap year
+        () -> weekdayQuery(DSL.weekday(
+            functionProperties,
+            DSL.literal("2020-03-01")), 6, "weekday(\"2020-03-01\")"),
+        //Feb. 28 of a non-leap year
+        () -> weekdayQuery(DSL.weekday(
+            functionProperties,
+            DSL.literal("2021-02-28")), 6, "weekday(\"2021-02-28\")"),
+        //Feb. 29 of a non-leap year
+        () -> assertThrows(
+            SemanticCheckException.class, () ->  testInvalidWeekday("2021-02-29"))
+    );
+  }
+
+  @Test
+  public void weekdayInvalidArgument() {
+    assertAll(
+        //40th day of the month
+        () -> assertThrows(SemanticCheckException.class,
+            () ->  testInvalidWeekday("2021-02-40")),
+
+        //13th month of the year
+        () -> assertThrows(SemanticCheckException.class,
+            () ->  testInvalidWeekday("2021-13-29")),
+
+        //incorrect format
+        () -> assertThrows(SemanticCheckException.class,
+            () ->  testInvalidWeekday("asdfasdf"))
+    );
+  }
+
+  private ExprValue eval(Expression expression) {
+    return expression.valueOf();
+  }
+}

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2627,6 +2627,30 @@ Example::
     | 7                          | 8                             |
     +----------------------------+-------------------------------+
 
+WEEKDAY
+_______
+
+Description
+>>>>>>>>>>>
+
+Usage: weekday(date) returns the weekday index for date (0 = Monday, 1 = Tuesday, ..., 6 = Sunday).
+
+It is similar to the `dayofweek`_ function, but returns different indexes for each day.
+
+Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    os> SELECT weekday('2020-08-26'), weekday('2020-08-27')
+    fetched rows / total rows = 1/1
+    +-------------------------+-------------------------+
+    | weekday('2020-08-26')   | weekday('2020-08-27')   |
+    |-------------------------+-------------------------|
+    | 2                       | 3                       |
+    +-------------------------+-------------------------+
+
 WEEK_OF_YEAR
 ------------
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -933,6 +933,12 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testWeekday() throws IOException {
+    JSONObject result = executeQuery(String.format("SELECT weekday(date0) FROM %s LIMIT 3", TEST_INDEX_CALCS));
+    verifyDataRows(result, rows(3), rows(1), rows(2));
+  }
+
+  @Test
   public void testWeekOfYearUnderscores() throws IOException {
     JSONObject result = executeQuery("select week_of_year(date('2008-02-20'))");
     verifySchema(result, schema("week_of_year(date('2008-02-20'))", null, "integer"));

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -331,6 +331,7 @@ TOPHITS:                            'TOPHITS';
 TYPEOF:                             'TYPEOF';
 WEEK_OF_YEAR:                       'WEEK_OF_YEAR';
 WEEKOFYEAR:                         'WEEKOFYEAR';
+WEEKDAY:                            'WEEKDAY';
 WILDCARDQUERY:                      'WILDCARDQUERY';
 WILDCARD_QUERY:                     'WILDCARD_QUERY';
 

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -479,6 +479,7 @@ dateTimeFunctionName
     | TO_DAYS
     | UNIX_TIMESTAMP
     | WEEK
+    | WEEKDAY
     | WEEK_OF_YEAR
     | WEEKOFYEAR
     | YEAR

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -175,6 +175,12 @@ class SQLSyntaxParserTest {
     );
   }
 
+  @Test
+  public void can_parse_weekday_function() {
+    assertNotNull(parser.parse("SELECT weekday('2022-11-18')"));
+    assertNotNull(parser.parse("SELECT day_of_week('2022-11-18')"));
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("nowLikeFunctionsData")
   public void can_parse_now_like_functions(String name, Boolean hasFsp, Boolean hasShortcut) {


### PR DESCRIPTION
### Description
Adds the `weekday` function to the SQL plugin. The function accepts a `DATE`/`TIME`/`DATETIME`/`TIMESTAMP`/`STRING` and returns an index 0-6 (Monday-Sunday) for the corresponding weekday the date lands on. If a `TIME` is used the function uses the current day. This is based on [MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_weekday).

Examples: 
`SELECT weekday('2020-08-27')` -> `3` 

### Issues Resolved
[722](https://github.com/opensearch-project/sql/issues/722)
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).