### PR TITLE
Add option to swap arguments in lucene queries

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneFunctionWrapper.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneFunctionWrapper.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene;
+
+import lombok.Getter;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+
+/**
+ * {@link FunctionExpression} wrapper for {@link LuceneQuery}. Helps build queries to Lucene.
+ */
+@Getter
+public class LuceneFunctionWrapper {
+
+  private final FunctionExpression func;
+  private final ReferenceExpression reference;
+  private final Expression literal;
+
+  public LuceneFunctionWrapper(FunctionExpression func) {
+    this.func = func;
+    ReferenceExpression reference = null;
+    Expression literal = null;
+    for (var arg : func.getArguments()) {
+      if (arg instanceof ReferenceExpression) {
+        reference = (ReferenceExpression) arg;
+      } else if (isArgASupportedLiteral(arg)) {
+        literal = arg;
+      }
+    }
+    this.reference = reference;
+    this.literal = literal;
+  }
+
+  /**
+   * Check if the argument of the function is a supported literal.
+   */
+  private boolean isArgASupportedLiteral(Expression arg) {
+    return arg instanceof LiteralExpression || isLiteralExpressionWrappedByCast(arg);
+  }
+
+  /**
+   * Check if the argument of the function is a literal expression wrapped by cast function.
+   */
+  private boolean isLiteralExpressionWrappedByCast(Expression arg) {
+    if (arg instanceof FunctionExpression) {
+      FunctionExpression expr = (FunctionExpression) arg;
+       return LuceneQuery.castMap.containsKey(expr.getFunctionName())
+          && isArgASupportedLiteral(expr.getArguments().get(0));
+    }
+    return false;
+  }
+
+  /**
+   * Check if the function expression has multiple named argument expressions as the parameters.
+   */
+  public boolean isMultiParameterQuery() {
+    for (Expression expr : func.getArguments()) {
+      if (!(expr instanceof NamedArgumentExpression)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Get the value of the {@link #literal}.
+   * The caller should be aware that {@link #func} may have no literal arguments.
+   */
+  public ExprValue getLiteralValue() {
+    return literal instanceof LiteralExpression
+        ? literal.valueOf()
+        : LuceneQuery.castMap.get(((FunctionExpression) literal).getFunctionName())
+            .apply((LiteralExpression) ((FunctionExpression) literal).getArguments().get(0));
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/NoFieldQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/NoFieldQuery.java
@@ -14,6 +14,7 @@ import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneFunctionWrapper;
 
 /**
  * Base class to represent relevance queries that have no 'fields' array as an argument.
@@ -47,12 +48,12 @@ abstract class NoFieldQuery<T extends QueryBuilder> extends RelevanceQuery<T> {
    */
 
   @Override
-  public QueryBuilder build(FunctionExpression func) {
-    var arguments = func.getArguments().stream().map(
+  public QueryBuilder build(LuceneFunctionWrapper func) {
+    var arguments = func.getFunc().getArguments().stream().map(
         a -> (NamedArgumentExpression) a).collect(Collectors.toList());
     if (arguments.size() < 1) {
       throw new SyntaxCheckException(String.format(
-          "%s requires at least one parameter", func.getFunctionName()));
+          "%s requires at least one parameter", func.getFunc().getFunctionName()));
     }
 
     return loadArguments(arguments);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/relevance/RelevanceQuery.java
@@ -18,6 +18,7 @@ import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneFunctionWrapper;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
 
 /**
@@ -73,8 +74,8 @@ public abstract class RelevanceQuery<T extends QueryBuilder> extends LuceneQuery
   }
 
   @Override
-  public QueryBuilder build(FunctionExpression func) {
-    var arguments = func.getArguments().stream()
+  public QueryBuilder build(LuceneFunctionWrapper func) {
+    var arguments = func.getFunc().getArguments().stream()
         .map(a -> (NamedArgumentExpression)a).collect(Collectors.toList());
     if (arguments.size() < 2) {
       throw new SyntaxCheckException(
@@ -82,7 +83,6 @@ public abstract class RelevanceQuery<T extends QueryBuilder> extends LuceneQuery
     }
 
     return loadArguments(arguments);
-
   }
 
   protected abstract T createQueryBuilder(List<NamedArgumentExpression> arguments);


### PR DESCRIPTION
### Description
Lucene queries accept field reference (column/field name) at the first arg only (on the left side). If reference is on the right - query fails or performed with significant overhead.

#### Example 1
```
opensearchsql> select * from bank where address = '282 Kings Place';
Output longer than terminal width
Do you want to display data vertically for better visual effect? [y/N]:
fetched rows / total rows = 0/0
+------------------+-------------+-----------+-------------+----------+--------+------------+-----------+------------+---------+----->
| account_number   | firstname   | address   | birthdate   | gender   | city   | lastname   | balance   | employer   | state   | age >
|------------------+-------------+-----------+-------------+----------+--------+------------+-----------+------------+---------+----->
+------------------+-------------+-----------+-------------+----------+--------+------------+-----------+------------+---------+----->
```
(_query succeeded_)
```
opensearchsql> select * from bank where '282 Kings Place' = address;
TransportError(503, 'SearchPhaseExecutionException', {'error': {'reason': 'Error occurred in OpenSearch engine: all shards failed', 'details': 'Shard[0]: java.lang.IllegalArgumentException: Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [address] in order to load field data by uninverting the inverted index. Note that this can use significant memory.\n\nFor more details, please send request for Json format to see the raw response from OpenSearch engine.', 'type': 'SearchPhaseExecutionException'}, 'status': 400})
```
(_query failed_)

#### Example 2
Query 1
```sql
select account_number from bank where age = 30;
```
Explain
```json
{
  "from": 0,
  "size": 200,
  "timeout": "1m",
  "query": {
    "term": {
      "age": {
        "value": 30,
        "boost": 1
      }
    }
  },
  "_source": {
    "includes": [
      "account_number"
    ],
    "excludes": []
  },
  "sort": [
    {
      "_doc": {
        "order": "asc"
      }
    }
  ]
}
```
Query 2
```sql
select account_number from bank where 30 = age;
```
Explain
```json
{
  "from": 0,
  "size": 200,
  "timeout": "1m",
  "query": {
    "script": {
      "script": {
        "source": " ... huge serialized script contains encoded function '=(30, age)'",
        "lang": "opensearch_query_expression"
      },
      "boost": 1
    }
  },
  "_source": {
    "includes": [
      "account_number"
    ],
    "excludes": []
  },
  "sort": [
    {
      "_doc": {
        "order": "asc"
      }
    }
  ]
}
```

With proposed changes `explain` for both queries in the second example will be same. Query in the first example would work properly.

### Notes
This is a PoC. WIP.
With a properly wrapped lucene query we can avoid storing (and using) `castMap` in `LuceneQuery`, which completely duplicates `TypeCastOperator`.

This should be done before or together with moving OpenSearch functions out of `:core`. Ref: UDF (User Defined Functions), #811.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).