### PR TITLE
Add infer schema support for basic data types 

### DIFF
--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/datatype/FlintDataType.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql.flint.datatype
+
+import org.json4s.{Formats, JField, JValue, NoTypeHints}
+import org.json4s.JsonAST.{JNothing, JObject, JString}
+import org.json4s.jackson.JsonMethods
+import org.json4s.native.Serialization
+
+import org.apache.spark.sql.types._
+
+object FlintDataType {
+
+  implicit val formats: Formats = Serialization.formats(NoTypeHints)
+
+  def deserialize(metadata: String): StructType = {
+    deserializeJValue(JsonMethods.parse(metadata))
+  }
+
+  def deserializeJValue(json: JValue): StructType = {
+    val properties = (json \ "properties").extract[Map[String, JValue]]
+    val fields = properties.map { case (fieldName, fieldProperties) =>
+      deserializeFiled(fieldName, fieldProperties)
+    }
+
+    StructType(fields.toSeq)
+  }
+
+  def deserializeFiled(fieldName: String, fieldProperties: JValue): StructField = {
+    val metadataBuilder = new MetadataBuilder()
+    val dataType = fieldProperties \ "type" match {
+      // boolean
+      case JString("boolean") => BooleanType
+
+      // Keywords
+      case JString("keyword") => StringType
+
+      // Numbers
+      case JString("long") => LongType
+      case JString("integer") => IntegerType
+      case JString("short") => ShortType
+      case JString("byte") => ByteType
+      case JString("double") => DoubleType
+      case JString("float") => FloatType
+
+      // Dates
+      case JString("date") =>
+        metadataBuilder.putString("format", (fieldProperties \ "format").extract[String])
+        DateType
+
+      // Text
+      case JString("text") =>
+        metadataBuilder.putString("osType", "text")
+        StringType
+
+      // object types
+      case JString("object") | JNothing => deserializeJValue(fieldProperties)
+
+      // not supported
+      case _ => throw new IllegalStateException(s"unsupported data type")
+    }
+    DataTypes.createStructField(fieldName, dataType, true, metadataBuilder.build())
+  }
+
+  def serialize(structType: StructType): String = {
+    val jValue = serializeJValue(structType)
+    JsonMethods.compact(JsonMethods.render(jValue))
+  }
+
+  def serializeJValue(structType: StructType): JValue = {
+    JObject("properties" -> JObject(structType.fields.map(field => serializeField(field)).toList))
+  }
+
+  def serializeField(structField: StructField): JField = {
+    val metadata = structField.metadata
+    val dataType = structField.dataType match {
+      // boolean
+      case BooleanType => JObject("type" -> JString("boolean"))
+
+      // string
+      case StringType =>
+        if (metadata.contains("osType") && metadata.getString("osType") == "text") {
+          JObject("type" -> JString("text"))
+        } else {
+          JObject("type" -> JString("keyword"))
+        }
+
+      // Numbers
+      case LongType => JObject("type" -> JString("long"))
+      case IntegerType => JObject("type" -> JString("integer"))
+      case ShortType => JObject("type" -> JString("short"))
+      case ByteType => JObject("type" -> JString("byte"))
+      case DoubleType => JObject("type" -> JString("double"))
+      case FloatType => JObject("type" -> JString("float"))
+
+      // date
+      case DateType =>
+        JObject("type" -> JString("date"), "format" -> JString(metadata.getString("format")))
+
+      // objects
+      case st: StructType => serializeJValue(st)
+      case _ => throw new IllegalStateException(s"unsupported data type")
+    }
+    JField(structField.name, dataType)
+  }
+}

--- a/flint/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
@@ -40,10 +40,6 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
                           |    "floatField": {
                           |      "type": "float"
                           |    },
-                          |    "dateField": {
-                          |      "type": "date",
-                          |      "format": "yyyy-MM-dd"
-                          |    },
                           |    "textField": {
                           |      "type": "text"
                           |    }
