### PR TITLE
Pagination: Add Close Cursor API in v2.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -41,6 +41,7 @@ import org.opensearch.sql.ast.statement.Query;
 import org.opensearch.sql.ast.statement.Statement;
 import org.opensearch.sql.ast.tree.AD;
 import org.opensearch.sql.ast.tree.Aggregation;
+import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.Dedupe;
 import org.opensearch.sql.ast.tree.Eval;
 import org.opensearch.sql.ast.tree.FetchCursor;
@@ -302,6 +303,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitFetchCursor(FetchCursor cursor, C context) {
-    return visit(cursor, context);
+    return visitChildren(cursor, context);
+  }
+
+  public T visitCloseCursor(CloseCursor closeCursor, C context) {
+    return visitChildren(closeCursor, context);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/tree/CloseCursor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/CloseCursor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import java.util.List;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.Node;
+
+/**
+ * AST node to represent close cursor operation.
+ * Actually a wrapper to the AST.
+ */
+public class CloseCursor extends UnresolvedPlan {
+
+  /**
+   * An instance of {@link FetchCursor}.
+   */
+  private UnresolvedPlan cursor;
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitCloseCursor(this, context);
+  }
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    this.cursor = child;
+    return this;
+  }
+
+  @Override
+  public List<? extends Node> getChild() {
+    return List.of(cursor);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/executor/execution/CommandPlan.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/CommandPlan.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sql.executor.execution;
+
+import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.executor.ExecutionEngine;
+import org.opensearch.sql.executor.QueryId;
+import org.opensearch.sql.executor.QueryService;
+
+/**
+ * Query plan which does not reflect a search query being executed.
+ * It contains a command or an action, for example, a DDL query.
+ */
+public class CommandPlan extends AbstractPlan {
+
+  /**
+   * The query plan ast.
+   */
+  protected final UnresolvedPlan plan;
+
+  /**
+   * Query service.
+   */
+  protected final QueryService queryService;
+
+  protected final ResponseListener<ExecutionEngine.QueryResponse> listener;
+
+  /** Constructor. */
+  public CommandPlan(QueryId queryId, UnresolvedPlan plan, QueryService queryService,
+                     ResponseListener<ExecutionEngine.QueryResponse> listener) {
+    super(queryId);
+    this.plan = plan;
+    this.queryService = queryService;
+    this.listener = listener;
+  }
+
+  @Override
+  public void execute() {
+    queryService.execute(plan, listener);
+  }
+
+  @Override
+  public void explain(ResponseListener<ExecutionEngine.ExplainResponse> listener) {
+    throw new UnsupportedOperationException("CommandPlan does not support explain");
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlan.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlan.java
@@ -18,9 +18,7 @@ import org.opensearch.sql.executor.QueryId;
 import org.opensearch.sql.executor.QueryService;
 
 /**
- * Query plan. Which includes.
- *
- * <p>select query.
+ * Query plan which includes a <em>select</em> query.
  */
 public class QueryPlan extends AbstractPlan {
 

--- a/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlanFactory.java
+++ b/core/src/main/java/org/opensearch/sql/executor/execution/QueryPlanFactory.java
@@ -17,6 +17,7 @@ import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.statement.Explain;
 import org.opensearch.sql.ast.statement.Query;
 import org.opensearch.sql.ast.statement.Statement;
+import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.FetchCursor;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.response.ResponseListener;
@@ -86,6 +87,15 @@ public class QueryPlanFactory
 
   boolean canConvertToCursor(UnresolvedPlan plan) {
     return plan.accept(new CanPaginateVisitor(), null);
+  }
+
+  /**
+   * Creates a {@link CloseCursor} command on a cursor.
+   */
+  public AbstractPlan createCloseCursor(String cursor,
+      ResponseListener<ExecutionEngine.QueryResponse> queryResponseListener) {
+    return new CommandPlan(QueryId.queryId(), new CloseCursor().attach(new FetchCursor(cursor)),
+        queryService, queryResponseListener);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/planner/DefaultImplementor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/DefaultImplementor.java
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.planner;
 
 import org.opensearch.sql.executor.pagination.PlanSerializer;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
+import org.opensearch.sql.planner.logical.LogicalCloseCursor;
 import org.opensearch.sql.planner.logical.LogicalDedupe;
 import org.opensearch.sql.planner.logical.LogicalEval;
 import org.opensearch.sql.planner.logical.LogicalFetchCursor;
@@ -25,6 +25,7 @@ import org.opensearch.sql.planner.logical.LogicalSort;
 import org.opensearch.sql.planner.logical.LogicalValues;
 import org.opensearch.sql.planner.logical.LogicalWindow;
 import org.opensearch.sql.planner.physical.AggregationOperator;
+import org.opensearch.sql.planner.physical.CursorCloseOperator;
 import org.opensearch.sql.planner.physical.DedupeOperator;
 import org.opensearch.sql.planner.physical.EvalOperator;
 import org.opensearch.sql.planner.physical.FilterOperator;
@@ -153,6 +154,11 @@ public class DefaultImplementor<C> extends LogicalPlanNodeVisitor<PhysicalPlan, 
   @Override
   public PhysicalPlan visitFetchCursor(LogicalFetchCursor plan, C context) {
     return new PlanSerializer(plan.getEngine()).convertToPlan(plan.getCursor());
+  }
+
+  @Override
+  public PhysicalPlan visitCloseCursor(LogicalCloseCursor node, C context) {
+    return new CursorCloseOperator(visitChild(node, context));
   }
 
   protected PhysicalPlan visitChild(LogicalPlan node, C context) {

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalCloseCursor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalCloseCursor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.logical;
+
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * A logical plan node which wraps {@link org.opensearch.sql.planner.LogicalCursor}
+ * and represent a cursor close operation.
+ */
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class LogicalCloseCursor extends LogicalPlan {
+
+  public LogicalCloseCursor(LogicalPlan child) {
+    super(List.of(child));
+  }
+
+  @Override
+  public <R, C> R accept(LogicalPlanNodeVisitor<R, C> visitor, C context) {
+    return visitor.visitCloseCursor(this, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalFetchCursor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalFetchCursor.java
@@ -13,6 +13,9 @@ import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalPlanNodeVisitor;
 import org.opensearch.sql.storage.StorageEngine;
 
+/**
+ * A plan node which represents operation of fetching a next page from the cursor.
+ */
 @EqualsAndHashCode(callSuper = false)
 @ToString
 public class LogicalFetchCursor extends LogicalPlan {

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitor.java
@@ -112,4 +112,8 @@ public abstract class LogicalPlanNodeVisitor<R, C> {
   public R visitFetchCursor(LogicalFetchCursor plan, C context) {
     return visitNode(plan, context);
   }
+
+  public R visitCloseCursor(LogicalCloseCursor plan, C context) {
+    return visitNode(plan, context);
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/CursorCloseOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/CursorCloseOperator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.executor.ExecutionEngine;
+
+/**
+ * A plan node which blocks issuing a request in {@link #open} and
+ * getting results in {@link #hasNext}, but doesn't block releasing resources in {@link #close}.
+ * Designed to be on top of the deserialized tree.
+ */
+@RequiredArgsConstructor
+public class CursorCloseOperator extends PhysicalPlan {
+
+  // Entire deserialized from cursor plan tree
+  private final PhysicalPlan input;
+
+  @Override
+  public <R, C> R accept(PhysicalPlanNodeVisitor<R, C> visitor, C context) {
+    return visitor.visitCursorClose(this, context);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return false;
+  }
+
+  @Override
+  public ExprValue next() {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public List<PhysicalPlan> getChild() {
+    return List.of(input);
+  }
+
+  /**
+   * Provides an empty schema, because this plan node is always located on the top of the tree.
+   */
+  @Override
+  public ExecutionEngine.Schema schema() {
+    return new ExecutionEngine.Schema(List.of());
+  }
+
+  // TODO remove
+  @Override
+  public long getTotalHits() {
+    return 0;
+  }
+
+  @Override
+  public void open() {
+    // no-op, no search should be invoked.
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/PhysicalPlanNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/PhysicalPlanNodeVisitor.java
@@ -92,4 +92,8 @@ public abstract class PhysicalPlanNodeVisitor<R, C> {
   public R visitML(PhysicalPlan node, C context) {
     return visitNode(node, context);
   }
+
+  public R visitCursorClose(CursorCloseOperator node, C context) {
+    return visitNode(node, context);
+  }
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.analysis;
 
 import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,6 +76,7 @@ import org.opensearch.sql.ast.expression.ParseMethod;
 import org.opensearch.sql.ast.expression.ScoreFunction;
 import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.AD;
+import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.FetchCursor;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.ML;
@@ -91,6 +93,7 @@ import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.function.OpenSearchFunctions;
 import org.opensearch.sql.expression.window.WindowDefinition;
 import org.opensearch.sql.planner.logical.LogicalAD;
+import org.opensearch.sql.planner.logical.LogicalCloseCursor;
 import org.opensearch.sql.planner.logical.LogicalFetchCursor;
 import org.opensearch.sql.planner.logical.LogicalFilter;
 import org.opensearch.sql.planner.logical.LogicalMLCommons;
@@ -1650,5 +1653,15 @@ class AnalyzerTest extends AnalyzerTestBase {
     assertTrue(actual instanceof LogicalFetchCursor);
     assertEquals(new LogicalFetchCursor("test",
         dataSourceService.getDataSource("@opensearch").getStorageEngine()), actual);
+  }
+
+  @Test
+  public void visit_close_cursor() {
+    var analyzed = analyze(new CloseCursor().attach(new FetchCursor("pewpew")));
+    assertAll(
+        () -> assertTrue(analyzed instanceof LogicalCloseCursor),
+        () -> assertTrue(analyzed.getChild().get(0) instanceof LogicalFetchCursor),
+        () -> assertEquals("pewpew", ((LogicalFetchCursor) analyzed.getChild().get(0)).getCursor())
+    );
   }
 }

--- a/core/src/test/java/org/opensearch/sql/executor/execution/CommandPlanTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/execution/CommandPlanTest.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sql.executor.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.executor.QueryId;
+import org.opensearch.sql.executor.QueryService;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class CommandPlanTest {
+
+  @Test
+  public void execute_without_error() {
+    QueryService qs = mock(QueryService.class);
+    ResponseListener listener = mock(ResponseListener.class);
+    doNothing().when(qs).execute(any(), any());
+
+    new CommandPlan(QueryId.queryId(), mock(UnresolvedPlan.class), qs, listener).execute();
+
+    verify(qs).execute(any(), any());
+    verify(listener, never()).onFailure(any());
+  }
+
+  @Test
+  public void execute_with_error() {
+    QueryService qs = mock(QueryService.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    ResponseListener listener = mock(ResponseListener.class);
+    doThrow(new RuntimeException())
+        .when(qs).executePlan(any(LogicalPlan.class), any(), any());
+
+    new CommandPlan(QueryId.queryId(), mock(UnresolvedPlan.class), qs, listener).execute();
+
+    verify(listener).onFailure(any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void explain_not_supported() {
+    QueryService qs = mock(QueryService.class);
+    ResponseListener listener = mock(ResponseListener.class);
+    ResponseListener explainListener = mock(ResponseListener.class);
+
+    var exception = assertThrows(Throwable.class, () ->
+        new CommandPlan(QueryId.queryId(), mock(UnresolvedPlan.class), qs, listener)
+            .explain(explainListener));
+    assertEquals("CommandPlan does not support explain", exception.getMessage());
+
+    verify(listener, never()).onResponse(any());
+    verify(listener, never()).onFailure(any());
+    verify(explainListener, never()).onResponse(any());
+    verify(explainListener, never()).onFailure(any());
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
@@ -132,10 +132,13 @@ class LogicalPlanNodeVisitorTest {
     LogicalNested nested = new LogicalNested(null, nestedArgs, projectList);
 
     LogicalFetchCursor cursor = new LogicalFetchCursor("n:test", mock(StorageEngine.class));
+
+    LogicalCloseCursor closeCursor = new LogicalCloseCursor(cursor);
+
     return Stream.of(
         relation, tableScanBuilder, write, tableWriteBuilder, filter, aggregation, rename, project,
         remove, eval, sort, dedup, window, rareTopN, highlight, mlCommons, ad, ml, paginate, nested,
-        cursor
+        cursor, closeCursor
     ).map(Arguments::of);
   }
 

--- a/core/src/test/java/org/opensearch/sql/planner/physical/CursorCloseOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/CursorCloseOperatorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class CursorCloseOperatorTest {
+
+  @Test
+  public void never_hasNext() {
+    var plan = new CursorCloseOperator(null);
+    assertFalse(plan.hasNext());
+    plan.open();
+    assertFalse(plan.hasNext());
+  }
+
+  // TODO remove
+  @Test
+  public void no_total_hits() {
+    var plan = new CursorCloseOperator(null);
+    assertEquals(0, plan.getTotalHits());
+    plan.open();
+    assertEquals(0, plan.getTotalHits());
+  }
+
+  @Test
+  public void open_is_not_propagated() {
+    var child = mock(PhysicalPlan.class);
+    var plan = new CursorCloseOperator(child);
+    plan.open();
+    verify(child, never()).open();
+  }
+
+  @Test
+  public void close_is_propagated() {
+    var child = mock(PhysicalPlan.class);
+    var plan = new CursorCloseOperator(child);
+    plan.close();
+    verify(child).close();
+  }
+
+  @Test
+  public void next_always_throws() {
+    var plan = new CursorCloseOperator(null);
+    assertThrows(Throwable.class, plan::next);
+    plan.open();
+    assertThrows(Throwable.class, plan::next);
+  }
+
+  @Test
+  public void produces_empty_schema() {
+    var child = mock(PhysicalPlan.class);
+    var plan = new CursorCloseOperator(child);
+    assertEquals(0, plan.schema().getColumns().size());
+    verify(child, never()).schema();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/util/StandaloneModule.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/StandaloneModule.java
@@ -99,7 +99,7 @@ public class StandaloneModule extends AbstractModule {
   }
 
   @Provides
-  public PlanSerializer paginatedPlanCache(StorageEngine storageEngine) {
+  public PlanSerializer planSerializer(StorageEngine storageEngine) {
     return new PlanSerializer(storageEngine);
   }
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -34,6 +34,7 @@ import org.opensearch.sql.protocol.response.format.CsvResponseFormatter;
 import org.opensearch.sql.protocol.response.format.Format;
 import org.opensearch.sql.protocol.response.format.JdbcResponseFormatter;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
+import org.opensearch.sql.protocol.response.format.CommandResponseFormatter;
 import org.opensearch.sql.protocol.response.format.RawResponseFormatter;
 import org.opensearch.sql.protocol.response.format.ResponseFormatter;
 import org.opensearch.sql.sql.SQLService;
@@ -164,7 +165,10 @@ public class RestSQLQueryAction extends BaseRestHandler {
       BiConsumer<RestChannel, Exception> errorHandler) {
     Format format = request.format();
     ResponseFormatter<QueryResult> formatter;
-    if (format.equals(Format.CSV)) {
+
+    if (request.isCursorCloseRequest()) {
+      formatter = new CommandResponseFormatter();
+    } else if (format.equals(Format.CSV)) {
       formatter = new CsvResponseFormatter(request.sanitize());
     } else if (format.equals(Format.RAW)) {
       formatter = new RawResponseFormatter();

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
@@ -6,7 +6,6 @@
 
 package org.opensearch.sql.opensearch.executor;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtector.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/protector/OpenSearchExecutionProtector.java
@@ -12,6 +12,7 @@ import org.opensearch.sql.opensearch.planner.physical.ADOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLCommonsOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLOperator;
 import org.opensearch.sql.planner.physical.AggregationOperator;
+import org.opensearch.sql.planner.physical.CursorCloseOperator;
 import org.opensearch.sql.planner.physical.DedupeOperator;
 import org.opensearch.sql.planner.physical.EvalOperator;
 import org.opensearch.sql.planner.physical.FilterOperator;
@@ -40,6 +41,15 @@ public class OpenSearchExecutionProtector extends ExecutionProtector {
 
   public PhysicalPlan protect(PhysicalPlan physicalPlan) {
     return physicalPlan.accept(this, null);
+  }
+
+  /**
+   * Don't protect {@link CursorCloseOperator} and entire nested tree, because
+   * {@link CursorCloseOperator} as designed as no-op.
+   */
+  @Override
+  public PhysicalPlan visitCursorClose(CursorCloseOperator node, Object context) {
+    return node;
   }
 
   @Override

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequestTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchScrollRequestTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.lucene.search.TotalHits;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -188,7 +189,9 @@ class OpenSearchScrollRequestTest {
   }
 
   @Test
+  @SneakyThrows
   void hasAnotherBatch() {
+    FieldUtils.writeField(request, "needClean", false, true);
     request.setScrollId("scroll123");
     assertTrue(request.hasAnotherBatch());
 

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.protocol.response.format;
+
+import lombok.Getter;
+import org.opensearch.sql.executor.execution.CommandPlan;
+import org.opensearch.sql.opensearch.response.error.ErrorMessage;
+import org.opensearch.sql.opensearch.response.error.ErrorMessageFactory;
+import org.opensearch.sql.protocol.response.QueryResult;
+
+/**
+ * A simple response formatter which contains no data.
+ * Supposed to use with {@link CommandPlan} only.
+ */
+public class CommandResponseFormatter extends JsonResponseFormatter<QueryResult> {
+
+  public CommandResponseFormatter() {
+    super(Style.PRETTY);
+  }
+
+  @Override
+  protected Object buildJsonObject(QueryResult response) {
+    return new NoQueryResponse();
+  }
+
+  @Override
+  public String format(Throwable t) {
+    return new JdbcResponseFormatter(Style.PRETTY).format(t);
+  }
+
+  @Getter
+  public static class NoQueryResponse {
+    // in case of failure an exception is thrown
+    private final boolean succeeded = true;
+  }
+}

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.protocol.response.format;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.opensearch.sql.data.model.ExprValueUtils.tupleValue;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.executor.ExecutionEngine;
+import org.opensearch.sql.executor.pagination.Cursor;
+import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
+import org.opensearch.sql.protocol.response.QueryResult;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class CommandResponseFormatterTest {
+
+  @Test
+  public void produces_always_same_output_for_any_query_response() {
+    var formatter = new CommandResponseFormatter();
+    assertEquals(formatter.format(mock(QueryResult.class)),
+        formatter.format(mock(QueryResult.class)));
+
+    QueryResult response = new QueryResult(
+        new ExecutionEngine.Schema(ImmutableList.of(
+            new ExecutionEngine.Schema.Column("name", "name", STRING),
+            new ExecutionEngine.Schema.Column("address", "address", OpenSearchTextType.of()),
+            new ExecutionEngine.Schema.Column("age", "age", INTEGER))),
+        ImmutableList.of(
+            tupleValue(ImmutableMap.<String, Object>builder()
+                    .put("name", "John")
+                    .put("address", "Seattle")
+                    .put("age", 20)
+                .build())),
+        new Cursor("test_cursor"), 42);
+
+    assertEquals("{\n"
+                + "  \"succeeded\": true\n"
+                + "}",
+        formatter.format(response));
+  }
+
+  @Test
+  public void formats_error_as_default_formatter() {
+    var exception = new Exception("pewpew", new RuntimeException("meow meow"));
+    assertEquals(new JdbcResponseFormatter(PRETTY).format(exception),
+        new CommandResponseFormatter().format(exception));
+  }
+}

--- a/sql/src/main/java/org/opensearch/sql/sql/SQLService.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/SQLService.java
@@ -72,6 +72,10 @@ public class SQLService {
         throw new UnsupportedOperationException("Explain of a paged query continuation "
           + "is not supported. Use `explain` for the initial query request.");
       }
+      if (request.isCursorCloseRequest()) {
+        return queryExecutionFactory.createCloseCursor(request.getCursor().get(),
+            queryListener.orElse(null));
+      }
       return queryExecutionFactory.create(request.getCursor().get(),
         isExplainRequest, queryListener.orElse(null), explainListener.orElse(null));
     } else {

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -112,6 +112,10 @@ public class SQLQueryRequest {
     return path.endsWith("/_explain");
   }
 
+  public boolean isCursorCloseRequest() {
+    return path.endsWith("/close");
+  }
+
   /**
    * Decide on the formatter by the requested format.
    */

--- a/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/SQLServiceTest.java
@@ -95,6 +95,24 @@ class SQLServiceTest {
   }
 
   @Test
+  public void can_execute_close_cursor_query() {
+    sqlService.execute(
+        new SQLQueryRequest(new JSONObject(), null, QUERY + "/close",
+            Map.of("format", "jdbc"), "n:cursor"),
+        new ResponseListener<>() {
+          @Override
+          public void onResponse(QueryResponse response) {
+            assertNotNull(response);
+          }
+
+          @Override
+          public void onFailure(Exception e) {
+            fail(e);
+          }
+        });
+  }
+
+  @Test
   public void can_execute_csv_format_request() {
     sqlService.execute(
         new SQLQueryRequest(new JSONObject(), "SELECT 123", QUERY, "csv"),

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -125,6 +125,35 @@ public class SQLQueryRequestTest {
   }
 
   @Test
+  public void should_support_cursor_close_request() {
+    SQLQueryRequest closeRequest =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("pewpew")
+                              .path("_plugins/_sql/close")
+                              .build();
+
+    SQLQueryRequest emptyCloseRequest =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("")
+                              .path("_plugins/_sql/close")
+                              .build();
+
+    SQLQueryRequest pagingRequest =
+        SQLQueryRequestBuilder.request(null)
+                              .cursor("pewpew")
+                              .build();
+
+    assertAll(
+        () -> assertTrue(closeRequest.isSupported()),
+        () -> assertTrue(closeRequest.isCursorCloseRequest()),
+        () -> assertTrue(pagingRequest.isSupported()),
+        () -> assertFalse(pagingRequest.isCursorCloseRequest()),
+        () -> assertFalse(emptyCloseRequest.isSupported()),
+        () -> assertTrue(emptyCloseRequest.isCursorCloseRequest())
+    );
+  }
+
+  @Test
   public void should_not_support_request_with_empty_cursor() {
     SQLQueryRequest requestWithEmptyCursor =
         SQLQueryRequestBuilder.request(null)


### PR DESCRIPTION
### Description
Add close cursor API to V2 similar to V1. Refer to [pagination doc](https://github.com/opensearch-project/sql/blob/main/docs/dev/opensearch-pagination.md#32-protocol).

This code branched of #1600. Once #1600 merged I'll update this branch and change base branch of this PR. Currently, it is a temporary branch to show the changes and approach.

### Design
https://github.com/opensearch-project/sql/blob/9100c6285f033784b5a2e58f53d575ece360737f/docs/dev/Pagination-v2.md#close-cursor

### Issues Resolved
New endpoint on `_plugins/_sql/close`. Under the hood it works as a subsequent query request, reserialized the cursor, but instead of executing it, just closes to encoded `scroll`.

### TODOs
- [x] Update docs
- [x] Add UT with coverage
- [x] Complete todos in code
- [ ] ~Return an error on repetitive `close` or on failure~
- [x] Don't fallback to V1 on `close` failure
- [ ] Record a demo
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).