### PR TITLE
Add Support for Nested Function in Order By Clause

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/NestedAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/NestedAnalyzer.java
@@ -17,6 +17,8 @@ import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
@@ -105,7 +107,18 @@ public class NestedAnalyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisCon
    * @param field : Nested field to generate path of.
    * @return : Path of field derived from last level of nesting.
    */
-  private ReferenceExpression generatePath(String field) {
+  public static ReferenceExpression generatePath(String field) {
     return new ReferenceExpression(field.substring(0, field.lastIndexOf(".")), STRING);
+  }
+
+  /**
+   * Check if supplied expression is a nested function.
+   * @param expr Expression checking if is nested function.
+   * @return True if expression is a nested function.
+   */
+  public static Boolean isNestedFunction(Expression expr) {
+    return (expr instanceof FunctionExpression
+        && ((FunctionExpression) expr).getFunctionName().getFunctionName()
+        .equalsIgnoreCase(BuiltinFunctionName.NESTED.name()));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -9,9 +9,11 @@ package org.opensearch.sql.analysis;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
+import static org.opensearch.sql.analysis.NestedAnalyzer.isNestedFunction;
 import static org.opensearch.sql.ast.dsl.AstDSL.aggregate;
 import static org.opensearch.sql.ast.dsl.AstDSL.alias;
 import static org.opensearch.sql.ast.dsl.AstDSL.argument;
@@ -39,6 +41,7 @@ import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.LONG;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
+import static org.opensearch.sql.expression.DSL.literal;
 import static org.opensearch.sql.utils.MLCommonsConstants.ACTION;
 import static org.opensearch.sql.utils.MLCommonsConstants.ALGO;
 import static org.opensearch.sql.utils.MLCommonsConstants.ASYNC;
@@ -574,6 +577,10 @@ class AnalyzerTest extends AnalyzerTestBase {
                 function("nested", qualifiedName("message", "info")), null)
         )
     );
+
+    assertTrue(isNestedFunction(DSL.nested(DSL.ref("message.info", STRING))));
+    assertFalse(isNestedFunction(DSL.literal("fieldA")));
+    assertFalse(isNestedFunction(DSL.match(DSL.namedArgument("field", literal("message")))));
   }
 
   @Test

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -4469,6 +4469,17 @@ Example with ``field`` and ``path`` parameters in the SELECT and WHERE clause::
     | b                               |
     +---------------------------------+
 
+Example with ``field`` and ``path`` parameters in the SELECT and ORDER BY clause::
+
+    os> SELECT nested(message.info, message) FROM nested ORDER BY nested(message.info, message) DESC;
+    fetched rows / total rows = 2/2
+    +---------------------------------+
+    | nested(message.info, message)   |
+    |---------------------------------|
+    | b                               |
+    | a                               |
+    +---------------------------------+
+
 
 System Functions
 ================

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -187,6 +187,40 @@ public class NestedIT extends SQLIntegTestCase {
         rows("zz"));
   }
 
+  @Test
+  public void nested_function_with_order_by_clause_desc() {
+    String query =
+        "SELECT nested(message.info) FROM " + TEST_INDEX_NESTED_TYPE
+            + " ORDER BY nested(message.info, message) DESC";
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(6, result.getInt("total"));
+    verifyDataRows(result,
+        rows("zz"),
+        rows("c"),
+        rows("c"),
+        rows("a"),
+        rows("b"),
+        rows("a"));
+  }
+
+  @Test
+  public void nested_function_and_field_with_order_by_clause() {
+    String query =
+        "SELECT nested(message.info), myNum FROM " + TEST_INDEX_NESTED_TYPE
+            + " ORDER BY nested(message.info, message), myNum";
+    JSONObject result = executeJdbcRequest(query);
+
+    assertEquals(6, result.getInt("total"));
+    verifyDataRows(result,
+        rows("a", 1),
+        rows("c", 4),
+        rows("a", 4),
+        rows("b", 2),
+        rows("c", 3),
+        rows("zz", new JSONArray(List.of(3, 4))));
+  }
+
   // Nested function in GROUP BY clause is not yet implemented for JDBC format. This test ensures
   // that the V2 engine falls back to legacy implementation.
   // TODO Fix the test when NESTED is supported in GROUP BY in the V2 engine.

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanBuilder.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.opensearch.storage.scan;
 
