### PR TITLE
Manually Backporting 1779 to 2.x

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
@@ -67,6 +67,6 @@ public class CsvFormatIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType().getName(), CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType().getValue(), CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
@@ -64,6 +64,6 @@ public class CsvFormatIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType(), CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType(), "content-type: " + CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
@@ -12,6 +12,9 @@ import static org.opensearch.sql.protocol.response.format.FlatResponseFormatter.
 import java.io.IOException;
 import java.util.Locale;
 
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
+import org.apache.http.ParseException;
 import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -64,6 +67,6 @@ public class CsvFormatIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType(), "content-type: " + CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType().getName(), CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
@@ -12,9 +12,6 @@ import static org.opensearch.sql.protocol.response.format.FlatResponseFormatter.
 import java.io.IOException;
 import java.util.Locale;
 
-import org.apache.http.Header;
-import org.apache.http.HeaderElement;
-import org.apache.http.ParseException;
 import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/CsvFormatIT.java
@@ -7,10 +7,14 @@
 package org.opensearch.sql.sql;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_CSV_SANITIZE;
+import static org.opensearch.sql.protocol.response.format.FlatResponseFormatter.CONTENT_TYPE;
 
 import java.io.IOException;
 import java.util.Locale;
+
 import org.junit.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
@@ -48,5 +52,18 @@ public class CsvFormatIT extends SQLIntegTestCase {
             + "@Dale,Adams@%n"
             + "\",Elinor\",\"Ratliff,,,\"%n"),
         result);
+  }
+
+  @Test
+  public void contentHeaderTest() throws IOException {
+    String query = String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_CSV_SANITIZE);
+    String requestBody = makeRequest(query);
+
+    Request sqlRequest = new Request("POST", "/_plugins/_sql?format=csv");
+    sqlRequest.setJsonEntity(requestBody);
+
+    Response response = client().performRequest(sqlRequest);
+
+    assertEquals(response.getEntity().getContentType(), CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -6,11 +6,15 @@
 
 package org.opensearch.sql.sql;
 
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_CSV_SANITIZE;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_RAW_SANITIZE;
+import static org.opensearch.sql.protocol.response.format.FlatResponseFormatter.CONTENT_TYPE;
 
 import java.io.IOException;
 import java.util.Locale;
 import org.junit.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
@@ -35,4 +39,16 @@ public class RawFormatIT extends SQLIntegTestCase {
         result);
   }
 
+  @Test
+  public void contentHeaderTest() throws IOException {
+    String query = String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE);
+    String requestBody = makeRequest(query);
+
+    Request sqlRequest = new Request("POST", "/_plugins/_sql?format=raw");
+    sqlRequest.setJsonEntity(requestBody);
+
+    Response response = client().performRequest(sqlRequest);
+
+    assertEquals(response.getEntity().getContentType(), CONTENT_TYPE);
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -49,6 +49,6 @@ public class RawFormatIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType(), "content-type: " + CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType().getName(), CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -49,6 +49,6 @@ public class RawFormatIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType(), CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType(), "content-type: " + CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -49,6 +49,6 @@ public class RawFormatIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType().getName(), CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType().getValue(), CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
@@ -79,6 +79,6 @@ public class SimpleQueryStringIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType(), "content-type: " + CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType().getName(), CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
@@ -79,6 +79,6 @@ public class SimpleQueryStringIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType(), CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType(), "content-type: " + CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
@@ -5,11 +5,17 @@
 
 package org.opensearch.sql.sql;
 
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_CSV_SANITIZE;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
+import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.CONTENT_TYPE;
 
 import java.io.IOException;
