### PR TITLE
Update sqlite-jdbc to 3.41.2.2 to address CVE-2023-32697

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
 
     testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
-    testImplementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.32.3.3'
+    testImplementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.41.2.2'
     testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 
     // Needed for BWC tests

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/runner/resultset/DBResult.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/runner/resultset/DBResult.java
@@ -202,9 +202,11 @@ public class DBResult {
     // H2 calculates the value before setting column name
     // for example, for query "select 1 + 1" it returns a column named "2" instead of "1 + 1"
     boolean skipColumnNameCheck = databaseName.equalsIgnoreCase("h2") || other.databaseName.equalsIgnoreCase("h2");
-    if ((!skipColumnNameCheck && !schema.equals(other.schema) || (skipColumnNameCheck &&
-            !schema.stream().map(Type::getType).collect(Collectors.toList())
-                .equals(other.schema.stream().map(Type::getType).collect(Collectors.toList()))))) {
+    if (!skipColumnNameCheck && !schema.equals(other.schema)) {
+      return false;
+    }
+    if (skipColumnNameCheck && !schema.stream().map(Type::getType).collect(Collectors.toList())
+                    .equals(other.schema.stream().map(Type::getType).collect(Collectors.toList()))) {
       return false;
     }
     return dataRows.equals(other.dataRows);

--- a/integ-test/src/test/java/org/opensearch/sql/correctness/runner/resultset/DBResult.java
+++ b/integ-test/src/test/java/org/opensearch/sql/correctness/runner/resultset/DBResult.java
@@ -12,8 +12,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import lombok.EqualsAndHashCode;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.ToString;
 import org.json.JSONPropertyName;
@@ -24,7 +25,6 @@ import org.opensearch.sql.legacy.utils.StringUtils;
  * query with SELECT columns or just *, order of column and row may matter or not. So the internal data structure of this
  * class is passed in from outside either list or set, hash map or linked hash map etc.
  */
-@EqualsAndHashCode(exclude = "databaseName")
 @ToString
 public class DBResult {
 
@@ -191,4 +191,22 @@ public class DBResult {
     return list;
   }
 
+  public boolean equals(final Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof DBResult)) {
+      return false;
+    }
+    final DBResult other = (DBResult) o;
+    // H2 calculates the value before setting column name
+    // for example, for query "select 1 + 1" it returns a column named "2" instead of "1 + 1"
+    boolean skipColumnNameCheck = databaseName.equalsIgnoreCase("h2") || other.databaseName.equalsIgnoreCase("h2");
+    if ((!skipColumnNameCheck && !schema.equals(other.schema) || (skipColumnNameCheck &&
+            !schema.stream().map(Type::getType).collect(Collectors.toList())
+                .equals(other.schema.stream().map(Type::getType).collect(Collectors.toList()))))) {
+      return false;
+    }
+    return dataRows.equals(other.dataRows);
+  }
 }


### PR DESCRIPTION
CVE is [here](https://www.mend.io/vulnerability-database/CVE-2023-32697).

This CVE does not affect deployments of sql plugin because only integration tests use `sqlite-jdbc`.

### Issues Resolved
https://github.com/opensearch-project/sql/issues/1669
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).