### PR TITLE
[Spotless] Applying Google Code Format for protocol files #14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,8 @@ spotless {
         target fileTree('.') {
             include 'common/**/*.java',
                     'datasources/**/*.java',
-                    'core/**/*.java'
+                    'core/**/*.java',
+                    'protocol/**/*.java'
             exclude '**/build/**', '**/build-*/**'
         }
         importOrder()
@@ -115,9 +116,8 @@ allprojects {
         sourceCompatibility = targetCompatibility = "11"
     }
     configurations.all {
-        resolutionStrategy.force "com.squareup.okio:okio:3.5.0"
-        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.9.0"
-        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0"
+        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.6.0"
+        resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0"
     }
 }
 

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.12.4'
 }
 
+checkstyleTest.ignoreFailures = true
+checkstyleMain.ignoreFailures = true
+
 configurations.all {
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/QueryResult.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/QueryResult.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response;
 
 import java.util.Collection;
@@ -20,22 +19,18 @@ import org.opensearch.sql.executor.ExecutionEngine.Schema.Column;
 import org.opensearch.sql.executor.pagination.Cursor;
 
 /**
- * Query response that encapsulates query results and isolate {@link ExprValue}
- * related from formatter implementation.
+ * Query response that encapsulates query results and isolate {@link ExprValue} related from
+ * formatter implementation.
  */
 @RequiredArgsConstructor
 public class QueryResult implements Iterable<Object[]> {
 
-  @Getter
-  private final ExecutionEngine.Schema schema;
+  @Getter private final ExecutionEngine.Schema schema;
 
-  /**
-   * Results which are collection of expression.
-   */
+  /** Results which are collection of expression. */
   private final Collection<ExprValue> exprValues;
 
-  @Getter
-  private final Cursor cursor;
+  @Getter private final Cursor cursor;
 
   public QueryResult(ExecutionEngine.Schema schema, Collection<ExprValue> exprValues) {
     this(schema, exprValues, Cursor.None);
@@ -43,6 +38,7 @@ public class QueryResult implements Iterable<Object[]> {
 
   /**
    * size of results.
+   *
    * @return size of results
    */
   public int size() {
@@ -52,14 +48,18 @@ public class QueryResult implements Iterable<Object[]> {
   /**
    * Parse column name from results.
    *
-   * @return mapping from column names to its expression type.
-   *        note that column name could be original name or its alias if any.
+   * @return mapping from column names to its expression type. note that column name could be
+   *     original name or its alias if any.
    */
   public Map<String, String> columnNameTypes() {
     Map<String, String> colNameTypes = new LinkedHashMap<>();
-    schema.getColumns().forEach(column -> colNameTypes.put(
-        getColumnName(column),
-        column.getExprType().typeName().toLowerCase(Locale.ROOT)));
+    schema
+        .getColumns()
+        .forEach(
+            column ->
+                colNameTypes.put(
+                    getColumnName(column),
+                    column.getExprType().typeName().toLowerCase(Locale.ROOT)));
     return colNameTypes;
   }
 
@@ -78,9 +78,6 @@ public class QueryResult implements Iterable<Object[]> {
   }
 
   private Object[] convertExprValuesToValues(Collection<ExprValue> exprValues) {
-    return exprValues
-        .stream()
-        .map(ExprValue::value)
-        .toArray(Object[]::new);
+    return exprValues.stream().map(ExprValue::value).toArray(Object[]::new);
   }
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatter.java
@@ -10,8 +10,8 @@ import org.opensearch.sql.executor.execution.CommandPlan;
 import org.opensearch.sql.protocol.response.QueryResult;
 
 /**
- * A simple response formatter which contains no data.
- * Supposed to use with {@link CommandPlan} only.
+ * A simple response formatter which contains no data. Supposed to use with {@link CommandPlan}
+ * only.
  */
 public class CommandResponseFormatter extends JsonResponseFormatter<QueryResult> {
 

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatter.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 public class CsvResponseFormatter extends FlatResponseFormatter {
@@ -14,5 +13,4 @@ public class CsvResponseFormatter extends FlatResponseFormatter {
   public CsvResponseFormatter(boolean sanitize) {
     super(",", sanitize);
   }
-
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import com.google.gson.Gson;
@@ -17,35 +16,28 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class ErrorFormatter {
 
-  private static final Gson PRETTY_PRINT_GSON = AccessController.doPrivileged(
-          (PrivilegedAction<Gson>) () -> new GsonBuilder()
-              .setPrettyPrinting()
-              .disableHtmlEscaping()
-              .create());
-  private static final Gson GSON = AccessController.doPrivileged(
-      (PrivilegedAction<Gson>) () -> new GsonBuilder().disableHtmlEscaping().create());
+  private static final Gson PRETTY_PRINT_GSON =
+      AccessController.doPrivileged(
+          (PrivilegedAction<Gson>)
+              () -> new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create());
+  private static final Gson GSON =
+      AccessController.doPrivileged(
+          (PrivilegedAction<Gson>) () -> new GsonBuilder().disableHtmlEscaping().create());
 
-  /**
-   * Util method to format {@link Throwable} response to JSON string in compact printing.
-   */
+  /** Util method to format {@link Throwable} response to JSON string in compact printing. */
   public static String compactFormat(Throwable t) {
-    JsonError error = new ErrorFormatter.JsonError(t.getClass().getSimpleName(),
-        t.getMessage());
+    JsonError error = new ErrorFormatter.JsonError(t.getClass().getSimpleName(), t.getMessage());
     return compactJsonify(error);
   }
 
-  /**
-   * Util method to format {@link Throwable} response to JSON string in pretty printing.
-   */
-  public static  String prettyFormat(Throwable t) {
-    JsonError error = new ErrorFormatter.JsonError(t.getClass().getSimpleName(),
-        t.getMessage());
+  /** Util method to format {@link Throwable} response to JSON string in pretty printing. */
+  public static String prettyFormat(Throwable t) {
+    JsonError error = new ErrorFormatter.JsonError(t.getClass().getSimpleName(), t.getMessage());
     return prettyJsonify(error);
   }
 
   public static String compactJsonify(Object jsonObject) {
-    return AccessController.doPrivileged(
-        (PrivilegedAction<String>) () -> GSON.toJson(jsonObject));
+    return AccessController.doPrivileged((PrivilegedAction<String>) () -> GSON.toJson(jsonObject));
   }
 
   public static String prettyJsonify(Object jsonObject) {

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/FlatResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/FlatResponseFormatter.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import com.google.common.collect.ImmutableList;
@@ -48,9 +47,8 @@ public abstract class FlatResponseFormatter implements ResponseFormatter<QueryRe
   }
 
   /**
-   * Sanitize methods are migrated from legacy CSV result.
-   * Sanitize both headers and data lines by:
-   *  1) Second double quote entire cell if any comma is found.
+   * Sanitize methods are migrated from legacy CSV result. Sanitize both headers and data lines by:
+   * 1) Second double quote entire cell if any comma is found.
    */
   @Getter
   @RequiredArgsConstructor
@@ -84,29 +82,30 @@ public abstract class FlatResponseFormatter implements ResponseFormatter<QueryRe
 
     private List<List<String>> getData(QueryResult response, boolean sanitize) {
       ImmutableList.Builder<List<String>> dataLines = new ImmutableList.Builder<>();
-      response.iterator().forEachRemaining(row -> {
-        ImmutableList.Builder<String> line = new ImmutableList.Builder<>();
-        // replace null values with empty string
-        Arrays.asList(row).forEach(val -> line.add(val == null ? "" : val.toString()));
-        dataLines.add(line.build());
-      });
+      response
+          .iterator()
+          .forEachRemaining(
+              row -> {
+                ImmutableList.Builder<String> line = new ImmutableList.Builder<>();
+                // replace null values with empty string
+                Arrays.asList(row).forEach(val -> line.add(val == null ? "" : val.toString()));
+                dataLines.add(line.build());
+              });
       List<List<String>> result = dataLines.build();
       return sanitizeData(result);
     }
 
-    /**
-     * Sanitize headers because OpenSearch allows special character present in field names.
-     */
+    /** Sanitize headers because OpenSearch allows special character present in field names. */
     private List<String> sanitizeHeaders(List<String> headers) {
       if (sanitize) {
         return headers.stream()
-                .map(this::sanitizeCell)
-                .map(cell -> quoteIfRequired(INLINE_SEPARATOR, cell))
-                .collect(Collectors.toList());
+            .map(this::sanitizeCell)
+            .map(cell -> quoteIfRequired(INLINE_SEPARATOR, cell))
+            .collect(Collectors.toList());
       } else {
         return headers.stream()
-                .map(cell -> quoteIfRequired(INLINE_SEPARATOR, cell))
-                .collect(Collectors.toList());
+            .map(cell -> quoteIfRequired(INLINE_SEPARATOR, cell))
+            .collect(Collectors.toList());
       }
     }
 
@@ -114,14 +113,16 @@ public abstract class FlatResponseFormatter implements ResponseFormatter<QueryRe
       List<List<String>> result = new ArrayList<>();
       if (sanitize) {
         for (List<String> line : lines) {
-          result.add(line.stream()
+          result.add(
+              line.stream()
                   .map(this::sanitizeCell)
                   .map(cell -> quoteIfRequired(INLINE_SEPARATOR, cell))
                   .collect(Collectors.toList()));
         }
       } else {
         for (List<String> line : lines) {
-          result.add(line.stream()
+          result.add(
+              line.stream()
                   .map(cell -> quoteIfRequired(INLINE_SEPARATOR, cell))
                   .collect(Collectors.toList()));
         }
@@ -138,13 +139,11 @@ public abstract class FlatResponseFormatter implements ResponseFormatter<QueryRe
 
     private String quoteIfRequired(String separator, String cell) {
       final String quote = "\"";
-      return cell.contains(separator)
-              ? quote + cell.replaceAll("\"", "\"\"") + quote : cell;
+      return cell.contains(separator) ? quote + cell.replaceAll("\"", "\"\"") + quote : cell;
     }
 
     private boolean isStartWithSensitiveChar(String cell) {
       return SENSITIVE_CHAR.stream().anyMatch(cell::startsWith);
     }
   }
-
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import com.google.common.base.Strings;
@@ -20,8 +19,7 @@ public enum Format {
   RAW("raw"),
   VIZ("viz");
 
-  @Getter
-  private final String formatName;
+  @Getter private final String formatName;
 
   private static final Map<String, Format> ALL_FORMATS;
 

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/JdbcResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/JdbcResponseFormatter.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import java.util.List;
@@ -40,9 +39,7 @@ public class JdbcResponseFormatter extends JsonResponseFormatter<QueryResult> {
     json.datarows(fetchDataRows(response));
 
     // Populate other fields
-    json.total(response.size())
-        .size(response.size())
-        .status(200);
+    json.total(response.size()).size(response.size()).status(200);
     if (!response.getCursor().equals(Cursor.None)) {
       json.cursor(response.getCursor().toString());
     }
@@ -54,10 +51,7 @@ public class JdbcResponseFormatter extends JsonResponseFormatter<QueryResult> {
   public String format(Throwable t) {
     int status = getStatus(t);
     ErrorMessage message = ErrorMessageFactory.createErrorMessage(t, status);
-    Error error = new Error(
-        message.getType(),
-        message.getReason(),
-        message.getDetails());
+    Error error = new Error(message.getType(), message.getReason(), message.getDetails());
     return jsonify(new JdbcErrorResponse(error, status));
   }
 
@@ -66,8 +60,8 @@ public class JdbcResponseFormatter extends JsonResponseFormatter<QueryResult> {
   }
 
   /**
-   * Convert type that exists in both legacy and new engine but has different name.
-   * Return old type name to avoid breaking impact on client-side.
+   * Convert type that exists in both legacy and new engine but has different name. Return old type
+   * name to avoid breaking impact on client-side.
    */
   private String convertToLegacyType(ExprType type) {
     return type.legacyTypeName().toLowerCase();
@@ -83,18 +77,16 @@ public class JdbcResponseFormatter extends JsonResponseFormatter<QueryResult> {
   }
 
   private int getStatus(Throwable t) {
-    return (t instanceof SyntaxCheckException
-        || t instanceof QueryEngineException) ? 400 : 503;
+    return (t instanceof SyntaxCheckException || t instanceof QueryEngineException) ? 400 : 503;
   }
 
-  /**
-   * org.json requires these inner data classes be public (and static)
-   */
+  /** org.json requires these inner data classes be public (and static) */
   @Builder
   @Getter
   public static class JdbcResponse {
     @Singular("column")
     private final List<Column> schema;
+
     private final Object[][] datarows;
     private final long total;
     private final long size;
@@ -125,5 +117,4 @@ public class JdbcResponseFormatter extends JsonResponseFormatter<QueryResult> {
     private final String reason;
     private final String details;
   }
-
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/JsonResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/JsonResponseFormatter.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import static org.opensearch.sql.protocol.response.format.ErrorFormatter.compactFormat;
@@ -24,16 +23,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public abstract class JsonResponseFormatter<R> implements ResponseFormatter<R> {
 
-  /**
-   * JSON format styles: pretty format or compact format without indent and space.
-   */
+  /** JSON format styles: pretty format or compact format without indent and space. */
   public enum Style {
-    PRETTY, COMPACT
+    PRETTY,
+    COMPACT
   }
 
-  /**
-   * JSON format style.
-   */
+  /** JSON format style. */
   private final Style style;
 
   public static final String CONTENT_TYPE = "application/json; charset=UTF-8";
@@ -45,8 +41,8 @@ public abstract class JsonResponseFormatter<R> implements ResponseFormatter<R> {
 
   @Override
   public String format(Throwable t) {
-    return AccessController.doPrivileged((PrivilegedAction<String>) () ->
-        (style == PRETTY) ? prettyFormat(t) : compactFormat(t));
+    return AccessController.doPrivileged(
+        (PrivilegedAction<String>) () -> (style == PRETTY) ? prettyFormat(t) : compactFormat(t));
   }
 
   public String contentType() {
@@ -62,7 +58,8 @@ public abstract class JsonResponseFormatter<R> implements ResponseFormatter<R> {
   protected abstract Object buildJsonObject(R response);
 
   protected String jsonify(Object jsonObject) {
-    return AccessController.doPrivileged((PrivilegedAction<String>) () ->
-        (style == PRETTY) ? prettyJsonify(jsonObject) : compactJsonify(jsonObject));
+    return AccessController.doPrivileged(
+        (PrivilegedAction<String>)
+            () -> (style == PRETTY) ? prettyJsonify(jsonObject) : compactJsonify(jsonObject));
   }
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/RawResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/RawResponseFormatter.java
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
-/**
- * Response formatter to format response to csv or raw format.
- */
-//@RequiredArgsConstructor
+/** Response formatter to format response to csv or raw format. */
+// @RequiredArgsConstructor
 public class RawResponseFormatter extends FlatResponseFormatter {
   public RawResponseFormatter() {
     super("|", false);
   }
-
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/RawResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/RawResponseFormatter.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.protocol.response.format;
 
 /** Response formatter to format response to csv or raw format. */
-// @RequiredArgsConstructor
 public class RawResponseFormatter extends FlatResponseFormatter {
   public RawResponseFormatter() {
     super("|", false);

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ResponseFormatter.java
@@ -3,12 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
-/**
- * Response formatter to format response to different formats.
- */
+/** Response formatter to format response to different formats. */
 public interface ResponseFormatter<R> {
 
   /**
@@ -33,5 +30,4 @@ public interface ResponseFormatter<R> {
    * @return string
    */
   String contentType();
-
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/SimpleJsonResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/SimpleJsonResponseFormatter.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import java.util.List;
@@ -43,8 +42,7 @@ public class SimpleJsonResponseFormatter extends JsonResponseFormatter<QueryResu
   public Object buildJsonObject(QueryResult response) {
     JsonResponse.JsonResponseBuilder json = JsonResponse.builder();
 
-    json.total(response.size())
-        .size(response.size());
+    json.total(response.size()).size(response.size());
 
     response.columnNameTypes().forEach((name, type) -> json.column(new Column(name, type)));
 
@@ -61,9 +59,7 @@ public class SimpleJsonResponseFormatter extends JsonResponseFormatter<QueryResu
     return rows;
   }
 
-  /**
-   * org.json requires these inner data classes be public (and static)
-   */
+  /** org.json requires these inner data classes be public (and static) */
   @Builder
   @Getter
   public static class JsonResponse {
@@ -82,5 +78,4 @@ public class SimpleJsonResponseFormatter extends JsonResponseFormatter<QueryResu
     private final String name;
     private final String type;
   }
-
 }

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatter.java
@@ -72,21 +72,20 @@ public class VisualizationResponseFormatter extends JsonResponseFormatter<QueryR
   public String format(Throwable t) {
     int status = getStatus(t);
     ErrorMessage message = ErrorMessageFactory.createErrorMessage(t, status);
-    VisualizationResponseFormatter.Error error = new Error(
-        message.getType(),
-        message.getReason(),
-        message.getDetails());
+    VisualizationResponseFormatter.Error error =
+        new Error(message.getType(), message.getReason(), message.getDetails());
     return jsonify(new VisualizationErrorResponse(error, status));
   }
 
   private int getStatus(Throwable t) {
-    return (t instanceof SyntaxCheckException
-        || t instanceof QueryEngineException) ? 400 : 503;
+    return (t instanceof SyntaxCheckException || t instanceof QueryEngineException) ? 400 : 503;
   }
 
   private Map<String, List<Object>> fetchData(QueryResult response) {
     Map<String, List<Object>> columnMap = new LinkedHashMap<>();
-    response.getSchema().getColumns()
+    response
+        .getSchema()
+        .getColumns()
         .forEach(column -> columnMap.put(column.getName(), new LinkedList<>()));
 
     for (Object[] dataRow : response) {
@@ -107,16 +106,17 @@ public class VisualizationResponseFormatter extends JsonResponseFormatter<QueryR
   private List<Field> fetchFields(QueryResult response) {
     List<ExecutionEngine.Schema.Column> columns = response.getSchema().getColumns();
     ImmutableList.Builder<Field> fields = ImmutableList.builder();
-    columns.forEach(column -> {
-      Field field = new Field(column.getName(), convertToLegacyType(column.getExprType()));
-      fields.add(field);
-    });
+    columns.forEach(
+        column -> {
+          Field field = new Field(column.getName(), convertToLegacyType(column.getExprType()));
+          fields.add(field);
+        });
     return fields.build();
   }
 
   /**
-   * Convert type that exists in both legacy and new engine but has different name.
-   * Return old type name to avoid breaking impact on client-side.
+   * Convert type that exists in both legacy and new engine but has different name. Return old type
+   * name to avoid breaking impact on client-side.
    */
   private String convertToLegacyType(ExprType type) {
     return type.legacyTypeName().toLowerCase();

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/QueryResultTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/QueryResultTest.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -23,86 +22,77 @@ import org.opensearch.sql.executor.pagination.Cursor;
 
 class QueryResultTest {
 
-  private ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-      new ExecutionEngine.Schema.Column("name", null, STRING),
-      new ExecutionEngine.Schema.Column("age", null, INTEGER)));
-
+  private ExecutionEngine.Schema schema =
+      new ExecutionEngine.Schema(
+          ImmutableList.of(
+              new ExecutionEngine.Schema.Column("name", null, STRING),
+              new ExecutionEngine.Schema.Column("age", null, INTEGER)));
 
   @Test
   void size() {
-    QueryResult response = new QueryResult(
-        schema,
-        Arrays.asList(
-            tupleValue(ImmutableMap.of("name", "John", "age", 20)),
-            tupleValue(ImmutableMap.of("name", "Allen", "age", 30)),
-            tupleValue(ImmutableMap.of("name", "Smith", "age", 40))
-        ), Cursor.None);
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("name", "John", "age", 20)),
+                tupleValue(ImmutableMap.of("name", "Allen", "age", 30)),
+                tupleValue(ImmutableMap.of("name", "Smith", "age", 40))),
+            Cursor.None);
     assertEquals(3, response.size());
   }
 
   @Test
   void columnNameTypes() {
-    QueryResult response = new QueryResult(
-        schema,
-        Collections.singletonList(
-            tupleValue(ImmutableMap.of("name", "John", "age", 20))
-        ), Cursor.None);
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Collections.singletonList(tupleValue(ImmutableMap.of("name", "John", "age", 20))),
+            Cursor.None);
 
-    assertEquals(
-        ImmutableMap.of("name", "string", "age", "integer"),
-        response.columnNameTypes()
-    );
+    assertEquals(ImmutableMap.of("name", "string", "age", "integer"), response.columnNameTypes());
   }
 
   @Test
   void columnNameTypesWithAlias() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("name", "n", STRING)));
-    QueryResult response = new QueryResult(
-        schema,
-        Collections.singletonList(tupleValue(ImmutableMap.of("n", "John"))),
-        Cursor.None);
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(new ExecutionEngine.Schema.Column("name", "n", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Collections.singletonList(tupleValue(ImmutableMap.of("n", "John"))),
+            Cursor.None);
 
-    assertEquals(
-        ImmutableMap.of("n", "string"),
-        response.columnNameTypes()
-    );
+    assertEquals(ImmutableMap.of("n", "string"), response.columnNameTypes());
   }
 
   @Test
   void columnNameTypesFromEmptyExprValues() {
-    QueryResult response = new QueryResult(
-        schema,
-        Collections.emptyList(), Cursor.None);
-    assertEquals(
-        ImmutableMap.of("name", "string", "age", "integer"),
-        response.columnNameTypes()
-    );
+    QueryResult response = new QueryResult(schema, Collections.emptyList(), Cursor.None);
+    assertEquals(ImmutableMap.of("name", "string", "age", "integer"), response.columnNameTypes());
   }
 
   @Test
   void columnNameTypesFromExprValuesWithMissing() {
-    QueryResult response = new QueryResult(
-        schema,
-        Arrays.asList(
-            tupleValue(ImmutableMap.of("name", "John")),
-            tupleValue(ImmutableMap.of("name", "John", "age", 20))
-        ));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("name", "John")),
+                tupleValue(ImmutableMap.of("name", "John", "age", 20))));
 
-    assertEquals(
-        ImmutableMap.of("name", "string", "age", "integer"),
-        response.columnNameTypes()
-    );
+    assertEquals(ImmutableMap.of("name", "string", "age", "integer"), response.columnNameTypes());
   }
 
   @Test
   void iterate() {
-    QueryResult response = new QueryResult(
-        schema,
-        Arrays.asList(
-            tupleValue(ImmutableMap.of("name", "John", "age", 20)),
-            tupleValue(ImmutableMap.of("name", "Allen", "age", 30))
-        ), Cursor.None);
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("name", "John", "age", 20)),
+                tupleValue(ImmutableMap.of("name", "Allen", "age", 30))),
+            Cursor.None);
 
     int i = 0;
     for (Object[] objects : response) {
@@ -116,5 +106,4 @@ class QueryResultTest {
       i++;
     }
   }
-
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
@@ -49,7 +49,7 @@ public class CommandResponseFormatterTest {
                         .build())),
             new Cursor("test_cursor"));
 
-    assertEquals("{\n" + "  \"succeeded\": true\n" + "}", formatter.format(response));
+    assertEquals("{\n  \"succeeded\": true\n}", formatter.format(response));
   }
 
   @Test

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CommandResponseFormatterTest.java
@@ -29,32 +29,34 @@ public class CommandResponseFormatterTest {
   @Test
   public void produces_always_same_output_for_any_query_response() {
     var formatter = new CommandResponseFormatter();
-    assertEquals(formatter.format(mock(QueryResult.class)),
-        formatter.format(mock(QueryResult.class)));
+    assertEquals(
+        formatter.format(mock(QueryResult.class)), formatter.format(mock(QueryResult.class)));
 
-    QueryResult response = new QueryResult(
-        new ExecutionEngine.Schema(ImmutableList.of(
-            new ExecutionEngine.Schema.Column("name", "name", STRING),
-            new ExecutionEngine.Schema.Column("address", "address", OpenSearchTextType.of()),
-            new ExecutionEngine.Schema.Column("age", "age", INTEGER))),
-        ImmutableList.of(
-            tupleValue(ImmutableMap.<String, Object>builder()
-                    .put("name", "John")
-                    .put("address", "Seattle")
-                    .put("age", 20)
-                .build())),
-        new Cursor("test_cursor"));
+    QueryResult response =
+        new QueryResult(
+            new ExecutionEngine.Schema(
+                ImmutableList.of(
+                    new ExecutionEngine.Schema.Column("name", "name", STRING),
+                    new ExecutionEngine.Schema.Column(
+                        "address", "address", OpenSearchTextType.of()),
+                    new ExecutionEngine.Schema.Column("age", "age", INTEGER))),
+            ImmutableList.of(
+                tupleValue(
+                    ImmutableMap.<String, Object>builder()
+                        .put("name", "John")
+                        .put("address", "Seattle")
+                        .put("age", 20)
+                        .build())),
+            new Cursor("test_cursor"));
 
-    assertEquals("{\n"
-                + "  \"succeeded\": true\n"
-                + "}",
-        formatter.format(response));
+    assertEquals("{\n" + "  \"succeeded\": true\n" + "}", formatter.format(response));
   }
 
   @Test
   public void formats_error_as_default_formatter() {
     var exception = new Exception("pewpew", new RuntimeException("meow meow"));
-    assertEquals(new JdbcResponseFormatter(PRETTY).format(exception),
+    assertEquals(
+        new JdbcResponseFormatter(PRETTY).format(exception),
         new CommandResponseFormatter().format(exception));
   }
 

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatterTest.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,20 +23,23 @@ import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.protocol.response.QueryResult;
 
-/**
- * Unit test for {@link CsvResponseFormatter}.
- */
+/** Unit test for {@link CsvResponseFormatter}. */
 public class CsvResponseFormatterTest {
   private static final CsvResponseFormatter formatter = new CsvResponseFormatter();
 
   @Test
   void formatResponse() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("name", "name", STRING),
-        new ExecutionEngine.Schema.Column("age", "age", INTEGER)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of("name", "John", "age", 20)),
-        tupleValue(ImmutableMap.of("name", "Smith", "age", 30))));
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(
+                new ExecutionEngine.Schema.Column("name", "name", STRING),
+                new ExecutionEngine.Schema.Column("age", "age", INTEGER)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("name", "John", "age", 20)),
+                tupleValue(ImmutableMap.of("name", "Smith", "age", 30))));
     CsvResponseFormatter formatter = new CsvResponseFormatter();
     String expected = "name,age%nJohn,20%nSmith,30";
     assertEquals(format(expected), formatter.format(response));
@@ -45,49 +47,69 @@ public class CsvResponseFormatterTest {
 
   @Test
   void sanitizeHeaders() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("=firstname", null, STRING),
-        new ExecutionEngine.Schema.Column("+lastname", null, STRING),
-        new ExecutionEngine.Schema.Column("-city", null, STRING),
-        new ExecutionEngine.Schema.Column("@age", null, INTEGER)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of(
-            "=firstname", "John", "+lastname", "Smith", "-city", "Seattle", "@age", 20))));
-    String expected = "'=firstname,'+lastname,'-city,'@age%n"
-        + "John,Smith,Seattle,20";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(
+                new ExecutionEngine.Schema.Column("=firstname", null, STRING),
+                new ExecutionEngine.Schema.Column("+lastname", null, STRING),
+                new ExecutionEngine.Schema.Column("-city", null, STRING),
+                new ExecutionEngine.Schema.Column("@age", null, INTEGER)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(
+                    ImmutableMap.of(
+                        "=firstname",
+                        "John",
+                        "+lastname",
+                        "Smith",
+                        "-city",
+                        "Seattle",
+                        "@age",
+                        20))));
+    String expected = "'=firstname,'+lastname,'-city,'@age%n" + "John,Smith,Seattle,20";
     assertEquals(format(expected), formatter.format(response));
   }
 
   @Test
   void sanitizeData() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("city", "city", STRING)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of("city", "Seattle")),
-        tupleValue(ImmutableMap.of("city", "=Seattle")),
-        tupleValue(ImmutableMap.of("city", "+Seattle")),
-        tupleValue(ImmutableMap.of("city", "-Seattle")),
-        tupleValue(ImmutableMap.of("city", "@Seattle")),
-        tupleValue(ImmutableMap.of("city", "Seattle="))));
-    String expected = "city%n"
-        + "Seattle%n"
-        + "'=Seattle%n"
-        + "'+Seattle%n"
-        + "'-Seattle%n"
-        + "'@Seattle%n"
-        + "Seattle=";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(new ExecutionEngine.Schema.Column("city", "city", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("city", "Seattle")),
+                tupleValue(ImmutableMap.of("city", "=Seattle")),
+                tupleValue(ImmutableMap.of("city", "+Seattle")),
+                tupleValue(ImmutableMap.of("city", "-Seattle")),
+                tupleValue(ImmutableMap.of("city", "@Seattle")),
+                tupleValue(ImmutableMap.of("city", "Seattle="))));
+    String expected =
+        "city%n"
+            + "Seattle%n"
+            + "'=Seattle%n"
+            + "'+Seattle%n"
+            + "'-Seattle%n"
+            + "'@Seattle%n"
+            + "Seattle=";
     assertEquals(format(expected), formatter.format(response));
   }
 
   @Test
   void quoteIfRequired() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("na,me", "na,me", STRING),
-        new ExecutionEngine.Schema.Column(",,age", ",,age", INTEGER)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of("na,me", "John,Smith", ",,age", "30,,,"))));
-    String expected = "\"na,me\",\",,age\"%n"
-        + "\"John,Smith\",\"30,,,\"";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(
+                new ExecutionEngine.Schema.Column("na,me", "na,me", STRING),
+                new ExecutionEngine.Schema.Column(",,age", ",,age", INTEGER)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(tupleValue(ImmutableMap.of("na,me", "John,Smith", ",,age", "30,,,"))));
+    String expected = "\"na,me\",\",,age\"%n" + "\"John,Smith\",\"30,,,\"";
     assertEquals(format(expected), formatter.format(response));
   }
 
