### PR TITLE
Backport breaking changes to 2.x

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -94,7 +94,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
 
     testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
-    testImplementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.28.0'
+    testImplementation group: 'org.xerial', name: 'sqlite-jdbc', version: '3.41.2.2'
     testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 }
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/mapping/IndexMappings.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/mapping/IndexMappings.java
@@ -12,8 +12,6 @@ import java.util.Map;
 import java.util.Objects;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
-import org.opensearch.sql.legacy.domain.Field;
 
 /**
  * Index mappings in the cluster.
@@ -51,7 +49,7 @@ public class IndexMappings implements Mappings<FieldMappings> {
                 indexMetaData -> new FieldMappings(indexMetaData.mapping()));
     }
 
-    public IndexMappings(ImmutableOpenMap<String, MappingMetadata> mappings) {
+    public IndexMappings(Map<String, MappingMetadata> mappings) {
         this.indexMappings = buildMappings(mappings, FieldMappings::new);
     }
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/mapping/Mappings.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/mapping/Mappings.java
@@ -6,12 +6,10 @@
 
 package org.opensearch.sql.legacy.esdomain.mapping;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
-import org.opensearch.common.collect.ImmutableOpenMap;
+import java.util.stream.Collectors;
 
 /**
  * Mappings interface to provide default implementation (minimal set of Map methods) for subclass in hierarchy.
@@ -47,13 +45,10 @@ public interface Mappings<T> {
     Map<String, T> data();
 
     /**
-     * Convert OpenSearch ImmutableOpenMap<String, X> to JDK Map<String, Y> by applying function: Y func(X)
+     * Build a map from an existing map by applying provided function to each value.
      */
-    default <X, Y> Map<String, Y> buildMappings(ImmutableOpenMap<String, X> mappings, Function<X, Y> func) {
-        ImmutableMap.Builder<String, Y> builder = ImmutableMap.builder();
-        for (ObjectObjectCursor<String, X> mapping : mappings) {
-            builder.put(mapping.key, func.apply(mapping.value));
-        }
-        return builder.build();
+    default <X, Y> Map<String, Y> buildMappings(Map<String, X> mappings, Function<X, Y> func) {
+        return mappings.entrySet().stream().collect(
+            Collectors.toUnmodifiableMap(Map.Entry::getKey, func.compose(Map.Entry::getValue)));
     }
 }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/DescribeResultSet.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/DescribeResultSet.java
@@ -6,7 +6,6 @@
 
 package org.opensearch.sql.legacy.executor.format;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -15,7 +14,6 @@ import java.util.Map.Entry;
 import org.opensearch.action.admin.indices.get.GetIndexResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.MappingMetadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.sql.legacy.domain.IndexStatement;
 import org.opensearch.sql.legacy.executor.format.DataRows.Row;
 import org.opensearch.sql.legacy.executor.format.Schema.Column;
