### PR TITLE
Improve filter push down on skipping index

### DIFF
--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingStrategy.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/FlintSparkSkippingStrategy.scala
@@ -9,6 +9,7 @@ import org.json4s.CustomSerializer
 import org.json4s.JsonAST.JString
 import org.opensearch.flint.spark.skipping.FlintSparkSkippingStrategy.SkippingKind.SkippingKind
 
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.Predicate
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
 
@@ -54,6 +55,9 @@ trait FlintSparkSkippingStrategy {
    *   new filtering condition on index data or empty if index not applicable
    */
   def rewritePredicate(predicate: Predicate): Option[Predicate]
+
+  // Convert a column to a predicate
+  protected def convertToPredicate(col: Column): Predicate = col.expr.asInstanceOf[Predicate]
 }
 
 object FlintSparkSkippingStrategy {

--- a/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/partition/PartitionSkippingStrategy.scala
+++ b/flint/flint-spark-integration/src/main/scala/org/opensearch/flint/spark/skipping/partition/PartitionSkippingStrategy.scala
@@ -32,7 +32,7 @@ case class PartitionSkippingStrategy(
   override def rewritePredicate(predicate: Predicate): Option[Predicate] = {
     // Column has same name in index data, so just rewrite to the same equation
     predicate.collect { case EqualTo(AttributeReference(`columnName`, _, _, _), value: Literal) =>
-      EqualTo(col(columnName).expr, value)
+      convertToPredicate(col(columnName) === value)
     }.headOption
   }
 }

--- a/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/minmax/MinMaxSkippingStrategySuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/minmax/MinMaxSkippingStrategySuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.skipping.minmax
+
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, GreaterThan, GreaterThanOrEqual, In, LessThan, LessThanOrEqual, Literal, Or}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.IntegerType
+
+class MinMaxSkippingStrategySuite extends SparkFunSuite with Matchers {
+
+  private val strategy = MinMaxSkippingStrategy(columnName = "age", columnType = "integer")
+
+  private val indexCol = AttributeReference("age", IntegerType, nullable = false)()
+
+  private val minCol = col("MinMax_age_0").expr
+  private val maxCol = col("MinMax_age_1").expr
+
+  test("should rewrite EqualTo(<indexCol>, <value>)") {
+    strategy.rewritePredicate(EqualTo(indexCol, Literal(30))) shouldBe Some(
+      And(LessThanOrEqual(minCol, Literal(30)), GreaterThanOrEqual(maxCol, Literal(30))))
+  }
+
+  test("should rewrite LessThan(<indexCol>, <value>)") {
+    strategy.rewritePredicate(LessThan(indexCol, Literal(30))) shouldBe Some(
+      LessThan(minCol, Literal(30)))
+  }
+
+  test("should rewrite LessThanOrEqual(<indexCol>, <value>)") {
+    strategy.rewritePredicate(LessThanOrEqual(indexCol, Literal(30))) shouldBe Some(
+      LessThanOrEqual(minCol, Literal(30)))
+  }
+
+  test("should rewrite GreaterThan(<indexCol>, <value>)") {
+    strategy.rewritePredicate(GreaterThan(indexCol, Literal(30))) shouldBe Some(
+      GreaterThan(maxCol, Literal(30)))
+  }
+
+  test("should rewrite GreaterThanOrEqual(<indexCol>, <value>)") {
+    strategy.rewritePredicate(GreaterThanOrEqual(indexCol, Literal(30))) shouldBe Some(
+      GreaterThanOrEqual(maxCol, Literal(30)))
+  }
+
+  test("should rewrite In(<indexCol>, <value1, value2 ...>") {
+    strategy.rewritePredicate(In(indexCol, Seq(Literal(25), Literal(30)))) shouldBe Some(
+      Or(
+        And(LessThanOrEqual(minCol, Literal(25)), GreaterThanOrEqual(maxCol, Literal(25))),
+        And(LessThanOrEqual(minCol, Literal(30)), GreaterThanOrEqual(maxCol, Literal(30)))))
+  }
+}

--- a/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/partition/PartitionSkippingStrategySuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/partition/PartitionSkippingStrategySuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.skipping.partition
+
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, GreaterThan, Literal}
+import org.apache.spark.sql.types.IntegerType
+
+class PartitionSkippingStrategySuite extends SparkFunSuite with Matchers {
+
+  private val strategy = PartitionSkippingStrategy(columnName = "year", columnType = "int")
+
+  private val indexCol = AttributeReference("year", IntegerType, nullable = false)()
+
+  test("should rewrite EqualTo(<indexCol>, <value>)") {
+    strategy.rewritePredicate(EqualTo(indexCol, Literal(2023))) shouldBe Some(
+      EqualTo(UnresolvedAttribute("year"), Literal(2023)))
+  }
+
+  test("should not rewrite predicate with other column)") {
+    val predicate =
+      EqualTo(AttributeReference("month", IntegerType, nullable = false)(), Literal(4))
+
+    strategy.rewritePredicate(predicate) shouldBe empty
+  }
+
+  test("should not rewrite GreaterThan(<indexCol>, <value>)") {
+    strategy.rewritePredicate(GreaterThan(indexCol, Literal(2023))) shouldBe empty
+  }
+
+  test("should only rewrite EqualTo(<indexCol>, <value>) in conjunction") {
+    val predicate =
+      And(EqualTo(indexCol, Literal(2023)), GreaterThan(indexCol, Literal(2023)))
+
+    strategy.rewritePredicate(predicate) shouldBe Some(
+      EqualTo(UnresolvedAttribute("year"), Literal(2023)))
+  }
+}

--- a/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/valueset/ValueSetSkippingStrategySuite.scala
+++ b/flint/flint-spark-integration/src/test/scala/org/opensearch/flint/spark/skipping/valueset/ValueSetSkippingStrategySuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.flint.spark.skipping.valueset
+
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, GreaterThan, Literal}
+import org.apache.spark.sql.types.StringType
+
+class ValueSetSkippingStrategySuite extends SparkFunSuite with Matchers {
+
+  private val strategy = ValueSetSkippingStrategy(columnName = "name", columnType = "string")
+
+  private val indexCol = AttributeReference("name", StringType, nullable = false)()
+
+  test("should rewrite EqualTo(<indexCol>, <value>)") {
+    strategy.rewritePredicate(EqualTo(indexCol, Literal("hello"))) shouldBe Some(
+      EqualTo(UnresolvedAttribute("name"), Literal("hello")))
+  }
+
+  test("should not rewrite predicate with other column") {
+    val predicate =
+      EqualTo(AttributeReference("address", StringType, nullable = false)(), Literal("hello"))
+
+    strategy.rewritePredicate(predicate) shouldBe empty
+  }
+
+  test("should not rewrite GreaterThan(<indexCol>, <value>)") {
+    strategy.rewritePredicate(GreaterThan(indexCol, Literal("hello"))) shouldBe empty
+  }
+
+  test("should only rewrite EqualTo(<indexCol>, <value>) in conjunction") {
+    val predicate =
+      And(EqualTo(indexCol, Literal("hello")), GreaterThan(indexCol, Literal(2023)))
+
+    strategy.rewritePredicate(predicate) shouldBe Some(
+      EqualTo(UnresolvedAttribute("name"), Literal("hello")))
+  }
+}


### PR DESCRIPTION
### Description

Add more support for different expression that can be pushed down to skipping index.
 
### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/2
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).