### PR TITLE
Added support of timestamp/date/time using curly brackets

### DIFF
--- a/docs/user/dql/expressions.rst
+++ b/docs/user/dql/expressions.rst
@@ -25,7 +25,7 @@ A literal is a symbol that represents a value. The most common literal values in
 1. Numeric literals: specify numeric values such as integer and floating-point numbers.
 2. String literals: specify a string enclosed by single or double quotes.
 3. Boolean literals: ``true`` or ``false``.
-4. Date and Time literals: DATE 'YYYY-MM-DD' represent the date, TIME 'hh:mm:ss' represent the time, TIMESTAMP 'YYYY-MM-DD hh:mm:ss' represent the timestamp.
+4. Date and Time literals: DATE 'YYYY-MM-DD' represent the date, TIME 'hh:mm:ss' represent the time, TIMESTAMP 'YYYY-MM-DD hh:mm:ss' represent the timestamp. You can also surround the literals with curly brackets, if you do, you can replace date with d, time with t, and timestamp with ts
 
 Examples
 --------
@@ -48,6 +48,15 @@ Here is an example for different type of literals::
     |-----------+-----------+-----------+-----------+----------+-----------+-----------+-------------+------------|
     | Hello     | Hello     | It"s      | It's      | It's     | "Its"     | It's      | It\'s       | \I\t\s     |
     +-----------+-----------+-----------+-----------+----------+-----------+-----------+-------------+------------+
+
+
+    os> SELECT {DATE '2020-07-07'}, {D '2020-07-07'}, {TIME '01:01:01'}, {T '01:01:01'}, {TIMESTAMP '2020-07-07 01:01:01'}, {TS '2020-07-07 01:01:01'}
+    fetched rows / total rows = 1/1
+    +-----------------------+--------------------+---------------------+------------------+-------------------------------------+------------------------------+
+    | {DATE '2020-07-07'}   | {D '2020-07-07'}   | {TIME '01:01:01'}   | {T '01:01:01'}   | {TIMESTAMP '2020-07-07 01:01:01'}   | {TS '2020-07-07 01:01:01'}   |
+    |-----------------------+--------------------+---------------------+------------------+-------------------------------------+------------------------------|
+    | 2020-07-07            | 2020-07-07         | 01:01:01            | 01:01:01         | 2020-07-07 01:01:01                 | 2020-07-07 01:01:01          |
+    +-----------------------+--------------------+---------------------+------------------+-------------------------------------+------------------------------+
 
 Limitations
 -----------

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -1319,13 +1319,13 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
     verifySchema(result, schema("{t '17:30:00'}", null, "time"));
     verifyDataRows(result, rows("17:30:00"));
 
-    result = executeQuery("select {time '17:30:00'}");
-    verifySchema(result, schema("{time '17:30:00'}", null, "time"));
-    verifyDataRows(result, rows("17:30:00"));
+    result = executeQuery("select {time '17:30:00.123'}");
+    verifySchema(result, schema("{time '17:30:00.123'}", null, "time"));
+    verifyDataRows(result, rows("17:30:00.123"));
 
-    result = executeQuery("select {t '17:30:00'}");
-    verifySchema(result, schema("{t '17:30:00'}", null, "time"));
-    verifyDataRows(result, rows("17:30:00"));
+    result = executeQuery("select {t '17:30:00.123'}");
+    verifySchema(result, schema("{t '17:30:00.123'}", null, "time"));
+    verifyDataRows(result, rows("17:30:00.123"));
   }
 
   @Test
