### PR TITLE
Fixed exception when datasource is updated with existing configuration.

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
@@ -150,7 +150,8 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
       throw new RuntimeException(e);
     }
 
-    if (updateResponse.getResult().equals(DocWriteResponse.Result.UPDATED)) {
+    if (updateResponse.getResult().equals(DocWriteResponse.Result.UPDATED)
+        || updateResponse.getResult().equals(DocWriteResponse.Result.NOOP)) {
       LOG.debug("DatasourceMetadata : {}  successfully updated", dataSourceMetadata.getName());
     } else {
       throw new RuntimeException(

--- a/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
@@ -452,6 +452,24 @@ public class OpenSearchDataSourceMetadataStorageTest {
   }
 
   @Test
+  public void testUpdateDataSourceMetadataWithNOOP() {
+    Mockito.when(encryptor.encrypt("secret_key")).thenReturn("secret_key");
+    Mockito.when(encryptor.encrypt("access_key")).thenReturn("access_key");
+    Mockito.when(client.update(ArgumentMatchers.any())).thenReturn(updateResponseActionFuture);
+    Mockito.when(updateResponseActionFuture.actionGet()).thenReturn(updateResponse);
+    Mockito.when(updateResponse.getResult()).thenReturn(DocWriteResponse.Result.NOOP);
+    DataSourceMetadata dataSourceMetadata = getDataSourceMetadata();
+
+    this.openSearchDataSourceMetadataStorage.updateDataSourceMetadata(dataSourceMetadata);
+
+    Mockito.verify(encryptor, Mockito.times(1)).encrypt("secret_key");
+    Mockito.verify(encryptor, Mockito.times(1)).encrypt("access_key");
+    Mockito.verify(client.admin().indices(), Mockito.times(0)).create(ArgumentMatchers.any());
+    Mockito.verify(client, Mockito.times(1)).update(ArgumentMatchers.any());
+    Mockito.verify(client.threadPool().getThreadContext(), Mockito.times(1)).stashContext();
+  }
+
+  @Test
   public void testUpdateDataSourceMetadataWithNotFoundResult() {
     Mockito.when(encryptor.encrypt("secret_key")).thenReturn("secret_key");
     Mockito.when(encryptor.encrypt("access_key")).thenReturn("access_key");


### PR DESCRIPTION
### Description
In the current state when datasource is updated with existing configuration, it results in 503 error.
With this PR, it returns 200.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).