### PR TITLE
Bump BWC test version to 2.8

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'java'
 apply plugin: 'io.freefair.lombok'
 apply plugin: 'com.wiredforcode.spawn'
 
-String baseVersion = "2.7.0"
+String baseVersion = "2.8.0"
 String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"


### PR DESCRIPTION
### Description
The 2.8.0 snapshot is ready not. https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-sql-plugin/2.8.0.0-SNAPSHOT/
Bump BWC test version to 2.8.0. 
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).