### PR TITLE
Add Support for Nested Function Use In WHERE Clause Predicate Expresion

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -63,7 +63,6 @@ import org.opensearch.sql.ast.tree.Values;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.data.model.ExprMissingValue;
 import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
@@ -220,7 +219,6 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   public LogicalPlan visitFilter(Filter node, AnalysisContext context) {
     LogicalPlan child = node.getChild().get(0).accept(this, context);
     Expression condition = expressionAnalyzer.analyze(node.getCondition(), context);
-    verifySupportsCondition(condition);
 
     ExpressionReferenceOptimizer optimizer =
         new ExpressionReferenceOptimizer(expressionAnalyzer.getRepository(), child);
@@ -229,7 +227,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   }
 
   /**
-   * Ensure NESTED function is not used in WHERE, GROUP BY, and HAVING clauses.
+   * Ensure NESTED function is not used in GROUP BY, and HAVING clauses.
    * Fallback to legacy engine. Can remove when support is added for NESTED function in WHERE,
    * GROUP BY, ORDER BY, and HAVING clauses.
    * @param condition : Filter condition

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -1042,29 +1042,6 @@ class AnalyzerTest extends AnalyzerTestBase {
   }
 
   /**
-   * Ensure Nested function falls back to legacy engine when used in WHERE clause.
-   * TODO Remove this test when support is added.
-   */
-  @Test
-  public void nested_where_clause_throws_syntax_exception() {
-    SyntaxCheckException exception = assertThrows(SyntaxCheckException.class,
-        () -> analyze(
-            AstDSL.filter(
-                AstDSL.relation("schema"),
-                AstDSL.equalTo(
-                    AstDSL.function("nested", qualifiedName("message", "info")),
-                    AstDSL.stringLiteral("str")
-                )
-            )
-        )
-    );
-    assertEquals("Falling back to legacy engine. Nested function is not supported in WHERE,"
-            + " GROUP BY, and HAVING clauses.",
-        exception.getMessage());
-  }
-
-
-  /**
    * SELECT name, AVG(age) FROM test GROUP BY name.
    */
   @Test

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -4456,6 +4456,17 @@ Example with ``field`` and ``path`` parameters::
     +---------------------------------+
 
 