@@ -58,11 +54,6 @@ class FlintDataTypeSuite extends FlintSuite with Matchers {
         StructField("byteField", ByteType, true) ::
         StructField("doubleField", DoubleType, true) ::
         StructField("floatField", FloatType, true) ::
-        StructField(
-          "dateField",
-          DateType,
-          true,
-          new MetadataBuilder().putString("format", "yyyy-MM-dd").build()) ::
         StructField(
           "textField",
           StringType,

--- a/flint/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/datatype/FlintDataTypeSuite.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.spark.sql.flint.datatype
+
+import org.json4s.JValue
+import org.json4s.jackson.JsonMethods
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.FlintSuite
+import org.apache.spark.sql.types._
+
+class FlintDataTypeSuite extends FlintSuite with Matchers {
+  test("basic deserialize and serialize") {
+    val flintDataType = """{
+                          |  "properties": {
+                          |    "booleanField": {
+                          |      "type": "boolean"
+                          |    },
+                          |    "keywordField": {
+                          |      "type": "keyword"
+                          |    },
+                          |    "longField": {
+                          |      "type": "long"
+                          |    },
+                          |    "integerField": {
+                          |      "type": "integer"
+                          |    },
+                          |    "shortField": {
+                          |      "type": "short"
+                          |    },
+                          |    "byteField": {
+                          |      "type": "byte"
+                          |    },
+                          |    "doubleField": {
+                          |      "type": "double"
+                          |    },
+                          |    "floatField": {
+                          |      "type": "float"
+                          |    },
+                          |    "dateField": {
+                          |      "type": "date",
+                          |      "format": "yyyy-MM-dd"
+                          |    },
+                          |    "textField": {
+                          |      "type": "text"
+                          |    }
+                          |  }
+                          |}""".stripMargin
+    val sparkStructType = StructType(
+      StructField("booleanField", BooleanType, true) ::
+        StructField("keywordField", StringType, true) ::
+        StructField("longField", LongType, true) ::
+        StructField("integerField", IntegerType, true) ::
+        StructField("shortField", ShortType, true) ::
+        StructField("byteField", ByteType, true) ::
+        StructField("doubleField", DoubleType, true) ::
+        StructField("floatField", FloatType, true) ::
+        StructField(
+          "dateField",
+          DateType,
+          true,
+          new MetadataBuilder().putString("format", "yyyy-MM-dd").build()) ::
+        StructField(
+          "textField",
+          StringType,
+          true,
+          new MetadataBuilder().putString("osType", "text").build()) ::
+        Nil)
+
+    FlintDataType.serialize(sparkStructType) shouldBe compactJson(flintDataType)
+    FlintDataType.deserialize(flintDataType) should contain theSameElementsAs sparkStructType
+  }
+
+  test("deserialize unsupported flint data type throw exception") {
+    val unsupportedField = """{
+      "properties": {
+        "rangeField": {
+          "type": "integer_range"
+        }
+      }
+    }"""
+    an[IllegalStateException] should be thrownBy FlintDataType.deserialize(unsupportedField)
+  }
+
+  test("flint object type deserialize and serialize") {
+    val flintDataType = """{
+                             |  "properties": {
+                             |    "object1": {
+                             |      "properties": {
+                             |        "shortField": {
+                             |          "type": "short"
+                             |        }
+                             |      }
+                             |    },
+                             |    "object2": {
+                             |      "type": "object",
+                             |      "properties": {
+                             |        "integerField": {
+                             |          "type": "integer"
+                             |        }
+                             |      }
+                             |    }
+                             |  }
+                             |}""".stripMargin
+    val sparkStructType = StructType(
+      StructField("object1", StructType(StructField("shortField", ShortType) :: Nil)) ::
+        StructField("object2", StructType(StructField("integerField", IntegerType) :: Nil)) ::
+        Nil)
+
+    FlintDataType.deserialize(flintDataType) should contain theSameElementsAs sparkStructType
+
+    FlintDataType.serialize(sparkStructType) shouldBe compactJson("""{
+                                                                    |  "properties": {
+                                                                    |    "object1": {
+                                                                    |      "properties": {
+                                                                    |        "shortField": {
+                                                                    |          "type": "short"
+                                                                    |        }
+                                                                    |      }
+                                                                    |    },
+                                                                    |    "object2": {
+                                                                    |      "properties": {
+                                                                    |        "integerField": {
+                                                                    |          "type": "integer"
+                                                                    |        }
+                                                                    |      }
+                                                                    |    }
+                                                                    |  }
+                                                                    |}""".stripMargin)
+  }
+
+  def compactJson(json: String): String = {
+    val data: JValue = JsonMethods.parse(json)
+    JsonMethods.compact(JsonMethods.render(data))
+  }
+}


### PR DESCRIPTION
### Description
1. support basic data type mapping between flint and spark.
2. will post seperate PR for date type field.
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).