### PR TITLE
[Backport 2.x] Applied formatting improvements to Antlr files based on spotless changes (#2017)

### DIFF
--- a/legacy/src/main/antlr/OpenSearchLegacySqlParser.g4
+++ b/legacy/src/main/antlr/OpenSearchLegacySqlParser.g4
@@ -30,324 +30,280 @@ THE SOFTWARE.
 
 parser grammar OpenSearchLegacySqlParser;
 
-options { tokenVocab=OpenSearchLegacySqlLexer; }
 
-
+options { tokenVocab = OpenSearchLegacySqlLexer; }
 // Top Level Description
 
-//    Root rule
+// Root rule
 root
-    : sqlStatement? SEMI? EOF
-    ;
+   : sqlStatement? SEMI? EOF
+   ;
 
-//    Only SELECT, DELETE, SHOW and DSCRIBE are supported for now
+// Only SELECT, DELETE, SHOW and DSCRIBE are supported for now
 sqlStatement
-    : dmlStatement | administrationStatement | utilityStatement
-    ;
+   : dmlStatement
+   | administrationStatement
+   | utilityStatement
+   ;
 
 dmlStatement
-    : selectStatement | deleteStatement
-    ;
+   : selectStatement
+   | deleteStatement
+   ;
 
+   // Data Manipulation Language
 
-// Data Manipulation Language
-
-//    Primary DML Statements
-
+   // Primary DML Statements
 selectStatement
-    : querySpecification                                 #simpleSelect
-    | queryExpression                                    #parenthesisSelect
-    | querySpecification unionStatement+
-        orderByClause? limitClause?                      #unionSelect
-    | querySpecification minusStatement+
-        orderByClause? limitClause?                      #minusSelect
-    ;
+   : querySpecification                                                 # simpleSelect
+   | queryExpression                                                    # parenthesisSelect
+   | querySpecification unionStatement+ orderByClause? limitClause?     # unionSelect
+   | querySpecification minusStatement+ orderByClause? limitClause?     # minusSelect
+   ;
 
 deleteStatement
-    : singleDeleteStatement
-    ;
+   : singleDeleteStatement
+   ;
 
-//    Detailed DML Statements
-
+// Detailed DML Statements
 singleDeleteStatement
-    : DELETE FROM tableName
-      (WHERE expression)?
-      orderByClause? (LIMIT decimalLiteral)?
-    ;
+   : DELETE FROM tableName (WHERE expression)? orderByClause? (LIMIT decimalLiteral)?
+   ;
 
 orderByClause
-    : ORDER BY orderByExpression (',' orderByExpression)*
-    ;
+   : ORDER BY orderByExpression (',' orderByExpression)*
+   ;
 
 orderByExpression
-    : expression order=(ASC | DESC)?
-    ;
+   : expression order = (ASC | DESC)?
+   ;
 
 tableSources
-    : tableSource (',' tableSource)*
-    ;
+   : tableSource (',' tableSource)*
+   ;
 
 tableSource
-    : tableSourceItem joinPart*                                     #tableSourceBase
-    | '(' tableSourceItem joinPart* ')'                             #tableSourceNested
-    ;
+   : tableSourceItem joinPart*          # tableSourceBase
+   | '(' tableSourceItem joinPart* ')'  # tableSourceNested
+   ;
 
 tableSourceItem
-    : tableName (AS? alias=uid)?                                    #atomTableItem
-    | (
-      selectStatement
-      | '(' parenthesisSubquery=selectStatement ')'
-      )
-      AS? alias=uid                                                 #subqueryTableItem
-    | '(' tableSources ')'                                          #tableSourcesItem
-    ;
+   : tableName (AS? alias = uid)?                                                       # atomTableItem
+   | (selectStatement | '(' parenthesisSubquery = selectStatement ')') AS? alias = uid  # subqueryTableItem
+   | '(' tableSources ')'                                                               # tableSourcesItem
+   ;
 
 joinPart
-    : (INNER | CROSS)? JOIN tableSourceItem
-      (
-        ON expression
-        | USING '(' uidList ')'
-      )?                                                            #innerJoin
-    | (LEFT | RIGHT) OUTER? JOIN tableSourceItem
-        (
-          ON expression
-          | USING '(' uidList ')'
-        )?                                                          #outerJoin
-    | NATURAL ((LEFT | RIGHT) OUTER?)? JOIN tableSourceItem         #naturalJoin
-    ;
+   : (INNER | CROSS)? JOIN tableSourceItem (ON expression | USING '(' uidList ')')?         # innerJoin
+   | (LEFT | RIGHT) OUTER? JOIN tableSourceItem (ON expression | USING '(' uidList ')')?    # outerJoin
+   | NATURAL ((LEFT | RIGHT) OUTER?)? JOIN tableSourceItem                                  # naturalJoin
+   ;
 
-//    Select Statement's Details
-
+// Select Statement's Details
 queryExpression
-    : '(' querySpecification ')'
-    | '(' queryExpression ')'
-    ;
+   : '(' querySpecification ')'
+   | '(' queryExpression ')'
+   ;
 
 querySpecification
-    : SELECT selectSpec* selectElements
-      fromClause orderByClause? limitClause?
-    ;
+   : SELECT selectSpec* selectElements fromClause orderByClause? limitClause?
+   ;
 
 unionStatement
-    : UNION unionType=(ALL | DISTINCT)?
-      (querySpecification | queryExpression)
-    ;
+   : UNION unionType = (ALL | DISTINCT)? (querySpecification | queryExpression)
+   ;
 
 minusStatement
-    : EXCEPT (querySpecification | queryExpression)
-    ;
+   : EXCEPT (querySpecification | queryExpression)
+   ;
 
 selectSpec
-    : (ALL | DISTINCT)
-    ;
+   : (ALL | DISTINCT)
+   ;
 
 selectElements
-    : (star='*' | selectElement ) (',' selectElement)*
-    ;
+   : (star = '*' | selectElement) (',' selectElement)*
+   ;
 
 selectElement
-    : fullId '.' '*'                                                #selectStarElement
-    | fullColumnName (AS? uid)?                                     #selectColumnElement
-    | functionCall (AS? uid)?                                       #selectFunctionElement
-    | expression (AS? uid)?                                         #selectExpressionElement
-    | NESTED '(' fullId DOT STAR ')'                                #selectNestedStarElement
-    ;
+   : fullId '.' '*'                 # selectStarElement
+   | fullColumnName (AS? uid)?      # selectColumnElement
+   | functionCall (AS? uid)?        # selectFunctionElement
+   | expression (AS? uid)?          # selectExpressionElement
+   | NESTED '(' fullId DOT STAR ')' # selectNestedStarElement
+   ;
 
 fromClause
-    : FROM tableSources
-      (WHERE whereExpr=expression)?
-      (
-        GROUP BY
-        groupByItem (',' groupByItem)*
-      )?
-      (HAVING havingExpr=expression)?
-    ;
+   : FROM tableSources (WHERE whereExpr = expression)? (GROUP BY groupByItem (',' groupByItem)*)? (HAVING havingExpr = expression)?
+   ;
 
 groupByItem
-    : expression order=(ASC | DESC)?
-    ;
+   : expression order = (ASC | DESC)?
+   ;
 
 limitClause
-    : LIMIT
-    (
-      (offset=limitClauseAtom ',')? limit=limitClauseAtom
-      | limit=limitClauseAtom OFFSET offset=limitClauseAtom
-    )
-    ;
+   : LIMIT ((offset = limitClauseAtom ',')? limit = limitClauseAtom | limit = limitClauseAtom OFFSET offset = limitClauseAtom)
+   ;
 
 limitClauseAtom
-	: decimalLiteral
-	;
+   : decimalLiteral
+   ;
 
-
-//    SHOW/DESCIRBE statements
-
+// SHOW/DESCIRBE statements
 administrationStatement
-    : showStatement
-    ;
+   : showStatement
+   ;
 
 showStatement
-    : SHOW showSchemaEntity
-        (schemaFormat=(FROM | IN) uid)? showFilter?
-    ;
+   : SHOW showSchemaEntity (schemaFormat = (FROM | IN) uid)? showFilter?
+   ;
 
 utilityStatement
-    : simpleDescribeStatement
-    ;
+   : simpleDescribeStatement
+   ;
 
 simpleDescribeStatement
-    : command=DESCRIBE tableName
-      (column=uid | pattern=STRING_LITERAL)?
-    ;
+   : command = DESCRIBE tableName (column = uid | pattern = STRING_LITERAL)?
+   ;
 
 showFilter
-    : LIKE STRING_LITERAL
-    | WHERE expression
-    ;
+   : LIKE STRING_LITERAL
+   | WHERE expression
+   ;
 
 showSchemaEntity
-    : FULL? TABLES
-    ;
-
+   : FULL? TABLES
+   ;
 
 // Common Clauses
 
-//    DB Objects
-
+// DB Objects
 fullId
-    : uid (DOT_ID | '.' uid)?
-    ;
+   : uid (DOT_ID | '.' uid)?
+   ;
 
 tableName
-    : fullId                                #simpleTableName
-    | uid STAR                              #tableNamePattern
-    | uid DIVIDE uid                        #tableAndTypeName
-    ;
+   : fullId         # simpleTableName
+   | uid STAR       # tableNamePattern
+   | uid DIVIDE uid # tableAndTypeName
+   ;
 
 fullColumnName
-    : uid dottedId*
-    ;
+   : uid dottedId*
+   ;
 
 uid
-    : simpleId
-    | REVERSE_QUOTE_ID
-    ;
+   : simpleId
+   | REVERSE_QUOTE_ID
+   ;
 
 simpleId
-    : ID
-    | DOT_ID  // note: the current scope by adding DOT_ID to simpleId is large, move DOT_ID upwards tablename if needed
-    | DOUBLE_QUOTE_ID
-    | BACKTICK_QUOTE_ID
-    | keywordsCanBeId
-    | functionNameBase
-    ;
+   : ID
+   | DOT_ID // note: the current scope by adding DOT_ID to simpleId is large, move DOT_ID upwards tablename if needed
+   | DOUBLE_QUOTE_ID
+   | BACKTICK_QUOTE_ID
+   | keywordsCanBeId
+   | functionNameBase
+   ;
 
 dottedId
-    : DOT_ID
-    | '.' uid
-    ;
+   : DOT_ID
+   | '.' uid
+   ;
 
-//    Literals
-
+// Literals
 decimalLiteral
-    : DECIMAL_LITERAL | ZERO_DECIMAL | ONE_DECIMAL | TWO_DECIMAL
-    ;
+   : DECIMAL_LITERAL
+   | ZERO_DECIMAL
+   | ONE_DECIMAL
+   | TWO_DECIMAL
+   ;
 
 stringLiteral
-    : (
-        STRING_LITERAL
-        | START_NATIONAL_STRING_LITERAL
-      ) STRING_LITERAL+
-    | (
-        STRING_LITERAL
-        | START_NATIONAL_STRING_LITERAL
-      )
-    ;
+   : (STRING_LITERAL | START_NATIONAL_STRING_LITERAL) STRING_LITERAL+
+   | (STRING_LITERAL | START_NATIONAL_STRING_LITERAL)
+   ;
 
 booleanLiteral
-    : TRUE | FALSE;
+   : TRUE
+   | FALSE
+   ;
 
 nullNotnull
-    : NOT? (NULL_LITERAL | NULL_SPEC_LITERAL)
-    ;
+   : NOT? (NULL_LITERAL | NULL_SPEC_LITERAL)
+   ;
 
 constant
-    : stringLiteral | decimalLiteral
-    | '-' decimalLiteral
-    | booleanLiteral
-    | REAL_LITERAL | BIT_STRING
-    | NOT? nullLiteral=(NULL_LITERAL | NULL_SPEC_LITERAL)
-    | LEFT_BRACE dateType=(D | T | TS | DATE | TIME | TIMESTAMP) stringLiteral RIGHT_BRACE
-    ;
+   : stringLiteral
+   | decimalLiteral
+   | '-' decimalLiteral
+   | booleanLiteral
+   | REAL_LITERAL
+   | BIT_STRING
+   | NOT? nullLiteral = (NULL_LITERAL | NULL_SPEC_LITERAL)
+   | LEFT_BRACE dateType = (D | T | TS | DATE | TIME | TIMESTAMP) stringLiteral RIGHT_BRACE
+   ;
 
-
-//    Common Lists
-
+// Common Lists
 uidList
-    : uid (',' uid)*
-    ;
+   : uid (',' uid)*
+   ;
 
 expressions
-    : expression (',' expression)*
-    ;
+   : expression (',' expression)*
+   ;
 
 aggregateFunction
-    : functionAsAggregatorFunction                                  #functionAsAggregatorFunctionCall
-    | aggregateWindowedFunction                                     #aggregateWindowedFunctionCall
-    ;
+   : functionAsAggregatorFunction   # functionAsAggregatorFunctionCall
+   | aggregateWindowedFunction      # aggregateWindowedFunctionCall
+   ;
 
 scalarFunction
-    : scalarFunctionName '(' nestedFunctionArgs+ ')'                #nestedFunctionCall
-    | scalarFunctionName '(' functionArgs? ')'                      #scalarFunctionCall
-    ;
+   : scalarFunctionName '(' nestedFunctionArgs+ ')' # nestedFunctionCall
+   | scalarFunctionName '(' functionArgs? ')'       # scalarFunctionCall
+   ;
 
 functionCall
-    : aggregateFunction                                             #aggregateFunctionCall
-    | scalarFunctionName '(' aggregateWindowedFunction ')'          #aggregationAsArgFunctionCall
-    | scalarFunction                                                #scalarFunctionsCall
-    | specificFunction                                              #specificFunctionCall
-    | fullId '(' functionArgs? ')'                                  #udfFunctionCall
-    ;
+   : aggregateFunction                                      # aggregateFunctionCall
+   | scalarFunctionName '(' aggregateWindowedFunction ')'   # aggregationAsArgFunctionCall
+   | scalarFunction                                         # scalarFunctionsCall
+   | specificFunction                                       # specificFunctionCall
+   | fullId '(' functionArgs? ')'                           # udfFunctionCall
+   ;
 
 specificFunction
-    : CAST '(' expression AS convertedDataType ')'                  #dataTypeFunctionCall
-    | CASE expression caseFuncAlternative+
-      (ELSE elseArg=functionArg)? END                               #caseFunctionCall
-    | CASE caseFuncAlternative+
-      (ELSE elseArg=functionArg)? END                               #caseFunctionCall
-    ;
+   : CAST '(' expression AS convertedDataType ')'                               # dataTypeFunctionCall
+   | CASE expression caseFuncAlternative+ (ELSE elseArg = functionArg)? END     # caseFunctionCall
+   | CASE caseFuncAlternative+ (ELSE elseArg = functionArg)? END                # caseFunctionCall
+   ;
 
 caseFuncAlternative
-    : WHEN condition=functionArg
-      THEN consequent=functionArg
-    ;
+   : WHEN condition = functionArg THEN consequent = functionArg
+   ;
 
 convertedDataType
-    : typeName=DATETIME
-    | typeName=INT
-    | typeName=DOUBLE
-    | typeName=LONG
-    | typeName=FLOAT
-    | typeName=STRING
-    ;
+   : typeName = DATETIME
+   | typeName = INT
+   | typeName = DOUBLE
+   | typeName = LONG
+   | typeName = FLOAT
+   | typeName = STRING
+   ;
 
 aggregateWindowedFunction
-    : (AVG | MAX | MIN | SUM)
-      '(' aggregator=(ALL | DISTINCT)? functionArg ')'
-    | COUNT '(' (starArg='*' | aggregator=ALL? functionArg) ')'
-    | COUNT '(' aggregator=DISTINCT functionArgs ')'
-    ;
+   : (AVG | MAX | MIN | SUM) '(' aggregator = (ALL | DISTINCT)? functionArg ')'
+   | COUNT '(' (starArg = '*' | aggregator = ALL? functionArg) ')'
+   | COUNT '(' aggregator = DISTINCT functionArgs ')'
+   ;
 
 functionAsAggregatorFunction
-    : (AVG | MAX | MIN | SUM)
-      '(' aggregator=(ALL | DISTINCT)? functionCall ')'
-    | COUNT '(' aggregator=(ALL | DISTINCT)? functionCall ')'
-    ;
+   : (AVG | MAX | MIN | SUM) '(' aggregator = (ALL | DISTINCT)? functionCall ')'
+   | COUNT '(' aggregator = (ALL | DISTINCT)? functionCall ')'
+   ;
 
 scalarFunctionName
-    : functionNameBase
-    ;
-
+   : functionNameBase
+   ;
 /*
 Separated aggregate to function-aggregator and nonfunction-aggregator aggregations.
 
@@ -387,107 +343,226 @@ functionCall
     | fullId '(' functionArgs? ')'                                  #udfFunctionCall
     ;
 */
-
+   
+   
 functionArgs
-    : (constant | fullColumnName | expression)
-    (
-      ','
-      (constant | fullColumnName | expression)
-    )*
-    ;
+   : (constant | fullColumnName | expression) (',' (constant | fullColumnName | expression))*
+   ;
 
 functionArg
-    : constant | fullColumnName |  expression
-    ;
+   : constant
+   | fullColumnName
+   | expression
+   ;
 
 nestedFunctionArgs
-    : functionCall (',' functionArgs)?
-    ;
+   : functionCall (',' functionArgs)?
+   ;
 
-
-//    Expressions, predicates
+// Expressions, predicates
 
 // Simplified approach for expression
 expression
-    : notOperator=(NOT | '!') expression                            #notExpression
-    | expression logicalOperator expression                         #logicalExpression
-    | predicate IS NOT? testValue=(TRUE | FALSE | MISSING)          #isExpression
-    | predicate                                                     #predicateExpression
-    ;
+   : notOperator = (NOT | '!') expression                       # notExpression
+   | expression logicalOperator expression                      # logicalExpression
+   | predicate IS NOT? testValue = (TRUE | FALSE | MISSING)     # isExpression
+   | predicate                                                  # predicateExpression
+   ;
 
 predicate
-    : predicate NOT? IN '(' (selectStatement | expressions) ')'     #inPredicate
-    | predicate IS nullNotnull                                      #isNullPredicate
-    | left=predicate comparisonOperator right=predicate             #binaryComparisonPredicate
-    | predicate NOT? BETWEEN predicate AND predicate                #betweenPredicate
-    | predicate NOT? LIKE predicate                                 #likePredicate
-    | predicate NOT? regex=REGEXP predicate                         #regexpPredicate
-    | expressionAtom                                                #expressionAtomPredicate
-    ;
-
+   : predicate NOT? IN '(' (selectStatement | expressions) ')'  # inPredicate
+   | predicate IS nullNotnull                                   # isNullPredicate
+   | left = predicate comparisonOperator right = predicate      # binaryComparisonPredicate
+   | predicate NOT? BETWEEN predicate AND predicate             # betweenPredicate
+   | predicate NOT? LIKE predicate                              # likePredicate
+   | predicate NOT? regex = REGEXP predicate                    # regexpPredicate
+   | expressionAtom                                             # expressionAtomPredicate
+   ;
 
 // Add in ASTVisitor nullNotnull in constant
 expressionAtom
-    : constant                                                      #constantExpressionAtom
-    | fullColumnName                                                #fullColumnNameExpressionAtom
-    | functionCall                                                  #functionCallExpressionAtom
-    | unaryOperator expressionAtom                                  #unaryExpressionAtom
-    | '(' expression (',' expression)* ')'                          #nestedExpressionAtom
-    | EXISTS '(' selectStatement ')'                                #existsExpessionAtom
-    | '(' selectStatement ')'                                       #subqueryExpessionAtom
-    | left=expressionAtom bitOperator right=expressionAtom          #bitExpressionAtom
-    | left=expressionAtom mathOperator right=expressionAtom         #mathExpressionAtom
-    ;
+   : constant                                                   # constantExpressionAtom
+   | fullColumnName                                             # fullColumnNameExpressionAtom
+   | functionCall                                               # functionCallExpressionAtom
+   | unaryOperator expressionAtom                               # unaryExpressionAtom
+   | '(' expression (',' expression)* ')'                       # nestedExpressionAtom
+   | EXISTS '(' selectStatement ')'                             # existsExpessionAtom
+   | '(' selectStatement ')'                                    # subqueryExpessionAtom
+   | left = expressionAtom bitOperator right = expressionAtom   # bitExpressionAtom
+   | left = expressionAtom mathOperator right = expressionAtom  # mathExpressionAtom
+   ;
 
 unaryOperator
-    : '!' | '~' | '+' | '-' | NOT
-    ;
+   : '!'
+   | '~'
+   | '+'
+   | '-'
+   | NOT
+   ;
 
 comparisonOperator
-    : '=' | '>' | '<' | '<' '=' | '>' '='
-    | '<' '>' | '!' '='
-    ;
+   : '='
+   | '>'
+   | '<'
+   | '<' '='
+   | '>' '='
+   | '<' '>'
+   | '!' '='
+   ;
 
 logicalOperator
-    : AND | '&' '&' | OR | '|' '|'
-    ;
+   : AND
+   | '&' '&'
+   | OR
+   | '|' '|'
+   ;
 
 bitOperator
-    : '<' '<' | '>' '>' | '&' | '^' | '|'
-    ;
+   : '<' '<'
+   | '>' '>'
+   | '&'
+   | '^'
+   | '|'
+   ;
 
 mathOperator
-    : '*' | '/' | '%' | DIV | MOD | '+' | '-'
-    ;
+   : '*'
+   | '/'
+   | '%'
+   | DIV
+   | MOD
+   | '+'
+   | '-'
+   ;
 
-
-//    Simple id sets
-//     (that keyword, which can be id)
-
+// Simple id sets
+// (that keyword, which can be id)
 keywordsCanBeId
-    : FULL
-    | FIELD | D | T | TS // OD SQL and ODBC special
-    | COUNT | MIN | MAX | AVG | SUM
-    ;
+   : FULL
+   | FIELD
+   | D
+   | T
+   | TS // OD SQL and ODBC special
+   | COUNT
+   | MIN
+   | MAX
+   | AVG
+   | SUM
+   ;
 
 functionNameBase
-    : openSearchFunctionNameBase
-    | ABS | ACOS | ADD | ASCII | ASIN | ATAN | ATAN2 | CBRT | CEIL | CONCAT | CONCAT_WS
-    | COS | COSH | COT | CURDATE | DATE | DATE_FORMAT | DAYOFMONTH | DEGREES
-    | E | EXP | EXPM1 | FLOOR | IF | IFNULL | ISNULL | LEFT | LENGTH | LN | LOCATE | LOG
-    | LOG10 | LOG2 | LOWER | LTRIM | MAKETIME | MODULUS | MONTH | MONTHNAME | MULTIPLY
-    | NOW | PI | POW | POWER | RADIANS | RAND | REPLACE | RIGHT | RINT | ROUND | RTRIM
-    | SIGN | SIGNUM | SIN | SINH | SQRT | SUBSTRING | SUBTRACT | TAN | TIMESTAMP | TRIM
-    | UPPER | YEAR | ADDDATE | ADDTIME | GREATEST | LEAST | STRCMP
-    ;
+   : openSearchFunctionNameBase
+   | ABS
+   | ACOS
+   | ADD
+   | ASCII
+   | ASIN
+   | ATAN
+   | ATAN2
+   | CBRT
+   | CEIL
+   | CONCAT
+   | CONCAT_WS
+   | COS
+   | COSH
+   | COT
+   | CURDATE
+   | DATE
+   | DATE_FORMAT
+   | DAYOFMONTH
+   | DEGREES
+   | E
+   | EXP
+   | EXPM1
+   | FLOOR
+   | IF
+   | IFNULL
+   | ISNULL
+   | LEFT
+   | LENGTH
+   | LN
+   | LOCATE
+   | LOG
+   | LOG10
+   | LOG2
+   | LOWER
+   | LTRIM
+   | MAKETIME
+   | MODULUS
+   | MONTH
+   | MONTHNAME
+   | MULTIPLY
+   | NOW
+   | PI
+   | POW
+   | POWER
+   | RADIANS
+   | RAND
+   | REPLACE
+   | RIGHT
+   | RINT
+   | ROUND
+   | RTRIM
+   | SIGN
+   | SIGNUM
+   | SIN
+   | SINH
+   | SQRT
+   | SUBSTRING
+   | SUBTRACT
+   | TAN
+   | TIMESTAMP
+   | TRIM
+   | UPPER
+   | YEAR
+   | ADDDATE
+   | ADDTIME
+   | GREATEST
+   | LEAST
+   | STRCMP
+   ;
 
 openSearchFunctionNameBase
-    : DATE_HISTOGRAM | DAY_OF_MONTH | DAY_OF_YEAR | DAY_OF_WEEK | EXCLUDE
-    | EXTENDED_STATS | FILTER | GEO_BOUNDING_BOX | GEO_CELL | GEO_DISTANCE | GEO_DISTANCE_RANGE | GEO_INTERSECTS
-    | GEO_POLYGON | INCLUDE | IN_TERMS | HISTOGRAM | HOUR_OF_DAY
-    | MATCHPHRASE | MATCH_PHRASE | MATCHQUERY | MATCH_QUERY | MINUTE_OF_DAY
-    | MINUTE_OF_HOUR | MISSING | MONTH_OF_YEAR | MULTIMATCH | MULTI_MATCH | NESTED
-    | PERCENTILES | QUERY | RANGE | REGEXP_QUERY | REVERSE_NESTED | SCORE
-    | SECOND_OF_MINUTE | STATS | TERM | TERMS | TOPHITS
-    | WEEK_OF_YEAR | WILDCARDQUERY | WILDCARD_QUERY
-    ;
+   : DATE_HISTOGRAM
+   | DAY_OF_MONTH
+   | DAY_OF_YEAR
+   | DAY_OF_WEEK
+   | EXCLUDE
+   | EXTENDED_STATS
+   | FILTER
+   | GEO_BOUNDING_BOX
+   | GEO_CELL
+   | GEO_DISTANCE
+   | GEO_DISTANCE_RANGE
+   | GEO_INTERSECTS
+   | GEO_POLYGON
+   | INCLUDE
+   | IN_TERMS
+   | HISTOGRAM
+   | HOUR_OF_DAY
+   | MATCHPHRASE
+   | MATCH_PHRASE
+   | MATCHQUERY
+   | MATCH_QUERY
+   | MINUTE_OF_DAY
+   | MINUTE_OF_HOUR
+   | MISSING
+   | MONTH_OF_YEAR
+   | MULTIMATCH
+   | MULTI_MATCH
+   | NESTED
+   | PERCENTILES
+   | QUERY
+   | RANGE
+   | REGEXP_QUERY
+   | REVERSE_NESTED
+   | SCORE
+   | SECOND_OF_MINUTE
+   | STATS
+   | TERM
+   | TERMS
+   | TOPHITS
+   | WEEK_OF_YEAR
+   | WILDCARDQUERY
+   | WILDCARD_QUERY
+   ;

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -4,854 +4,911 @@
  */
 
 
-
 parser grammar OpenSearchPPLParser;
-options { tokenVocab=OpenSearchPPLLexer; }
 
+
+options { tokenVocab = OpenSearchPPLLexer; }
 root
-    : pplStatement? EOF
-    ;
+   : pplStatement? EOF
+   ;
 
-/** statement */
+// statement
 pplStatement
-    : dmlStatement
-    ;
+   : dmlStatement
+   ;
 
 dmlStatement
-    : queryStatement
-    ;
+   : queryStatement
+   ;
 
 queryStatement
-    : pplCommands (PIPE commands)*
-    ;
+   : pplCommands (PIPE commands)*
+   ;
 
-/** commands */
+// commands
 pplCommands
-    : searchCommand
-    | describeCommand
-    | showDataSourcesCommand
-    ;
+   : searchCommand
+   | describeCommand
+   | showDataSourcesCommand
+   ;
 
 commands
-    : whereCommand
-    | fieldsCommand
-    | renameCommand
-    | statsCommand
-    | dedupCommand
-    | sortCommand
-    | evalCommand
-    | headCommand
-    | topCommand
-    | rareCommand
-    | grokCommand
-    | parseCommand
-    | patternsCommand
-    | kmeansCommand
-    | adCommand
-    | mlCommand;
+   : whereCommand
+   | fieldsCommand
+   | renameCommand
+   | statsCommand
+   | dedupCommand
+   | sortCommand
+   | evalCommand
+   | headCommand
+   | topCommand
+   | rareCommand
+   | grokCommand
+   | parseCommand
+   | patternsCommand
+   | kmeansCommand
+   | adCommand
+   | mlCommand
+   ;
 
 searchCommand
-    : (SEARCH)? fromClause                                          #searchFrom
-    | (SEARCH)? fromClause logicalExpression                        #searchFromFilter
-    | (SEARCH)? logicalExpression fromClause                        #searchFilterFrom
-    ;
+   : (SEARCH)? fromClause                       # searchFrom
+   | (SEARCH)? fromClause logicalExpression     # searchFromFilter
+   | (SEARCH)? logicalExpression fromClause     # searchFilterFrom
+   ;
 
 describeCommand
-    : DESCRIBE tableSourceClause
-    ;
+   : DESCRIBE tableSourceClause
+   ;
 
 showDataSourcesCommand
-    : SHOW DATASOURCES
-    ;
+   : SHOW DATASOURCES
+   ;
 
 whereCommand
-    : WHERE logicalExpression
-    ;
+   : WHERE logicalExpression
+   ;
 
 fieldsCommand
-    : FIELDS (PLUS | MINUS)? fieldList
-    ;
+   : FIELDS (PLUS | MINUS)? fieldList
+   ;
 
 renameCommand
-    : RENAME renameClasue (COMMA renameClasue)*
-    ;
+   : RENAME renameClasue (COMMA renameClasue)*
+   ;
 
 statsCommand
-    : STATS
-    (PARTITIONS EQUAL partitions=integerLiteral)?
-    (ALLNUM EQUAL allnum=booleanLiteral)?
-    (DELIM EQUAL delim=stringLiteral)?
-    statsAggTerm (COMMA statsAggTerm)*
-    (statsByClause)?
-    (DEDUP_SPLITVALUES EQUAL dedupsplit=booleanLiteral)?
-    ;
+   : STATS (PARTITIONS EQUAL partitions = integerLiteral)? (ALLNUM EQUAL allnum = booleanLiteral)? (DELIM EQUAL delim = stringLiteral)? statsAggTerm (COMMA statsAggTerm)* (statsByClause)? (DEDUP_SPLITVALUES EQUAL dedupsplit = booleanLiteral)?
+   ;
 
 dedupCommand
-    : DEDUP
-    (number=integerLiteral)?
-    fieldList
-    (KEEPEMPTY EQUAL keepempty=booleanLiteral)?
-    (CONSECUTIVE EQUAL consecutive=booleanLiteral)?
-    ;
+   : DEDUP (number = integerLiteral)? fieldList (KEEPEMPTY EQUAL keepempty = booleanLiteral)? (CONSECUTIVE EQUAL consecutive = booleanLiteral)?
+   ;
 
 sortCommand
-    : SORT sortbyClause
-    ;
+   : SORT sortbyClause
+   ;
 
 evalCommand
-    : EVAL evalClause (COMMA evalClause)*
-    ;
+   : EVAL evalClause (COMMA evalClause)*
+   ;
 
 headCommand
-    : HEAD
-    (number=integerLiteral)?
-    (FROM from=integerLiteral)?
-    ;
-    
+   : HEAD (number = integerLiteral)? (FROM from = integerLiteral)?
+   ;
+
 topCommand
-    : TOP
-    (number=integerLiteral)?
-    fieldList
-    (byClause)?
-    ;
+   : TOP (number = integerLiteral)? fieldList (byClause)?
+   ;
 
 rareCommand
-    : RARE
-    fieldList
-    (byClause)?
-    ;
+   : RARE fieldList (byClause)?
+   ;
 
 grokCommand
-    : GROK (source_field=expression) (pattern=stringLiteral)
-    ;
+   : GROK (source_field = expression) (pattern = stringLiteral)
+   ;
 
 parseCommand
-    : PARSE (source_field=expression) (pattern=stringLiteral)
-    ;
+   : PARSE (source_field = expression) (pattern = stringLiteral)
+   ;
 
 patternsCommand
-    : PATTERNS (patternsParameter)* (source_field=expression)
-    ;
+   : PATTERNS (patternsParameter)* (source_field = expression)
+   ;
 
 patternsParameter
-    : (NEW_FIELD EQUAL new_field=stringLiteral)
-    | (PATTERN EQUAL pattern=stringLiteral)
-    ;
+   : (NEW_FIELD EQUAL new_field = stringLiteral)
+   | (PATTERN EQUAL pattern = stringLiteral)
+   ;
 
 patternsMethod
-    : PUNCT | REGEX
-    ;
+   : PUNCT
+   | REGEX
+   ;
 
 kmeansCommand
-    : KMEANS (kmeansParameter)*
-    ;
+   : KMEANS (kmeansParameter)*
+   ;
 
 kmeansParameter
-    : (CENTROIDS EQUAL centroids=integerLiteral)
-    | (ITERATIONS EQUAL iterations=integerLiteral)
-    | (DISTANCE_TYPE EQUAL distance_type=stringLiteral)
-    ;
+   : (CENTROIDS EQUAL centroids = integerLiteral)
+   | (ITERATIONS EQUAL iterations = integerLiteral)
+   | (DISTANCE_TYPE EQUAL distance_type = stringLiteral)
+   ;
 
 adCommand
-    : AD (adParameter)*
-    ;
+   : AD (adParameter)*
+   ;
 
 adParameter
-    : (NUMBER_OF_TREES EQUAL number_of_trees=integerLiteral)
-    | (SHINGLE_SIZE EQUAL shingle_size=integerLiteral)
-    | (SAMPLE_SIZE EQUAL sample_size=integerLiteral)
-    | (OUTPUT_AFTER EQUAL output_after=integerLiteral)
-    | (TIME_DECAY EQUAL time_decay=decimalLiteral)
-    | (ANOMALY_RATE EQUAL anomaly_rate=decimalLiteral)
-    | (CATEGORY_FIELD EQUAL category_field=stringLiteral)
-    | (TIME_FIELD EQUAL time_field=stringLiteral)
-    | (DATE_FORMAT EQUAL date_format=stringLiteral)
-    | (TIME_ZONE EQUAL time_zone=stringLiteral)
-    | (TRAINING_DATA_SIZE EQUAL training_data_size=integerLiteral)
-    | (ANOMALY_SCORE_THRESHOLD EQUAL anomaly_score_threshold=decimalLiteral)
-    ;
+   : (NUMBER_OF_TREES EQUAL number_of_trees = integerLiteral)
+   | (SHINGLE_SIZE EQUAL shingle_size = integerLiteral)
+   | (SAMPLE_SIZE EQUAL sample_size = integerLiteral)
+   | (OUTPUT_AFTER EQUAL output_after = integerLiteral)
+   | (TIME_DECAY EQUAL time_decay = decimalLiteral)
+   | (ANOMALY_RATE EQUAL anomaly_rate = decimalLiteral)
+   | (CATEGORY_FIELD EQUAL category_field = stringLiteral)
+   | (TIME_FIELD EQUAL time_field = stringLiteral)
+   | (DATE_FORMAT EQUAL date_format = stringLiteral)
+   | (TIME_ZONE EQUAL time_zone = stringLiteral)
+   | (TRAINING_DATA_SIZE EQUAL training_data_size = integerLiteral)
+   | (ANOMALY_SCORE_THRESHOLD EQUAL anomaly_score_threshold = decimalLiteral)
+   ;
 
 mlCommand
-    : ML (mlArg)*
-    ;
+   : ML (mlArg)*
+   ;
 
 mlArg
-    : (argName=ident EQUAL argValue=literalValue)
-    ;
+   : (argName = ident EQUAL argValue = literalValue)
+   ;
 
-/** clauses */
+// clauses
 fromClause
-    : SOURCE EQUAL tableSourceClause
-    | INDEX EQUAL tableSourceClause
-    | SOURCE EQUAL tableFunction
-    | INDEX EQUAL tableFunction
-    ;
-
+   : SOURCE EQUAL tableSourceClause
+   | INDEX EQUAL tableSourceClause
+   | SOURCE EQUAL tableFunction
+   | INDEX EQUAL tableFunction
+   ;
 
 tableSourceClause
-    : tableSource (COMMA tableSource)*
-    ;
+   : tableSource (COMMA tableSource)*
+   ;
 
 renameClasue
-    : orignalField=wcFieldExpression AS renamedField=wcFieldExpression
-    ;
+   : orignalField = wcFieldExpression AS renamedField = wcFieldExpression
+   ;
 
 byClause
-    : BY fieldList
-    ;
+   : BY fieldList
+   ;
 
 statsByClause
-    : BY fieldList
-    | BY bySpanClause
-    | BY bySpanClause COMMA fieldList
-    ;
+   : BY fieldList
+   | BY bySpanClause
+   | BY bySpanClause COMMA fieldList
+   ;
 
 bySpanClause
-    : spanClause (AS alias=qualifiedName)?
-    ;
+   : spanClause (AS alias = qualifiedName)?
+   ;
 
 spanClause
-    : SPAN LT_PRTHS fieldExpression COMMA value=literalValue (unit=timespanUnit)? RT_PRTHS
-    ;
+   : SPAN LT_PRTHS fieldExpression COMMA value = literalValue (unit = timespanUnit)? RT_PRTHS
+   ;
 
 sortbyClause
-    : sortField (COMMA sortField)*
-    ;
+   : sortField (COMMA sortField)*
+   ;
 
 evalClause
-    : fieldExpression EQUAL expression
-    ;
+   : fieldExpression EQUAL expression
+   ;
 
-/** aggregation terms */
+// aggregation terms
 statsAggTerm
-    : statsFunction (AS alias=wcFieldExpression)?
-    ;
+   : statsFunction (AS alias = wcFieldExpression)?
+   ;
 
-/** aggregation functions */
+// aggregation functions
 statsFunction
-    : statsFunctionName LT_PRTHS valueExpression RT_PRTHS           #statsFunctionCall
-    | COUNT LT_PRTHS RT_PRTHS                                       #countAllFunctionCall
-    | (DISTINCT_COUNT | DC) LT_PRTHS valueExpression RT_PRTHS       #distinctCountFunctionCall
-    | percentileAggFunction                                         #percentileAggFunctionCall
-    | takeAggFunction                                               #takeAggFunctionCall
-    ;
+   : statsFunctionName LT_PRTHS valueExpression RT_PRTHS        # statsFunctionCall
+   | COUNT LT_PRTHS RT_PRTHS                                    # countAllFunctionCall
+   | (DISTINCT_COUNT | DC) LT_PRTHS valueExpression RT_PRTHS    # distinctCountFunctionCall
+   | percentileAggFunction                                      # percentileAggFunctionCall
+   | takeAggFunction                                            # takeAggFunctionCall
+   ;
 
 statsFunctionName
-    : AVG
-    | COUNT
-    | SUM
-    | MIN
-    | MAX
-    | VAR_SAMP
-    | VAR_POP
-    | STDDEV_SAMP
-    | STDDEV_POP
-    ;
+   : AVG
+   | COUNT
+   | SUM
+   | MIN
+   | MAX
+   | VAR_SAMP
+   | VAR_POP
+   | STDDEV_SAMP
+   | STDDEV_POP
+   ;
 
 takeAggFunction
-    : TAKE LT_PRTHS fieldExpression (COMMA size=integerLiteral)? RT_PRTHS
-    ;
+   : TAKE LT_PRTHS fieldExpression (COMMA size = integerLiteral)? RT_PRTHS
+   ;
 
 percentileAggFunction
-    : PERCENTILE LESS value=integerLiteral GREATER LT_PRTHS aggField=fieldExpression RT_PRTHS
-    ;
+   : PERCENTILE LESS value = integerLiteral GREATER LT_PRTHS aggField = fieldExpression RT_PRTHS
+   ;
 
-/** expressions */
+// expressions
 expression
-    : logicalExpression
-    | comparisonExpression
-    | valueExpression
-    ;
+   : logicalExpression
+   | comparisonExpression
+   | valueExpression
+   ;
 
 logicalExpression
-    : comparisonExpression                                          #comparsion
-    | NOT logicalExpression                                         #logicalNot
-    | left=logicalExpression OR right=logicalExpression             #logicalOr
-    | left=logicalExpression (AND)? right=logicalExpression         #logicalAnd
-    | left=logicalExpression XOR right=logicalExpression            #logicalXor
-    | booleanExpression                                             #booleanExpr
-    | relevanceExpression                                           #relevanceExpr
-    ;
+   : comparisonExpression                                       # comparsion
+   | NOT logicalExpression                                      # logicalNot
+   | left = logicalExpression OR right = logicalExpression      # logicalOr
+   | left = logicalExpression (AND)? right = logicalExpression  # logicalAnd
+   | left = logicalExpression XOR right = logicalExpression     # logicalXor
+   | booleanExpression                                          # booleanExpr
+   | relevanceExpression                                        # relevanceExpr
+   ;
 
 comparisonExpression
-    : left=valueExpression comparisonOperator right=valueExpression #compareExpr
-    | valueExpression IN valueList                                  #inExpr
-    ;
+   : left = valueExpression comparisonOperator right = valueExpression  # compareExpr
+   | valueExpression IN valueList                                       # inExpr
+   ;
 
 valueExpression
-    : left=valueExpression
-        binaryOperator=(STAR | DIVIDE | MODULE)
-            right=valueExpression                                   #binaryArithmetic
-    | left=valueExpression
-        binaryOperator=(PLUS | MINUS)
-            right=valueExpression                                   #binaryArithmetic
-    | primaryExpression                                             #valueExpressionDefault
-    | positionFunction                                              #positionFunctionCall
-    | extractFunction                                               #extractFunctionCall
-    | getFormatFunction                                             #getFormatFunctionCall
-    | timestampFunction                                             #timestampFunctionCall
-    | LT_PRTHS valueExpression RT_PRTHS                             #parentheticValueExpr
-    ;
+   : left = valueExpression binaryOperator = (STAR | DIVIDE | MODULE) right = valueExpression   # binaryArithmetic
+   | left = valueExpression binaryOperator = (PLUS | MINUS) right = valueExpression             # binaryArithmetic
+   | primaryExpression                                                                          # valueExpressionDefault
+   | positionFunction                                                                           # positionFunctionCall
+   | extractFunction                                                                            # extractFunctionCall
+   | getFormatFunction                                                                          # getFormatFunctionCall
+   | timestampFunction                                                                          # timestampFunctionCall
+   | LT_PRTHS valueExpression RT_PRTHS                                                          # parentheticValueExpr
+   ;
 
 primaryExpression
-    : evalFunctionCall
-    | dataTypeFunctionCall
-    | fieldExpression
-    | literalValue
-    ;
+   : evalFunctionCall
+   | dataTypeFunctionCall
+   | fieldExpression
+   | literalValue
+   ;
 
 positionFunction
-    : positionFunctionName LT_PRTHS functionArg IN functionArg RT_PRTHS
-    ;
+   : positionFunctionName LT_PRTHS functionArg IN functionArg RT_PRTHS
+   ;
 
 booleanExpression
-    : booleanFunctionCall
-    ;
+   : booleanFunctionCall
+   ;
 
 relevanceExpression
-    : singleFieldRelevanceFunction | multiFieldRelevanceFunction
-    ;
+   : singleFieldRelevanceFunction
+   | multiFieldRelevanceFunction
+   ;
 
 // Field is a single column
 singleFieldRelevanceFunction
-    : singleFieldRelevanceFunctionName LT_PRTHS
-        field=relevanceField COMMA query=relevanceQuery
-        (COMMA relevanceArg)* RT_PRTHS
-    ;
+   : singleFieldRelevanceFunctionName LT_PRTHS field = relevanceField COMMA query = relevanceQuery (COMMA relevanceArg)* RT_PRTHS
+   ;
 
 // Field is a list of columns
 multiFieldRelevanceFunction
-    : multiFieldRelevanceFunctionName LT_PRTHS
-        LT_SQR_PRTHS field=relevanceFieldAndWeight (COMMA field=relevanceFieldAndWeight)* RT_SQR_PRTHS
-        COMMA query=relevanceQuery (COMMA relevanceArg)* RT_PRTHS
-    ;
+   : multiFieldRelevanceFunctionName LT_PRTHS LT_SQR_PRTHS field = relevanceFieldAndWeight (COMMA field = relevanceFieldAndWeight)* RT_SQR_PRTHS COMMA query = relevanceQuery (COMMA relevanceArg)* RT_PRTHS
+   ;
 
-/** tables */
+// tables
 tableSource
-    : tableQualifiedName
-    | ID_DATE_SUFFIX
-    ;
+   : tableQualifiedName
+   | ID_DATE_SUFFIX
+   ;
 
 tableFunction
-    : qualifiedName LT_PRTHS functionArgs RT_PRTHS
-    ;
+   : qualifiedName LT_PRTHS functionArgs RT_PRTHS
+   ;
 
-/** fields */
+// fields
 fieldList
-    : fieldExpression (COMMA fieldExpression)*
-    ;
+   : fieldExpression (COMMA fieldExpression)*
+   ;
 
 wcFieldList
-    : wcFieldExpression (COMMA wcFieldExpression)*
-    ;
+   : wcFieldExpression (COMMA wcFieldExpression)*
+   ;
 
 sortField
-    : (PLUS | MINUS)? sortFieldExpression
-    ;
+   : (PLUS | MINUS)? sortFieldExpression
+   ;
 
 sortFieldExpression
-    : fieldExpression
-    | AUTO LT_PRTHS fieldExpression RT_PRTHS
-    | STR LT_PRTHS fieldExpression RT_PRTHS
-    | IP LT_PRTHS fieldExpression RT_PRTHS
-    | NUM LT_PRTHS fieldExpression RT_PRTHS
-    ;
+   : fieldExpression
+   | AUTO LT_PRTHS fieldExpression RT_PRTHS
+   | STR LT_PRTHS fieldExpression RT_PRTHS
+   | IP LT_PRTHS fieldExpression RT_PRTHS
+   | NUM LT_PRTHS fieldExpression RT_PRTHS
+   ;
 
 fieldExpression
-    : qualifiedName
-    ;
+   : qualifiedName
+   ;
 
 wcFieldExpression
-    : wcQualifiedName
-    ;
+   : wcQualifiedName
+   ;
 
-/** functions */
+// functions
 evalFunctionCall
-    : evalFunctionName LT_PRTHS functionArgs RT_PRTHS
-    ;
+   : evalFunctionName LT_PRTHS functionArgs RT_PRTHS
+   ;
 
-/** cast function */
+// cast function
 dataTypeFunctionCall
-    : CAST LT_PRTHS expression AS convertedDataType RT_PRTHS
-    ;
+   : CAST LT_PRTHS expression AS convertedDataType RT_PRTHS
+   ;
 
-/** boolean functions */
+// boolean functions
 booleanFunctionCall
-    : conditionFunctionBase LT_PRTHS functionArgs RT_PRTHS
-    ;
+   : conditionFunctionBase LT_PRTHS functionArgs RT_PRTHS
+   ;
 
 convertedDataType
-    : typeName=DATE
-    | typeName=TIME
-    | typeName=TIMESTAMP
-    | typeName=INT
-    | typeName=INTEGER
-    | typeName=DOUBLE
-    | typeName=LONG
-    | typeName=FLOAT
-    | typeName=STRING
-    | typeName=BOOLEAN
-    ;
+   : typeName = DATE
+   | typeName = TIME
+   | typeName = TIMESTAMP
+   | typeName = INT
+   | typeName = INTEGER
+   | typeName = DOUBLE
+   | typeName = LONG
+   | typeName = FLOAT
+   | typeName = STRING
+   | typeName = BOOLEAN
+   ;
 
 evalFunctionName
-    : mathematicalFunctionName
-    | dateTimeFunctionName
-    | textFunctionName
-    | conditionFunctionBase
-    | systemFunctionName
-    | positionFunctionName
-    ;
+   : mathematicalFunctionName
+   | dateTimeFunctionName
+   | textFunctionName
+   | conditionFunctionBase
+   | systemFunctionName
+   | positionFunctionName
+   ;
 
 functionArgs
-    : (functionArg (COMMA functionArg)*)?
-    ;
+   : (functionArg (COMMA functionArg)*)?
+   ;
 
 functionArg
-    : (ident EQUAL)? valueExpression
-    ;
+   : (ident EQUAL)? valueExpression
+   ;
 
 relevanceArg
-    : relevanceArgName EQUAL relevanceArgValue
-    ;
+   : relevanceArgName EQUAL relevanceArgValue
+   ;
 
 relevanceArgName
-    : ALLOW_LEADING_WILDCARD
-    | ANALYZER
-    | ANALYZE_WILDCARD
-    | AUTO_GENERATE_SYNONYMS_PHRASE_QUERY
-    | BOOST
-    | CUTOFF_FREQUENCY
-    | DEFAULT_FIELD
-    | DEFAULT_OPERATOR
-    | ENABLE_POSITION_INCREMENTS
-    | ESCAPE
-    | FIELDS
-    | FLAGS
-    | FUZZINESS
-    | FUZZY_MAX_EXPANSIONS
-    | FUZZY_PREFIX_LENGTH
-    | FUZZY_REWRITE
-    | FUZZY_TRANSPOSITIONS
-    | LENIENT
-    | LOW_FREQ_OPERATOR
-    | MAX_DETERMINIZED_STATES
-    | MAX_EXPANSIONS
-    | MINIMUM_SHOULD_MATCH
-    | OPERATOR
-    | PHRASE_SLOP
-    | PREFIX_LENGTH
-    | QUOTE_ANALYZER
-    | QUOTE_FIELD_SUFFIX
-    | REWRITE
-    | SLOP
-    | TIE_BREAKER
-    | TIME_ZONE
-    | TYPE
-    | ZERO_TERMS_QUERY
-    ;
+   : ALLOW_LEADING_WILDCARD
+   | ANALYZER
+   | ANALYZE_WILDCARD
+   | AUTO_GENERATE_SYNONYMS_PHRASE_QUERY
+   | BOOST
+   | CUTOFF_FREQUENCY
+   | DEFAULT_FIELD
+   | DEFAULT_OPERATOR
+   | ENABLE_POSITION_INCREMENTS
+   | ESCAPE
+   | FIELDS
+   | FLAGS
+   | FUZZINESS
+   | FUZZY_MAX_EXPANSIONS
+   | FUZZY_PREFIX_LENGTH
+   | FUZZY_REWRITE
+   | FUZZY_TRANSPOSITIONS
+   | LENIENT
+   | LOW_FREQ_OPERATOR
+   | MAX_DETERMINIZED_STATES
+   | MAX_EXPANSIONS
+   | MINIMUM_SHOULD_MATCH
+   | OPERATOR
+   | PHRASE_SLOP
+   | PREFIX_LENGTH
+   | QUOTE_ANALYZER
+   | QUOTE_FIELD_SUFFIX
+   | REWRITE
+   | SLOP
+   | TIE_BREAKER
+   | TIME_ZONE
+   | TYPE
+   | ZERO_TERMS_QUERY
+   ;
 
 relevanceFieldAndWeight
-    : field=relevanceField
-    | field=relevanceField weight=relevanceFieldWeight
-    | field=relevanceField BIT_XOR_OP weight=relevanceFieldWeight
-    ;
+   : field = relevanceField
+   | field = relevanceField weight = relevanceFieldWeight
+   | field = relevanceField BIT_XOR_OP weight = relevanceFieldWeight
+   ;
 
 relevanceFieldWeight
-    : integerLiteral
-    | decimalLiteral
-    ;
+   : integerLiteral
+   | decimalLiteral
+   ;
 
 relevanceField
-    : qualifiedName
-    | stringLiteral
-    ;
+   : qualifiedName
+   | stringLiteral
+   ;
 
 relevanceQuery
-    : relevanceArgValue
-    ;
+   : relevanceArgValue
+   ;
 
 relevanceArgValue
-    : qualifiedName
-    | literalValue
-    ;
+   : qualifiedName
+   | literalValue
+   ;
 
 mathematicalFunctionName
-    : ABS
-    | CBRT
-    | CEIL
-    | CEILING
-    | CONV
-    | CRC32
-    | E
-    | EXP
-    | FLOOR
-    | LN
-    | LOG
-    | LOG10
-    | LOG2
-    | MOD
-    | PI
-    | POW
-    | POWER
-    | RAND
-    | ROUND
-    | SIGN
-    | SQRT
-    | TRUNCATE
-    | trigonometricFunctionName
-    ;
+   : ABS
+   | CBRT
+   | CEIL
+   | CEILING
+   | CONV
+   | CRC32
+   | E
+   | EXP
+   | FLOOR
+   | LN
+   | LOG
+   | LOG10
+   | LOG2
+   | MOD
+   | PI
+   | POW
+   | POWER
+   | RAND
+   | ROUND
+   | SIGN
+   | SQRT
+   | TRUNCATE
+   | trigonometricFunctionName
+   ;
 
 trigonometricFunctionName
-    : ACOS
-    | ASIN
-    | ATAN
-    | ATAN2
-    | COS
-    | COT
-    | DEGREES
-    | RADIANS
-    | SIN
-    | TAN
-    ;
+   : ACOS
+   | ASIN
+   | ATAN
+   | ATAN2
+   | COS
+   | COT
+   | DEGREES
+   | RADIANS
+   | SIN
+   | TAN
+   ;
 
 dateTimeFunctionName
-    : ADDDATE
-    | ADDTIME
-    | CONVERT_TZ
-    | CURDATE
-    | CURRENT_DATE
-    | CURRENT_TIME
-    | CURRENT_TIMESTAMP
-    | CURTIME
-    | DATE
-    | DATEDIFF
-    | DATETIME
-    | DATE_ADD
-    | DATE_FORMAT
-    | DATE_SUB
-    | DAY
-    | DAYNAME
-    | DAYOFMONTH
-    | DAYOFWEEK
-    | DAYOFYEAR
-    | DAY_OF_MONTH
-    | DAY_OF_WEEK
-    | DAY_OF_YEAR
-    | FROM_DAYS
-    | FROM_UNIXTIME
-    | HOUR
-    | HOUR_OF_DAY
-    | LAST_DAY
-    | LOCALTIME
-    | LOCALTIMESTAMP
-    | MAKEDATE
-    | MAKETIME
-    | MICROSECOND
-    | MINUTE
-    | MINUTE_OF_DAY
-    | MINUTE_OF_HOUR
-    | MONTH
-    | MONTHNAME
-    | MONTH_OF_YEAR
-    | NOW
-    | PERIOD_ADD
-    | PERIOD_DIFF
-    | QUARTER
-    | SECOND
-    | SECOND_OF_MINUTE
-    | SEC_TO_TIME
-    | STR_TO_DATE
-    | SUBDATE
-    | SUBTIME
-    | SYSDATE
-    | TIME
-    | TIMEDIFF
-    | TIMESTAMP
-    | TIME_FORMAT
-    | TIME_TO_SEC
-    | TO_DAYS
-    | TO_SECONDS
-    | UNIX_TIMESTAMP
-    | UTC_DATE
-    | UTC_TIME
-    | UTC_TIMESTAMP
-    | WEEK
-    | WEEKDAY
-    | WEEK_OF_YEAR
-    | YEAR
-    | YEARWEEK
-    ;
+   : ADDDATE
+   | ADDTIME
+   | CONVERT_TZ
+   | CURDATE
+   | CURRENT_DATE
+   | CURRENT_TIME
+   | CURRENT_TIMESTAMP
+   | CURTIME
+   | DATE
+   | DATEDIFF
+   | DATETIME
+   | DATE_ADD
+   | DATE_FORMAT
+   | DATE_SUB
+   | DAY
+   | DAYNAME
+   | DAYOFMONTH
+   | DAYOFWEEK
+   | DAYOFYEAR
+   | DAY_OF_MONTH
+   | DAY_OF_WEEK
+   | DAY_OF_YEAR
+   | FROM_DAYS
+   | FROM_UNIXTIME
+   | HOUR
+   | HOUR_OF_DAY
+   | LAST_DAY
+   | LOCALTIME
+   | LOCALTIMESTAMP
+   | MAKEDATE
+   | MAKETIME
+   | MICROSECOND
+   | MINUTE
+   | MINUTE_OF_DAY
+   | MINUTE_OF_HOUR
+   | MONTH
+   | MONTHNAME
+   | MONTH_OF_YEAR
+   | NOW
+   | PERIOD_ADD
+   | PERIOD_DIFF
+   | QUARTER
+   | SECOND
+   | SECOND_OF_MINUTE
+   | SEC_TO_TIME
+   | STR_TO_DATE
+   | SUBDATE
+   | SUBTIME
+   | SYSDATE
+   | TIME
+   | TIMEDIFF
+   | TIMESTAMP
+   | TIME_FORMAT
+   | TIME_TO_SEC
+   | TO_DAYS
+   | TO_SECONDS
+   | UNIX_TIMESTAMP
+   | UTC_DATE
+   | UTC_TIME
+   | UTC_TIMESTAMP
+   | WEEK
+   | WEEKDAY
+   | WEEK_OF_YEAR
+   | YEAR
+   | YEARWEEK
+   ;
 
 getFormatFunction
-    : GET_FORMAT LT_PRTHS getFormatType COMMA functionArg RT_PRTHS
-    ;
+   : GET_FORMAT LT_PRTHS getFormatType COMMA functionArg RT_PRTHS
+   ;
 
 getFormatType
-    : DATE
-    | DATETIME
-    | TIME
-    | TIMESTAMP
-    ;
+   : DATE
+   | DATETIME
+   | TIME
+   | TIMESTAMP
+   ;
 
 extractFunction
-    : EXTRACT LT_PRTHS datetimePart FROM functionArg RT_PRTHS
-    ;
+   : EXTRACT LT_PRTHS datetimePart FROM functionArg RT_PRTHS
+   ;
 
 simpleDateTimePart
-    : MICROSECOND
-    | SECOND
-    | MINUTE
-    | HOUR
-    | DAY
-    | WEEK
-    | MONTH
-    | QUARTER
-    | YEAR
-    ;
+   : MICROSECOND
+   | SECOND
+   | MINUTE
+   | HOUR
+   | DAY
+   | WEEK
+   | MONTH
+   | QUARTER
+   | YEAR
+   ;
 
 complexDateTimePart
-    : SECOND_MICROSECOND
-    | MINUTE_MICROSECOND
-    | MINUTE_SECOND
-    | HOUR_MICROSECOND
-    | HOUR_SECOND
-    | HOUR_MINUTE
-    | DAY_MICROSECOND
-    | DAY_SECOND
-    | DAY_MINUTE
-    | DAY_HOUR
-    | YEAR_MONTH
-    ;
+   : SECOND_MICROSECOND
+   | MINUTE_MICROSECOND
+   | MINUTE_SECOND
+   | HOUR_MICROSECOND
+   | HOUR_SECOND
+   | HOUR_MINUTE
+   | DAY_MICROSECOND
+   | DAY_SECOND
+   | DAY_MINUTE
+   | DAY_HOUR
+   | YEAR_MONTH
+   ;
 
 datetimePart
-    : simpleDateTimePart
-    | complexDateTimePart
-    ;
+   : simpleDateTimePart
+   | complexDateTimePart
+   ;
 
 timestampFunction
-    : timestampFunctionName LT_PRTHS simpleDateTimePart COMMA firstArg=functionArg COMMA secondArg=functionArg RT_PRTHS
-    ;
+   : timestampFunctionName LT_PRTHS simpleDateTimePart COMMA firstArg = functionArg COMMA secondArg = functionArg RT_PRTHS
+   ;
 
 timestampFunctionName
-    : TIMESTAMPADD
-    | TIMESTAMPDIFF
-    ;
+   : TIMESTAMPADD
+   | TIMESTAMPDIFF
+   ;
 
-/** condition function return boolean value */
+// condition function return boolean value
 conditionFunctionBase
-    : LIKE
-    | IF
-    | ISNULL
-    | ISNOTNULL
-    | IFNULL
-    | NULLIF
-    ;
+   : LIKE
+   | IF
+   | ISNULL
+   | ISNOTNULL
+   | IFNULL
+   | NULLIF
+   ;
 
 systemFunctionName
-    : TYPEOF
-    ;
+   : TYPEOF
+   ;
 
 textFunctionName
-    : SUBSTR
-    | SUBSTRING
-    | TRIM
-    | LTRIM
-    | RTRIM
-    | LOWER
-    | UPPER
-    | CONCAT
-    | CONCAT_WS
-    | LENGTH
-    | STRCMP
-    | RIGHT
-    | LEFT
-    | ASCII
-    | LOCATE
-    | REPLACE
-    | REVERSE
-    ;
+   : SUBSTR
+   | SUBSTRING
+   | TRIM
+   | LTRIM
+   | RTRIM
+   | LOWER
+   | UPPER
+   | CONCAT
+   | CONCAT_WS
+   | LENGTH
+   | STRCMP
+   | RIGHT
+   | LEFT
+   | ASCII
+   | LOCATE
+   | REPLACE
+   | REVERSE
+   ;
 
 positionFunctionName
-    : POSITION
-    ;
+   : POSITION
+   ;
 
-/** operators */
-comparisonOperator
-    : EQUAL
-    | NOT_EQUAL
-    | LESS
-    | NOT_LESS
-    | GREATER
-    | NOT_GREATER
-    | REGEXP
-    ;
+// operators
+ comparisonOperator
+   : EQUAL
+   | NOT_EQUAL
+   | LESS
+   | NOT_LESS
+   | GREATER
+   | NOT_GREATER
+   | REGEXP
+   ;
 
 singleFieldRelevanceFunctionName
-    : MATCH
-    | MATCH_PHRASE
-    | MATCH_BOOL_PREFIX
-    | MATCH_PHRASE_PREFIX
-    ;
+   : MATCH
+   | MATCH_PHRASE
+   | MATCH_BOOL_PREFIX
+   | MATCH_PHRASE_PREFIX
+   ;
 
 multiFieldRelevanceFunctionName
-    : SIMPLE_QUERY_STRING
-    | MULTI_MATCH
-    | QUERY_STRING
-    ;
+   : SIMPLE_QUERY_STRING
+   | MULTI_MATCH
+   | QUERY_STRING
+   ;
 
-/** literals and values*/
+// literals and values
 literalValue
-    : intervalLiteral
-    | stringLiteral
-    | integerLiteral
-    | decimalLiteral
-    | booleanLiteral
-    | datetimeLiteral           //#datetime
-    ;
+   : intervalLiteral
+   | stringLiteral
+   | integerLiteral
+   | decimalLiteral
+   | booleanLiteral
+   | datetimeLiteral //#datetime
+   ;
 
 intervalLiteral
-    : INTERVAL valueExpression intervalUnit
-    ;
+   : INTERVAL valueExpression intervalUnit
+   ;
 
 stringLiteral
-    : DQUOTA_STRING | SQUOTA_STRING
-    ;
+   : DQUOTA_STRING
+   | SQUOTA_STRING
+   ;
 
 integerLiteral
-    : (PLUS | MINUS)? INTEGER_LITERAL
-    ;
+   : (PLUS | MINUS)? INTEGER_LITERAL
+   ;
 
 decimalLiteral
-    : (PLUS | MINUS)? DECIMAL_LITERAL
-    ;
+   : (PLUS | MINUS)? DECIMAL_LITERAL
+   ;
 
 booleanLiteral
-    : TRUE | FALSE
-    ;
+   : TRUE
+   | FALSE
+   ;
 
 // Date and Time Literal, follow ANSI 92
 datetimeLiteral
-    : dateLiteral
-    | timeLiteral
-    | timestampLiteral
-    ;
+   : dateLiteral
+   | timeLiteral
+   | timestampLiteral
+   ;
 
 dateLiteral
-    : DATE date=stringLiteral
-    ;
+   : DATE date = stringLiteral
+   ;
 
 timeLiteral
-    : TIME time=stringLiteral
-    ;
+   : TIME time = stringLiteral
+   ;
 
 timestampLiteral
-    : TIMESTAMP timestamp=stringLiteral
-    ;
+   : TIMESTAMP timestamp = stringLiteral
+   ;
 
 intervalUnit
-    : MICROSECOND
-    | SECOND
-    | MINUTE
-    | HOUR
-    | DAY
-    | WEEK
-    | MONTH
-    | QUARTER
-    | YEAR
-    | SECOND_MICROSECOND
-    | MINUTE_MICROSECOND
-    | MINUTE_SECOND
-    | HOUR_MICROSECOND
-    | HOUR_SECOND
-    | HOUR_MINUTE
-    | DAY_MICROSECOND
-    | DAY_SECOND
-    | DAY_MINUTE
-    | DAY_HOUR
-    | YEAR_MONTH
-    ;
+   : MICROSECOND
+   | SECOND
+   | MINUTE
+   | HOUR
+   | DAY
+   | WEEK
+   | MONTH
+   | QUARTER
+   | YEAR
+   | SECOND_MICROSECOND
+   | MINUTE_MICROSECOND
+   | MINUTE_SECOND
+   | HOUR_MICROSECOND
+   | HOUR_SECOND
+   | HOUR_MINUTE
+   | DAY_MICROSECOND
+   | DAY_SECOND
+   | DAY_MINUTE
+   | DAY_HOUR
+   | YEAR_MONTH
+   ;
 
 timespanUnit
-    : MS
-    | S
-    | M
-    | H
-    | D
-    | W
-    | Q
-    | Y
-    | MILLISECOND
-    | SECOND
-    | MINUTE
-    | HOUR
-    | DAY
-    | WEEK
-    | MONTH
-    | QUARTER
-    | YEAR
-    ;
-
+   : MS
+   | S
+   | M
+   | H
+   | D
+   | W
+   | Q
+   | Y
+   | MILLISECOND
+   | SECOND
+   | MINUTE
+   | HOUR
+   | DAY
+   | WEEK
+   | MONTH
+   | QUARTER
+   | YEAR
+   ;
 
 valueList
-    : LT_PRTHS literalValue (COMMA literalValue)* RT_PRTHS
-    ;
+   : LT_PRTHS literalValue (COMMA literalValue)* RT_PRTHS
+   ;
 
 qualifiedName
-    : ident (DOT ident)*                             #identsAsQualifiedName
-    ;
+   : ident (DOT ident)* # identsAsQualifiedName
+   ;
 
 tableQualifiedName
-    : tableIdent (DOT ident)*                        #identsAsTableQualifiedName
-    ;
+   : tableIdent (DOT ident)* # identsAsTableQualifiedName
+   ;
 
 wcQualifiedName
-    : wildcard (DOT wildcard)*                       #identsAsWildcardQualifiedName
-    ;
+   : wildcard (DOT wildcard)* # identsAsWildcardQualifiedName
+   ;
 
 ident
-    : (DOT)? ID
-    | BACKTICK ident BACKTICK
-    | BQUOTA_STRING
-    | keywordsCanBeId
-    ;
+   : (DOT)? ID
+   | BACKTICK ident BACKTICK
+   | BQUOTA_STRING
+   | keywordsCanBeId
+   ;
 
 tableIdent
-    : (CLUSTER)? ident
-    ;
+   : (CLUSTER)? ident
+   ;
 
 wildcard
-    : ident (MODULE ident)* (MODULE)?
-    | SINGLE_QUOTE wildcard SINGLE_QUOTE
-    | DOUBLE_QUOTE wildcard DOUBLE_QUOTE
-    | BACKTICK wildcard BACKTICK
-    ;
+   : ident (MODULE ident)* (MODULE)?
+   | SINGLE_QUOTE wildcard SINGLE_QUOTE
+   | DOUBLE_QUOTE wildcard DOUBLE_QUOTE
+   | BACKTICK wildcard BACKTICK
+   ;
 
 keywordsCanBeId
-    : D // OD SQL and ODBC special
-    | timespanUnit | SPAN
-    | evalFunctionName
-    | relevanceArgName
-    | intervalUnit
-    | dateTimeFunctionName
-    | textFunctionName
-    | mathematicalFunctionName
-    | positionFunctionName
-    // commands
-    | SEARCH | DESCRIBE | SHOW | FROM | WHERE | FIELDS | RENAME | STATS | DEDUP | SORT | EVAL | HEAD | TOP | RARE
-    | PARSE | METHOD | REGEX | PUNCT | GROK | PATTERN | PATTERNS | NEW_FIELD | KMEANS | AD | ML
-    // commands assist keywords
-    | SOURCE | INDEX | DESC | DATASOURCES
-    // CLAUSEKEYWORDS
-    | SORTBY
-    // FIELDKEYWORDSAUTO
-    | STR | IP | NUM
-    // ARGUMENT KEYWORDS
-    | KEEPEMPTY | CONSECUTIVE | DEDUP_SPLITVALUES | PARTITIONS | ALLNUM | DELIM | CENTROIDS | ITERATIONS | DISTANCE_TYPE
-    | NUMBER_OF_TREES | SHINGLE_SIZE | SAMPLE_SIZE | OUTPUT_AFTER | TIME_DECAY | ANOMALY_RATE | CATEGORY_FIELD
-    | TIME_FIELD | TIME_ZONE | TRAINING_DATA_SIZE | ANOMALY_SCORE_THRESHOLD
-    // AGGREGATIONS
-    | AVG | COUNT | DISTINCT_COUNT | ESTDC | ESTDC_ERROR | MAX | MEAN | MEDIAN | MIN | MODE | RANGE | STDEV | STDEVP
-    | SUM | SUMSQ | VAR_SAMP | VAR_POP | STDDEV_SAMP | STDDEV_POP | PERCENTILE | TAKE | FIRST | LAST | LIST | VALUES
-    | EARLIEST | EARLIEST_TIME | LATEST | LATEST_TIME | PER_DAY | PER_HOUR | PER_MINUTE | PER_SECOND | RATE | SPARKLINE
-    | C | DC
-    ;
+   : D // OD SQL and ODBC special
+   | timespanUnit
+   | SPAN
+   | evalFunctionName
+   | relevanceArgName
+   | intervalUnit
+   | dateTimeFunctionName
+   | textFunctionName
+   | mathematicalFunctionName
+   | positionFunctionName
+   // commands
+   | SEARCH
+   | DESCRIBE
+   | SHOW
+   | FROM
+   | WHERE
+   | FIELDS
+   | RENAME
+   | STATS
+   | DEDUP
+   | SORT
+   | EVAL
+   | HEAD
+   | TOP
+   | RARE
+   | PARSE
+   | METHOD
+   | REGEX
+   | PUNCT
+   | GROK
+   | PATTERN
+   | PATTERNS
+   | NEW_FIELD
+   | KMEANS
+   | AD
+   | ML
+   // commands assist keywords
+   | SOURCE
+   | INDEX
+   | DESC
+   | DATASOURCES
+   // CLAUSEKEYWORDS
+   | SORTBY
+   // FIELDKEYWORDSAUTO
+   | STR
+   | IP
+   | NUM
+   // ARGUMENT KEYWORDS
+   | KEEPEMPTY
+   | CONSECUTIVE
+   | DEDUP_SPLITVALUES
+   | PARTITIONS
+   | ALLNUM
+   | DELIM
+   | CENTROIDS
+   | ITERATIONS
+   | DISTANCE_TYPE
+   | NUMBER_OF_TREES
+   | SHINGLE_SIZE
+   | SAMPLE_SIZE
+   | OUTPUT_AFTER
+   | TIME_DECAY
+   | ANOMALY_RATE
+   | CATEGORY_FIELD
+   | TIME_FIELD
+   | TIME_ZONE
+   | TRAINING_DATA_SIZE
+   | ANOMALY_SCORE_THRESHOLD
+   // AGGREGATIONS
+   | AVG
+   | COUNT
+   | DISTINCT_COUNT
+   | ESTDC
+   | ESTDC_ERROR
+   | MAX
+   | MEAN
+   | MEDIAN
+   | MIN
+   | MODE
+   | RANGE
+   | STDEV
+   | STDEVP
+   | SUM
+   | SUMSQ
+   | VAR_SAMP
+   | VAR_POP
+   | STDDEV_SAMP
+   | STDDEV_POP
+   | PERCENTILE
+   | TAKE
+   | FIRST
+   | LAST
+   | LIST
+   | VALUES
+   | EARLIEST
+   | EARLIEST_TIME
+   | LATEST
+   | LATEST_TIME
+   | PER_DAY
+   | PER_HOUR
+   | PER_MINUTE
+   | PER_SECOND
+   | RATE
+   | SPARKLINE
+   | C
+   | DC
+   ;

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -79,7 +79,12 @@ tableFilter
    ;
 
 showDescribePattern
-   : stringLiteral
+    : oldID=compatibleID | stringLiteral
+    ;
+
+compatibleID
+    : (MODULE | ID)+?
+    ;
    ;
 
 // Select Statement's Details

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -30,820 +30,805 @@ THE SOFTWARE.
 
 parser grammar OpenSearchSQLParser;
 
-options { tokenVocab=OpenSearchSQLLexer; }
 
-
+options { tokenVocab = OpenSearchSQLLexer; }
 // Top Level Description
 
 //    Root rule
-root
-    : sqlStatement? SEMI? EOF
-    ;
 
-//    Only SELECT
+root
+   : sqlStatement? SEMI? EOF
+   ;
+
+// Only SELECT
 sqlStatement
-    : dmlStatement | adminStatement
-    ;
+   : dmlStatement
+   | adminStatement
+   ;
 
 dmlStatement
-    : selectStatement
-    ;
-
+   : selectStatement
+   ;
 
 // Data Manipulation Language
 
-//    Primary DML Statements
-
+// Primary DML Statements
 selectStatement
-    : querySpecification                                 #simpleSelect
-    ;
+   : querySpecification # simpleSelect
+   ;
 
 adminStatement
-    : showStatement
-    | describeStatement
-    ;
+   : showStatement
+   | describeStatement
+   ;
 
 showStatement
-    : SHOW TABLES tableFilter
-    ;
+   : SHOW TABLES tableFilter
+   ;
 
 describeStatement
-    : DESCRIBE TABLES tableFilter columnFilter?
-    ;
+   : DESCRIBE TABLES tableFilter columnFilter?
+   ;
 
 columnFilter
-    : COLUMNS LIKE showDescribePattern
-    ;
+   : COLUMNS LIKE showDescribePattern
+   ;
 
 tableFilter
-    : LIKE showDescribePattern
-    ;
+   : LIKE showDescribePattern
+   ;
 
 showDescribePattern
-    : oldID=compatibleID | stringLiteral
-    ;
+   : stringLiteral
+   ;
 
-compatibleID
-    : (MODULE | ID)+?
-    ;
-
-//    Select Statement's Details
-
+// Select Statement's Details
 querySpecification
-    : selectClause
-      fromClause?
-      limitClause?
-    ;
+   : selectClause fromClause? limitClause?
+   ;
 
 selectClause
-    : SELECT selectSpec? selectElements
-    ;
+   : SELECT selectSpec? selectElements
+   ;
 
 selectSpec
-    : (ALL | DISTINCT)
-    ;
+   : (ALL | DISTINCT)
+   ;
 
 selectElements
-    : (star=STAR | selectElement) (COMMA selectElement)*
-    ;
+   : (star = STAR | selectElement) (COMMA selectElement)*
+   ;
 
 selectElement
-    : expression (AS? alias)?
-    ;
+   : expression (AS? alias)?
+   ;
 
 fromClause
-    : FROM relation
-      (whereClause)?
-      (groupByClause)?
-      (havingClause)?
-      (orderByClause)? // Place it under FROM for now but actually not necessary ex. A UNION B ORDER BY
-    ;
+   : FROM relation (whereClause)? (groupByClause)? (havingClause)? (orderByClause)? // Place it under FROM for now but actually not necessary ex. A UNION B ORDER BY
+   
+   ;
 
 relation
-    : tableName (AS? alias)?                                                #tableAsRelation
-    | LR_BRACKET subquery=querySpecification RR_BRACKET AS? alias           #subqueryAsRelation
-    ;
+   : tableName (AS? alias)?                                         # tableAsRelation
+   | LR_BRACKET subquery = querySpecification RR_BRACKET AS? alias  # subqueryAsRelation
+   ;
 
 whereClause
-    : WHERE expression
-    ;
+   : WHERE expression
+   ;
 
 groupByClause
-    : GROUP BY groupByElements
-    ;
+   : GROUP BY groupByElements
+   ;
 
 groupByElements
-    : groupByElement (COMMA groupByElement)*
-    ;
+   : groupByElement (COMMA groupByElement)*
+   ;
 
 groupByElement
-    : expression
-    ;
+   : expression
+   ;
 
 havingClause
-    : HAVING expression
-    ;
+   : HAVING expression
+   ;
 
 orderByClause
-    : ORDER BY orderByElement (COMMA orderByElement)*
-    ;
+   : ORDER BY orderByElement (COMMA orderByElement)*
+   ;
 
 orderByElement
-    : expression order=(ASC | DESC)? (NULLS (FIRST | LAST))?
-    ;
+   : expression order = (ASC | DESC)? (NULLS (FIRST | LAST))?
+   ;
 
 limitClause
-    : LIMIT (offset=decimalLiteral COMMA)? limit=decimalLiteral
-    | LIMIT limit=decimalLiteral OFFSET offset=decimalLiteral
-    ;
+   : LIMIT (offset = decimalLiteral COMMA)? limit = decimalLiteral
+   | LIMIT limit = decimalLiteral OFFSET offset = decimalLiteral
+   ;
 
 //  Window Function's Details
 windowFunctionClause
-    : function=windowFunction overClause
-    ;
+   : function = windowFunction overClause
+   ;
 
 windowFunction
-    : functionName=(ROW_NUMBER | RANK | DENSE_RANK)
-        LR_BRACKET functionArgs? RR_BRACKET              #scalarWindowFunction
-    | aggregateFunction                                  #aggregateWindowFunction
-    ;
+   : functionName = (ROW_NUMBER | RANK | DENSE_RANK) LR_BRACKET functionArgs? RR_BRACKET    # scalarWindowFunction
+   | aggregateFunction                                                                      # aggregateWindowFunction
+   ;
 
 overClause
-    : OVER LR_BRACKET partitionByClause? orderByClause? RR_BRACKET
-    ;
+   : OVER LR_BRACKET partitionByClause? orderByClause? RR_BRACKET
+   ;
 
 partitionByClause
-    : PARTITION BY expression (COMMA expression)*
-    ;
+   : PARTITION BY expression (COMMA expression)*
+   ;
 
-
-//    Literals
-
+// Literals
 constant
-    : stringLiteral             #string
-    | sign? decimalLiteral      #signedDecimal
-    | sign? realLiteral         #signedReal
-    | booleanLiteral            #boolean
-    | datetimeLiteral           #datetime
-    | intervalLiteral           #interval
-    | nullLiteral               #null
-    // Doesn't support the following types for now
-    //| BIT_STRING
-    //| NOT? nullLiteral=(NULL_LITERAL | NULL_SPEC_LITERAL)
-    ;
+   : stringLiteral          # string
+   | sign? decimalLiteral   # signedDecimal
+   | sign? realLiteral      # signedReal
+   | booleanLiteral         # boolean
+   | datetimeLiteral        # datetime
+   | intervalLiteral        # interval
+   | nullLiteral            # null
+   // Doesn't support the following types for now
+   //| BIT_STRING
+   //| NOT? nullLiteral=(NULL_LITERAL | NULL_SPEC_LITERAL)
+   ;
 
 decimalLiteral
-    : DECIMAL_LITERAL
-    | ZERO_DECIMAL
-    | ONE_DECIMAL
-    | TWO_DECIMAL
-    ;
+   : DECIMAL_LITERAL
+   | ZERO_DECIMAL
+   | ONE_DECIMAL
+   | TWO_DECIMAL
+   ;
 
 stringLiteral
-    : STRING_LITERAL
-    | DOUBLE_QUOTE_ID
-    ;
+   : STRING_LITERAL
+   | DOUBLE_QUOTE_ID
+   ;
 
 booleanLiteral
-    : TRUE
-    | FALSE
-    ;
+   : TRUE
+   | FALSE
+   ;
 
 realLiteral
-    : REAL_LITERAL
-    ;
+   : REAL_LITERAL
+   ;
 
 sign
-    : PLUS
-    | MINUS
-    ;
+   : PLUS
+   | MINUS
+   ;
 
 nullLiteral
-    : NULL_LITERAL
-    ;
+   : NULL_LITERAL
+   ;
 
 // Date and Time Literal, follow ANSI 92
 datetimeLiteral
-    : dateLiteral
-    | timeLiteral
-    | timestampLiteral
-    ;
+   : dateLiteral
+   | timeLiteral
+   | timestampLiteral
+   ;
 
 dateLiteral
-    : DATE date=stringLiteral
-    | LEFT_BRACE (DATE | D) date=stringLiteral RIGHT_BRACE
-    ;
+   : DATE date = stringLiteral
+   | LEFT_BRACE (DATE | D) date = stringLiteral RIGHT_BRACE
+   ;
 
 timeLiteral
-    : TIME time=stringLiteral
-    | LEFT_BRACE (TIME | T) time=stringLiteral RIGHT_BRACE
-    ;
+   : TIME time = stringLiteral
+   | LEFT_BRACE (TIME | T) time = stringLiteral RIGHT_BRACE
+   ;
 
 timestampLiteral
-    : TIMESTAMP timestamp=stringLiteral
-    | LEFT_BRACE (TIMESTAMP | TS) timestamp=stringLiteral RIGHT_BRACE
-    ;
+   : TIMESTAMP timestamp = stringLiteral
+   | LEFT_BRACE (TIMESTAMP | TS) timestamp = stringLiteral RIGHT_BRACE
+   ;
 
 // Actually, these constants are shortcuts to the corresponding functions
 datetimeConstantLiteral
-    : CURRENT_DATE
-    | CURRENT_TIME
-    | CURRENT_TIMESTAMP
-    | LOCALTIME
-    | LOCALTIMESTAMP
-    | UTC_TIMESTAMP
-    | UTC_DATE
-    | UTC_TIME
-    ;
+   : CURRENT_DATE
+   | CURRENT_TIME
+   | CURRENT_TIMESTAMP
+   | LOCALTIME
+   | LOCALTIMESTAMP
+   | UTC_TIMESTAMP
+   | UTC_DATE
+   | UTC_TIME
+   ;
 
 intervalLiteral
-    : INTERVAL expression intervalUnit
-    ;
+   : INTERVAL expression intervalUnit
+   ;
 
 intervalUnit
-    : MICROSECOND
-    | SECOND
-    | MINUTE
-    | HOUR
-    | DAY
-    | WEEK
-    | MONTH
-    | QUARTER
-    | YEAR
-    | SECOND_MICROSECOND
-    | MINUTE_MICROSECOND
-    | MINUTE_SECOND
-    | HOUR_MICROSECOND
-    | HOUR_SECOND
-    | HOUR_MINUTE
-    | DAY_MICROSECOND
-    | DAY_SECOND
-    | DAY_MINUTE
-    | DAY_HOUR
-    | YEAR_MONTH
-    ;
+   : MICROSECOND
+   | SECOND
+   | MINUTE
+   | HOUR
+   | DAY
+   | WEEK
+   | MONTH
+   | QUARTER
+   | YEAR
+   | SECOND_MICROSECOND
+   | MINUTE_MICROSECOND
+   | MINUTE_SECOND
+   | HOUR_MICROSECOND
+   | HOUR_SECOND
+   | HOUR_MINUTE
+   | DAY_MICROSECOND
+   | DAY_SECOND
+   | DAY_MINUTE
+   | DAY_HOUR
+   | YEAR_MONTH
+   ;
 
 // predicates
 
 // Simplified approach for expression
 expression
-    : NOT expression                                                #notExpression
-    | left=expression AND right=expression                          #andExpression
-    | left=expression OR right=expression                           #orExpression
-    | predicate                                                     #predicateExpression
-    ;
+   : NOT expression                             # notExpression
+   | left = expression AND right = expression   # andExpression
+   | left = expression OR right = expression    # orExpression
+   | predicate                                  # predicateExpression
+   ;
 
 predicate
-    : expressionAtom                                                #expressionAtomPredicate
-    | left=predicate comparisonOperator right=predicate             #binaryComparisonPredicate
-    | predicate IS nullNotnull                                      #isNullPredicate
-    | predicate NOT? BETWEEN predicate AND predicate                #betweenPredicate
-    | left=predicate NOT? LIKE right=predicate                      #likePredicate
-    | left=predicate REGEXP right=predicate                         #regexpPredicate
-    | predicate NOT? IN '(' expressions ')'                         #inPredicate
-    ;
+   : expressionAtom                                         # expressionAtomPredicate
+   | left = predicate comparisonOperator right = predicate  # binaryComparisonPredicate
+   | predicate IS nullNotnull                               # isNullPredicate
+   | predicate NOT? BETWEEN predicate AND predicate         # betweenPredicate
+   | left = predicate NOT? LIKE right = predicate           # likePredicate
+   | left = predicate REGEXP right = predicate              # regexpPredicate
+   | predicate NOT? IN '(' expressions ')'                  # inPredicate
+   ;
 
 expressions
-    : expression (',' expression)*
-    ;
+   : expression (',' expression)*
+   ;
 
 expressionAtom
-    : constant                                                      #constantExpressionAtom
-    | columnName                                                    #fullColumnNameExpressionAtom
-    | functionCall                                                  #functionCallExpressionAtom
-    | LR_BRACKET expression RR_BRACKET                              #nestedExpressionAtom
-    | left=expressionAtom
-        mathOperator=(STAR | SLASH | MODULE)
-            right=expressionAtom                                    #mathExpressionAtom
-    | left=expressionAtom
-        mathOperator=(PLUS | MINUS)
-            right=expressionAtom                                    #mathExpressionAtom
-    ;
+   : constant                                                                               # constantExpressionAtom
+   | columnName                                                                             # fullColumnNameExpressionAtom
+   | functionCall                                                                           # functionCallExpressionAtom
+   | LR_BRACKET expression RR_BRACKET                                                       # nestedExpressionAtom
+   | left = expressionAtom mathOperator = (STAR | SLASH | MODULE) right = expressionAtom    # mathExpressionAtom
+   | left = expressionAtom mathOperator = (PLUS | MINUS) right = expressionAtom             # mathExpressionAtom
+   ;
 
 comparisonOperator
-    : '='
-    | '>'
-    | '<'
-    | '<' '='
-    | '>' '='
-    | '<' '>'
-    | '!' '='
-    ;
+   : '='
+   | '>'
+   | '<'
+   | '<' '='
+   | '>' '='
+   | '<' '>'
+   | '!' '='
+   ;
 
 nullNotnull
-    : NOT? NULL_LITERAL
-    ;
+   : NOT? NULL_LITERAL
+   ;
 
 functionCall
-    : nestedFunctionName LR_BRACKET allTupleFields RR_BRACKET       #nestedAllFunctionCall
-    | scalarFunctionName LR_BRACKET functionArgs RR_BRACKET         #scalarFunctionCall
-    | specificFunction                                              #specificFunctionCall
-    | windowFunctionClause                                          #windowFunctionCall
-    | aggregateFunction                                             #aggregateFunctionCall
-    | aggregateFunction (orderByClause)? filterClause               #filteredAggregationFunctionCall
-    | scoreRelevanceFunction                                        #scoreRelevanceFunctionCall
-    | relevanceFunction                                             #relevanceFunctionCall
-    | highlightFunction                                             #highlightFunctionCall
-    | positionFunction                                              #positionFunctionCall
-    | extractFunction                                               #extractFunctionCall
-    | getFormatFunction                                             #getFormatFunctionCall
-    | timestampFunction                                             #timestampFunctionCall
-    ;
+   : nestedFunctionName LR_BRACKET allTupleFields RR_BRACKET    # nestedAllFunctionCall
+   | scalarFunctionName LR_BRACKET functionArgs RR_BRACKET      # scalarFunctionCall
+   | specificFunction                                           # specificFunctionCall
+   | windowFunctionClause                                       # windowFunctionCall
+   | aggregateFunction                                          # aggregateFunctionCall
+   | aggregateFunction (orderByClause)? filterClause            # filteredAggregationFunctionCall
+   | scoreRelevanceFunction                                     # scoreRelevanceFunctionCall
+   | relevanceFunction                                          # relevanceFunctionCall
+   | highlightFunction                                          # highlightFunctionCall
+   | positionFunction                                           # positionFunctionCall
+   | extractFunction                                            # extractFunctionCall
+   | getFormatFunction                                          # getFormatFunctionCall
+   | timestampFunction                                          # timestampFunctionCall
+   ;
 
 timestampFunction
-    : timestampFunctionName LR_BRACKET simpleDateTimePart COMMA firstArg=functionArg COMMA secondArg=functionArg RR_BRACKET
-    ;
+   : timestampFunctionName LR_BRACKET simpleDateTimePart COMMA firstArg = functionArg COMMA secondArg = functionArg RR_BRACKET
+   ;
 
 timestampFunctionName
-    : TIMESTAMPADD
-    | TIMESTAMPDIFF
-    ;
+   : TIMESTAMPADD
+   | TIMESTAMPDIFF
+   ;
 
 getFormatFunction
-    : GET_FORMAT LR_BRACKET getFormatType COMMA functionArg RR_BRACKET
-    ;
+   : GET_FORMAT LR_BRACKET getFormatType COMMA functionArg RR_BRACKET
+   ;
 
 getFormatType
-    : DATE
-    | DATETIME
-    | TIME
-    | TIMESTAMP
-    ;
+   : DATE
+   | DATETIME
+   | TIME
+   | TIMESTAMP
+   ;
 
 extractFunction
-    : EXTRACT LR_BRACKET datetimePart FROM functionArg RR_BRACKET
-    ;
+   : EXTRACT LR_BRACKET datetimePart FROM functionArg RR_BRACKET
+   ;
 
 simpleDateTimePart
-    : MICROSECOND
-    | SECOND
-    | MINUTE
-    | HOUR
-    | DAY
-    | WEEK
-    | MONTH
-    | QUARTER
-    | YEAR
-    ;
+   : MICROSECOND
+   | SECOND
+   | MINUTE
+   | HOUR
+   | DAY
+   | WEEK
+   | MONTH
+   | QUARTER
+   | YEAR
+   ;
 
 complexDateTimePart
-    : SECOND_MICROSECOND
-    | MINUTE_MICROSECOND
-    | MINUTE_SECOND
-    | HOUR_MICROSECOND
-    | HOUR_SECOND
-    | HOUR_MINUTE
-    | DAY_MICROSECOND
-    | DAY_SECOND
-    | DAY_MINUTE
-    | DAY_HOUR
-    | YEAR_MONTH
-    ;
+   : SECOND_MICROSECOND
+   | MINUTE_MICROSECOND
+   | MINUTE_SECOND
+   | HOUR_MICROSECOND
+   | HOUR_SECOND
+   | HOUR_MINUTE
+   | DAY_MICROSECOND
+   | DAY_SECOND
+   | DAY_MINUTE
+   | DAY_HOUR
+   | YEAR_MONTH
+   ;
 
 datetimePart
-    : simpleDateTimePart
-    | complexDateTimePart
-    ;
+   : simpleDateTimePart
+   | complexDateTimePart
+   ;
 
 highlightFunction
-    : HIGHLIGHT LR_BRACKET relevanceField (COMMA highlightArg)* RR_BRACKET
-    ;
+   : HIGHLIGHT LR_BRACKET relevanceField (COMMA highlightArg)* RR_BRACKET
+   ;
 
 positionFunction
-    : POSITION LR_BRACKET functionArg IN functionArg RR_BRACKET
-    ;
+   : POSITION LR_BRACKET functionArg IN functionArg RR_BRACKET
+   ;
 
 matchQueryAltSyntaxFunction
-    : field=relevanceField EQUAL_SYMBOL MATCH_QUERY LR_BRACKET query=relevanceQuery RR_BRACKET
-    ;
+   : field = relevanceField EQUAL_SYMBOL MATCH_QUERY LR_BRACKET query = relevanceQuery RR_BRACKET
+   ;
 
 scalarFunctionName
-    : mathematicalFunctionName
-    | dateTimeFunctionName
-    | textFunctionName
-    | flowControlFunctionName
-    | systemFunctionName
-    | nestedFunctionName
-    ;
+   : mathematicalFunctionName
+   | dateTimeFunctionName
+   | textFunctionName
+   | flowControlFunctionName
+   | systemFunctionName
+   | nestedFunctionName
+   ;
 
 specificFunction
-    : CASE expression caseFuncAlternative+
-        (ELSE elseArg=functionArg)? END                               #caseFunctionCall
-    | CASE caseFuncAlternative+
-        (ELSE elseArg=functionArg)? END                               #caseFunctionCall
-    | CAST '(' expression AS convertedDataType ')'                    #dataTypeFunctionCall
-    ;
+   : CASE expression caseFuncAlternative+ (ELSE elseArg = functionArg)? END     # caseFunctionCall
+   | CASE caseFuncAlternative+ (ELSE elseArg = functionArg)? END                # caseFunctionCall
+   | CAST '(' expression AS convertedDataType ')'                               # dataTypeFunctionCall
+   ;
 
 relevanceFunction
-    : noFieldRelevanceFunction | singleFieldRelevanceFunction | multiFieldRelevanceFunction | altSingleFieldRelevanceFunction | altMultiFieldRelevanceFunction
-    ;
+   : noFieldRelevanceFunction
+   | singleFieldRelevanceFunction
+   | multiFieldRelevanceFunction
+   | altSingleFieldRelevanceFunction
+   | altMultiFieldRelevanceFunction
+   ;
 
 scoreRelevanceFunction
-    : scoreRelevanceFunctionName LR_BRACKET relevanceFunction (COMMA weight=relevanceFieldWeight)? RR_BRACKET
-    ;
+   : scoreRelevanceFunctionName LR_BRACKET relevanceFunction (COMMA weight = relevanceFieldWeight)? RR_BRACKET
+   ;
 
 noFieldRelevanceFunction
-    : noFieldRelevanceFunctionName LR_BRACKET query=relevanceQuery (COMMA relevanceArg)* RR_BRACKET
-    ;
+   : noFieldRelevanceFunctionName LR_BRACKET query = relevanceQuery (COMMA relevanceArg)* RR_BRACKET
+   ;
 
 // Field is a single column
 singleFieldRelevanceFunction
-    : singleFieldRelevanceFunctionName LR_BRACKET
-        field=relevanceField COMMA query=relevanceQuery
-        (COMMA relevanceArg)* RR_BRACKET;
+   : singleFieldRelevanceFunctionName LR_BRACKET field = relevanceField COMMA query = relevanceQuery (COMMA relevanceArg)* RR_BRACKET
+   ;
 
 // Field is a list of columns
 multiFieldRelevanceFunction
-    : multiFieldRelevanceFunctionName LR_BRACKET
-        LT_SQR_PRTHS field=relevanceFieldAndWeight (COMMA field=relevanceFieldAndWeight)* RT_SQR_PRTHS
-        COMMA query=relevanceQuery (COMMA relevanceArg)* RR_BRACKET
-    | multiFieldRelevanceFunctionName LR_BRACKET
-        alternateMultiMatchQuery  COMMA alternateMultiMatchField (COMMA relevanceArg)* RR_BRACKET
-    ;
+   : multiFieldRelevanceFunctionName LR_BRACKET LT_SQR_PRTHS field = relevanceFieldAndWeight (COMMA field = relevanceFieldAndWeight)* RT_SQR_PRTHS COMMA query = relevanceQuery (COMMA relevanceArg)* RR_BRACKET
+   | multiFieldRelevanceFunctionName LR_BRACKET alternateMultiMatchQuery COMMA alternateMultiMatchField (COMMA relevanceArg)* RR_BRACKET
+   ;
 
 altSingleFieldRelevanceFunction
-    : field=relevanceField EQUAL_SYMBOL altSyntaxFunctionName=altSingleFieldRelevanceFunctionName LR_BRACKET query=relevanceQuery (COMMA relevanceArg)* RR_BRACKET
-    ;
+   : field = relevanceField EQUAL_SYMBOL altSyntaxFunctionName = altSingleFieldRelevanceFunctionName LR_BRACKET query = relevanceQuery (COMMA relevanceArg)* RR_BRACKET
+   ;
 
 altMultiFieldRelevanceFunction
-    : field=relevanceField EQUAL_SYMBOL altSyntaxFunctionName=altMultiFieldRelevanceFunctionName LR_BRACKET query=relevanceQuery (COMMA relevanceArg)* RR_BRACKET
-    ;
+   : field = relevanceField EQUAL_SYMBOL altSyntaxFunctionName = altMultiFieldRelevanceFunctionName LR_BRACKET query = relevanceQuery (COMMA relevanceArg)* RR_BRACKET
+   ;
 
 convertedDataType
-    : typeName=DATE
-    | typeName=TIME
-    | typeName=TIMESTAMP
-    | typeName=INT
-    | typeName=INTEGER
-    | typeName=DOUBLE
-    | typeName=LONG
-    | typeName=FLOAT
-    | typeName=STRING
-    | typeName=BOOLEAN
-    ;
+   : typeName = DATE
+   | typeName = TIME
+   | typeName = TIMESTAMP
+   | typeName = INT
+   | typeName = INTEGER
+   | typeName = DOUBLE
+   | typeName = LONG
+   | typeName = FLOAT
+   | typeName = STRING
+   | typeName = BOOLEAN
+   ;
 
 caseFuncAlternative
-    : WHEN condition=functionArg
-      THEN consequent=functionArg
-    ;
+   : WHEN condition = functionArg THEN consequent = functionArg
+   ;
 
 aggregateFunction
-    : functionName=aggregationFunctionName LR_BRACKET functionArg RR_BRACKET
-                                                                    #regularAggregateFunctionCall
-    | COUNT LR_BRACKET STAR RR_BRACKET                              #countStarFunctionCall
-    | COUNT LR_BRACKET DISTINCT functionArg RR_BRACKET              #distinctCountFunctionCall
-    ;
+   : functionName = aggregationFunctionName LR_BRACKET functionArg RR_BRACKET   # regularAggregateFunctionCall
+   | COUNT LR_BRACKET STAR RR_BRACKET                                           # countStarFunctionCall
+   | COUNT LR_BRACKET DISTINCT functionArg RR_BRACKET                           # distinctCountFunctionCall
+   ;
 
 filterClause
-    : FILTER LR_BRACKET WHERE expression RR_BRACKET
-    ;
+   : FILTER LR_BRACKET WHERE expression RR_BRACKET
+   ;
 
 aggregationFunctionName
-    : AVG
-    | COUNT
-    | SUM
-    | MIN
-    | MAX
-    | VAR_POP
-    | VAR_SAMP
-    | VARIANCE
-    | STD
-    | STDDEV
-    | STDDEV_POP
-    | STDDEV_SAMP
-    ;
+   : AVG
+   | COUNT
+   | SUM
+   | MIN
+   | MAX
+   | VAR_POP
+   | VAR_SAMP
+   | VARIANCE
+   | STD
+   | STDDEV
+   | STDDEV_POP
+   | STDDEV_SAMP
+   ;
 
 mathematicalFunctionName
-    : ABS
-    | CBRT
-    | CEIL
-    | CEILING
-    | CONV
-    | CRC32
-    | E
-    | EXP
-    | EXPM1
-    | FLOOR
-    | LN
-    | LOG
-    | LOG10
-    | LOG2
-    | MOD
-    | PI
-    | POW
-    | POWER
-    | RAND
-    | RINT
-    | ROUND
-    | SIGN
-    | SIGNUM
-    | SQRT
-    | TRUNCATE
-    | trigonometricFunctionName
-    | arithmeticFunctionName
-    ;
+   : ABS
+   | CBRT
+   | CEIL
+   | CEILING
+   | CONV
+   | CRC32
+   | E
+   | EXP
+   | EXPM1
+   | FLOOR
+   | LN
+   | LOG
+   | LOG10
+   | LOG2
+   | MOD
+   | PI
+   | POW
+   | POWER
+   | RAND
+   | RINT
+   | ROUND
+   | SIGN
+   | SIGNUM
+   | SQRT
+   | TRUNCATE
+   | trigonometricFunctionName
+   | arithmeticFunctionName
+   ;
 
 trigonometricFunctionName
-    : ACOS
-    | ASIN
-    | ATAN
-    | ATAN2
-    | COS
-    | COSH
-    | COT
-    | DEGREES
-    | RADIANS
-    | SIN
-    | SINH
-    | TAN
-    ;
+   : ACOS
+   | ASIN
+   | ATAN
+   | ATAN2
+   | COS
+   | COSH
+   | COT
+   | DEGREES
+   | RADIANS
+   | SIN
+   | SINH
+   | TAN
+   ;
 
 arithmeticFunctionName
-    : ADD
-    | SUBTRACT
-    | MULTIPLY
-    | DIVIDE
-    | MOD
-    | MODULUS
-    ;
+   : ADD
+   | SUBTRACT
+   | MULTIPLY
+   | DIVIDE
+   | MOD
+   | MODULUS
+   ;
 
 dateTimeFunctionName
-    : datetimeConstantLiteral
-    | ADDDATE
-    | ADDTIME
-    | CONVERT_TZ
-    | CURDATE
-    | CURTIME
-    | DATE
-    | DATE_ADD
-    | DATE_FORMAT
-    | DATE_SUB
-    | DATEDIFF
-    | DATETIME
-    | DAY
-    | DAYNAME
-    | DAYOFMONTH
-    | DAY_OF_MONTH
-    | DAYOFWEEK
-    | DAYOFYEAR
-    | DAY_OF_YEAR
-    | DAY_OF_WEEK
-    | FROM_DAYS
-    | FROM_UNIXTIME
-    | HOUR
-    | HOUR_OF_DAY
-    | LAST_DAY
-    | MAKEDATE
-    | MAKETIME
-    | MICROSECOND
-    | MINUTE
-    | MINUTE_OF_DAY
-    | MINUTE_OF_HOUR
-    | MONTH
-    | MONTHNAME
-    | MONTH_OF_YEAR
-    | NOW
-    | PERIOD_ADD
-    | PERIOD_DIFF
-    | QUARTER
-    | SEC_TO_TIME
-    | SECOND
-    | SECOND_OF_MINUTE
-    | SUBDATE
-    | SUBTIME
-    | SYSDATE
-    | STR_TO_DATE
-    | TIME
-    | TIME_FORMAT
-    | TIME_TO_SEC
-    | TIMEDIFF
-    | TIMESTAMP
-    | TO_DAYS
-    | TO_SECONDS
-    | UNIX_TIMESTAMP
-    | WEEK
-    | WEEKDAY
-    | WEEK_OF_YEAR
-    | WEEKOFYEAR
-    | YEAR
-    | YEARWEEK
-    ;
+   : datetimeConstantLiteral
+   | ADDDATE
+   | ADDTIME
+   | CONVERT_TZ
+   | CURDATE
+   | CURTIME
+   | DATE
+   | DATE_ADD
+   | DATE_FORMAT
+   | DATE_SUB
+   | DATEDIFF
+   | DATETIME
+   | DAY
+   | DAYNAME
+   | DAYOFMONTH
+   | DAY_OF_MONTH
+   | DAYOFWEEK
+   | DAYOFYEAR
+   | DAY_OF_YEAR
+   | DAY_OF_WEEK
+   | FROM_DAYS
+   | FROM_UNIXTIME
+   | HOUR
+   | HOUR_OF_DAY
+   | LAST_DAY
+   | MAKEDATE
+   | MAKETIME
+   | MICROSECOND
+   | MINUTE
+   | MINUTE_OF_DAY
+   | MINUTE_OF_HOUR
+   | MONTH
+   | MONTHNAME
+   | MONTH_OF_YEAR
+   | NOW
+   | PERIOD_ADD
+   | PERIOD_DIFF
+   | QUARTER
+   | SEC_TO_TIME
+   | SECOND
+   | SECOND_OF_MINUTE
+   | SUBDATE
+   | SUBTIME
+   | SYSDATE
+   | STR_TO_DATE
+   | TIME
+   | TIME_FORMAT
+   | TIME_TO_SEC
+   | TIMEDIFF
+   | TIMESTAMP
+   | TO_DAYS
+   | TO_SECONDS
+   | UNIX_TIMESTAMP
+   | WEEK
+   | WEEKDAY
+   | WEEK_OF_YEAR
+   | WEEKOFYEAR
+   | YEAR
+   | YEARWEEK
+   ;
 
 textFunctionName
-    : SUBSTR
-    | SUBSTRING
-    | TRIM
-    | LTRIM
-    | RTRIM
-    | LOWER
-    | UPPER
-    | CONCAT
-    | CONCAT_WS
-    | SUBSTR
-    | LENGTH
-    | STRCMP
-    | RIGHT
-    | LEFT
-    | ASCII
-    | LOCATE
-    | REPLACE
-    | REVERSE
-    ;
+   : SUBSTR
+   | SUBSTRING
+   | TRIM
+   | LTRIM
+   | RTRIM
+   | LOWER
+   | UPPER
+   | CONCAT
+   | CONCAT_WS
+   | SUBSTR
+   | LENGTH
+   | STRCMP
+   | RIGHT
+   | LEFT
+   | ASCII
+   | LOCATE
+   | REPLACE
+   | REVERSE
+   ;
 
 flowControlFunctionName
-    : IF
-    | IFNULL
-    | NULLIF
-    | ISNULL
-    ;
+   : IF
+   | IFNULL
+   | NULLIF
+   | ISNULL
+   ;
 
 noFieldRelevanceFunctionName
-    : QUERY
-    ;
+   : QUERY
+   ;
 
 systemFunctionName
-    : TYPEOF
-    ;
+   : TYPEOF
+   ;
 
 nestedFunctionName
-    : NESTED
-    ;
+   : NESTED
+   ;
 
 scoreRelevanceFunctionName
-    : SCORE | SCOREQUERY | SCORE_QUERY
-    ;
+   : SCORE
+   | SCOREQUERY
+   | SCORE_QUERY
+   ;
 
 singleFieldRelevanceFunctionName
-    : MATCH
-    | MATCHQUERY
-    | MATCH_QUERY
-    | MATCH_PHRASE
-    | MATCHPHRASE
-    | MATCHPHRASEQUERY
-    | MATCH_BOOL_PREFIX
-    | MATCH_PHRASE_PREFIX
-    | WILDCARD_QUERY
-    | WILDCARDQUERY
-    ;
+   : MATCH
+   | MATCHQUERY
+   | MATCH_QUERY
+   | MATCH_PHRASE
+   | MATCHPHRASE
+   | MATCHPHRASEQUERY
+   | MATCH_BOOL_PREFIX
+   | MATCH_PHRASE_PREFIX
+   | WILDCARD_QUERY
+   | WILDCARDQUERY
+   ;
 
 multiFieldRelevanceFunctionName
-    : MULTI_MATCH
-    | MULTIMATCH
-    | MULTIMATCHQUERY
-    | SIMPLE_QUERY_STRING
-    | QUERY_STRING
-    ;
+   : MULTI_MATCH
+   | MULTIMATCH
+   | MULTIMATCHQUERY
+   | SIMPLE_QUERY_STRING
+   | QUERY_STRING
+   ;
 
 altSingleFieldRelevanceFunctionName
-    : MATCH_QUERY
-    | MATCHQUERY
-    | MATCH_PHRASE
-    | MATCHPHRASE
-    ;
+   : MATCH_QUERY
+   | MATCHQUERY
+   | MATCH_PHRASE
+   | MATCHPHRASE
+   ;
 
 altMultiFieldRelevanceFunctionName
-    : MULTI_MATCH
-    | MULTIMATCH
-    ;
+   : MULTI_MATCH
+   | MULTIMATCH
+   ;
 
 functionArgs
-    : (functionArg (COMMA functionArg)*)?
-    ;
+   : (functionArg (COMMA functionArg)*)?
+   ;
 
 functionArg
-    : expression
-    ;
+   : expression
+   ;
 
 relevanceArg
-    : relevanceArgName EQUAL_SYMBOL relevanceArgValue
-    | argName=stringLiteral EQUAL_SYMBOL argVal=relevanceArgValue
-    ;
+   : relevanceArgName EQUAL_SYMBOL relevanceArgValue
+   | argName = stringLiteral EQUAL_SYMBOL argVal = relevanceArgValue
+   ;
 
 highlightArg
-    : highlightArgName EQUAL_SYMBOL highlightArgValue
-    ;
+   : highlightArgName EQUAL_SYMBOL highlightArgValue
+   ;
 
 relevanceArgName
-    : ALLOW_LEADING_WILDCARD
-    | ANALYZER
-    | ANALYZE_WILDCARD
-    | AUTO_GENERATE_SYNONYMS_PHRASE_QUERY
-    | BOOST
-    | CASE_INSENSITIVE
-    | CUTOFF_FREQUENCY
-    | DEFAULT_FIELD
-    | DEFAULT_OPERATOR
-    | ENABLE_POSITION_INCREMENTS
-    | ESCAPE
-    | FIELDS
-    | FLAGS
-    | FUZZINESS
-    | FUZZY_MAX_EXPANSIONS
-    | FUZZY_PREFIX_LENGTH
-    | FUZZY_REWRITE
-    | FUZZY_TRANSPOSITIONS
-    | LENIENT
-    | LOW_FREQ_OPERATOR
-    | MAX_DETERMINIZED_STATES
-    | MAX_EXPANSIONS
-    | MINIMUM_SHOULD_MATCH
-    | OPERATOR
-    | PHRASE_SLOP
-    | PREFIX_LENGTH
-    | QUOTE_ANALYZER
-    | QUOTE_FIELD_SUFFIX
-    | REWRITE
-    | SLOP
-    | TIE_BREAKER
-    | TIME_ZONE
-    | TYPE
-    | ZERO_TERMS_QUERY
-    ;
+   : ALLOW_LEADING_WILDCARD
+   | ANALYZER
+   | ANALYZE_WILDCARD
+   | AUTO_GENERATE_SYNONYMS_PHRASE_QUERY
+   | BOOST
+   | CASE_INSENSITIVE
+   | CUTOFF_FREQUENCY
+   | DEFAULT_FIELD
+   | DEFAULT_OPERATOR
+   | ENABLE_POSITION_INCREMENTS
+   | ESCAPE
+   | FIELDS
+   | FLAGS
+   | FUZZINESS
+   | FUZZY_MAX_EXPANSIONS
+   | FUZZY_PREFIX_LENGTH
+   | FUZZY_REWRITE
+   | FUZZY_TRANSPOSITIONS
+   | LENIENT
+   | LOW_FREQ_OPERATOR
+   | MAX_DETERMINIZED_STATES
+   | MAX_EXPANSIONS
+   | MINIMUM_SHOULD_MATCH
+   | OPERATOR
+   | PHRASE_SLOP
+   | PREFIX_LENGTH
+   | QUOTE_ANALYZER
+   | QUOTE_FIELD_SUFFIX
+   | REWRITE
+   | SLOP
+   | TIE_BREAKER
+   | TIME_ZONE
+   | TYPE
+   | ZERO_TERMS_QUERY
+   ;
 
 highlightArgName
-    : HIGHLIGHT_POST_TAGS
-    | HIGHLIGHT_PRE_TAGS
-    ;
+   : HIGHLIGHT_POST_TAGS
+   | HIGHLIGHT_PRE_TAGS
+   ;
 
 relevanceFieldAndWeight
-    : field=relevanceField
-    | field=relevanceField weight=relevanceFieldWeight
-    | field=relevanceField BIT_XOR_OP weight=relevanceFieldWeight
-    ;
+   : field = relevanceField
+   | field = relevanceField weight = relevanceFieldWeight
+   | field = relevanceField BIT_XOR_OP weight = relevanceFieldWeight
+   ;
 
 relevanceFieldWeight
-    : realLiteral
-    | decimalLiteral
-    ;
+   : realLiteral
+   | decimalLiteral
+   ;
 
 relevanceField
-    : qualifiedName
-    | stringLiteral
-    ;
+   : qualifiedName
+   | stringLiteral
+   ;
 
 relevanceQuery
-    : relevanceArgValue
-    ;
+   : relevanceArgValue
+   ;
 
 relevanceArgValue
-    : qualifiedName
-    | constant
-    ;
+   : qualifiedName
+   | constant
+   ;
 
 highlightArgValue
-    : stringLiteral
-    ;
+   : stringLiteral
+   ;
 
 alternateMultiMatchArgName
-    : FIELDS
-    | QUERY
-    | stringLiteral
-    ;
+   : FIELDS
+   | QUERY
+   | stringLiteral
+   ;
 
 alternateMultiMatchQuery
-    : argName=alternateMultiMatchArgName EQUAL_SYMBOL argVal=relevanceArgValue
-    ;
+   : argName = alternateMultiMatchArgName EQUAL_SYMBOL argVal = relevanceArgValue
+   ;
 
 alternateMultiMatchField
-    : argName=alternateMultiMatchArgName EQUAL_SYMBOL argVal=relevanceArgValue
-    | argName=alternateMultiMatchArgName EQUAL_SYMBOL
-    LT_SQR_PRTHS argVal=relevanceArgValue RT_SQR_PRTHS
-    ;
+   : argName = alternateMultiMatchArgName EQUAL_SYMBOL argVal = relevanceArgValue
+   | argName = alternateMultiMatchArgName EQUAL_SYMBOL LT_SQR_PRTHS argVal = relevanceArgValue RT_SQR_PRTHS
+   ;
 
-
-//    Identifiers
-
+// Identifiers
 tableName
-    : qualifiedName
-    ;
+   : qualifiedName
+   ;
 
 columnName
-    : qualifiedName
-    ;
+   : qualifiedName
+   ;
 
 allTupleFields
-    : path=qualifiedName DOT STAR
-    ;
+   : path = qualifiedName DOT STAR
+   ;
 
 alias
-    : ident
-    ;
+   : ident
+   ;
 
 qualifiedName
-    : ident (DOT ident)*
-    ;
+   : ident (DOT ident)*
+   ;
 
 ident
-    : DOT? ID
-    | BACKTICK_QUOTE_ID
-    | keywordsCanBeId
-    | scalarFunctionName
-    ;
+   : DOT? ID
+   | BACKTICK_QUOTE_ID
+   | keywordsCanBeId
+   | scalarFunctionName
+   ;
 
 keywordsCanBeId
-    : FULL
-    | FIELD | D | T | TS // OD SQL and ODBC special
-    | COUNT | SUM | AVG | MAX | MIN
-    | FIRST | LAST
-    | TYPE // TODO: Type is keyword required by relevancy function. Remove this when relevancy functions moved out
-    ;
+   : FULL
+   | FIELD
+   | D
+   | T
+   | TS // OD SQL and ODBC special
+   | COUNT
+   | SUM
+   | AVG
+   | MAX
+   | MIN
+   | FIRST
+   | LAST
+   | TYPE // TODO: Type is keyword required by relevancy function. Remove this when relevancy functions moved out
+   ;

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -79,13 +79,13 @@ tableFilter
    ;
 
 showDescribePattern
-    : oldID=compatibleID | stringLiteral
-    ;
+   : oldID=compatibleID | stringLiteral
+   ;
 
 compatibleID
-    : (MODULE | ID)+?
-    ;
+   : (MODULE | ID)+?
    ;
+
 
 // Select Statement's Details
 querySpecification


### PR DESCRIPTION
### Description
Changed formatting of Antlr parser files based on Spotless changes. I have not applied the changes made to the lexer files as it completely rewrites the files to make them much less readable

### Issues Resolved
N/A

### Check List

- [x]  New functionality includes testing.
- [x]  All tests pass, including unit test, integration test and doctest
- [x]  New functionality has been documented.
- [x]  New functionality has javadoc added
- [x]  New functionality has user manual doc added
- [x]  Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).