### PR TITLE
Fix IT on 2.x - address breaking changes from upstream.

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
@@ -33,7 +33,7 @@ import org.opensearch.client.RestClientBuilder;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.core.internal.io.IOUtils;
+import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 import static java.util.Collections.unmodifiableList;


### PR DESCRIPTION
### Description
IT fails on 2.x branch (can't compile)
```
2023-05-25T18:49:40.0119575Z /home/runner/work/sql/sql/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java:36: error: package org.opensearch.core.internal.io does not exist
2023-05-25T18:49:40.0120005Z 
2023-05-25T18:49:40.0120688Z import org.opensearch.core.internal.io.IOUtils;
```
caused by https://github.com/opensearch-project/OpenSearch/pull/7612
Fortunately, it is a simple fix.

on `main` it was fixed in scope of #1512, but this specific fix wasn't backported.
 
### Issues Resolved
Fix CI on 2.x
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).