### PR TITLE
[Backport 2.x] Adding Spotless support framework #1888

### DIFF
--- a/DEVELOPER_GUIDE.rst
+++ b/DEVELOPER_GUIDE.rst
@@ -113,8 +113,8 @@ Note that missing license header will be detected by Gradle license plugin and f
 Making Code Changes
 ===================
 
-Project Strucure
-----------------
+Project Structure
+-----------------
 
 The plugin codebase is in standard layout of Gradle project::
 
@@ -222,6 +222,12 @@ Most of the time you just need to run ./gradlew build which will make sure you p
      - Run all integration test (this takes time).
    * - ./gradlew build
      - Build plugin by run all tasks above (this takes time).
+   * - ./gradlew pitest
+     - Run PiTest mutation testing (see more info in `#1204 <https://github.com/opensearch-project/sql/pull/1204>`_)
+   * - ./gradlew spotlessCheck
+     - Runs Spotless to check for code style.
+   * - ./gradlew spotlessApply
+     - Automatically apply spotless code style changes.
 
 For integration test, you can use ``-Dtests.class`` “UT full path” to run a task individually. For example ``./gradlew :integ-test:integTest -Dtests.class="*QueryIT"``.
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ plugins {
     id 'checkstyle'
     id "io.freefair.lombok" version "6.4.0"
     id 'jacoco'
+    id 'com.diffplug.spotless' version '6.19.0'
 }
 
 // import versions defined in https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java#L94
@@ -77,6 +78,25 @@ repositories {
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
     maven { url 'https://jitpack.io' }
+}
+
+// Spotless checks will be added as PRs are applied to resolve each style issue is approved.
+spotless {
+    java {
+//        target fileTree('.') {
+//            include '**/*.java', 'src/*/java/**/*.java'
+//            exclude '**/build/**', '**/build-*/**'
+//        }
+//        importOrder()
+//        licenseHeader("/*\n" +
+//                " * Copyright OpenSearch Contributors\n" +
+//                " * SPDX-License-Identifier: Apache-2.0\n" +
+//                " */\n\n\n")
+//        removeUnusedImports()
+//        trimTrailingWhitespace()
+//        endWithNewline()
+//        googleJavaFormat('1.17.0').reflowLongStrings().groupArtifact('com.google.googlejavaformat:google-java-format')
+    }
 }
 
 allprojects {


### PR DESCRIPTION
### Description
Adds support for Spotless code formatter via ./gradlew spotlessApply and ./gradlew spotlessCheck. Apply applies the checks, check notifies which changes need to be applied.

Proposed checks commented out:
License header
Import order - sorts imports
Remove unused imports
Trim trailing whitespace
End with newline
Google Java format - https://github.com/google/google-java-format 

**Note: proposed spotless checks will be commented out until fix for each individual is merged. Lines will be uncommented as part of PRs addressing change.**

### Issues Resolved
https://github.com/opensearch-project/sql/issues/1101
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).