### PR TITLE
Upgrade guava version to 32.0.1-jre

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
-    compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    compile group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.13.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,7 +39,7 @@ repositories {
 //}
 
 dependencies {
-    compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    compile group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
     compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -88,7 +88,7 @@ dependencies {
             because 'https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379'
         }
     }
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     compile group: 'org.json', name: 'json', version:'20230227'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     compile group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     antlr "org.antlr:antlr4:4.7.1"
 
     compile "org.antlr:antlr4-runtime:4.7.1"
-    compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    compile group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     compile group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     compile group: 'org.json', name: 'json', version: '20230227'
     compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    compile group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     antlr "org.antlr:antlr4:4.7.1"
 
     compile "org.antlr:antlr4-runtime:4.7.1"
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     compile group: 'org.json', name: 'json', version:'20230227'
     compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
     compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"


### PR DESCRIPTION
### Description
Upgrade guava version to 32.0.1-jre
 
### Issues Resolved
There was a mismatch among files updated for guava version, few were pointing to 31 where others were pointing to 32 version. 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).