### PR TITLE
Support Array and ExprValue Parsing With Inner Hits

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/ObjectFieldSelectIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/ObjectFieldSelectIT.java
@@ -14,7 +14,6 @@ import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.Assume;
 import org.junit.Test;
 import org.opensearch.sql.legacy.utils.StringUtils;
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_MULTI_NESTED_TYPE;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_TYPE;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_WITH_NULLS;
@@ -31,6 +32,7 @@ public class NestedIT extends SQLIntegTestCase {
     loadIndex(Index.NESTED_WITHOUT_ARRAYS);
     loadIndex(Index.EMPLOYEE_NESTED);
     loadIndex(Index.NESTED_WITH_NULLS);
+    loadIndex(Index.NESTED_SIMPLE);
   }
 
   @Test
@@ -365,5 +367,35 @@ public class NestedIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest(query);
     assertEquals(1, result.getInt("total"));
     verifyDataRows(result, rows(10, "a"));
+  }
+
+  @Test
+  public void nested_function_with_date_types_as_object_arrays_within_arrays_test() {
+    String query = "SELECT nested(address.moveInDate) FROM " + TEST_INDEX_NESTED_SIMPLE;
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(11, result.getInt("total"));
+    verifyDataRows(result,
+        rows(new JSONObject(Map.of("dateAndTime","1984-04-12 09:07:42"))),
+        rows(new JSONArray(
+            List.of(
+                Map.of("dateAndTime", "2023-05-03 08:07:42"),
+                Map.of("dateAndTime", "2001-11-11 04:07:44"))
+            )
+        ),
+        rows(new JSONObject(Map.of("dateAndTime", "1966-03-19 03:04:55"))),
+        rows(new JSONObject(Map.of("dateAndTime", "2011-06-01 01:01:42"))),
+        rows(new JSONObject(Map.of("dateAndTime", "1901-08-11 04:03:33"))),
+        rows(new JSONObject(Map.of("dateAndTime", "2023-05-03 08:07:42"))),
+        rows(new JSONObject(Map.of("dateAndTime", "2001-11-11 04:07:44"))),
+        rows(new JSONObject(Map.of("dateAndTime", "1977-07-13 09:04:41"))),
+        rows(new JSONObject(Map.of("dateAndTime", "1933-12-12 05:05:45"))),
+        rows(new JSONObject(Map.of("dateAndTime", "1909-06-17 01:04:21"))),
+        rows(new JSONArray(
+            List.of(
+                Map.of("dateAndTime", "2001-11-11 04:07:44"))
+            )
+        )
+    );
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -375,6 +375,9 @@ public class NestedIT extends SQLIntegTestCase {
     JSONObject result = executeJdbcRequest(query);
 
     assertEquals(11, result.getInt("total"));
+    verifySchema(result,
+        schema("nested(address.moveInDate)", null, "object")
+    );
     verifyDataRows(result,
         rows(new JSONObject(Map.of("dateAndTime","1984-04-12 09:07:42"))),
         rows(new JSONArray(

--- a/integ-test/src/test/resources/indexDefinitions/nested_simple_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/nested_simple_index_mapping.json
@@ -21,6 +21,14 @@
                 "ignore_above": 256
               }
             }
+          },
+          "moveInDate" : {
+            "properties": {
+              "dateAndTime": {
+                "type": "date",
+                "format": "basic_date_time"
+              }
+            }
           }
         }
       },

--- a/integ-test/src/test/resources/nested_simple.json
+++ b/integ-test/src/test/resources/nested_simple.json
@@ -1,10 +1,10 @@
 {"index":{"_id":"1"}}
-{"name":"abbas","age":24,"address":[{"city":"New york city","state":"NY"},{"city":"bellevue","state":"WA"},{"city":"seattle","state":"WA"},{"city":"chicago","state":"IL"}]}
+{"name":"abbas","age":24,"address":[{"city":"New york city","state":"NY","moveInDate":{"dateAndTime":"19840412T090742.000Z"}},{"city":"bellevue","state":"WA","moveInDate":[{"dateAndTime":"20230503T080742.000Z"},{"dateAndTime":"20011111T040744.000Z"}]},{"city":"seattle","state":"WA","moveInDate":{"dateAndTime":"19660319T030455.000Z"}},{"city":"chicago","state":"IL","moveInDate":{"dateAndTime":"20110601T010142.000Z"}}]}
 {"index":{"_id":"2"}}
