### PR TITLE
Update guava to address CVE-2023-2976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ configurations.all {
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
-    resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
+    resolutionStrategy.force 'com.google.guava:guava:32.0.1-jre'
 }
 
 // updateVersion: Task to auto increment to the next development iteration

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -51,7 +51,7 @@ configurations.all {
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
-    resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
+    resolutionStrategy.force 'com.google.guava:guava:32.0.1-jre'
 }
 
 dependencies {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -58,7 +58,7 @@ configurations.all {
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
-    resolutionStrategy.force 'com.google.guava:guava:31.0.1-jre'
+    resolutionStrategy.force 'com.google.guava:guava:32.0.1-jre'
 }
 
 dependencies {

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     testImplementation('org.eclipse.jetty:jetty-server:11.0.14')
 
     // Enforce wiremock to use latest guava
-    testImplementation('com.google.guava:guava:31.1-jre')
+    testImplementation('com.google.guava:guava:32.0.1-jre')
 
     testRuntimeOnly('org.slf4j:slf4j-simple:1.7.25') // capture WireMock logging
 }


### PR DESCRIPTION
### Description

Update guava to address [CVE-2023-2976](https://www.cve.org/CVERecord?id=CVE-2023-2976).

It looks like https://github.com/opensearch-project/sql/pull/1768 has already addressed this for 2.x so this is just a backport into 1.3.

### Issues Resolved

https://github.com/opensearch-project/sql/issues/1767

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).