### PR TITLE
REST API for GET,PUT and DELETE

### DIFF
--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceLoaderCache.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceLoaderCache.java
@@ -1,0 +1,20 @@
+package org.opensearch.sql.datasource;
+
+import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+
+/**
+ * Interface for DataSourceLoaderCache which provides methods for
+ * fetch, loading and invalidating DataSource cache.
+ */
+public interface DataSourceLoaderCache {
+
+  /**
+   * Returns cached datasource object or loads a new one if not present.
+   *
+   * @param dataSourceMetadata {@link DataSourceMetadata}.
+   * @return {@link DataSource}
+   */
+  DataSource getOrLoadDataSource(DataSourceMetadata dataSourceMetadata);
+
+}

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceLoaderCacheImpl.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceLoaderCacheImpl.java
@@ -1,0 +1,50 @@
+package org.opensearch.sql.datasource;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.datasource.model.DataSourceType;
+import org.opensearch.sql.storage.DataSourceFactory;
+
+/**
+ * Default implementation of DataSourceLoaderCache. This implementation
+ * utilizes Google Guava Cache {@link Cache} for caching DataSource objects
+ * against {@link DataSourceMetadata}. Expires the cache objects every 24 hrs after
+ * the last access.
+ */
+public class DataSourceLoaderCacheImpl implements DataSourceLoaderCache {
+  private final Map<DataSourceType, DataSourceFactory> dataSourceFactoryMap;
+  private final Cache<DataSourceMetadata, DataSource> dataSourceCache;
+
+  /**
+   * DataSourceLoaderCacheImpl constructor.
+   *
+   * @param dataSourceFactorySet set of {@link DataSourceFactory}.
+   */
+  public DataSourceLoaderCacheImpl(Set<DataSourceFactory> dataSourceFactorySet) {
+    this.dataSourceFactoryMap = dataSourceFactorySet.stream()
+        .collect(Collectors.toMap(DataSourceFactory::getDataSourceType, f -> f));
+    this.dataSourceCache = CacheBuilder.newBuilder()
+        .maximumSize(1000)
+        .expireAfterAccess(24, TimeUnit.HOURS)
+        .build();
+  }
+
+  @Override
+  public DataSource getOrLoadDataSource(DataSourceMetadata dataSourceMetadata) {
+    DataSource dataSource = this.dataSourceCache.getIfPresent(dataSourceMetadata);
+    if (dataSource == null) {
+      dataSource = this.dataSourceFactoryMap.get(dataSourceMetadata.getConnector())
+          .createDataSource(dataSourceMetadata);
+      this.dataSourceCache.put(dataSourceMetadata, dataSource);
+      return dataSource;
+    }
+    return dataSource;
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
@@ -27,9 +27,21 @@ public interface DataSourceService {
    * Returns all dataSource Metadata objects. The returned objects won't contain
    * any of the credential info.
    *
+   * @param isDefaultDataSourceRequired is used to specify
+   *      if default opensearch connector is required in the output list.
    * @return set of {@link DataSourceMetadata}.
    */
-  Set<DataSourceMetadata> getDataSourceMetadataSet();
+  Set<DataSourceMetadata> getDataSourceMetadata(boolean isDefaultDataSourceRequired);
+
+
+  /**
+   * Returns dataSourceMetadata object with specific name.
+   * The returned objects won't contain any crendetial info.
+   *
+   * @param name name of the {@link DataSource}.
+   * @return set of {@link DataSourceMetadata}.
+   */
+  DataSourceMetadata getDataSourceMetadata(String name);
 
   /**
    * Register {@link DataSource} defined by {@link DataSourceMetadata}.

--- a/core/src/main/java/org/opensearch/sql/datasource/exceptions/DataSourceNotFoundException.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/exceptions/DataSourceNotFoundException.java
@@ -1,0 +1,18 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.datasource.exceptions;
+
+/**
+ * DataSourceNotFoundException.
+ */
+public class DataSourceNotFoundException extends RuntimeException {
+  public DataSourceNotFoundException(String message) {
+    super(message);
+  }
+
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScan.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScan.java
@@ -48,7 +48,7 @@ public class DataSourceTableScan extends TableScanOperator {
   public void open() {
     List<ExprValue> exprValues = new ArrayList<>();
     Set<DataSourceMetadata> dataSourceMetadataSet
-        = dataSourceService.getDataSourceMetadataSet();
+        = dataSourceService.getDataSourceMetadata(true);
     for (DataSourceMetadata dataSourceMetadata : dataSourceMetadataSet) {
       exprValues.add(
           new ExprTupleValue(new LinkedHashMap<>(ImmutableMap.of(

--- a/core/src/main/java/org/opensearch/sql/storage/DataSourceFactory.java
+++ b/core/src/main/java/org/opensearch/sql/storage/DataSourceFactory.java
@@ -7,6 +7,7 @@
 
 package org.opensearch.sql.storage;
 
+import java.util.Map;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSource;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
@@ -28,4 +29,5 @@ public interface DataSourceFactory {
    * Create {@link DataSource}.
    */
   DataSource createDataSource(DataSourceMetadata metadata);
+
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -185,11 +185,16 @@ public class AnalyzerTestBase {
 
 
     @Override
-    public Set<DataSourceMetadata> getDataSourceMetadataSet() {
+    public Set<DataSourceMetadata> getDataSourceMetadata(boolean isDefaultDataSourceRequired) {
       return Stream.of(opensearchDataSource, prometheusDataSource)
           .map(ds -> new DataSourceMetadata(ds.getName(),
               ds.getConnectorType(),Collections.emptyList(),
               ImmutableMap.of())).collect(Collectors.toSet());
+    }
+
+    @Override
+    public DataSourceMetadata getDataSourceMetadata(String name) {
+      return null;
     }
 
     @Override

--- a/core/src/test/java/org/opensearch/sql/datasource/DataSourceLoaderCacheImplTest.java
+++ b/core/src/test/java/org/opensearch/sql/datasource/DataSourceLoaderCacheImplTest.java
@@ -1,0 +1,85 @@
+package org.opensearch.sql.datasource;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.datasource.model.DataSourceType;
+import org.opensearch.sql.storage.DataSourceFactory;
+import org.opensearch.sql.storage.StorageEngine;
+
+@ExtendWith(MockitoExtension.class)
+class DataSourceLoaderCacheImplTest {
+
+  @Mock
+  private DataSourceFactory dataSourceFactory;
+
+  @Mock
+  private StorageEngine storageEngine;
+
+  @BeforeEach
+  public void setup() {
+    lenient()
+        .doAnswer(
+            invocation -> {
+              DataSourceMetadata metadata = invocation.getArgument(0);
+              return new DataSource(metadata.getName(), metadata.getConnector(), storageEngine);
+            })
+        .when(dataSourceFactory)
+        .createDataSource(any());
+    when(dataSourceFactory.getDataSourceType()).thenReturn(DataSourceType.OPENSEARCH);
+  }
+
+  @Test
+  void testGetOrLoadDataSource() {
+    DataSourceLoaderCache dataSourceLoaderCache =
+        new DataSourceLoaderCacheImpl(Collections.singleton(dataSourceFactory));
+    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
+    dataSourceMetadata.setName("testDS");
+    dataSourceMetadata.setConnector(DataSourceType.OPENSEARCH);
+    dataSourceMetadata.setAllowedRoles(Collections.emptyList());
+    dataSourceMetadata.setProperties(ImmutableMap.of());
+    DataSource dataSource = dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
+    verify(dataSourceFactory, times(1)).createDataSource(dataSourceMetadata);
+    Assertions.assertEquals(dataSource,
+        dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata));
+    verifyNoMoreInteractions(dataSourceFactory);
+  }
+
+  @Test
+  void testGetOrLoadDataSourceWithMetadataUpdate() {
+    DataSourceLoaderCache dataSourceLoaderCache =
+        new DataSourceLoaderCacheImpl(Collections.singleton(dataSourceFactory));
+    DataSourceMetadata dataSourceMetadata = getMetadata();
+    dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
+    dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
+    dataSourceMetadata.setAllowedRoles(List.of("testDS_access"));
+    dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
+    dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
+    verify(dataSourceFactory, times(2)).createDataSource(dataSourceMetadata);
+  }
+
+  private DataSourceMetadata getMetadata() {
+    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
+    dataSourceMetadata.setName("testDS");
+    dataSourceMetadata.setConnector(DataSourceType.OPENSEARCH);
+    dataSourceMetadata.setAllowedRoles(Collections.emptyList());
+    dataSourceMetadata.setProperties(ImmutableMap.of());
+    return dataSourceMetadata;
+  }
+
+}

--- a/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScanTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScanTest.java
@@ -62,7 +62,7 @@ public class DataSourceTableScanTest {
         .map(dataSource -> new DataSourceMetadata(dataSource.getName(),
         dataSource.getConnectorType(), Collections.emptyList(), ImmutableMap.of()))
         .collect(Collectors.toSet());
-    when(dataSourceService.getDataSourceMetadataSet()).thenReturn(dataSourceMetadata);
+    when(dataSourceService.getDataSourceMetadata(true)).thenReturn(dataSourceMetadata);
 
     assertFalse(dataSourceTableScan.hasNext());
     dataSourceTableScan.open();

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -1,49 +1,192 @@
-package org.opensearch.sql.datasource;/*
+/*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 
+package org.opensearch.sql.datasource;
 
+import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
-import java.io.IOException;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class DataSourceAPIsIT extends PPLIntegTestCase {
 
+  @SneakyThrows
   @Test
-  public void createDataSourceTest() throws IOException {
-    Request request = getCreateDataSourceRequest(getDataSourceMetadataJsonString());
-    String response = executeRequest(request);
-    Assert.assertEquals("Created DataSource with name prometheus1", response);
+  public void createDataSourceAPITest() {
+    //create datasource
+    DataSourceMetadata createDSM =
+        new DataSourceMetadata("create_prometheus", DataSourceType.PROMETHEUS,
+            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "https://localhost:9090"));
+    Request createRequest = getCreateDataSourceRequest(createDSM);
+    Response response = client().performRequest(createRequest);
+    Assert.assertEquals(201, response.getStatusLine().getStatusCode());
+    String createResponseString = getResponseBody(response);
+    Assert.assertEquals("Created DataSource with name create_prometheus", createResponseString);
+    //Datasource is not immediately created. so introducing a sleep of 2s.
+    Thread.sleep(2000);
+
+    //get datasource to validate the creation.
+    Request getRequest = getFetchDataSourceRequest("create_prometheus");
+    Response getResponse = client().performRequest(getRequest);
+    Assert.assertEquals(200, getResponse.getStatusLine().getStatusCode());
+    String getResponseString = getResponseBody(getResponse);
+    DataSourceMetadata dataSourceMetadata =
+        new Gson().fromJson(getResponseString, DataSourceMetadata.class);
+    Assert.assertEquals("https://localhost:9090",
+        dataSourceMetadata.getProperties().get("prometheus.uri"));
   }
 
-  private Request getCreateDataSourceRequest(String dataSourceMetadataJson) {
+
+  @SneakyThrows
+  @Test
+  public void updateDataSourceAPITest() {
+    //create datasource
+    DataSourceMetadata createDSM =
+        new DataSourceMetadata("update_prometheus", DataSourceType.PROMETHEUS,
+            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "https://localhost:9090"));
+    Request createRequest = getCreateDataSourceRequest(createDSM);
+    client().performRequest(createRequest);
+    //Datasource is not immediately created. so introducing a sleep of 2s.
+    Thread.sleep(2000);
+
+    //update datasource
+    DataSourceMetadata updateDSM =
+        new DataSourceMetadata("update_prometheus", DataSourceType.PROMETHEUS,
+            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "https://randomtest:9090"));
+    Request updateRequest = getUpdateDataSourceRequest(updateDSM);
+    Response updateResponse = client().performRequest(updateRequest);
+    Assert.assertEquals(200, updateResponse.getStatusLine().getStatusCode());
+    String updateResponseString = getResponseBody(updateResponse);
+    Assert.assertEquals("Updated DataSource with name update_prometheus", updateResponseString);
+
+    //Datasource is not immediately updated. so introducing a sleep of 2s.
+    Thread.sleep(2000);
+
+    //get datasource to validate the modification.
+    //get datasource
+    Request getRequest = getFetchDataSourceRequest("update_prometheus");
+    Response getResponse = client().performRequest(getRequest);
+    Assert.assertEquals(200, getResponse.getStatusLine().getStatusCode());
+    String getResponseString = getResponseBody(getResponse);
+    DataSourceMetadata dataSourceMetadata =
+        new Gson().fromJson(getResponseString, DataSourceMetadata.class);
+    Assert.assertEquals("https://randomtest:9090",
+        dataSourceMetadata.getProperties().get("prometheus.uri"));
+  }
+
+
+  @SneakyThrows
+  @Test
+  public void deleteDataSourceTest() {
+
+    //create datasource for deletion
+    DataSourceMetadata createDSM =
+        new DataSourceMetadata("delete_prometheus", DataSourceType.PROMETHEUS,
+            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "https://localhost:9090"));
+    Request createRequest = getCreateDataSourceRequest(createDSM);
+    client().performRequest(createRequest);
+    //Datasource is not immediately created. so introducing a sleep of 2s.
+    Thread.sleep(2000);
+
+    //delete datasource
+    Request deleteRequest = getDeleteDataSourceRequest("delete_prometheus");
+    Response deleteResponse = client().performRequest(deleteRequest);
+    Assert.assertEquals(204, deleteResponse.getStatusLine().getStatusCode());
+
+    //Datasource is not immediately deleted. so introducing a sleep of 2s.
+    Thread.sleep(2000);
+
+    //get datasources to verify the deletion
+    final Request prometheusGetRequest = getFetchDataSourceRequest("delete_prometheus");
+    ResponseException prometheusGetResponseException
+        = Assert.assertThrows(ResponseException.class, () -> client().performRequest(prometheusGetRequest));
+    Assert.assertEquals( 400, prometheusGetResponseException.getResponse().getStatusLine().getStatusCode());
+    String prometheusGetResponseString = getResponseBody(prometheusGetResponseException.getResponse());
+    JsonObject errorMessage = new Gson().fromJson(prometheusGetResponseString, JsonObject.class);
+    Assert.assertEquals("DataSource with name: delete_prometheus doesn't exist.",
+        errorMessage.get("error").getAsJsonObject().get("details").getAsString());
+
+  }
+
+  @SneakyThrows
+  @Test
+  public void getAllDataSourceTest() {
+//create datasource for deletion
+    DataSourceMetadata createDSM =
+        new DataSourceMetadata("get_all_prometheus", DataSourceType.PROMETHEUS,
+            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "https://localhost:9090"));
+    Request createRequest = getCreateDataSourceRequest(createDSM);
+    client().performRequest(createRequest);
+    //Datasource is not immediately created. so introducing a sleep of 2s.
+    Thread.sleep(2000);
+
+    Request getRequest = getFetchDataSourceRequest(null);
+    Response getResponse = client().performRequest(getRequest);
+    Assert.assertEquals(200, getResponse.getStatusLine().getStatusCode());
+    String getResponseString = getResponseBody(getResponse);
+    Type listType = new TypeToken<ArrayList<DataSourceMetadata>>() {}.getType();
+    List<DataSourceMetadata> dataSourceMetadataList =
+        new Gson().fromJson(getResponseString, listType);
+    Assert.assertTrue(
+        dataSourceMetadataList.stream().anyMatch(ds -> ds.getName().equals("get_all_prometheus")));
+  }
+
+
+    private Request getCreateDataSourceRequest(DataSourceMetadata dataSourceMetadata) {
     Request request = new Request("POST", "/_plugins/_query/_datasources");
-    request.setJsonEntity(dataSourceMetadataJson);
+    request.setJsonEntity(new Gson().toJson(dataSourceMetadata));
     RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
     restOptionsBuilder.addHeader("Content-Type", "application/json");
     request.setOptions(restOptionsBuilder);
     return request;
   }
 
-  private String getDataSourceMetadataJsonString() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("prometheus1");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-    dataSourceMetadata.setAllowedRoles(new ArrayList<>());
-    Map<String, String> propertiesMap = new HashMap<>();
-    propertiesMap.put("prometheus.uri", "http://localhost:9200");
-    dataSourceMetadata.setProperties(propertiesMap);
-    return new Gson().toJson(dataSourceMetadata);
+  private Request getUpdateDataSourceRequest(DataSourceMetadata dataSourceMetadata) {
+    Request request = new Request("PUT", "/_plugins/_query/_datasources");
+    request.setJsonEntity(new Gson().toJson(dataSourceMetadata));
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    return request;
+  }
+
+  private Request getFetchDataSourceRequest(String name) {
+    Request request = new Request("GET", "/_plugins/_query/_datasources" + "/" + name);
+    if (StringUtils.isEmpty(name)) {
+      request = new Request("GET", "/_plugins/_query/_datasources");
+    }
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    return request;
+  }
+
+
+  private Request getDeleteDataSourceRequest(String name) {
+    Request request = new Request("DELETE", "/_plugins/_query/_datasources" + "/" + name);
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    return request;
   }
 
 }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/model/DeleteDataSourceActionRequest.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/model/DeleteDataSourceActionRequest.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.plugin.model;
+
+import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
+
+import java.io.IOException;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.StreamInput;
+
+public class DeleteDataSourceActionRequest extends ActionRequest {
+
+  @Getter
+  private String dataSourceName;
+
+  /** Constructor of DeleteDataSourceActionRequest from StreamInput. */
+  public DeleteDataSourceActionRequest(StreamInput in) throws IOException {
+    super(in);
+  }
+
+  public DeleteDataSourceActionRequest(String dataSourceName) {
+    this.dataSourceName = dataSourceName;
+  }
+
+  @Override
+  public ActionRequestValidationException validate() {
+    if (StringUtils.isEmpty(this.dataSourceName)) {
+      ActionRequestValidationException exception = new ActionRequestValidationException();
+      exception
+          .addValidationError("Datasource Name cannot be empty or null");
+      return exception;
+    } else if (this.dataSourceName.equals(DEFAULT_DATASOURCE_NAME)) {
+      ActionRequestValidationException exception = new ActionRequestValidationException();
+      exception
+          .addValidationError(
+              "Not allowed to delete datasource with name : " + DEFAULT_DATASOURCE_NAME);
+      return exception;
+    } else {
+      return null;
+    }
+  }
+
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/model/DeleteDataSourceActionResponse.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/model/DeleteDataSourceActionResponse.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.plugin.model;
+
+import java.io.IOException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+@RequiredArgsConstructor
+public class DeleteDataSourceActionResponse extends ActionResponse {
+
+  @Getter
+  private final String result;
+
+  public DeleteDataSourceActionResponse(StreamInput in) throws IOException {
+    super(in);
+    result = in.readString();
+  }
+
+  @Override
+  public void writeTo(StreamOutput streamOutput) throws IOException {
+    streamOutput.writeString(result);
+  }
+
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/model/GetDataSourceActionRequest.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/model/GetDataSourceActionRequest.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.plugin.model;
+
+import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
+
+import java.io.IOException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.StreamInput;
+
+@NoArgsConstructor
+public class GetDataSourceActionRequest extends ActionRequest {
+
+  @Getter
+  private String dataSourceName;
+
+  /**
+   * Constructor of GetDataSourceActionRequest from StreamInput.
+   */
+  public GetDataSourceActionRequest(StreamInput in) throws IOException {
+    super(in);
+  }
+
+  public GetDataSourceActionRequest(String dataSourceName) {
+    this.dataSourceName = dataSourceName;
+  }
+
+  @Override
+  public ActionRequestValidationException validate() {
+    if (this.dataSourceName != null && this.dataSourceName.equals(DEFAULT_DATASOURCE_NAME)) {
+      ActionRequestValidationException exception = new ActionRequestValidationException();
+      exception
+          .addValidationError(
+              "Not allowed to fetch datasource with name : " + DEFAULT_DATASOURCE_NAME);
+      return exception;
+    } else {
+      return null;
+    }
+  }
+
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/model/GetDataSourceActionResponse.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/model/GetDataSourceActionResponse.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.plugin.model;
+
+import java.io.IOException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+@RequiredArgsConstructor
+public class GetDataSourceActionResponse extends ActionResponse {
+
+  @Getter
+  private final String result;
+
+  public GetDataSourceActionResponse(StreamInput in) throws IOException {
+    super(in);
+    result = in.readString();
+  }
+
+  @Override
+  public void writeTo(StreamOutput streamOutput) throws IOException {
+    streamOutput.writeString(result);
+  }
+
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/model/UpdateDataSourceActionRequest.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/model/UpdateDataSourceActionRequest.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.plugin.model;
+
+
+import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
+
+import java.io.IOException;
+import lombok.Getter;
+import org.json.JSONObject;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
+
+public class UpdateDataSourceActionRequest
+    extends ActionRequest {
+
+  @Getter
+  private DataSourceMetadata dataSourceMetadata;
+
+  /** Constructor of UpdateDataSourceActionRequest from StreamInput. */
+  public UpdateDataSourceActionRequest(StreamInput in) throws IOException {
+    super(in);
+  }
+
+  public UpdateDataSourceActionRequest(DataSourceMetadata dataSourceMetadata) {
+    this.dataSourceMetadata = dataSourceMetadata;
+  }
+
+  @Override
+  public ActionRequestValidationException validate() {
+    if (this.dataSourceMetadata.getName().equals(DEFAULT_DATASOURCE_NAME)) {
+      ActionRequestValidationException exception = new ActionRequestValidationException();
+      exception
+          .addValidationError(
+              "Not allowed to update datasource with name : " + DEFAULT_DATASOURCE_NAME);
+      return exception;
+    } else {
+      return null;
+    }
+  }
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/model/UpdateDataSourceActionResponse.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/model/UpdateDataSourceActionResponse.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.plugin.model;
+
+import java.io.IOException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+@RequiredArgsConstructor
+public class UpdateDataSourceActionResponse
+    extends ActionResponse {
+
+  @Getter
+  private final String result;
+
+  public UpdateDataSourceActionResponse(StreamInput in) throws IOException {
+    super(in);
+    result = in.readString();
+  }
+
+  @Override
+  public void writeTo(StreamOutput streamOutput) throws IOException {
+    streamOutput.writeString(result);
+  }
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestDataSourceQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestDataSourceQueryAction.java
@@ -7,31 +7,45 @@
 
 package org.opensearch.sql.plugin.rest;
 
+import static org.opensearch.rest.RestRequest.Method.DELETE;
+import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.rest.RestRequest.Method.PUT;
 import static org.opensearch.rest.RestStatus.BAD_REQUEST;
+import static org.opensearch.rest.RestStatus.NOT_FOUND;
 import static org.opensearch.rest.RestStatus.SERVICE_UNAVAILABLE;
 import static org.opensearch.sql.plugin.utils.Scheduler.schedule;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
+import org.opensearch.sql.datasource.exceptions.DataSourceNotFoundException;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.legacy.metrics.MetricName;
 import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.opensearch.response.error.ErrorMessageFactory;
 import org.opensearch.sql.plugin.model.CreateDataSourceActionRequest;
 import org.opensearch.sql.plugin.model.CreateDataSourceActionResponse;
+import org.opensearch.sql.plugin.model.DeleteDataSourceActionRequest;
+import org.opensearch.sql.plugin.model.DeleteDataSourceActionResponse;
+import org.opensearch.sql.plugin.model.GetDataSourceActionRequest;
+import org.opensearch.sql.plugin.model.GetDataSourceActionResponse;
+import org.opensearch.sql.plugin.model.UpdateDataSourceActionRequest;
+import org.opensearch.sql.plugin.model.UpdateDataSourceActionResponse;
 import org.opensearch.sql.plugin.transport.datasource.TransportCreateDataSourceAction;
+import org.opensearch.sql.plugin.transport.datasource.TransportDeleteDataSourceAction;
+import org.opensearch.sql.plugin.transport.datasource.TransportGetDataSourceAction;
+import org.opensearch.sql.plugin.transport.datasource.TransportUpdateDataSourceAction;
 import org.opensearch.sql.plugin.utils.XContentParserUtils;
 
 public class RestDataSourceQueryAction extends BaseRestHandler {
@@ -59,7 +73,42 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
          * Response body:
          * Ref [org.opensearch.sql.plugin.transport.datasource.model.CreateDataSourceActionResponse]
          */
-        new Route(POST, BASE_DATASOURCE_ACTION_URL)
+        new Route(POST, BASE_DATASOURCE_ACTION_URL),
+
+        /*
+         * GET datasources
+         * Request URL: GET
+         * Request body:
+         * Ref [org.opensearch.sql.plugin.transport.datasource.model.GetDataSourceActionRequest]
+         * Response body:
+         * Ref [org.opensearch.sql.plugin.transport.datasource.model.GetDataSourceActionResponse]
+         */
+        new Route(GET, String.format(Locale.ROOT, "%s/{%s}",
+            BASE_DATASOURCE_ACTION_URL, "dataSourceName")),
+        new Route(GET, BASE_DATASOURCE_ACTION_URL),
+
+        /*
+         * GET datasources
+         * Request URL: GET
+         * Request body:
+         * Ref
+         * [org.opensearch.sql.plugin.transport.datasource.model.UpdateDataSourceActionRequest]
+         * Response body:
+         * Ref
+         * [org.opensearch.sql.plugin.transport.datasource.model.UpdateDataSourceActionResponse]
+         */
+        new Route(PUT, BASE_DATASOURCE_ACTION_URL),
+
+        /*
+         * GET datasources
+         * Request URL: GET
+         * Request body: Ref
+         * [org.opensearch.sql.plugin.transport.datasource.model.DeleteDataSourceActionRequest]
+         * Response body: Ref
+         * [org.opensearch.sql.plugin.transport.datasource.model.DeleteDataSourceActionResponse]
+         */
+        new Route(DELETE, String.format(Locale.ROOT, "%s/{%s}",
+            BASE_DATASOURCE_ACTION_URL, "dataSourceName"))
     );
   }
 
@@ -69,6 +118,12 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
     switch (restRequest.method()) {
       case POST:
         return executePostRequest(restRequest, nodeClient);
+      case GET:
+        return executeGetRequest(restRequest, nodeClient);
+      case PUT:
+        return executeUpdateRequest(restRequest, nodeClient);
+      case DELETE:
+        return executeDeleteRequest(restRequest, nodeClient);
       default:
         return restChannel
             -> restChannel.sendResponse(new BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED,
@@ -89,30 +144,101 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
               public void onResponse(
                   CreateDataSourceActionResponse createDataSourceActionResponse) {
                 restChannel.sendResponse(
-                    new BytesRestResponse(RestStatus.OK, "application/json; charset=UTF-8",
+                    new BytesRestResponse(RestStatus.CREATED, "application/json; charset=UTF-8",
                         createDataSourceActionResponse.getResult()));
               }
 
               @Override
               public void onFailure(Exception e) {
-                if (e instanceof IllegalAccessException) {
-                  reportError(restChannel, e, BAD_REQUEST);
-                } else {
-                  LOG.error("Error happened during query handling", e);
-                  if (isClientError(e)) {
-                    Metrics.getInstance()
-                        .getNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_CUS)
-                        .increment();
-                    reportError(restChannel, e, BAD_REQUEST);
-                  } else {
-                    Metrics.getInstance()
-                        .getNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_SYS)
-                        .increment();
-                    reportError(restChannel, e, SERVICE_UNAVAILABLE);
-                  }
-                }
+                handleException(e, restChannel);
               }
             }));
+  }
+
+  private RestChannelConsumer executeGetRequest(RestRequest restRequest,
+                                                NodeClient nodeClient) {
+    String dataSourceName = restRequest.param("dataSourceName");
+    return restChannel -> schedule(nodeClient,
+        () -> nodeClient.execute(TransportGetDataSourceAction.ACTION_TYPE,
+            new GetDataSourceActionRequest(dataSourceName),
+            new ActionListener<>() {
+              @Override
+              public void onResponse(GetDataSourceActionResponse getDataSourceActionResponse) {
+                restChannel.sendResponse(
+                    new BytesRestResponse(RestStatus.OK, "application/json; charset=UTF-8",
+                        getDataSourceActionResponse.getResult()));
+              }
+
+              @Override
+              public void onFailure(Exception e) {
+                handleException(e, restChannel);
+              }
+            }));
+  }
+
+  private RestChannelConsumer executeUpdateRequest(RestRequest restRequest,
+                                                   NodeClient nodeClient) throws IOException {
+    DataSourceMetadata dataSourceMetadata
+        = XContentParserUtils.toDataSourceMetadata(restRequest.contentParser());
+    return restChannel -> schedule(nodeClient,
+        () -> nodeClient.execute(TransportUpdateDataSourceAction.ACTION_TYPE,
+            new UpdateDataSourceActionRequest(dataSourceMetadata),
+            new ActionListener<>() {
+              @Override
+              public void onResponse(
+                  UpdateDataSourceActionResponse updateDataSourceActionResponse) {
+                restChannel.sendResponse(
+                    new BytesRestResponse(RestStatus.OK, "application/json; charset=UTF-8",
+                        updateDataSourceActionResponse.getResult()));
+              }
+
+              @Override
+              public void onFailure(Exception e) {
+                handleException(e, restChannel);
+              }
+            }));
+  }
+
+  private RestChannelConsumer executeDeleteRequest(RestRequest restRequest,
+                                                   NodeClient nodeClient) {
+
+    String dataSourceName = restRequest.param("dataSourceName");
+    return restChannel -> schedule(nodeClient,
+        () -> nodeClient.execute(TransportDeleteDataSourceAction.ACTION_TYPE,
+            new DeleteDataSourceActionRequest(dataSourceName),
+            new ActionListener<>() {
+              @Override
+              public void onResponse(
+                  DeleteDataSourceActionResponse deleteDataSourceActionResponse) {
+                restChannel.sendResponse(
+                    new BytesRestResponse(RestStatus.NO_CONTENT, "application/json; charset=UTF-8",
+                        deleteDataSourceActionResponse.getResult()));
+              }
+
+              @Override
+              public void onFailure(Exception e) {
+                handleException(e, restChannel);
+              }
+            }));
+  }
+
+  private void handleException(Exception e, RestChannel restChannel) {
+    if (e instanceof DataSourceNotFoundException) {
+      reportError(restChannel, e, NOT_FOUND);
+    } else {
+      LOG.error("Error happened during request handling", e);
+      if (isClientError(e)) {
+        Metrics.getInstance()
+            .getNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_CUS)
+            .increment();
+        reportError(restChannel, e, BAD_REQUEST);
+      } else {
+        Metrics.getInstance()
+            .getNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_SYS)
+            .increment();
+        reportError(restChannel, e, SERVICE_UNAVAILABLE);
+      }
+    }
   }
 
   private void reportError(final RestChannel channel, final Exception e, final RestStatus status) {
@@ -124,8 +250,7 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
   private static boolean isClientError(Exception e) {
     return e instanceof NullPointerException
         // NPE is hard to differentiate but more likely caused by bad query
-        || e instanceof IllegalArgumentException
-        || e instanceof IndexNotFoundException;
+        || e instanceof IllegalArgumentException;
   }
 
 }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportCreateDataSourceAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportCreateDataSourceAction.java
@@ -30,7 +30,7 @@ public class TransportCreateDataSourceAction
     extends HandledTransportAction<CreateDataSourceActionRequest, CreateDataSourceActionResponse> {
 
   private static final Logger LOG = LogManager.getLogger();
-  public static final String NAME = "cluster:admin/opensearch/datasources/create";
+  public static final String NAME = "cluster:admin/opensearch/ql/datasources/create";
   public static final ActionType<CreateDataSourceActionResponse>
       ACTION_TYPE = new ActionType<>(NAME, CreateDataSourceActionResponse::new);
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportDeleteDataSourceAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportDeleteDataSourceAction.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.plugin.transport.datasource;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasource.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.metrics.Metrics;
+import org.opensearch.sql.opensearch.security.SecurityAccess;
+import org.opensearch.sql.plugin.model.DeleteDataSourceActionRequest;
+import org.opensearch.sql.plugin.model.DeleteDataSourceActionResponse;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class TransportDeleteDataSourceAction
+    extends HandledTransportAction<DeleteDataSourceActionRequest, DeleteDataSourceActionResponse> {
+
+  public static final String NAME = "cluster:admin/opensearch/datasources/delete";
+  public static final ActionType<DeleteDataSourceActionResponse>
+      ACTION_TYPE = new ActionType<>(NAME, DeleteDataSourceActionResponse::new);
+
+  private DataSourceService dataSourceService;
+  private Client client;
+
+  /**
+   * TransportDeleteDataSourceAction action for deleting datasource.
+   *
+   * @param transportService  transportService.
+   * @param actionFilters     actionFilters.
+   * @param client            client.
+   * @param dataSourceService dataSourceService.
+   */
+  @Inject
+  public TransportDeleteDataSourceAction(TransportService transportService,
+                                         ActionFilters actionFilters,
+                                         NodeClient client,
+                                         DataSourceServiceImpl dataSourceService) {
+    super(TransportDeleteDataSourceAction.NAME, transportService, actionFilters,
+        DeleteDataSourceActionRequest::new);
+    this.client = client;
+    this.dataSourceService = dataSourceService;
+  }
+
+  @Override
+  protected void doExecute(Task task, DeleteDataSourceActionRequest request,
+                           ActionListener<DeleteDataSourceActionResponse> actionListener) {
+    Metrics.getInstance().getNumericalMetric(MetricName.DATASOURCE_REQ_COUNT).increment();
+    dataSourceService.deleteDataSource(request.getDataSourceName());
+    actionListener.onResponse(new DeleteDataSourceActionResponse("Deleted DataSource with name "
+        + request.getDataSourceName()));
+  }
+
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportDeleteDataSourceAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportDeleteDataSourceAction.java
@@ -27,7 +27,7 @@ import org.opensearch.transport.TransportService;
 public class TransportDeleteDataSourceAction
     extends HandledTransportAction<DeleteDataSourceActionRequest, DeleteDataSourceActionResponse> {
 
-  public static final String NAME = "cluster:admin/opensearch/datasources/delete";
+  public static final String NAME = "cluster:admin/opensearch/ql/datasources/delete";
   public static final ActionType<DeleteDataSourceActionResponse>
       ACTION_TYPE = new ActionType<>(NAME, DeleteDataSourceActionResponse::new);
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportGetDataSourceAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportGetDataSourceAction.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.plugin.transport.datasource;
+
+import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
+
+import java.util.Set;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasource.DataSourceServiceImpl;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.plugin.model.GetDataSourceActionRequest;
+import org.opensearch.sql.plugin.model.GetDataSourceActionResponse;
+import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class TransportGetDataSourceAction
+    extends HandledTransportAction<GetDataSourceActionRequest, GetDataSourceActionResponse> {
+
+  public static final String NAME = "cluster:admin/opensearch/datasources/read";
+  public static final ActionType<GetDataSourceActionResponse>
+      ACTION_TYPE = new ActionType<>(NAME, GetDataSourceActionResponse::new);
+
+  private DataSourceService dataSourceService;
+  private Client client;
+
+  /**
+   * TransportGetDataSourceAction action for getting datasource.
+   *
+   * @param transportService  transportService.
+   * @param actionFilters     actionFilters.
+   * @param client            client.
+   * @param dataSourceService dataSourceService.
+   */
+  @Inject
+  public TransportGetDataSourceAction(TransportService transportService,
+                                      ActionFilters actionFilters,
+                                      NodeClient client,
+                                      DataSourceServiceImpl dataSourceService) {
+    super(TransportGetDataSourceAction.NAME, transportService, actionFilters,
+        GetDataSourceActionRequest::new);
+    this.client = client;
+    this.dataSourceService = dataSourceService;
+  }
+
+  @Override
+  protected void doExecute(Task task, GetDataSourceActionRequest request,
+                           ActionListener<GetDataSourceActionResponse> actionListener) {
+    try {
+      String responseContent;
+      if (request.getDataSourceName() == null) {
+        responseContent = handleGetAllDataSourcesRequest();
+
+      } else {
+        responseContent = handleSingleDataSourceRequest(request.getDataSourceName());
+      }
+      actionListener.onResponse(new GetDataSourceActionResponse(responseContent));
+    } catch (Exception e) {
+      actionListener.onFailure(e);
+    }
+  }
+
+  private String handleGetAllDataSourcesRequest() {
+    String responseContent;
+    Set<DataSourceMetadata> dataSourceMetadataSet =
+        dataSourceService.getDataSourceMetadata(false);
+    responseContent = new JsonResponseFormatter<Set<DataSourceMetadata>>(PRETTY) {
+      @Override
+      protected Object buildJsonObject(Set<DataSourceMetadata> response) {
+        return response;
+      }
+    }.format(dataSourceMetadataSet);
+    return responseContent;
+  }
+
+  private String handleSingleDataSourceRequest(String datasourceName) {
+    String responseContent;
+    DataSourceMetadata dataSourceMetadata
+        = dataSourceService
+        .getDataSourceMetadata(datasourceName);
+    responseContent = new JsonResponseFormatter<DataSourceMetadata>(PRETTY) {
+      @Override
+      protected Object buildJsonObject(DataSourceMetadata response) {
+        return response;
+      }
+    }.format(dataSourceMetadata);
+    return responseContent;
+  }
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportGetDataSourceAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportGetDataSourceAction.java
@@ -29,7 +29,7 @@ import org.opensearch.transport.TransportService;
 public class TransportGetDataSourceAction
     extends HandledTransportAction<GetDataSourceActionRequest, GetDataSourceActionResponse> {
 
-  public static final String NAME = "cluster:admin/opensearch/datasources/read";
+  public static final String NAME = "cluster:admin/opensearch/ql/datasources/read";
   public static final ActionType<GetDataSourceActionResponse>
       ACTION_TYPE = new ActionType<>(NAME, GetDataSourceActionResponse::new);
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportUpdateDataSourceAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportUpdateDataSourceAction.java
@@ -30,7 +30,7 @@ public class TransportUpdateDataSourceAction
     extends HandledTransportAction<UpdateDataSourceActionRequest, UpdateDataSourceActionResponse> {
 
   private static final Logger LOG = LogManager.getLogger();
-  public static final String NAME = "cluster:admin/opensearch/datasources/update";
+  public static final String NAME = "cluster:admin/opensearch/ql/datasources/update";
   public static final ActionType<UpdateDataSourceActionResponse>
       ACTION_TYPE = new ActionType<>(NAME, UpdateDataSourceActionResponse::new);
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportUpdateDataSourceAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/datasource/TransportUpdateDataSourceAction.java
@@ -18,53 +18,52 @@ import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.DataSourceServiceImpl;
-import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.legacy.metrics.MetricName;
 import org.opensearch.sql.legacy.metrics.Metrics;
-import org.opensearch.sql.plugin.model.CreateDataSourceActionRequest;
-import org.opensearch.sql.plugin.model.CreateDataSourceActionResponse;
+import org.opensearch.sql.opensearch.security.SecurityAccess;
+import org.opensearch.sql.plugin.model.UpdateDataSourceActionRequest;
+import org.opensearch.sql.plugin.model.UpdateDataSourceActionResponse;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
-public class TransportCreateDataSourceAction
-    extends HandledTransportAction<CreateDataSourceActionRequest, CreateDataSourceActionResponse> {
+public class TransportUpdateDataSourceAction
+    extends HandledTransportAction<UpdateDataSourceActionRequest, UpdateDataSourceActionResponse> {
 
   private static final Logger LOG = LogManager.getLogger();
-  public static final String NAME = "cluster:admin/opensearch/datasources/create";
-  public static final ActionType<CreateDataSourceActionResponse>
-      ACTION_TYPE = new ActionType<>(NAME, CreateDataSourceActionResponse::new);
+  public static final String NAME = "cluster:admin/opensearch/datasources/update";
+  public static final ActionType<UpdateDataSourceActionResponse>
+      ACTION_TYPE = new ActionType<>(NAME, UpdateDataSourceActionResponse::new);
 
   private DataSourceService dataSourceService;
   private Client client;
 
   /**
-   * TransportCreateDataSourceAction action for creating datasource.
+   * TransportUpdateDataSourceAction action for updating datasource.
    *
-   * @param transportService  transportService.
-   * @param actionFilters     actionFilters.
-   * @param client            client.
+   * @param transportService transportService.
+   * @param actionFilters actionFilters.
+   * @param client client.
    * @param dataSourceService dataSourceService.
    */
   @Inject
-  public TransportCreateDataSourceAction(TransportService transportService,
+  public TransportUpdateDataSourceAction(TransportService transportService,
                                          ActionFilters actionFilters,
                                          NodeClient client,
                                          DataSourceServiceImpl dataSourceService) {
-    super(TransportCreateDataSourceAction.NAME, transportService, actionFilters,
-        CreateDataSourceActionRequest::new);
+    super(TransportUpdateDataSourceAction.NAME, transportService, actionFilters,
+        UpdateDataSourceActionRequest::new);
     this.dataSourceService = dataSourceService;
     this.client = client;
   }
 
   @Override
-  protected void doExecute(Task task, CreateDataSourceActionRequest request,
-                           ActionListener<CreateDataSourceActionResponse> actionListener) {
+  protected void doExecute(Task task, UpdateDataSourceActionRequest request,
+                           ActionListener<UpdateDataSourceActionResponse> actionListener) {
 
     Metrics.getInstance().getNumericalMetric(MetricName.DATASOURCE_REQ_COUNT).increment();
-    DataSourceMetadata dataSourceMetadata = request.getDataSourceMetadata();
-    dataSourceService.createDataSource(dataSourceMetadata);
-    actionListener.onResponse(new CreateDataSourceActionResponse("Created DataSource with name "
-        + dataSourceMetadata.getName()));
+    dataSourceService.updateDataSource(request.getDataSourceMetadata());
+    actionListener.onResponse(new UpdateDataSourceActionResponse("Updated DataSource with name "
+        + request.getDataSourceMetadata().getName()));
   }
 
 }

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactory.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactory.java
@@ -39,6 +39,8 @@ public class PrometheusStorageFactory implements DataSourceFactory {
   public static final String ACCESS_KEY = "prometheus.auth.access_key";
   public static final String SECRET_KEY = "prometheus.auth.secret_key";
 
+  private static final Integer MAX_LENGTH_FOR_CONFIG_PROPERTY = 1000;
+
   @Override
   public DataSourceType getDataSourceType() {
     return DataSourceType.PROMETHEUS;
@@ -52,8 +54,24 @@ public class PrometheusStorageFactory implements DataSourceFactory {
         getStorageEngine(metadata.getName(), metadata.getProperties()));
   }
 
+
+  private void validateDataSourceConfigProperties(Map<String, String> dataSourceMetadataConfig) {
+    if (dataSourceMetadataConfig.get(AUTH_TYPE) != null) {
+      AuthenticationType authenticationType
+          = AuthenticationType.get(dataSourceMetadataConfig.get(AUTH_TYPE));
+      if (AuthenticationType.BASICAUTH.equals(authenticationType)) {
+        validateFields(dataSourceMetadataConfig, Set.of(URI, USERNAME, PASSWORD));
+      } else if (AuthenticationType.AWSSIGV4AUTH.equals(authenticationType)) {
+        validateFields(dataSourceMetadataConfig, Set.of(URI, ACCESS_KEY, SECRET_KEY,
+            REGION));
+      }
+    } else {
+      validateFields(dataSourceMetadataConfig, Set.of(URI));
+    }
+  }
+
   StorageEngine getStorageEngine(String catalogName, Map<String, String> requiredConfig) {
-    validateFieldsInConfig(requiredConfig, Set.of(URI));
+    validateDataSourceConfigProperties(requiredConfig);
     PrometheusClient prometheusClient;
     prometheusClient =
         AccessController.doPrivileged((PrivilegedAction<PrometheusClientImpl>) () -> {
@@ -76,11 +94,9 @@ public class PrometheusStorageFactory implements DataSourceFactory {
     if (config.get(AUTH_TYPE) != null) {
       AuthenticationType authenticationType = AuthenticationType.get(config.get(AUTH_TYPE));
       if (AuthenticationType.BASICAUTH.equals(authenticationType)) {
-        validateFieldsInConfig(config, Set.of(USERNAME, PASSWORD));
         okHttpClient.addInterceptor(new BasicAuthenticationInterceptor(config.get(USERNAME),
             config.get(PASSWORD)));
       } else if (AuthenticationType.AWSSIGV4AUTH.equals(authenticationType)) {
-        validateFieldsInConfig(config, Set.of(REGION, ACCESS_KEY, SECRET_KEY));
         okHttpClient.addInterceptor(new AwsSigningInterceptor(
             new AWSStaticCredentialsProvider(
                 new BasicAWSCredentials(config.get(ACCESS_KEY), config.get(SECRET_KEY))),
@@ -94,16 +110,28 @@ public class PrometheusStorageFactory implements DataSourceFactory {
     return okHttpClient.build();
   }
 
-  private void validateFieldsInConfig(Map<String, String> config, Set<String> fields) {
+  private void validateFields(Map<String, String> config, Set<String> fields) {
     Set<String> missingFields = new HashSet<>();
+    Set<String> invalidLengthFields = new HashSet<>();
     for (String field : fields) {
       if (!config.containsKey(field)) {
         missingFields.add(field);
+      } else if (config.get(field).length() > MAX_LENGTH_FOR_CONFIG_PROPERTY) {
+        invalidLengthFields.add(field);
       }
     }
+    StringBuilder errorStringBuilder = new StringBuilder();
     if (missingFields.size() > 0) {
-      throw new IllegalArgumentException(String.format(
+      errorStringBuilder.append(String.format(
           "Missing %s fields in the Prometheus connector properties.", missingFields));
+    }
+
+    if (invalidLengthFields.size() > 0) {
+      errorStringBuilder.append(String.format(
+          "Fields %s exceeds more than 1000 characters.", invalidLengthFields));
+    }
+    if (errorStringBuilder.length() > 0) {
+      throw new IllegalArgumentException(errorStringBuilder.toString());
     }
   }
 

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactoryTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactoryTest.java
@@ -9,6 +9,7 @@ package org.opensearch.sql.prometheus.storage;
 
 import java.util.HashMap;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,6 +88,24 @@ public class PrometheusStorageFactoryTest {
         () -> prometheusStorageFactory.getStorageEngine("my_prometheus", properties));
     Assertions.assertEquals("Missing [prometheus.auth.region] fields in the "
             + "Prometheus connector properties.",
+        exception.getMessage());
+  }
+
+
+  @Test
+  @SneakyThrows
+  void testGetStorageEngineWithLongConfigProperties() {
+    PrometheusStorageFactory prometheusStorageFactory = new PrometheusStorageFactory();
+    HashMap<String, String> properties = new HashMap<>();
+    properties.put("prometheus.uri", RandomStringUtils.random(1001));
+    properties.put("prometheus.auth.type", "awssigv4");
+    properties.put("prometheus.auth.secret_key", "accessKey");
+    properties.put("prometheus.auth.access_key", "secretKey");
+    IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
+        () -> prometheusStorageFactory.getStorageEngine("my_prometheus", properties));
+    Assertions.assertEquals("Missing [prometheus.auth.region] fields in the "
+            + "Prometheus connector properties."
+            + "Fields [prometheus.uri] exceeds more than 1000 characters.",
         exception.getMessage());
   }
 


### PR DESCRIPTION
### Description
These changes introduce REST APIs for GET DATASOURCE, UPDATE DATASOURCE and DELETE DATASOURCE APIS as follow up to CREATE DATASOURCE APIs https://github.com/opensearch-project/sql/pull/1458 
 
### Issues Resolved
* https://github.com/opensearch-project/sql/issues/1462
* https://github.com/opensearch-project/sql/issues/1461
* https://github.com/opensearch-project/sql/issues/1460


### Rough LLD Diagrams

Modification of datasource is similar to create apis. Below images corresponds to GET ALL and DELETE APIs.

<img width="793" alt="Screen Shot 2023-03-28 at 3 51 46 PM" src="https://user-images.githubusercontent.com/99925918/228384594-83c389ac-7585-4bea-9ca4-00a1d0390f96.png">
<img width="794" alt="Screen Shot 2023-03-28 at 3 51 33 PM" src="https://user-images.githubusercontent.com/99925918/228384603-4fa7b326-0ebe-47ba-8d23-15133b782b29.png">

 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).