### PR TITLE
Fix null response from pow/power and added missing integration testing

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunction.java
@@ -386,11 +386,15 @@ public class MathematicalFunction {
             DOUBLE, LONG, LONG),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
-                (v1, v2) -> new ExprDoubleValue(Math.pow(v1.floatValue(), v2.floatValue()))),
+                (v1, v2) -> v1.floatValue() <= 0  && v2.floatValue()
+                        != Math.floor(v2.floatValue()) ? ExprNullValue.of() :
+                    new ExprDoubleValue(Math.pow(v1.floatValue(), v2.floatValue()))),
             DOUBLE, FLOAT, FLOAT),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
-                (v1, v2) -> new ExprDoubleValue(Math.pow(v1.doubleValue(), v2.doubleValue()))),
+                (v1, v2) -> v1.doubleValue() <= 0  && v2.doubleValue()
+                        != Math.floor(v2.doubleValue()) ? ExprNullValue.of() :
+                    new ExprDoubleValue(Math.pow(v1.doubleValue(), v2.doubleValue()))),
             DOUBLE, DOUBLE, DOUBLE));
   }
 

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/MathematicalFunctionTest.java
@@ -1571,6 +1571,56 @@ public class MathematicalFunctionTest extends ExpressionTestBase {
   }
 
   /**
+   * Test pow/power with null output.
+   */
+  @Test
+  public void pow_null_output() {
+    FunctionExpression pow = DSL.pow(DSL.literal((double) -2), DSL.literal(1.5));
+    assertEquals(pow.type(), DOUBLE);
+    assertEquals(String.format("pow(%s, %s)", (double) -2, 1.5), pow.toString());
+    assertTrue(pow.valueOf(valueEnv()).isNull());
+
+    pow = DSL.pow(DSL.literal((float) -2), DSL.literal((float) 1.5));
+    assertEquals(pow.type(), DOUBLE);
+    assertEquals(String.format("pow(%s, %s)", (float) -2, (float) 1.5), pow.toString());
+    assertTrue(pow.valueOf(valueEnv()).isNull());
+  }
+
+  /**
+   * Test pow/power with edge cases.
+   */
+  @Test
+  public void pow_edge_cases() {
+    FunctionExpression pow = DSL.pow(DSL.literal((double) -2), DSL.literal((double) 2));
+    assertEquals(pow.type(), DOUBLE);
+    assertEquals(String.format("pow(%s, %s)",(double) -2, (double) 2), pow.toString());
+    assertThat(
+            pow.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.pow(-2, 2))));
+
+    pow = DSL.pow(DSL.literal((double) 2), DSL.literal((double) 1.5));
+    assertEquals(pow.type(), DOUBLE);
+    assertEquals(String.format("pow(%s, %s)", (double) 2, (double) 1.5), pow.toString());
+    assertThat(
+            pow.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.pow(2, 1.5))));
+
+    pow = DSL.pow(DSL.literal((float) -2), DSL.literal((float) 2));
+    assertEquals(pow.type(), DOUBLE);
+    assertEquals(String.format("pow(%s, %s)", (float) -2, (float) 2), pow.toString());
+    assertThat(
+            pow.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.pow((float) -2, (float) 2))));
+
+    pow = DSL.pow(DSL.literal((float) 2), DSL.literal((float) 1.5));
+    assertEquals(pow.type(), DOUBLE);
+    assertEquals(String.format("pow(%s, %s)", (float) 2, (float) 1.5), pow.toString());
+    assertThat(
+            pow.valueOf(valueEnv()),
+            allOf(hasType(DOUBLE), hasValue(Math.pow((float) 2, (float) 1.5))));
+  }
+
+  /**
    * Test rint with byte value.
    */
   @ParameterizedTest(name = "rint({0})")

--- a/integ-test/src/test/java/org/opensearch/sql/sql/MathematicalFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/MathematicalFunctionIT.java
@@ -114,6 +114,68 @@ public class MathematicalFunctionIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testPow() throws IOException {
+    JSONObject result = executeQuery("select pow(3, 2)");
+    verifySchema(result, schema("pow(3, 2)", null, "double"));
+    verifyDataRows(result, rows(9.0));
+
+    result = executeQuery("select pow(0, 2)");
+    verifySchema(result, schema("pow(0, 2)", null, "double"));
+    verifyDataRows(result, rows(0.0));
+
+    result = executeQuery("select pow(3, 0)");
+    verifySchema(result, schema("pow(3, 0)", null, "double"));
+    verifyDataRows(result, rows(1.0));
+
+    result = executeQuery("select pow(-2, 3)");
+    verifySchema(result, schema("pow(-2, 3)", null, "double"));
+    verifyDataRows(result, rows(-8.0));
+
+    result = executeQuery("select pow(2, -2)");
+    verifySchema(result, schema("pow(2, -2)", null, "double"));
+    verifyDataRows(result, rows(0.25));
+
+    result = executeQuery("select pow(-2, -3)");
+    verifySchema(result, schema("pow(-2, -3)", null, "double"));
+    verifyDataRows(result, rows(-0.125));
+
+    result = executeQuery("select pow(-1, 0.5)");
+    verifySchema(result, schema("pow(-1, 0.5)", null, "double"));
+    verifyDataRows(result, rows((Object) null));
+  }
+
+  @Test
+  public void testPower() throws IOException {
+    JSONObject result = executeQuery("select power(3, 2)");
+    verifySchema(result, schema("power(3, 2)", null, "double"));
+    verifyDataRows(result, rows(9.0));
+
+    result = executeQuery("select power(0, 2)");
+    verifySchema(result, schema("power(0, 2)", null, "double"));
+    verifyDataRows(result, rows(0.0));
+
+    result = executeQuery("select power(3, 0)");
+    verifySchema(result, schema("power(3, 0)", null, "double"));
+    verifyDataRows(result, rows(1.0));
+
+    result = executeQuery("select power(-2, 3)");
+    verifySchema(result, schema("power(-2, 3)", null, "double"));
+    verifyDataRows(result, rows(-8.0));
+
+    result = executeQuery("select power(2, -2)");
+    verifySchema(result, schema("power(2, -2)", null, "double"));
+    verifyDataRows(result, rows(0.25));
+
+    result = executeQuery("select power(2, -2)");
+    verifySchema(result, schema("power(2, -2)", null, "double"));
+    verifyDataRows(result, rows(0.25));
+
+    result = executeQuery("select power(-2, -3)");
+    verifySchema(result, schema("power(-2, -3)", null, "double"));
+    verifyDataRows(result, rows(-0.125));
+  }
+
+  @Test
   public void testRint() throws IOException {
     JSONObject result = executeQuery("select rint(56.78)");
     verifySchema(result, schema("rint(56.78)", null, "double"));


### PR DESCRIPTION
### Description
Changed implementation of pow and power such that when an invalid response would be returned from having a negative base and a floating point exponent it returns null instead of crashing.

In addition I also added integration testing which was previously missing.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1190
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).