### PR TITLE
Pagination Phase 2: Support `ORDER BY` clauses and queries without `FROM`.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/DefaultImplementor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/DefaultImplementor.java
@@ -14,6 +14,7 @@ import org.opensearch.sql.planner.logical.LogicalFetchCursor;
 import org.opensearch.sql.planner.logical.LogicalFilter;
 import org.opensearch.sql.planner.logical.LogicalLimit;
 import org.opensearch.sql.planner.logical.LogicalNested;
+import org.opensearch.sql.planner.logical.LogicalPaginate;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalPlanNodeVisitor;
 import org.opensearch.sql.planner.logical.LogicalProject;
@@ -159,6 +160,12 @@ public class DefaultImplementor<C> extends LogicalPlanNodeVisitor<PhysicalPlan, 
   @Override
   public PhysicalPlan visitCloseCursor(LogicalCloseCursor node, C context) {
     return new CursorCloseOperator(visitChild(node, context));
+  }
+
+  // Called when paging query requested without `FROM` clause only
+  @Override
+  public PhysicalPlan visitPaginate(LogicalPaginate plan, C context) {
+    return visitChild(plan, context);
   }
 
   protected PhysicalPlan visitChild(LogicalPlan node, C context) {

--- a/core/src/test/java/org/opensearch/sql/executor/pagination/CanPaginateVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/pagination/CanPaginateVisitorTest.java
@@ -5,20 +5,60 @@
 
 package org.opensearch.sql.executor.pagination;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
+import static org.opensearch.sql.ast.dsl.AstDSL.agg;
+import static org.opensearch.sql.ast.dsl.AstDSL.aggregate;
+import static org.opensearch.sql.ast.dsl.AstDSL.alias;
+import static org.opensearch.sql.ast.dsl.AstDSL.allFields;
+import static org.opensearch.sql.ast.dsl.AstDSL.and;
+import static org.opensearch.sql.ast.dsl.AstDSL.argument;
+import static org.opensearch.sql.ast.dsl.AstDSL.between;
+import static org.opensearch.sql.ast.dsl.AstDSL.booleanLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.caseWhen;
+import static org.opensearch.sql.ast.dsl.AstDSL.cast;
+import static org.opensearch.sql.ast.dsl.AstDSL.compare;
+import static org.opensearch.sql.ast.dsl.AstDSL.equalTo;
+import static org.opensearch.sql.ast.dsl.AstDSL.eval;
+import static org.opensearch.sql.ast.dsl.AstDSL.field;
+import static org.opensearch.sql.ast.dsl.AstDSL.filter;
+import static org.opensearch.sql.ast.dsl.AstDSL.function;
+import static org.opensearch.sql.ast.dsl.AstDSL.highlight;
+import static org.opensearch.sql.ast.dsl.AstDSL.in;
+import static org.opensearch.sql.ast.dsl.AstDSL.intLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.intervalLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.limit;
+import static org.opensearch.sql.ast.dsl.AstDSL.map;
+import static org.opensearch.sql.ast.dsl.AstDSL.not;
+import static org.opensearch.sql.ast.dsl.AstDSL.or;
+import static org.opensearch.sql.ast.dsl.AstDSL.project;
+import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
+import static org.opensearch.sql.ast.dsl.AstDSL.relation;
+import static org.opensearch.sql.ast.dsl.AstDSL.sort;
+import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.tableFunction;
+import static org.opensearch.sql.ast.dsl.AstDSL.unresolvedArg;
+import static org.opensearch.sql.ast.dsl.AstDSL.unresolvedAttr;
+import static org.opensearch.sql.ast.dsl.AstDSL.values;
+import static org.opensearch.sql.ast.dsl.AstDSL.when;
+import static org.opensearch.sql.ast.dsl.AstDSL.window;
+import static org.opensearch.sql.ast.dsl.AstDSL.xor;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.dsl.AstDSL;
+import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.Relation;
-import org.opensearch.sql.executor.pagination.CanPaginateVisitor;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class CanPaginateVisitorTest {
@@ -28,84 +68,132 @@ public class CanPaginateVisitorTest {
   @Test
   // select * from y
   public void accept_query_with_select_star_and_from() {
-    var plan = AstDSL.project(AstDSL.relation("dummy"), AstDSL.allFields());
+    var plan = project(relation("dummy"), allFields());
     assertTrue(plan.accept(visitor, null));
   }
 
   @Test
   // select x from y
   public void reject_query_with_select_field_and_from() {
-    var plan = AstDSL.project(AstDSL.relation("dummy"), AstDSL.field("pewpew"));
+    var plan = project(relation("dummy"), field("pewpew"));
     assertFalse(plan.accept(visitor, null));
   }
 
   @Test
   // select x,z from y
   public void reject_query_with_select_fields_and_from() {
-    var plan = AstDSL.project(AstDSL.relation("dummy"),
-        AstDSL.field("pewpew"), AstDSL.field("pewpew"));
+    var plan = project(relation("dummy"),
+        field("pewpew"), field("pewpew"));
     assertFalse(plan.accept(visitor, null));
   }
 
   @Test
   // select x
-  public void reject_query_without_from() {
-    var plan = AstDSL.project(AstDSL.values(List.of(AstDSL.intLiteral(1))),
-        AstDSL.alias("1",AstDSL.intLiteral(1)));
-    assertFalse(plan.accept(visitor, null));
+  public void allow_query_without_from() {
+    // bypass check for `AllFields` in `visitProject`
+    // TODO remove after #1500 merge https://github.com/opensearch-project/sql/pull/1500
+    var visitor = new CanPaginateVisitor() {
+      @Override
+      public Boolean visitProject(Project node, Object context) {
+        return node.getChild().get(0).accept(this, context);
+      }
+    };
+    var plan = project(values(List.of(intLiteral(1))),
+        alias("1", intLiteral(1)));
+    assertTrue(plan.accept(visitor, null));
   }
 
   @Test
   // select * from y limit z
-  public void reject_query_with_limit() {
-    var plan = AstDSL.project(AstDSL.limit(AstDSL.relation("dummy"), 1, 2), AstDSL.allFields());
+  public void reject_query_with_limit_but_no_offset() {
+    var plan = project(limit(relation("dummy"), 1, 0), allFields());
+    assertFalse(plan.accept(visitor, null));
+  }
+
+  @Test
+  // select * from y limit z, n
+  public void reject_query_with_offset() {
+    var plan = project(limit(relation("dummy"), 0, 1), allFields());
+    assertFalse(plan.accept(visitor, null));
+  }
+
+  // test added for coverage only
+  @Test
+  public void visitLimit() {
+    var visitor = new CanPaginateVisitor() {
+      @Override
+      public Boolean visitRelation(Relation node, Object context) {
+        return Boolean.FALSE;
+      }
+    };
+    var plan = project(limit(relation("dummy"), 0, 0), allFields());
     assertFalse(plan.accept(visitor, null));
   }
 
   @Test
   // select * from y where z
   public void reject_query_with_where() {
-    var plan = AstDSL.project(AstDSL.filter(AstDSL.relation("dummy"),
-        AstDSL.booleanLiteral(true)), AstDSL.allFields());
+    var plan = project(filter(relation("dummy"),
+        booleanLiteral(true)), allFields());
     assertFalse(plan.accept(visitor, null));
   }
 
   @Test
   // select * from y order by z
-  public void reject_query_with_order_by() {
-    var plan = AstDSL.project(AstDSL.sort(AstDSL.relation("dummy"), AstDSL.field("1")),
-        AstDSL.allFields());
+  public void allow_query_with_order_by_with_column_references_only() {
+    var plan = project(sort(relation("dummy"), field("1")), allFields());
+    assertTrue(plan.accept(visitor, null));
+  }
+
+  @Test
+  // select * from y order by func(z)
+  public void reject_query_with_order_by_with_an_expression() {
+    var plan = project(sort(relation("dummy"), field(function("func"))),
+        allFields());
+    assertFalse(plan.accept(visitor, null));
+  }
+
+  // test added for coverage only
+  @Test
+  public void visitSort() {
+    var visitor = new CanPaginateVisitor() {
+      @Override
+      public Boolean visitRelation(Relation node, Object context) {
+        return Boolean.FALSE;
+      }
+    };
+    var plan = project(sort(relation("dummy"), field("1")), allFields());
     assertFalse(plan.accept(visitor, null));
   }
 
   @Test
   // select * from y group by z
   public void reject_query_with_group_by() {
-    var plan = AstDSL.project(AstDSL.agg(
-        AstDSL.relation("dummy"), List.of(), List.of(), List.of(AstDSL.field("1")), List.of()),
-        AstDSL.allFields());
+    var plan = project(agg(
+        relation("dummy"), List.of(), List.of(), List.of(field("1")), List.of()),
+        allFields());
     assertFalse(plan.accept(visitor, null));
   }
 
   @Test
   // select agg(x) from y
   public void reject_query_with_aggregation_function() {
-    var plan = AstDSL.project(AstDSL.agg(
-        AstDSL.relation("dummy"),
-        List.of(AstDSL.alias("agg", AstDSL.aggregate("func", AstDSL.field("pewpew")))),
+    var plan = project(agg(
+        relation("dummy"),
+        List.of(alias("agg", aggregate("func", field("pewpew")))),
         List.of(), List.of(), List.of()),
-        AstDSL.allFields());
+        allFields());
     assertFalse(plan.accept(visitor, null));
   }
 
   @Test
   // select window(x) from y
   public void reject_query_with_window_function() {
-    var plan = AstDSL.project(AstDSL.relation("dummy"),
-        AstDSL.alias("pewpew",
-            AstDSL.window(
-                AstDSL.aggregate("func", AstDSL.field("pewpew")),
-                    List.of(AstDSL.qualifiedName("1")), List.of())));
+    var plan = project(relation("dummy"),
+        alias("pewpew",
+            window(
+                aggregate("func", field("pewpew")),
+                    List.of(qualifiedName("1")), List.of())));
     assertFalse(plan.accept(visitor, null));
   }
 
@@ -113,20 +201,31 @@ public class CanPaginateVisitorTest {
   // select * from y, z
   public void reject_query_with_select_from_multiple_indices() {
     var plan = mock(Project.class);
-    when(plan.getChild()).thenReturn(List.of(AstDSL.relation("dummy"), AstDSL.relation("pummy")));
-    when(plan.getProjectList()).thenReturn(List.of(AstDSL.allFields()));
+    when(plan.getChild()).thenReturn(List.of(relation("dummy"), relation("pummy")));
+    when(plan.getProjectList()).thenReturn(List.of(allFields()));
     assertFalse(visitor.visitProject(plan, null));
   }
 
   @Test
   // unreal case, added for coverage only
   public void reject_project_when_relation_has_child() {
-    var relation = mock(Relation.class, withSettings().useConstructor(AstDSL.qualifiedName("42")));
-    when(relation.getChild()).thenReturn(List.of(AstDSL.relation("pewpew")));
+    var relation = mock(Relation.class, withSettings().useConstructor(qualifiedName("42")));
+    when(relation.getChild()).thenReturn(List.of(relation("pewpew")));
     when(relation.accept(visitor, null)).thenCallRealMethod();
     var plan = mock(Project.class);
     when(plan.getChild()).thenReturn(List.of(relation));
-    when(plan.getProjectList()).thenReturn(List.of(AstDSL.allFields()));
+    when(plan.getProjectList()).thenReturn(List.of(allFields()));
     assertFalse(visitor.visitProject((Project) plan, null));
+  }
+
+  @Test
+  // test added just for coverage
+  public void canPaginate() {
+    assertTrue(visitor.canPaginate(new Node() {
+      @Override
+      public List<? extends Node> getChild() {
+        return null;
+      }
+    }, null));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/planner/DefaultImplementorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/DefaultImplementorTest.java
@@ -58,12 +58,17 @@ import org.opensearch.sql.expression.aggregation.NamedAggregator;
 import org.opensearch.sql.expression.window.WindowDefinition;
 import org.opensearch.sql.expression.window.ranking.RowNumberFunction;
 import org.opensearch.sql.planner.logical.LogicalCloseCursor;
+import org.opensearch.sql.planner.logical.LogicalPaginate;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalPlanDSL;
+import org.opensearch.sql.planner.logical.LogicalProject;
 import org.opensearch.sql.planner.logical.LogicalRelation;
+import org.opensearch.sql.planner.logical.LogicalValues;
 import org.opensearch.sql.planner.physical.CursorCloseOperator;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlanDSL;
+import org.opensearch.sql.planner.physical.ProjectOperator;
+import org.opensearch.sql.planner.physical.ValuesOperator;
 import org.opensearch.sql.storage.StorageEngine;
 import org.opensearch.sql.storage.Table;
 import org.opensearch.sql.storage.TableScanOperator;
@@ -272,5 +277,15 @@ class DefaultImplementorTest {
     var implemented = logicalPlan.accept(implementor, null);
     assertTrue(implemented instanceof CursorCloseOperator);
     assertSame(physicalChild, implemented.getChild().get(0));
+  }
+
+  @Test
+  public void visitPaginate_should_remove_it_from_tree() {
+    var logicalPlanTree = new LogicalPaginate(42, List.of(
+        new LogicalProject(
+            new LogicalValues(List.of(List.of())), List.of(), List.of())));
+    var physicalPlanTree = new ProjectOperator(
+        new ValuesOperator(List.of(List.of())), List.of(), List.of());
+    assertEquals(physicalPlanTree, logicalPlanTree.accept(implementor, null));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
@@ -8,6 +8,9 @@ package org.opensearch.sql.planner.physical;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +25,7 @@ import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.planner.SerializablePlan;
 
 public class PhysicalPlanTestBase {
 
@@ -208,7 +212,7 @@ public class PhysicalPlanTestBase {
     return new TestScan(inputs);
   }
 
-  protected static class TestScan extends PhysicalPlan {
+  protected static class TestScan extends PhysicalPlan implements SerializablePlan {
     private final Iterator<ExprValue> iterator;
 
     public TestScan() {
@@ -237,6 +241,22 @@ public class PhysicalPlanTestBase {
     @Override
     public ExprValue next() {
       return iterator.next();
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+    }
+
+    public boolean equals(final Object o) {
+      return o == this || o.hashCode() == hashCode();
+    }
+
+    public int hashCode() {
+      return 42;
     }
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationFallbackIT.java
@@ -124,8 +124,6 @@ public class PaginationFallbackIT extends SQLIntegTestCase {
   public void testOrderBy() throws IOException {
     var response = executeQueryTemplate("SELECT * FROM %s ORDER By `107`",
         TEST_INDEX_ONLINE);
-    verifyIsV1Cursor(response);
+    verifyIsV2Cursor(response);
   }
-
-
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -12,6 +12,7 @@ import static org.opensearch.sql.legacy.plugin.RestSqlAction.EXPLAIN_API_ENDPOIN
 import java.io.IOException;
 
 import lombok.SneakyThrows;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -111,5 +112,95 @@ public class PaginationIT extends SQLIntegTestCase {
         .contains("SearchContextMissingException[No search context found for id"));
     assertEquals(response.getJSONObject("error").getString("type"),
         "SearchPhaseExecutionException");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testQueryWithOrderBy() {
+    var response = executeJdbcRequest(String.format("select * from %s", TEST_INDEX_CALCS));
+    var indexSize = response.getInt("total");
+    var rows = response.getJSONArray("datarows");
+    var schema = response.getJSONArray("schema");
+
+    var rowsPagedAsc = new JSONArray();
+    var rowsReturnedAsc = 0;
+    var rowsPagedDesc = new JSONArray();
+    var rowsReturnedDesc = 0;
+
+    var query = String.format("SELECT * from %s ORDER BY num1 ASC", TEST_INDEX_CALCS);
+    response = new JSONObject(executeFetchQuery(query, 4, "jdbc"));
+    assertTrue(response.has("cursor"));
+    TestUtils.verifyIsV2Cursor(response);
+    var cursor = response.getString("cursor");
+    do {
+      assertTrue(cursor.isEmpty() || cursor.startsWith("n:"));
+      assertTrue("Paged response schema doesn't match to non-paged",
+          schema.similar(response.getJSONArray("schema")));
+
+      rowsReturnedAsc += response.getInt("size");
+      var datarows = response.getJSONArray("datarows");
+      for (int i = 0; i < datarows.length(); i++) {
+        rowsPagedAsc.put(datarows.get(i));
+      }
+
+      if (response.has("cursor")) {
+        TestUtils.verifyIsV2Cursor(response);
+        cursor = response.getString("cursor");
+        response = executeCursorQuery(cursor);
+      } else {
+        cursor = "";
+      }
+
+    } while(!cursor.isEmpty());
+
+    query = String.format("SELECT * from %s ORDER BY num1 DESC", TEST_INDEX_CALCS);
+    response = new JSONObject(executeFetchQuery(query, 7, "jdbc"));
+    assertTrue(response.has("cursor"));
+    TestUtils.verifyIsV2Cursor(response);
+    cursor = response.getString("cursor");
+    do {
+      assertTrue(cursor.isEmpty() || cursor.startsWith("n:"));
+      assertTrue("Paged response schema doesn't match to non-paged",
+          schema.similar(response.getJSONArray("schema")));
+
+      rowsReturnedDesc += response.getInt("size");
+      var datarows = response.getJSONArray("datarows");
+      for (int i = 0; i < datarows.length(); i++) {
+        rowsPagedDesc.put(datarows.get(i));
+      }
+
+      if (response.has("cursor")) {
+        TestUtils.verifyIsV2Cursor(response);
+        cursor = response.getString("cursor");
+        response = executeCursorQuery(cursor);
+      } else {
+        cursor = "";
+      }
+
+    } while(!cursor.isEmpty());
+
+    assertEquals("Paged responses return another row count that non-paged",
+        indexSize, rowsReturnedAsc);
+    assertEquals("Paged responses return another row count that non-paged",
+        indexSize, rowsReturnedDesc);
+    assertTrue("Paged accumulated result has other rows than non-paged",
+        rows.toList().containsAll(rowsPagedAsc.toList()));
+    assertTrue("Paged accumulated result has other rows than non-paged",
+        rows.toList().containsAll(rowsPagedDesc.toList()));
+
+    for (int row = 0; row < indexSize; row++) {
+      assertTrue(String.format("Row %d: row order is incorrect", row),
+          rowsPagedAsc.getJSONArray(row).similar(rowsPagedDesc.getJSONArray(indexSize - row - 1)));
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  @Ignore("Activate test after PR #1500 merge")
+  public void testQueryWithoutFrom() {
+    var response = new JSONObject(executeFetchQuery("SELECT 1", 4, "jdbc"));
+    assertFalse(response.has("cursor"));
+    assertEquals(1, response.getInt("total"));
+    assertEquals(1, response.getJSONArray("datarows").getJSONArray(0).getInt(0));
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequest.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequest.java
@@ -38,7 +38,11 @@ import org.opensearch.sql.opensearch.storage.OpenSearchStorageEngine;
 @Getter
 @ToString
 public class OpenSearchScrollRequest implements OpenSearchRequest {
-  private final SearchRequest initialSearchRequest;
+  /**
+   * Search request used to initiate paged (scrolled) search. Not needed to get subsequent pages.
+   */
+  @EqualsAndHashCode.Exclude
+  private final transient SearchRequest initialSearchRequest;
   /** Scroll context timeout. */
   private final TimeValue scrollTimeout;
 
@@ -154,7 +158,6 @@ public class OpenSearchScrollRequest implements OpenSearchRequest {
 
   @Override
   public void writeTo(StreamOutput out) throws IOException {
-    initialSearchRequest.writeTo(out);
     out.writeTimeValue(scrollTimeout);
     out.writeString(scrollId);
     out.writeStringCollection(includes);
@@ -169,7 +172,7 @@ public class OpenSearchScrollRequest implements OpenSearchRequest {
    */
   public OpenSearchScrollRequest(StreamInput in, OpenSearchStorageEngine engine)
       throws IOException {
-    initialSearchRequest = new SearchRequest(in);
+    initialSearchRequest = null;
     scrollTimeout = in.readTimeValue();
     scrollId = in.readString();
     includes = in.readStringList();

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequestTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequestTest.java
@@ -273,7 +273,7 @@ class OpenSearchScrollRequestTest {
     var engine = mock(OpenSearchStorageEngine.class);
     when(engine.getTable(any(), any())).thenReturn(indexMock);
     var newRequest = new OpenSearchScrollRequest(inStream, engine);
-    assertEquals(request.getInitialSearchRequest(), newRequest.getInitialSearchRequest());
+    assertEquals(request, newRequest);
     assertEquals("", newRequest.getScrollId());
   }
 
@@ -296,7 +296,7 @@ class OpenSearchScrollRequestTest {
     var engine = mock(OpenSearchStorageEngine.class);
     when(engine.getTable(any(), any())).thenReturn(indexMock);
     var newRequest = new OpenSearchScrollRequest(inStream, engine);
-    assertEquals(request.getInitialSearchRequest(), newRequest.getInitialSearchRequest());
+    assertEquals(request, newRequest);
     assertEquals("", newRequest.getScrollId());
   }
 


### PR DESCRIPTION
Pagination in V2: Phase 2. See Phase 1 in #1497.

Doc: https://github.com/Bit-Quill/opensearch-project-sql/blob/61767f2b200b2a7f8c8b2df32de209b3c30caa61/docs/dev/Pagination-v2.md

This PR depends on #1500.

```
curl -XPOST http://localhost:9200/_plugins/_sql -H 'Content-Type: application/json' -d '{"query": "select * from calcs order by int0, num1;", "fetch_size": 3 }'
```

You can use attached script for testing as well. Command line: `./cursor_test.sh <table> <page size>`. Requires `jq`. Rename the script before use.
[cursor_test.sh.txt](https://github.com/opensearch-project/sql/files/11166838/cursor_test.sh.txt)

### Description
Add support for more complex queries in paged requests.
Supported things:
- `GROUP BY` clause
- queries without `FROM` clause
 
Unsupported things:
- expressions in `GROUP BY` - #1471

### Issues Resolved
Support of `ORDER BY` clause and support queries without `FROM` clause.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).