### PR TITLE
[Spotless] Exclude generated files from spotless 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ spotless {
     java {
         target fileTree('.') {
             include '**/*.java'
-            exclude '**/build/**', '**/build-*/**'
+            exclude '**/build/**', '**/build-*/**', '**/gen/**'
         }
         importOrder()
 //        licenseHeader("/*\n" +


### PR DESCRIPTION
### Description
Spotless runs on generated files. Generated files may not be properly formatted, and spotless should not try to modify them. This PR adds `**/gen/**` to the excludes list, for example `ppl\src\main\antlr\gen\OpenSearchPPLLexer.java`.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).