@@ -102,32 +124,36 @@ public class CsvResponseFormatterTest {
   @Test
   void escapeSanitize() {
     CsvResponseFormatter escapeFormatter = new CsvResponseFormatter(false);
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("city", "city", STRING)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of("city", "=Seattle")),
-        tupleValue(ImmutableMap.of("city", ",,Seattle"))));
-    String expected = "city%n"
-        + "=Seattle%n"
-        + "\",,Seattle\"";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(new ExecutionEngine.Schema.Column("city", "city", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("city", "=Seattle")),
+                tupleValue(ImmutableMap.of("city", ",,Seattle"))));
+    String expected = "city%n" + "=Seattle%n" + "\",,Seattle\"";
     assertEquals(format(expected), escapeFormatter.format(response));
   }
 
   @Test
   void replaceNullValues() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("name", "name", STRING),
-        new ExecutionEngine.Schema.Column("city", "city", STRING)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of("name", "John","city", "Seattle")),
-        ExprTupleValue.fromExprValueMap(
-            ImmutableMap.of("firstname", LITERAL_NULL, "city", stringValue("Seattle"))),
-        ExprTupleValue.fromExprValueMap(
-            ImmutableMap.of("firstname", stringValue("John"), "city", LITERAL_MISSING))));
-    String expected = "name,city%n"
-        + "John,Seattle%n"
-        + ",Seattle%n"
-        + "John,";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(
+                new ExecutionEngine.Schema.Column("name", "name", STRING),
+                new ExecutionEngine.Schema.Column("city", "city", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("name", "John", "city", "Seattle")),
+                ExprTupleValue.fromExprValueMap(
+                    ImmutableMap.of("firstname", LITERAL_NULL, "city", stringValue("Seattle"))),
+                ExprTupleValue.fromExprValueMap(
+                    ImmutableMap.of("firstname", stringValue("John"), "city", LITERAL_MISSING))));
+    String expected = "name,city%n" + "John,Seattle%n" + ",Seattle%n" + "John,";
     assertEquals(format(expected), formatter.format(response));
   }
 
