### PR TITLE
Fix CI

### DIFF
--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     implementation group: 'org.json', name: 'json', version:'20230227'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
-    implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation group: 'org.json', name: 'json', version:'20230227'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
+    implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -129,8 +129,8 @@ dependencies {
 
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.12.13'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.2.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.2.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.4.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
 }
 


### PR DESCRIPTION
### Description
In https://github.com/opensearch-project/OpenSearch/pull/8035 some classes were moved from `core` to `common-utils` without renaming or changing hierarchy. In `ml-commons` in https://github.com/opensearch-project/ml-commons/pull/993 a new dependency was added to keep things up to date, but the same dependency should be added in SQL plugin as well.
This fix adds:
1. `common-utils` dependency to `:opensearch`
2. updates `mockito` version in `plugin` (`:opensearch-sql-plugin`) to avoid conflicts between 5.2.0 and 5.4.0 versions. 5.4.0 comes from upstream.

```
Execution failed for task ':opensearch-sql-plugin:compileTestJava'.
> Could not resolve all dependencies for configuration ':opensearch-sql-plugin:testCompileClasspath'.
   > Conflict(s) found for the following module(s):
       - org.mockito:mockito-core between versions 5.4.0 and 5.2.0
     Run with:
         --scan or
         :opensearch-sql-plugin:dependencyInsight --configuration testCompileClasspath --dependency org.mockito:mockito-core
     to get more insight on how to solve the conflict.
```

### Issues Resolved
https://github.com/opensearch-project/sql/pull/1753
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).