@@ -79,14 +77,14 @@ public class DescribeResultSet extends ResultSet {
     private List<Row> loadRows() {
         List<Row> rows = new ArrayList<>();
         GetIndexResponse indexResponse = (GetIndexResponse) queryResult;
-        ImmutableOpenMap<String, MappingMetadata> indexMappings = indexResponse.getMappings();
+        Map<String, MappingMetadata> indexMappings = indexResponse.getMappings();
 
         // Iterate through indices in indexMappings
-        for (ObjectObjectCursor<String, MappingMetadata> indexCursor : indexMappings) {
-            String index = indexCursor.key;
+        for (Entry<String, MappingMetadata> indexCursor : indexMappings.entrySet()) {
+            String index = indexCursor.getKey();
 
             if (matchesPatternIfRegex(index, statement.getIndexPattern())) {
-                rows.addAll(loadIndexData(index, indexCursor.value.getSourceAsMap()));
+                rows.addAll(loadIndexData(index, indexCursor.getValue().getSourceAsMap()));
             }
         }
         return rows;

--- a/legacy/src/test/java/org/opensearch/sql/legacy/util/CheckScriptContents.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/util/CheckScriptContents.java
@@ -23,6 +23,7 @@ import com.alibaba.druid.sql.parser.ParserException;
 import java.io.IOException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.mockito.stubbing.Answer;
@@ -227,9 +228,9 @@ public class CheckScriptContents {
         when(mockService.state()).thenReturn(mockState);
         when(mockState.metadata()).thenReturn(mockMetaData);
         try {
-            ImmutableOpenMap.Builder<String, MappingMetadata> builder = ImmutableOpenMap.builder();
-            builder.put(TestsConstants.TEST_INDEX_BANK, IndexMetadata.fromXContent(createParser(mappings)).mapping());
-            when(mockMetaData.findMappings(any(),  any())).thenReturn(builder.build());
+            when(mockMetaData.findMappings(any(),  any())).thenReturn(
+                Map.of(TestsConstants.TEST_INDEX_BANK, IndexMetadata.fromXContent(
+                    createParser(mappings)).mapping()));
         }
         catch (IOException e) {
             throw new IllegalStateException(e);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
@@ -9,7 +9,6 @@ package org.opensearch.sql.opensearch.client;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -89,9 +88,9 @@ public class OpenSearchNodeClient implements OpenSearchClient {
           .prepareGetMappings(indexExpression)
           .setLocal(true)
           .get();
-      return Streams.stream(mappingsResponse.mappings().iterator())
-          .collect(Collectors.toMap(cursor -> cursor.key,
-              cursor -> new IndexMapping(cursor.value)));
+      return mappingsResponse.mappings().entrySet().stream().collect(Collectors.toUnmodifiableMap(
+              Map.Entry::getKey,
+              cursor -> new IndexMapping(cursor.getValue())));
     } catch (IndexNotFoundException e) {
       // Re-throw directly to be treated as client error finally
       throw e;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
@@ -151,7 +151,7 @@ public class OpenSearchNodeClient implements OpenSearchClient {
         .setLocal(true)
         .get();
     final Stream<String> aliasStream =
-        ImmutableList.copyOf(indexResponse.aliases().valuesIt()).stream()
+        ImmutableList.copyOf(indexResponse.aliases().values()).stream()
             .flatMap(Collection::stream).map(AliasMetadata::alias);
 
     return Stream.concat(Arrays.stream(indexResponse.getIndices()), aliasStream)

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -437,16 +437,12 @@ class OpenSearchNodeClientTest {
         .setLocal(anyBoolean())
         .get()).thenReturn(mockResponse);
     try {
-      ImmutableOpenMap<String, MappingMetadata> metadata;
+      Map<String, MappingMetadata> metadata;
       if (mappings.isEmpty()) {
-        when(emptyMapping.getSourceAsMap()).thenReturn(ImmutableMap.of());
-        metadata =
-            new ImmutableOpenMap.Builder<String, MappingMetadata>()
-                .fPut(indexName, emptyMapping)
-                .build();
+        when(emptyMapping.getSourceAsMap()).thenReturn(Map.of());
+        metadata = Map.of(indexName, emptyMapping);
       } else {
-        metadata = new ImmutableOpenMap.Builder<String, MappingMetadata>().fPut(indexName,
-            IndexMetadata.fromXContent(createParser(mappings)).mapping()).build();
+        metadata = Map.of(indexName, IndexMetadata.fromXContent(createParser(mappings)).mapping());
       }
       when(mockResponse.mappings()).thenReturn(metadata);
     } catch (IOException e) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -399,9 +399,7 @@ class OpenSearchNodeClientTest {
   @Test
   void get_indices() {
     AliasMetadata aliasMetadata = mock(AliasMetadata.class);
-    ImmutableOpenMap.Builder<String, List<AliasMetadata>> builder = ImmutableOpenMap.builder();
-    builder.fPut("index", Arrays.asList(aliasMetadata));
-    final ImmutableOpenMap<String, List<AliasMetadata>> openMap = builder.build();
+    final var openMap = Map.of("index", List.of(aliasMetadata));
     when(aliasMetadata.alias()).thenReturn("index_alias");
     when(nodeClient.admin().indices()
         .prepareGetIndex()


### PR DESCRIPTION
### Description
Backport #1571, #1580 and #1667
 
### Issues Resolved
Backport breaking changes to 2.x, since they were backported in core.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).