### PR TITLE
Add JSON Support to V2 Engine (#217)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/JsonSupportVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/JsonSupportVisitor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.analysis;
+
+import org.apache.commons.lang3.StringUtils;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.Cast;
+import org.opensearch.sql.ast.expression.Function;
+import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.tree.Aggregation;
+import org.opensearch.sql.ast.tree.Project;
+
+/**
+ * This visitor's sole purpose is to throw UnsupportedOperationExceptions
+ * for unsupported features in the new engine when JSON format is specified.
+ * Unsupported features in V2 are ones the produce results that differ from
+ * legacy results.
+ */
+public class JsonSupportVisitor extends AbstractNodeVisitor<Void, JsonSupportVisitorContext> {
+  @Override
+  public Void visit(Node node, JsonSupportVisitorContext context) {
+    visitChildren(node, context);
+    return null;
+  }
+
+  @Override
+  public Void visitChildren(Node node, JsonSupportVisitorContext context) {
+    for (Node child : node.getChild()) {
+      child.accept(this, context);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitAggregation(Aggregation node, JsonSupportVisitorContext context) {
+    if (!node.getGroupExprList().isEmpty()) {
+      throw new UnsupportedOperationException(
+          "Queries with aggregation are not yet supported with json format in the new engine");
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitFunction(Function node, JsonSupportVisitorContext context) {
+    // Supported if outside of Project
+    if (context.isVisitingProject()) {
+      // queries with function calls are not supported.
+      throw new UnsupportedOperationException(
+          "Queries with functions are not yet supported with json format in the new engine");
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitLiteral(Literal node, JsonSupportVisitorContext context) {
+    // Supported if outside of Project
+    if (context.isVisitingProject()) {
+      // queries with literal values are not supported
+      throw new UnsupportedOperationException(
+          "Queries with literals are not yet supported with json format in the new engine");
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitCast(Cast node, JsonSupportVisitorContext context) {
+    // Supported if outside of Project
+    if (context.isVisitingProject()) {
+      // Queries with cast are not supported
+      throw new UnsupportedOperationException(
+          "Queries with casts are not yet supported with json format in the new engine");
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitAlias(Alias node, JsonSupportVisitorContext context) {
+    // Supported if outside of Project
+    if (context.isVisitingProject()) {
+      // Alias node is accepted if it does not have a user-defined alias
+      // and if the delegated expression is accepted.
+      if (StringUtils.isEmpty(node.getAlias())) {
+        node.getDelegated().accept(this, context);
+      } else {
+        throw new UnsupportedOperationException(
+            "Queries with aliases are not yet supported with json format in the new engine");
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitProject(Project node, JsonSupportVisitorContext context) {
+    visit(node, context);
+
+    context.setVisitingProject(true);
+    node.getProjectList().forEach(e -> e.accept(this, context));
+    context.setVisitingProject(false);
+    return null;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/analysis/JsonSupportVisitorContext.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/JsonSupportVisitorContext.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.analysis;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,4 +17,12 @@ public class JsonSupportVisitorContext {
   @Getter
   @Setter
   private boolean isVisitingProject = false;
+
+  @Getter
+  @Setter
+  private List<String> unsupportedNodes = new ArrayList<>();
+
+  public void addToUnsupportedNodes(String unsupportedNode) {
+    unsupportedNodes.add(unsupportedNode);
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/analysis/JsonSupportVisitorContext.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/JsonSupportVisitorContext.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.analysis;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The context used for JsonSupportVisitor.
+ */
+public class JsonSupportVisitorContext {
+  @Getter
+  @Setter
+  private boolean isVisitingProject = false;
+}

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -82,7 +82,7 @@ public abstract class AbstractNodeVisitor<T, C> {
     return result;
   }
 
-  private T defaultResult() {
+  protected T defaultResult() {
     return null;
   }
 

--- a/core/src/main/java/org/opensearch/sql/executor/ExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/ExecutionEngine.java
@@ -50,9 +50,23 @@ public interface ExecutionEngine {
    * Data class that encapsulates ExprValue.
    */
   @Data
+  @RequiredArgsConstructor
   class QueryResponse {
     private final Schema schema;
     private final List<ExprValue> results;
+    private final String rawResponse; // JSON response from the OpenSearch instance
+
+    /**
+     * Constructor for Query Response.
+     *
+     * @param schema  schema of the query
+     * @param results list of expressions
+     */
+    public QueryResponse(Schema schema, List<ExprValue> results) {
+      this.schema = schema;
+      this.results = results;
+      this.rawResponse = "";
+    }
   }
 
   @Data

--- a/core/src/main/java/org/opensearch/sql/planner/physical/PhysicalPlan.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/PhysicalPlan.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.planner.physical;
 
 import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.planner.PlanNode;
@@ -48,6 +49,6 @@ public abstract class PhysicalPlan implements PlanNode<PhysicalPlan>,
 
   public String getRawResponse() {
     return getChild().stream().map(PhysicalPlan::getRawResponse)
-        .filter(r -> r != null && !r.isEmpty()).findFirst().orElse("");
+        .filter(StringUtils::isNotEmpty).findFirst().orElse("");
   }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/PhysicalPlan.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/PhysicalPlan.java
@@ -45,4 +45,9 @@ public abstract class PhysicalPlan implements PlanNode<PhysicalPlan>,
     throw new IllegalStateException(String.format("[BUG] schema can been only applied to "
         + "ProjectOperator, instead of %s", toString()));
   }
+
+  public String getRawResponse() {
+    return getChild().stream().map(PhysicalPlan::getRawResponse)
+        .filter(r -> r != null && !r.isEmpty()).findFirst().orElse("");
+  }
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/JsonSupportVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/JsonSupportVisitorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ast.dsl.AstDSL;
+import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.ast.tree.UnresolvedPlan;
+
+class JsonSupportVisitorTest {
+  @Test
+  public void visitLiteralInProject() {
+    UnresolvedPlan project = AstDSL.project(
+        AstDSL.relation("table", "table"),
+        AstDSL.intLiteral(1));
+    assertThrows(UnsupportedOperationException.class,
+        () -> project.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitLiteralOutsideProject() {
+    Literal intLiteral = AstDSL.intLiteral(1);
+    assertNull(intLiteral.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitCastInProject() {
+    UnresolvedPlan project = AstDSL.project(
+        AstDSL.relation("table", "table"),
+        AstDSL.cast(AstDSL.intLiteral(1), AstDSL.stringLiteral("INT")));
+    assertThrows(UnsupportedOperationException.class,
+        () -> project.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitCastOutsideProject() {
+    UnresolvedExpression intCast = AstDSL.cast(
+        AstDSL.intLiteral(1),
+        AstDSL.stringLiteral("INT"));
+    assertNull(intCast.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitAliasInProject() {
+    UnresolvedPlan project = AstDSL.project(
+        AstDSL.relation("table", "table"),
+        AstDSL.alias("alias", AstDSL.intLiteral(1)));
+    assertThrows(UnsupportedOperationException.class,
+        () -> project.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitAliasInProjectWithUnsupportedDelegated() {
+    UnresolvedPlan project = AstDSL.project(
+        AstDSL.relation("table", "table"),
+        AstDSL.alias("alias", AstDSL.intLiteral(1), "alias"));
+    assertThrows(UnsupportedOperationException.class,
+        () -> project.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitAliasInProjectWithSupportedDelegated() {
+    UnresolvedPlan project = AstDSL.project(
+        AstDSL.relation("table", "table"),
+        AstDSL.alias("alias", AstDSL.field("field")));
+    assertNull(project.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitAliasOutsideProject() {
+    UnresolvedExpression alias = AstDSL.alias("alias", AstDSL.intLiteral(1));
+    assertNull(alias.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitFunctionInProject() {
+    UnresolvedPlan function = AstDSL.project(
+        AstDSL.relation("table", "table"),
+        AstDSL.function("abs", AstDSL.intLiteral(-1)));
+    assertThrows(UnsupportedOperationException.class,
+        () -> function.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitFunctionOutsideProject() {
+    UnresolvedExpression function = AstDSL.function("abs", AstDSL.intLiteral(-1));
+    assertNull(function.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitAggregationWithGroupExprList() {
+    UnresolvedPlan projectAggr = AstDSL.project(AstDSL.agg(
+        AstDSL.relation("table", "table"),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        ImmutableList.of(AstDSL.alias("alias", qualifiedName("integer_value"))),
+        Collections.emptyList()));
+    assertThrows(UnsupportedOperationException.class,
+        () -> projectAggr.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+
+  @Test
+  public void visitAggregationWithAggExprList() {
+    UnresolvedPlan aggregation = AstDSL.agg(
+        AstDSL.relation("table", "table"),
+        ImmutableList.of(
+            AstDSL.alias("AVG(alias)",
+                AstDSL.aggregate("AVG",
+                    qualifiedName("integer_value")))),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+    assertNull(aggregation.accept(new JsonSupportVisitor(), new JsonSupportVisitorContext()));
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTest.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.sql.planner.physical;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -49,5 +51,13 @@ class PhysicalPlanTest {
   void addSplitToChildByDefault() {
     testPlan.add(split);
     verify(child).add(split);
+  }
+
+  @Test
+  void testGetRawResponse() {
+    when(child.getRawResponse()).thenReturn("not empty", "", null);
+    assertEquals("not empty", testPlan.getRawResponse());
+    assertEquals("", testPlan.getRawResponse());
+    assertEquals("", testPlan.getRawResponse());
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/DateFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/DateFormatIT.java
@@ -75,7 +75,7 @@ public class DateFormatIT extends SQLIntegTestCase {
 
   // DATE_FORMAT with timezone argument is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
-  @Test(expected = SqlParseException.class)
+  @Test
   public void lessThanOrEqualTo() throws SqlParseException {
     assertThat(
         dateQuery(
@@ -99,7 +99,7 @@ public class DateFormatIT extends SQLIntegTestCase {
 
   // DATE_FORMAT with timezone argument is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
-  @Test(expected = SqlParseException.class)
+  @Test
   public void greaterThanOrEqualTo() throws SqlParseException {
     assertThat(
         dateQuery(
@@ -112,7 +112,7 @@ public class DateFormatIT extends SQLIntegTestCase {
 
   // DATE_FORMAT with timezone argument is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
-  @Test(expected = SqlParseException.class)
+  @Test
   public void and() throws SqlParseException {
     assertThat(
         dateQuery(SELECT_FROM +
@@ -137,7 +137,7 @@ public class DateFormatIT extends SQLIntegTestCase {
 
   // DATE_FORMAT with timezone argument is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
-  @Test(expected = SqlParseException.class)
+  @Test
   public void or() throws SqlParseException {
     assertThat(
         dateQuery(SELECT_FROM +
@@ -151,7 +151,7 @@ public class DateFormatIT extends SQLIntegTestCase {
 
   // DATE_FORMAT with timezone argument is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
-  @Test(expected = ResponseException.class)
+  @Test
   public void sortByDateFormat() throws IOException {
     // Sort by expression in descending order, but sort inside in ascending order, so we increase our confidence
     // that successful test isn't just random chance.

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/DateFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/DateFormatIT.java
@@ -28,6 +28,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.opensearch.client.ResponseException;
 import org.opensearch.sql.legacy.exception.SqlParseException;
 
 public class DateFormatIT extends SQLIntegTestCase {
@@ -50,7 +51,9 @@ public class DateFormatIT extends SQLIntegTestCase {
    * this ends up excluding some of the expected values causing the assertion to fail. LIMIT overrides this.
    */
 
-  @Test
+  // DATE_FORMAT with timezone argument is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
+  @Test(expected = SqlParseException.class)
   public void equalTo() throws SqlParseException {
     assertThat(
         dateQuery(
@@ -59,7 +62,9 @@ public class DateFormatIT extends SQLIntegTestCase {
     );
   }
 
-  @Test
+  // DATE_FORMAT with timezone argument is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
+  @Test(expected = SqlParseException.class)
   public void lessThan() throws SqlParseException {
     assertThat(
         dateQuery(
@@ -68,7 +73,9 @@ public class DateFormatIT extends SQLIntegTestCase {
     );
   }
 
-  @Test
+  // DATE_FORMAT with timezone argument is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
+  @Test(expected = SqlParseException.class)
   public void lessThanOrEqualTo() throws SqlParseException {
     assertThat(
         dateQuery(
@@ -79,7 +86,9 @@ public class DateFormatIT extends SQLIntegTestCase {
     );
   }
 
-  @Test
+  // DATE_FORMAT with timezone argument is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
+  @Test(expected = SqlParseException.class)
   public void greaterThan() throws SqlParseException {
     assertThat(
         dateQuery(
@@ -88,7 +97,9 @@ public class DateFormatIT extends SQLIntegTestCase {
     );
   }
 
-  @Test
+  // DATE_FORMAT with timezone argument is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
+  @Test(expected = SqlParseException.class)
   public void greaterThanOrEqualTo() throws SqlParseException {
     assertThat(
         dateQuery(
@@ -99,7 +110,9 @@ public class DateFormatIT extends SQLIntegTestCase {
     );
   }
 
-  @Test
+  // DATE_FORMAT with timezone argument is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
+  @Test(expected = SqlParseException.class)
   public void and() throws SqlParseException {
     assertThat(
         dateQuery(SELECT_FROM +
@@ -122,7 +135,9 @@ public class DateFormatIT extends SQLIntegTestCase {
     );
   }
 
-  @Test
+  // DATE_FORMAT with timezone argument is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
+  @Test(expected = SqlParseException.class)
   public void or() throws SqlParseException {
     assertThat(
         dateQuery(SELECT_FROM +
@@ -134,8 +149,9 @@ public class DateFormatIT extends SQLIntegTestCase {
     );
   }
 
-
-  @Test
+  // DATE_FORMAT with timezone argument is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1436
+  @Test(expected = ResponseException.class)
   public void sortByDateFormat() throws IOException {
     // Sort by expression in descending order, but sort inside in ascending order, so we increase our confidence
     // that successful test isn't just random chance.

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/QueryFunctionsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/QueryFunctionsIT.java
@@ -28,6 +28,7 @@ import org.hamcrest.Matcher;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.ResponseException;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
@@ -133,7 +134,9 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
     );
   }
 
-  @Test
+  // Specifying city.keyword is not supported in V2
+  // Rework on data types is in progress and tracked with https://github.com/opensearch-project/sql/pull/1314
+  @Test(expected = ResponseException.class)
   public void wildcardQuery() throws IOException {
     assertThat(
         query(

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/QueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/QueryIT.java
@@ -102,7 +102,9 @@ public class QueryIT extends SQLIntegTestCase {
     Assert.assertEquals(14, getTotalHits(response));
   }
 
-  @Test
+  // Duplicated column names like SELECT *, age is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/785
+  @Test(expected = ResponseException.class)
   public void selectAllWithFieldReturnsAll() throws IOException {
     JSONObject response = executeQuery(StringUtils.format(
         "SELECT *, age " +
@@ -114,7 +116,9 @@ public class QueryIT extends SQLIntegTestCase {
     checkSelectAllAndFieldResponseSize(response);
   }
 
-  @Test
+  // Duplicated column names like SELECT *, age is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/785
+  @Test(expected = ResponseException.class)
   public void selectAllWithFieldReverseOrder() throws IOException {
     JSONObject response = executeQuery(StringUtils.format(
         "SELECT *, age " +
@@ -126,7 +130,9 @@ public class QueryIT extends SQLIntegTestCase {
     checkSelectAllAndFieldResponseSize(response);
   }
 
-  @Test
+  // Duplicated column names like SELECT *, age is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/785
+  @Test(expected = ResponseException.class)
   public void selectAllWithMultipleFields() throws IOException {
     JSONObject response = executeQuery(StringUtils.format(
         "SELECT *, age, address " +
@@ -138,7 +144,9 @@ public class QueryIT extends SQLIntegTestCase {
     checkSelectAllAndFieldResponseSize(response);
   }
 
-  @Test
+  // Duplicated column names like SELECT *, age is not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/785
+  @Test(expected = ResponseException.class)
   public void selectAllWithFieldAndOrderBy() throws IOException {
     JSONObject response = executeQuery(StringUtils.format(
         "SELECT *, age " +
@@ -577,7 +585,7 @@ public class QueryIT extends SQLIntegTestCase {
   public void inTest() throws IOException {
     JSONObject response = executeQuery(
         String.format(Locale.ROOT, "SELECT age FROM %s WHERE age IN (20, 22) LIMIT 1000",
-            TestsConstants.TEST_INDEX_PHRASE));
+            TestsConstants.TEST_INDEX_PEOPLE));
 
     JSONArray hits = getHits(response);
     for (int i = 0; i < hits.length(); i++) {
@@ -725,7 +733,9 @@ public class QueryIT extends SQLIntegTestCase {
     }
   }
 
-  @Test
+  // Unsupported date format in V2
+  // Can be tracked through https://github.com/opensearch-project/sql/issues/856
+  @Test(expected = ResponseException.class)
   public void dateSearch() throws IOException {
     DateTimeFormatter formatter = DateTimeFormat.forPattern(TestsConstants.DATE_FORMAT);
     DateTime dateToCompare = new DateTime(2014, 8, 18, 0, 0, 0);
@@ -770,7 +780,9 @@ public class QueryIT extends SQLIntegTestCase {
     }
   }
 
-  @Test
+  // Unsupported date format in V2
+  // Can be tracked through https://github.com/opensearch-project/sql/issues/856
+  @Test(expected = ResponseException.class)
   public void dateBetweenSearch() throws IOException {
     DateTimeFormatter formatter = DateTimeFormat.forPattern(TestsConstants.DATE_FORMAT);
 
@@ -1270,7 +1282,9 @@ public class QueryIT extends SQLIntegTestCase {
     Assert.assertTrue(response.contains("PhD"));
   }
 
-  @Test
+  // Objects in IS NOT NULL not yet supported in V2
+  // Can be tracked with https://github.com/opensearch-project/sql/issues/1425
+  @Test(expected = ResponseException.class)
   public void notLikeTests() throws IOException {
     JSONObject response = executeQuery(
         String.format(Locale.ROOT, "SELECT name " +

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/QueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/QueryIT.java
@@ -104,7 +104,7 @@ public class QueryIT extends SQLIntegTestCase {
 
   // Duplicated column names like SELECT *, age is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/785
-  @Test(expected = ResponseException.class)
+  @Test
   public void selectAllWithFieldReturnsAll() throws IOException {
     JSONObject response = executeQuery(StringUtils.format(
         "SELECT *, age " +
@@ -118,7 +118,7 @@ public class QueryIT extends SQLIntegTestCase {
 
   // Duplicated column names like SELECT *, age is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/785
-  @Test(expected = ResponseException.class)
+  @Test
   public void selectAllWithFieldReverseOrder() throws IOException {
     JSONObject response = executeQuery(StringUtils.format(
         "SELECT *, age " +
@@ -132,7 +132,7 @@ public class QueryIT extends SQLIntegTestCase {
 
   // Duplicated column names like SELECT *, age is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/785
-  @Test(expected = ResponseException.class)
+  @Test
   public void selectAllWithMultipleFields() throws IOException {
     JSONObject response = executeQuery(StringUtils.format(
         "SELECT *, age, address " +
@@ -146,7 +146,7 @@ public class QueryIT extends SQLIntegTestCase {
 
   // Duplicated column names like SELECT *, age is not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/785
-  @Test(expected = ResponseException.class)
+  @Test
   public void selectAllWithFieldAndOrderBy() throws IOException {
     JSONObject response = executeQuery(StringUtils.format(
         "SELECT *, age " +
@@ -782,7 +782,7 @@ public class QueryIT extends SQLIntegTestCase {
 
   // Unsupported date format in V2
   // Can be tracked through https://github.com/opensearch-project/sql/issues/856
-  @Test(expected = ResponseException.class)
+  @Test
   public void dateBetweenSearch() throws IOException {
     DateTimeFormatter formatter = DateTimeFormat.forPattern(TestsConstants.DATE_FORMAT);
 
@@ -1284,7 +1284,7 @@ public class QueryIT extends SQLIntegTestCase {
 
   // Objects in IS NOT NULL not yet supported in V2
   // Can be tracked with https://github.com/opensearch-project/sql/issues/1425
-  @Test(expected = ResponseException.class)
+  @Test
   public void notLikeTests() throws IOException {
     JSONObject response = executeQuery(
         String.format(Locale.ROOT, "SELECT name " +

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
@@ -49,7 +49,8 @@ public class OpenSearchExecutionEngine implements ExecutionEngine {
               result.add(plan.next());
             }
 
-            QueryResponse response = new QueryResponse(physicalPlan.schema(), result);
+            String rawResponse = physicalPlan.getRawResponse();
+            QueryResponse response = new QueryResponse(physicalPlan.schema(), result, rawResponse);
             listener.onResponse(response);
           } catch (Exception e) {
             listener.onFailure(e);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.ToString;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.search.SearchHits;
@@ -43,6 +44,9 @@ public class OpenSearchResponse implements Iterable<ExprValue> {
    */
   @EqualsAndHashCode.Exclude
   private final OpenSearchExprValueFactory exprValueFactory;
+  @EqualsAndHashCode.Exclude
+  @Getter
+  private String rawResponse;
 
   /**
    * Constructor of ElasticsearchResponse.
@@ -52,6 +56,7 @@ public class OpenSearchResponse implements Iterable<ExprValue> {
     this.hits = searchResponse.getHits();
     this.aggregations = searchResponse.getAggregations();
     this.exprValueFactory = exprValueFactory;
+    this.rawResponse = searchResponse.toString();
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndexScan.java
@@ -52,6 +52,9 @@ public class OpenSearchIndexScan extends TableScanOperator {
   /** Search response for current batch. */
   private Iterator<ExprValue> iterator;
 
+  @Getter
+  private String rawResponse;
+
   /**
    * Constructor.
    */
@@ -80,7 +83,7 @@ public class OpenSearchIndexScan extends TableScanOperator {
     request = requestBuilder.build();
     iterator = Collections.emptyIterator();
     queryCount = 0;
-    fetchNextBatch();
+    rawResponse = fetchNextBatch().getRawResponse();
   }
 
   @Override
@@ -99,11 +102,12 @@ public class OpenSearchIndexScan extends TableScanOperator {
     return iterator.next();
   }
 
-  private void fetchNextBatch() {
+  protected OpenSearchResponse fetchNextBatch() {
     OpenSearchResponse response = client.search(request);
     if (!response.isEmpty()) {
       iterator = response.iterator();
     }
+    return response;
   }
 
   @Override

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Format {
   JDBC("jdbc"),
+  JSON("json"),
   CSV("csv"),
   RAW("raw"),
   VIZ("viz");

--- a/sql/src/main/java/org/opensearch/sql/sql/SQLService.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/SQLService.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.sql;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.opensearch.sql.analysis.JsonSupportVisitor;
@@ -87,7 +88,13 @@ public class SQLService {
 
       // Go through the tree and throw exceptions when unsupported
       JsonSupportVisitorContext jsonSupportVisitorContext = new JsonSupportVisitorContext();
-      ((Query) statement).getPlan().accept(new JsonSupportVisitor(), jsonSupportVisitorContext);
+      if (!((Query) statement).getPlan().accept(new JsonSupportVisitor(),
+          jsonSupportVisitorContext)) {
+        throw new UnsupportedOperationException(
+            "The following features are not supported with JSON format: "
+                .concat(jsonSupportVisitorContext.getUnsupportedNodes().stream()
+                .collect(Collectors.joining(", "))));
+      }
     }
 
     return queryExecutionFactory.create(statement, queryListener, explainListener);

--- a/sql/src/main/java/org/opensearch/sql/sql/antlr/SQLSyntaxParser.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/antlr/SQLSyntaxParser.java
@@ -32,4 +32,15 @@ public class SQLSyntaxParser implements Parser {
     return parser.root();
   }
 
+  /**
+   * Checks if the query contains hints as it is not yet support in V2.
+   * @param query   a SQL query
+   * @return        boolean value if query contains hints
+   */
+  public ParseTree parseHints(String query) {
+    OpenSearchSQLLexer lexer = new OpenSearchSQLLexer(new CaseInsensitiveCharStream(query));
+    OpenSearchSQLParser hintsParser = new OpenSearchSQLParser(
+        new CommonTokenStream(lexer, OpenSearchSQLLexer.SQLCOMMENT));
+    return hintsParser.root();
+  }
 }

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.sql.domain;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
@@ -33,6 +34,7 @@ public class SQLQueryRequest {
       "query", "fetch_size", "parameters");
   private static final String QUERY_PARAMS_FORMAT = "format";
   private static final String QUERY_PARAMS_SANITIZE = "sanitize";
+  private static final String[] SUPPORTED_FORMATS = {"jdbc", "csv", "raw", "json"};
 
   /**
    * JSON payload in REST request.
@@ -121,8 +123,8 @@ public class SQLQueryRequest {
   }
 
   private boolean isSupportedFormat() {
-    return Strings.isNullOrEmpty(format) || "jdbc".equalsIgnoreCase(format)
-        || "csv".equalsIgnoreCase(format) || "raw".equalsIgnoreCase(format);
+    return Strings.isNullOrEmpty(format)
+        || Arrays.stream(SUPPORTED_FORMATS).anyMatch(format::equalsIgnoreCase);
   }
 
   private String getFormat(Map<String, String> params) {

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -291,7 +291,7 @@ class SQLSyntaxParserTest {
     assertNotNull(parser.parse("SELECT dayofmonth('2022-11-18')"));
     assertNotNull(parser.parse("SELECT day_of_month('2022-11-18')"));
   }
-    
+
   @Test
   public void can_parse_day_of_week_functions() {
     assertNotNull(parser.parse("SELECT dayofweek('2022-11-18')"));
@@ -718,6 +718,12 @@ class SQLSyntaxParserTest {
     assertNotNull(parser.parse("SELECT * FROM test WHERE Field = multi_match(\"query\")"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE Field = multimatch('query')"));
     assertNotNull(parser.parse("SELECT * FROM test WHERE Field = multimatch(\"query\")"));
+  }
+
+  @Test
+  public void canParseHints() {
+    assertNotNull(parser.parseHints("SELECT /*! HINTS */ field FROM test"));
+    assertNotNull(parser.parseHints("SELECT field FROM test"));
   }
 
   private static Stream<String> matchPhraseQueryComplexQueries() {

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -142,6 +142,15 @@ public class SQLQueryRequestTest {
     assertTrue(csvRequest.isSupported());
   }
 
+  @Test
+  public void shouldSupportJsonFormat() {
+    SQLQueryRequest jsonRequest =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .format("json")
+            .build();
+    assertTrue(jsonRequest.isSupported());
+  }
+
   /**
    * SQL query request build helper to improve test data setup readability.
    */


### PR DESCRIPTION
### Description
Phase 1 of adding JSON Support to V2 Engine
For example: The following request was handled by V2 engine: 
```
curl --location 'http://localhost:9200/_plugins/_sql?format=json' --header 'Content-Type: application/json' --data '{ 
    "query": "SELECT * FROM calcs LIMIT 1;"
}'
{
    "took": 13,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 17,
            "relation": "eq"
        },
        "max_score": 1.0,
        "hits": [
            {
                "_index": "calcs",
                "_id": "1",
                "_score": 1.0,
                "_source": {
                    "int0": 1,
                    "bool3": true,
                    "time1": "19:36:22",
                    "bool2": false,
                    "int2": 5,
                    "int1": -3,
                    "str3": "e",
                    "int3": 8,
                    "str1": "CLAMP ON LAMPS",
                    "str2": "one",
                    "time0": "1899-12-30T21:07:32Z",
                    "num1": 8.42,
                    "datetime0": "2004-07-09T10:17:35Z",
                    "num0": 12.3,
                    "datetime1": null,
                    "num4": null,
                    "key": "key00",
                    "num3": -11.52,
                    "bool1": true,
                    "num2": 17.86,
                    "bool0": true,
                    "str0": "FURNITURE",
                    "date3": "1986-03-20",
                    "date2": "1977-04-20",
                    "date1": "2004-04-01",
                    "date0": "2004-04-15",
                    "zzz": "a"
                }
            }
        ]
    }
}
```
 
Returning the raw response from OpenSearch made IT tests fail due to missing in-memory operations, difference in aggregation type (V2 is composite_bucket), and some bugs were discovered. The solution for these failing IT tests were to fall back to legacy for all functions, expect failures for IT tests with a comment for issues related.

**List of expected failures in legacy IT**:

- DateFormatIT.and [(1436)](https://github.com/opensearch-project/sql/issues/1436)

- DateFormatIT.equalTo [(1436)](https://github.com/opensearch-project/sql/issues/1436)

- DateFormatIT.greaterThan [(1436)](https://github.com/opensearch-project/sql/issues/1436) 

- DateFormatIT.greaterThanOrEqualTo [(1436)](https://github.com/opensearch-project/sql/issues/1436)

- DateFormatIT.lessThan [(1436)](https://github.com/opensearch-project/sql/issues/1436)

- DateFormatIT.lessThanOrEqualTo [(1436)](https://github.com/opensearch-project/sql/issues/1436)

- DateFormatIT.or [(1436)](https://github.com/opensearch-project/sql/issues/1436)
- DateFormatIT.sortByDateFormat [(1436)](https://github.com/opensearch-project/sql/issues/1436)
- QueryFunctionsIT.wildcardQuery (Dependent on [PR #1314](https://github.com/opensearch-project/sql/pull/1314))
- QueryIT.selectAllWithFieldAndOrderBy [(785)](https://github.com/opensearch-project/sql/issues/785) 

- QueryIT.selectAllWithFieldReturnsAll [(785)](https://github.com/opensearch-project/sql/issues/785) 

- QueryIT.selectAllWithFieldReverseOrder [(785)](https://github.com/opensearch-project/sql/issues/785)

- QueryIT.selectAllWithMultipleFields [(785)](https://github.com/opensearch-project/sql/issues/785) 

- QueryIT.notLikeTests [(1425)](https://github.com/opensearch-project/sql/issues/1425) 


### Proposal for phase 2 of JSON support for V2
https://github.com/opensearch-project/sql/issues/1450

### Issues Resolved
https://github.com/opensearch-project/sql/issues/1317
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).