### PR TITLE
Fix doctest data

### DIFF
--- a/doctest/test_data/nested_objects.json
+++ b/doctest/test_data/nested_objects.json
@@ -1,4 +1,2 @@
-{"index":{"_id":"1"}}
 {"message":{"info":"a","author":"e","dayOfWeek":1},"comment":{"data":"ab","likes":3},"myNum":1,"someField":"b"}
-{"index":{"_id":"2"}}
 {"message":{"info":"b","author":"f","dayOfWeek":2},"comment":{"data":"aa","likes":2},"myNum":2,"someField":"a"}

--- a/doctest/test_data/wildcard.json
+++ b/doctest/test_data/wildcard.json
@@ -1,22 +1,11 @@
-{"index":{"_id":"0"}}
 {"Body":"test wildcard"}
-{"index":{"_id":"1"}}
 {"Body":"test wildcard in the end of the text%"}
-{"index":{"_id":"2"}}
 {"Body":"%test wildcard in the beginning of the text"}
-{"index":{"_id":"3"}}
 {"Body":"test wildcard in % the middle of the text"}
-{"index":{"_id":"4"}}
 {"Body":"test wildcard %% beside each other"}
-{"index":{"_id":"5"}}
 {"Body":"test wildcard in the end of the text_"}
-{"index":{"_id":"6"}}
 {"Body":"_test wildcard in the beginning of the text"}
-{"index":{"_id":"7"}}
 {"Body":"test wildcard in _ the middle of the text"}
-{"index":{"_id":"8"}}
 {"Body":"test wildcard __ beside each other"}
-{"index":{"_id":"9"}}
 {"Body":"test backslash wildcard \\_"}
-{"index":{"_id":"10"}}
 {"Body":"tEsT wIlDcArD sensitive cases"}


### PR DESCRIPTION
### Description

Clean up doctest test data. Fortunately, no test failed due to incorrect import.
Doctest uses python client to manipulate with test data and it interpreted `{"index":{"_id":"0"}}` as a doc to import. Fortunately, opensearch DSL ignores such docs for queries being tested, so it didn't affect the test.

```
opensearchsql> select * from nested;
fetched rows / total rows = 4/4
+--------------+------------------------------+---------+-------------+------------------------------------------------+
| index        | comment                      | myNum   | someField   | message                                        |
|--------------+------------------------------+---------+-------------+------------------------------------------------|
| {'_id': '1'} | null                         | null    | null        | null                                           |
| null         | [{'data': 'ab', 'likes': 3}] | 1       | b           | [{'dayOfWeek': 1, 'author': 'e', 'info': 'a'}] |
| {'_id': '2'} | null                         | null    | null        | null                                           |
| null         | [{'data': 'aa', 'likes': 2}] | 2       | a           | [{'dayOfWeek': 2, 'author': 'f', 'info': 'b'}] |
+--------------+------------------------------+---------+-------------+------------------------------------------------+

opensearchsql> select message.info from nested;
fetched rows / total rows = 4/4
+----------------+
| message.info   |
|----------------|
| null           |
| a              |
| null           |
| b              |
+----------------+

opensearchsql> select nested(message.info) from nested;
fetched rows / total rows = 2/2
+----------------+
| message.info   |
|----------------|
| a              |
| b              |
+----------------+

opensearchsql> select * from wildcard;
fetched rows / total rows = 22/22
+---------------------------------------------+---------------+
| Body                                        | index         |
|---------------------------------------------+---------------|
| null                                        | {'_id': '0'}  |
| test wildcard                               | null          |
| null                                        | {'_id': '1'}  |
| test wildcard in the end of the text%       | null          |
| null                                        | {'_id': '2'}  |
| %test wildcard in the beginning of the text | null          |
| null                                        | {'_id': '3'}  |
| test wildcard in % the middle of the text   | null          |
| null                                        | {'_id': '4'}  |
| test wildcard %% beside each other          | null          |
| null                                        | {'_id': '5'}  |
| test wildcard in the end of the text_       | null          |
| null                                        | {'_id': '6'}  |
| _test wildcard in the beginning of the text | null          |
| null                                        | {'_id': '7'}  |
| test wildcard in _ the middle of the text   | null          |
| null                                        | {'_id': '8'}  |
| test wildcard __ beside each other          | null          |
| null                                        | {'_id': '9'}  |
| test backslash wildcard \_                  | null          |
| null                                        | {'_id': '10'} |
| tEsT wIlDcArD sensitive cases               | null          |
+---------------------------------------------+---------------+
```
 
### Issues Resolved
Fix doctest samples.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).