### PR TITLE
New config to choose between keystore and REST api interface for datasource metadata management.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.datasource;
 
 import java.util.Set;
 import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 
 /**
@@ -28,7 +29,8 @@ public interface DataSourceService {
    * any of the credential info.
    *
    * @param isDefaultDataSourceRequired is used to specify
-   *      if default opensearch connector is required in the output list.
+   *                                    if default opensearch connector is required
+   *                                    in the output list.
    * @return set of {@link DataSourceMetadata}.
    */
   Set<DataSourceMetadata> getDataSourceMetadata(boolean isDefaultDataSourceRequired);
@@ -72,4 +74,11 @@ public interface DataSourceService {
    * @param dataSourceName name of the {@link DataSource}.
    */
   Boolean dataSourceExists(String dataSourceName);
+
+  /**
+   * This method helps in identifing the datasource interface.
+   *
+   * @return {@code API} or {@code KEYSTORE} based on interface.
+   */
+  DataSourceInterfaceType datasourceInterfaceType();
 }

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceServiceHolder.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceServiceHolder.java
@@ -1,0 +1,23 @@
+package org.opensearch.sql.datasource;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * This class is created to solve the problem in binding implementation classes to interface.
+ * For eg: If we return KeyStoreDataServiceImpl from createComponents in SQLPlugin.
+ * It will bind the instance to KeyStoreDataServiceImpl instead of DataSourceService.
+ * <a href="https://github.com/opensearch-project/OpenSearch/blob/632eb44a541b28ef16ed261904b45d74b84f3b9f/server/src/main/java/org/opensearch/node/Node.java#L1117">Guice Bindings</a>
+ * These bindings are later used to inject DataSourceService in TransportActions.
+ * Since the instances are not bound to interface,
+ * it is leading to construction errors when we have DataSourceService as parameter in Constructor.
+ * Inorder to circumvent this problem,
+ * we have introduced this DataSourceServiceHolder class which is a concrete class.
+ * This class is bound in guice injector and later injected to TransportAction classes.
+ */
+@Data
+@AllArgsConstructor
+public class DataSourceServiceHolder {
+  private DataSourceService dataSourceService;
+
+}

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceInterfaceType.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceInterfaceType.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.datasource.model;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum DataSourceInterfaceType {
+
+  API("api"), KEYSTORE("keystore");
+
+  private String name;
+
+  private static final Map<String, DataSourceInterfaceType> ENUM_MAP;
+
+  DataSourceInterfaceType(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  static {
+    Map<String, DataSourceInterfaceType> map = new HashMap<>();
+    for (DataSourceInterfaceType instance : DataSourceInterfaceType.values()) {
+      map.put(instance.getName().toLowerCase(), instance);
+    }
+    ENUM_MAP = Collections.unmodifiableMap(map);
+  }
+
+  public static DataSourceInterfaceType get(String name) {
+    return ENUM_MAP.get(name.toLowerCase());
+  }
+
+}

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -30,6 +30,7 @@ import org.opensearch.sql.config.TestConfig;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
@@ -228,6 +229,11 @@ public class AnalyzerTestBase {
     public Boolean dataSourceExists(String dataSourceName) {
       return dataSourceName.equals(DEFAULT_DATASOURCE_NAME)
           || dataSourceName.equals("prometheus");
+    }
+
+    @Override
+    public DataSourceInterfaceType datasourceInterfaceType() {
+      return null;
     }
   }
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceServiceImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelper;
 import org.opensearch.sql.datasources.exceptions.DataSourceNotFoundException;
@@ -128,6 +129,11 @@ public class DataSourceServiceImpl implements DataSourceService {
   public Boolean dataSourceExists(String dataSourceName) {
     return DEFAULT_DATASOURCE_NAME.equals(dataSourceName)
         || this.dataSourceMetadataStorage.getDataSourceMetadata(dataSourceName).isPresent();
+  }
+
+  @Override
+  public DataSourceInterfaceType datasourceInterfaceType() {
+    return DataSourceInterfaceType.API;
   }
 
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/KeyStoreDataSourceServiceImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/KeyStoreDataSourceServiceImpl.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.datasources.service;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.datasource.model.DataSourceType;
+import org.opensearch.sql.datasources.exceptions.DataSourceNotFoundException;
+import org.opensearch.sql.storage.DataSourceFactory;
+
+/**
+ * Default implementation of {@link DataSourceService}. It is per-jvm single instance.
+ *
+ * <p>{@link DataSourceService} is constructed by the list of {@link DataSourceFactory} at service
+ * bootstrap time. The set of {@link DataSourceFactory} is immutable. Client could add {@link
+ * DataSource} defined by {@link DataSourceMetadata} at any time. {@link DataSourceService} use
+ * {@link DataSourceFactory} to create {@link DataSource}.
+ */
+public class KeyStoreDataSourceServiceImpl implements DataSourceService {
+
+  private static String DATASOURCE_NAME_REGEX = "[@*A-Za-z]+?[*a-zA-Z_\\-0-9]*";
+
+  private final ConcurrentHashMap<String, DataSource> dataSourceMap;
+
+  private final ConcurrentHashMap<String, DataSourceMetadata> dataSourceMetadataMap;
+
+  private final Map<DataSourceType, DataSourceFactory> dataSourceFactoryMap;
+
+  /**
+   * Construct from the set of {@link DataSourceFactory} at bootstrap time.
+   */
+  public KeyStoreDataSourceServiceImpl(Set<DataSourceFactory> dataSourceFactories) {
+    dataSourceFactoryMap =
+        dataSourceFactories.stream()
+            .collect(Collectors.toMap(DataSourceFactory::getDataSourceType, f -> f));
+    dataSourceMap = new ConcurrentHashMap<>();
+    dataSourceMetadataMap = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public DataSource getDataSource(String dataSourceName) {
+    if (!dataSourceMap.containsKey(dataSourceName)) {
+      throw new DataSourceNotFoundException(
+          String.format("DataSource with name %s doesn't exist.", dataSourceName));
+    }
+    return dataSourceMap.get(dataSourceName);
+  }
+
+  @Override
+  public Set<DataSourceMetadata> getDataSourceMetadata(boolean isDefaultDataSourceRequired) {
+    return Set.copyOf(this.dataSourceMetadataMap.values());
+  }
+
+  @Override
+  public DataSourceMetadata getDataSourceMetadata(String name) {
+    if (!this.dataSourceMetadataMap.containsKey(name)) {
+      throw new IllegalArgumentException("DataSourceMetadata with name: " + name
+          + " doesn't exist.");
+    }
+    return this.dataSourceMetadataMap.get(name);
+  }
+
+  @Override
+  public void createDataSource(DataSourceMetadata metadata) {
+    validateDataSourceMetaData(metadata);
+    dataSourceMap.put(
+        metadata.getName(),
+        dataSourceFactoryMap.get(metadata.getConnector()).createDataSource(metadata));
+    removeAuthInfo(metadata);
+    dataSourceMetadataMap.put(metadata.getName(), metadata);
+  }
+
+  @Override
+  public void updateDataSource(DataSourceMetadata dataSourceMetadata) {
+    throw new UnsupportedOperationException(
+        "Update operation is not supported in KeyStoreDataService");
+  }
+
+  @Override
+  public void deleteDataSource(String dataSourceName) {
+    dataSourceMap.remove(dataSourceName);
+    dataSourceMetadataMap.remove(dataSourceName);
+  }
+
+  @Override
+  public Boolean dataSourceExists(String dataSourceName) {
+    return dataSourceMap.containsKey(dataSourceName);
+  }
+
+  @Override
+  public DataSourceInterfaceType datasourceInterfaceType() {
+    return DataSourceInterfaceType.KEYSTORE;
+  }
+
+  /**
+   * This can be moved to a different validator class when we introduce more connectors.
+   *
+   * @param metadata {@link DataSourceMetadata}.
+   */
+  private void validateDataSourceMetaData(DataSourceMetadata metadata) {
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(metadata.getName()),
+        "Missing Name Field from a DataSource. Name is a required parameter.");
+    Preconditions.checkArgument(
+        !dataSourceMap.containsKey(metadata.getName()),
+        StringUtils.format(
+            "Datasource name should be unique, Duplicate datasource found %s.",
+            metadata.getName()));
+    Preconditions.checkArgument(
+        metadata.getName().matches(DATASOURCE_NAME_REGEX),
+        StringUtils.format(
+            "DataSource Name: %s contains illegal characters. Allowed characters: a-zA-Z0-9_-*@.",
+            metadata.getName()));
+    Preconditions.checkArgument(
+        !Objects.isNull(metadata.getProperties()),
+        "Missing properties field in catalog configuration. Properties are required parameters.");
+  }
+
+  // It is advised to avoid storing any kind credentials.
+  private void removeAuthInfo(DataSourceMetadata dataSourceMetadata) {
+    HashMap<String, String> safeProperties
+        = new HashMap<>(dataSourceMetadata.getProperties());
+    safeProperties
+        .entrySet()
+        .removeIf(entry -> entry.getKey().contains("auth"));
+    dataSourceMetadata.setProperties(safeProperties);
+  }
+
+  public void clear() {
+    this.dataSourceMap.clear();
+    this.dataSourceMetadataMap.clear();
+  }
+
+}

--- a/datasources/src/main/java/org/opensearch/sql/datasources/settings/DataSourceSettings.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/settings/DataSourceSettings.java
@@ -11,13 +11,20 @@ import org.opensearch.common.settings.Setting;
 
 public class DataSourceSettings {
 
+  public static final String DEFAULT_MASTER_KEY = "0000000000000000";
+
   public static final Setting<InputStream> DATASOURCE_CONFIG = SecureSetting.secureFile(
       "plugins.query.federation.datasources.config",
       null);
 
+  public static final Setting<String> DATASOURCE_INTERFACE = Setting.simpleString(
+      "plugins.query.federation.datasources.interface",
+      Setting.Property.NodeScope,
+      Setting.Property.Dynamic);
+
   public static final Setting<String> DATASOURCE_MASTER_SECRET_KEY = Setting.simpleString(
-      "plugins.query.datasources.encryption.masterkey",
-      "0000000000000000",
+      "plugins.query.federation.datasources.encryption.masterkey",
+      DEFAULT_MASTER_KEY,
       Setting.Property.NodeScope,
       Setting.Property.Dynamic);
 }

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceAction.java
@@ -13,6 +13,8 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasource.DataSourceServiceHolder;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasources.model.transport.CreateDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.CreateDataSourceActionResponse;
@@ -33,20 +35,27 @@ public class TransportCreateDataSourceAction
    *
    * @param transportService  transportService.
    * @param actionFilters     actionFilters.
-   * @param dataSourceService dataSourceService.
+   * @param dataSourceServiceHolder dataSourceServiceHolder.
    */
   @Inject
   public TransportCreateDataSourceAction(TransportService transportService,
                                          ActionFilters actionFilters,
-                                         DataSourceServiceImpl dataSourceService) {
+                                         DataSourceServiceHolder dataSourceServiceHolder) {
     super(TransportCreateDataSourceAction.NAME, transportService, actionFilters,
         CreateDataSourceActionRequest::new);
-    this.dataSourceService = dataSourceService;
+    this.dataSourceService = dataSourceServiceHolder.getDataSourceService();
   }
 
   @Override
   protected void doExecute(Task task, CreateDataSourceActionRequest request,
                            ActionListener<CreateDataSourceActionResponse> actionListener) {
+    if (dataSourceService.datasourceInterfaceType().equals(DataSourceInterfaceType.KEYSTORE)) {
+      actionListener.onFailure(new UnsupportedOperationException(
+          "Please set datasource interface settings(plugins.query.federation.datasources.interface)"
+              + "to api in opensearch.yml to enable apis for datasource management. "
+              + "Please port any datasources configured in keystore using create api."));
+      return;
+    }
     try {
       DataSourceMetadata dataSourceMetadata = request.getDataSourceMetadata();
       dataSourceService.createDataSource(dataSourceMetadata);

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceAction.java
@@ -13,6 +13,8 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasource.DataSourceServiceHolder;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
 import org.opensearch.sql.datasources.model.transport.DeleteDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.DeleteDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
@@ -33,20 +35,27 @@ public class TransportDeleteDataSourceAction
    *
    * @param transportService  transportService.
    * @param actionFilters     actionFilters.
-   * @param dataSourceService dataSourceService.
+   * @param dataSourceServiceHolder dataSourceServiceHolder.
    */
   @Inject
   public TransportDeleteDataSourceAction(TransportService transportService,
                                          ActionFilters actionFilters,
-                                         DataSourceServiceImpl dataSourceService) {
+                                         DataSourceServiceHolder dataSourceServiceHolder) {
     super(TransportDeleteDataSourceAction.NAME, transportService, actionFilters,
         DeleteDataSourceActionRequest::new);
-    this.dataSourceService = dataSourceService;
+    this.dataSourceService = dataSourceServiceHolder.getDataSourceService();
   }
 
   @Override
   protected void doExecute(Task task, DeleteDataSourceActionRequest request,
                            ActionListener<DeleteDataSourceActionResponse> actionListener) {
+    if (dataSourceService.datasourceInterfaceType().equals(DataSourceInterfaceType.KEYSTORE)) {
+      actionListener.onFailure(new UnsupportedOperationException(
+          "Please set datasource interface settings(plugins.query.federation.datasources.interface)"
+              + "to api in opensearch.yml to enable apis for datasource management. "
+              + "Please port any datasources configured in keystore using create api."));
+      return;
+    }
     try {
       dataSourceService.deleteDataSource(request.getDataSourceName());
       actionListener.onResponse(new DeleteDataSourceActionResponse("Deleted DataSource with name "

--- a/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceServiceImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceServiceImplTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelper;
@@ -123,7 +124,7 @@ class DataSourceServiceImplTest {
     DataSourceMetadata dataSourceMetadata = metadata("test", DataSourceType.OPENSEARCH,
         Collections.singletonList("prometheus_access"), ImmutableMap.of());
     doThrow(new SecurityException("User is not authorized to access datasource test. "
-            + "User should be mapped to any of the roles in [prometheus_access] for access."))
+        + "User should be mapped to any of the roles in [prometheus_access] for access."))
         .when(dataSourceUserAuthorizationHelper)
         .authorizeDataSource(dataSourceMetadata);
     when(dataSourceMetadataStorage.getDataSourceMetadata("test"))
@@ -288,7 +289,7 @@ class DataSourceServiceImplTest {
   void testDeleteDefaultDatasource() {
     UnsupportedOperationException unsupportedOperationException
         = assertThrows(UnsupportedOperationException.class,
-           () -> dataSourceService.deleteDataSource(DEFAULT_DATASOURCE_NAME));
+            () -> dataSourceService.deleteDataSource(DEFAULT_DATASOURCE_NAME));
     assertEquals("Not allowed to delete default datasource :" + DEFAULT_DATASOURCE_NAME,
         unsupportedOperationException.getMessage());
   }
@@ -370,6 +371,12 @@ class DataSourceServiceImplTest {
     assertFalse(dataSourceMetadata.getProperties().containsKey("prometheus.auth.username"));
     assertFalse(dataSourceMetadata.getProperties().containsKey("prometheus.auth.password"));
     verify(dataSourceMetadataStorage, times(1)).getDataSourceMetadata("testDS");
+  }
+
+  @Test
+  void testDatastoreInterfaceType() {
+    Assertions.assertEquals(DataSourceInterfaceType.API,
+        this.dataSourceService.datasourceInterfaceType());
   }
 
 }

--- a/datasources/src/test/java/org/opensearch/sql/datasources/service/KeyStoreDataSourceServiceImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/service/KeyStoreDataSourceServiceImplTest.java
@@ -1,0 +1,215 @@
+package org.opensearch.sql.datasources.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashSet;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.datasource.model.DataSourceType;
+import org.opensearch.sql.datasources.exceptions.DataSourceNotFoundException;
+import org.opensearch.sql.storage.DataSourceFactory;
+import org.opensearch.sql.storage.StorageEngine;
+
+@ExtendWith(MockitoExtension.class)
+class KeyStoreDataSourceServiceImplTest {
+  static final String NAME = "opensearch";
+  static final String TEST_DS_NAME = "testDS";
+
+  @Mock
+  private DataSourceFactory dataSourceFactory;
+
+  @Mock
+  private StorageEngine storageEngine;
+
+  private KeyStoreDataSourceServiceImpl keyStoreDataSourceService;
+
+  @BeforeEach
+  public void setup() {
+    lenient()
+        .doAnswer(
+            invocation -> {
+              DataSourceMetadata metadata = invocation.getArgument(0);
+              return new DataSource(metadata.getName(), metadata.getConnector(), storageEngine);
+            })
+        .when(dataSourceFactory)
+        .createDataSource(any());
+    when(dataSourceFactory.getDataSourceType()).thenReturn(DataSourceType.OPENSEARCH);
+    keyStoreDataSourceService =
+        new KeyStoreDataSourceServiceImpl(
+            new HashSet<>() {
+              {
+                add(dataSourceFactory);
+              }
+            });
+  }
+
+  @AfterEach
+  public void clear() {
+    keyStoreDataSourceService.clear();
+  }
+
+  @Test
+  void getDataSourceSuccess() {
+    keyStoreDataSourceService.createDataSource(
+        DataSourceMetadata.defaultOpenSearchDataSourceMetadata());
+
+    Assertions.assertEquals(
+        new DataSource(DEFAULT_DATASOURCE_NAME, DataSourceType.OPENSEARCH, storageEngine),
+        keyStoreDataSourceService.getDataSource(DEFAULT_DATASOURCE_NAME));
+  }
+
+  @Test
+  void getNotExistDataSourceShouldFail() {
+    DataSourceNotFoundException exception =
+        Assertions.assertThrows(DataSourceNotFoundException.class,
+            () -> keyStoreDataSourceService.getDataSource("mock"));
+    Assertions.assertEquals("DataSource with name mock doesn't exist.", exception.getMessage());
+  }
+
+  @Test
+  void getAddDataSourcesShouldSuccess() {
+    Assertions.assertEquals(0, keyStoreDataSourceService.getDataSourceMetadata(false).size());
+
+    keyStoreDataSourceService.createDataSource(
+        metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    Assertions.assertEquals(1, keyStoreDataSourceService.getDataSourceMetadata(false).size());
+  }
+
+  @Test
+  void noDataSourceExistAfterClear() {
+    keyStoreDataSourceService.createDataSource(
+        metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    Assertions.assertEquals(1, keyStoreDataSourceService.getDataSourceMetadata(false).size());
+
+    keyStoreDataSourceService.clear();
+    Assertions.assertEquals(0, keyStoreDataSourceService.getDataSourceMetadata(false).size());
+  }
+
+  @Test
+  void metaDataMissingNameShouldFail() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                keyStoreDataSourceService.createDataSource(
+                    metadata(null, DataSourceType.OPENSEARCH, ImmutableMap.of())));
+    Assertions.assertEquals(
+        "Missing Name Field from a DataSource. Name is a required parameter.",
+        exception.getMessage());
+  }
+
+  @Test
+  void metaDataHasIllegalDataSourceNameShouldFail() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                keyStoreDataSourceService.createDataSource(
+                    metadata("prometheus.test", DataSourceType.OPENSEARCH, ImmutableMap.of())));
+    Assertions.assertEquals(
+        "DataSource Name: prometheus.test contains illegal characters. "
+            + "Allowed characters: a-zA-Z0-9_-*@.",
+        exception.getMessage());
+  }
+
+  @Test
+  void metaDataMissingPropertiesShouldFail() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> keyStoreDataSourceService.createDataSource(
+                metadata(NAME, DataSourceType.OPENSEARCH, null)));
+    Assertions.assertEquals(
+        "Missing properties field in catalog configuration. Properties are required parameters.",
+        exception.getMessage());
+  }
+
+  @Test
+  void metaDataHasDuplicateNameShouldFail() {
+    keyStoreDataSourceService.createDataSource(
+        metadata(NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    Assertions.assertEquals(1, keyStoreDataSourceService.getDataSourceMetadata(false).size());
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> keyStoreDataSourceService.createDataSource(
+                metadata(NAME, DataSourceType.OPENSEARCH, null)));
+    Assertions.assertEquals(
+        String.format("Datasource name should be unique, Duplicate datasource found %s.", NAME),
+        exception.getMessage());
+  }
+
+  @Test
+  void testDatastoreInterfaceType() {
+    Assertions.assertEquals(DataSourceInterfaceType.KEYSTORE,
+        this.keyStoreDataSourceService.datasourceInterfaceType());
+  }
+
+  @Test
+  void testDataSourceExists() {
+    Assertions.assertFalse(keyStoreDataSourceService.dataSourceExists(TEST_DS_NAME));
+    keyStoreDataSourceService.createDataSource(
+        metadata(TEST_DS_NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    Assertions.assertTrue(keyStoreDataSourceService.dataSourceExists(TEST_DS_NAME));
+    keyStoreDataSourceService.deleteDataSource(TEST_DS_NAME);
+    Assertions.assertFalse(keyStoreDataSourceService.dataSourceExists(TEST_DS_NAME));
+  }
+
+  @Test
+  void testGetDataSourceMetadataByName() {
+    keyStoreDataSourceService.createDataSource(
+        metadata(TEST_DS_NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    DataSourceMetadata dataSourceMetadata
+        = keyStoreDataSourceService.getDataSourceMetadata(TEST_DS_NAME);
+    Assertions.assertEquals(TEST_DS_NAME, dataSourceMetadata.getName());
+    Assertions.assertEquals(DataSourceType.OPENSEARCH, dataSourceMetadata.getConnector());
+    Assertions.assertEquals(ImmutableMap.of(), dataSourceMetadata.getProperties());
+  }
+
+  @Test
+  void testUpdateDataSource() {
+    UnsupportedOperationException unsupportedOperationException
+        = Assertions.assertThrows(UnsupportedOperationException.class,
+            () -> keyStoreDataSourceService
+                .updateDataSource(metadata(TEST_DS_NAME, DataSourceType.OPENSEARCH,
+                    ImmutableMap.of())));
+    Assertions.assertEquals("Update operation is not supported in KeyStoreDataService",
+        unsupportedOperationException.getMessage());
+  }
+
+  @Test
+  void testDeleteDataSource() {
+    keyStoreDataSourceService.createDataSource(
+        metadata(TEST_DS_NAME, DataSourceType.OPENSEARCH, ImmutableMap.of()));
+    Assertions.assertTrue(keyStoreDataSourceService.dataSourceExists(TEST_DS_NAME));
+    keyStoreDataSourceService.deleteDataSource(TEST_DS_NAME);
+    Assertions.assertFalse(keyStoreDataSourceService.dataSourceExists(TEST_DS_NAME));
+    IllegalArgumentException illegalArgumentException
+        = Assertions.assertThrows(IllegalArgumentException.class,
+              () ->  keyStoreDataSourceService.getDataSourceMetadata(TEST_DS_NAME));
+    Assertions.assertEquals("DataSourceMetadata with name: testDS doesn't exist.",
+        illegalArgumentException.getMessage());
+  }
+
+  DataSourceMetadata metadata(String name, DataSourceType type, Map<String, String> properties) {
+    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
+    dataSourceMetadata.setName(name);
+    dataSourceMetadata.setConnector(type);
+    dataSourceMetadata.setProperties(properties);
+    return dataSourceMetadata;
+  }
+}

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceActionTest.java
@@ -3,6 +3,7 @@ package org.opensearch.sql.datasources.transport;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
 import org.junit.jupiter.api.Assertions;
@@ -16,6 +17,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.sql.datasource.DataSourceServiceHolder;
+import org.opensearch.sql.datasource.model.DataSourceInterfaceType;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.datasources.model.transport.UpdateDataSourceActionRequest;
@@ -48,11 +51,12 @@ public class TransportUpdateDataSourceActionTest {
   @BeforeEach
   public void setUp() {
     action = new TransportUpdateDataSourceAction(transportService,
-        new ActionFilters(new HashSet<>()), dataSourceService);
+        new ActionFilters(new HashSet<>()), new DataSourceServiceHolder(dataSourceService));
   }
 
   @Test
   public void testDoExecute() {
+    when(dataSourceService.datasourceInterfaceType()).thenReturn(DataSourceInterfaceType.API);
     DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
     dataSourceMetadata.setName("test_datasource");
     dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
@@ -69,7 +73,27 @@ public class TransportUpdateDataSourceActionTest {
   }
 
   @Test
+  public void testDoExecuteWithKeyStoreInterface() {
+    when(dataSourceService.datasourceInterfaceType()).thenReturn(DataSourceInterfaceType.KEYSTORE);
+    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
+    dataSourceMetadata.setName("test_datasource");
+    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
+    UpdateDataSourceActionRequest request = new UpdateDataSourceActionRequest(dataSourceMetadata);
+    action.doExecute(task, request, actionListener);
+    verify(dataSourceService, times(0)).updateDataSource(dataSourceMetadata);
+    Mockito.verify(actionListener).onFailure(exceptionArgumentCaptor.capture());
+    Exception exception = exceptionArgumentCaptor.getValue();
+    Assertions.assertTrue(exception instanceof UnsupportedOperationException);
+    Assertions.assertEquals(
+        "Please set datasource interface settings(plugins.query.federation.datasources.interface)"
+            + "to api in opensearch.yml to enable apis for datasource management. "
+            + "Please port any datasources configured in keystore using create api.",
+        exception.getMessage());
+  }
+
+  @Test
   public void testDoExecuteWithException() {
+    when(dataSourceService.datasourceInterfaceType()).thenReturn(DataSourceInterfaceType.API);
     DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
     dataSourceMetadata.setName("test_datasource");
     dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -124,7 +124,7 @@ testClusters.all {
 
 testClusters.integTest {
     plugin ":opensearch-sql-plugin"
-    keystore 'plugins.query.federation.datasources.config', new File("$projectDir/src/test/resources/datasource/", 'datasources.json')
+    setting "plugins.query.federation.datasources.interface", "api"
 }
 
 task startPrometheus(type: SpawnProcessTask) {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,18 @@ public class InformationSchemaCommandIT extends PPLIntegTestCase {
   @Override
   protected void init() throws Exception {
     loadIndex(Index.DATASOURCES);
+  }
+
+  /**
+   * Integ tests are dependent on self generated metrics in prometheus instance.
+   * When running individual integ tests there
+   * is no time for generation of metrics in test prometheus instance.
+   * This method gives prometheus time to generate metrics on itself.
+   * @throws InterruptedException
+   */
+  @BeforeClass
+  protected static void metricGenerationWait() throws InterruptedException {
+    Thread.sleep(20000);
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
@@ -18,7 +18,9 @@ import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
@@ -27,6 +29,18 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @Override
   protected void init() throws Exception {
     loadIndex(Index.DATASOURCES);
+  }
+
+  /**
+   * Integ tests are dependent on self generated metrics in prometheus instance.
+   * When running individual integ tests there
+   * is no time for generation of metrics in test prometheus instance.
+   * This method gives prometheus time to generate metrics on itself.
+   * @throws InterruptedException
+   */
+  @BeforeClass
+  protected static void metricGenerationWait() throws InterruptedException {
+    Thread.sleep(20000);
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
@@ -14,12 +14,25 @@ import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
 import java.io.IOException;
 import org.json.JSONObject;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.Test;
 
 public class ShowDataSourcesCommandIT extends PPLIntegTestCase {
   @Override
   protected void init() throws Exception {
     loadIndex(Index.DATASOURCES);
+  }
+
+  /**
+   * Integ tests are dependent on self generated metrics in prometheus instance.
+   * When running individual integ tests there
+   * is no time for generation of metrics in test prometheus instance.
+   * This method gives prometheus time to generate metrics on itself.
+   * @throws InterruptedException
+   */
+  @BeforeClass
+  protected static void metricGenerationWait() throws InterruptedException {
+    Thread.sleep(20000);
   }
 
   @Test

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
@@ -21,6 +21,7 @@ import org.opensearch.common.inject.ModulesBuilder;
 import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.common.utils.QueryContext;
 import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasource.DataSourceServiceHolder;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.legacy.metrics.MetricName;
@@ -54,7 +55,7 @@ public class TransportPPLQueryAction
       ActionFilters actionFilters,
       NodeClient client,
       ClusterService clusterService,
-      DataSourceServiceImpl dataSourceService) {
+      DataSourceServiceHolder dataSourceServiceHolder) {
     super(PPLQueryAction.NAME, transportService, actionFilters, TransportPPLQueryRequest::new);
 
     ModulesBuilder modules = new ModulesBuilder();
@@ -64,7 +65,8 @@ public class TransportPPLQueryAction
           b.bind(NodeClient.class).toInstance(client);
           b.bind(org.opensearch.sql.common.setting.Settings.class)
               .toInstance(new OpenSearchSettings(clusterService.getClusterSettings()));
-          b.bind(DataSourceService.class).toInstance(dataSourceService);
+          b.bind(DataSourceService.class)
+              .toInstance(dataSourceServiceHolder.getDataSourceService());
         });
     this.injector = modules.createInjector();
   }


### PR DESCRIPTION
### Description
* Introduced new config to choose between keystore and REST api interface for datasource metadata management.
* Doctests are carried out using key-store config.
* IntegTests are carried out using api interface.

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).