### PR TITLE
Add Support for Field Star in Nested Function

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -186,7 +186,16 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
     FunctionName functionName = FunctionName.of(node.getFuncName());
     List<Expression> arguments =
         node.getFuncArgs().stream()
-            .map(unresolvedExpression -> analyze(unresolvedExpression, context))
+            .map(unresolvedExpression -> {
+              var ret = analyze(unresolvedExpression, context);
+              if (ret == null) {
+                throw new UnsupportedOperationException(
+                    String.format("Invalid use of expression %s", unresolvedExpression)
+                );
+              } else {
+                return ret;
+              }
+            })
             .collect(Collectors.toList());
     return (Expression) repository.compile(context.getFunctionProperties(),
         functionName, arguments);

--- a/core/src/main/java/org/opensearch/sql/analysis/NestedAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/NestedAnalyzer.java
@@ -50,11 +50,7 @@ public class NestedAnalyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisCon
   public LogicalPlan visitNestedAllTupleFields(NestedAllTupleFields node, AnalysisContext context) {
     List<Map<String, ReferenceExpression>> args = new ArrayList<>();
     for (NamedExpression namedExpr : namedExpressions) {
-
-      if (namedExpr.getDelegated() instanceof FunctionExpression
-          && ((FunctionExpression) namedExpr.getDelegated()).getFunctionName()
-          .getFunctionName().equalsIgnoreCase(BuiltinFunctionName.NESTED.name())) {
-
+      if (isNestedFunction(namedExpr.getDelegated())) {
         ReferenceExpression field =
             (ReferenceExpression) ((FunctionExpression) namedExpr.getDelegated())
                 .getArguments().get(0);

--- a/core/src/main/java/org/opensearch/sql/analysis/NestedAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/NestedAnalyzer.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.Function;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.expression.Expression;
@@ -46,6 +47,32 @@ public class NestedAnalyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisCon
   }
 
   @Override
+  public LogicalPlan visitNestedAllTupleFields(NestedAllTupleFields node, AnalysisContext context) {
+    List<Map<String, ReferenceExpression>> args = new ArrayList<>();
+    for (NamedExpression namedExpr : namedExpressions) {
+
+      if (namedExpr.getDelegated() instanceof FunctionExpression
+          && ((FunctionExpression) namedExpr.getDelegated()).getFunctionName()
+          .getFunctionName().equalsIgnoreCase(BuiltinFunctionName.NESTED.name())) {
+
+        ReferenceExpression field =
+            (ReferenceExpression) ((FunctionExpression) namedExpr.getDelegated())
+                .getArguments().get(0);
+
+        // If path is same as NestedAllTupleFields path
+        if (field.getAttr().substring(0, field.getAttr().lastIndexOf("."))
+            .equalsIgnoreCase(node.getPath())) {
+          args.add(Map.of(
+              "field", field,
+              "path", new ReferenceExpression(node.getPath(), STRING)));
+        }
+      }
+    }
+
+    return mergeChildIfLogicalNested(args);
+  }
+
+  @Override
   public LogicalPlan visitFunction(Function node, AnalysisContext context) {
     if (node.getFuncName().equalsIgnoreCase(BuiltinFunctionName.NESTED.name())) {
 
@@ -54,6 +81,8 @@ public class NestedAnalyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisCon
       ReferenceExpression nestedField =
           (ReferenceExpression)expressionAnalyzer.analyze(expressions.get(0), context);
       Map<String, ReferenceExpression> args;
+
+      // Path parameter is supplied
       if (expressions.size() == 2) {
         args = Map.of(
             "field", nestedField,
@@ -65,14 +94,26 @@ public class NestedAnalyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisCon
             "path", generatePath(nestedField.toString())
         );
       }
-      if (child instanceof LogicalNested) {
-        ((LogicalNested)child).addFields(args);
-        return child;
-      } else {
-        return new LogicalNested(child, new ArrayList<>(Arrays.asList(args)), namedExpressions);
-      }
+
+      return mergeChildIfLogicalNested(new ArrayList<>(Arrays.asList(args)));
     }
     return null;
+  }
+
+  /**
+   * NestedAnalyzer visits all functions in SELECT clause, creates logical plans for each and
+   * merges them. This is to avoid another merge rule in LogicalPlanOptimizer:create().
+   * @param args field and path params to add to logical plan.
+   * @return child of logical nested with added args, or new LogicalNested.
+   */
+  private LogicalPlan mergeChildIfLogicalNested(List<Map<String, ReferenceExpression>> args) {
+    if (child instanceof LogicalNested) {
+      for (var arg : args) {
+        ((LogicalNested) child).addFields(arg);
+      }
+      return child;
+    }
+    return new LogicalNested(child, args, namedExpressions);
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/analysis/TypeEnvironment.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/TypeEnvironment.java
@@ -86,6 +86,17 @@ public class TypeEnvironment implements Environment<Symbol, ExprType> {
   }
 
   /**
+   * Resolve all fields in the current environment.
+   * @param namespace     a namespace
+   * @return              all symbols in the namespace
+   */
+  public Map<String, ExprType> lookupAllTupleFields(Namespace namespace) {
+    Map<String, ExprType> result = new LinkedHashMap<>();
+    symbolTable.lookupAllTupleFields(namespace).forEach(result::putIfAbsent);
+    return result;
+  }
+
+  /**
    * Define symbol with the type.
    *
    * @param symbol symbol to define

--- a/core/src/main/java/org/opensearch/sql/analysis/symbol/SymbolTable.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/symbol/SymbolTable.java
@@ -129,6 +129,21 @@ public class SymbolTable {
   }
 
   /**
+   * Look up all top level symbols in the namespace.
+   *
+   * @param namespace     a namespace
+   * @return              all symbols in the namespace map
+   */
+  public Map<String, ExprType> lookupAllTupleFields(Namespace namespace) {
+    final LinkedHashMap<String, ExprType> allSymbols =
+        orderedTable.getOrDefault(namespace, new LinkedHashMap<>());
+    final LinkedHashMap<String, ExprType> result = new LinkedHashMap<>();
+    allSymbols.entrySet().stream()
+        .forEach(entry -> result.put(entry.getKey(), entry.getValue()));
+    return result;
+  }
+
+  /**
    * Check if namespace map in empty (none definition).
    *
    * @param namespace a namespace

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -25,6 +25,7 @@ import org.opensearch.sql.ast.expression.Interval;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Map;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.QualifiedName;
@@ -235,6 +236,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitAllFields(AllFields node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitNestedAllTupleFields(NestedAllTupleFields node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -30,6 +30,7 @@ import org.opensearch.sql.ast.expression.Interval;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Map;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.ParseMethod;
@@ -375,6 +376,10 @@ public class AstDSL {
 
   public Alias alias(String name, UnresolvedExpression expr, String alias) {
     return new Alias(name, expr, alias);
+  }
+
+  public NestedAllTupleFields nestedAllTupleFields(String path) {
+    return new NestedAllTupleFields(path);
   }
 
   public static List<UnresolvedExpression> exprList(UnresolvedExpression... exprList) {

--- a/core/src/main/java/org/opensearch/sql/ast/expression/NestedAllTupleFields.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/NestedAllTupleFields.java
@@ -18,7 +18,6 @@ import org.opensearch.sql.ast.Node;
 /**
  * Represents all tuple fields used in nested function.
  */
-@ToString
 @RequiredArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 public class NestedAllTupleFields extends UnresolvedExpression {

--- a/core/src/main/java/org/opensearch/sql/ast/expression/NestedAllTupleFields.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/NestedAllTupleFields.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.ast.expression;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.Node;
+
+/**
+ * Represents all tuple fields used in nested function.
+ */
+@ToString
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class NestedAllTupleFields extends UnresolvedExpression {
+  @Getter
+  private final String path;
+
+  @Override
+  public List<? extends Node> getChild() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
+    return nodeVisitor.visitNestedAllTupleFields(this, context);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("nested(%s.*)", path);
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -24,6 +24,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.filter;
 import static org.opensearch.sql.ast.dsl.AstDSL.filteredAggregate;
 import static org.opensearch.sql.ast.dsl.AstDSL.function;
 import static org.opensearch.sql.ast.dsl.AstDSL.intLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.nestedAllTupleFields;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.ast.dsl.AstDSL.relation;
 import static org.opensearch.sql.ast.dsl.AstDSL.span;
@@ -556,7 +557,7 @@ class AnalyzerTest extends AnalyzerTestBase {
     List<NamedExpression> projectList =
         List.of(
             new NamedExpression(
-                "message.info",
+                "nested(message.info)",
                 DSL.nested(DSL.ref("message.info", STRING)),
                 null)
         );
@@ -567,13 +568,13 @@ class AnalyzerTest extends AnalyzerTestBase {
                 LogicalPlanDSL.relation("schema", table),
                 nestedArgs,
                 projectList),
-            DSL.named("message.info",
+            DSL.named("nested(message.info)",
                 DSL.nested(DSL.ref("message.info", STRING)))
         ),
         AstDSL.projectWithArg(
             AstDSL.relation("schema"),
             AstDSL.defaultFieldsArgs(),
-            AstDSL.alias("message.info",
+            AstDSL.alias("nested(message.info)",
                 function("nested", qualifiedName("message", "info")), null)
         )
     );
@@ -581,6 +582,195 @@ class AnalyzerTest extends AnalyzerTestBase {
     assertTrue(isNestedFunction(DSL.nested(DSL.ref("message.info", STRING))));
     assertFalse(isNestedFunction(DSL.literal("fieldA")));
     assertFalse(isNestedFunction(DSL.match(DSL.namedArgument("field", literal("message")))));
+  }
+
+  @Test
+  public void sort_with_nested_all_tuple_fields_throws_exception() {
+    assertThrows(UnsupportedOperationException.class, () -> analyze(
+        AstDSL.project(
+          AstDSL.sort(
+                AstDSL.relation("schema"),
+                field(nestedAllTupleFields("message"))
+              ),
+            AstDSL.alias("nested(message.*)",
+                nestedAllTupleFields("message"))
+        )
+    ));
+  }
+
+  @Test
+  public void filter_with_nested_all_tuple_fields_throws_exception() {
+    assertThrows(UnsupportedOperationException.class, () -> analyze(
+        AstDSL.project(
+            AstDSL.filter(
+                AstDSL.relation("schema"),
+                AstDSL.function("=", nestedAllTupleFields("message"), AstDSL.intLiteral(1))),
+            AstDSL.alias("nested(message.*)",
+                nestedAllTupleFields("message"))
+        )
+    ));
+  }
+
+
+  @Test
+  public void project_nested_field_star_arg() {
+    List<Map<String, ReferenceExpression>> nestedArgs =
+        List.of(
+            Map.of(
+                "field", new ReferenceExpression("message.info", STRING),
+                "path", new ReferenceExpression("message", STRING)
+            )
+        );
+
+    List<NamedExpression> projectList =
+        List.of(
+            new NamedExpression("nested(message.info)",
+                DSL.nested(DSL.ref("message.info", STRING)))
+        );
+
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.nested(
+                LogicalPlanDSL.relation("schema", table),
+                nestedArgs,
+                projectList),
+            DSL.named("nested(message.info)",
+                DSL.nested(DSL.ref("message.info", STRING)))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.relation("schema"),
+            AstDSL.defaultFieldsArgs(),
+            AstDSL.alias("nested(message.*)",
+                nestedAllTupleFields("message"))
+        )
+    );
+  }
+
+  @Test
+  public void project_nested_field_star_arg_with_another_nested_function() {
+    List<Map<String, ReferenceExpression>> nestedArgs =
+        List.of(
+            Map.of(
+                "field", new ReferenceExpression("message.info", STRING),
+                "path", new ReferenceExpression("message", STRING)
+            ),
+            Map.of(
+                "field", new ReferenceExpression("comment.data", STRING),
+                "path", new ReferenceExpression("comment", STRING)
+            )
+        );
+
+    List<NamedExpression> projectList =
+        List.of(
+            new NamedExpression("nested(message.info)",
+                DSL.nested(DSL.ref("message.info", STRING))),
+            new NamedExpression("nested(comment.data)",
+                DSL.nested(DSL.ref("comment.data", STRING)))
+        );
+
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.nested(
+                LogicalPlanDSL.relation("schema", table),
+                nestedArgs,
+                projectList),
+            DSL.named("nested(message.info)",
+                DSL.nested(DSL.ref("message.info", STRING))),
+            DSL.named("nested(comment.data)",
+                DSL.nested(DSL.ref("comment.data", STRING)))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.relation("schema"),
+            AstDSL.defaultFieldsArgs(),
+            AstDSL.alias("nested(message.*)",
+                nestedAllTupleFields("message")),
+            AstDSL.alias("nested(comment.*)",
+                nestedAllTupleFields("comment"))
+        )
+    );
+  }
+
+  @Test
+  public void project_nested_field_star_arg_with_another_field() {
+    List<Map<String, ReferenceExpression>> nestedArgs =
+        List.of(
+            Map.of(
+                "field", new ReferenceExpression("message.info", STRING),
+                "path", new ReferenceExpression("message", STRING)
+            )
+        );
+
+    List<NamedExpression> projectList =
+        List.of(
+            new NamedExpression("nested(message.info)",
+                DSL.nested(DSL.ref("message.info", STRING))),
+            new NamedExpression("comment.data",
+                DSL.ref("comment.data", STRING))
+        );
+
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.nested(
+                LogicalPlanDSL.relation("schema", table),
+                nestedArgs,
+                projectList),
+            DSL.named("nested(message.info)",
+                DSL.nested(DSL.ref("message.info", STRING))),
+            DSL.named("comment.data",
+                DSL.ref("comment.data", STRING))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.relation("schema"),
+            AstDSL.defaultFieldsArgs(),
+            AstDSL.alias("nested(message.*)",
+                nestedAllTupleFields("message")),
+            AstDSL.alias("comment.data",
+                field("comment.data"))
+        )
+    );
+  }
+
+  @Test
+  public void project_nested_field_star_arg_with_highlight() {
+    List<Map<String, ReferenceExpression>> nestedArgs =
+        List.of(
+            Map.of(
+                "field", new ReferenceExpression("message.info", STRING),
+                "path", new ReferenceExpression("message", STRING)
+            )
+        );
+
+    List<NamedExpression> projectList =
+        List.of(
+            new NamedExpression("nested(message.info)",
+                DSL.nested(DSL.ref("message.info", STRING))),
+            DSL.named("highlight(fieldA)",
+                new HighlightExpression(DSL.literal("fieldA")))
+        );
+
+    Map<String, Literal> highlightArgs = new HashMap<>();
+
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.nested(
+                LogicalPlanDSL.highlight(LogicalPlanDSL.relation("schema", table),
+                    DSL.literal("fieldA"), highlightArgs),
+                nestedArgs,
+                projectList),
+            DSL.named("nested(message.info)",
+                DSL.nested(DSL.ref("message.info", STRING))),
+            DSL.named("highlight(fieldA)",
+                new HighlightExpression(DSL.literal("fieldA")))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.relation("schema"),
+            AstDSL.defaultFieldsArgs(),
+            AstDSL.alias("nested(message.*)",
+                nestedAllTupleFields("message")),
+            AstDSL.alias("highlight(fieldA)",
+                new HighlightFunction(AstDSL.stringLiteral("fieldA"), highlightArgs))
+        )
+    );
   }
 
   @Test
