### PR TITLE
Improved error codes in case of security exception

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/ErrorMessage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/ErrorMessage.java
@@ -7,6 +7,7 @@
 package org.opensearch.sql.datasources.exceptions;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import lombok.Getter;
 import org.opensearch.rest.RestStatus;
@@ -65,7 +66,8 @@ public class ErrorMessage {
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("status", status);
     jsonObject.add("error", getErrorAsJson());
-    return new Gson().toJson(jsonObject);
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    return gson.toJson(jsonObject);
   }
 
   private JsonObject getErrorAsJson() {

--- a/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionListener;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.rest.BaseRestHandler;
@@ -224,6 +225,9 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
   private void handleException(Exception e, RestChannel restChannel) {
     if (e instanceof DataSourceNotFoundException) {
       reportError(restChannel, e, NOT_FOUND);
+    } else if (e instanceof OpenSearchException) {
+      OpenSearchException exception = (OpenSearchException) e;
+      reportError(restChannel, exception, exception.status());
     } else {
       LOG.error("Error happened during request handling", e);
       if (isClientError(e)) {


### PR DESCRIPTION
### Description
Currently all the security exceptions related to datasource APIs are thrown as internal server errors.
With this change, the error message will respect the status received from upstream core service/plugins.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).