### PR TITLE
enhance flint spark configuration

### DIFF
--- a/flint/docs/index.md
+++ b/flint/docs/index.md
@@ -269,18 +269,26 @@ trait FlintSparkSkippingStrategy {
 Here is an example for read index data from AWS OpenSearch domain.
 
 ```scala
-val aos = Map(
-  "host" -> "yourdomain.us-west-2.es.amazonaws.com", 
-  "port" -> "-1", 
-  "scheme" -> "https", 
-  "auth" -> "sigv4", 
-  "region" -> "us-west-2")
+
+spark.conf.set("spark.datasource.flint.host", "yourdomain.us-west-2.es.amazonaws.com")
+spark.conf.set("spark.datasource.flint.port", "-1")
+spark.conf.set("spark.datasource.flint.scheme", "https")
+spark.conf.set("spark.datasource.flint.auth", "sigv4")
+spark.conf.set("spark.datasource.flint.region", "us-west-2")
+spark.conf.set("spark.datasource.flint.refresh_policy", "wait_for")
+
+val df = spark.range(15).toDF("aInt")
+
+val re = df.coalesce(1)
+        .write
+        .format("flint")
+        .mode("overwrite")
+        .save("t001")
 
 val df = new SQLContext(sc).read
         .format("flint")
-        .options(aos)
-        .schema("aInt int")
         .load("t001")
+
 ```
 
 ## Benchmarks

--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintPartitionReader.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintPartitionReader.scala
@@ -30,7 +30,7 @@ class FlintPartitionReader(reader: FlintReader, schema: StructType, options: Fli
 
   lazy val parser = new FlintJacksonParser(
     schema,
-    new JSONOptionsInRead(CaseInsensitiveMap(DATE_FORMAT_PARAMETERS), options.timeZone(), ""),
+    new JSONOptionsInRead(CaseInsensitiveMap(DATE_FORMAT_PARAMETERS), options.timeZone, ""),
     allowArrayAsStructs = true)
   lazy val stringParser: (JsonFactory, String) => JsonParser =
     CreateJacksonParser.string(_: JsonFactory, _: String)

--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintPartitionWriter.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/FlintPartitionWriter.scala
@@ -32,7 +32,7 @@ case class FlintPartitionWriter(
     with Logging {
 
   private lazy val jsonOptions = {
-    new JSONOptions(CaseInsensitiveMap(DATE_FORMAT_PARAMETERS), options.timeZone(), "")
+    new JSONOptions(CaseInsensitiveMap(DATE_FORMAT_PARAMETERS), options.timeZone, "")
   }
   private lazy val gen = FlintJacksonGenerator(dataSchema, flintWriter, jsonOptions)
 

--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintConfig.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintConfig.scala
@@ -6,6 +6,7 @@
 package org.apache.spark.sql.flint.config
 
 import org.apache.spark.internal.config.ConfigReader
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Similar to SPARK ConfigEntry. ConfigEntry register the configuration which can not been
@@ -15,44 +16,87 @@ private case class FlintConfig(key: String) {
 
   private var doc = ""
 
+  private var dataSourcePrefix: Option[String] = None
+
+  val DATASOURCE_FLINT_PREFIX = "spark.datasource.flint."
+
   def doc(s: String): FlintConfig = {
     doc = s
     this
   }
 
+  /**
+   * if the configuration is datasource option also. which means user could define it using
+   * dataframe.option() interface. for example, sql.read.format("flint").options(Map("host" ->
+   * "localhost"))
+   * @return
+   */
+  def datasourceOption(): FlintConfig = {
+    dataSourcePrefix = Some(DATASOURCE_FLINT_PREFIX)
+    this
+  }
+
   def createWithDefault(defaultValue: String): FlintConfigEntry[String] = {
-    new FlintConfigEntryWithDefault(key, defaultValue, doc)
+    new FlintConfigEntryWithDefault(key, defaultValue, doc, dataSourcePrefix)
   }
 
   def createOptional(): FlintConfigEntry[Option[String]] = {
-    new FlintOptionalConfigEntry(key, doc)
+    new FlintOptionalConfigEntry(key, doc, dataSourcePrefix)
   }
 }
 
-abstract class FlintConfigEntry[T](val key: String, val doc: String) {
-  protected def readString(reader: ConfigReader): Option[String] = {
-    reader.get(key)
-  }
+abstract class FlintConfigEntry[T](val key: String, val doc: String, val prefix: Option[String]) {
 
+  protected val DATASOURCE_FLINT_PREFIX = "spark.datasource.flint."
+
+  protected def readOptionKeyString(reader: ConfigReader): Option[String] = reader.get(optionKey)
+
+  /**
+   * Get configuration from {@link ConfigReader}
+   */
   def readFrom(reader: ConfigReader): T
 
-  def defaultValue: Option[String] = None
+  /**
+   * Get configuration defined by key from {@link SQLConf}.
+   */
+  protected def readFromConf(): Option[String] = {
+    if (SQLConf.get.contains(key)) {
+      Some(SQLConf.get.getConfString(key))
+    } else {
+      None
+    }
+  }
+
+  def defaultValue: Option[T] = None
+
+  /**
+   * DataSource option key. for example, the key = spark.datasource.flint.host, prefix = spark
+   * .datasource.flint. the optionKey is host.
+   */
+  def optionKey: String = prefix.map(key.stripPrefix(_)).getOrElse(key)
 }
 
-private class FlintConfigEntryWithDefault(key: String, defaultValue: String, doc: String)
-    extends FlintConfigEntry[String](key, doc) {
+private class FlintConfigEntryWithDefault(
+    key: String,
+    defaultValue: String,
+    doc: String,
+    prefix: Option[String])
+    extends FlintConfigEntry[String](key, doc, prefix) {
 
   override def defaultValue: Option[String] = Some(defaultValue)
 
-  def readFrom(reader: ConfigReader): String = {
-    readString(reader).getOrElse(defaultValue)
+  override def readFrom(reader: ConfigReader): String = {
+    readOptionKeyString(reader)
+      .orElse(readFromConf())
+      .getOrElse(defaultValue)
   }
 }
 
-private class FlintOptionalConfigEntry(key: String, doc: String)
-    extends FlintConfigEntry[Option[String]](key, doc) {
+private class FlintOptionalConfigEntry(key: String, doc: String, prefix: Option[String])
+    extends FlintConfigEntry[Option[String]](key, doc, prefix) {
 
-  def readFrom(reader: ConfigReader): Option[String] = {
-    readString(reader)
+  override def readFrom(reader: ConfigReader): Option[String] = {
+    readOptionKeyString(reader)
+      .orElse(readFromConf())
   }
 }

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.streaming.OutputMode.Append
 class FlintSpark(val spark: SparkSession) {
 
   /** Flint client for low-level index operation */
-  private val flintClient: FlintClient = FlintClientBuilder.build(FlintSparkConf(spark.conf))
+  private val flintClient: FlintClient = FlintClientBuilder.build(FlintSparkConf().flintOptions())
 
   /** Required by json4s parse function */
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
@@ -182,9 +182,8 @@ class FlintSpark(val spark: SparkSession) {
 object FlintSpark {
 
   /**
-   * Index refresh mode:
-   *  FULL: refresh on current source data in batch style at one shot
-   *  INCREMENTAL: auto refresh on new data in continuous streaming style
+   * Index refresh mode: FULL: refresh on current source data in batch style at one shot
+   * INCREMENTAL: auto refresh on new data in continuous streaming style
    */
   object RefreshMode extends Enumeration {
     type RefreshMode = Value

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkOptimizer.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSparkOptimizer.scala
@@ -5,8 +5,6 @@
 
 package org.opensearch.flint.spark
 
-import scala.collection.JavaConverters._
-
 import org.opensearch.flint.spark.skipping.ApplyFlintSparkSkippingIndex
 
 import org.apache.spark.sql.SparkSession
@@ -36,7 +34,6 @@ class FlintSparkOptimizer(spark: SparkSession) extends Rule[LogicalPlan] {
   }
 
   private def isOptimizerEnabled: Boolean = {
-    val flintConf = new FlintSparkConf(spark.conf.getAll.asJava)
-    flintConf.isOptimizerEnabled
+    FlintSparkConf().isOptimizerEnabled
   }
 }

--- a/flint/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
@@ -9,7 +9,7 @@ import org.opensearch.flint.spark.FlintSparkExtensions
 
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
-import org.apache.spark.sql.flint.config.{FlintConfigEntry, FlintSparkConf}
+import org.apache.spark.sql.flint.config.FlintConfigEntry
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -32,6 +32,6 @@ trait FlintSuite extends SharedSparkSession {
    * Set Flint Spark configuration. (Generic "value: T" has problem with FlintConfigEntry[Any])
    */
   protected def setFlintSparkConf[T](config: FlintConfigEntry[T], value: Any): Unit = {
-    spark.conf.set(FlintSparkConf.sparkConf(config.key), value.toString)
+    spark.conf.set(config.key, value.toString)
   }
 }

--- a/flint/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/apache/spark/sql/flint/config/FlintSparkConfSuite.scala
@@ -11,16 +11,18 @@ import org.apache.spark.FlintSuite
 
 class FlintSparkConfSuite extends FlintSuite {
   test("test spark conf") {
-    spark.conf.set("spark.datasource.flint.host", "127.0.0.1")
-    spark.conf.set("spark.datasource.flint.read.scroll_size", "10")
+    withSparkConf("spark.datasource.flint.host", "spark.datasource.flint.read.scroll_size") {
+      spark.conf.set("spark.datasource.flint.host", "127.0.0.1")
+      spark.conf.set("spark.datasource.flint.read.scroll_size", "10")
 
-    val flintOptions = FlintSparkConf(spark.conf)
-    assert(flintOptions.getHost == "127.0.0.1")
-    assert(flintOptions.getScrollSize == 10)
+      val flintOptions = FlintSparkConf().flintOptions()
+      assert(flintOptions.getHost == "127.0.0.1")
+      assert(flintOptions.getScrollSize == 10)
 
-    // default value
-    assert(flintOptions.getPort == 9200)
-    assert(flintOptions.getRefreshPolicy == "false")
+      // default value
+      assert(flintOptions.getPort == 9200)
+      assert(flintOptions.getRefreshPolicy == "false")
+    }
   }
 
   test("test spark options") {
@@ -32,5 +34,16 @@ class FlintSparkConfSuite extends FlintSuite {
     // default value
     assert(options.flintOptions().getHost == "localhost")
     assert(options.flintOptions().getPort == 9200)
+  }
+
+  /**
+   * Delete index `indexNames` after calling `f`.
+   */
+  protected def withSparkConf(configs: String*)(f: => Unit): Unit = {
+    try {
+      f
+    } finally {
+      configs.foreach { config => spark.conf.unset(config) }
+    }
   }
 }

--- a/flint/integ-test/src/test/scala/org/apache/spark/FlintDataSourceV2ITSuite.scala
+++ b/flint/integ-test/src/test/scala/org/apache/spark/FlintDataSourceV2ITSuite.scala
@@ -52,7 +52,7 @@ class FlintDataSourceV2ITSuite
 
       val df = spark.sqlContext.read
         .format("flint")
-        .options(openSearchOptions + (s"${FlintSparkConf.SCROLL_SIZE.key}" -> "1"))
+        .options(openSearchOptions + (s"${FlintSparkConf.SCROLL_SIZE.optionKey}" -> "1"))
         .load(indexName)
         .sort(asc("id"))
 
@@ -132,8 +132,8 @@ class FlintDataSourceV2ITSuite
         |  }
         |}""".stripMargin
     val options =
-      openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.key}" -> "wait_for",
-      s"${FlintSparkConf.DOC_ID_COLUMN_NAME.key}" -> "aInt")
+      openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.optionKey}" -> "wait_for",
+      s"${FlintSparkConf.DOC_ID_COLUMN_NAME.optionKey}" -> "aInt")
     Seq(Seq.empty, 1 to 14).foreach(data => {
       withIndexName(indexName) {
         index(indexName, oneNodeSetting, mappings, Seq.empty)
@@ -168,8 +168,8 @@ class FlintDataSourceV2ITSuite
   test("write dataframe to flint with batch size configuration") {
     val indexName = "t0004"
     val options =
-      openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.key}" -> "wait_for",
-      s"${FlintSparkConf.DOC_ID_COLUMN_NAME.key}" -> "aInt")
+      openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.optionKey}" -> "wait_for",
+      s"${FlintSparkConf.DOC_ID_COLUMN_NAME.optionKey}" -> "aInt")
     Seq(0, 1).foreach(batchSize => {
       withIndexName(indexName) {
         val mappings =
@@ -224,8 +224,8 @@ class FlintDataSourceV2ITSuite
           .option("checkpointLocation", checkpointDir)
           .format("flint")
           .options(openSearchOptions)
-          .option(s"${FlintSparkConf.REFRESH_POLICY.key}", "wait_for")
-          .option(s"${FlintSparkConf.DOC_ID_COLUMN_NAME.key}", "aInt")
+          .option(s"${FlintSparkConf.REFRESH_POLICY.optionKey}", "wait_for")
+          .option(s"${FlintSparkConf.DOC_ID_COLUMN_NAME.optionKey}", "aInt")
           .start(indexName)
 
         inputData.addData(1, 2, 3)
@@ -253,8 +253,8 @@ class FlintDataSourceV2ITSuite
     val indexName = "t0001"
     withIndexName(indexName) {
       simpleIndex(indexName)
-      spark.conf.set(FlintSparkConf.sparkConf(FlintSparkConf.HOST_ENDPOINT.key), openSearchHost)
-      spark.conf.set(FlintSparkConf.sparkConf(FlintSparkConf.HOST_PORT.key), openSearchPort)
+      spark.conf.set(FlintSparkConf.HOST_ENDPOINT.key, openSearchHost)
+      spark.conf.set(FlintSparkConf.HOST_PORT.key, openSearchPort)
 
       val df = spark.sqlContext.read
         .format("flint")
@@ -271,8 +271,8 @@ class FlintDataSourceV2ITSuite
     withIndexName(indexName) {
       simpleIndex(indexName)
       // set invalid host name and port which should be overwrite by datasource option.
-      spark.conf.set(FlintSparkConf.sparkConf(FlintSparkConf.HOST_ENDPOINT.key), "invalid host")
-      spark.conf.set(FlintSparkConf.sparkConf(FlintSparkConf.HOST_PORT.key), "0")
+      spark.conf.set(FlintSparkConf.HOST_ENDPOINT.key, "invalid host")
+      spark.conf.set(FlintSparkConf.HOST_PORT.key, "0")
 
       val df = spark.sqlContext.read
         .format("flint")
@@ -288,7 +288,8 @@ class FlintDataSourceV2ITSuite
 
   test("load and save date and timestamp type field") {
     val indexName = "t0001"
-    val options = openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.key}" -> "wait_for")
+    val options =
+      openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.optionKey}" -> "wait_for")
     Seq(
       """{
           |  "properties": {
@@ -339,7 +340,8 @@ class FlintDataSourceV2ITSuite
 
   test("load timestamp field in epoch format") {
     val indexName = "t0001"
-    val options = openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.key}" -> "wait_for")
+    val options =
+      openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.optionKey}" -> "wait_for")
     Seq(
       """{
         |  "properties": {
@@ -416,7 +418,8 @@ class FlintDataSourceV2ITSuite
 
   test("scan with date filter push-down") {
     val indexName = "t0001"
-    val options = openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.key}" -> "wait_for")
+    val options =
+      openSearchOptions + (s"${FlintSparkConf.REFRESH_POLICY.optionKey}" -> "wait_for")
     withIndexName(indexName) {
       val mappings = """{
                        |  "properties": {

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/core/FlintOpenSearchClientSuite.scala
@@ -73,7 +73,7 @@ class FlintOpenSearchClientSuite extends AnyFlatSpec with OpenSearchSuite with M
           |  }
           |}""".stripMargin
 
-      val options = openSearchOptions + (s"${REFRESH_POLICY.key}" -> "wait_for")
+      val options = openSearchOptions + (s"${REFRESH_POLICY.optionKey}" -> "wait_for")
       val flintClient = new FlintOpenSearchClient(new FlintOptions(options.asJava))
       index(indexName, oneNodeSetting, mappings, Seq.empty)
       val writer = flintClient.createWriter(indexName)


### PR DESCRIPTION
### Description
improve the FlintSparkConf to support the following use cases.
- storage options, user provide options in DF
    - `write.refresh_policy`
- flint spark configuration, user set using spark.conf.set(). there are two set of configs
    - `spark.flint.xxx.yyy`, for example, `spark.flint.optimizer.enabled`
    - `spark.datasource.flint.xxx.yyy` , for example, `spark.datasource.flint.write.refresh_policy`
- sql configuration, generic configuration defined by spark
    - `spark.sql.session.timeZone`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).