### PR TITLE
Add refresh index API for partition skipping index

### DIFF
--- a/flint/docs/index.md
+++ b/flint/docs/index.md
@@ -28,9 +28,13 @@ Currently, Flint metadata is only static configuration without version control a
 {
   "version": "0.1",
   "indexConfig": {
-    "kind": "SkippingIndex",
+    "kind": "skipping",
     "properties": {
-      "indexedColumns": ...
+      "indexedColumns": [{
+        "kind": "...",
+        "columnName": "...",
+        "columnType": "..."
+      }]
      }
   },
   "source": "alb_logs",

--- a/flint/docs/index.md
+++ b/flint/docs/index.md
@@ -125,28 +125,39 @@ OpenSearch stores the Flint index in an OpenSearch index of the given name.
 In the index mapping, the `_meta` and `properties`field stores meta and schema info of a Flint index.
 
 ```json
-alb_logs_skipping_index
 {
   "_meta": {
     "version": "0.1",
     "indexConfig": {
-        "kind": "SkippingIndex",
+        "kind": "skipping",
         "properties": {
           "indexedColumns": [
-            "elb_status_code": "value_list"
+            {
+              "kind": "partition",
+              "columnName": "year",
+              "columnType": "int"
+            },
+            {
+              "kind": "value_list",
+              "columnName": "elb_status_code",
+              "columnType": "int"
+            }
           ]
         }
-    }
-    ......
+    },
+    "source": "alb_logs"
   },
   "properties": {
-     "file_path": {
-       "type": "keyword"
-     },
-     "elb_status_code": {
-         "type": "integer"
-     }
-   }
+    "year": {
+      "type": "integer"
+    },
+    "elb_status_code": {
+      "type": "integer"
+    },
+    "file_path": {
+      "type": "keyword"
+    }
+  }
 }
 ```
 
@@ -173,6 +184,8 @@ flint.skippingIndex()
     .addValueListIndex("elb_status_code")
     .addBloomFilterIndex("client_ip")
     .create()
+
+flint.refresh("flint_alb_logs_skipping_index", FULL)
 ```
 
 #### Skipping Index Provider SPI

--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -19,10 +19,13 @@ import org.apache.spark.sql.flint.config.FlintSparkConf._
  * Define all the Flint Spark Related configuration. <p> User define the config as xxx.yyy using
  * {@link FlintConfig}.
  *
- * <p> How to use config <ol> <li> define config using spark.datasource.flint.xxx.yyy in spark
- * conf. <li> define config using xxx.yyy in datasource options. <li> Configurations defined in
- * the datasource options will override the same configurations present in the Spark
- * configuration. </ol>
+ * <p> How to use config
+ *  <ol>
+ *    <li> define config using spark.datasource.flint.xxx.yyy in spark conf.
+ *    <li> define config using xxx.yyy in datasource options.
+ *    <li> Configurations defined in the datasource options will override the same configurations
+ *    present in the Spark configuration.
+ *  </ol>
  */
 object FlintSparkConf {
 

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -182,8 +182,9 @@ class FlintSpark(val spark: SparkSession) {
 object FlintSpark {
 
   /**
-   * Index refresh mode: FULL: refresh on current source data in batch style at one shot
-   * INCREMENTAL: auto refresh on new data in continuous streaming style
+   * Index refresh mode:
+   *  FULL: refresh on current source data in batch style at one shot
+   *  INCREMENTAL: auto refresh on new data in continuous streaming style
    */
   object RefreshMode extends Enumeration {
     type RefreshMode = Value

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -17,6 +17,7 @@ import org.opensearch.flint.spark.skipping.partition.PartitionSkippingStrategy
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalog.Column
+import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
 import org.apache.spark.sql.flint.config.FlintSparkConf
 
 /**
@@ -77,7 +78,7 @@ class FlintSpark(val spark: SparkSession) {
         index
           .build(batchDF)
           .write
-          .format("flint")
+          .format(FLINT_DATASOURCE)
           .mode("overwrite")
           .save(indexName)
       }

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -20,6 +20,7 @@ import org.opensearch.flint.spark.skipping.partition.PartitionSkippingStrategy
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalog.Column
+import org.apache.spark.sql.flint.FlintPartitionWriter.BATCH_SIZE
 
 /**
  * Flint Spark integration API entrypoint.
@@ -30,7 +31,9 @@ class FlintSpark(val spark: SparkSession) {
   private val flintClientOptions =
     Map(
       HOST -> spark.conf.get(FLINT_INDEX_STORE_LOCATION, FLINT_INDEX_STORE_LOCATION_DEFAULT),
-      PORT -> spark.conf.get(FLINT_INDEX_STORE_PORT, FLINT_INDEX_STORE_PORT_DEFAULT)).asJava
+      PORT -> spark.conf.get(FLINT_INDEX_STORE_PORT, FLINT_INDEX_STORE_PORT_DEFAULT),
+      BATCH_SIZE -> spark.conf.get(BATCH_SIZE, "1000"),
+      REFRESH_POLICY -> spark.conf.get(REFRESH_POLICY, DEFAULT_REFRESH_POLICY)).asJava
 
   /** Flint client for low-level index operation */
   private val flintClient: FlintClient = {

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkIndex.scala
@@ -7,10 +7,17 @@ package org.opensearch.flint.spark
 
 import org.opensearch.flint.core.metadata.FlintMetadata
 
+import org.apache.spark.sql.DataFrame
+
 /**
  * Flint index interface in Spark.
  */
 trait FlintSparkIndex {
+
+  /**
+   * Index type
+   */
+  val kind: String
 
   /**
    * @return
@@ -24,4 +31,14 @@ trait FlintSparkIndex {
    */
   def metadata(): FlintMetadata
 
+  /**
+   * Build a data frame to represent index data computation logic. Upper level code decides how to
+   * use this, ex. batch or streaming, fully or incremental refresh.
+   *
+   * @param df
+   *   data frame to append building logic
+   * @return
+   *   index building data frame
+   */
+  def build(df: DataFrame): DataFrame
 }

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingStrategy.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingStrategy.scala
@@ -5,19 +5,33 @@
 
 package org.opensearch.flint.spark.skipping
 
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
+
 /**
  * Skipping index strategy that defines skipping data structure building and reading logic.
  */
 trait FlintSparkSkippingStrategy {
 
   /**
+   * Skipping strategy kind.
+   */
+  val kind: String
+
+  /**
    * Indexed column name and its Spark SQL type.
    */
-  val indexedColumn: (String, String)
+  val columnName: String
+  val columnType: String
 
   /**
    * @return
    *   output schema mapping from Flint field name to Flint field type
    */
   def outputSchema(): Map[String, String]
+
+  /**
+   * @return
+   *   aggregators that generate skipping data structure
+   */
+  def getAggregators: Seq[AggregateFunction]
 }

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/partition/PartitionSkippingStrategy.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/partition/PartitionSkippingStrategy.scala
@@ -7,14 +7,24 @@ package org.opensearch.flint.spark.skipping.partition
 
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy
 
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, First}
+
 /**
  * Skipping strategy for partitioned columns of source table.
  */
-class PartitionSkippingStrategy(override val indexedColumn: (String, String))
+class PartitionSkippingStrategy(
+    override val kind: String = "partition",
+    override val columnName: String,
+    override val columnType: String)
     extends FlintSparkSkippingStrategy {
 
   override def outputSchema(): Map[String, String] = {
-    Map(indexedColumn._1 -> convertToFlintType(indexedColumn._2))
+    Map(columnName -> convertToFlintType(columnType))
+  }
+
+  override def getAggregators: Seq[AggregateFunction] = {
+    Seq(First(new Column(columnName).expr, ignoreNulls = true))
   }
 
   // TODO: move this mapping info to single place

--- a/flint/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
@@ -7,6 +7,7 @@ package org.apache.spark
 
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
+import org.apache.spark.sql.flint.config.{FlintConfigEntry, FlintSparkConf}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -22,5 +23,12 @@ trait FlintSuite extends SharedSparkSession {
       // ConstantPropagation etc.
       .set(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, ConvertToLocalRelation.ruleName)
     conf
+  }
+
+  /**
+   * Set Flint Spark configuration. (Generic "value: T" has problem with FlintConfigEntry[Any])
+   */
+  protected def setFlintSparkConf[T](config: FlintConfigEntry[T], value: Any): Unit = {
+    spark.conf.set(FlintSparkConf.sparkConf(config.key), value.toString)
   }
 }

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
@@ -9,29 +9,35 @@ import scala.Option._
 
 import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
 import org.opensearch.flint.OpenSearchSuite
-import org.opensearch.flint.spark.FlintSpark.FLINT_INDEX_STORE_LOCATION
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
-import org.scalatest.matchers.must.Matchers.defined
+import org.opensearch.flint.spark.FlintSpark.{FLINT_INDEX_STORE_LOCATION, FLINT_INDEX_STORE_PORT}
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
+import org.scalatest.matchers.must.Matchers.{defined, have}
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.FlintSuite
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.streaming.StreamTest
 
-class FlintSparkSkippingIndexSuite extends FlintSuite with OpenSearchSuite {
+class FlintSparkSkippingIndexSuite
+    extends QueryTest
+    with FlintSuite
+    with OpenSearchSuite
+    with StreamTest {
 
   /** Flint Spark high level API being tested */
   lazy val flint: FlintSpark = {
     spark.conf.set(FLINT_INDEX_STORE_LOCATION, openSearchHost)
-    spark.conf.set(FlintSpark.FLINT_INDEX_STORE_PORT, openSearchPort)
+    spark.conf.set(FLINT_INDEX_STORE_PORT, openSearchPort)
     new FlintSpark(spark)
   }
 
   /** Test table name. */
   private val testTable = "test"
+  private val testIndex = getSkippingIndexName(testTable)
 
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    val tempLocation = spark.conf.get("spark.sql.warehouse.dir")
     sql(s"""
         | CREATE TABLE $testTable
         | (
@@ -39,7 +45,6 @@ class FlintSparkSkippingIndexSuite extends FlintSuite with OpenSearchSuite {
         | )
         | USING CSV
         | OPTIONS (
-        |  path '$tempLocation/$testTable',
         |  header 'false',
         |  delimiter '\t'
         | )
@@ -48,13 +53,31 @@ class FlintSparkSkippingIndexSuite extends FlintSuite with OpenSearchSuite {
         |    month INT
         | )
         |""".stripMargin)
+
+    sql(s"""
+        | INSERT INTO $testTable
+        | PARTITION (year=2023, month=04)
+        | VALUES ('Hello')
+        | """.stripMargin)
+
+    sql(s"""
+        | INSERT INTO $testTable
+        | PARTITION (year=2023, month=05)
+        | VALUES ('World')
+        | """.stripMargin)
   }
 
   override def afterEach(): Unit = {
     super.afterEach()
 
-    val indexName = FlintSparkSkippingIndex.getIndexName(testTable)
-    flint.deleteIndex(indexName)
+    // Delete all test indices
+    flint.deleteIndex(testIndex)
+
+    // Stop all streaming jobs if any
+    spark.streams.active.foreach { job =>
+      job.stop()
+      job.awaitTermination()
+    }
   }
 
   test("create skipping index with metadata successfully") {
@@ -65,18 +88,23 @@ class FlintSparkSkippingIndexSuite extends FlintSuite with OpenSearchSuite {
       .create()
 
     val indexName = s"flint_${testTable}_skipping_index"
-    val metadata = flint.describeIndex(indexName)
-    metadata shouldBe defined
-    metadata.get.getContent should matchJson(""" {
+    val index = flint.describeIndex(indexName)
+    index shouldBe defined
+    index.get.metadata().getContent should matchJson(s"""{
         |   "_meta": {
-        |     "kind": "SkippingIndex",
+        |     "kind": "skipping",
         |     "indexedColumns": [
         |     {
-        |       "year": "int"
+        |        "kind": "partition",
+        |        "columnName": "year",
+        |        "columnType": "int"
         |     },
         |     {
-        |       "month": "int"
-        |     }]
+        |        "kind": "partition",
+        |        "columnName": "month",
+        |        "columnType": "int"
+        |     }],
+        |     "source": "$testTable"
         |   },
         |   "properties": {
         |     "year": {
@@ -91,6 +119,30 @@ class FlintSparkSkippingIndexSuite extends FlintSuite with OpenSearchSuite {
         |   }
         | }
         |""".stripMargin)
+  }
+
+  test("refresh skipping index successfully") {
+    flint
+      .skippingIndex()
+      .onTable(testTable)
+      .addPartitionIndex("year", "month")
+      .create()
+
+    val jobId = flint.refreshIndex(testIndex)
+    val job = spark.streams.get(jobId)
+    failAfter(streamingTimeout) {
+      job.processAllAvailable()
+    }
+
+    val indexData =
+      spark.read
+        .format("flint")
+        .schema("year INT, month INT, file_path STRING")
+        .options(openSearchOptions)
+        .load(testIndex)
+        .collect()
+        .toSet
+    indexData should have size 2
   }
 
   test("can have only 1 skipping index on a table") {

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
@@ -15,7 +15,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.flint.config.FlintSparkConf
+import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
 import org.apache.spark.sql.flint.config.FlintSparkConf._
 import org.apache.spark.sql.streaming.StreamTest
 
@@ -27,9 +27,9 @@ class FlintSparkSkippingIndexSuite
 
   /** Flint Spark high level API being tested */
   lazy val flint: FlintSpark = {
-    spark.conf.set(FlintSparkConf.sparkConf(HOST_ENDPOINT.key), openSearchHost)
-    spark.conf.set(FlintSparkConf.sparkConf(HOST_PORT.key), openSearchPort)
-    spark.conf.set(FlintSparkConf.sparkConf(REFRESH_POLICY.key), "true")
+    setFlintSparkConf(HOST_ENDPOINT, openSearchHost)
+    setFlintSparkConf(HOST_PORT, openSearchPort)
+    setFlintSparkConf(REFRESH_POLICY, "true")
     new FlintSpark(spark)
   }
 
@@ -138,7 +138,7 @@ class FlintSparkSkippingIndexSuite
 
     val indexData =
       spark.read
-        .format("flint")
+        .format(FLINT_DATASOURCE)
         .schema("year INT, month INT, file_path STRING")
         .options(openSearchOptions)
         .load(testIndex)

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
@@ -135,6 +135,7 @@ class FlintSparkSkippingIndexSuite
     val jobId = flint.refreshIndex(testIndex, FULL)
     jobId shouldBe empty
 
+    // TODO: add query index API to avoid this duplicate
     val indexData =
       spark.read
         .format(FLINT_DATASOURCE)

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
@@ -9,6 +9,7 @@ import scala.Option._
 
 import com.stephenn.scalatest.jsonassert.JsonMatchers.matchJson
 import org.opensearch.flint.OpenSearchSuite
+import org.opensearch.flint.core.FlintOptions._
 import org.opensearch.flint.spark.FlintSpark.{FLINT_INDEX_STORE_LOCATION, FLINT_INDEX_STORE_PORT}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
 import org.scalatest.matchers.must.Matchers.{defined, have}
@@ -16,6 +17,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.FlintSuite
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.flint.FlintPartitionWriter.BATCH_SIZE
 import org.apache.spark.sql.streaming.StreamTest
 
 class FlintSparkSkippingIndexSuite
@@ -28,6 +30,8 @@ class FlintSparkSkippingIndexSuite
   lazy val flint: FlintSpark = {
     spark.conf.set(FLINT_INDEX_STORE_LOCATION, openSearchHost)
     spark.conf.set(FLINT_INDEX_STORE_PORT, openSearchPort)
+    spark.conf.set(BATCH_SIZE, 1)
+    spark.conf.set(REFRESH_POLICY, "true")
     new FlintSpark(spark)
   }
 


### PR DESCRIPTION
### Description

Please see more details in changes in doc: https://github.com/dai-chen/sql-1/blob/add-partion-index-building/flint/docs/index.md

#### Flint Metadata Spec

Update metadata with more info (index kind, column name and type). In this way, `FlintSparkSkippingIndex` can be deserialized out of `_meta` JSON.

#### Flint Spark API

Add `refreshIndex` API with `FULL` (batch) and `INCREMENTAL` (streaming) mode.

#### Partition Index Implementation

Followed the first approach below for now. Need to evaluate the performance later.

- Approach 1: treat partition columns as normal and use `FIRST_VALUE` function to aggregate
- Approach 2: treat partition columns as special and add partition columns to `GROUP BY`

```
scala> spark.sql("select first_value(year, true) as year, first_value(month, true) as month, first_value(day, true), first_value(hour, true), input_file_name() from alb_logs group by input_file_name()").explain
== Physical Plan ==
*(2) HashAggregate(keys=[_nondeterministic#146], functions=[first_value(year#33, true), first_value(month#34, true), first_value(day#35, true), first_value(hour#36, true)])
+- Exchange hashpartitioning(_nondeterministic#146, 200), ENSURE_REQUIREMENTS, [id=#112]
   +- *(1) HashAggregate(keys=[_nondeterministic#146], functions=[partial_first_value(year#33, true), partial_first_value(month#34, true), partial_first_value(day#35, true), partial_first_value(hour#36, true)])
      +- *(1) Project [year#33, month#34, day#35, hour#36, input_file_name() AS _nondeterministic#146]
         +- FileScan csv default.alb_logs[year#33,month#34,day#35,hour#36] Batched: false, DataFilters: [], Format: CSV, Location: CatalogFileIndex[s3a://maximus.dev.daichen.us-west-2/alb-log-daily], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<>

scala> spark.sql("select year, month, day, hour, input_file_name() from alb_logs group by year, month, day, hour, input_file_name()").explain
== Physical Plan ==
*(2) HashAggregate(keys=[year#33, month#34, day#35, hour#36, _nondeterministic#169], functions=[])
+- Exchange hashpartitioning(year#33, month#34, day#35, hour#36, _nondeterministic#169, 200), ENSURE_REQUIREMENTS, [id=#134]
   +- *(1) HashAggregate(keys=[year#33, month#34, day#35, hour#36, _nondeterministic#169], functions=[])
      +- *(1) Project [year#33, month#34, day#35, hour#36, input_file_name() AS _nondeterministic#169]
         +- FileScan csv default.alb_logs[year#33,month#34,day#35,hour#36] Batched: false, DataFilters: [], Format: CSV, Location: CatalogFileIndex[s3a://maximus.dev.daichen.us-west-2/alb-log-daily], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<>
```

Sample index data:

```
curl "localhost:9200/flint_test_skipping_index/_search?pretty"
{
  "took" : 121,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 18,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "flint_test_skipping_index",
        "_id" : "LWt3VIgBQCGf4ClzQDd8",
        "_score" : 1.0,
        "_source" : {
          "file_path" : "file:///.../spark-warehouse/test/year=2023/month=4/part-00000-c2f88187-da00-40aa-981a-471df2e15ca1.c000.csv",
          "year" : 2023,
          "month" : 4
        }
      },
      {
        "_index" : "flint_test_skipping_index",
        "_id" : "L2t6VIgBQCGf4ClzVzcU",
        "_score" : 1.0,
        "_source" : {
          "file_path" : "file:///.../spark-warehouse/test/year=2023/month=5/part-00000-10f5c696-8fd8-4b28-8d41-62ac9c39f905.c000.csv",
          "year" : 2023,
          "month" : 5
        }
      }
      ...
```
 
### Issues Resolved

https://github.com/opensearch-project/sql/issues/1602
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).