### PR TITLE
Add Streaming write support

### DIFF
--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintPartitionWriter.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintPartitionWriter.scala
@@ -30,7 +30,8 @@ case class FlintPartitionWriter(
     dataSchema: StructType,
     properties: util.Map[String, String],
     partitionId: Int,
-    taskId: Long)
+    taskId: Long,
+    epochId: Long = -1)
     extends DataWriter[InternalRow]
     with Logging {
 
@@ -69,8 +70,8 @@ case class FlintPartitionWriter(
 
   override def commit(): WriterCommitMessage = {
     gen.flush()
-    logDebug(s"Write commit on partitionId: $partitionId, taskId: $taskId")
-    FlintWriterCommitMessage(partitionId, taskId)
+    logDebug(s"Write commit on partitionId: $partitionId, taskId: $taskId, epochId: $epochId")
+    FlintWriterCommitMessage(partitionId, taskId, epochId)
   }
 
   override def abort(): Unit = {
@@ -79,11 +80,12 @@ case class FlintPartitionWriter(
 
   override def close(): Unit = {
     gen.close()
-    logDebug(s"Write close on partitionId: $partitionId, taskId: $taskId")
+    logDebug(s"Write close on partitionId: $partitionId, taskId: $taskId, epochId: $epochId")
   }
 }
 
-case class FlintWriterCommitMessage(partitionId: Int, taskId: Long) extends WriterCommitMessage
+case class FlintWriterCommitMessage(partitionId: Int, taskId: Long, epochId: Long)
+    extends WriterCommitMessage
 
 /**
  * Todo. Move to FlintSparkConfiguration.

--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintPartitionWriterFactory.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintPartitionWriterFactory.scala
@@ -12,6 +12,7 @@ import org.opensearch.flint.core.{FlintClientBuilder, FlintOptions}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.write.{DataWriter, DataWriterFactory}
+import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory
 import org.apache.spark.sql.types.StructType
 
 case class FlintPartitionWriterFactory(
@@ -19,15 +20,31 @@ case class FlintPartitionWriterFactory(
     schema: StructType,
     properties: util.Map[String, String])
     extends DataWriterFactory
+    with StreamingDataWriterFactory
     with Logging {
+
+  private lazy val flintClient = FlintClientBuilder.build(new FlintOptions(properties))
+
   override def createWriter(partitionId: Int, taskId: Long): DataWriter[InternalRow] = {
     logDebug(s"create writer for partition: $partitionId, task: $taskId")
-    val flintClient = FlintClientBuilder.build(new FlintOptions(properties))
     FlintPartitionWriter(
       flintClient.createWriter(tableName),
       schema,
       properties,
       partitionId,
       taskId)
+  }
+
+  override def createWriter(
+      partitionId: Int,
+      taskId: Long,
+      epochId: Long): DataWriter[InternalRow] = {
+    FlintPartitionWriter(
+      flintClient.createWriter(tableName),
+      schema,
+      properties,
+      partitionId,
+      taskId,
+      epochId)
   }
 }

--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintTable.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintTable.scala
@@ -9,7 +9,7 @@ import java.util
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
-import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, BATCH_WRITE, TRUNCATE}
+import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, BATCH_WRITE, STREAMING_WRITE, TRUNCATE}
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.types.StructType
@@ -44,7 +44,7 @@ case class FlintTable(
   }
 
   override def capabilities(): util.Set[TableCapability] =
-    util.EnumSet.of(BATCH_READ, BATCH_WRITE, TRUNCATE)
+    util.EnumSet.of(BATCH_READ, BATCH_WRITE, TRUNCATE, STREAMING_WRITE)
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     FlintScanBuilder(name, sparkSession, schema, options.asCaseSensitiveMap())

--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintWrite.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintWrite.scala
@@ -7,15 +7,17 @@ package org.apache.spark.sql.flint
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.write._
+import org.apache.spark.sql.connector.write.streaming.{StreamingDataWriterFactory, StreamingWrite}
 
 case class FlintWrite(tableName: String, logicalWriteInfo: LogicalWriteInfo)
     extends Write
     with BatchWrite
+    with StreamingWrite
     with Logging {
 
   override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
-    logDebug(
-      s"Create factory of ${logicalWriteInfo.queryId()} with ${info.numPartitions()} partitions")
+    logDebug(s"""Create batch write factory of ${logicalWriteInfo.queryId()} with ${info
+        .numPartitions()} partitions""")
     FlintPartitionWriterFactory(
       tableName,
       logicalWriteInfo.schema(),
@@ -28,5 +30,24 @@ case class FlintWrite(tableName: String, logicalWriteInfo: LogicalWriteInfo)
 
   override def abort(messages: Array[WriterCommitMessage]): Unit = {}
 
+  override def createStreamingWriterFactory(
+      info: PhysicalWriteInfo): StreamingDataWriterFactory = {
+    logDebug(s"""Create streaming write factory of ${logicalWriteInfo.queryId()} with ${info
+        .numPartitions()} partitions""")
+    FlintPartitionWriterFactory(
+      tableName,
+      logicalWriteInfo.schema(),
+      logicalWriteInfo.options().asCaseSensitiveMap())
+  }
+
+  override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {
+    logDebug(s"""Write of ${logicalWriteInfo
+        .queryId()} committed for epochId: $epochId, ${messages.length} tasks""")
+  }
+
+  override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
+
   override def toBatch: BatchWrite = this
+
+  override def toStreaming: StreamingWrite = this
 }


### PR DESCRIPTION
### Description
1. Add Streaming write support for FlintTable. As Streaming Sink, FlintWriter depend on _id field in DataFrame to achieve idempotent. It is should fine for now. We will revist it if sink commit id is required.


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).