### PR TITLE
Patch 1.3 MED+ CVE's

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "1.3.10-SNAPSHOT")
-        spring_version = "5.3.25"
+        spring_version = "5.3.27"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -119,11 +119,11 @@ jacocoTestCoverageVerification {
 check.dependsOn jacocoTestCoverageVerification
 
 // TODO: fix code style in main and test source code
-subprojects {
+allprojects {
     apply plugin: 'checkstyle'
     checkstyle {
         configFile rootProject.file("config/checkstyle/google_checks.xml")
-        toolVersion "8.29"
+        toolVersion "8.45.1"
         configProperties = [
                 "org.checkstyle.google.suppressionfilter.config": rootProject.file("config/checkstyle/suppressions.xml")]
         ignoreFailures = false

--- a/config/checkstyle/google_checks.xml
+++ b/config/checkstyle/google_checks.xml
@@ -279,7 +279,7 @@
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -714,10 +714,10 @@ class AnalyzerTest extends AnalyzerTestBase {
   public void ad_batchRCF_relation() {
     Map<String, Literal> argumentMap =
             new HashMap<String, Literal>() {{
-        put("shingle_size", new Literal(8, DataType.INTEGER));
-        put("time_decay", new Literal(0.0001, DataType.DOUBLE));
-        put("time_field", new Literal(null, DataType.STRING));
-      }};
+                put("shingle_size", new Literal(8, DataType.INTEGER));
+                put("time_decay", new Literal(0.0001, DataType.DOUBLE));
+                put("time_field", new Literal(null, DataType.STRING));
+            }};
     assertAnalyzeEqual(
             new LogicalAD(LogicalPlanDSL.relation("schema"), argumentMap),
             new AD(AstDSL.relation("schema"), argumentMap)

--- a/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
@@ -124,8 +124,8 @@ class LogicalPlanNodeVisitorTest {
               put("shingle_size", new Literal(8, DataType.INTEGER));
               put("time_decay", new Literal(0.0001, DataType.DOUBLE));
               put("time_field", new Literal(null, DataType.STRING));
-        }
-      });
+            }
+        });
     assertNull(ad.accept(new LogicalPlanNodeVisitor<Integer, Object>() {
     }, null));
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
@@ -71,7 +71,7 @@ public class ExpressionScript {
    * Evaluate on the doc generate by the doc provider.
    * @param docProvider doc provider.
    * @param evaluator evaluator
-   * @return
+   * @return expr value
    */
   public ExprValue execute(Supplier<Map<String, ScriptDocValues<?>>> docProvider,
                          BiFunction<Expression,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtectorTest.java
@@ -277,13 +277,14 @@ class OpenSearchExecutionProtectorTest {
     NodeClient nodeClient = mock(NodeClient.class);
     ADOperator adOperator =
             new ADOperator(
-                    values(emptyList()),
-                    new HashMap<String, Literal>() {{
-          put("shingle_size", new Literal(8, DataType.INTEGER));
-          put("time_decay", new Literal(0.0001, DataType.DOUBLE));
-          put("time_field", new Literal(null, DataType.STRING));
-        }
-      }, nodeClient);
+                values(emptyList()),
+                new HashMap<String, Literal>() {{
+                    put("shingle_size", new Literal(8, DataType.INTEGER));
+                    put("time_decay", new Literal(0.0001, DataType.DOUBLE));
+                    put("time_field", new Literal(null, DataType.STRING));
+                }},
+                nodeClient
+            );
 
     assertEquals(executionProtector.doProtect(adOperator),
             executionProtector.visitAD(adOperator, null));

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java
@@ -24,6 +24,7 @@ public enum Format {
   private final String formatName;
 
   private static final Map<String, Format> ALL_FORMATS;
+
   static {
     ImmutableMap.Builder<String, Format> builder = new ImmutableMap.Builder<>();
     for (Format format : Format.values()) {

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.3.1')
-    testImplementation('com.github.tomakehurst:wiremock:3.0.0-beta-2')
+    testImplementation('com.github.tomakehurst:wiremock:3.0.0-beta-7')
     testImplementation('org.mockito:mockito-core:2.23.0')
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.3.1')
     testImplementation('org.junit-pioneer:junit-pioneer:0.3.0')


### PR DESCRIPTION
### Description
Patched CVE's
* CVE-2019-10782
* CVE-2020-8908
* CVE-2023-1370
* CVE-2023-20861
* CVE-2023-20863
* CVE-2023-24998
* CVE-2023-26048 (*)
* CVE-2023-26049 (*)

(\*) This requires the use of `jetty-server@11.0.14` instead of `jetty-server@11.0.12`
However, the latest version of `wiremock@3.0.0-beta-8` still uses `jetty-server@11.0.12`
Wiremock is used in testing only. We can probably exempt these CVE's *after* we make sure that wiremock is the only source of these CVE's.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).