### PR TITLE
Backport codeowners changes to 2.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @anirudha @penghuo @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @Yury-Fridlyand @MaxKsyunz
+*   @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @MaxKsyunz @Yury-Fridlyand

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/sql
+*   @anirudha @penghuo @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @Yury-Fridlyand @MaxKsyunz

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,14 +4,23 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer            | GitHub ID                                           | Affiliation |
-| --------------------- | --------------------------------------------------- | ----------- |
-| Peng Huo              | [penghuo](https://github.com/penghuo)               | Amazon      |
-| Chen Dai              | [dai-chen](https://github.com/dai-chen)             | Amazon      |
-| Chloe Zhang           | [chloe-zh](https://github.com/chloe-zh)             | Amazon      |
-| Vamsi Manohar         | [vamsi-amazon](https://github.com/vamsi-amazon)     | Amazon      |
-| Max Ksyunz            | [MaxKsyunz](https://github.com/MaxKsyunz)           | BitQuill    |
-| Yury Fridlyand        | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill    |
+| Maintainer        | GitHub ID                                           | Affiliation |
+| ----------------- | -------------------------------------------------   | ----------- |
+| Eric Wei          | [mengweieric](https://github.com/mengweieric)       | Amazon      |
+| Joshua Li         | [joshuali925](https://github.com/joshuali925)       | Amazon      |
+| Shenoy Pratik     | [ps48](https://github.com/ps48)                     | Amazon      |
+| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)           | Amazon      |
+| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)             | Amazon      |
+| Derek Ho          | [derek-ho](https://github.com/derek-ho)             | Amazon      |
+| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)               | Amazon      |
+| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons)   | Amazon      |
+| Simeon Widdis     | [swiddis](https://github.com/swiddis)               | Amazon      |
+| Chen Dai          | [dai-chen](https://github.com/dai-chen)             | Amazon      |
+| Vamsi Manohar     | [vamsi-amazon](https://github.com/vamsi-amazon)     | Amazon      |
+| Peng Huo          | [penghuo](https://github.com/penghuo)               | Amazon      |
+| Sean Kao          | [seankao-az](https://github.com/seankao-az)         | Amazon      |
+| Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)           | BitQuill    |
+| Yury Fridlyand    | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill    |
 
 ## Emeritus Maintainers
 
@@ -20,3 +29,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
 | Anirudha Jadhav   | [anirudha](https://github.com/anirudha)                 | Amazon      |
 | Nick Knize        | [nknize](https://github.com/nknize)                     | Amazon      |
+| David Cui         | [davidcui1225](https://github.com/davidcui1225)         | Amazon      |
+| Eugene Lee        | [eugenesk24](https://github.com/eugenesk24)             | Amazon      |
+| Zhongnan Su       | [zhongnansu](https://github.com/zhongnansu)             | Amazon      |
+| Chloe Zhang       | [chloe-zh](https://github.com/chloe-zh)                 | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,11 +6,17 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer            | GitHub ID                                           | Affiliation |
 | --------------------- | --------------------------------------------------- | ----------- |
-| Anirudha (Ani) Jadhav | [anirudha](https://github.com/anirudha)             | Amazon      |
 | Peng Huo              | [penghuo](https://github.com/penghuo)               | Amazon      |
 | Chen Dai              | [dai-chen](https://github.com/dai-chen)             | Amazon      |
 | Chloe Zhang           | [chloe-zh](https://github.com/chloe-zh)             | Amazon      |
-| Nick Knize            | [nknize](https://github.com/nknize)                 | Amazon      |
-| Charlotte Henkle      | [CEHENKLE](https://github.com/CEHENKLE)             | Amazon      |
+| Vamsi Manohar         | [vamsi-amazon](https://github.com/vamsi-amazon)     | Amazon      |
 | Max Ksyunz            | [MaxKsyunz](https://github.com/MaxKsyunz)           | BitQuill    |
 | Yury Fridlyand        | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill    |
+
+## Emeritus Maintainers
+
+| Maintainer        | GitHub ID                                               | Affiliation |
+| ----------------- | ------------------------------------------------------- | ----------- |
+| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
+| Anirudha Jadhav   | [anirudha](https://github.com/anirudha)                 | Amazon      |
+| Nick Knize        | [nknize](https://github.com/nknize)                     | Amazon      |


### PR DESCRIPTION
### Description
Backport #1384, #1466 #1579 to 2.x.
 
### Issues Resolved
#1337
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).