@@ -135,5 +161,4 @@ public class CsvResponseFormatterTest {
   void testContentType() {
     assertEquals(formatter.contentType(), CONTENT_TYPE);
   }
-
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatterTest.java
@@ -68,7 +68,7 @@ public class CsvResponseFormatterTest {
                         "Seattle",
                         "@age",
                         20))));
-    String expected = "'=firstname,'+lastname,'-city,'@age%n" + "John,Smith,Seattle,20";
+    String expected = "'=firstname,'+lastname,'-city,'@age%nJohn,Smith,Seattle,20";
     assertEquals(format(expected), formatter.format(response));
   }
 
@@ -109,7 +109,7 @@ public class CsvResponseFormatterTest {
         new QueryResult(
             schema,
             Arrays.asList(tupleValue(ImmutableMap.of("na,me", "John,Smith", ",,age", "30,,,"))));
-    String expected = "\"na,me\",\",,age\"%n" + "\"John,Smith\",\"30,,,\"";
+    String expected = "\"na,me\",\",,age\"%n\"John,Smith\",\"30,,,\"";
     assertEquals(format(expected), formatter.format(response));
   }
 
@@ -133,7 +133,7 @@ public class CsvResponseFormatterTest {
             Arrays.asList(
                 tupleValue(ImmutableMap.of("city", "=Seattle")),
                 tupleValue(ImmutableMap.of("city", ",,Seattle"))));
