### PR TITLE
Provide hybrid scan setting for consistency requirement

### DIFF
--- a/flint/docs/index.md
+++ b/flint/docs/index.md
@@ -219,6 +219,7 @@ In the index mapping, the `_meta` and `properties`field stores meta and schema i
   IMMEDIATE(true), WAIT_UNTIL(wait_for)]
 - `spark.datasource.flint.read.scroll_size`: default value is 100.
 - `spark.flint.optimizer.enabled`: default is true.
+- `spark.flint.index.hybridscan.enabled`: default is false.
 
 #### Data Type Mapping
 

--- a/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/apache/spark/sql/flint/config/FlintSparkConf.scala
@@ -92,6 +92,10 @@ object FlintSparkConf {
   val OPTIMIZER_RULE_ENABLED = FlintConfig("spark.flint.optimizer.enabled")
     .doc("Enable Flint optimizer rule for query rewrite with Flint index")
     .createWithDefault("true")
+
+  val HYBRID_SCAN_ENABLED = FlintConfig("spark.flint.index.hybridscan.enabled")
+    .doc("Enable hybrid scan to include latest source data not refreshed to index yet")
+    .createWithDefault("false")
 }
 
 /**
@@ -113,6 +117,8 @@ class FlintSparkConf(properties: JMap[String, String]) extends Serializable {
   }
 
   def isOptimizerEnabled: Boolean = OPTIMIZER_RULE_ENABLED.readFrom(reader).toBoolean
+
+  def isHybridScanEnabled: Boolean = HYBRID_SCAN_ENABLED.readFrom(reader).toBoolean
 
   /**
    * spark.sql.session.timeZone

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndex.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndex.scala
@@ -17,10 +17,10 @@ import org.apache.spark.sql.types.StructType
  *
  * @param baseFileIndex
  *   original file index
- * @param filterByIndex
- *   pushed down filtering on index data
+ * @param queryIndex
+ *   query skipping index DF with pushed down filters
  */
