### PR TITLE
Disable CCS IT test

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -298,6 +298,9 @@ integTest {
 
     // Exclude JDBC related tests
     exclude 'org/opensearch/sql/jdbc/**'
+
+    // Exclude this IT until running IT with security plugin enabled is ready
+    exclude 'org/opensearch/sql/ppl/CrossClusterSearchIT.class'
 }
 
 


### PR DESCRIPTION
### Description
Disable CCS IT test case. It fails when security plugin is enabled.
Currently we don't have a way to run IT test with security plugin. Fix for the CCS IT will come after that is ready. Tracking issue: #1713
 
### Issues Resolved
#1707 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).