@@ -596,7 +786,7 @@ class AnalyzerTest extends AnalyzerTestBase {
     List<NamedExpression> projectList =
         List.of(
             new NamedExpression(
-                "message.info",
+                "nested(message.info)",
                 DSL.nested(DSL.ref("message.info", STRING), DSL.ref("message", STRING)),
                 null)
         );
@@ -607,13 +797,13 @@ class AnalyzerTest extends AnalyzerTestBase {
                 LogicalPlanDSL.relation("schema", table),
                 nestedArgs,
                 projectList),
-            DSL.named("message.info",
+            DSL.named("nested(message.info)",
                 DSL.nested(DSL.ref("message.info", STRING), DSL.ref("message", STRING)))
         ),
         AstDSL.projectWithArg(
             AstDSL.relation("schema"),
             AstDSL.defaultFieldsArgs(),
-            AstDSL.alias("message.info",
+            AstDSL.alias("nested(message.info)",
                 function(
                     "nested",
                     qualifiedName("message", "info"),
@@ -638,7 +828,7 @@ class AnalyzerTest extends AnalyzerTestBase {
     List<NamedExpression> projectList =
         List.of(
             new NamedExpression(
-                "message.info.id",
+                "nested(message.info.id)",
                 DSL.nested(DSL.ref("message.info.id", STRING)),
                 null)
         );
@@ -649,13 +839,13 @@ class AnalyzerTest extends AnalyzerTestBase {
                 LogicalPlanDSL.relation("schema", table),
                 nestedArgs,
                 projectList),
-            DSL.named("message.info.id",
+            DSL.named("nested(message.info.id)",
                 DSL.nested(DSL.ref("message.info.id", STRING)))
         ),
         AstDSL.projectWithArg(
             AstDSL.relation("schema"),
             AstDSL.defaultFieldsArgs(),
-            AstDSL.alias("message.info.id",
+            AstDSL.alias("nested(message.info.id)",
                 function("nested", qualifiedName("message", "info", "id")), null)
         )
     );
@@ -678,11 +868,11 @@ class AnalyzerTest extends AnalyzerTestBase {
     List<NamedExpression> projectList =
         List.of(
             new NamedExpression(
-                "message.info",
+                "nested(message.info)",
                 DSL.nested(DSL.ref("message.info", STRING)),
                 null),
             new NamedExpression(
-                "comment.data",
+                "nested(comment.data)",
                 DSL.nested(DSL.ref("comment.data", STRING)),
                 null)
         );
@@ -693,17 +883,17 @@ class AnalyzerTest extends AnalyzerTestBase {
                 LogicalPlanDSL.relation("schema", table),
                 nestedArgs,
                 projectList),
-            DSL.named("message.info",
+            DSL.named("nested(message.info)",
                 DSL.nested(DSL.ref("message.info", STRING))),
-            DSL.named("comment.data",
+            DSL.named("nested(comment.data)",
                 DSL.nested(DSL.ref("comment.data", STRING)))
         ),
         AstDSL.projectWithArg(
             AstDSL.relation("schema"),
             AstDSL.defaultFieldsArgs(),
-            AstDSL.alias("message.info",
+            AstDSL.alias("nested(message.info)",
                 function("nested", qualifiedName("message", "info")), null),
-            AstDSL.alias("comment.data",
+            AstDSL.alias("nested(comment.data)",
                 function("nested", qualifiedName("comment", "data")), null)
         )
     );

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -4458,6 +4458,17 @@ Example with ``field`` and ``path`` parameters::
     | b                               |
     +---------------------------------+
 
+Example with ``field.*`` used in SELECT clause::
+
+    os> SELECT nested(message.*) FROM nested;
+    fetched rows / total rows = 2/2
+    +--------------------------+-----------------------------+------------------------+
+    | nested(message.author)   | nested(message.dayOfWeek)   | nested(message.info)   |
+    |--------------------------+-----------------------------+------------------------|
+    | e                        | 1                           | a                      |
+    | f                        | 2                           | b                      |
+    +--------------------------+-----------------------------+------------------------+
+
 
 Example with ``field`` and ``path`` parameters in the SELECT and WHERE clause::
 

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatResponseIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatResponseIT.java
@@ -53,6 +53,9 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
   private static final Set<String> messageFields = Sets.newHashSet(
       "message.dayOfWeek", "message.info", "message.author");
 
+  private static final Set<String> messageFieldsWithNestedFunction = Sets.newHashSet(
+      "nested(message.dayOfWeek)", "nested(message.info)", "nested(message.author)");
+
   private static final Set<String> commentFields = Sets.newHashSet("comment.data", "comment.likes");
 
   private static final List<String> nameFields = Arrays.asList("firstname", "lastname");
@@ -211,7 +214,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
         String.format(Locale.ROOT, "SELECT nested(message.*) FROM %s",
             TestsConstants.TEST_INDEX_NESTED_TYPE));
 
-    assertContainsColumnsInAnyOrder(getSchema(response), messageFields);
+    assertContainsColumnsInAnyOrder(getSchema(response), messageFieldsWithNestedFunction);
     assertContainsData(getDataRows(response), messageFields);
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -89,8 +89,7 @@ public class NestedIT extends SQLIntegTestCase {
     verifyDataRows(result, rows(19));
   }
 
-  // TODO not currently supported by legacy, should we add implementation in AstBuilder?
-  @Disabled
+  @Test
   public void nested_function_in_a_function_in_select_test() {
     String query = "SELECT upper(nested(message.info)) FROM " +
         TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
@@ -103,6 +102,41 @@ public class NestedIT extends SQLIntegTestCase {
         rows("C"),
         rows("ZZ"));
   }
+
+  @Test
+  public void nested_all_function_in_a_function_in_select_test() {
+    String query = "SELECT nested(message.*) FROM " +
+        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS + " WHERE nested(message.info) = 'a'";
+    JSONObject result = executeJdbcRequest(query);
+    verifyDataRows(result, rows("e", 1, "a"));
+  }
+
+  @Test
+  public void invalid_multiple_nested_all_function_in_a_function_in_select_test() {
+    String query = "SELECT nested(message.*), nested(message.info) FROM " +
+        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
+    RuntimeException result = assertThrows(
+        RuntimeException.class,
+        () -> executeJdbcRequest(query)
+    );
+    assertTrue(
+        result.getMessage().contains("IllegalArgumentException")
+        && result.getMessage().contains("Multiple entries with same key")
+    );
+  }
+
+  @Test
+  public void nested_all_function_with_limit_test() {
+    String query = "SELECT nested(message.*) FROM " +
+        TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS + " LIMIT 3";
+    JSONObject result = executeJdbcRequest(query);
+    verifyDataRows(result,
+        rows("e", 1, "a"),
+        rows("f", 2, "b"),
+        rows("g", 1, "c")
+    );
+  }
+
 
   @Test
   public void nested_function_with_array_of_multi_nested_field_test() {
@@ -404,6 +438,107 @@ public class NestedIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void nested_function_all_subfields() {
+    String query = "SELECT nested(message.*) FROM " + TEST_INDEX_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(6, result.getInt("total"));
+    verifySchema(result,
+        schema("nested(message.author)", null, "keyword"),
+        schema("nested(message.dayOfWeek)", null, "long"),
+        schema("nested(message.info)", null, "keyword"));
+    verifyDataRows(result,
+        rows("e", 1, "a"),
+        rows("f", 2, "b"),
+        rows("g", 1, "c"),
+        rows("h", 4, "c"),
+        rows("i", 5, "a"),
+        rows("zz", 6, "zz"));
+  }
+
+  @Test
+  public void nested_function_all_subfields_and_specified_subfield() {
+    String query = "SELECT nested(message.*), nested(comment.data) FROM "
+        + TEST_INDEX_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(6, result.getInt("total"));
+    verifySchema(result,
+        schema("nested(message.author)", null, "keyword"),
+        schema("nested(message.dayOfWeek)", null, "long"),
+        schema("nested(message.info)", null, "keyword"),
+        schema("nested(comment.data)", null, "keyword"));
+    verifyDataRows(result,
+        rows("e", 1, "a", "ab"),
+        rows("f", 2, "b", "aa"),
+        rows("g", 1, "c", "aa"),
+        rows("h", 4, "c", "ab"),
+        rows("i", 5, "a", "ab"),
+        rows("zz", 6, "zz", new JSONArray(List.of("aa", "bb"))));
+  }
+
+  @Test
+  public void nested_function_all_deep_nested_subfields() {
+    String query = "SELECT nested(message.author.address.*) FROM "
+        + TEST_INDEX_MULTI_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(6, result.getInt("total"));
+    verifySchema(result,
+        schema("nested(message.author.address.number)", null, "integer"),
+        schema("nested(message.author.address.street)", null, "keyword"));
+    verifyDataRows(result,
+        rows(1, "bc"),
+        rows(2, "ab"),
+        rows(3, "sk"),
+        rows(4, "mb"),
+        rows(5, "on"),
+        rows(6, "qc"));
+  }
+
+  @Test
+  public void nested_function_all_subfields_for_two_nested_fields() {
+    String query = "SELECT nested(message.*), nested(comment.*) FROM "
+        + TEST_INDEX_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(6, result.getInt("total"));
+    verifySchema(result,
+        schema("nested(message.author)", null, "keyword"),
+        schema("nested(message.dayOfWeek)", null, "long"),
+        schema("nested(message.info)", null, "keyword"),
+        schema("nested(comment.data)", null, "keyword"),
+        schema("nested(comment.likes)", null, "long"));
+    verifyDataRows(result,
+        rows("e", 1, "a", "ab", 3),
+        rows("f", 2, "b", "aa", 2),
+        rows("g", 1, "c", "aa", 3),
+        rows("h", 4, "c", "ab", 1),
+        rows("i", 5, "a", "ab", 1),
+        rows("zz", 6, "zz", new JSONArray(List.of("aa", "bb")), 10));
+  }
+
+  @Test
+  public void nested_function_all_subfields_and_non_nested_field() {
+    String query = "SELECT nested(message.*), myNum FROM " + TEST_INDEX_NESTED_TYPE;
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(6, result.getInt("total"));
+    verifySchema(result,
+        schema("nested(message.author)", null, "keyword"),
+        schema("nested(message.dayOfWeek)", null, "long"),
+        schema("nested(message.info)", null, "keyword"),
+        schema("myNum", null, "long"));
+    verifyDataRows(result,
+        rows("e", 1, "a", 1),
+        rows("f", 2, "b", 2),
+        rows("g", 1, "c", 3),
+        rows("h", 4, "c", 4),
+        rows("i", 5, "a", 4),
+        rows("zz", 6, "zz", new JSONArray(List.of(3, 4))));
+  }
+
+  @Test
   public void nested_function_with_date_types_as_object_arrays_within_arrays_test() {
     String query = "SELECT nested(address.moveInDate) FROM " + TEST_INDEX_NESTED_SIMPLE;
     JSONObject result = executeJdbcRequest(query);
@@ -415,9 +550,9 @@ public class NestedIT extends SQLIntegTestCase {
     verifyDataRows(result,
         rows(new JSONObject(Map.of("dateAndTime","1984-04-12 09:07:42"))),
         rows(new JSONArray(
-            List.of(
-                Map.of("dateAndTime", "2023-05-03 08:07:42"),
-                Map.of("dateAndTime", "2001-11-11 04:07:44"))
+                List.of(
+                    Map.of("dateAndTime", "2023-05-03 08:07:42"),
+                    Map.of("dateAndTime", "2001-11-11 04:07:44"))
             )
         ),
         rows(new JSONObject(Map.of("dateAndTime", "1966-03-19 03:04:55"))),
@@ -429,8 +564,8 @@ public class NestedIT extends SQLIntegTestCase {
         rows(new JSONObject(Map.of("dateAndTime", "1933-12-12 05:05:45"))),
         rows(new JSONObject(Map.of("dateAndTime", "1909-06-17 01:04:21"))),
         rows(new JSONArray(
-            List.of(
-                Map.of("dateAndTime", "2001-11-11 04:07:44"))
+                List.of(
+                    Map.of("dateAndTime", "2001-11-11 04:07:44"))
             )
         )
     );

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -550,9 +550,9 @@ public class NestedIT extends SQLIntegTestCase {
     verifyDataRows(result,
         rows(new JSONObject(Map.of("dateAndTime","1984-04-12 09:07:42"))),
         rows(new JSONArray(
-                List.of(
-                    Map.of("dateAndTime", "2023-05-03 08:07:42"),
-                    Map.of("dateAndTime", "2001-11-11 04:07:44"))
+            List.of(
+                Map.of("dateAndTime", "2023-05-03 08:07:42"),
+                Map.of("dateAndTime", "2001-11-11 04:07:44"))
             )
         ),
         rows(new JSONObject(Map.of("dateAndTime", "1966-03-19 03:04:55"))),
@@ -564,8 +564,8 @@ public class NestedIT extends SQLIntegTestCase {
         rows(new JSONObject(Map.of("dateAndTime", "1933-12-12 05:05:45"))),
         rows(new JSONObject(Map.of("dateAndTime", "1909-06-17 01:04:21"))),
         rows(new JSONArray(
-                List.of(
-                    Map.of("dateAndTime", "2001-11-11 04:07:44"))
+            List.of(
+                Map.of("dateAndTime", "2001-11-11 04:07:44"))
             )
         )
     );

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -570,4 +570,23 @@ public class NestedIT extends SQLIntegTestCase {
         )
     );
   }
+
+  @Test
+  public void nested_function_all_subfields_in_wrong_clause() {
+    String query = "SELECT * FROM " + TEST_INDEX_NESTED_TYPE + " ORDER BY nested(message.*)";
+
+    Exception exception = assertThrows(RuntimeException.class, () ->
+        executeJdbcRequest(query));
+
+    assertTrue(exception.getMessage().contains("" +
+        "{\n" +
+        "  \"error\": {\n" +
+        "    \"reason\": \"There was internal problem at backend\",\n" +
+        "    \"details\": \"Invalid use of expression nested(message.*)\",\n" +
+        "    \"type\": \"UnsupportedOperationException\"\n" +
+        "  },\n" +
+        "  \"status\": 503\n" +
+        "}"
+    ));
+  }
 }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -328,7 +328,8 @@ nullNotnull
     ;
 
 functionCall
-    : scalarFunctionName LR_BRACKET functionArgs RR_BRACKET         #scalarFunctionCall
+    : nestedFunctionName LR_BRACKET allTupleFields RR_BRACKET       #nestedAllFunctionCall
+    | scalarFunctionName LR_BRACKET functionArgs RR_BRACKET         #scalarFunctionCall
     | specificFunction                                              #specificFunctionCall
     | windowFunctionClause                                          #windowFunctionCall
     | aggregateFunction                                             #aggregateFunctionCall
@@ -811,6 +812,10 @@ tableName
 
 columnName
     : qualifiedName
+    ;
+
+allTupleFields
+    : path=qualifiedName DOT STAR
     ;
 
 alias

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -9,7 +9,6 @@ package org.opensearch.sql.sql.parser;
 import static org.opensearch.sql.ast.dsl.AstDSL.between;
 import static org.opensearch.sql.ast.dsl.AstDSL.not;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
-import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NOT_NULL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NULL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.LIKE;
@@ -41,6 +40,7 @@ import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.IsNullPred
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.LikePredicateContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.MathExpressionAtomContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.MultiFieldRelevanceFunctionContext;
+import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.NestedAllFunctionCallContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.NoFieldRelevanceFunctionContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.NotExpressionContext;
 import static org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.NullLiteralContext;
@@ -90,6 +90,7 @@ import org.opensearch.sql.ast.expression.HighlightFunction;
 import org.opensearch.sql.ast.expression.Interval;
 import org.opensearch.sql.ast.expression.IntervalUnit;
 import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.QualifiedName;
@@ -102,6 +103,7 @@ import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AlternateMultiMatchQueryContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.AndExpressionContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.ColumnNameContext;
@@ -148,6 +150,14 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitNestedExpressionAtom(NestedExpressionAtomContext ctx) {
     return visit(ctx.expression()); // Discard parenthesis around
+  }
+
+  @Override
+  public UnresolvedExpression visitNestedAllFunctionCall(
+      NestedAllFunctionCallContext ctx) {
+    return new NestedAllTupleFields(
+        visitQualifiedName(ctx.allTupleFields().path).toString()
+    );
   }
 
   @Override

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -39,6 +39,7 @@ import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.expression.NestedAllTupleFields;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 
 class AstBuilderTest extends AstBuilderTestBase {
@@ -84,6 +85,19 @@ class AstBuilderTest extends AstBuilderTestBase {
     );
 
     assertThrows(SyntaxCheckException.class, () -> buildAST("SELECT *"));
+  }
+
+  @Test
+  public void can_build_nested_select_all() {
+    assertEquals(
+        project(
+            relation("test"),
+            alias("nested(field.*)",
+                new NestedAllTupleFields("field")
+            )
+        ),
+        buildAST("SELECT nested(field.*) FROM test")
+    );
   }
 
   @Test


### PR DESCRIPTION
### Description
Add support for using the `*` at end of field parameter in the nested function. All nested fields under supplied path will be expanded as column identifiers. Grammar has been added to only support the `AllTupleFields` usage with the nested function since this change will effect field usage in all queries and needs further planning with V2 implementation.
 
### Example Queries
```sql
SELECT nested(message.*) from nested_objects;
```

### Issues Resolved
Portion of Issue: [1111](https://github.com/opensearch-project/sql/issues/1111)

### Changes From Legacy
- Path parameter is redundant therefore not supported in parser and will fallback to legacy engine.

### Edge Cases
Queries that produce repeating column identifiers like: 
```sql
SELECT nested(field.*), nested(field.innerField) ...
```
Or 
```sql
SELECT nested(field.*), nested(field.*) ...
```
Will result in error:
```json
{
  "error": {
    "reason": "Invalid SQL query",
    "details": "Multiple entries with same key: nested(message.info)=\"a\" and nested(message.info)=\"a\"",
    "type": "IllegalArgumentException"
  },
  "status": 400
}
```


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).