-case class FlintSparkSkippingFileIndex(baseFileIndex: FileIndex, filterByIndex: DataFrame)
+case class FlintSparkSkippingFileIndex(baseFileIndex: FileIndex, queryIndex: DataFrame)
     extends FileIndex {
 
   override def listFiles(
@@ -28,7 +28,7 @@ case class FlintSparkSkippingFileIndex(baseFileIndex: FileIndex, filterByIndex: 
       dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
 
     val selectedFiles =
-      filterByIndex.collect
+      queryIndex.collect
         .map(_.getString(0))
         .toSet
 

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndex.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndex.scala
@@ -6,10 +6,12 @@
 package org.opensearch.flint.spark.skipping
 
 import org.apache.hadoop.fs.{FileStatus, Path}
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.FILE_PATH_COLUMN
 
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Predicate}
 import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory}
+import org.apache.spark.sql.flint.config.FlintSparkConf
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -17,25 +19,27 @@ import org.apache.spark.sql.types.StructType
  *
  * @param baseFileIndex
  *   original file index
- * @param queryIndex
+ * @param indexScan
  *   query skipping index DF with pushed down filters
  */
-case class FlintSparkSkippingFileIndex(baseFileIndex: FileIndex, queryIndex: DataFrame)
+case class FlintSparkSkippingFileIndex(
+    baseFileIndex: FileIndex,
+    indexScan: DataFrame,
+    indexFilter: Predicate)
     extends FileIndex {
 
   override def listFiles(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
 
-    val selectedFiles =
-      queryIndex.collect
-        .map(_.getString(0))
-        .toSet
-
+    // TODO: try to avoid the list call if no hybrid scan
     val partitions = baseFileIndex.listFiles(partitionFilters, dataFilters)
-    partitions
-      .map(p => p.copy(files = p.files.filter(f => isFileNotSkipped(selectedFiles, f))))
-      .filter(p => p.files.nonEmpty)
+
+    if (FlintSparkConf().isHybridScanEnabled) {
+      scanFilesFromIndexAndSource(partitions)
+    } else {
+      scanFilesFromIndex(partitions)
+    }
   }
 
   override def rootPaths: Seq[Path] = baseFileIndex.rootPaths
@@ -47,6 +51,25 @@ case class FlintSparkSkippingFileIndex(baseFileIndex: FileIndex, queryIndex: Dat
   override def sizeInBytes: Long = baseFileIndex.sizeInBytes
 
   override def partitionSchema: StructType = baseFileIndex.partitionSchema
+
+  private def scanFilesFromIndexAndSource(
+      partitions: Seq[PartitionDirectory]): Seq[PartitionDirectory] = {
+    Seq.empty
+  }
+
+  private def scanFilesFromIndex(partitions: Seq[PartitionDirectory]): Seq[PartitionDirectory] = {
+    val selectedFiles =
+      indexScan
+        .filter(new Column(indexFilter))
+        .select(FILE_PATH_COLUMN)
+        .collect
+        .map(_.getString(0))
+        .toSet
+
+    partitions
+      .map(p => p.copy(files = p.files.filter(f => isFileNotSkipped(selectedFiles, f))))
+      .filter(p => p.files.nonEmpty)
+  }
 
   private def isFileNotSkipped(selectedFiles: Set[String], f: FileStatus) = {
     selectedFiles.contains(f.getPath.toUri.toString)

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndex.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndex.scala
@@ -12,6 +12,7 @@ import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.catalyst.expressions.{Expression, Predicate}
 import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory}
 import org.apache.spark.sql.flint.config.FlintSparkConf
+import org.apache.spark.sql.functions.isnull
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -32,14 +33,19 @@ case class FlintSparkSkippingFileIndex(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
 
-    // TODO: try to avoid the list call if no hybrid scan
+    // TODO: make this listFile call only in hybrid scan mode
     val partitions = baseFileIndex.listFiles(partitionFilters, dataFilters)
+    val selectedFiles =
+      if (FlintSparkConf().isHybridScanEnabled) {
+        selectFilesFromIndexAndSource(partitions)
+      } else {
+        selectFilesFromIndexOnly()
+      }
 
-    if (FlintSparkConf().isHybridScanEnabled) {
-      scanFilesFromIndexAndSource(partitions)
-    } else {
-      scanFilesFromIndex(partitions)
-    }
+    // Keep partition files present in selected file list above
+    partitions
+      .map(p => p.copy(files = p.files.filter(f => isFileNotSkipped(selectedFiles, f))))
+      .filter(p => p.files.nonEmpty)
   }
 
   override def rootPaths: Seq[Path] = baseFileIndex.rootPaths
@@ -52,23 +58,42 @@ case class FlintSparkSkippingFileIndex(
 
   override def partitionSchema: StructType = baseFileIndex.partitionSchema
 
-  private def scanFilesFromIndexAndSource(
-      partitions: Seq[PartitionDirectory]): Seq[PartitionDirectory] = {
-    Seq.empty
-  }
-
-  private def scanFilesFromIndex(partitions: Seq[PartitionDirectory]): Seq[PartitionDirectory] = {
-    val selectedFiles =
-      indexScan
-        .filter(new Column(indexFilter))
-        .select(FILE_PATH_COLUMN)
-        .collect
-        .map(_.getString(0))
-        .toSet
+  /*
+   * Left join source partitions and index data to keep unrefreshed source files:
+   * Express the logic in SQL:
+   *   SELECT left.file_path
+   *   FROM partitions AS left
+   *   LEFT OUTER JOIN indexScan AS right
+   *   ON left.file_path = right.file_path
+   *   WHERE right.file_path IS NULL
+   *     OR [indexFilter]
+   */
+  private def selectFilesFromIndexAndSource(partitions: Seq[PartitionDirectory]): Set[String] = {
+    val sparkSession = indexScan.sparkSession
+    import sparkSession.implicits._
 
     partitions
-      .map(p => p.copy(files = p.files.filter(f => isFileNotSkipped(selectedFiles, f))))
-      .filter(p => p.files.nonEmpty)
+      .flatMap(_.files.map(f => f.getPath.toString))
+      .toDF(FILE_PATH_COLUMN)
+      .join(indexScan, Seq(FILE_PATH_COLUMN), "left")
+      .filter(isnull(indexScan(FILE_PATH_COLUMN)) || new Column(indexFilter))
+      .select(FILE_PATH_COLUMN)
+      .collect()
+      .map(_.getString(0))
+      .toSet
+  }
+
+  /*
+   * Consider file paths in index data alone. In this case, index filter can be pushed down
+   * to index store.
+   */
+  private def selectFilesFromIndexOnly(): Set[String] = {
+    indexScan
+      .filter(new Column(indexFilter))
+      .select(FILE_PATH_COLUMN)
+      .collect
+      .map(_.getString(0))
+      .toSet
   }
 
   private def isFileNotSkipped(selectedFiles: Set[String], f: FileStatus) = {

--- a/flint/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/apache/spark/FlintSuite.scala
@@ -10,6 +10,7 @@ import org.opensearch.flint.spark.FlintSparkExtensions
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
 import org.apache.spark.sql.flint.config.FlintConfigEntry
+import org.apache.spark.sql.flint.config.FlintSparkConf.HYBRID_SCAN_ENABLED
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -33,5 +34,14 @@ trait FlintSuite extends SharedSparkSession {
    */
   protected def setFlintSparkConf[T](config: FlintConfigEntry[T], value: Any): Unit = {
     spark.conf.set(config.key, value.toString)
+  }
+
+  protected def withHybridScanEnabled(block: => Unit): Unit = {
+    setFlintSparkConf(HYBRID_SCAN_ENABLED, "true")
+    try {
+      block
+    } finally {
+      setFlintSparkConf(HYBRID_SCAN_ENABLED, "false")
+    }
   }
 }

--- a/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndexSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndexSuite.scala
@@ -17,7 +17,6 @@ import org.apache.spark.sql.{Column, DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Literal, Predicate}
 import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory}
-import org.apache.spark.sql.flint.config.FlintSparkConf.HYBRID_SCAN_ENABLED
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 
@@ -46,7 +45,7 @@ class FlintSparkSkippingFileIndexSuite extends FlintSuite with Matchers {
       .shouldScanSourceFiles(Map("partition-1" -> Seq("file-1"), "partition-2" -> Seq("file-3")))
   }
 
-  test("should skip unrefreshed source files by default") {
+  test("should skip unknown source files by default") {
     assertFlintFileIndex()
       .withSourceFiles(Map(partition1))
       .withIndexData(
@@ -57,7 +56,7 @@ class FlintSparkSkippingFileIndexSuite extends FlintSuite with Matchers {
       .shouldScanSourceFiles(Map("partition-1" -> Seq("file-1")))
   }
 
-  test("should not skip unrefreshed source files in hybrid-scan mode") {
+  test("should not skip unknown source files in hybrid-scan mode") {
     withHybridScanEnabled {
       assertFlintFileIndex()
         .withSourceFiles(Map(partition1))
@@ -70,7 +69,7 @@ class FlintSparkSkippingFileIndexSuite extends FlintSuite with Matchers {
     }
   }
 
-  test("should not skip unrefreshed source files of multiple partitions in hybrid-scan mode") {
+  test("should not skip unknown source files of multiple partitions in hybrid-scan mode") {
     withHybridScanEnabled {
       assertFlintFileIndex()
         .withSourceFiles(Map(partition1, partition2))
@@ -81,15 +80,6 @@ class FlintSparkSkippingFileIndexSuite extends FlintSuite with Matchers {
         .withIndexFilter(col("year") === 2023)
         .shouldScanSourceFiles(
           Map("partition-1" -> Seq("file-1", "file-2"), "partition-2" -> Seq("file-3")))
-    }
-  }
-
-  private def withHybridScanEnabled(block: => Unit): Unit = {
-    setFlintSparkConf(HYBRID_SCAN_ENABLED, "true")
-    try {
-      block
-    } finally {
-      setFlintSparkConf(HYBRID_SCAN_ENABLED, "false")
     }
   }
 

--- a/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndexSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndexSuite.scala
@@ -13,37 +13,63 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.FlintSuite
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{Column, DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.{Literal, Predicate}
 import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types._
 
 class FlintSparkSkippingFileIndexSuite extends FlintSuite with Matchers {
 
-  test("") {
-    val baseFileIndex = mock[FileIndex]
-    when(baseFileIndex.listFiles(any(), any()))
-      .thenReturn(mockPartitions(Map("partition-1" -> Seq("filepath-1"))))
-
-    val queryIndex = mockQueryIndexDf(Seq("filepath-1"))
-
-    val fileIndex = FlintSparkSkippingFileIndex(baseFileIndex, queryIndex)
-    fileIndex.listFiles(Seq.empty, Seq.empty) shouldBe
-      mockPartitions(Map("partition-1" -> Seq("filepath-1")))
+  test("should skip unknown source files in non-hybrid-scan mode") {
+    assertFlintFileIndex()
+      .withSourceFiles(Map("partition-1" -> Seq("file-1", "file-2")))
+      .withIndexData(
+        Map((FILE_PATH_COLUMN, StringType), ("year", IntegerType)),
+        Seq(Row("file-1", 2023), Row("file-2", 2022)))
+      .withIndexFilter(col("year") === 2023)
+      .shouldScanSourceFiles(Map("partition-1" -> Seq("file-1")))
   }
 
-  private def mockPartitions(partitions: Map[String, Seq[String]]): Seq[PartitionDirectory] = {
-    partitions.map { case (partitionName, filePaths) =>
-      val files = filePaths.map(path => new FileStatus(0, false, 0, 0, 0, new Path(path)))
-      PartitionDirectory(InternalRow(Literal(partitionName)), files)
-    }.toSeq
+  private def assertFlintFileIndex(): AssertionHelper = {
+    new AssertionHelper
   }
 
-  private def mockQueryIndexDf(filePaths: Seq[String]): DataFrame = {
-    val mySpark = spark
-    import mySpark.implicits._
+  private class AssertionHelper {
+    private val baseFileIndex = mock[FileIndex]
+    private var indexScan: DataFrame = _
+    private var indexFilter: Predicate = _
 
-    val columns = Seq(FILE_PATH_COLUMN)
-    filePaths.toDF(columns: _*)
+    def withSourceFiles(partitions: Map[String, Seq[String]]): AssertionHelper = {
+      when(baseFileIndex.listFiles(any(), any()))
+        .thenReturn(mockPartitions(partitions))
+      this
+    }
+
+    def withIndexData(columns: Map[String, DataType], data: Seq[Row]): AssertionHelper = {
+      val schema = StructType(columns.map { case (colName, colType) =>
+        StructField(colName, colType, nullable = false)
+      }.toSeq)
+      indexScan = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      this
+    }
+
+    def withIndexFilter(pred: Column): AssertionHelper = {
+      indexFilter = pred.expr.asInstanceOf[Predicate]
+      this
+    }
+
+    def shouldScanSourceFiles(partitions: Map[String, Seq[String]]): Unit = {
+      val fileIndex = FlintSparkSkippingFileIndex(baseFileIndex, indexScan, indexFilter)
+      fileIndex.listFiles(Seq.empty, Seq.empty) shouldBe mockPartitions(partitions)
+    }
+
+    private def mockPartitions(partitions: Map[String, Seq[String]]): Seq[PartitionDirectory] = {
+      partitions.map { case (partitionName, filePaths) =>
+        val files = filePaths.map(path => new FileStatus(0, false, 0, 0, 0, new Path(path)))
+        PartitionDirectory(InternalRow(Literal(partitionName)), files)
+      }.toSeq
+    }
   }
 }

--- a/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndexSuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingFileIndexSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.skipping
+
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.opensearch.flint.spark.skipping.FlintSparkSkippingIndex.FILE_PATH_COLUMN
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import org.apache.spark.FlintSuite
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.execution.datasources.{FileIndex, PartitionDirectory}
+
+class FlintSparkSkippingFileIndexSuite extends FlintSuite with Matchers {
+
+  test("") {
+    val baseFileIndex = mock[FileIndex]
+    when(baseFileIndex.listFiles(any(), any()))
+      .thenReturn(mockPartitions(Map("partition-1" -> Seq("filepath-1"))))
+
+    val queryIndex = mockQueryIndexDf(Seq("filepath-1"))
+
+    val fileIndex = FlintSparkSkippingFileIndex(baseFileIndex, queryIndex)
+    fileIndex.listFiles(Seq.empty, Seq.empty) shouldBe
+      mockPartitions(Map("partition-1" -> Seq("filepath-1")))
+  }
+
+  private def mockPartitions(partitions: Map[String, Seq[String]]): Seq[PartitionDirectory] = {
+    partitions.map { case (partitionName, filePaths) =>
+      val files = filePaths.map(path => new FileStatus(0, false, 0, 0, 0, new Path(path)))
+      PartitionDirectory(InternalRow(Literal(partitionName)), files)
+    }.toSeq
+  }
+
+  private def mockQueryIndexDf(filePaths: Seq[String]): DataFrame = {
+    val mySpark = spark
+    import mySpark.implicits._
+
+    val columns = Seq(FILE_PATH_COLUMN)
+    filePaths.toDF(columns: _*)
+  }
+}

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
@@ -333,7 +333,7 @@ class FlintSparkSkippingIndexSuite
   // Custom matcher to check if FlintSparkSkippingFileIndex has expected filter condition
   def hasIndexFilter(expect: Column): Matcher[FlintSparkSkippingFileIndex] = {
     Matcher { (fileIndex: FlintSparkSkippingFileIndex) =>
-      val plan = fileIndex.filterByIndex.queryExecution.logical
+      val plan = fileIndex.queryIndex.queryExecution.logical
       val hasExpectedFilter = plan.find {
         case Filter(actual, _) =>
           actual.semanticEquals(expect.expr)

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
@@ -301,6 +301,32 @@ class FlintSparkSkippingIndexSuite
         hasIndexFilter(col("MinMax_age_0") <= 25 && col("MinMax_age_1") >= 25))
   }
 
+  test("should rewrite applicable query to scan latest source files in hybrid scan mode") {
+    flint
+      .skippingIndex()
+      .onTable(testTable)
+      .addPartitions("month")
+      .create()
+    flint.refreshIndex(testIndex, FULL)
+
+    // Generate a new source file which is not in index data
+    sql(s"""
+           | INSERT INTO $testTable
+           | PARTITION (year=2023, month=4)
+           | VALUES ('Hello', 35, 'Vancouver')
+           | """.stripMargin)
+
+    withHybridScanEnabled {
+      val query = sql(s"""
+                         | SELECT address
+                         | FROM $testTable
+                         | WHERE month = 4
+                         |""".stripMargin)
+
+      checkAnswer(query, Seq(Row("Seattle"), Row("Vancouver")))
+    }
+  }
+
   test("should return empty if describe index not exist") {
     flint.describeIndex("non-exist") shouldBe empty
   }

--- a/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
+++ b/flint/integ-test/src/test/scala/org/opensearch/flint/spark/FlintSparkSkippingIndexSuite.scala
@@ -333,7 +333,7 @@ class FlintSparkSkippingIndexSuite
   // Custom matcher to check if FlintSparkSkippingFileIndex has expected filter condition
   def hasIndexFilter(expect: Column): Matcher[FlintSparkSkippingFileIndex] = {
     Matcher { (fileIndex: FlintSparkSkippingFileIndex) =>
-      val plan = fileIndex.queryIndex.queryExecution.logical
+      val plan = fileIndex.indexScan.queryExecution.logical
       val hasExpectedFilter = plan.find {
         case Filter(actual, _) =>
           actual.semanticEquals(expect.expr)


### PR DESCRIPTION
### Description

Add hybrid scan mode which covers the latest source files that haven't refreshed to Flint index yet:

1. For skipping index, this means source file unknown in skipping index will not be skipped (because we're not sure if it has the answer for a query <= this is covered in this PR
2. For covered index/MV, this means we need to union all the results from unknown files and index data
 
### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/2
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).