### PR TITLE
Bump org.json dependency version

### DIFF
--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -89,7 +89,7 @@ dependencies {
         }
     }
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    implementation group: 'org.json', name: 'json', version:'20180813'
+    implementation group: 'org.json', name: 'json', version:'20230227'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     // add geo module as dependency. https://github.com/opensearch-project/OpenSearch/pull/4180/.

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
-    implementation group: 'org.json', name: 'json', version:'20180813'
+    implementation group: 'org.json', name: 'json', version:'20230227'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
 

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     implementation "org.antlr:antlr4-runtime:4.7.1"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    api group: 'org.json', name: 'json', version: '20180813'
+    api group: 'org.json', name: 'json', version: '20230227'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     api project(':common')
     api project(':core')

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'com.github.babbel:okhttp-aws-signer:1.0.2'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.12.1'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.12.1'
-    implementation group: 'org.json', name: 'json', version: '20180813'
+    implementation group: 'org.json', name: 'json', version: '20230227'
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     implementation "org.antlr:antlr4-runtime:4.7.1"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    implementation group: 'org.json', name: 'json', version:'20180813'
+    implementation group: 'org.json', name: 'json', version:'20230227'
     implementation project(':common')
     implementation project(':core')
     api project(':protocol')


### PR DESCRIPTION
### Description

Bump `org.json` version for CVE fix.
 
### Issues Resolved

[CVE-2022-45688](https://github.com/advisories/GHSA-3vqj-43w4-2q58)
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).