### PR TITLE
Update dependencies to patch CVE

### DIFF
--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.1'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.12.1'
 

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -47,7 +47,7 @@ repositories {
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.1'
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.12.1'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.3.1')

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -51,11 +51,14 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.3.1')
-    testImplementation('com.github.tomakehurst:wiremock:2.20.0')
+    testImplementation('com.github.tomakehurst:wiremock:3.0.0-beta-2')
     testImplementation('org.mockito:mockito-core:2.23.0')
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.3.1')
     testImplementation('org.junit-pioneer:junit-pioneer:0.3.0')
-    testImplementation('org.eclipse.jetty:jetty-server:9.2.24.v20180105')
+    testImplementation('org.eclipse.jetty:jetty-server:11.0.14')
+
+    // Enforce wiremock to use latest guava
+    testImplementation('com.google.guava:guava:31.1-jre')
 
     testRuntimeOnly('org.slf4j:slf4j-simple:1.7.25') // capture WireMock logging
 }

--- a/sql-jdbc/src/test/java/org/opensearch/jdbc/transport/http/auth/aws/AWSRequestSigningApacheInterceptorTests.java
+++ b/sql-jdbc/src/test/java/org/opensearch/jdbc/transport/http/auth/aws/AWSRequestSigningApacheInterceptorTests.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AWSRequestSigningApacheInterceptorTests {


### PR DESCRIPTION
### Description

Update `httpclient`, `aws-java-sdk-core`, `wiremock`, `jetty-server`, `guava`

Patch the following CVE:
* CVE-2018-12536
* CVE-2019-10241
* CVE-2019-10246
* CVE-2019-10247
* CVE-2019-10426
* CVE-2020-13956
* CVE-2020-28491
* CVE-2021-34428
* CVE-2022-2047
* CVE-2023-26048
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).