### PR TITLE
[Backport 2.x] Add The `TO_SECONDS` Function To The SQL Plugin

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -314,6 +314,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.DATETIME, expressions);
   }
 
+  public static FunctionExpression date_add(Expression... expressions) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.DATE_ADD, expressions);
+  }
+
   public static FunctionExpression day(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.DAY, expressions);
   }
@@ -450,6 +454,16 @@ public class DSL {
   public static FunctionExpression to_days(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.TO_DAYS, expressions);
   }
+
+  public static FunctionExpression to_seconds(FunctionProperties functionProperties,
+                                              Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.TO_SECONDS, expressions);
+  }
+
+  public static FunctionExpression to_seconds(Expression... expressions) {
+    return to_seconds(FunctionProperties.None, expressions);
+  }
+
 
   public static FunctionExpression week(
       FunctionProperties functionProperties, Expression... expressions) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -109,6 +109,7 @@ public enum BuiltinFunctionName {
   TIMESTAMP(FunctionName.of("timestamp")),
   TIME_FORMAT(FunctionName.of("time_format")),
   TO_DAYS(FunctionName.of("to_days")),
+  TO_SECONDS(FunctionName.of("to_seconds")),
   UTC_DATE(FunctionName.of("utc_date")),
   UTC_TIME(FunctionName.of("utc_time")),
   UTC_TIMESTAMP(FunctionName.of("utc_timestamp")),

--- a/core/src/main/java/org/opensearch/sql/utils/DateTimeFormatters.java
+++ b/core/src/main/java/org/opensearch/sql/utils/DateTimeFormatters.java
@@ -29,6 +29,21 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class DateTimeFormatters {
 
+  //Length of a date formatted as YYYYMMDD.
+  public static final int FULL_DATE_LENGTH = 8;
+
+  //Length of a date formatted as YYMMDD.
+  public static final int SHORT_DATE_LENGTH = 6;
+
+  //Length of a date formatted as YMMDD.
+  public static final int SINGLE_DIGIT_YEAR_DATE_LENGTH = 5;
+
+  //Length of a date formatted as MMDD.
+  public static final int NO_YEAR_DATE_LENGTH = 4;
+
+  //Length of a date formatted as MDD.
+  public static final int SINGLE_DIGIT_MONTH_DATE_LENGTH = 3;
+
   public static final DateTimeFormatter TIME_ZONE_FORMATTER_NO_COLON =
       new DateTimeFormatterBuilder()
           .appendOffset("+HHmm", "Z")
@@ -131,6 +146,30 @@ public class DateTimeFormatters {
               MAX_FRACTION_SECONDS,
               true)
           .toFormatter(Locale.ROOT)
+          .withResolverStyle(ResolverStyle.STRICT);
+
+  // MDD
+  public static final DateTimeFormatter DATE_FORMATTER_SINGLE_DIGIT_MONTH =
+      new DateTimeFormatterBuilder()
+          .parseDefaulting(YEAR, 2000)
+          .appendPattern("Mdd")
+          .toFormatter()
+          .withResolverStyle(ResolverStyle.STRICT);
+
+  // MMDD
+  public static final DateTimeFormatter DATE_FORMATTER_NO_YEAR =
+      new DateTimeFormatterBuilder()
+          .parseDefaulting(YEAR, 2000)
+          .appendPattern("MMdd")
+          .toFormatter()
+          .withResolverStyle(ResolverStyle.STRICT);
+
+  // YMMDD
+  public static final DateTimeFormatter DATE_FORMATTER_SINGLE_DIGIT_YEAR =
+      new DateTimeFormatterBuilder()
+          .appendValueReduced(YEAR, 1, 1, 2000)
+          .appendPattern("MMdd")
+          .toFormatter()
           .withResolverStyle(ResolverStyle.STRICT);
 
   // YYMMDD

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/ToSecondsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/ToSecondsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.expression.datetime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.sql.data.type.ExprCoreType.LONG;
+import static org.opensearch.sql.expression.datetime.DateTimeFunction.SECONDS_PER_DAY;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprIntervalValue;
+import org.opensearch.sql.data.model.ExprLongValue;
+import org.opensearch.sql.data.model.ExprNullValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ExpressionTestBase;
+import org.opensearch.sql.expression.FunctionExpression;
+
+
+class ToSecondsTest extends ExpressionTestBase {
+
+  private static final long SECONDS_FROM_0001_01_01_TO_EPOCH_START = 62167219200L;
+
+  private static Stream<Arguments> getTestDataForToSeconds() {
+    return Stream.of(
+        Arguments.of(new ExprLongValue(101), new ExprLongValue(63113904000L)),
+        Arguments.of(new ExprLongValue(1030), new ExprLongValue(63140083200L)),
+        Arguments.of(new ExprLongValue(50101), new ExprLongValue(63271756800L)),
+        Arguments.of(new ExprLongValue(950501), new ExprLongValue(62966505600L)),
+        Arguments.of(new ExprLongValue(19950501), new ExprLongValue(62966505600L)),
+        Arguments.of(new ExprLongValue(9950501), ExprNullValue.of()),
+        Arguments.of(new ExprLongValue(-123L), ExprNullValue.of()),
+        Arguments.of(new ExprLongValue(1), ExprNullValue.of()),
+        Arguments.of(new ExprLongValue(919950501), ExprNullValue.of()),
+        Arguments.of(new ExprStringValue("2009-11-29 00:00:00"), new ExprLongValue(63426672000L)),
+        Arguments.of(new ExprStringValue("2009-11-29 13:43:32"), new ExprLongValue(63426721412L)),
+        Arguments.of(new ExprDateValue("2009-11-29"), new ExprLongValue(63426672000L)),
+        Arguments.of(new ExprDatetimeValue("2009-11-29 13:43:32"),
+            new ExprLongValue(63426721412L)),
+        Arguments.of(new ExprTimestampValue("2009-11-29 13:43:32"),
+            new ExprLongValue(63426721412L))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getTestDataForToSeconds")
+  public void testToSeconds(ExprValue arg, ExprValue expected) {
+    FunctionExpression expr = DSL.to_seconds(DSL.literal(arg));
+    assertEquals(LONG, expr.type());
+    assertEquals(expected, eval(expr));
+  }
+
+  @Test
+  public void testToSecondsWithTimeType() {
+    FunctionExpression expr = DSL.to_seconds(functionProperties,
+        DSL.literal(new ExprTimeValue("10:11:12")));
+
+    long expected = SECONDS_FROM_0001_01_01_TO_EPOCH_START
+        + LocalDate.now(functionProperties.getQueryStartClock())
+            .toEpochSecond(LocalTime.parse("10:11:12"), ZoneOffset.UTC);
+
+    assertEquals(expected, eval(expr).longValue());
+  }
+
+  private static Stream<Arguments> getInvalidTestDataForToSeconds() {
+    return Stream.of(
+        Arguments.of(new ExprStringValue("asdfasdf")),
+        Arguments.of(new ExprStringValue("2000-14-10")),
+        Arguments.of(new ExprStringValue("2000-10-45")),
+        Arguments.of(new ExprStringValue("2000-10-10 70:00:00")),
+        Arguments.of(new ExprStringValue("2000-10-10 00:70:00")),
+        Arguments.of(new ExprStringValue("2000-10-10 00:00:70"))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInvalidTestDataForToSeconds")
+  public void testToSecondsInvalidArg(ExprValue arg) {
+    FunctionExpression expr = DSL.to_seconds(DSL.literal(arg));
+    assertThrows(SemanticCheckException.class, () -> eval(expr));
+  }
+
+  @Test
+  public void testToSecondsWithDateAdd() {
+    LocalDate date = LocalDate.of(2000, 1, 1);
+    FunctionExpression dateExpr = DSL.to_seconds(DSL.literal(new ExprDateValue(date)));
+    long addedSeconds = SECONDS_PER_DAY;
+    long expected = eval(dateExpr).longValue() + addedSeconds;
+
+    FunctionExpression dateAddExpr = DSL.date_add(
+        DSL.literal(new ExprDateValue(date)),
+        DSL.literal(new ExprIntervalValue(Duration.ofSeconds(addedSeconds))));
+
+    long result = eval(DSL.to_seconds(DSL.literal(eval(dateAddExpr)))).longValue();
+
+    assertEquals(expected, result);
+  }
+
+  private ExprValue eval(Expression expression) {
+    return expression.valueOf();
+  }
+}

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2619,6 +2619,28 @@ Example::
     | 733687                       |
     +------------------------------+
 
+TO_SECONDS
+----------
+
+Description
+>>>>>>>>>>>
+
+Usage: to_seconds(date) returns the number of seconds since the year 0 of the given value. Returns NULL if value is invalid.
+An argument of a LONG type can be used. It must be formatted as YMMDD, YYMMDD, YYYMMDD or YYYYMMDD. Note that a LONG type argument cannot have leading 0s as it will be parsed using an octal numbering system.
+
+Argument type: STRING/LONG/DATE/DATETIME/TIME/TIMESTAMP
+
+Return type: LONG
+
+Example::
+
+    os> SELECT TO_SECONDS(DATE '2008-10-07'), TO_SECONDS(950228)
+    fetched rows / total rows = 1/1
+    +---------------------------------+----------------------+
+    | TO_SECONDS(DATE '2008-10-07')   | TO_SECONDS(950228)   |
+    |---------------------------------+----------------------|
+    | 63390556800                     | 62961148800          |
+    +---------------------------------+----------------------+
 
 UNIX_TIMESTAMP
 --------------

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -985,6 +985,21 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testToSeconds() throws IOException {
+    JSONObject result = executeQuery(
+        String.format("select to_seconds(date(date0)) FROM %s LIMIT 2", TEST_INDEX_CALCS));
+    verifyDataRows(result, rows(63249206400L), rows(62246275200L));
+
+    result = executeQuery(
+        String.format("SELECT to_seconds(datetime(cast(datetime0 AS string))) FROM %s LIMIT 2", TEST_INDEX_CALCS));
+    verifyDataRows(result, rows(63256587455L), rows(63258064234L));
+
+    result = executeQuery(String.format(
+        "select to_seconds(timestamp(datetime0)) FROM %s LIMIT 2", TEST_INDEX_CALCS));
+    verifyDataRows(result, rows(63256587455L), rows(63258064234L));
+  }
+
+  @Test
   public void testYear() throws IOException {
     JSONObject result = executeQuery("select year(date('2020-09-16'))");
     verifySchema(result, schema("year(date('2020-09-16'))", null, "integer"));

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -268,6 +268,7 @@ TIME_TO_SEC:                        'TIME_TO_SEC';
 TIMESTAMP:                          'TIMESTAMP';
 TRUNCATE:                           'TRUNCATE';
 TO_DAYS:                            'TO_DAYS';
+TO_SECONDS:                         'TO_SECONDS';
 UNIX_TIMESTAMP:                     'UNIX_TIMESTAMP';
 UPPER:                              'UPPER';
 UTC_DATE:                           'UTC_DATE';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -511,6 +511,7 @@ dateTimeFunctionName
     | TIMEDIFF
     | TIMESTAMP
     | TO_DAYS
+    | TO_SECONDS
     | UNIX_TIMESTAMP
     | WEEK
     | WEEKDAY

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -602,6 +602,12 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void can_parse_to_seconds_function() {
+    assertNotNull(parser.parse("SELECT to_seconds(\"2023-02-20\")"));
+    assertNotNull(parser.parse("SELECT to_seconds(950501)"));
+  }
+
+  @Test
   public void can_parse_wildcard_query_relevance_function() {
     assertNotNull(
         parser.parse("SELECT * FROM test WHERE wildcard_query(column, \"this is a test*\")"));


### PR DESCRIPTION
Manually backport d38a6ec20d1ddc035adf53f610af05cfad812b6a FROM #1419.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).