### PR TITLE
Add Flint create and refresh index SQL support

### DIFF
--- a/flint/docs/index.md
+++ b/flint/docs/index.md
@@ -301,3 +301,7 @@ val df = new SQLContext(sc).read
 ## Benchmarks
 
 TODO
+
+## Limitations
+
+Manual refreshing a table which already has skipping index being auto-refreshed, will be prevented. However, this assumption relies on the condition that the incremental refresh job is actively running in the same Spark cluster, which can be identified when performing the check.

--- a/flint/docs/index.md
+++ b/flint/docs/index.md
@@ -126,6 +126,8 @@ ON <object>
 WHERE <filter_predicate>
 WITH (auto_refresh = (true|false))
 
+REFRESH SKIPPING INDEX ON <object>
+
 DESCRIBE SKIPPING INDEX ON <object>
 
 DROP SKIPPING INDEX ON <object>
@@ -147,6 +149,8 @@ CREATE SKIPPING INDEX ON alb_logs
   elb_status_code VALUE_SET
 )
 WHERE time > '2023-04-01 00:00:00'
+
+REFRESH SKIPPING INDEX ON alb_logs
 
 DESCRIBE SKIPPING INDEX ON alb_logs
 

--- a/flint/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
+++ b/flint/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
@@ -19,8 +19,19 @@ statement
     ;
 
 skippingIndexStatement
-    : describeSkippingIndexStatement
+    : createSkippingIndexStatement
+    | refreshSkippingIndexStatement
+    | describeSkippingIndexStatement
     | dropSkippingIndexStatement
+    ;
+
+createSkippingIndexStatement
+    : CREATE SKIPPING INDEX ON tableName=multipartIdentifier
+        LEFT_PAREN indexColTypeList RIGHT_PAREN
+    ;
+
+refreshSkippingIndexStatement
+    : REFRESH SKIPPING INDEX ON tableName=multipartIdentifier
     ;
 
 describeSkippingIndexStatement
@@ -29,4 +40,12 @@ describeSkippingIndexStatement
 
 dropSkippingIndexStatement
     : DROP SKIPPING INDEX ON tableName=multipartIdentifier
+    ;
+
+indexColTypeList
+    : indexColType (COMMA indexColType)*
+    ;
+
+indexColType
+    : identifier skipType=(PARTITION | VALUE_SET | MIN_MAX)
     ;

--- a/flint/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
+++ b/flint/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4
@@ -28,6 +28,7 @@ skippingIndexStatement
 createSkippingIndexStatement
     : CREATE SKIPPING INDEX ON tableName=multipartIdentifier
         LEFT_PAREN indexColTypeList RIGHT_PAREN
+        (WITH LEFT_PAREN propertyList RIGHT_PAREN)?
     ;
 
 refreshSkippingIndexStatement

--- a/flint/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4
+++ b/flint/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4
@@ -85,6 +85,31 @@ grammar SparkSqlBase;
 }
 
 
+propertyList
+    : property (COMMA property)*
+    ;
+
+property
+    : key=propertyKey (EQ? value=propertyValue)?
+    ;
+
+propertyKey
+    : identifier (DOT identifier)*
+    | STRING
+    ;
+
+propertyValue
+    : INTEGER_VALUE
+    | DECIMAL_VALUE
+    | booleanValue
+    | STRING
+    ;
+
+booleanValue
+    : TRUE | FALSE
+    ;
+
+
 multipartIdentifier
     : parts+=identifier (DOT parts+=identifier)*
     ;
@@ -120,16 +145,32 @@ RIGHT_PAREN: ')';
 COMMA: ',';
 DOT: '.';
 
+
 CREATE: 'CREATE';
 DESC: 'DESC';
 DESCRIBE: 'DESCRIBE';
 DROP: 'DROP';
+FALSE: 'FALSE';
 INDEX: 'INDEX';
 ON: 'ON';
 PARTITION: 'PARTITION';
 REFRESH: 'REFRESH';
+STRING: 'STRING';
+TRUE: 'TRUE';
+WITH: 'WITH';
 