-    String expected = "city%n" + "=Seattle%n" + "\",,Seattle\"";
+    String expected = "city%n=Seattle%n\",,Seattle\"";
     assertEquals(format(expected), escapeFormatter.format(response));
   }
 
@@ -153,7 +153,7 @@ public class CsvResponseFormatterTest {
                     ImmutableMap.of("firstname", LITERAL_NULL, "city", stringValue("Seattle"))),
                 ExprTupleValue.fromExprValueMap(
                     ImmutableMap.of("firstname", stringValue("John"), "city", LITERAL_MISSING))));
-    String expected = "name,city%n" + "John,Seattle%n" + ",Seattle%n" + "John,";
+    String expected = "name,city%nJohn,Seattle%n,Seattle%nJohn,";
     assertEquals(format(expected), formatter.format(response));
   }
 

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/FormatTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/FormatTest.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,9 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
-/**
- * Unit test for {@link Format}.
- */
+/** Unit test for {@link Format}. */
 public class FormatTest {
 
   @Test
@@ -58,5 +55,4 @@ public class FormatTest {
     Optional<Format> format = Format.of("notsupport");
     assertFalse(format.isPresent());
   }
-
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/JdbcResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/JdbcResponseFormatterTest.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,26 +42,35 @@ class JdbcResponseFormatterTest {
 
   @Test
   void format_response() {
-    QueryResult response = new QueryResult(
-        new Schema(ImmutableList.of(
-            new Column("name", "name", STRING),
-            new Column("address1", "address1", OpenSearchTextType.of()),
-            new Column("address2", "address2", OpenSearchTextType.of(Map.of("words",
-                OpenSearchDataType.of(OpenSearchDataType.MappingType.Keyword)))),
-            new Column("location", "location", STRUCT),
-            new Column("employer", "employer", ARRAY),
-            new Column("age", "age", INTEGER))),
-        ImmutableList.of(
-            tupleValue(ImmutableMap.<String, Object>builder()
-                    .put("name", "John")
-                    .put("address1", "Seattle")
-                    .put("address2", "WA")
-                    .put("location", ImmutableMap.of("x", "1", "y", "2"))
-                    .put("employments", ImmutableList.of(
-                        ImmutableMap.of("name", "Amazon"),
-                        ImmutableMap.of("name", "AWS")))
-                    .put("age", 20)
-                .build())));
+    QueryResult response =
+        new QueryResult(
+            new Schema(
+                ImmutableList.of(
+                    new Column("name", "name", STRING),
+                    new Column("address1", "address1", OpenSearchTextType.of()),
+                    new Column(
+                        "address2",
+                        "address2",
+                        OpenSearchTextType.of(
+                            Map.of(
+                                "words",
+                                OpenSearchDataType.of(OpenSearchDataType.MappingType.Keyword)))),
+                    new Column("location", "location", STRUCT),
+                    new Column("employer", "employer", ARRAY),
+                    new Column("age", "age", INTEGER))),
+            ImmutableList.of(
+                tupleValue(
+                    ImmutableMap.<String, Object>builder()
+                        .put("name", "John")
+                        .put("address1", "Seattle")
+                        .put("address2", "WA")
+                        .put("location", ImmutableMap.of("x", "1", "y", "2"))
+                        .put(
+                            "employments",
+                            ImmutableList.of(
+                                ImmutableMap.of("name", "Amazon"), ImmutableMap.of("name", "AWS")))
+                        .put("age", 20)
+                        .build())));
 
     assertJsonEquals(
         "{"
@@ -76,7 +84,8 @@ class JdbcResponseFormatterTest {
             + "],"
             + "\"datarows\":["
             + "[\"John\",\"Seattle\",\"WA\",{\"x\":\"1\",\"y\":\"2\"},"
-            + "[{\"name\":\"Amazon\"}," + "{\"name\":\"AWS\"}],"
+            + "[{\"name\":\"Amazon\"},"
+            + "{\"name\":\"AWS\"}],"
             + "20]],"
             + "\"total\":1,"
             + "\"size\":1,"
@@ -86,18 +95,21 @@ class JdbcResponseFormatterTest {
 
   @Test
   void format_response_with_cursor() {
-    QueryResult response = new QueryResult(
-        new Schema(ImmutableList.of(
-            new Column("name", "name", STRING),
-            new Column("address", "address", OpenSearchTextType.of()),
-            new Column("age", "age", INTEGER))),
-        ImmutableList.of(
-            tupleValue(ImmutableMap.<String, Object>builder()
-                    .put("name", "John")
-                    .put("address", "Seattle")
-                    .put("age", 20)
-                .build())),
-        new Cursor("test_cursor"));
+    QueryResult response =
+        new QueryResult(
+            new Schema(
+                ImmutableList.of(
+                    new Column("name", "name", STRING),
+                    new Column("address", "address", OpenSearchTextType.of()),
+                    new Column("age", "age", INTEGER))),
+            ImmutableList.of(
+                tupleValue(
+                    ImmutableMap.<String, Object>builder()
+                        .put("name", "John")
+                        .put("address", "Seattle")
+                        .put("age", 20)
+                        .build())),
+            new Cursor("test_cursor"));
 
     assertJsonEquals(
         "{"
@@ -119,9 +131,9 @@ class JdbcResponseFormatterTest {
   void format_response_with_missing_and_null_value() {
     QueryResult response =
         new QueryResult(
-            new Schema(ImmutableList.of(
-                new Column("name", null, STRING),
-                new Column("age", null, INTEGER))),
+            new Schema(
+                ImmutableList.of(
+                    new Column("name", null, STRING), new Column("age", null, INTEGER))),
             Arrays.asList(
                 ExprTupleValue.fromExprValueMap(
                     ImmutableMap.of("name", stringValue("John"), "age", LITERAL_MISSING)),
@@ -147,8 +159,7 @@ class JdbcResponseFormatterTest {
             + "\"details\":\"Invalid query syntax\""
             + "},"
             + "\"status\":400}",
-        formatter.format(new SyntaxCheckException("Invalid query syntax"))
-    );
+        formatter.format(new SyntaxCheckException("Invalid query syntax")));
   }
 
   @Test
@@ -161,8 +172,7 @@ class JdbcResponseFormatterTest {
             + "\"details\":\"Invalid query semantics\""
             + "},"
             + "\"status\":400}",
-        formatter.format(new SemanticCheckException("Invalid query semantics"))
-    );
+        formatter.format(new SemanticCheckException("Invalid query semantics")));
   }
 
   @Test
@@ -175,8 +185,7 @@ class JdbcResponseFormatterTest {
             + "\"details\":\"Execution error\""
             + "},"
             + "\"status\":503}",
-        formatter.format(new IllegalStateException("Execution error"))
-    );
+        formatter.format(new IllegalStateException("Execution error")));
   }
 
   @Test
@@ -193,15 +202,12 @@ class JdbcResponseFormatterTest {
             + "from OpenSearch engine.\""
             + "},"
             + "\"status\":503}",
-        formatter.format(new OpenSearchException("all shards failed",
-            new IllegalStateException("Execution error")))
-    );
+        formatter.format(
+            new OpenSearchException(
+                "all shards failed", new IllegalStateException("Execution error"))));
   }
 
   private static void assertJsonEquals(String expected, String actual) {
-    assertEquals(
-        JsonParser.parseString(expected),
-        JsonParser.parseString(actual));
+    assertEquals(JsonParser.parseString(expected), JsonParser.parseString(actual));
   }
-
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/RawResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/RawResponseFormatterTest.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,69 +23,92 @@ import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.protocol.response.QueryResult;
 
-/**
- * Unit test for {@link FlatResponseFormatter}.
- */
+/** Unit test for {@link FlatResponseFormatter}. */
 public class RawResponseFormatterTest {
   private FlatResponseFormatter rawFormatter = new RawResponseFormatter();
 
   @Test
   void formatResponse() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("name", "name", STRING),
-        new ExecutionEngine.Schema.Column("age", "age", INTEGER)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of("name", "John", "age", 20)),
-        tupleValue(ImmutableMap.of("name", "Smith", "age", 30))));
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(
+                new ExecutionEngine.Schema.Column("name", "name", STRING),
+                new ExecutionEngine.Schema.Column("age", "age", INTEGER)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("name", "John", "age", 20)),
+                tupleValue(ImmutableMap.of("name", "Smith", "age", 30))));
     String expected = "name|age%nJohn|20%nSmith|30";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
   void sanitizeHeaders() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("=firstname", null, STRING),