@@ -1361,11 +1361,13 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   
   @Test
   public void testBracketFails() {
-    assertThrows(ResponseException.class, ()->executeQuery("select {time 'failure'}"));
-    assertThrows(ResponseException.class, ()->executeQuery("select {t 'failure'}"));
-    assertThrows(ResponseException.class, ()->executeQuery("select {date 'failure'}"));
-    assertThrows(ResponseException.class, ()->executeQuery("select {d 'failure'}"));
-    assertThrows(ResponseException.class, ()->executeQuery("select {timestamp 'failure'}"));
-    assertThrows(ResponseException.class, ()->executeQuery("select {ts 'failure'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {time '2020-09-16'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {t '2020-09-16'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {date '17:30:00'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {d '17:30:00'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {timestamp '2020-09-16'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {ts '2020-09-16'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {timestamp '17:30:00'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {ts '17:30:00'}"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -1358,18 +1358,14 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
     compareBrackets("time", "time", "17:30:00");
     compareBrackets("time", "t", "17:30:00");
   }
-
-  private void queryFails(String query) {
-    assertThrows(ResponseException.class, ()->executeQuery(query));
-  }
-
+  
   @Test
   public void testBracketFails() {
-    queryFails("select {time 'failure'}");
-    queryFails("select {t 'failure'}");
-    queryFails("select {date 'failure'}");
-    queryFails("select {d 'failure'}");
-    queryFails("select {timestamp 'failure'}");
-    queryFails("select {ts 'failure'}");
+    assertThrows(ResponseException.class, ()->executeQuery("select {time 'failure'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {t 'failure'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {date 'failure'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {d 'failure'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {timestamp 'failure'}"));
+    assertThrows(ResponseException.class, ()->executeQuery("select {ts 'failure'}"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
@@ -1359,22 +1360,7 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
   }
 
   private void queryFails(String query) {
-    Request request = new Request("POST", QUERY_API_ENDPOINT);
-    request.setJsonEntity(String.format(Locale.ROOT, "{\n" + "  \"query\": \"%s\"\n" + "}", query));
-
-    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
-    restOptionsBuilder.addHeader("Content-Type", "application/json");
-    request.setOptions(restOptionsBuilder);
-
-    boolean fails = false;
-
-    try {
-      client().performRequest(request);
-    } catch(Exception ignored) {
-      fails = true;
-    }
-
-    assertTrue(fails);
+    assertThrows(ResponseException.class, ()->executeQuery(query));
   }
 
   @Test
@@ -1385,6 +1371,5 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
     queryFails("select {d 'failure'}");
     queryFails("select {timestamp 'failure'}");
     queryFails("select {ts 'failure'}");
-
   }
 }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -185,7 +185,6 @@ constant
     // Doesn't support the following types for now
     //| BIT_STRING
     //| NOT? nullLiteral=(NULL_LITERAL | NULL_SPEC_LITERAL)
-    //| LEFT_BRACE dateType=(D | T | TS | DATE | TIME | TIMESTAMP) stringLiteral RIGHT_BRACE
     ;
 
 decimalLiteral
@@ -227,14 +226,17 @@ datetimeLiteral
 
 dateLiteral
     : DATE date=stringLiteral
+    | LEFT_BRACE (DATE | D) date=stringLiteral RIGHT_BRACE
     ;
 
 timeLiteral
     : TIME time=stringLiteral
+    | LEFT_BRACE (TIME | T) time=stringLiteral RIGHT_BRACE
     ;
 
 timestampLiteral
     : TIMESTAMP timestamp=stringLiteral
+    | LEFT_BRACE (TIMESTAMP | TS) timestamp=stringLiteral RIGHT_BRACE
     ;
 
 // Actually, these constants are shortcuts to the corresponding functions

--- a/sql/src/test/java/org/opensearch/sql/common/antlr/SyntaxParserTestBase.java
+++ b/sql/src/test/java/org/opensearch/sql/common/antlr/SyntaxParserTestBase.java
@@ -1,13 +1,11 @@
 package org.opensearch.sql.common.antlr;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
 
 /**
  * A base class for tests for SQL or PPL parser.

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/BracketedTimestampTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/BracketedTimestampTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.sql.antlr;
+
+import org.junit.jupiter.api.Test;
+
+public class BracketedTimestampTest extends SQLParserTest {
+  @Test
+  void date_shortened_test() {
+    acceptQuery("SELECT {d '2001-05-07'}");
+  }
+
+  @Test
+  void date_test() {
+    acceptQuery("SELECT {date '2001-05-07'}");
+  }
+
+  @Test
+  void time_shortened_test() {
+    acceptQuery("SELECT {t '10:11:12'}");
+  }
+
+  @Test
+  void time_test() {
+    acceptQuery("SELECT {time '10:11:12'}");
+  }
+
+  @Test
+  void timestamp_shortened_test() {
+    acceptQuery("SELECT {ts '2001-05-07 10:11:12'}");
+  }
+
+  @Test
+  void timestamp_test() {
+    acceptQuery("SELECT {timestamp '2001-05-07 10:11:12'}");
+  }
+}

--- a/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLParserTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/antlr/SQLParserTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
 package org.opensearch.sql.sql.antlr;
 
 import org.opensearch.sql.common.antlr.SyntaxParserTestBase;


### PR DESCRIPTION
### Description
Added support for using timestamp/date/time using curly brackets in the following ways to fix failing date filters in PowerBI:
| Definition | Type |
| --- | --- |
| {ts 'YYYY-MM-DD hh:mm:ss[.SSS]'} | Timestamp |
| {timestamp 'YYYY-MM-DD hh:mm:ss[.SSS]'} | Timestamp |
| {d 'YYYY-MM-DD'} | Date |
| {date 'YYYY-MM-DD'} | Date |
| {t 'hh:mm:ss[.SSS]'} | Time |
| {time 'hh:mm:ss[.SSS]'} | Time |

 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/364
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).