+import static org.opensearch.sql.analysis.NestedAnalyzer.isNestedFunction;
+
 import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import org.opensearch.sql.expression.ReferenceExpression;
@@ -113,9 +115,15 @@ public class OpenSearchIndexScanBuilder extends TableScanBuilder {
     return delegate.pushDownNested(nested);
   }
 
+  /**
+   * Valid if sorting is only by fields.
+   * @param sort Logical sort
+   * @return True if sorting by fields only
+   */
   private boolean sortByFieldsOnly(LogicalSort sort) {
     return sort.getSortList().stream()
-        .map(sortItem -> sortItem.getRight() instanceof ReferenceExpression)
+        .map(sortItem -> sortItem.getRight() instanceof ReferenceExpression
+        || isNestedFunction(sortItem.getRight()))
         .reduce(true, Boolean::logicalAnd);
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -6,6 +6,8 @@
 
 package org.opensearch.sql.opensearch.storage.script.filter.lucene;
 
+import static org.opensearch.sql.analysis.NestedAnalyzer.isNestedFunction;
+
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -62,10 +64,7 @@ public abstract class LuceneQuery {
    * @return return true if function has supported nested function expression.
    */
   public boolean isNestedPredicate(FunctionExpression func) {
-    return ((func.getArguments().get(0) instanceof FunctionExpression
-        && ((FunctionExpression)func.getArguments().get(0))
-        .getFunctionName().getFunctionName().equalsIgnoreCase(BuiltinFunctionName.NESTED.name()))
-      );
+    return isNestedFunction(func.getArguments().get(0));
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/sort/SortQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/sort/SortQueryBuilder.java
@@ -80,7 +80,7 @@ public class SortQueryBuilder {
    * @param nestedFunc Nested function expression.
    */
   private void validateNestedArgs(FunctionExpression nestedFunc) {
-    if (nestedFunc.getArguments().size() > 2) {
+    if (nestedFunc.getArguments().size() < 1 || nestedFunc.getArguments().size() > 2) {
       throw new IllegalArgumentException(
           "nested function supports 2 parameters (field, path) or 1 parameter (field)"
       );

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/sort/SortQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/sort/SortQueryBuilder.java
@@ -6,15 +6,21 @@
 
 package org.opensearch.sql.opensearch.storage.script.sort;
 
+import static org.opensearch.sql.analysis.NestedAnalyzer.generatePath;
+import static org.opensearch.sql.analysis.NestedAnalyzer.isNestedFunction;
+
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.NestedSortBuilder;
 import org.opensearch.search.sort.SortBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 
 /**
@@ -53,8 +59,41 @@ public class SortQueryBuilder {
         return SortBuilders.scoreSort().order(sortOrderMap.get(option.getSortOrder()));
       }
       return fieldBuild((ReferenceExpression) expression, option);
+    } else if (isNestedFunction(expression)) {
+
+      validateNestedArgs((FunctionExpression) expression);
+      String orderByName = ((FunctionExpression)expression).getArguments().get(0).toString();
+      // Generate path if argument not supplied in function.
+      ReferenceExpression path = ((FunctionExpression)expression).getArguments().size() == 2
+          ? (ReferenceExpression) ((FunctionExpression)expression).getArguments().get(1)
+          : generatePath(orderByName);
+      return SortBuilders.fieldSort(orderByName)
+              .order(sortOrderMap.get(option.getSortOrder()))
+              .setNestedSort(new NestedSortBuilder(path.toString()));
     } else {
       throw new IllegalStateException("unsupported expression " + expression.getClass());
+    }
+  }
+
+  /**
+   * Validate semantics for arguments in nested function.
+   * @param nestedFunc Nested function expression.
+   */
+  private void validateNestedArgs(FunctionExpression nestedFunc) {
+    if (nestedFunc.getArguments().size() > 2) {
+      throw new IllegalArgumentException(
+          "nested function supports 2 parameters (field, path) or 1 parameter (field)"
+      );
+    }
+
+    for (Expression arg : nestedFunc.getArguments()) {
+      if (!(arg instanceof ReferenceExpression)) {
+        throw new IllegalArgumentException(
+            String.format("Illegal nested field name: %s",
+                arg.toString()
+            )
+        );
+      }
     }
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/sort/SortQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/sort/SortQueryBuilderTest.java
@@ -64,6 +64,17 @@ class SortQueryBuilderTest {
   }
 
   @Test
+  void nested_with_too_few_args_throws_exception() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> sortQueryBuilder.build(
+            DSL.nested(),
+            Sort.SortOption.DEFAULT_ASC
+        )
+    );
+  }
+
+  @Test
   void nested_with_invalid_arg_type_throws_exception() {
     assertThrows(
         IllegalArgumentException.class,

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstSortBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstSortBuilder.java
@@ -17,17 +17,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Field;
-import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.NullOrder;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.Sort.SortOrder;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
-import org.opensearch.sql.common.antlr.SyntaxCheckException;
-import org.opensearch.sql.exception.SemanticCheckException;
-import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParserBaseVisitor;
 import org.opensearch.sql.sql.parser.context.QuerySpecification;
 
@@ -53,15 +48,6 @@ public class AstSortBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPla
     List<UnresolvedExpression> items = querySpec.getOrderByItems();
     List<SortOption> options = querySpec.getOrderByOptions();
     for (int i = 0; i < items.size(); i++) {
-      // TODO remove me when Nested function is supported in ORDER BY clause.
-      if (items.get(i) instanceof Function
-          && ((Function)items.get(i)).getFuncName().equalsIgnoreCase(
-              BuiltinFunctionName.NESTED.name())
-      ) {
-        throw new SyntaxCheckException(
-            "Falling back to legacy engine. Nested function is not supported in ORDER BY clause."
-        );
-      }
       fields.add(
           new Field(
               querySpec.replaceIfAliasOrOrdinal(items.get(i)),

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -638,13 +638,28 @@ class SQLSyntaxParserTest {
   @Test
   public void can_parse_nested_function() {
     assertNotNull(
-        parser.parse("SELECT NESTED(FIELD.DAYOFWEEK) FROM TEST"));
+        parser.parse("SELECT NESTED(PATH.INNER_FIELD) FROM TEST"));
     assertNotNull(
-        parser.parse("SELECT NESTED('FIELD.DAYOFWEEK') FROM TEST"));
+        parser.parse("SELECT NESTED('PATH.INNER_FIELD') FROM TEST"));
     assertNotNull(
-        parser.parse("SELECT SUM(NESTED(FIELD.SUBFIELD)) FROM TEST"));
+        parser.parse("SELECT SUM(NESTED(PATH.INNER_FIELD)) FROM TEST"));
     assertNotNull(
-        parser.parse("SELECT NESTED(FIELD.DAYOFWEEK, PATH) FROM TEST"));
+        parser.parse("SELECT NESTED(PATH.INNER_FIELD, PATH) FROM TEST"));
+    assertNotNull(
+        parser.parse(
+            "SELECT * FROM TEST WHERE NESTED(PATH.INNER_FIELDS) = 'A'"
+        )
+    );
+    assertNotNull(
+        parser.parse(
+            "SELECT * FROM TEST WHERE NESTED(PATH.INNER_FIELDS, PATH) = 'A'"
+        )
+    );
+    assertNotNull(
+        parser.parse(
+        "SELECT FIELD FROM TEST ORDER BY nested(PATH.INNER_FIELD, PATH)"
+        )
+    );
   }
 
   @Test

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -463,21 +463,6 @@ class AstBuilderTest extends AstBuilderTestBase {
   }
 
   /**
-   * Ensure Nested function falls back to legacy engine when used in an ORDER BY clause.
-   * TODO Remove this test when support is added.
-   */
-  @Test
-  public void nested_in_order_by_clause_throws_exception() {
-    SyntaxCheckException exception = assertThrows(SyntaxCheckException.class,
-        () -> buildAST("SELECT * FROM test ORDER BY nested(message.info)")
-    );
-
-    assertEquals(
-        "Falling back to legacy engine. Nested function is not supported in ORDER BY clause.",
-        exception.getMessage());
-  }
-
-  /**
    * Ensure Nested function falls back to legacy engine when used in an HAVING clause.
    * TODO Remove this test when support is added.
    */


### PR DESCRIPTION
### Description
Add support for nested function use in the `ORDER BY` clause.
 
### Example Queries
```sql
SELECT nested(message.info) from nested_objects ORDER BY nested(message.info);
```

### Issues Resolved
Portion of Issue: [1111](https://github.com/opensearch-project/sql/issues/1111)
Note this does not resolve issue [1777](https://github.com/opensearch-project/sql/issues/1788) but only bring V2 engine to parity with V1 engine.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).