### PR TITLE
Add _routing to SQL includes list (#277)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,7 @@ configurations.all {
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
-    resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
+    resolutionStrategy.force 'com.google.guava:guava:32.0.1-jre'
 }
 
 // updateVersion: Task to auto increment to the next development iteration

--- a/docs/user/dql/basics.rst
+++ b/docs/user/dql/basics.rst
@@ -158,6 +158,9 @@ Result set:
 One can also provide meta-field name(s) to retrieve reserved-fields (beginning with underscore) from OpenSearch documents.  They may also be used
 in the query `WHERE` or `ORDER BY` clauses. Meta-fields are not output from wildcard calls (`SELECT *`) and must be explicitly included to be returned.
 
+Note: `_routing` is used differently in the `SELECT` and `WHERE` clauses.  In `WHERE`, it contains the routing hash id. In `SELECT`,
+it returns the shard used for the query (unless shards aren't active, in which case it returns the routing hash id).
+
 SQL query::
 
 	POST /_plugins/_sql

--- a/docs/user/dql/basics.rst
+++ b/docs/user/dql/basics.rst
@@ -155,14 +155,14 @@ Result set:
 |  Nanette|   Bates|
 +---------+--------+
 
-One can also provide meta-field name(s) to retrieve reserved-fields (beginning with underscore) from OpenSearch documents. Meta-fields are not output
-from wildcard calls (`SELECT *`) and must be explicitly included to be returned.
+One can also provide meta-field name(s) to retrieve reserved-fields (beginning with underscore) from OpenSearch documents.  They may also be used
+in the query `WHERE` or `ORDER BY` clauses. Meta-fields are not output from wildcard calls (`SELECT *`) and must be explicitly included to be returned.
 
 SQL query::
 
 	POST /_plugins/_sql
 	{
-	  "query" : "SELECT firstname, lastname, _id, _index, _sort FROM accounts"
+	  "query" : "SELECT firstname, lastname, _id, _index, _sort, _routing FROM accounts WHERE _index = 'accounts'"
 	}
 
 Explain::
@@ -175,6 +175,7 @@ Explain::
 	      "firstname",
 	      "_id",
 	      "_index",
+	      "_routing",
 	      "_sort",
 	      "lastname"
 	    ],

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -901,7 +901,10 @@ Usage: ROUND(x, d) rounds the argument x to d decimal places, d defaults to 0 if
 Argument 1 type: INTEGER/LONG/FLOAT/DOUBLE
 Argument 2 type (optional): INTEGER
 
-Return type: LONG
+Return type map:
+
+(INTEGER/LONG[, INTEGER]) -> LONG
+(FLOAT/DOUBLE[, INTEGER]) -> DOUBLE
 
 Example::
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -72,7 +72,7 @@ configurations.all {
     resolutionStrategy.force "commons-logging:commons-logging:1.2"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
-    resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
+    resolutionStrategy.force 'com.google.guava:guava:32.0.1-jre'
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"

--- a/integ-test/src/test/java/org/opensearch/sql/sql/IdentifierIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/IdentifierIT.java
@@ -107,12 +107,12 @@ public class IdentifierIT extends SQLIntegTestCase {
     String index = "test.routing_select";
     String mapping = "{\"_routing\": {\"required\": true }}";
     new Index(index, mapping)
+        .addDocWithShardId("{\"age\": 31}", "test0", "test0")
         .addDocWithShardId("{\"age\": 31}", "test1", "test1")
         .addDocWithShardId("{\"age\": 32}", "test2", "test2")
         .addDocWithShardId("{\"age\": 33}", "test3", "test3")
         .addDocWithShardId("{\"age\": 34}", "test4", "test4")
-        .addDocWithShardId("{\"age\": 35}", "test5", "test5")
-        .addDocWithShardId("{\"age\": 36}", "test6", "test6");
+        .addDocWithShardId("{\"age\": 35}", "test5", "test5");
 
     // Execute using field metadata values filtering on the routing shard hash id
     final JSONObject result = new JSONObject(executeQuery(
@@ -122,7 +122,7 @@ public class IdentifierIT extends SQLIntegTestCase {
 
     // Verify that the metadata values are returned when requested
     verifySchema(result,
-        schema("age", null, "keyword"),
+        schema("age", null, "long"),
         schema("_id", null, "keyword"),
         schema("_index", null, "keyword"),
         schema("_routing", null, "keyword"));
@@ -145,7 +145,7 @@ public class IdentifierIT extends SQLIntegTestCase {
     String index = "test.routing_filter";
     String mapping = "{\"_routing\": {\"required\": true }}";
     new Index(index, mapping)
-        .addDocWithShardId("{\"age\": 30}", "test1", "test1")
+        .addDocWithShardId("{\"age\": 31}", "test1", "test1")
         .addDocWithShardId("{\"age\": 32}", "test2", "test2")
         .addDocWithShardId("{\"age\": 33}", "test3", "test3")
         .addDocWithShardId("{\"age\": 34}", "test4", "test4")

--- a/integ-test/src/test/java/org/opensearch/sql/sql/IdentifierIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/IdentifierIT.java
@@ -169,8 +169,10 @@ public class IdentifierIT extends SQLIntegTestCase {
     var datarows = result.getJSONArray("datarows");
     assertEquals(1, datarows.length());
 
-    // note that _routing in the SELECT clause returns the shard
+    assertEquals("test4", datarows.getJSONArray(0).getString(0));
+    // note that _routing in the SELECT clause returns the shard, not the routing hash id
     assertTrue(datarows.getJSONArray(0).getString(2).contains("[" + index + "]"));
+
   }
 
   @Test

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -97,7 +97,7 @@ configurations.all {
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
-    resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
+    resolutionStrategy.force 'com.google.guava:guava:32.0.1-jre'
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"


### PR DESCRIPTION
### Description
Add the `_routing` reserved word as a metafield accessible as an identifier from any opensearch index. 

Example: 
```
select _id, _index, _routing, int0 from calcs limit 5
```

Example response:
```
        [
            "1",
            "calcs",
            "[xoyIAOdqQsS74x2yKSgiEQ][calcs][0]",
            1
        ],
```
 
### Issues Resolved
Partially resolves: [sql#1478](https://github.com/opensearch-project/sql/issues/1478)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).