### PR TITLE
Statically init `typeActionMap` in `OpenSearchExprValueFactory`.

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -105,7 +105,7 @@ public class OpenSearchExprValueFactory {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  private final Map<ExprType, BiFunction<Content, ExprType, ExprValue>> typeActionMap =
+  private static final Map<ExprType, BiFunction<Content, ExprType, ExprValue>> typeActionMap =
       new ImmutableMap.Builder<ExprType, BiFunction<Content, ExprType, ExprValue>>()
           .put(OpenSearchDataType.of(OpenSearchDataType.MappingType.Integer),
               (c, dt) -> new ExprIntegerValue(c.intValue()))
@@ -126,10 +126,12 @@ public class OpenSearchExprValueFactory {
           .put(OpenSearchDataType.of(OpenSearchDataType.MappingType.Boolean),
               (c, dt) -> ExprBooleanValue.of(c.booleanValue()))
           //Handles the creation of DATE, TIME & DATETIME
-          .put(OpenSearchDateType.of(TIME), this::createOpenSearchDateType)
-          .put(OpenSearchDateType.of(DATE), this::createOpenSearchDateType)
-          .put(OpenSearchDateType.of(TIMESTAMP), this::createOpenSearchDateType)
-          .put(OpenSearchDateType.of(DATETIME), this::createOpenSearchDateType)
+          .put(OpenSearchDateType.of(TIME), OpenSearchExprValueFactory::createOpenSearchDateType)
+          .put(OpenSearchDateType.of(DATE), OpenSearchExprValueFactory::createOpenSearchDateType)
+          .put(OpenSearchDateType.of(TIMESTAMP),
+              OpenSearchExprValueFactory::createOpenSearchDateType)
+          .put(OpenSearchDateType.of(DATETIME),
+              OpenSearchExprValueFactory::createOpenSearchDateType)
           .put(OpenSearchDataType.of(OpenSearchDataType.MappingType.Ip),
               (c, dt) -> new OpenSearchExprIpValue(c.stringValue()))
           .put(OpenSearchDataType.of(OpenSearchDataType.MappingType.GeoPoint),
@@ -222,7 +224,7 @@ public class OpenSearchExprValueFactory {
    * @param dataType - field data type
    * @return Parsed value
    */
-  private ExprValue parseDateTimeString(String value, OpenSearchDateType dataType) {
+  private static ExprValue parseDateTimeString(String value, OpenSearchDateType dataType) {
     List<DateFormatter> formatters = dataType.getAllNamedFormatters();
     formatters.addAll(dataType.getAllCustomFormatters());
     ExprCoreType returnFormat = (ExprCoreType) dataType.getExprType();
@@ -262,7 +264,7 @@ public class OpenSearchExprValueFactory {
         "Construct %s from \"%s\" failed, unsupported format.", returnFormat, value));
   }
 
-  private ExprValue createOpenSearchDateType(Content value, ExprType type) {
+  private static ExprValue createOpenSearchDateType(Content value, ExprType type) {
     OpenSearchDateType dt = (OpenSearchDateType) type;
     ExprType returnFormat = dt.getExprType();
 


### PR DESCRIPTION
### Description
`OpenSearchExprValueFactory` created for every query for every index and it creates a constant `typeActionMap` every time from the scratch.
Current fix makes `typeActionMap` initiated statically, so it will be created only once. This slightly increases query processing performance.
 
### Issues Resolved
Performance boost.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).