### PR TITLE
Ensure Nested Function Falls Back to Legacy Engine Where Not Supported

### DIFF
--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -79,6 +79,7 @@ import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.ML;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
@@ -1015,6 +1016,53 @@ class AnalyzerTest extends AnalyzerTestBase {
         )
     );
   }
+
+  /**
+   * Ensure Nested function falls back to legacy engine when used in GROUP BY clause.
+   * TODO Remove this test when support is added.
+   */
+  @Test
+  public void nested_group_by_clause_throws_syntax_exception() {
+    SyntaxCheckException exception = assertThrows(SyntaxCheckException.class,
+        () -> analyze(
+            AstDSL.project(
+                AstDSL.agg(
+                    AstDSL.relation("schema"),
+                    emptyList(),
+                    emptyList(),
+                    ImmutableList.of(alias("nested(message.info)",
+                        function("nested",
+                            qualifiedName("message", "info")))),
+                    emptyList()
+                )))
+    );
+    assertEquals("Falling back to legacy engine. Nested function is not supported in WHERE,"
+            + " GROUP BY, and HAVING clauses.",
+        exception.getMessage());
+  }
+
+  /**
+   * Ensure Nested function falls back to legacy engine when used in WHERE clause.
+   * TODO Remove this test when support is added.
+   */
+  @Test
+  public void nested_where_clause_throws_syntax_exception() {
+    SyntaxCheckException exception = assertThrows(SyntaxCheckException.class,
+        () -> analyze(
+            AstDSL.filter(
+                AstDSL.relation("schema"),
+                AstDSL.equalTo(
+                    AstDSL.function("nested", qualifiedName("message", "info")),
+                    AstDSL.stringLiteral("str")
+                )
+            )
+        )
+    );
+    assertEquals("Falling back to legacy engine. Nested function is not supported in WHERE,"
+            + " GROUP BY, and HAVING clauses.",
+        exception.getMessage());
+  }
+
 
   /**
    * SELECT name, AVG(age) FROM test GROUP BY name.

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstSortBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstSortBuilder.java
@@ -17,12 +17,17 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.NullOrder;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.Sort.SortOrder;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParserBaseVisitor;
 import org.opensearch.sql.sql.parser.context.QuerySpecification;
 
@@ -48,6 +53,15 @@ public class AstSortBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPla
     List<UnresolvedExpression> items = querySpec.getOrderByItems();
     List<SortOption> options = querySpec.getOrderByOptions();
     for (int i = 0; i < items.size(); i++) {
+      // TODO remove me when Nested function is supported in ORDER BY clause.
+      if (items.get(i) instanceof Function
+          && ((Function)items.get(i)).getFuncName().equalsIgnoreCase(
+              BuiltinFunctionName.NESTED.name())
+      ) {
+        throw new SyntaxCheckException(
+            "Falling back to legacy engine. Nested function is not supported in ORDER BY clause."
+        );
+      }
       fields.add(
           new Field(
               querySpec.replaceIfAliasOrOrdinal(items.get(i)),

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -462,6 +462,21 @@ class AstBuilderTest extends AstBuilderTestBase {
         buildAST("SELECT name FROM test ORDER BY name NULLS LAST"));
   }
 
+  /**
+   * Ensure Nested function falls back to legacy engine when used in an ORDER BY clause.
+   * TODO Remove this test when support is added.
+   */
+  @Test
+  public void nested_in_order_by_clause_throws_exception() {
+    SyntaxCheckException exception = assertThrows(SyntaxCheckException.class,
+        () -> buildAST("SELECT * FROM test ORDER BY nested(message.info)")
+    );
+
+    assertEquals(
+        "Falling back to legacy engine. Nested function is not supported in ORDER BY clause.",
+        exception.getMessage());
+  }
+
   @Test
   public void can_build_order_by_sort_order_keyword_insensitive() {
     assertEquals(


### PR DESCRIPTION
### Description
Fallback to legacy engine when the nested function is used in the `WHERE`, `GROUP BY`, `ORDER BY`, and `HAVING` clauses. Support has not been added to the V2 engine for the nested query in these clauses.
 
### Issues Resolved
[1548](https://github.com/opensearch-project/sql/issues/1548)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).