### PR TITLE
Fixed missing underscores in day_of_week doctest

### DIFF
--- a/docs/user/ppl/functions/datetime.rst
+++ b/docs/user/ppl/functions/datetime.rst
@@ -754,13 +754,13 @@ Synonyms: `DAYOFWEEK`_
 
 Example::
 
-    os> source=people | eval `DAYOFWEEK(DATE('2020-08-26'))` = DAYOFWEEK(DATE('2020-08-26')) | fields `DAYOFWEEK(DATE('2020-08-26'))`
+    os> source=people | eval `DAY_OF_WEEK(DATE('2020-08-26'))` = DAY_OF_WEEK(DATE('2020-08-26')) | fields `DAY_OF_WEEK(DATE('2020-08-26'))`
     fetched rows / total rows = 1/1
-    +---------------------------------+
-    | DAYOFWEEK(DATE('2020-08-26'))   |
-    |---------------------------------|
-    | 4                               |
-    +---------------------------------+
+    +-----------------------------------+
+    | DAY_OF_WEEK(DATE('2020-08-26'))   |
+    |-----------------------------------|
+    | 4                                 |
+    +-----------------------------------+
 
 
 DAYOFYEAR


### PR DESCRIPTION
### Description
Fixed the `day_of_week` PPL doctest accidentally calling the `dayofweek` function instead
 
### Issues Resolved
No related issues
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).