### PR TITLE
Change query range response structure

### DIFF
--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_query_range.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_query_range.json
@@ -1,0 +1,9 @@
+{
+    "root": {
+        "name": "QueryRangeFunctionTableScanOperator",
+        "description": {
+            "request": "query_range(prometheus_http_requests_total, 1689281439, 1689291439, 14)"
+        },
+        "children": []
+    }
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricScan.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricScan.java
@@ -41,10 +41,6 @@ public class PrometheusMetricScan extends TableScanOperator {
   private Iterator<ExprValue> iterator;
 
   @Setter
-  @Getter
-  private Boolean isQueryRangeFunctionScan = Boolean.FALSE;
-
-  @Setter
   private PrometheusResponseFieldNames prometheusResponseFieldNames;
 
 
@@ -69,8 +65,7 @@ public class PrometheusMetricScan extends TableScanOperator {
         JSONObject responseObject = prometheusClient.queryRange(
             request.getPromQl(),
             request.getStartTime(), request.getEndTime(), request.getStep());
-        return new PrometheusResponse(responseObject, prometheusResponseFieldNames,
-            isQueryRangeFunctionScan).iterator();
+        return new PrometheusResponse(responseObject, prometheusResponseFieldNames).iterator();
       } catch (IOException e) {
         LOG.error(e.getMessage());
         throw new RuntimeException("Error fetching data from prometheus server. " + e.getMessage());

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTable.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTable.java
@@ -97,10 +97,6 @@ public class PrometheusMetricTable implements Table {
   public PhysicalPlan implement(LogicalPlan plan) {
     PrometheusMetricScan metricScan =
         new PrometheusMetricScan(prometheusClient);
-    if (prometheusQueryRequest != null) {
-      metricScan.setRequest(prometheusQueryRequest);
-      metricScan.setIsQueryRangeFunctionScan(Boolean.TRUE);
-    }
     return plan.accept(new PrometheusDefaultImplementor(), metricScan);
   }
 

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/implementor/PrometheusDefaultImplementor.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/implementor/PrometheusDefaultImplementor.java
@@ -94,14 +94,12 @@ public class PrometheusDefaultImplementor
   public PhysicalPlan visitRelation(LogicalRelation node,
                                     PrometheusMetricScan context) {
     PrometheusMetricTable prometheusMetricTable = (PrometheusMetricTable) node.getTable();
-    if (prometheusMetricTable.getMetricName() != null) {
-      String query = SeriesSelectionQueryBuilder.build(node.getRelationName(), null);
-      context.getRequest().setPromQl(query);
-      setTimeRangeParameters(null, context);
-      context.getRequest()
-          .setStep(StepParameterResolver.resolve(context.getRequest().getStartTime(),
-              context.getRequest().getEndTime(), null));
-    }
+    String query = SeriesSelectionQueryBuilder.build(node.getRelationName(), null);
+    context.getRequest().setPromQl(query);
+    setTimeRangeParameters(null, context);
+    context.getRequest()
+        .setStep(StepParameterResolver.resolve(context.getRequest().getStartTime(),
+            context.getRequest().getEndTime(), null));
     return context;
   }
 

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/scan/QueryRangeFunctionTableScanOperatorTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/functions/scan/QueryRangeFunctionTableScanOperatorTest.java
@@ -15,6 +15,7 @@ import static org.opensearch.sql.prometheus.constants.TestConstants.ENDTIME;
 import static org.opensearch.sql.prometheus.constants.TestConstants.QUERY;
 import static org.opensearch.sql.prometheus.constants.TestConstants.STARTTIME;
 import static org.opensearch.sql.prometheus.constants.TestConstants.STEP;
+import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.LABELS;
 import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.TIMESTAMP;
 import static org.opensearch.sql.prometheus.data.constants.PrometheusFieldConstants.VALUE;
 import static org.opensearch.sql.prometheus.utils.TestUtils.getJson;
@@ -22,6 +23,7 @@ import static org.opensearch.sql.prometheus.utils.TestUtils.getJson;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import lombok.SneakyThrows;
 import org.json.JSONObject;
@@ -30,17 +32,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.model.ExprCollectionValue;
 import org.opensearch.sql.data.model.ExprDoubleValue;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.prometheus.client.PrometheusClient;
 import org.opensearch.sql.prometheus.request.PrometheusQueryRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class QueryRangeFunctionTableScanOperatorTest {
+class QueryRangeFunctionTableScanOperatorTest {
   @Mock
   private PrometheusClient prometheusClient;
 
@@ -61,22 +65,32 @@ public class QueryRangeFunctionTableScanOperatorTest {
         .thenReturn(new JSONObject(getJson("query_range_result.json")));
     queryRangeFunctionTableScanOperator.open();
     Assertions.assertTrue(queryRangeFunctionTableScanOperator.hasNext());
-    ExprTupleValue firstRow = new ExprTupleValue(new LinkedHashMap<>() {{
-        put(TIMESTAMP, new ExprTimestampValue(Instant.ofEpochMilli(1435781430781L)));
-        put(VALUE, new ExprDoubleValue(1));
+    LinkedHashMap<String, ExprValue> labelsMap = new LinkedHashMap<>() {{
         put("instance", new ExprStringValue("localhost:9090"));
         put("__name__", new ExprStringValue("up"));
         put("job", new ExprStringValue("prometheus"));
+      }};
+    ExprTupleValue firstRow = new ExprTupleValue(new LinkedHashMap<>() {{
+        put(LABELS, new ExprTupleValue(labelsMap));
+        put(TIMESTAMP, new ExprCollectionValue(Collections
+            .singletonList(new ExprTimestampValue(Instant.ofEpochMilli(1435781430781L)))));
+        put(VALUE, new ExprCollectionValue(Collections.singletonList(new ExprDoubleValue(1))));
       }
     });
+
     assertEquals(firstRow, queryRangeFunctionTableScanOperator.next());
     Assertions.assertTrue(queryRangeFunctionTableScanOperator.hasNext());
-    ExprTupleValue secondRow = new ExprTupleValue(new LinkedHashMap<>() {{
-        put("@timestamp", new ExprTimestampValue(Instant.ofEpochMilli(1435781430781L)));
-        put("@value", new ExprDoubleValue(0));
+
+    LinkedHashMap<String, ExprValue> labelsMap2 = new LinkedHashMap<>() {{
         put("instance", new ExprStringValue("localhost:9091"));
         put("__name__", new ExprStringValue("up"));
         put("job", new ExprStringValue("node"));
+      }};
+    ExprTupleValue secondRow = new ExprTupleValue(new LinkedHashMap<>() {{
+        put(LABELS, new ExprTupleValue(labelsMap2));
+        put(TIMESTAMP, new ExprCollectionValue(Collections
+            .singletonList(new ExprTimestampValue(Instant.ofEpochMilli(1435781430781L)))));
+        put(VALUE, new ExprCollectionValue(Collections.singletonList(new ExprDoubleValue(0))));
       }
     });
     assertEquals(secondRow, queryRangeFunctionTableScanOperator.next());
@@ -120,11 +134,9 @@ public class QueryRangeFunctionTableScanOperatorTest {
         .thenReturn(new JSONObject(getJson("query_range_result.json")));
     queryRangeFunctionTableScanOperator.open();
     ArrayList<ExecutionEngine.Schema.Column> columns = new ArrayList<>();
-    columns.add(new ExecutionEngine.Schema.Column(TIMESTAMP, TIMESTAMP, ExprCoreType.TIMESTAMP));
-    columns.add(new ExecutionEngine.Schema.Column(VALUE, VALUE, ExprCoreType.DOUBLE));
-    columns.add(new ExecutionEngine.Schema.Column("instance", "instance", ExprCoreType.STRING));
-    columns.add(new ExecutionEngine.Schema.Column("__name__", "__name__", ExprCoreType.STRING));
-    columns.add(new ExecutionEngine.Schema.Column("job", "job", ExprCoreType.STRING));
+    columns.add(new ExecutionEngine.Schema.Column(TIMESTAMP, TIMESTAMP, ExprCoreType.ARRAY));
+    columns.add(new ExecutionEngine.Schema.Column(VALUE, VALUE, ExprCoreType.ARRAY));
+    columns.add(new ExecutionEngine.Schema.Column(LABELS, LABELS, ExprCoreType.STRUCT));
     ExecutionEngine.Schema expectedSchema = new ExecutionEngine.Schema(columns);
     assertEquals(expectedSchema, queryRangeFunctionTableScanOperator.schema());
   }

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricScanTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricScanTest.java
@@ -209,39 +209,6 @@ public class PrometheusMetricScanTest {
     Assertions.assertFalse(prometheusMetricScan.hasNext());
   }
 
-  @Test
-  @SneakyThrows
-  void testQueryResponseIteratorForQueryRangeFunction() {
-    PrometheusMetricScan prometheusMetricScan = new PrometheusMetricScan(prometheusClient);
-    prometheusMetricScan.setIsQueryRangeFunctionScan(Boolean.TRUE);
-    prometheusMetricScan.getRequest().setPromQl(QUERY);
-    prometheusMetricScan.getRequest().setStartTime(STARTTIME);
-    prometheusMetricScan.getRequest().setEndTime(ENDTIME);
-    prometheusMetricScan.getRequest().setStep(STEP);
-
-    when(prometheusClient.queryRange(any(), any(), any(), any()))
-        .thenReturn(new JSONObject(getJson("query_range_result.json")));
-    prometheusMetricScan.open();
-    Assertions.assertTrue(prometheusMetricScan.hasNext());
-    ExprTupleValue firstRow = new ExprTupleValue(new LinkedHashMap<>() {{
-        put(TIMESTAMP, new ExprTimestampValue(Instant.ofEpochMilli(1435781430781L)));
-        put(VALUE, new ExprLongValue(1));
-        put(LABELS, new ExprStringValue(
-            "{\"instance\":\"localhost:9090\",\"__name__\":\"up\",\"job\":\"prometheus\"}"));
-      }
-    });
-    assertEquals(firstRow, prometheusMetricScan.next());
-    Assertions.assertTrue(prometheusMetricScan.hasNext());
-    ExprTupleValue secondRow = new ExprTupleValue(new LinkedHashMap<>() {{
-        put(TIMESTAMP, new ExprTimestampValue(Instant.ofEpochMilli(1435781430781L)));
-        put(VALUE, new ExprLongValue(0));
-        put(LABELS, new ExprStringValue(
-            "{\"instance\":\"localhost:9091\",\"__name__\":\"up\",\"job\":\"node\"}"));
-      }
-    });
-    assertEquals(secondRow, prometheusMetricScan.next());
-    Assertions.assertFalse(prometheusMetricScan.hasNext());
-  }
 
   @Test
   @SneakyThrows

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTableTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusMetricTableTest.java
@@ -112,32 +112,6 @@ class PrometheusMetricTableTest {
   }
 
   @Test
-  void testImplementWithQueryRangeFunction() {
-    PrometheusQueryRequest prometheusQueryRequest = new PrometheusQueryRequest();
-    prometheusQueryRequest.setPromQl("test");
-    prometheusQueryRequest.setStep("15m");
-    PrometheusMetricTable prometheusMetricTable =
-        new PrometheusMetricTable(client, prometheusQueryRequest);
-    List<NamedExpression> finalProjectList = new ArrayList<>();
-    finalProjectList.add(DSL.named(VALUE, DSL.ref(VALUE, STRING)));
-    finalProjectList.add(DSL.named(TIMESTAMP, DSL.ref(TIMESTAMP, ExprCoreType.TIMESTAMP)));
-    PhysicalPlan plan = prometheusMetricTable.implement(
-        project(relation("query_range", prometheusMetricTable),
-            finalProjectList, null));
-
-
-    assertTrue(plan instanceof ProjectOperator);
-    List<NamedExpression> projectList = ((ProjectOperator) plan).getProjectList();
-    List<String> outputFields
-        = projectList.stream().map(NamedExpression::getName).collect(Collectors.toList());
-    assertEquals(List.of(VALUE, TIMESTAMP), outputFields);
-    assertTrue(((ProjectOperator) plan).getInput() instanceof PrometheusMetricScan);
-    PrometheusMetricScan prometheusMetricScan =
-        (PrometheusMetricScan) ((ProjectOperator) plan).getInput();
-    assertEquals(prometheusQueryRequest, prometheusMetricScan.getRequest());
-  }
-
-  @Test
   void testImplementWithBasicMetricQuery() {
     PrometheusMetricTable prometheusMetricTable =
         new PrometheusMetricTable(client, "prometheus_http_requests_total");


### PR DESCRIPTION
### Description
This PR is for changing the response structure of query_range table function in Prometheus Connector.

BWC failures are unrelated. WIll get fixed with the below PRs
https://github.com/opensearch-project/sql/pull/1876
https://github.com/opensearch-project/sql/pull/1868

Request::
PUT http://localhost:9200/_plugins/_ppl
```
{
    "query" : "source = my_prometheus.query_range('prometheus_http_requests_total',1689281439,1689291439,14)"
}
```
Sample Old Response
```
{
    "schema": [
        {
            "name": "@timestamp",
            "type": "timestamp"
        },
        {
            "name": "@value",
            "type": "double"
        },
        {
            "name": "handler",
            "type": "string"
        },
        {
            "name": "code",
            "type": "string"
        },
        {
            "name": "instance",
            "type": "string"
        },
        {
            "name": "__name__",
            "type": "string"
        },
        {
            "name": "job",
            "type": "string"
        }
    ],
    "datarows": [
        [
            "2023-07-17 23:57:07",
            5.0,
            "/api/v1/query_range",
            "200",
            "localhost:9090",
            "prometheus_http_requests_total",
            "prometheus"
        ],
        [
            "2023-07-17 23:49:39",
            1.0,
            "/metrics",
            "200",
            "localhost:9090",
            "prometheus_http_requests_total",
            "prometheus"
        ]
    "total": 34,
    "size": 34
}
```
There is no segregation of data among different timeseries in a metric.

In the new response below...each timeseries of a metric is a row individually.


Response::
```
{
    "schema": [
        {
            "name": "@timestamp",
            "type": "array"
        },
        {
            "name": "@value",
            "type": "array"
        },
        {
            "name": "@labels",
            "type": "struct"
        }
    ],
    "datarows": [
        [
            {
                "handler": "/api/v1/query_range",
                "code": "200",
                "instance": "localhost:9090",
                "__name__": "prometheus_http_requests_total",
                "job": "prometheus"
            },
            [
                "2023-07-13 23:37:15"
            ],
            [
                3.0
            ]
        ],
        [
            {
                "handler": "/metrics",
                "code": "200",
                "instance": "localhost:9090",
                "__name__": "prometheus_http_requests_total",
                "job": "prometheus"
            },
            [
                "2023-07-13 23:33:17",
                "2023-07-13 23:33:31",
                "2023-07-13 23:33:45",
                "2023-07-13 23:33:59",
                "2023-07-13 23:34:13",
                "2023-07-13 23:34:27",
                "2023-07-13 23:34:41",
                "2023-07-13 23:34:55",
                "2023-07-13 23:35:09",
                "2023-07-13 23:35:23",
                "2023-07-13 23:35:37",
                "2023-07-13 23:35:51",
                "2023-07-13 23:36:05",
                "2023-07-13 23:36:19",
                "2023-07-13 23:36:33",
                "2023-07-13 23:36:47",
                "2023-07-13 23:37:01",
                "2023-07-13 23:37:15"
            ],
            [
                1.0,
                2.0,
                3.0,
                4.0,
                5.0,
                6.0,
                7.0,
                7.0,
                8.0,
                9.0,
                10.0,
                11.0,
                12.0,
                13.0,
                14.0,
                15.0,
                16.0,
                17.0
            ]
        ]
    ],
    "total": 2,
    "size": 2
}
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).