+import java.util.Locale;
+
 import org.json.JSONObject;
 import org.junit.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
 public class SimpleQueryStringIT extends SQLIntegTestCase {
@@ -60,5 +66,19 @@ public class SimpleQueryStringIT extends SQLIntegTestCase {
         + " WHERE simple_query_string(['*Date'], '2014-01-22');";
     var result = new JSONObject(executeQuery(query, "jdbc"));
     assertEquals(10, result.getInt("total"));
+  }
+
+  @Test
+  public void contentHeaderTest() throws IOException {
+    String query = "SELECT Id FROM " + TEST_INDEX_BEER
+            + " WHERE simple_query_string([\\\"Tags\\\" ^ 1.5, Title, 'Body' 4.2], 'taste')";
+    String requestBody = makeRequest(query);
+
+    Request sqlRequest = new Request("POST", "/_plugins/_sql");
+    sqlRequest.setJsonEntity(requestBody);
+
+    Response response = client().performRequest(sqlRequest);
+
+    assertEquals(response.getEntity().getContentType(), CONTENT_TYPE);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/SimpleQueryStringIT.java
@@ -79,6 +79,6 @@ public class SimpleQueryStringIT extends SQLIntegTestCase {
 
     Response response = client().performRequest(sqlRequest);
 
-    assertEquals(response.getEntity().getContentType().getName(), CONTENT_TYPE);
+    assertEquals(response.getEntity().getContentType().getValue(), CONTENT_TYPE);
   }
 }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -141,15 +141,16 @@ public class RestSQLQueryAction extends BaseRestHandler {
 
   private ResponseListener<ExplainResponse> createExplainResponseListener(
       RestChannel channel, BiConsumer<RestChannel, Exception> errorHandler) {
-    return new ResponseListener<ExplainResponse>() {
+    return new ResponseListener<>() {
       @Override
       public void onResponse(ExplainResponse response) {
-        sendResponse(channel, OK, new JsonResponseFormatter<ExplainResponse>(PRETTY) {
+        JsonResponseFormatter<ExplainResponse> formatter = new JsonResponseFormatter<>(PRETTY) {
           @Override
           protected Object buildJsonObject(ExplainResponse response) {
             return response;
           }
-        }.format(response));
+        };
+        sendResponse(channel, OK, formatter.format(response), formatter.contentType());
       }
 
       @Override
@@ -180,7 +181,7 @@ public class RestSQLQueryAction extends BaseRestHandler {
       public void onResponse(QueryResponse response) {
         sendResponse(channel, OK,
             formatter.format(new QueryResult(response.getSchema(), response.getResults(),
-                response.getCursor())));
+                response.getCursor())), formatter.contentType());
       }
 
       @Override
@@ -190,9 +191,9 @@ public class RestSQLQueryAction extends BaseRestHandler {
     };
   }
 
-  private void sendResponse(RestChannel channel, RestStatus status, String content) {
+  private void sendResponse(RestChannel channel, RestStatus status, String content, String contentType) {
     channel.sendResponse(new BytesRestResponse(
-        status, "application/json; charset=UTF-8", content));
+        status, contentType, content));
   }
 
   private static void logAndPublishMetrics(Exception e) {

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/FlatResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/FlatResponseFormatter.java
@@ -23,11 +23,17 @@ public abstract class FlatResponseFormatter implements ResponseFormatter<QueryRe
   private static final String INTERLINE_SEPARATOR = System.lineSeparator();
   private static final Set<String> SENSITIVE_CHAR = ImmutableSet.of("=", "+", "-", "@");
 
+  public static final String CONTENT_TYPE = "plain/text; charset=UTF-8";
+
   private boolean sanitize = false;
 
   public FlatResponseFormatter(String seperator, boolean sanitize) {
     this.INLINE_SEPARATOR = seperator;
     this.sanitize = sanitize;
+  }
+
+  public String contentType() {
+    return CONTENT_TYPE;
   }
 
   @Override

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/JsonResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/JsonResponseFormatter.java
@@ -36,6 +36,8 @@ public abstract class JsonResponseFormatter<R> implements ResponseFormatter<R> {
    */
   private final Style style;
 
+  public static final String CONTENT_TYPE = "application/json; charset=UTF-8";
+
   @Override
   public String format(R response) {
     return jsonify(buildJsonObject(response));
@@ -45,6 +47,10 @@ public abstract class JsonResponseFormatter<R> implements ResponseFormatter<R> {
   public String format(Throwable t) {
     return AccessController.doPrivileged((PrivilegedAction<String>) () ->
         (style == PRETTY) ? prettyFormat(t) : compactFormat(t));
+  }
+
+  public String contentType() {
+    return CONTENT_TYPE;
   }
 
   /**

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ResponseFormatter.java
@@ -27,4 +27,11 @@ public interface ResponseFormatter<R> {
    */
   String format(Throwable t);
 
+  /**
+   * Getter for the content type header of the response.
+   *
+   * @return string
+   */
+  String contentType();
+
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.opensearch.sql.data.model.ExprValueUtils.tupleValue;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.CONTENT_TYPE;
 import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
 import com.google.common.collect.ImmutableList;
@@ -55,5 +56,11 @@ public class CommandResponseFormatterTest {
     var exception = new Exception("pewpew", new RuntimeException("meow meow"));
     assertEquals(new JdbcResponseFormatter(PRETTY).format(exception),
         new CommandResponseFormatter().format(exception));
+  }
+
+  @Test
+  void testContentType() {
+    var formatter = new CommandResponseFormatter();
+    assertEquals(formatter.contentType(), CONTENT_TYPE);
   }
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatterTest.java
@@ -14,6 +14,7 @@ import static org.opensearch.sql.data.model.ExprValueUtils.stringValue;
 import static org.opensearch.sql.data.model.ExprValueUtils.tupleValue;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.protocol.response.format.FlatResponseFormatter.CONTENT_TYPE;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -128,6 +129,11 @@ public class CsvResponseFormatterTest {
         + ",Seattle%n"
         + "John,";
     assertEquals(format(expected), formatter.format(response));
+  }
+
+  @Test
+  void testContentType() {
+    assertEquals(formatter.contentType(), CONTENT_TYPE);
   }
 
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/RawResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/RawResponseFormatterTest.java
@@ -14,6 +14,7 @@ import static org.opensearch.sql.data.model.ExprValueUtils.stringValue;
 import static org.opensearch.sql.data.model.ExprValueUtils.tupleValue;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.protocol.response.format.FlatResponseFormatter.CONTENT_TYPE;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -27,7 +28,7 @@ import org.opensearch.sql.protocol.response.QueryResult;
  * Unit test for {@link FlatResponseFormatter}.
  */
 public class RawResponseFormatterTest {
-  private FlatResponseFormatter rawFormater = new RawResponseFormatter();
+  private FlatResponseFormatter rawFormatter = new RawResponseFormatter();
 
   @Test
   void formatResponse() {
@@ -38,7 +39,7 @@ public class RawResponseFormatterTest {
         tupleValue(ImmutableMap.of("name", "John", "age", 20)),
         tupleValue(ImmutableMap.of("name", "Smith", "age", 30))));
     String expected = "name|age%nJohn|20%nSmith|30";
-    assertEquals(format(expected), rawFormater.format(response));
+    assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
@@ -53,7 +54,7 @@ public class RawResponseFormatterTest {
             "=firstname", "John", "+lastname", "Smith", "-city", "Seattle", "@age", 20))));
     String expected = "=firstname|+lastname|-city|@age%n"
         + "John|Smith|Seattle|20";
-    assertEquals(format(expected), rawFormater.format(response));
+    assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
@@ -74,7 +75,7 @@ public class RawResponseFormatterTest {
         + "-Seattle%n"
         + "@Seattle%n"
         + "Seattle=";
-    assertEquals(format(expected), rawFormater.format(response));
+    assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
@@ -86,7 +87,7 @@ public class RawResponseFormatterTest {
             tupleValue(ImmutableMap.of("na|me", "John|Smith", "||age", "30|||"))));
     String expected = "\"na|me\"|\"||age\"%n"
             + "\"John|Smith\"|\"30|||\"";
-    assertEquals(format(expected), rawFormater.format(response));
+    assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
@@ -94,7 +95,7 @@ public class RawResponseFormatterTest {
     Throwable t = new RuntimeException("This is an exception");
     String expected =
         "{\n  \"type\": \"RuntimeException\",\n  \"reason\": \"This is an exception\"\n}";
-    assertEquals(expected, rawFormater.format(t));
+    assertEquals(expected, rawFormatter.format(t));
   }
 
   @Test
@@ -121,7 +122,7 @@ public class RawResponseFormatterTest {
     String expected = "city%n"
             + "@Seattle%n"
             + "++Seattle";
-    assertEquals(format(expected), rawFormater.format(response));
+    assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
@@ -153,7 +154,12 @@ public class RawResponseFormatterTest {
         + "John|Seattle%n"
         + "|Seattle%n"
         + "John|";
-    assertEquals(format(expected), rawFormater.format(response));
+    assertEquals(format(expected), rawFormatter.format(response));
+  }
+
+  @Test
+  void testContentType() {
+    assertEquals(rawFormatter.contentType(), CONTENT_TYPE);
   }
 
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatterTest.java
@@ -11,6 +11,7 @@ import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_NULL;
 import static org.opensearch.sql.data.model.ExprValueUtils.tupleValue;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.CONTENT_TYPE;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -186,5 +187,11 @@ public class VisualizationResponseFormatterTest {
     assertEquals(
         JsonParser.parseString(expected),
         JsonParser.parseString(actual));
+  }
+
+  @Test
+  void testContentType() {
+    var formatter = new CommandResponseFormatter();
+    assertEquals(formatter.contentType(), CONTENT_TYPE);
   }
 }


### PR DESCRIPTION
### Description
Manually backporting #1779 into 2.x as a few of the IT tests failed due to a small difference in the `getContentType` method
 
### Issues Resolved
Automatic [backport](https://github.com/opensearch-project/sql/pull/1795) to 2.x failing
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).