+
+EQ  : '=' | '==';
 MINUS: '-';
+
+
+INTEGER_VALUE
+    : DIGIT+
+    ;
+
+DECIMAL_VALUE
+    : DECIMAL_DIGITS {isValidDecimal()}?
+    ;
 
 IDENTIFIER
     : (LETTER | DIGIT | '_')+
@@ -137,6 +178,11 @@ IDENTIFIER
 
 BACKQUOTED_IDENTIFIER
     : '`' ( ~'`' | '``' )* '`'
+    ;
+
+fragment DECIMAL_DIGITS
+    : DIGIT+ '.' DIGIT*
+    | '.' DIGIT+
     ;
 
 fragment DIGIT

--- a/flint/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4
+++ b/flint/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4
@@ -106,20 +106,30 @@ nonReserved
 
 // Flint lexical tokens
 
-SKIPPING : 'SKIPPING';
+MIN_MAX: 'MIN_MAX';
+SKIPPING: 'SKIPPING';
+VALUE_SET: 'VALUE_SET';
 
 
 // Spark lexical tokens
 
 SEMICOLON: ';';
 
+LEFT_PAREN: '(';
+RIGHT_PAREN: ')';
+COMMA: ',';
+DOT: '.';
+
+CREATE: 'CREATE';
 DESC: 'DESC';
 DESCRIBE: 'DESCRIBE';
-DOT: '.';
 DROP: 'DROP';
 INDEX: 'INDEX';
-MINUS: '-';
 ON: 'ON';
+PARTITION: 'PARTITION';
+REFRESH: 'REFRESH';
+
+MINUS: '-';
 
 IDENTIFIER
     : (LETTER | DIGIT | '_')+

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -15,7 +15,7 @@ import org.opensearch.flint.spark.FlintSpark.RefreshMode.{FULL, INCREMENTAL, Ref
 import org.opensearch.flint.spark.skipping.{FlintSparkSkippingIndex, FlintSparkSkippingStrategy}
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.SKIPPING_INDEX_TYPE
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.{SkippingKind, SkippingKindSerializer}
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MinMax, Partition, ValuesSet}
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MIN_MAX, PARTITION, VALUE_SET}
 import org.opensearch.flint.spark.skipping.minmax.MinMaxSkippingStrategy
 import org.opensearch.flint.spark.skipping.partition.PartitionSkippingStrategy
 import org.opensearch.flint.spark.skipping.valueset.ValueSetSkippingStrategy
