### PR TITLE
Okio upgrade to 3.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,8 @@ allprojects {
     configurations.all {
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0"
+        resolutionStrategy.force "com.squareup.okio:okio:3.5.0"
+
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -115,8 +115,6 @@ allprojects {
         sourceCompatibility = targetCompatibility = "11"
     }
     configurations.all {
-        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"
-        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0"
         resolutionStrategy.force "com.squareup.okio:okio:3.5.0"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,8 @@ allprojects {
     }
     configurations.all {
         resolutionStrategy.force "com.squareup.okio:okio:3.5.0"
+        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.9.0"
+        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,6 @@ allprojects {
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0"
         resolutionStrategy.force "com.squareup.okio:okio:3.5.0"
-
     }
 }
 


### PR DESCRIPTION
### Description
Okio upgrade to 3.5.0
 
### Issues Resolved
Fixes CVE-2023-3635 from transitive dependency 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).