### PR TITLE
[BACKPORT 1.3] Update sqlite-jdbc to 3.41.2.2 to address CVE-2023-32697 (#1667)

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -71,7 +71,7 @@ dependencies {
         builtBy 'compileJdbc'
     }
     testCompile group: 'com.h2database', name: 'h2', version: '2.1.214'
-    testCompile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.28.0'
+    testCompile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.41.2.2'
     testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 }
 


### PR DESCRIPTION
* Update sqlite-jdbc to 3.41.2.2 to address CVE-2023-32697



* Don't check column names on H2 results for correctness tests as described in https://github.com/opensearch-project/sql/pull/1667#issuecomment-1603659136.



* Address PR review comment.



---------

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).