-        new ExecutionEngine.Schema.Column("+lastname", null, STRING),
-        new ExecutionEngine.Schema.Column("-city", null, STRING),
-        new ExecutionEngine.Schema.Column("@age", null, INTEGER)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of(
-            "=firstname", "John", "+lastname", "Smith", "-city", "Seattle", "@age", 20))));
-    String expected = "=firstname|+lastname|-city|@age%n"
-        + "John|Smith|Seattle|20";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(
+                new ExecutionEngine.Schema.Column("=firstname", null, STRING),
+                new ExecutionEngine.Schema.Column("+lastname", null, STRING),
+                new ExecutionEngine.Schema.Column("-city", null, STRING),
+                new ExecutionEngine.Schema.Column("@age", null, INTEGER)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(
+                    ImmutableMap.of(
+                        "=firstname",
+                        "John",
+                        "+lastname",
+                        "Smith",
+                        "-city",
+                        "Seattle",
+                        "@age",
+                        20))));
+    String expected = "=firstname|+lastname|-city|@age%n" + "John|Smith|Seattle|20";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
   void sanitizeData() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("city", "city", STRING)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of("city", "Seattle")),
-        tupleValue(ImmutableMap.of("city", "=Seattle")),
-        tupleValue(ImmutableMap.of("city", "+Seattle")),
-        tupleValue(ImmutableMap.of("city", "-Seattle")),
-        tupleValue(ImmutableMap.of("city", "@Seattle")),
-        tupleValue(ImmutableMap.of("city", "Seattle="))));
-    String expected = "city%n"
-        + "Seattle%n"
-        + "=Seattle%n"
-        + "+Seattle%n"
-        + "-Seattle%n"
-        + "@Seattle%n"
-        + "Seattle=";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(new ExecutionEngine.Schema.Column("city", "city", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("city", "Seattle")),
+                tupleValue(ImmutableMap.of("city", "=Seattle")),
+                tupleValue(ImmutableMap.of("city", "+Seattle")),
+                tupleValue(ImmutableMap.of("city", "-Seattle")),
+                tupleValue(ImmutableMap.of("city", "@Seattle")),
+                tupleValue(ImmutableMap.of("city", "Seattle="))));
+    String expected =
+        "city%n"
+            + "Seattle%n"
+            + "=Seattle%n"
+            + "+Seattle%n"
+            + "-Seattle%n"
+            + "@Seattle%n"
+            + "Seattle=";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
   void quoteIfRequired() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-            new ExecutionEngine.Schema.Column("na|me", "na|me", STRING),
