### PR TITLE
Added RINT function to V2 engine 

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -218,6 +218,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.RAND, expressions);
   }
 
+  public static FunctionExpression rint(Expression... expressions) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.RINT, expressions);
+  }
+
   public static FunctionExpression round(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.ROUND, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -39,6 +39,7 @@ public enum BuiltinFunctionName {
   POW(FunctionName.of("pow")),
   POWER(FunctionName.of("power")),
   RAND(FunctionName.of("rand")),
+  RINT(FunctionName.of("rint")),
   ROUND(FunctionName.of("round")),
   SIGN(FunctionName.of("sign")),
   SQRT(FunctionName.of("sqrt")),

--- a/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
@@ -69,6 +69,7 @@ public class MathematicalFunction {
     repository.register(mod());
     repository.register(pow());
     repository.register(power());
+    repository.register(rint());
     repository.register(round());
     repository.register(sign());
     repository.register(sqrt());
@@ -407,6 +408,17 @@ public class MathematicalFunction {
             FunctionDSL.nullMissingHandling(
                 v -> new ExprFloatValue(new Random(v.integerValue()).nextFloat())), FLOAT, INTEGER)
     );
+  }
+
+  /**
+   * Definition of rint(x) function.
+   * Returns the closest whole integer value to x
+   * The supported signature is
+   * BYTE/SHORT/INTEGER/LONG/FLOAT/DOUBLE -> DOUBLE
+   */
+  private static DefaultFunctionResolver rint() {
+    return baseMathFunction(BuiltinFunctionName.RINT.getName(),
+            v -> new ExprDoubleValue(Math.rint(v.doubleValue())), DOUBLE);
   }
 
   /**

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
@@ -642,7 +642,7 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
   }
 
   /**
-   * Test expm1 with short value.
+   * Test expm1 with byte value.
    */
   @ParameterizedTest(name = "expm1({0})")
   @ValueSource(bytes = {
@@ -1568,6 +1568,92 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
         DSL.ref(INT_TYPE_NULL_VALUE_FIELD, INTEGER));
     assertEquals(DOUBLE, power.type());
     assertTrue(power.valueOf(valueEnv()).isMissing());
+  }
+
+  /**
+   * Test rint with byte value.
+   */
+  @ParameterizedTest(name = "rint({0})")
+  @ValueSource(bytes = {
+      -1, 0, 1, Byte.MAX_VALUE, Byte.MIN_VALUE})
+  public void rint_byte_value(Byte value) {
+    FunctionExpression rint = DSL.rint(DSL.literal(value));
+    assertThat(
+            rint.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.rint(value))));
+    assertEquals(String.format("rint(%s)", value), rint.toString());
+  }
+
+  /**
+   * Test rint with short value.
+   */
+  @ParameterizedTest(name = "rint({0})")
+  @ValueSource(shorts = {
+      -1, 0, 1, Short.MAX_VALUE, Short.MIN_VALUE})
+  public void rint_short_value(Short value) {
+    FunctionExpression rint = DSL.rint(DSL.literal(value));
+    assertThat(
+            rint.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.rint(value))));
+    assertEquals(String.format("rint(%s)", value), rint.toString());
+  }
+
+  /**
+   * Test rint with integer value.
+   */
+  @ParameterizedTest(name = "rint({0})")
+  @ValueSource(ints = {
+      -1, 0, 1, Integer.MAX_VALUE, Integer.MIN_VALUE})
+  public void rint_int_value(Integer value) {
+    FunctionExpression rint = DSL.rint(DSL.literal(value));
+    assertThat(
+            rint.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.rint(value))));
+    assertEquals(String.format("rint(%s)", value), rint.toString());
+  }
+
+  /**
+   * Test rint with long value.
+   */
+  @ParameterizedTest(name = "rint({0})")
+  @ValueSource(longs = {
+      -1L, 0L, 1L, Long.MAX_VALUE, Long.MIN_VALUE})
+  public void rint_long_value(Long value) {
+    FunctionExpression rint = DSL.rint(DSL.literal(value));
+    assertThat(
+            rint.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.rint(value))));
+    assertEquals(String.format("rint(%s)", value), rint.toString());
+  }
+
+  /**
+   * Test rint with float value.
+   */
+  @ParameterizedTest(name = "rint({0})")
+  @ValueSource(floats = {
+      -1F, -0.75F, -0.5F, 0F, 0.5F, 0.500000001F,
+      0.75F, 1F, 1.9999F, 42.42F, Float.MAX_VALUE, Float.MIN_VALUE})
+  public void rint_float_value(Float value) {
+    FunctionExpression rint = DSL.rint(DSL.literal(value));
+    assertThat(
+            rint.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.rint(value))));
+    assertEquals(String.format("rint(%s)", value), rint.toString());
+  }
+
+  /**
+   * Test rint with double value.
+   */
+  @ParameterizedTest(name = "rint({0})")
+  @ValueSource(doubles = {
+      -1F, -0.75F, -0.5F, 0F, 0.5F, 0.500000001F,
+      0.75F, 1F, 1.9999F, 42.42F, Double.MAX_VALUE, Double.MIN_VALUE})
+  public void rint_double_value(Double value) {
+    FunctionExpression rint = DSL.rint(DSL.literal(value));
+    assertThat(
+            rint.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.rint(value))));
+    assertEquals(String.format("rint(%s)", value), rint.toString());
   }
 
   /**

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -700,9 +700,21 @@ RINT
 Description
 >>>>>>>>>>>
 
-Specifications:
+Usage: RINT(NUMBER T) returns T rounded to the closest whole integer number
 
-1. RINT(NUMBER T) -> T
+Argument type: BYTE/SHORT/INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    os> SELECT RINT(1.7);
+    fetched rows / total rows = 1/1
+    +-------------+
+    | RINT(1.7)   |
+    |-------------|
+    | 2.0         |
+    +-------------+
 
 
 ROUND

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MathematicalFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MathematicalFunctionIT.java
@@ -99,6 +99,25 @@ public class MathematicalFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testRint() throws IOException {
+    JSONObject result = executeQuery("select rint(56.78)");
+    verifySchema(result, schema("rint(56.78)", null, "double"));
+    verifyDataRows(result, rows(57.0));
+
+    result = executeQuery("select rint(-56)");
+    verifySchema(result, schema("rint(-56)", null, "double"));
+    verifyDataRows(result, rows(-56.0));
+
+    result = executeQuery("select rint(3.5)");
+    verifySchema(result, schema("rint(3.5)", null, "double"));
+    verifyDataRows(result, rows(4.0));
+
+    result = executeQuery("select rint(-3.5)");
+    verifySchema(result, schema("rint(-3.5)", null, "double"));
+    verifyDataRows(result, rows(-4.0));
+  }
+
+  @Test
   public void testRound() throws IOException {
     JSONObject result = executeQuery("select round(56.78)");
     verifySchema(result, schema("round(56.78)", null, "double"));

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -419,7 +419,7 @@ aggregationFunctionName
 
 mathematicalFunctionName
     : ABS | CBRT | CEIL | CEILING | CONV | CRC32 | E | EXP | EXPM1 | FLOOR | LN | LOG | LOG10 | LOG2 | MOD | PI | POW | POWER
-    | RAND | ROUND | SIGN | SQRT | TRUNCATE
+    | RAND | RINT | ROUND | SIGN | SQRT | TRUNCATE
     | trigonometricFunctionName
     ;
 


### PR DESCRIPTION
### Description
Added math function RINT to V2 engine, updated documentation, and added unit/IT tests. Additionally fixed small typo in the EXPM1 description 
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1190
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).