### PR TITLE
Bump `log4j` version.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -34,7 +34,7 @@ repositories {
 dependencies {
     api "org.antlr:antlr4-runtime:4.7.1"
     api group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
-    api group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
+    api group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.20.0'
     api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.3'
     implementation 'com.github.babbel:okhttp-aws-signer:1.0.2'

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -94,7 +94,7 @@ dependencies {
     testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
     testImplementation group: 'org.opensearch.driver', name: 'opensearch-sql-jdbc', version: System.getProperty("jdbcDriverVersion", '1.2.0.0')
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.20.0'
     testImplementation project(':opensearch-sql-plugin')
     testImplementation project(':legacy')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation "org.antlr:antlr4-runtime:4.7.1"
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     api group: 'org.json', name: 'json', version: '20230227'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.20.0'
     api project(':common')
     api project(':core')
     api project(':protocol')


### PR DESCRIPTION
### Description
`log4j` was updated on upstream https://github.com/opensearch-project/OpenSearch/pull/8307.
 
### Issues Resolved
Fix build failures caused by referencing different `log4j` versions.
```
Could not determine the dependencies of task ':opensearch-sql-plugin:thirdPartyAudit'.
> Could not resolve all dependencies for configuration ':opensearch-sql-plugin:runtimeClasspath'.
   > Conflict(s) found for the following module(s):
       - org.apache.logging.log4j:log4j-api between versions 2.20.0 and 2.17.1
       - org.apache.logging.log4j:log4j-core between versions 2.20.0 and 2.17.1
     Run with:
         --scan or
         :opensearch-sql-plugin:dependencyInsight --configuration runtimeClasspath --dependency org.apache.logging.log4j:log4j-api
     to get more insight on how to solve the conflict.
```
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).