-            new ExecutionEngine.Schema.Column("||age", "||age", INTEGER)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-            tupleValue(ImmutableMap.of("na|me", "John|Smith", "||age", "30|||"))));
-    String expected = "\"na|me\"|\"||age\"%n"
-            + "\"John|Smith\"|\"30|||\"";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(
+                new ExecutionEngine.Schema.Column("na|me", "na|me", STRING),
+                new ExecutionEngine.Schema.Column("||age", "||age", INTEGER)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(tupleValue(ImmutableMap.of("na|me", "John|Smith", "||age", "30|||"))));
+    String expected = "\"na|me\"|\"||age\"%n" + "\"John|Smith\"|\"30|||\"";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
@@ -101,59 +123,67 @@ public class RawResponseFormatterTest {
   @Test
   void escapeSanitize() {
     FlatResponseFormatter escapeFormatter = new RawResponseFormatter();
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-            new ExecutionEngine.Schema.Column("city", "city", STRING)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-            tupleValue(ImmutableMap.of("city", "=Seattle")),
-            tupleValue(ImmutableMap.of("city", "||Seattle"))));
-    String expected = "city%n"
-            + "=Seattle%n"
-            + "\"||Seattle\"";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(new ExecutionEngine.Schema.Column("city", "city", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("city", "=Seattle")),
+                tupleValue(ImmutableMap.of("city", "||Seattle"))));
+    String expected = "city%n" + "=Seattle%n" + "\"||Seattle\"";
     assertEquals(format(expected), escapeFormatter.format(response));
   }
 
   @Test
   void senstiveCharater() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-            new ExecutionEngine.Schema.Column("city", "city", STRING)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-            tupleValue(ImmutableMap.of("city", "@Seattle")),