+Example with ``field`` and ``path`` parameters in the SELECT and WHERE clause::
+
+    os> SELECT nested(message.info, message) FROM nested WHERE nested(message.info, message) = 'b';
+    fetched rows / total rows = 1/1
+    +---------------------------------+
+    | nested(message.info, message)   |
+    |---------------------------------|
+    | b                               |
+    +---------------------------------+
+
+
 System Functions
 ================
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -336,6 +336,16 @@ public class NestedIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void test_nested_in_where_as_predicate_expression_with_like() {
+    String query = "SELECT message.info FROM " + TEST_INDEX_NESTED_TYPE
+        + " WHERE nested(message.info) LIKE 'a'";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(2, result.getInt("total"));
+    // Only first index of array is returned. Second index has 'a'
+    verifyDataRows(result, rows("a"), rows("c"));
+  }
+
+  @Test
   public void test_nested_in_where_as_predicate_expression_with_multiple_conditions() {
     String query = "SELECT message.info, comment.data, message.dayOfWeek FROM " + TEST_INDEX_NESTED_TYPE
         + " WHERE nested(message.info) = 'zz' OR nested(comment.data) = 'ab' AND nested(message.dayOfWeek) >= 4";

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -171,18 +171,6 @@ public class NestedIT extends SQLIntegTestCase {
   }
 
   @Test
-  public void nested_function_with_where_clause() {
-    String query =
-        "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE + " WHERE nested(message.info) = 'a'";
-    JSONObject result = executeJdbcRequest(query);
-
-    assertEquals(2, result.getInt("total"));
-    verifyDataRows(result,
-        rows("a"),
-        rows("a"));
-  }
-
-  @Test
   public void nested_function_with_order_by_clause() {
     String query =
         "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE
@@ -312,5 +300,60 @@ public class NestedIT extends SQLIntegTestCase {
         "  \"status\": 400\n" +
         "}"
     ));
+  }
+
+  @Test
+  public void test_nested_where_with_and_conditional() {
+    String query = "SELECT nested(message.info), nested(message.author) FROM " + TEST_INDEX_NESTED_TYPE
+        + " WHERE nested(message, message.info = 'a' AND message.author = 'e')";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(1, result.getInt("total"));
+    verifyDataRows(result, rows("a", "e"));
+  }
+
+  @Test
+  public void test_nested_in_select_and_where_as_predicate_expression() {
+    String query = "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE
+        + " WHERE nested(message.info) = 'a'";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(3, result.getInt("total"));
+    verifyDataRows(
+        result,
+        rows("a"),
+        rows("c"),
+        rows("a")
+    );
+  }
+
+  @Test
+  public void test_nested_in_where_as_predicate_expression() {
+    String query = "SELECT message.info FROM " + TEST_INDEX_NESTED_TYPE
+        + " WHERE nested(message.info) = 'a'";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(2, result.getInt("total"));
+    // Only first index of array is returned. Second index has 'a'
+    verifyDataRows(result, rows("a"), rows("c"));
+  }
+
+  @Test
+  public void test_nested_in_where_as_predicate_expression_with_multiple_conditions() {
+    String query = "SELECT message.info, comment.data, message.dayOfWeek FROM " + TEST_INDEX_NESTED_TYPE
+        + " WHERE nested(message.info) = 'zz' OR nested(comment.data) = 'ab' AND nested(message.dayOfWeek) >= 4";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(2, result.getInt("total"));
+    verifyDataRows(
+        result,
+        rows("c", "ab", 4),
+        rows("zz", "aa", 6)
+    );
+  }
+
+  @Test
+  public void test_nested_in_where_as_predicate_expression_with_relevance_query() {
+    String query = "SELECT comment.likes, someField FROM " + TEST_INDEX_NESTED_TYPE
+        + " WHERE nested(comment.likes) = 10 AND match(someField, 'a')";
+    JSONObject result = executeJdbcRequest(query);
+    assertEquals(1, result.getInt("total"));
+    verifyDataRows(result, rows(10, "a"));
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
@@ -8,17 +8,20 @@ package org.opensearch.sql.opensearch.request;
 
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
-import static org.opensearch.index.query.QueryBuilders.boolQuery;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.index.query.QueryBuilders.nestedQuery;
 import static org.opensearch.search.sort.FieldSortBuilder.DOC_FIELD_NAME;
 import static org.opensearch.search.sort.SortOrder.ASC;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -44,7 +47,6 @@ import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.response.agg.OpenSearchAggregationResponseParser;
-import org.opensearch.sql.planner.logical.LogicalNested;
 
 /**
  * OpenSearch search request builder.
@@ -257,11 +259,31 @@ public class OpenSearchRequestBuilder {
    */
   public void pushDownNested(List<Map<String, ReferenceExpression>> nestedArgs) {
     initBoolQueryFilter();
+    List<NestedQueryBuilder> nestedQueries = extractNestedQueries(query());
     groupFieldNamesByPath(nestedArgs).forEach(
-          (path, fieldNames) -> buildInnerHit(
-              fieldNames, createEmptyNestedQuery(path)
-          )
+        (path, fieldNames) ->
+            buildInnerHit(fieldNames, findNestedQueryWithSamePath(nestedQueries, path))
     );
+  }
+
+  /**
+   * InnerHit must be added to the NestedQueryBuilder. We need to extract
+   * the nested queries currently in the query if there is already a filter
+   * push down with nested query.
+   * @param query : current query.
+   * @return : grouped nested queries currently in query.
+   */
+  private List<NestedQueryBuilder> extractNestedQueries(QueryBuilder query) {
+    List<NestedQueryBuilder> result = new ArrayList<>();
+    if (query instanceof NestedQueryBuilder) {
+      result.add((NestedQueryBuilder) query);
+    } else if (query instanceof BoolQueryBuilder) {
+      BoolQueryBuilder boolQ = (BoolQueryBuilder) query;
+      Stream.of(boolQ.filter(), boolQ.must(), boolQ.should())
+          .flatMap(Collection::stream)
+          .forEach(q -> result.addAll(extractNestedQueries(q)));
+    }
+    return result;
   }
 
   /**
@@ -308,12 +330,40 @@ public class OpenSearchRequestBuilder {
   }
 
   /**
+   * We need to group nested queries with same path for adding new fields with same path of
+   * inner hits. If we try to add additional inner hits with same path we get an OS error.
+   * @param nestedQueries Current list of nested queries in query.
+   * @param path path comparing with current nested queries.
+   * @return Query with same path or new empty nested query.
+   */
+  private NestedQueryBuilder findNestedQueryWithSamePath(
+      List<NestedQueryBuilder> nestedQueries, String path
+  ) {
+    return nestedQueries.stream()
+        .filter(query -> isSamePath(path, query))
+        .findAny()
+        .orElseGet(createEmptyNestedQuery(path));
+  }
+
+  /**
+   * Check if is nested query is of the same path value.
+   * @param path Value of path to compare with nested query.
+   * @param query nested query builder to compare with path.
+   * @return true if nested query has same path.
+   */
+  private boolean isSamePath(String path, NestedQueryBuilder query) {
+    return nestedQuery(path, query.query(), query.scoreMode()).equals(query);
+  }
+
+  /**
    * Create a nested query with match all filter to place inner hits.
    */
-  private NestedQueryBuilder createEmptyNestedQuery(String path) {
-    NestedQueryBuilder nestedQuery = nestedQuery(path, matchAllQuery(), ScoreMode.None);
-    ((BoolQueryBuilder) query().filter().get(0)).must(nestedQuery);
-    return nestedQuery;
+  private Supplier<NestedQueryBuilder> createEmptyNestedQuery(String path) {
+    return () -> {
+      NestedQueryBuilder nestedQuery = nestedQuery(path, matchAllQuery(), ScoreMode.None);
+      ((BoolQueryBuilder) query().filter().get(0)).must(nestedQuery);
+      return nestedQuery;
+    };
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -14,18 +14,23 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import lombok.RequiredArgsConstructor;
+import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.ScriptQueryBuilder;
 import org.opensearch.script.Script;
+import org.opensearch.sql.ast.expression.Function;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ExpressionNodeVisitor;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.LikeQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.NestedQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.RangeQuery.Comparison;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.TermQuery;
@@ -75,6 +80,7 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.MATCH_PHRASE_PREFIX.getName(), new MatchPhrasePrefixQuery())
           .put(BuiltinFunctionName.WILDCARD_QUERY.getName(), new WildcardQuery())
           .put(BuiltinFunctionName.WILDCARDQUERY.getName(), new WildcardQuery())
+          .put(BuiltinFunctionName.NESTED.getName(), new NestedQuery())
           .build();
 
   /**
@@ -96,10 +102,20 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
         return buildBoolQuery(func, context, BoolQueryBuilder::should);
       case "not":
         return buildBoolQuery(func, context, BoolQueryBuilder::mustNot);
+      case "nested":
+        // TODO Fill in case when adding support for syntax - nested(path, condition)
+        throw new SyntaxCheckException(
+            "Invalid syntax used for nested function in WHERE clause: "
+                + "nested(field | field, path) OPERATOR LITERAL"
+        );
       default: {
         LuceneQuery query = luceneQueries.get(name);
         if (query != null && query.canSupport(func)) {
           return query.build(func);
+        } else if (query != null && query.isNestedPredicate(func)) {
+          NestedQuery nestedQuery = (NestedQuery) luceneQueries.get(
+              ((FunctionExpression)func.getArguments().get(0)).getFunctionName());
+          return nestedQuery.buildNested(func, query);
         }
         return buildScriptQuery(func);
       }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LikeQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LikeQuery.java
@@ -9,20 +9,15 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.sql.data.model.ExprValue;
-import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.storage.script.StringUtils;
 
 public class LikeQuery extends LuceneQuery {
   @Override
-  public QueryBuilder build(FunctionExpression func) {
-    ReferenceExpression ref = (ReferenceExpression) func.getArguments().get(0);
-    String field = OpenSearchTextType.convertTextToKeyword(ref.getAttr(), ref.type());
-    Expression expr = func.getArguments().get(1);
-    ExprValue literalValue = expr.valueOf();
-    return createBuilder(field, literalValue.stringValue());
+  public QueryBuilder doBuild(String fieldName, ExprType fieldType, ExprValue literal) {
+    String field = OpenSearchTextType.convertTextToKeyword(fieldName, fieldType);
+    return createBuilder(field, literal.stringValue());
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -32,7 +32,6 @@ import org.opensearch.sql.expression.NamedArgumentExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.FunctionName;
-import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 
 /**
  * Lucene query abstraction that builds Lucene query from function expression.
@@ -54,6 +53,19 @@ public abstract class LuceneQuery {
         && (func.getArguments().get(1) instanceof LiteralExpression
         || literalExpressionWrappedByCast(func))
         || isMultiParameterQuery(func);
+  }
+
+  /**
+   * Check if predicate expression has nested function on left side of predicate expression.
+   * Validation for right side being a `LiteralExpression` is done in NestedQuery.
+   * @param func function.
+   * @return return true if function has supported nested function expression.
+   */
+  public boolean isNestedPredicate(FunctionExpression func) {
+    return ((func.getArguments().get(0) instanceof FunctionExpression
+        && ((FunctionExpression)func.getArguments().get(0))
+        .getFunctionName().getFunctionName().equalsIgnoreCase(BuiltinFunctionName.NESTED.name()))
+      );
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/NestedQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/NestedQuery.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene;
+
+import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+
+/**
+ * Lucene query that build nested query.
+ */
+public class NestedQuery extends LuceneQuery {
+
+  /**
+   * Build query for 'nested' function used in predicate expression. Supports 'nested' function on
+   * left and literal on right.
+   * @param func Function expression.
+   * @param innerQuery Comparison query to be place inside nested query.
+   * @return Nested query.
+   */
+  public QueryBuilder buildNested(FunctionExpression func, LuceneQuery innerQuery) {
+    // Generate inner query for placement inside nested query
+    FunctionExpression nestedFunc = (FunctionExpression)func.getArguments().get(0);
+    validateArgs(nestedFunc, func.getArguments().get(1));
+    ExprValue literalValue = func.getArguments().get(1).valueOf();
+    ReferenceExpression ref = (ReferenceExpression) nestedFunc.getArguments().get(0);
+    QueryBuilder innerQueryResult =
+        innerQuery.doBuild(ref.getAttr(), nestedFunc.type(), literalValue);
+
+    // Generate nested query
+    boolean hasPathParam = nestedFunc.getArguments().size() == 2;
+    String pathStr = hasPathParam ? nestedFunc.getArguments().get(1).toString() :
+        getNestedPathString((ReferenceExpression) nestedFunc.getArguments().get(0));
+    return QueryBuilders.nestedQuery(pathStr, innerQueryResult, ScoreMode.None);
+  }
+
+  /**
+   * Dynamically generate path for nested field. An example field of 'office.section.cubicle'
+   * would dynamically generate the path 'office.section'.
+   * @param field nested field to generate path for.
+   * @return path for nested field.
+   */
+  private String getNestedPathString(ReferenceExpression field) {
+    String ret = "";
+    for (int i = 0; i < field.getPaths().size() - 1; i++) {
+      ret += (i == 0) ? field.getPaths().get(i) : "." + field.getPaths().get(i);
+    }
+    return ret;
+  }
+
+  /**
+   * Validate arguments in nested function and predicate expression.
+   * @param nestedFunc Nested function expression.
+   */
+  private void validateArgs(FunctionExpression nestedFunc, Expression rightExpression) {
+    if (nestedFunc.getArguments().size() > 2) {
+      throw new IllegalArgumentException(
+          "nested function supports 2 parameters (field, path) or 1 parameter (field)"
+      );
+    }
+
+    for (var arg : nestedFunc.getArguments()) {
+      if (!(arg instanceof ReferenceExpression)) {
+        throw new IllegalArgumentException(
+            String.format("Illegal nested field name: %s",
+                arg.toString()
+            )
+        );
+      }
+    }
+
+    if (!(rightExpression instanceof LiteralExpression)) {
+      throw new IllegalArgumentException(
+          String.format("Illegal argument on right side of predicate expression: %s",
+              rightExpression.toString()
+          )
+      );
+    }
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
@@ -325,6 +325,45 @@ public class OpenSearchRequestBuilderTest {
   }
 
   @Test
+  void testPushDownNestedWithNestedFilter() {
+    List<Map<String, ReferenceExpression>> args = List.of(
+        Map.of(
+            "field", new ReferenceExpression("message.info", STRING),
+            "path", new ReferenceExpression("message", STRING)
+        )
+    );
+
+    List<NamedExpression> projectList =
+        List.of(
+            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING)), null)
+        );
+
+    QueryBuilder innerFilterQuery = QueryBuilders.rangeQuery("myNum").gt(3);
+    QueryBuilder filterQuery =
+        QueryBuilders.nestedQuery("message", innerFilterQuery, ScoreMode.None);
+    LogicalNested nested = new LogicalNested(null, args, projectList);
+    requestBuilder.getSourceBuilder().query(filterQuery);
+    requestBuilder.pushDownNested(nested.getFields());
+
+    NestedQueryBuilder nestedQuery = nestedQuery("message", matchAllQuery(), ScoreMode.None)
+        .innerHit(new InnerHitBuilder().setFetchSourceContext(
+            new FetchSourceContext(true, new String[]{"message.info"}, null)));
+
+    assertEquals(
+        new SearchSourceBuilder()
+            .query(
+                QueryBuilders.boolQuery().filter(
+                    QueryBuilders.boolQuery()
+                        .must(filterQuery)
+                )
+            )
+            .from(DEFAULT_OFFSET)
+            .size(DEFAULT_LIMIT)
+            .timeout(DEFAULT_QUERY_TIMEOUT),
+        requestBuilder.getSourceBuilder());
+  }
+
+  @Test
   void testPushTypeMapping() {
     Map<String, OpenSearchDataType> typeMapping = Map.of("intA", OpenSearchDataType.of(INTEGER));
     requestBuilder.pushTypeMapping(typeMapping);

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -477,6 +477,21 @@ class AstBuilderTest extends AstBuilderTestBase {
         exception.getMessage());
   }
 
+  /**
+   * Ensure Nested function falls back to legacy engine when used in an HAVING clause.
+   * TODO Remove this test when support is added.
+   */
+  @Test
+  public void nested_in_having_clause_throws_exception() {
+    SyntaxCheckException exception = assertThrows(SyntaxCheckException.class,
+        () -> buildAST("SELECT count(*) FROM test HAVING nested(message.info)")
+    );
+
+    assertEquals(
+        "Falling back to legacy engine. Nested function is not supported in the HAVING clause.",
+        exception.getMessage());
+  }
+
   @Test
   public void can_build_order_by_sort_order_keyword_insensitive() {
     assertEquals(


### PR DESCRIPTION
### Description
Syntax: `nested( [field] | [field,path] )`

 Add support for use of the nested function in the `WHERE` clause as a predicate expression. Supports `nested` function on left of operator, and literal on right. When using `nested` function in `WHERE` clause, the inner hits of the query are not added to the `nested` query DSL. To do this you must use the `nested` function in conjunction with a `SELECT` clause nested function call. See documentation for this nested implementation [HERE (WIP)](https://github.com/opensearch-project/sql/pull/1640). 

### Example Queries
`SELECT message.info FROM nested_objects WHERE nested(message.info, message) = 'a';`
`SELECT nested(message.info) FROM nested_objects WHERE nested(message.info, message) = 'a';`
`SELECT message.info FROM nested_objects WHERE nested(message.info) = 'a' OR nested(comment.data) = 'b' AND nested(message.dayOfWeek) = 4;`
 
### Issues Resolved
Issue: [1111](https://github.com/opensearch-project/sql/issues/1111)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).