@@ -170,11 +170,11 @@ class FlintSpark(val spark: SparkSession) {
           val columnType = (colInfo \ "columnType").extract[String]
 
           skippingKind match {
-            case Partition =>
+            case PARTITION =>
               PartitionSkippingStrategy(columnName = columnName, columnType = columnType)
-            case ValuesSet =>
+            case VALUE_SET =>
               ValueSetSkippingStrategy(columnName = columnName, columnType = columnType)
-            case MinMax =>
+            case MIN_MAX =>
               MinMaxSkippingStrategy(columnName = columnName, columnType = columnType)
             case other =>
               throw new IllegalStateException(s"Unknown skipping strategy: $other")

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -101,6 +101,7 @@ class FlintSpark(val spark: SparkSession) {
         val job = spark.readStream
           .table(tableName)
           .writeStream
+          .queryName(indexName)
           .outputMode(Append())
           .foreachBatch { (batchDF: DataFrame, _: Long) =>
             writeFlintIndex(batchDF)

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/FlintSpark.scala
@@ -89,6 +89,9 @@ class FlintSpark(val spark: SparkSession) {
     }
 
     mode match {
+      case FULL if isIncrementalRefreshing(indexName) =>
+        throw new IllegalStateException(
+          s"Index $indexName is incremental refreshing and cannot be manual refreshed")
       case FULL =>
         writeFlintIndex(
           spark.read
@@ -144,6 +147,9 @@ class FlintSpark(val spark: SparkSession) {
       false
     }
   }
+
+  private def isIncrementalRefreshing(indexName: String): Boolean =
+    spark.streams.active.exists(_.name == indexName)
 
   // TODO: Remove all parsing logic below once Flint spec finalized and FlintMetadata strong typed
   private def getSourceTableName(index: FlintSparkIndex): String = {

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingStrategy.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingStrategy.scala
@@ -65,7 +65,7 @@ object FlintSparkSkippingStrategy {
     type SkippingKind = Value
 
     // Use Value[s]Set because ValueSet already exists in Enumeration
-    val Partition, ValuesSet, MinMax = Value
+    val PARTITION, VALUE_SET, MIN_MAX = Value
   }
 
   /** json4s doesn't serialize Enum by default */

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/minmax/MinMaxSkippingStrategy.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/minmax/MinMaxSkippingStrategy.scala
@@ -6,7 +6,7 @@
 package org.opensearch.flint.spark.skipping.minmax
 
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MinMax, SkippingKind}
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{MIN_MAX, SkippingKind}
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal, Predicate}
@@ -17,7 +17,7 @@ import org.apache.spark.sql.functions.col
  * Skipping strategy based on min-max boundary of column values.
  */
 case class MinMaxSkippingStrategy(
-    override val kind: SkippingKind = MinMax,
+    override val kind: SkippingKind = MIN_MAX,
     override val columnName: String,
     override val columnType: String)
     extends FlintSparkSkippingStrategy {

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/partition/PartitionSkippingStrategy.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/partition/PartitionSkippingStrategy.scala
@@ -6,7 +6,7 @@
 package org.opensearch.flint.spark.skipping.partition
 
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{Partition, SkippingKind}
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{PARTITION, SkippingKind}
 
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal, Predicate}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, First}
@@ -16,7 +16,7 @@ import org.apache.spark.sql.functions.col
  * Skipping strategy for partitioned columns of source table.
  */
 case class PartitionSkippingStrategy(
-    override val kind: SkippingKind = Partition,
+    override val kind: SkippingKind = PARTITION,
     override val columnName: String,
     override val columnType: String)
     extends FlintSparkSkippingStrategy {

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/valueset/ValueSetSkippingStrategy.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/valueset/ValueSetSkippingStrategy.scala
@@ -6,7 +6,7 @@
 package org.opensearch.flint.spark.skipping.valueset
 
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy
-import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{SkippingKind, ValuesSet}
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.{SkippingKind, VALUE_SET}
 
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal, Predicate}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, CollectSet}
@@ -16,7 +16,7 @@ import org.apache.spark.sql.functions.col
  * Skipping strategy based on unique column value set.
  */
 case class ValueSetSkippingStrategy(
-    override val kind: SkippingKind = ValuesSet,
+    override val kind: SkippingKind = VALUE_SET,
     override val columnName: String,
     override val columnType: String)
     extends FlintSparkSkippingStrategy {

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/sql/FlintSparkSqlAstBuilder.scala
@@ -5,11 +5,11 @@
 
 package org.opensearch.flint.spark.sql
 
-import java.util.Locale
-
 import org.opensearch.flint.spark.FlintSpark.RefreshMode
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.getSkippingIndexName
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind._
 import org.opensearch.flint.spark.sql.FlintSparkSqlExtensionsParser.{CreateSkippingIndexStatementContext, DescribeSkippingIndexStatementContext, DropSkippingIndexStatementContext, RefreshSkippingIndexStatementContext}
 
 import org.apache.spark.sql.Row
@@ -31,12 +31,12 @@ class FlintSparkSqlAstBuilder extends FlintSparkSqlExtensionsBaseVisitor[Command
 
       ctx.indexColTypeList().indexColType().forEach { colTypeCtx =>
         val colName = colTypeCtx.identifier().getText
-        val skipType = colTypeCtx.skipType.getText.toLowerCase(Locale.ROOT)
+        val skipType = SkippingKind.withName(colTypeCtx.skipType.getText)
 
         skipType match {
-          case "partition" => indexBuilder.addPartitions(colName)
-          case "value_set" => indexBuilder.addValueSet(colName)
-          case "min_max" => indexBuilder.addMinMax(colName)
+          case PARTITION => indexBuilder.addPartitions(colName)
+          case VALUE_SET => indexBuilder.addValueSet(colName)
+          case MIN_MAX => indexBuilder.addMinMax(colName)
         }
       }
       indexBuilder.create()

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -207,7 +207,12 @@ class FlintSparkSkippingIndexITSuite
       .onTable(testTable)
       .addPartitions("year", "month")
       .create()
-    flint.refreshIndex(testIndex, INCREMENTAL)
+
+    val jobId = flint.refreshIndex(testIndex, INCREMENTAL)
+    val job = spark.streams.get(jobId.get)
+    failAfter(streamingTimeout) {
+      job.processAllAvailable()
+    }
 
     assertThrows[IllegalStateException] {
       flint.refreshIndex(testIndex, FULL)

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.flint.config.FlintSparkConf._
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.streaming.StreamTest
 
-class FlintSparkSkippingIndexSuite
+class FlintSparkSkippingIndexITSuite
     extends QueryTest
     with FlintSuite
     with OpenSearchSuite

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexITSuite.scala
@@ -201,6 +201,19 @@ class FlintSparkSkippingIndexITSuite
     indexData should have size 2
   }
 
+  test("should fail to manual refresh an incremental refreshing index") {
+    flint
+      .skippingIndex()
+      .onTable(testTable)
+      .addPartitions("year", "month")
+      .create()
+    flint.refreshIndex(testIndex, INCREMENTAL)
+
+    assertThrows[IllegalStateException] {
+      flint.refreshIndex(testIndex, FULL)
+    }
+  }
+
   test("can have only 1 skipping index on a table") {
     flint
       .skippingIndex()

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
@@ -108,22 +108,22 @@ class FlintSparkSkippingIndexSuite
         |     "kind": "skipping",
         |     "indexedColumns": [
         |     {
-        |        "kind": "Partition",
+        |        "kind": "PARTITION",
         |        "columnName": "year",
         |        "columnType": "int"
         |     },
         |     {
-        |        "kind": "Partition",
+        |        "kind": "PARTITION",
         |        "columnName": "month",
         |        "columnType": "int"
         |     },
         |     {
-        |        "kind": "ValuesSet",
+        |        "kind": "VALUE_SET",
         |        "columnName": "address",
         |        "columnType": "string"
         |     },
         |     {
-        |        "kind": "MinMax",
+        |        "kind": "MIN_MAX",
         |        "columnName": "age",
         |        "columnType": "int"
         |     }],

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSqlITSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSqlITSuite.scala
@@ -17,7 +17,7 @@ import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.flint.FlintDataSourceV2.FLINT_DATASOURCE
 import org.apache.spark.sql.flint.config.FlintSparkConf.{HOST_ENDPOINT, HOST_PORT, REFRESH_POLICY}
 
-class FlintSparkSqlSuite extends QueryTest with FlintSuite with OpenSearchSuite {
+class FlintSparkSqlITSuite extends QueryTest with FlintSuite with OpenSearchSuite {
 
   /** Flint Spark high level API for assertion */
   private lazy val flint: FlintSpark = new FlintSpark(spark)
@@ -101,9 +101,9 @@ class FlintSparkSqlSuite extends QueryTest with FlintSuite with OpenSearchSuite 
     checkAnswer(
       result,
       Seq(
-        Row("year", "int", "Partition"),
-        Row("name", "string", "ValuesSet"),
-        Row("age", "int", "MinMax")))
+        Row("year", "int", "PARTITION"),
+        Row("name", "string", "VALUE_SET"),
+        Row("age", "int", "MIN_MAX")))
   }
 
   test("should return empty if no skipping index to describe") {


### PR DESCRIPTION
### Description

1. Add SQL support for create and refresh skipping index statement. Please find SQL syntax and example in https://github.com/dai-chen/sql-1/blob/add-create-skipping-index-sql-statement/flint/docs/index.md#sql
2. Rename skipping kind to match its name in SQL grammar
3. Add check for manual refresh on incremental refreshing index
 
### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/2
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).