-            tupleValue(ImmutableMap.of("city", "++Seattle"))));
-    String expected = "city%n"
-            + "@Seattle%n"
-            + "++Seattle";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(new ExecutionEngine.Schema.Column("city", "city", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("city", "@Seattle")),
+                tupleValue(ImmutableMap.of("city", "++Seattle"))));
+    String expected = "city%n" + "@Seattle%n" + "++Seattle";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
   @Test
   void senstiveCharaterWithSanitize() {
     FlatResponseFormatter testFormater = new RawResponseFormatter();
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-            new ExecutionEngine.Schema.Column("city", "city", STRING)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-            tupleValue(ImmutableMap.of("city", "@Seattle")),
-            tupleValue(ImmutableMap.of("city", "++Seattle|||"))));
-    String expected = "city%n"
-            + "@Seattle%n"
-            + "\"++Seattle|||\"";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(new ExecutionEngine.Schema.Column("city", "city", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("city", "@Seattle")),
+                tupleValue(ImmutableMap.of("city", "++Seattle|||"))));
+    String expected = "city%n" + "@Seattle%n" + "\"++Seattle|||\"";
     assertEquals(format(expected), testFormater.format(response));
   }
 
   @Test
   void replaceNullValues() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("name", "name", STRING),
-        new ExecutionEngine.Schema.Column("city", "city", STRING)));
-    QueryResult response = new QueryResult(schema, Arrays.asList(
-        tupleValue(ImmutableMap.of("name", "John","city", "Seattle")),
-        ExprTupleValue.fromExprValueMap(
-            ImmutableMap.of("firstname", LITERAL_NULL, "city", stringValue("Seattle"))),
-        ExprTupleValue.fromExprValueMap(
-            ImmutableMap.of("firstname", stringValue("John"), "city", LITERAL_MISSING))));
-    String expected = "name|city%n"
-        + "John|Seattle%n"
-        + "|Seattle%n"
-        + "John|";
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(
+                new ExecutionEngine.Schema.Column("name", "name", STRING),
+                new ExecutionEngine.Schema.Column("city", "city", STRING)));
+    QueryResult response =
+        new QueryResult(
+            schema,
+            Arrays.asList(
+                tupleValue(ImmutableMap.of("name", "John", "city", "Seattle")),
+                ExprTupleValue.fromExprValueMap(
+                    ImmutableMap.of("firstname", LITERAL_NULL, "city", stringValue("Seattle"))),
+                ExprTupleValue.fromExprValueMap(
+                    ImmutableMap.of("firstname", stringValue("John"), "city", LITERAL_MISSING))));
+    String expected = "name|city%n" + "John|Seattle%n" + "|Seattle%n" + "John|";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
@@ -161,5 +191,4 @@ public class RawResponseFormatterTest {
   void testContentType() {
     assertEquals(rawFormatter.contentType(), CONTENT_TYPE);
   }
-
 }

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/RawResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/RawResponseFormatterTest.java
@@ -67,7 +67,7 @@ public class RawResponseFormatterTest {
                         "Seattle",
                         "@age",
                         20))));
-    String expected = "=firstname|+lastname|-city|@age%n" + "John|Smith|Seattle|20";
+    String expected = "=firstname|+lastname|-city|@age%nJohn|Smith|Seattle|20";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
@@ -108,7 +108,7 @@ public class RawResponseFormatterTest {
         new QueryResult(
             schema,
             Arrays.asList(tupleValue(ImmutableMap.of("na|me", "John|Smith", "||age", "30|||"))));
-    String expected = "\"na|me\"|\"||age\"%n" + "\"John|Smith\"|\"30|||\"";
+    String expected = "\"na|me\"|\"||age\"%n\"John|Smith\"|\"30|||\"";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
@@ -132,7 +132,7 @@ public class RawResponseFormatterTest {
             Arrays.asList(
                 tupleValue(ImmutableMap.of("city", "=Seattle")),
                 tupleValue(ImmutableMap.of("city", "||Seattle"))));
-    String expected = "city%n" + "=Seattle%n" + "\"||Seattle\"";
+    String expected = "city%n=Seattle%n\"||Seattle\"";
     assertEquals(format(expected), escapeFormatter.format(response));
   }
 
@@ -147,7 +147,7 @@ public class RawResponseFormatterTest {
             Arrays.asList(
                 tupleValue(ImmutableMap.of("city", "@Seattle")),
                 tupleValue(ImmutableMap.of("city", "++Seattle"))));
-    String expected = "city%n" + "@Seattle%n" + "++Seattle";
+    String expected = "city%n@Seattle%n++Seattle";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 
@@ -163,7 +163,7 @@ public class RawResponseFormatterTest {
             Arrays.asList(
                 tupleValue(ImmutableMap.of("city", "@Seattle")),
                 tupleValue(ImmutableMap.of("city", "++Seattle|||"))));
-    String expected = "city%n" + "@Seattle%n" + "\"++Seattle|||\"";
+    String expected = "city%n@Seattle%n\"++Seattle|||\"";
     assertEquals(format(expected), testFormater.format(response));
   }
 
@@ -183,7 +183,7 @@ public class RawResponseFormatterTest {
                     ImmutableMap.of("firstname", LITERAL_NULL, "city", stringValue("Seattle"))),
                 ExprTupleValue.fromExprValueMap(
                     ImmutableMap.of("firstname", stringValue("John"), "city", LITERAL_MISSING))));