-{"name":"chen","age":32,"address":[{"city":"Miami","state":"Florida"},{"city":"los angeles","state":"CA"}]}
+{"name":"chen","age":32,"address":[{"city":"Miami","state":"Florida","moveInDate":{"dateAndTime":"19010811T040333.000Z"}},{"city":"los angeles","state":"CA","moveInDate":{"dateAndTime":"20230503T080742.000Z"}}]}
 {"index":{"_id":"3"}}
-{"name":"peng","age":26,"address":[{"city":"san diego","state":"CA"},{"city":"austin","state":"TX"}]}
+{"name":"peng","age":26,"address":[{"city":"san diego","state":"CA","moveInDate":{"dateAndTime":"20011111T040744.000Z"}},{"city":"austin","state":"TX","moveInDate":{"dateAndTime":"19770713T090441.000Z"}}]}
 {"index":{"_id":"4"}}
-{"name":"andy","age":19,"id":4,"address":[{"city":"houston","state":"TX"}]}
+{"name":"andy","age":19,"id":4,"address":[{"city":"houston","state":"TX","moveInDate":{"dateAndTime":"19331212T050545.000Z"}}]}
 {"index":{"_id":"5"}}
-{"name":"david","age":25,"address":[{"city":"raleigh","state":"NC"},{"city":"charlotte","state":"SC"}]}
+{"name":"david","age":25,"address":[{"city":"raleigh","state":"NC","moveInDate":{"dateAndTime":"19090617T010421.000Z"}},{"city":"charlotte","state":"SC","moveInDate":[{"dateAndTime":"20011111T040744.000Z"}]}]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/Content.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/Content.java
@@ -30,9 +30,34 @@ public interface Content {
   boolean isNumber();
 
   /**
+   * Is float value.
+   */
+  boolean isFloat();
+
+  /**
+   * Is double value.
+   */
+  boolean isDouble();
+
+  /**
+   * Is long value.
+   */
+  boolean isLong();
+
+  /**
+   * Is boolean value.
+   */
+  boolean isBoolean();
+
+  /**
    * Is string value.
    */
   boolean isString();
+
+  /**
+   * Is array value.
+   */
+  boolean isArray();
 
   /**
    * Get integer value.

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
@@ -6,6 +6,7 @@
 
 package org.opensearch.sql.opensearch.data.utils;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.AbstractMap;
 import java.util.Iterator;
 import java.util.List;
@@ -101,6 +102,31 @@ public class ObjectContent implements Content {
   @Override
   public boolean isNumber() {
     return value instanceof Number;
+  }
+
+  @Override
+  public boolean isFloat() {
+    return value instanceof Float;
+  }
+
+  @Override
+  public boolean isDouble() {
+    return value instanceof Double;
+  }
+
+  @Override
+  public boolean isLong() {
+    return value instanceof Long;
+  }
+
+  @Override
+  public boolean isBoolean() {
+    return value instanceof Boolean;
+  }
+
+  @Override
+  public boolean isArray() {
+    return value instanceof ArrayNode;
   }
 
   @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -89,8 +89,33 @@ public class OpenSearchJsonContent implements Content {
   }
 
   @Override
+  public boolean isLong() {
+    return value().isLong();
+  }
+
+  @Override
+  public boolean isFloat() {
+    return value().isFloat();
+  }
+
+  @Override
+  public boolean isDouble() {
+    return value().isDouble();
+  }
+
+  @Override
   public boolean isString() {
     return value().isTextual();
+  }
+
+  @Override
+  public boolean isBoolean() {
+    return value().isBoolean();
+  }
+
+  @Override
+  public boolean isArray() {
+    return value().isArray();
   }
 
   @Override
@@ -126,11 +151,10 @@ public class OpenSearchJsonContent implements Content {
   }
 
   /**
-   * Return the first element if is OpenSearch Array.
-   * https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html.
+   * Getter for value. If value is array the whole array is returned.
    */
   private JsonNode value() {
-    return value.isArray() ? value.get(0) : value;
+    return value;
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
@@ -195,7 +195,7 @@ public class OpenSearchResponse implements Iterable<ExprValue> {
    * Handle an aggregation response.
    * @return Parsed and built return values from response.
    */
-  public Iterator<ExprValue> handleAggregationResponse() {
+  private Iterator<ExprValue> handleAggregationResponse() {
     return exprValueFactory.getParser().parse(aggregations).stream().map(entry -> {
       ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
       for (Map.Entry<String, Object> value : entry.entrySet()) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/OpenSearchResponse.java
@@ -15,15 +15,15 @@ import static org.opensearch.sql.opensearch.storage.OpenSearchIndex.METADATA_FIE
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.text.Text;
+import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.sql.data.model.ExprFloatValue;
@@ -107,61 +107,108 @@ public class OpenSearchResponse implements Iterable<ExprValue> {
    */
   public Iterator<ExprValue> iterator() {
     if (isAggregationResponse()) {
-      return exprValueFactory.getParser().parse(aggregations).stream().map(entry -> {
-        ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
-        for (Map.Entry<String, Object> value : entry.entrySet()) {
-          builder.put(value.getKey(), exprValueFactory.construct(value.getKey(), value.getValue()));
-        }
-        return (ExprValue) ExprTupleValue.fromExprValueMap(builder.build());
-      }).iterator();
+      return handleAggregationResponse();
     } else {
-      List<String> metaDataFieldSet = includes.stream()
-          .filter(include -> METADATAFIELD_TYPE_MAP.containsKey(include))
-          .collect(Collectors.toList());
-      ExprFloatValue maxScore = Float.isNaN(hits.getMaxScore())
-          ? null : new ExprFloatValue(hits.getMaxScore());
       return Arrays.stream(hits.getHits())
           .map(hit -> {
-            String source = hit.getSourceAsString();
-            ExprValue docData = exprValueFactory.construct(source);
-
             ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
-            if (hit.getInnerHits() == null || hit.getInnerHits().isEmpty()) {
-              builder.putAll(docData.tupleValue());
-            } else {
-              Map<String, Object> rowSource = hit.getSourceAsMap();
-              builder.putAll(ExprValueUtils.tupleValue(rowSource).tupleValue());
-            }
-
-            metaDataFieldSet.forEach(metaDataField -> {
-              if (metaDataField.equals(METADATA_FIELD_INDEX)) {
-                builder.put(METADATA_FIELD_INDEX, new ExprStringValue(hit.getIndex()));
-              } else if (metaDataField.equals(METADATA_FIELD_ID)) {
-                builder.put(METADATA_FIELD_ID, new ExprStringValue(hit.getId()));
-              } else if (metaDataField.equals(METADATA_FIELD_SCORE)) {
-                if (!Float.isNaN(hit.getScore())) {
-                  builder.put(METADATA_FIELD_SCORE, new ExprFloatValue(hit.getScore()));
-                }
-              } else if (metaDataField.equals(METADATA_FIELD_MAXSCORE)) {
-                if (maxScore != null) {
-                  builder.put(METADATA_FIELD_MAXSCORE, maxScore);
-                }
-              } else { // if (metaDataField.equals(METADATA_FIELD_SORT)) {
-                builder.put(METADATA_FIELD_SORT, new ExprLongValue(hit.getSeqNo()));
-              }
-            });
-
-            if (!hit.getHighlightFields().isEmpty()) {
-              var hlBuilder = ImmutableMap.<String, ExprValue>builder();
-              for (var es : hit.getHighlightFields().entrySet()) {
-                hlBuilder.put(es.getKey(), ExprValueUtils.collectionValue(
-                    Arrays.stream(es.getValue().fragments()).map(
-                        t -> (t.toString())).collect(Collectors.toList())));
-              }
-              builder.put("_highlight", ExprTupleValue.fromExprValueMap(hlBuilder.build()));
-            }
+            addParsedHitsToBuilder(builder, hit);
+            addMetaDataFieldsToBuilder(builder, hit);
+            addHighlightsToBuilder(builder, hit);
             return (ExprValue) ExprTupleValue.fromExprValueMap(builder.build());
           }).iterator();
     }
+  }
+
+  /**
+   * Parse response for all hits to add to builder. Inner_hits supports arrays of objects
+   * with nested type.
+   * @param builder builder to build values from response.
+   * @param hit Search hit from response.
+   */
+  private void addParsedHitsToBuilder(
+      ImmutableMap.Builder<String, ExprValue> builder,
+      SearchHit hit
+  ) {
+    builder.putAll(
+        exprValueFactory.construct(
+            hit.getSourceAsString(),
+            !(hit.getInnerHits() == null || hit.getInnerHits().isEmpty())
+        ).tupleValue());
+  }
+
+  /**
+   * If highlight fields are present in response add the fields to the builder.
+   * @param builder builder to build values from response.
+   * @param hit Search hit from response.
+   */
+  private void addHighlightsToBuilder(
+      ImmutableMap.Builder<String, ExprValue> builder,
+      SearchHit hit
+  ) {
+    if (!hit.getHighlightFields().isEmpty()) {
+      var hlBuilder = ImmutableMap.<String, ExprValue>builder();
+      for (var es : hit.getHighlightFields().entrySet()) {
+        hlBuilder.put(es.getKey(), ExprValueUtils.collectionValue(
+            Arrays.stream(es.getValue().fragments()).map(
+                Text::toString).collect(Collectors.toList())));
+      }
+      builder.put("_highlight", ExprTupleValue.fromExprValueMap(hlBuilder.build()));
+    }
+  }
+
+  /**
+   * Add metadata fields to builder from response.
+   * @param builder builder to build values from response.
+   * @param hit Search hit from response.
+   */
+  private void addMetaDataFieldsToBuilder(
+      ImmutableMap.Builder<String, ExprValue> builder,
+      SearchHit hit
+  ) {
+    List<String> metaDataFieldSet = includes.stream()
+        .filter(METADATAFIELD_TYPE_MAP::containsKey)
+        .collect(Collectors.toList());
+    ExprFloatValue maxScore = Float.isNaN(hits.getMaxScore())
+        ? null : new ExprFloatValue(hits.getMaxScore());
+
+    metaDataFieldSet.forEach(metaDataField -> {
+      if (metaDataField.equals(METADATA_FIELD_INDEX)) {
+        builder.put(METADATA_FIELD_INDEX, new ExprStringValue(hit.getIndex()));
+      } else if (metaDataField.equals(METADATA_FIELD_ID)) {
+        builder.put(METADATA_FIELD_ID, new ExprStringValue(hit.getId()));
+      } else if (metaDataField.equals(METADATA_FIELD_SCORE)) {
+        if (!Float.isNaN(hit.getScore())) {
+          builder.put(METADATA_FIELD_SCORE, new ExprFloatValue(hit.getScore()));
+        }
+      } else if (metaDataField.equals(METADATA_FIELD_MAXSCORE)) {
+        if (maxScore != null) {
+          builder.put(METADATA_FIELD_MAXSCORE, maxScore);
+        }
+      } else { // if (metaDataField.equals(METADATA_FIELD_SORT)) {
+        builder.put(METADATA_FIELD_SORT, new ExprLongValue(hit.getSeqNo()));
+      }
+    });
+  }
+
+  /**
+   * Handle an aggregation response.
+   * @return Parsed and built return values from response.
+   */
+  public Iterator<ExprValue> handleAggregationResponse() {
+    return exprValueFactory.getParser().parse(aggregations).stream().map(entry -> {
+      ImmutableMap.Builder<String, ExprValue> builder = new ImmutableMap.Builder<>();
+      for (Map.Entry<String, Object> value : entry.entrySet()) {
+        builder.put(
+            value.getKey(),
+            exprValueFactory.construct(
+                value.getKey(),
+                value.getValue(),
+                false
+            )
+        );
+      }
+      return (ExprValue) ExprTupleValue.fromExprValueMap(builder.build());
+    }).iterator();
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
@@ -118,7 +118,11 @@ public class ExpressionScript {
     Map<Expression, ExprValue> valueEnv = new HashMap<>();
     for (ReferenceExpression field : fields) {
       String fieldName = field.getAttr();
-      ExprValue exprValue = valueFactory.construct(fieldName, getDocValue(field, docProvider));
+      ExprValue exprValue = valueFactory.construct(
+          fieldName,
+          getDocValue(field, docProvider),
+          false
+      );
       valueEnv.put(field, exprValue);
     }
     // Encapsulate map data structure into anonymous Environment class

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -313,7 +313,7 @@ class OpenSearchNodeClientTest {
                 1.0F));
     when(searchHit.getSourceAsString()).thenReturn("{\"id\", 1}");
     when(searchHit.getInnerHits()).thenReturn(null);
-    when(factory.construct(any())).thenReturn(exprTupleValue);
+    when(factory.construct(any(), anyBoolean())).thenReturn(exprTupleValue);
 
     // Mock second scroll request followed
     SearchResponse scrollResponse = mock(SearchResponse.class);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -297,7 +298,7 @@ class OpenSearchRestClientTest {
                 1.0F));
     when(searchHit.getSourceAsString()).thenReturn("{\"id\", 1}");
     when(searchHit.getInnerHits()).thenReturn(null);
-    when(factory.construct(any())).thenReturn(exprTupleValue);
+    when(factory.construct(any(), anyBoolean())).thenReturn(exprTupleValue);
 
     // Mock second scroll request followed
     SearchResponse scrollResponse = mock(SearchResponse.class);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -453,6 +453,19 @@ class OpenSearchExprValueFactoryTest {
   }
 
   @Test
+  public void constructMultiNestedArraysOfStringsReturnsFirstIndex() {
+    assertEquals(
+        stringValue("z"),
+        tupleValue(
+            "{\"stringV\":"
+                + "[\"z\","
+                + "[\"s\"],"
+                + "[\"zz\", \"au\"]"
+                + "]}"
+        ).get("stringV"));
+  }
+
+  @Test
   public void constructArrayOfInts() {
     assertEquals(new ExprCollectionValue(
             List.of(integerValue(1), integerValue(2))),

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchResponseTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchResponseTest.java
@@ -12,7 +12,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
@@ -114,7 +118,8 @@ class OpenSearchResponseTest {
     when(searchHit2.getSourceAsString()).thenReturn("{\"id1\", 2}");
     when(searchHit1.getInnerHits()).thenReturn(null);
     when(searchHit2.getInnerHits()).thenReturn(null);
-    when(factory.construct(any())).thenReturn(exprTupleValue1).thenReturn(exprTupleValue2);
+    when(factory.construct(any(), anyBoolean()))
+        .thenReturn(exprTupleValue1).thenReturn(exprTupleValue2);
 
     int i = 0;
     for (ExprValue hit : new OpenSearchResponse(searchResponse, factory, List.of("id1"))) {
@@ -149,7 +154,7 @@ class OpenSearchResponseTest {
     when(searchHit1.getScore()).thenReturn(3.75F);
     when(searchHit1.getSeqNo()).thenReturn(123456L);
 
-    when(factory.construct(any())).thenReturn(exprTupleHit);
+    when(factory.construct(any(), anyBoolean())).thenReturn(exprTupleHit);
 
     ExprTupleValue exprTupleResponse = ExprTupleValue.fromExprValueMap(ImmutableMap.of(
         "id1", new ExprIntegerValue(1),
@@ -187,7 +192,7 @@ class OpenSearchResponseTest {
 
     when(searchHit1.getSourceAsString()).thenReturn("{\"id1\", 1}");
 
-    when(factory.construct(any())).thenReturn(exprTupleHit);
+    when(factory.construct(any(), anyBoolean())).thenReturn(exprTupleHit);
 
     List includes = List.of("id1");
     ExprTupleValue exprTupleResponse = ExprTupleValue.fromExprValueMap(ImmutableMap.of(
@@ -224,7 +229,7 @@ class OpenSearchResponseTest {
     when(searchHit1.getScore()).thenReturn(Float.NaN);
     when(searchHit1.getSeqNo()).thenReturn(123456L);
 
-    when(factory.construct(any())).thenReturn(exprTupleHit);
+    when(factory.construct(any(), anyBoolean())).thenReturn(exprTupleHit);
 
     List includes = List.of("id1", "_index", "_id", "_sort", "_score", "_maxscore");
     ExprTupleValue exprTupleResponse = ExprTupleValue.fromExprValueMap(ImmutableMap.of(
@@ -252,8 +257,6 @@ class OpenSearchResponseTest {
                 new SearchHit[] {searchHit1},
                 new TotalHits(2L, TotalHits.Relation.EQUAL_TO),
                 1.0F));
-    when(searchHit1.getSourceAsString()).thenReturn("{\"id1\", 1}");
-    when(searchHit1.getSourceAsMap()).thenReturn(Map.of("id1", 1));
     when(searchHit1.getInnerHits()).thenReturn(
         Map.of(
             "innerHit",
@@ -262,7 +265,7 @@ class OpenSearchResponseTest {
                 new TotalHits(2L, TotalHits.Relation.EQUAL_TO),
                 1.0F)));
 
-    when(factory.construct(any())).thenReturn(exprTupleValue1);
+    when(factory.construct(any(), anyBoolean())).thenReturn(exprTupleValue1);
 
     for (ExprValue hit : new OpenSearchResponse(searchResponse, factory, includes)) {
       assertEquals(exprTupleValue1, hit);
@@ -293,7 +296,7 @@ class OpenSearchResponseTest {
         .thenReturn(Arrays.asList(ImmutableMap.of("id1", 1), ImmutableMap.of("id2", 2)));
     when(searchResponse.getAggregations()).thenReturn(aggregations);
     when(factory.getParser()).thenReturn(parser);
-    when(factory.construct(anyString(), any()))
+    when(factory.construct(anyString(), anyInt(), anyBoolean()))
         .thenReturn(new ExprIntegerValue(1))
         .thenReturn(new ExprIntegerValue(2));
 
@@ -329,7 +332,7 @@ class OpenSearchResponseTest {
                 1.0F));
 
     when(searchHit1.getHighlightFields()).thenReturn(highlightMap);
-    when(factory.construct(any())).thenReturn(resultTuple);
+    when(factory.construct(any(), anyBoolean())).thenReturn(resultTuple);
 
     for (ExprValue resultHit : new OpenSearchResponse(searchResponse, factory, includes)) {
       var expected = ExprValueUtils.collectionValue(


### PR DESCRIPTION
### Description
With the addition of the nested function support in the V2 engine the `inner_hits` portion of the OS response needs to  be parsed for OS types. Previously arrays were not entirely parsed due to lack of support.


### Parsing Functionality
Parsing of each value in arrays needs to be supported for proper `nested` functionality. The following gives examples of the current response formats when parsing arrays.

***

#### Object Type - Array Of Objects
Dataset:
`"obj": [{"key": "val1"}, {"key": "val2"}]`

SQL Query:
```sql
SELECT obj FROM objects;
```
V1 Engine Response:
`[{'key': 'val1'},{'key': 'val2'}]`

V2 Engine Response:
`{'key': 'val1'}`

***

#### Nested Type - Array Of Objects
Dataset:
`"obj": [{"key": "val1"}, {"key": "val2"}]`

SQL Query:
```sql
SELECT obj FROM nested_objects;
```
V1 and V2 Engine Response:
`[{'key': 'val1'},{'key': 'val2'}]`

***

#### Array Of Values (Nested only supports objects and not arrays of values):
Dataset:
`"obj": ["val1", "val2"]`

SQL Query:
```sql
SELECT obj FROM objects;
```
V1 Engine Response:
`['val1','val2']`

V2 Engine Response:
`{'val1'}`

***

### Issues Resolved
Issue: [1686](https://github.com/opensearch-project/sql/issues/1686)


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).