### PR TITLE
Add `TIMESTAMPADD` Function To OpenSearch SQL Plugin

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -919,6 +919,15 @@ public class DSL {
     return compile(functionProperties, BuiltinFunctionName.TIME_FORMAT, expressions);
   }
 
+  public static FunctionExpression timestampadd(Expression... expressions) {
+    return timestampadd(FunctionProperties.None, expressions);
+  }
+
+  public static FunctionExpression timestampadd(FunctionProperties functionProperties,
+                                               Expression... expressions) {
+    return compile(functionProperties, BuiltinFunctionName.TIMESTAMPADD, expressions);
+  }
+
   public static FunctionExpression utc_date(FunctionProperties functionProperties,
                                                 Expression... args) {
     return compile(functionProperties, BuiltinFunctionName.UTC_DATE, args);

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -108,6 +108,7 @@ public enum BuiltinFunctionName {
   TIMEDIFF(FunctionName.of("timediff")),
   TIME_TO_SEC(FunctionName.of("time_to_sec")),
   TIMESTAMP(FunctionName.of("timestamp")),
+  TIMESTAMPADD(FunctionName.of("timestampadd")),
   TIME_FORMAT(FunctionName.of("time_format")),
   TO_DAYS(FunctionName.of("to_days")),
   TO_SECONDS(FunctionName.of("to_seconds")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionDSL.java
@@ -184,6 +184,60 @@ public class FunctionDSL {
   }
 
   /**
+   * Implementation of a function that takes three arguments, returns a value, and
+   * requires FunctionProperties to complete.
+   *
+   * @param function   {@link ExprValue} based Binary function.
+   * @param returnType return type.
+   * @param args1Type first argument type.
+   * @param args2Type second argument type.
+   * @param args3Type third argument type.
+   * @return Binary Function Implementation.
+   */
+  public static SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+      implWithProperties(
+      SerializableQuadFunction<
+          FunctionProperties,
+          ExprValue,
+          ExprValue,
+          ExprValue,
+          ExprValue> function,
+      ExprType returnType,
+      ExprType args1Type,
+      ExprType args2Type,
+      ExprType args3Type) {
+
+    return functionName -> {
+      FunctionSignature functionSignature =
+          new FunctionSignature(functionName, Arrays.asList(args1Type, args2Type, args3Type));
+      FunctionBuilder functionBuilder =
+          (functionProperties, arguments) -> new FunctionExpression(functionName, arguments) {
+            @Override
+            public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+              ExprValue arg1 = arguments.get(0).valueOf(valueEnv);
+              ExprValue arg2 = arguments.get(1).valueOf(valueEnv);
+              ExprValue arg3 = arguments.get(2).valueOf(valueEnv);
+              return function.apply(functionProperties, arg1, arg2, arg3);
+            }
+
+            @Override
+            public ExprType type() {
+              return returnType;
+            }
+
+            @Override
+            public String toString() {
+              return String.format("%s(%s)", functionName,
+                  arguments.stream()
+                      .map(Object::toString)
+                      .collect(Collectors.joining(", ")));
+            }
+          };
+      return Pair.of(functionSignature, functionBuilder);
+    };
+  }
+
+  /**
    * No Arg Function Implementation.
    *
    * @param function   {@link ExprValue} based unary function.
@@ -276,6 +330,59 @@ public class FunctionDSL {
   }
 
   /**
+   * Quadruple Function Implementation.
+   *
+   * @param function   {@link ExprValue} based unary function.
+   * @param returnType return type.
+   * @param args1Type  argument type.
+   * @param args2Type  argument type.
+   * @param args3Type  argument type.
+   * @return Quadruple Function Implementation.
+   */
+  public static SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>> impl(
+      SerializableQuadFunction<ExprValue, ExprValue, ExprValue, ExprValue, ExprValue> function,
+      ExprType returnType,
+      ExprType args1Type,
+      ExprType args2Type,
+      ExprType args3Type,
+      ExprType args4Type) {
+
+    return functionName -> {
+      FunctionSignature functionSignature =
+          new FunctionSignature(functionName, Arrays.asList(
+              args1Type,
+              args2Type,
+              args3Type,
+              args4Type));
+      FunctionBuilder functionBuilder =
+          (functionProperties, arguments) -> new FunctionExpression(functionName, arguments) {
+            @Override
+            public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+              ExprValue arg1 = arguments.get(0).valueOf(valueEnv);
+              ExprValue arg2 = arguments.get(1).valueOf(valueEnv);
+              ExprValue arg3 = arguments.get(2).valueOf(valueEnv);
+              ExprValue arg4 = arguments.get(3).valueOf(valueEnv);
+              return function.apply(arg1, arg2, arg3, arg4);
+            }
+
+            @Override
+            public ExprType type() {
+              return returnType;
+            }
+
+            @Override
+            public String toString() {
+              return String.format("%s(%s, %s, %s, %s)", functionName, arguments.get(0).toString(),
+                  arguments.get(1).toString(),
+                  arguments.get(2).toString(),
+                  arguments.get(3).toString());
+            }
+          };
+      return Pair.of(functionSignature, functionBuilder);
+    };
+  }
+
+  /**
    * Wrapper the unary ExprValue function with default NULL and MISSING handling.
    */
   public static SerializableFunction<ExprValue, ExprValue> nullMissingHandling(
@@ -356,6 +463,36 @@ public class FunctionDSL {
       } else {
         return implementation.apply(functionProperties, v1, v2);
       }
+    };
+  }
+
+  /**
+   * Wrapper for the ExprValue function that takes 3 arguments and is aware of FunctionProperties,
+   * with default NULL and MISSING handling.
+   */
+  public static SerializableQuadFunction<
+      FunctionProperties,
+      ExprValue,
+      ExprValue,
+      ExprValue,
+      ExprValue>
+      nullMissingHandlingWithProperties(
+      SerializableQuadFunction<
+          FunctionProperties,
+          ExprValue,
+          ExprValue,
+          ExprValue,
+          ExprValue> implementation) {
+    return (functionProperties, v1, v2, v3) -> {
+      if (v1.isMissing() || v2.isMissing() || v3.isMissing()) {
+        return ExprValueUtils.missingValue();
+      }
+
+      if (v1.isNull() || v2.isNull() || v3.isNull()) {
+        return ExprValueUtils.nullValue();
+      }
+
+      return implementation.apply(functionProperties, v1, v2, v3);
     };
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/SerializableQuadFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/SerializableQuadFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.expression.function;
+
+import java.io.Serializable;
+
+/**
+ * Serializable Triple Function.
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <V> the type of the third argument to the function
+ * @param <W> the type of the fourth argument to the function
+ * @param <R> the type of the result of the function
+ */
+public interface SerializableQuadFunction<T, U, V, W, R> extends Serializable {
+  /**
+   * Applies this function to the given arguments.
+   *
+   * @param t the first function argument
+   * @param u the second function argument
+   * @param v the third function argument
+   * @param w the fourth function argument
+   * @return the function result
+   */
+  R apply(T t, U u, V v, W w);
+}

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampAddTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampAddTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.expression.datetime;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprDatetimeValue;
+import org.opensearch.sql.data.model.ExprIntegerValue;
+import org.opensearch.sql.data.model.ExprNullValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTimeValue;
+import org.opensearch.sql.data.model.ExprTimestampValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ExpressionTestBase;
+import org.opensearch.sql.expression.FunctionExpression;
+
+class TimeStampAddTest extends ExpressionTestBase {
+
+  private static Stream<Arguments> getTestDataForTimestampAdd() {
+    return Stream.of(
+        Arguments.of("MINUTE", 1, new ExprStringValue("2003-01-02 00:00:00"),
+            "2003-01-02 00:01:00"),
+        Arguments.of("WEEK", 1, new ExprStringValue("2003-01-02 00:00:00"),
+            "2003-01-09 00:00:00"),
+        //Date
+        Arguments.of("MINUTE", 1, new ExprDateValue("2003-01-02"),
+            "2003-01-02 00:01:00"),
+        Arguments.of("WEEK", 1, new ExprDateValue("2003-01-02"),
+            "2003-01-09 00:00:00"),
+        //Datetime
+        Arguments.of("MINUTE", 1, new ExprDatetimeValue("2003-01-02 00:00:00"),
+            "2003-01-02 00:01:00"),
+        Arguments.of("WEEK", 1, new ExprDatetimeValue("2003-01-02 00:00:00"),
+            "2003-01-09 00:00:00"),
+        //timstamp
+        Arguments.of("MINUTE", 1, new ExprTimestampValue("2003-01-02 00:00:00"),
+            "2003-01-02 00:01:00"),
+        Arguments.of("WEEK", 1, new ExprTimestampValue("2003-01-02 00:00:00"),
+            "2003-01-09 00:00:00"),
+        //Cases surrounding leap year
+        Arguments.of("SECOND", 1, new ExprTimestampValue("2020-02-28 23:59:59"),
+            "2020-02-29 00:00:00"),
+        Arguments.of("MINUTE", 1, new ExprTimestampValue("2020-02-28 23:59:59"),
+            "2020-02-29 00:00:59"),
+        Arguments.of("HOUR", 1, new ExprTimestampValue("2020-02-28 23:59:59"),
+            "2020-02-29 00:59:59"),
+        Arguments.of("DAY", 1, new ExprTimestampValue("2020-02-28 23:59:59"),
+            "2020-02-29 23:59:59"),
+        Arguments.of("WEEK", 1, new ExprTimestampValue("2020-02-28 23:59:59"),
+            "2020-03-06 23:59:59"),
+        //Cases surrounding end-of-year
+        Arguments.of("SECOND", 1, new ExprTimestampValue("2020-12-31 23:59:59"),
+            "2021-01-01 00:00:00"),
+        Arguments.of("MINUTE", 1, new ExprTimestampValue("2020-12-31 23:59:59"),
+            "2021-01-01 00:00:59"),
+        Arguments.of("HOUR", 1, new ExprTimestampValue("2020-12-31 23:59:59"),
+            "2021-01-01 00:59:59"),
+        Arguments.of("DAY", 1, new ExprTimestampValue("2020-12-31 23:59:59"),
+            "2021-01-01 23:59:59"),
+        Arguments.of("WEEK", 1, new ExprTimestampValue("2020-12-31 23:59:59"),
+            "2021-01-07 23:59:59"),
+
+        //Test adding a month (including special cases)
+        Arguments.of("MONTH", 1, new ExprStringValue("2003-01-02 00:00:00"),
+            "2003-02-02 00:00:00"),
+        Arguments.of("MONTH", 1, new ExprDateValue("2024-03-30"),
+            "2024-04-30 00:00:00"),
+        Arguments.of("MONTH", 1, new ExprDateValue("2024-03-31"),
+            "2024-04-30 00:00:00"),
+
+        //Test remaining interval types
+        Arguments.of("MICROSECOND", 123, new ExprStringValue("2003-01-02 00:00:00"),
+            "2003-01-02 00:00:00.000123"),
+        Arguments.of("QUARTER", 1, new ExprStringValue("2003-01-02 00:00:00"),
+            "2003-04-02 00:00:00"),
+        Arguments.of("YEAR", 1, new ExprStringValue("2003-01-02 00:00:00"),
+            "2004-01-02 00:00:00"),
+
+        //Test negative value for amount (Test for all intervals)
+        Arguments.of("MICROSECOND", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-12-31 23:59:59.999999"),
+        Arguments.of("SECOND", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-12-31 23:59:59"),
+        Arguments.of("MINUTE", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-12-31 23:59:00"),
+        Arguments.of("HOUR", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-12-31 23:00:00"),
+        Arguments.of("DAY", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-12-31 00:00:00"),
+        Arguments.of("WEEK", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-12-25 00:00:00"),
+        Arguments.of("MONTH", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-12-01 00:00:00"),
+        Arguments.of("QUARTER", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-10-01 00:00:00"),
+        Arguments.of("YEAR", -1, new ExprStringValue("2000-01-01 00:00:00"),
+            "1999-01-01 00:00:00")
+    );
+  }
+
+  private static FunctionExpression timestampaddQuery(String unit,
+                                                      int amount,
+                                                      ExprValue datetimeExpr) {
+    return DSL.timestampadd(
+        DSL.literal(unit),
+        DSL.literal(new ExprIntegerValue(amount)),
+        DSL.literal(datetimeExpr)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getTestDataForTimestampAdd")
+  public void testTimestampadd(String unit, int amount, ExprValue datetimeExpr, String expected) {
+    FunctionExpression expr = timestampaddQuery(unit, amount, datetimeExpr);
+    assertEquals(new ExprDatetimeValue(expected), eval(expr));
+  }
+
+  private static Stream<Arguments> getTestDataForTestAddingDatePartToTime() {
+    return Stream.of(
+        Arguments.of("DAY", 1, "10:11:12", LocalDate.now().plusDays(1)),
+        Arguments.of("DAY", 5, "10:11:12", LocalDate.now().plusDays(5)),
+        Arguments.of("DAY", 10, "10:11:12", LocalDate.now().plusDays(10)),
+        Arguments.of("DAY", -10, "10:11:12", LocalDate.now().plusDays(-10)),
+        Arguments.of("WEEK", 1, "10:11:12", LocalDate.now().plusWeeks(1)),
+        Arguments.of("WEEK", 5, "10:11:12", LocalDate.now().plusWeeks(5)),
+        Arguments.of("WEEK", 10, "10:11:12", LocalDate.now().plusWeeks(10)),
+        Arguments.of("WEEK", -10, "10:11:12", LocalDate.now().plusWeeks(-10)),
+        Arguments.of("MONTH", 1, "10:11:12", LocalDate.now().plusMonths(1)),
+        Arguments.of("MONTH", 5, "10:11:12", LocalDate.now().plusMonths(5)),
+        Arguments.of("MONTH", 10, "10:11:12", LocalDate.now().plusMonths(10)),
+        Arguments.of("MONTH", -10, "10:11:12", LocalDate.now().plusMonths(-10)),
+        Arguments.of("QUARTER", 1, "10:11:12", LocalDate.now().plusMonths(3 * 1)),
+        Arguments.of("QUARTER", 3, "10:11:12", LocalDate.now().plusMonths(3 * 3)),
+        Arguments.of("QUARTER", 5, "10:11:12", LocalDate.now().plusMonths(3 * 5)),
+        Arguments.of("QUARTER", -5, "10:11:12", LocalDate.now().plusMonths(3 * -5)),
+        Arguments.of("YEAR", 1, "10:11:12", LocalDate.now().plusYears(1)),
+        Arguments.of("YEAR", 5, "10:11:12", LocalDate.now().plusYears(5)),
+        Arguments.of("YEAR", 10, "10:11:12", LocalDate.now().plusYears(10)),
+        Arguments.of("YEAR", -10, "10:11:12", LocalDate.now().plusYears(-10))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getTestDataForTestAddingDatePartToTime")
+  public void testAddingDatePartToTime(String interval,
+                                       int addedInterval,
+                                       String timeArg,
+                                       LocalDate expectedDate) {
+    FunctionExpression expr = DSL.timestampadd(
+        functionProperties,
+        DSL.literal(interval),
+        DSL.literal(new ExprIntegerValue(addedInterval)),
+        DSL.literal(new ExprTimeValue(timeArg))
+    );
+
+    LocalDateTime expected1 = LocalDateTime.of(expectedDate, LocalTime.parse(timeArg));
+
+    assertEquals(new ExprDatetimeValue(expected1), eval(expr));
+  }
+
+  @Test
+  public void testAddingTimePartToTime() {
+    String interval = "MINUTE";
+    int addedInterval = 1;
+    String timeArg = "10:11:12";
+
+    FunctionExpression expr = DSL.timestampadd(
+        functionProperties,
+        DSL.literal(interval),
+        DSL.literal(new ExprIntegerValue(addedInterval)),
+        DSL.literal(new ExprTimeValue(timeArg))
+    );
+
+    LocalDateTime expected = LocalDateTime.of(
+        LocalDate.now(),
+        LocalTime.parse(timeArg).plusMinutes(addedInterval));
+
+    assertEquals(new ExprDatetimeValue(expected), eval(expr));
+  }
+
+  @Test
+  public void testDifferentInputTypesHaveSameResult() {
+    String part = "SECOND";
+    int amount = 1;
+    FunctionExpression dateExpr = timestampaddQuery(
+        part,
+        amount,
+        new ExprDateValue("2000-01-01"));
+
+    FunctionExpression stringExpr = timestampaddQuery(
+        part,
+        amount,
+        new ExprStringValue("2000-01-01 00:00:00"));
+
+    FunctionExpression datetimeExpr = timestampaddQuery(
+        part,
+        amount,
+        new ExprDatetimeValue("2000-01-01 00:00:00"));
+
+    FunctionExpression timestampExpr = timestampaddQuery(
+        part,
+        amount,
+        new ExprTimestampValue("2000-01-01 00:00:00"));
+
+    assertAll(
+        () -> assertEquals(eval(dateExpr), eval(stringExpr)),
+        () -> assertEquals(eval(dateExpr), eval(datetimeExpr)),
+        () -> assertEquals(eval(dateExpr), eval(timestampExpr))
+    );
+  }
+
+  private static Stream<Arguments> getInvalidTestDataForTimestampAdd() {
+    return Stream.of(
+        Arguments.of("WEEK", 1, new ExprStringValue("2000-13-01")),
+        Arguments.of("WEEK", 1, new ExprStringValue("2000-01-40"))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInvalidTestDataForTimestampAdd")
+  public void testInvalidArguments(String interval, int amount, ExprValue datetimeExpr) {
+    FunctionExpression expr = timestampaddQuery(interval, amount, datetimeExpr);
+    assertThrows(SemanticCheckException.class, () -> eval(expr));
+  }
+
+  @Test
+  public void testNullReturnValue() {
+    FunctionExpression expr = timestampaddQuery("INVALID", 1, new ExprDateValue("2000-01-01"));
+    assertEquals(ExprNullValue.of(), eval(expr));
+  }
+
+  private ExprValue eval(Expression expression) {
+    return expression.valueOf();
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampAddTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampAddTest.java
@@ -40,21 +40,25 @@ class TimeStampAddTest extends ExpressionTestBase {
             "2003-01-02 00:01:00"),
         Arguments.of("WEEK", 1, new ExprStringValue("2003-01-02 00:00:00"),
             "2003-01-09 00:00:00"),
+
         //Date
         Arguments.of("MINUTE", 1, new ExprDateValue("2003-01-02"),
             "2003-01-02 00:01:00"),
         Arguments.of("WEEK", 1, new ExprDateValue("2003-01-02"),
             "2003-01-09 00:00:00"),
+
         //Datetime
         Arguments.of("MINUTE", 1, new ExprDatetimeValue("2003-01-02 00:00:00"),
             "2003-01-02 00:01:00"),
         Arguments.of("WEEK", 1, new ExprDatetimeValue("2003-01-02 00:00:00"),
             "2003-01-09 00:00:00"),
-        //timstamp
+
+        //Timestamp
         Arguments.of("MINUTE", 1, new ExprTimestampValue("2003-01-02 00:00:00"),
             "2003-01-02 00:01:00"),
         Arguments.of("WEEK", 1, new ExprTimestampValue("2003-01-02 00:00:00"),
             "2003-01-09 00:00:00"),
+
         //Cases surrounding leap year
         Arguments.of("SECOND", 1, new ExprTimestampValue("2020-02-28 23:59:59"),
             "2020-02-29 00:00:00"),
@@ -66,6 +70,7 @@ class TimeStampAddTest extends ExpressionTestBase {
             "2020-02-29 23:59:59"),
         Arguments.of("WEEK", 1, new ExprTimestampValue("2020-02-28 23:59:59"),
             "2020-03-06 23:59:59"),
+
         //Cases surrounding end-of-year
         Arguments.of("SECOND", 1, new ExprTimestampValue("2020-12-31 23:59:59"),
             "2021-01-01 00:00:00"),

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLTestBase.java
@@ -55,10 +55,18 @@ public class FunctionDSLTestBase {
   static final SerializableTriFunction<FunctionProperties, ExprValue, ExprValue, ExprValue>
       twoArgWithProperties = (functionProperties, v1, v2) -> ANY;
 
+  static final SerializableQuadFunction
+      <FunctionProperties, ExprValue, ExprValue, ExprValue, ExprValue>
+      threeArgsWithProperties = (functionProperties, v1, v2, v3) -> ANY;
+
   static final SerializableBiFunction<ExprValue, ExprValue, ExprValue>
       twoArgs = (v1, v2) -> ANY;
   static final SerializableTriFunction<ExprValue, ExprValue, ExprValue, ExprValue>
       threeArgs = (v1, v2, v3) -> ANY;
+
+  static final SerializableQuadFunction<ExprValue, ExprValue, ExprValue, ExprValue, ExprValue>
+      fourArgs = (v1, v2, v3, v4) -> ANY;
+
   @Mock
   FunctionProperties mockProperties;
 }

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplFourArgTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplFourArgTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+import static org.opensearch.sql.expression.function.FunctionDSL.impl;
+
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+
+class FunctionDSLimplFourArgTest extends FunctionDSLimplTestBase {
+
+  @Override
+  SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+      getImplementationGenerator() {
+    return impl(fourArgs, ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE);
+  }
+
+  @Override
+  List<Expression> getSampleArguments() {
+    return List.of(DSL.literal(ANY), DSL.literal(ANY), DSL.literal(ANY), DSL.literal(ANY));
+  }
+
+  @Override
+  String getExpected_toString() {
+    return "sample(ANY, ANY, ANY, ANY)";
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesThreeArgsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLimplWithPropertiesThreeArgsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+
+class FunctionDSLimplWithPropertiesThreeArgsTest extends FunctionDSLimplTestBase {
+
+  @Override
+  SerializableFunction<FunctionName, Pair<FunctionSignature, FunctionBuilder>>
+      getImplementationGenerator() {
+    SerializableQuadFunction<FunctionProperties, ExprValue, ExprValue, ExprValue, ExprValue>
+        functionBody = (fp, arg1, arg2, arg3) -> ANY;
+    return FunctionDSL.implWithProperties(functionBody, ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE);
+  }
+
+  @Override
+  List<Expression> getSampleArguments() {
+    return List.of(DSL.literal(ANY), DSL.literal(ANY), DSL.literal(ANY));
+  }
+
+  @Override
+  String getExpected_toString() {
+    return "sample(ANY, ANY, ANY)";
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLnullMissingHandlingTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionDSLnullMissingHandlingTest.java
@@ -83,6 +83,56 @@ class FunctionDSLnullMissingHandlingTest extends FunctionDSLTestBase {
   }
 
   @Test
+  void nullMissingHandling_threeArgs_FunctionProperties_nullValue_firstArg() {
+    assertEquals(NULL,
+        nullMissingHandlingWithProperties(threeArgsWithProperties)
+            .apply(functionProperties, NULL, ANY, ANY));
+  }
+
+  @Test
+  void nullMissingHandling_threeArgs_FunctionProperties_nullValue_secondArg() {
+    assertEquals(NULL,
+        nullMissingHandlingWithProperties(threeArgsWithProperties)
+            .apply(functionProperties, ANY, NULL, ANY));
+  }
+
+  @Test
+  void nullMissingHandling_threeArgs_FunctionProperties_nullValue_thirdArg() {
+    assertEquals(NULL,
+        nullMissingHandlingWithProperties(threeArgsWithProperties)
+            .apply(functionProperties, ANY, ANY, NULL));
+  }
+
+
+  @Test
+  void nullMissingHandling_threeArgs_FunctionProperties_missingValue_firstArg() {
+    assertEquals(MISSING,
+        nullMissingHandlingWithProperties(threeArgsWithProperties)
+            .apply(functionProperties, MISSING, ANY, ANY));
+  }
+
+  @Test
+  void nullMissingHandling_threeArgs_FunctionProperties_missingValue_secondArg() {
+    assertEquals(MISSING,
+        nullMissingHandlingWithProperties(threeArgsWithProperties)
+            .apply(functionProperties, ANY, MISSING, ANY));
+  }
+
+  @Test
+  void nullMissingHandling_threeArgs_FunctionProperties_missingValue_thirdArg() {
+    assertEquals(MISSING,
+        nullMissingHandlingWithProperties(threeArgsWithProperties)
+            .apply(functionProperties, ANY, ANY, MISSING));
+  }
+
+  @Test
+  void nullMissingHandling_threeArgs_FunctionProperties_apply() {
+    assertEquals(ANY,
+        nullMissingHandlingWithProperties(threeArgsWithProperties)
+            .apply(functionProperties, ANY, ANY, ANY));
+  }
+
+  @Test
   void nullMissingHandling_twoArgs_firstArg_nullValue() {
     assertEquals(NULL, nullMissingHandling(twoArgs).apply(NULL, ANY));
   }

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -2704,6 +2704,29 @@ Example::
     | 2020-08-26 13:49:00                | 2020-08-27 02:04:42                                  |
     +------------------------------------+------------------------------------------------------+
 
+TIMESTAMPADD
+------------
+
+
+Description
+>>>>>>>>>>>
+
+Usage: Returns a DATETIME value based on a passed in DATE/DATETIME/TIME/TIMESTAMP/STRING argument and an INTERVAL and INTEGER argument which determine the amount of time to be added.
+If the third argument is a STRING, it must be formatted as a valid DATETIME. If only a TIME is provided, a DATETIME is still returned with the DATE portion filled in using the current date.
+If the third argument is a DATE, it will be automatically converted to a DATETIME.
+
+Argument type: INTERVAL, INTEGER, DATE/DATETIME/TIME/TIMESTAMP/STRING
+INTERVAL must be one of the following tokens: [MICROSECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR]
+
+Examples::
+
+    os> SELECT TIMESTAMPADD(DAY, 17, '2000-01-01 00:00:00'), TIMESTAMPADD(QUARTER, -1, '2000-01-01 00:00:00')
+    fetched rows / total rows = 1/1
+    +------------------------------------------------+----------------------------------------------------+
+    | TIMESTAMPADD(DAY, 17, '2000-01-01 00:00:00')   | TIMESTAMPADD(QUARTER, -1, '2000-01-01 00:00:00')   |
+    |------------------------------------------------+----------------------------------------------------|
+    | 2000-01-18 00:00:00                            | 1999-10-01 00:00:00                                |
+    +------------------------------------------------+----------------------------------------------------+
 
 TO_DAYS
 -------

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -963,6 +963,17 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testTimstampadd() throws  IOException {
+    JSONObject result = executeQuery(
+        String.format("SELECT timestampadd(WEEK, 2, time0) FROM %s LIMIT 3", TEST_INDEX_CALCS));
+
+    verifyDataRows(result,
+        rows("1900-01-13 21:07:32"),
+        rows("1900-01-15 13:48:48"),
+        rows("1900-01-15 18:21:08"));
+  }
+
+  @Test
   public void testTimeToSec() throws IOException {
     JSONObject result = executeQuery("select time_to_sec(time('17:30:00'))");
     verifySchema(result, schema("time_to_sec(time('17:30:00'))", null, "long"));

--- a/sql/src/main/antlr/OpenSearchSQLLexer.g4
+++ b/sql/src/main/antlr/OpenSearchSQLLexer.g4
@@ -332,6 +332,7 @@ SECOND_OF_MINUTE:                   'SECOND_OF_MINUTE';
 STATS:                              'STATS';
 TERM:                               'TERM';
 TERMS:                              'TERMS';
+TIMESTAMPADD:                       'TIMESTAMPADD';
 TOPHITS:                            'TOPHITS';
 TYPEOF:                             'TYPEOF';
 WEEK_OF_YEAR:                       'WEEK_OF_YEAR';

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -318,7 +318,6 @@ timestampAddFunction
     : TIMESTAMPADD LR_BRACKET simpleDateTimePart COMMA length=functionArg COMMA timestampExpr=functionArg RR_BRACKET
     ;
 
-
 getFormatFunction
     : GET_FORMAT LR_BRACKET getFormatType COMMA functionArg RR_BRACKET
     ;

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -311,7 +311,13 @@ functionCall
     | positionFunction                                              #positionFunctionCall
     | extractFunction                                               #extractFunctionCall
     | getFormatFunction                                             #getFormatFunctionCall
+    | timestampAddFunction                                          #timestampAddFunctionCall
     ;
+
+timestampAddFunction
+    : TIMESTAMPADD LR_BRACKET simpleDateTimePart COMMA length=functionArg COMMA timestampExpr=functionArg RR_BRACKET
+    ;
+
 
 getFormatFunction
     : GET_FORMAT LR_BRACKET getFormatType COMMA functionArg RR_BRACKET
@@ -328,7 +334,7 @@ extractFunction
     : EXTRACT LR_BRACKET datetimePart FROM functionArg RR_BRACKET
     ;
 
-datetimePart
+simpleDateTimePart
     : MICROSECOND
     | SECOND
     | MINUTE
@@ -338,7 +344,10 @@ datetimePart
     | MONTH
     | QUARTER
     | YEAR
-    | SECOND_MICROSECOND
+    ;
+
+complexDateTimePart
+    : SECOND_MICROSECOND
     | MINUTE_MICROSECOND
     | MINUTE_SECOND
     | HOUR_MICROSECOND
@@ -349,6 +358,11 @@ datetimePart
     | DAY_MINUTE
     | DAY_HOUR
     | YEAR_MONTH
+    ;
+
+datetimePart
+    : simpleDateTimePart
+    | complexDateTimePart
     ;
 
 highlightFunction

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -61,6 +61,7 @@ import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.StringCont
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.StringLiteralContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TableFilterContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimeLiteralContext;
+import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampAddFunctionCallContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.TimestampLiteralContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.WindowFunctionClauseContext;
 import static org.opensearch.sql.sql.parser.ParserUtils.createSortOption;
@@ -171,6 +172,14 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
 
     return new HighlightFunction(visit(ctx.highlightFunction().relevanceField()),
         builder.build());
+  }
+
+
+  @Override
+  public UnresolvedExpression visitTimestampAddFunctionCall(TimestampAddFunctionCallContext ctx) {
+    return new Function(
+        ctx.timestampAddFunction().TIMESTAMPADD().toString(),
+        timestampAddFunctionArguments(ctx));
   }
 
   @Override
@@ -577,6 +586,18 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
     List<UnresolvedExpression> args = Arrays.asList(
         new Literal(ctx.getFormatFunction().getFormatType().getText(), DataType.STRING),
         visitFunctionArg(ctx.getFormatFunction().functionArg())
+    );
+    return args;
+  }
+
+  private List<UnresolvedExpression> timestampAddFunctionArguments(
+      TimestampAddFunctionCallContext ctx) {
+    List<UnresolvedExpression> args = Arrays.asList(
+        new Literal(
+            ctx.timestampAddFunction().simpleDateTimePart().getText(),
+            DataType.STRING),
+        visitFunctionArg(ctx.timestampAddFunction().length),
+        visitFunctionArg(ctx.timestampAddFunction().timestampExpr)
     );
     return args;
   }

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -603,6 +603,12 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void can_parse_timestampadd_function() {
+    assertNotNull(parser.parse("SELECT TIMESTAMPADD(MINUTE, 1, '2003-01-02')"));
+    assertNotNull(parser.parse("SELECT TIMESTAMPADD(WEEK,1,'2003-01-02')"));
+  }
+  
+  @Test
   public void can_parse_to_seconds_function() {
     assertNotNull(parser.parse("SELECT to_seconds(\"2023-02-20\")"));
     assertNotNull(parser.parse("SELECT to_seconds(950501)"));

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -230,6 +230,14 @@ class AstExpressionBuilderTest {
   }
 
   @Test
+  public void canBuildTimestampAddFunctionCall() {
+    assertEquals(
+        function("timestampadd", stringLiteral("WEEK"), intLiteral(1), dateLiteral("2023-03-14")),
+        buildExprAst("timestampadd(WEEK, 1, DATE '2023-03-14')")
+    );
+  }
+
+  @Test
   public void canBuildComparisonExpression() {
     assertEquals(
         function("!=", intLiteral(1), intLiteral(2)),


### PR DESCRIPTION
### Description
Adds the `timestampadd()` function to the OpenSearch SQL Plugin. Based off of the [MySQL Implementation](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_timestampadd), but some changes were made due to the limitations of the plugin. Specifically, the return of this function is always a `DATETIME`. If an argument of type `TIME` is provided for the third argument, the `DATE` portion of the returned `DATETIME` will be filled in with values using the current date.

Examples:
```
opensearchsql> SELECT TIMESTAMPADD(MINUTE, 1, '2003-01-02 00:00:00');
fetched rows / total rows = 1/1
+--------------------------------------------------+
| TIMESTAMPADD(MINUTE, 1, '2003-01-02 00:00:00')   |
|--------------------------------------------------|
| 2003-01-02 00:01:00                              |
+--------------------------------------------------+
```
```
opensearchsql> SELECT TIMESTAMPADD(WEEK, 1, '2003-01-02 00:00:00');
fetched rows / total rows = 1/1
+------------------------------------------------+
| TIMESTAMPADD(WEEK, 1, '2003-01-02 00:00:00')   |
|------------------------------------------------|
| 2003-01-09 00:00:00                            |
+------------------------------------------------+
```
```
opensearchsql> SELECT TIMESTAMPADD(QUARTER, 1, '2003-01-02 00:00:00');
fetched rows / total rows = 1/1
+---------------------------------------------------+
| TIMESTAMPADD(QUARTER, 1, '2003-01-02 00:00:00')   |
|---------------------------------------------------|
| 2003-04-02 00:00:00                               |
+---------------------------------------------------+
```

### Issues Resolved
#722 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).