### PR TITLE
fix flakytest when tests.locale=tr

### DIFF
--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/QueryResult.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/QueryResult.java
@@ -9,6 +9,7 @@ package org.opensearch.sql.protocol.response;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +59,7 @@ public class QueryResult implements Iterable<Object[]> {
     Map<String, String> colNameTypes = new LinkedHashMap<>();
     schema.getColumns().forEach(column -> colNameTypes.put(
         getColumnName(column),
-        column.getExprType().typeName().toLowerCase()));
+        column.getExprType().typeName().toLowerCase(Locale.ROOT)));
     return colNameTypes;
   }
 


### PR DESCRIPTION
### Description
* Fix flaktest found in IT when -Dtests.locale=tr.
* Failed IT.
```
./gradlew ':integ-test:integTest' --tests "org.opensearch.sql.ppl.StandaloneIT.testSourceFieldQuery" -Dtests.seed=8DBF6CCDC4AAC1CC -Dtests.security.manager=false -Dtests.locale=tr -Dtests.timezone=Pacific/Marquesas -Druntime.java=11
```
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).