### PR TITLE
Datasources Integ Test Fix

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -124,7 +124,6 @@ testClusters.all {
 
 testClusters.integTest {
     plugin ":opensearch-sql-plugin"
-    keystore 'plugins.query.federation.datasources.config', new File("$projectDir/src/test/resources/datasource/", 'datasources.json')
 }
 
 task startPrometheus(type: SpawnProcessTask) {

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -12,12 +12,15 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
@@ -28,6 +31,21 @@ import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class DataSourceAPIsIT extends PPLIntegTestCase {
+
+  @AfterClass
+  protected static void deleteDataSourcesCreated() throws IOException {
+    Request deleteRequest = getDeleteDataSourceRequest("create_prometheus");
+    Response deleteResponse = client().performRequest(deleteRequest);
+    Assert.assertEquals(204, deleteResponse.getStatusLine().getStatusCode());
+
+    deleteRequest = getDeleteDataSourceRequest("update_prometheus");
+    deleteResponse = client().performRequest(deleteRequest);
+    Assert.assertEquals(204, deleteResponse.getStatusLine().getStatusCode());
+
+    deleteRequest = getDeleteDataSourceRequest("get_all_prometheus");
+    deleteResponse = client().performRequest(deleteRequest);
+    Assert.assertEquals(204, deleteResponse.getStatusLine().getStatusCode());
+  }
 
   @SneakyThrows
   @Test
@@ -148,45 +166,6 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
         new Gson().fromJson(getResponseString, listType);
     Assert.assertTrue(
         dataSourceMetadataList.stream().anyMatch(ds -> ds.getName().equals("get_all_prometheus")));
-  }
-
-
-    private Request getCreateDataSourceRequest(DataSourceMetadata dataSourceMetadata) {
-    Request request = new Request("POST", "/_plugins/_query/_datasources");
-    request.setJsonEntity(new Gson().toJson(dataSourceMetadata));
-    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
-    restOptionsBuilder.addHeader("Content-Type", "application/json");
-    request.setOptions(restOptionsBuilder);
-    return request;
-  }
-
-  private Request getUpdateDataSourceRequest(DataSourceMetadata dataSourceMetadata) {
-    Request request = new Request("PUT", "/_plugins/_query/_datasources");
-    request.setJsonEntity(new Gson().toJson(dataSourceMetadata));
-    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
-    restOptionsBuilder.addHeader("Content-Type", "application/json");
-    request.setOptions(restOptionsBuilder);
-    return request;
-  }
-
-  private Request getFetchDataSourceRequest(String name) {
-    Request request = new Request("GET", "/_plugins/_query/_datasources" + "/" + name);
-    if (StringUtils.isEmpty(name)) {
-      request = new Request("GET", "/_plugins/_query/_datasources");
-    }
-    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
-    restOptionsBuilder.addHeader("Content-Type", "application/json");
-    request.setOptions(restOptionsBuilder);
-    return request;
-  }
-
-
-  private Request getDeleteDataSourceRequest(String name) {
-    Request request = new Request("DELETE", "/_plugins/_query/_datasources" + "/" + name);
-    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
-    restOptionsBuilder.addHeader("Content-Type", "application/json");
-    request.setOptions(restOptionsBuilder);
-    return request;
   }
 
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -7,6 +7,8 @@
 package org.opensearch.sql.legacy;
 
 import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.AfterClass;
@@ -30,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.opensearch.sql.legacy.TestUtils.createIndexByRestClient;
@@ -441,6 +444,44 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return hit.getJSONObject("_source");
   }
 
+  protected static Request getCreateDataSourceRequest(DataSourceMetadata dataSourceMetadata) {
+    Request request = new Request("POST", "/_plugins/_query/_datasources");
+    request.setJsonEntity(new Gson().toJson(dataSourceMetadata));
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    return request;
+  }
+
+  protected static Request getUpdateDataSourceRequest(DataSourceMetadata dataSourceMetadata) {
+    Request request = new Request("PUT", "/_plugins/_query/_datasources");
+    request.setJsonEntity(new Gson().toJson(dataSourceMetadata));
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    return request;
+  }
+
+  protected static Request getFetchDataSourceRequest(String name) {
+    Request request = new Request("GET", "/_plugins/_query/_datasources" + "/" + name);
+    if (StringUtils.isEmpty(name)) {
+      request = new Request("GET", "/_plugins/_query/_datasources");
+    }
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    return request;
+  }
+
+
+  protected static Request getDeleteDataSourceRequest(String name) {
+    Request request = new Request("DELETE", "/_plugins/_query/_datasources" + "/" + name);
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    return request;
+  }
+
   /**
    * Enum for associating test index with relevant mapping and data.
    */
@@ -637,5 +678,7 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     public String getDataSet() {
       return this.dataSet;
     }
+
+
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
@@ -7,27 +7,30 @@
 
 package org.opensearch.sql.ppl;
 
+import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
 import static org.opensearch.sql.util.MatcherUtils.columnName;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.datasource.model.DataSourceType;
 
 public class InformationSchemaCommandIT extends PPLIntegTestCase {
-
-
-  @Override
-  protected void init() throws Exception {
-    loadIndex(Index.DATASOURCES);
-  }
 
   /**
    * Integ tests are dependent on self generated metrics in prometheus instance.
@@ -39,6 +42,23 @@ public class InformationSchemaCommandIT extends PPLIntegTestCase {
   @BeforeClass
   protected static void metricGenerationWait() throws InterruptedException {
     Thread.sleep(10000);
+  }
+
+  @Override
+  protected void init() throws InterruptedException, IOException {
+    DataSourceMetadata createDSM =
+        new DataSourceMetadata("my_prometheus", DataSourceType.PROMETHEUS,
+            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "http://localhost:9090"));
+    Request createRequest = getCreateDataSourceRequest(createDSM);
+    Response response = client().performRequest(createRequest);
+    Assert.assertEquals(201, response.getStatusLine().getStatusCode());
+  }
+
+  @After
+  protected void deleteDataSourceMetadata() throws IOException {
+    Request deleteRequest = getDeleteDataSourceRequest("my_prometheus");
+    Response deleteResponse = client().performRequest(deleteRequest);
+    Assert.assertEquals(204, deleteResponse.getStatusLine().getStatusCode());
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
@@ -12,23 +12,27 @@ import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConsta
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.datasource.model.DataSourceType;
 
 public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
-
-
-  @Override
-  protected void init() throws Exception {
-    loadIndex(Index.DATASOURCES);
-  }
 
   /**
    * Integ tests are dependent on self generated metrics in prometheus instance.
@@ -40,6 +44,23 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @BeforeClass
   protected static void metricGenerationWait() throws InterruptedException {
     Thread.sleep(10000);
+  }
+
+  @Override
+  protected void init() throws InterruptedException, IOException {
+    DataSourceMetadata createDSM =
+        new DataSourceMetadata("my_prometheus", DataSourceType.PROMETHEUS,
+            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "http://localhost:9090"));
+    Request createRequest = getCreateDataSourceRequest(createDSM);
+    Response response = client().performRequest(createRequest);
+    Assert.assertEquals(201, response.getStatusLine().getStatusCode());
+  }
+
+  @After
+  protected void deleteDataSourceMetadata() throws IOException {
+    Request deleteRequest = getDeleteDataSourceRequest("my_prometheus");
+    Response deleteResponse = client().performRequest(deleteRequest);
+    Assert.assertEquals(204, deleteResponse.getStatusLine().getStatusCode());
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
@@ -7,21 +7,27 @@
 
 package org.opensearch.sql.ppl;
 
+import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
 import static org.opensearch.sql.util.MatcherUtils.columnName;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.datasource.model.DataSourceType;
 
 public class ShowDataSourcesCommandIT extends PPLIntegTestCase {
-  @Override
-  protected void init() throws Exception {
-    loadIndex(Index.DATASOURCES);
-  }
 
   /**
    * Integ tests are dependent on self generated metrics in prometheus instance.
@@ -33,6 +39,23 @@ public class ShowDataSourcesCommandIT extends PPLIntegTestCase {
   @BeforeClass
   protected static void metricGenerationWait() throws InterruptedException {
     Thread.sleep(10000);
+  }
+
+  @Override
+  protected void init() throws InterruptedException, IOException {
+    DataSourceMetadata createDSM =
+        new DataSourceMetadata("my_prometheus", DataSourceType.PROMETHEUS,
+            ImmutableList.of(), ImmutableMap.of("prometheus.uri", "http://localhost:9090"));
+    Request createRequest = getCreateDataSourceRequest(createDSM);
+    Response response = client().performRequest(createRequest);
+    Assert.assertEquals(201, response.getStatusLine().getStatusCode());
+  }
+
+  @After
+  protected void deleteDataSourceMetadata() throws IOException {
+    Request deleteRequest = getDeleteDataSourceRequest("my_prometheus");
+    Response deleteResponse = client().performRequest(deleteRequest);
+    Assert.assertEquals(204, deleteResponse.getStatusLine().getStatusCode());
   }
 
   @Test


### PR DESCRIPTION
### Description
* with the current state, integ-state fails when cluster restricts actions on system index .ql-datasources.
* In order to avoid this, moved populating datasources using APIs instead of loading data directly in .ql-datasources.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1538
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).