### PR TITLE
Bump guava version to 32.0.1

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 dependencies {
     api "org.antlr:antlr4-runtime:4.7.1"
-    api group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    api group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     api group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.3'
@@ -43,7 +43,7 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.9.1'
-    testImplementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    testImplementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -44,7 +44,7 @@ pitest {
 }
 
 dependencies {
-    api group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    api group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     api group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -88,7 +88,7 @@ dependencies {
             because 'https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379'
         }
     }
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'org.json', name: 'json', version:'20230227'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     runtimeOnly group: 'org.reflections', name: 'reflections', version: '0.9.12'
 
     implementation "org.antlr:antlr4-runtime:4.7.1"
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     api group: 'org.json', name: 'json', version: '20230227'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
     api project(':common')

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     antlr "org.antlr:antlr4:4.7.1"
 
     implementation "org.antlr:antlr4-runtime:4.7.1"
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'org.json', name: 'json', version:'20230227'
     implementation project(':common')
     implementation project(':core')


### PR DESCRIPTION
### Description
- Bump guava version to 32.0.1
 
### Issues Resolved
CVE-2023-2976
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).