### PR TITLE
Fixed bug of byte/short not handling 0 denominator in divide/modulus equations

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/ArithmeticFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/operator/arthmetic/ArithmeticFunction.java
@@ -106,7 +106,8 @@ public class ArithmeticFunction {
   private static DefaultFunctionResolver divideBase(FunctionName functionName) {
     return define(functionName,
         impl(nullMissingHandling(
-            (v1, v2) -> new ExprByteValue(v1.byteValue() / v2.byteValue())),
+            (v1, v2) -> v2.byteValue() == 0 ? ExprNullValue.of() :
+                    new ExprByteValue(v1.byteValue() / v2.byteValue())),
                 BYTE, BYTE, BYTE),
         impl(nullMissingHandling(
             (v1, v2) -> v2.shortValue() == 0 ? ExprNullValue.of() :
@@ -140,7 +141,7 @@ public class ArithmeticFunction {
   }
 
   /**
-   * Definition of modulo(x, y) function.
+   * Definition of modulus(x, y) function.
    * Returns the number x modulo by number y
    * The supported signature of modulo function is
    * (x: BYTE/SHORT/INTEGER/LONG/FLOAT/DOUBLE, y: BYTE/SHORT/INTEGER/LONG/FLOAT/DOUBLE)
@@ -149,7 +150,8 @@ public class ArithmeticFunction {
   private static DefaultFunctionResolver modulusBase(FunctionName functionName) {
     return define(functionName,
             impl(nullMissingHandling(
-                (v1, v2) -> new ExprByteValue(v1.byteValue() % v2.byteValue())),
+                (v1, v2) -> v2.byteValue() == 0 ? ExprNullValue.of() :
+                        new ExprByteValue(v1.byteValue() % v2.byteValue())),
                     BYTE, BYTE, BYTE),
             impl(nullMissingHandling(
                 (v1, v2) -> v2.shortValue() == 0 ? ExprNullValue.of() :

--- a/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/ArithmeticFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/operator/arthmetic/ArithmeticFunctionTest.java
@@ -113,7 +113,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     assertEquals(String.format("mod(%s, %s)", op1.toString(), op2.toString()),
             expression.toString());
 
-    expression = DSL.mod(literal(op1), literal(new ExprShortValue(0)));
+    expression = DSL.mod(literal(op1), literal(new ExprByteValue(0)));
     assertTrue(expression.valueOf(valueEnv()).isNull());
     assertEquals(String.format("mod(%s, 0)", op1.toString()), expression.toString());
   }
@@ -128,7 +128,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     assertEquals(String.format("%%(%s, %s)", op1.toString(), op2.toString()),
             expression.toString());
 
-    expression = DSL.modulus(literal(op1), literal(new ExprShortValue(0)));
+    expression = DSL.modulus(literal(op1), literal(new ExprByteValue(0)));
     assertTrue(expression.valueOf(valueEnv()).isNull());
     assertEquals(String.format("%%(%s, 0)", op1.toString()), expression.toString());
   }
@@ -144,7 +144,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     assertEquals(String.format("modulus(%s, %s)", op1.toString(), op2.toString()),
             expression.toString());
 
-    expression = DSL.modulusFunction(literal(op1), literal(new ExprShortValue(0)));
+    expression = DSL.modulusFunction(literal(op1), literal(new ExprByteValue(0)));
     assertTrue(expression.valueOf(valueEnv()).isNull());
     assertEquals(String.format("modulus(%s, 0)", op1.toString()), expression.toString());
   }
@@ -183,7 +183,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     assertEquals(String.format("/(%s, %s)", op1.toString(), op2.toString()),
         expression.toString());
 
-    expression = DSL.divide(literal(op1), literal(new ExprShortValue(0)));
+    expression = DSL.divide(literal(op1), literal(new ExprByteValue(0)));
     assertTrue(expression.valueOf(valueEnv()).isNull());
     assertEquals(String.format("/(%s, 0)", op1.toString()), expression.toString());
   }
@@ -199,7 +199,7 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
     assertEquals(String.format("divide(%s, %s)", op1.toString(), op2.toString()),
             expression.toString());
 
-    expression = DSL.divideFunction(literal(op1), literal(new ExprShortValue(0)));
+    expression = DSL.divideFunction(literal(op1), literal(new ExprByteValue(0)));
     assertTrue(expression.valueOf(valueEnv()).isNull());
     assertEquals(String.format("divide(%s, 0)", op1.toString()), expression.toString());
   }


### PR DESCRIPTION
### Description
Previously there was no handling of a 0 denominator for byte and short in the divide and modulus arithmetic operators, I have fixed that and updated it's testing.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1582
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).