### PR TITLE
Revert "Guarantee datasource read api is strong consistent read (#1815)"

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
@@ -224,9 +224,6 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
     searchSourceBuilder.query(query);
     searchSourceBuilder.size(DATASOURCE_QUERY_RESULT_SIZE);
     searchRequest.source(searchSourceBuilder);
-    // strongly consistent reads is requred. more info
-    // https://github.com/opensearch-project/sql/issues/1801.
-    searchRequest.preference("_primary");
     ActionFuture<SearchResponse> searchResponseActionFuture;
     try (ThreadContext.StoredContext ignored =
         client.threadPool().getThreadContext().stashContext()) {


### PR DESCRIPTION
This reverts commit f38ffed084cdcfc288eb32b35f3f3f1e5f5425d9.

### Description
This change reverts the commit f38ffed084cdcfc288eb32b35f3f3f1e5f5425d9 as 
1. With https://github.com/opensearch-project/OpenSearch/issues/8536, core now supports realtime reads with [get](https://opensearch.org/docs/latest/api-reference/document-apis/get-documents/)/[mget](https://opensearch.org/docs/latest/api-reference/document-apis/multi-get/) APIs. Thus, if strong reads are desired plugin can use get/mget queries. get/mget is recommended over `_primary` based routing preference in order to reduce load on primary.
2. Existing OpenSearchDataSourceMetadataStorage.java uses `match_all` & `term` based search queries which does not provide strong reads and thus as part of https://github.com/opensearch-project/sql/issues/1801 there was no need to perform `_primary` based routing.
 
### Issues Resolved
Relates: https://github.com/opensearch-project/sql/issues/1801
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).