### PR TITLE
Restrict master key config only to integTest cluster

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -129,11 +129,11 @@ testClusters.all {
     if (System.getProperty("debugJVM") != null) {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
     }
-    setting "plugins.query.datasources.encryption.masterkey", "1234567812345678"
 }
 
 testClusters.integTest {
     plugin ":opensearch-sql-plugin"
+    setting "plugins.query.datasources.encryption.masterkey", "1234567812345678"
 }
 
 testClusters {


### PR DESCRIPTION
### Description
Instead of applying master key config to all clusters. Applied only to integTest cluster.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).