-    String expected = "name|city%n" + "John|Seattle%n" + "|Seattle%n" + "John|";
+    String expected = "name|city%nJohn|Seattle%n|Seattle%nJohn|";
     assertEquals(format(expected), rawFormatter.format(response));
   }
 

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/SimpleJsonResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/SimpleJsonResponseFormatterTest.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 package org.opensearch.sql.protocol.response.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,9 +24,11 @@ import org.opensearch.sql.protocol.response.QueryResult;
 
 class SimpleJsonResponseFormatterTest {
 
-  private final ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-      new ExecutionEngine.Schema.Column("firstname", null, STRING),
-      new ExecutionEngine.Schema.Column("age", null, INTEGER)));
+  private final ExecutionEngine.Schema schema =
+      new ExecutionEngine.Schema(
+          ImmutableList.of(
+              new ExecutionEngine.Schema.Column("firstname", null, STRING),
+              new ExecutionEngine.Schema.Column("age", null, INTEGER)));
 
   @Test
   void formatResponse() {
@@ -84,12 +85,12 @@ class SimpleJsonResponseFormatterTest {
 
   @Test
   void formatResponseSchemaWithAlias() {
-    ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
-        new ExecutionEngine.Schema.Column("firstname", "name", STRING)));
+    ExecutionEngine.Schema schema =
+        new ExecutionEngine.Schema(
+            ImmutableList.of(new ExecutionEngine.Schema.Column("firstname", "name", STRING)));
     QueryResult response =
         new QueryResult(
-            schema,
-            ImmutableList.of(tupleValue(ImmutableMap.of("name", "John", "age", 20))));
+            schema, ImmutableList.of(tupleValue(ImmutableMap.of("name", "John", "age", 20))));
     SimpleJsonResponseFormatter formatter = new SimpleJsonResponseFormatter(COMPACT);
     assertEquals(
         "{\"schema\":[{\"name\":\"name\",\"type\":\"string\"}],"
@@ -120,10 +121,13 @@ class SimpleJsonResponseFormatterTest {
         new QueryResult(
             schema,
             Arrays.asList(
-                tupleValue(ImmutableMap
-                    .of("name", "Smith",
-                        "address", ImmutableMap.of("state", "WA", "street",
-                            ImmutableMap.of("city", "seattle"))))));
+                tupleValue(
+                    ImmutableMap.of(
+                        "name",
+                        "Smith",
+                        "address",
+                        ImmutableMap.of(
+                            "state", "WA", "street", ImmutableMap.of("city", "seattle"))))));
     SimpleJsonResponseFormatter formatter = new SimpleJsonResponseFormatter(COMPACT);
 
     assertEquals(
@@ -140,11 +144,13 @@ class SimpleJsonResponseFormatterTest {
         new QueryResult(
             schema,
             Arrays.asList(
-                tupleValue(ImmutableMap
-                    .of("name", "Smith",
-                        "address", Arrays.asList(
-                            ImmutableMap.of("state", "WA"), ImmutableMap.of("state", "NYC")
-                        )))));
+                tupleValue(
+                    ImmutableMap.of(
+                        "name",
+                        "Smith",
+                        "address",
+                        Arrays.asList(
+                            ImmutableMap.of("state", "WA"), ImmutableMap.of("state", "NYC"))))));
     SimpleJsonResponseFormatter formatter = new SimpleJsonResponseFormatter(COMPACT);
     assertEquals(
         "{\"schema\":[{\"name\":\"firstname\",\"type\":\"string\"},"

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/VisualizationResponseFormatterTest.java
@@ -24,18 +24,21 @@ import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.protocol.response.QueryResult;
 
 public class VisualizationResponseFormatterTest {
-  private final VisualizationResponseFormatter formatter = new VisualizationResponseFormatter(
-      JsonResponseFormatter.Style.COMPACT);
+  private final VisualizationResponseFormatter formatter =
+      new VisualizationResponseFormatter(JsonResponseFormatter.Style.COMPACT);
 
   @Test
   void formatResponse() {
-    QueryResult response = new QueryResult(
-        new ExecutionEngine.Schema(ImmutableList.of(
-            new ExecutionEngine.Schema.Column("name", "name", STRING),
-            new ExecutionEngine.Schema.Column("age", "age", INTEGER))),
-        ImmutableList.of(tupleValue(ImmutableMap.of("name", "John", "age", 20)),
-            tupleValue(ImmutableMap.of("name", "Amy", "age", 31)),
-            tupleValue(ImmutableMap.of("name", "Bob", "age", 28))));
+    QueryResult response =
+        new QueryResult(
+            new ExecutionEngine.Schema(
+                ImmutableList.of(
+                    new ExecutionEngine.Schema.Column("name", "name", STRING),
+                    new ExecutionEngine.Schema.Column("age", "age", INTEGER))),
+            ImmutableList.of(
+                tupleValue(ImmutableMap.of("name", "John", "age", 20)),
+                tupleValue(ImmutableMap.of("name", "Amy", "age", 31)),
+                tupleValue(ImmutableMap.of("name", "Bob", "age", 28))));
 
     assertJsonEquals(
         "{\"data\":{"
@@ -55,10 +58,12 @@ public class VisualizationResponseFormatterTest {
   void formatResponseWithNull() {
     QueryResult response =
         new QueryResult(
-            new ExecutionEngine.Schema(ImmutableList.of(
-                new ExecutionEngine.Schema.Column("name", null, STRING),
-                new ExecutionEngine.Schema.Column("age", null, INTEGER))),
-            ImmutableList.of(tupleValue(ImmutableMap.of("name", "John", "age", LITERAL_MISSING)),
+            new ExecutionEngine.Schema(
+                ImmutableList.of(
+                    new ExecutionEngine.Schema.Column("name", null, STRING),
+                    new ExecutionEngine.Schema.Column("age", null, INTEGER))),
+            ImmutableList.of(
+                tupleValue(ImmutableMap.of("name", "John", "age", LITERAL_MISSING)),
                 tupleValue(ImmutableMap.of("name", "Allen", "age", LITERAL_NULL)),
                 tupleValue(ImmutableMap.of("name", "Smith", "age", 30))));
 
@@ -73,8 +78,7 @@ public class VisualizationResponseFormatterTest {
             + "\"size\":3,"
             + "\"status\":200"
             + "}",
-        formatter.format(response)
-    );
+        formatter.format(response));
   }
 
   @Test
@@ -87,8 +91,7 @@ public class VisualizationResponseFormatterTest {
             + "\"details\":\"Invalid query syntax\""
             + "},"
             + "\"status\":400}",
-        formatter.format(new SyntaxCheckException("Invalid query syntax"))
-    );
+        formatter.format(new SyntaxCheckException("Invalid query syntax")));
   }
 
   @Test
@@ -101,8 +104,7 @@ public class VisualizationResponseFormatterTest {
             + "\"details\":\"Invalid query semantics\""
             + "},"
             + "\"status\":400}",
-        formatter.format(new SemanticCheckException("Invalid query semantics"))
-    );
+        formatter.format(new SemanticCheckException("Invalid query semantics")));
   }
 
   @Test
@@ -115,8 +117,7 @@ public class VisualizationResponseFormatterTest {
             + "\"details\":\"Execution error\""
             + "},"
             + "\"status\":503}",
-        formatter.format(new IllegalStateException("Execution error"))
-    );
+        formatter.format(new IllegalStateException("Execution error")));
   }
 
   @Test
@@ -133,22 +134,25 @@ public class VisualizationResponseFormatterTest {
             + "from OpenSearch engine.\""
             + "},"
             + "\"status\":503}",
-        formatter.format(new OpenSearchException("all shards failed",
-            new IllegalStateException("Execution error")))
-    );
+        formatter.format(
+            new OpenSearchException(
+                "all shards failed", new IllegalStateException("Execution error"))));
   }
 
   @Test
   void prettyStyle() {
-    VisualizationResponseFormatter prettyFormatter = new VisualizationResponseFormatter(
-        JsonResponseFormatter.Style.PRETTY);
-    QueryResult response = new QueryResult(
-        new ExecutionEngine.Schema(ImmutableList.of(
-            new ExecutionEngine.Schema.Column("name", "name", STRING),
-            new ExecutionEngine.Schema.Column("age", "age", INTEGER))),
-        ImmutableList.of(tupleValue(ImmutableMap.of("name", "John", "age", 20)),
-            tupleValue(ImmutableMap.of("name", "Amy", "age", 31)),
-            tupleValue(ImmutableMap.of("name", "Bob", "age", 28))));
+    VisualizationResponseFormatter prettyFormatter =
+        new VisualizationResponseFormatter(JsonResponseFormatter.Style.PRETTY);
+    QueryResult response =
+        new QueryResult(
+            new ExecutionEngine.Schema(
+                ImmutableList.of(
+                    new ExecutionEngine.Schema.Column("name", "name", STRING),
+                    new ExecutionEngine.Schema.Column("age", "age", INTEGER))),
+            ImmutableList.of(
+                tupleValue(ImmutableMap.of("name", "John", "age", 20)),
+                tupleValue(ImmutableMap.of("name", "Amy", "age", 31)),
+                tupleValue(ImmutableMap.of("name", "Bob", "age", 28))));
 
     assertJsonEquals(
         "{\n"
@@ -179,14 +183,11 @@ public class VisualizationResponseFormatterTest {
             + "  \"size\": 3,\n"
             + "  \"status\": 200\n"
             + "}",
-        prettyFormatter.format(response)
-    );
+        prettyFormatter.format(response));
   }
 
   private static void assertJsonEquals(String expected, String actual) {
-    assertEquals(
-        JsonParser.parseString(expected),
-        JsonParser.parseString(actual));
+    assertEquals(JsonParser.parseString(expected), JsonParser.parseString(actual));
   }
 
   @Test


### PR DESCRIPTION
### Description
Applies spotless for protocol directory in project. Sets checkstyle to not fail on failure for protocol directory.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1101
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).