### PR TITLE
Fixed response codes For Requests With security exception.

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/DataSourceClientException.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/DataSourceClientException.java
@@ -1,0 +1,19 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.datasources.exceptions;
+
+/**
+ * This is the base class for all DataSource Client Exceptions. All datasource connector modules
+ * will extend this exception for their respective connection clients.
+ */
+public class DataSourceClientException extends RuntimeException {
+
+  public DataSourceClientException(String message) {
+    super(message);
+  }
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLQueryAction.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -28,6 +29,7 @@ import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.datasources.exceptions.DataSourceClientException;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.QueryEngineException;
 import org.opensearch.sql.exception.SemanticCheckException;
@@ -67,7 +69,9 @@ public class RestPPLQueryAction extends BaseRestHandler {
         || e instanceof SemanticCheckException
         || e instanceof ExpressionEvaluationException
         || e instanceof QueryEngineException
-        || e instanceof SyntaxCheckException;
+        || e instanceof SyntaxCheckException
+        || e instanceof DataSourceClientException
+        || e instanceof IllegalAccessException;
   }
 
   @Override
@@ -132,8 +136,9 @@ public class RestPPLQueryAction extends BaseRestHandler {
                       channel,
                       INTERNAL_SERVER_ERROR,
                       "Failed to explain the query due to error: " + e.getMessage());
-                } else if (e instanceof IllegalAccessException) {
-                  reportError(channel, e, BAD_REQUEST);
+                } else if (e instanceof OpenSearchSecurityException) {
+                  OpenSearchSecurityException exception = (OpenSearchSecurityException) e;
+                  reportError(channel, exception, exception.status());
                 } else {
                   LOG.error("Error happened during query handling", e);
                   if (isClientError(e)) {

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
@@ -22,7 +22,9 @@ import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
+import org.opensearch.sql.prometheus.exceptions.PrometheusClientException;
 import org.opensearch.sql.prometheus.request.system.model.MetricMetadata;
 
 public class PrometheusClientImpl implements PrometheusClient {
@@ -111,14 +113,21 @@ public class PrometheusClientImpl implements PrometheusClient {
 
   private JSONObject readResponse(Response response) throws IOException {
     if (response.isSuccessful()) {
-      JSONObject jsonObject = new JSONObject(Objects.requireNonNull(response.body()).string());
+      JSONObject jsonObject;
+      try {
+        jsonObject = new JSONObject(Objects.requireNonNull(response.body()).string());
+      } catch (JSONException jsonException) {
+        throw new PrometheusClientException(
+            "Prometheus returned unexpected body, "
+                + "please verify your prometheus server setup.");
+      }
       if ("success".equals(jsonObject.getString("status"))) {
         return jsonObject;
       } else {
-        throw new RuntimeException(jsonObject.getString("error"));
+        throw new PrometheusClientException(jsonObject.getString("error"));
       }
     } else {
-      throw new RuntimeException(
+      throw new PrometheusClientException(
           String.format(
               "Request to Prometheus is Unsuccessful with : %s",
               Objects.requireNonNull(response.body(), "Response body can't be null").string()));

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/exceptions/PrometheusClientException.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/exceptions/PrometheusClientException.java
@@ -1,0 +1,17 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.exceptions;
+
+import org.opensearch.sql.datasources.exceptions.DataSourceClientException;
+
+/** PrometheusClientException. */
+public class PrometheusClientException extends DataSourceClientException {
+  public PrometheusClientException(String message) {
+    super(message);
+  }
+}

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/request/system/PrometheusDescribeMetricRequest.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/request/system/PrometheusDescribeMetricRequest.java
@@ -27,6 +27,7 @@ import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.prometheus.client.PrometheusClient;
+import org.opensearch.sql.prometheus.exceptions.PrometheusClientException;
 import org.opensearch.sql.prometheus.storage.PrometheusMetricDefaultSchema;
 
 /**
@@ -80,7 +81,7 @@ public class PrometheusDescribeMetricRequest implements PrometheusSystemRequest 
                     "Error while fetching labels for {} from prometheus: {}",
                     metricName,
                     e.getMessage());
-                throw new RuntimeException(
+                throw new PrometheusClientException(
                     String.format(
                         "Error while fetching labels " + "for %s from prometheus: %s",
                         metricName, e.getMessage()));

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactory.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactory.java
@@ -99,6 +99,7 @@ public class PrometheusStorageFactory implements DataSourceFactory {
     OkHttpClient.Builder okHttpClient = new OkHttpClient.Builder();
     okHttpClient.callTimeout(1, TimeUnit.MINUTES);
     okHttpClient.connectTimeout(30, TimeUnit.SECONDS);
+    okHttpClient.followRedirects(false);
     if (config.get(AUTH_TYPE) != null) {
       AuthenticationType authenticationType = AuthenticationType.get(config.get(AUTH_TYPE));
       if (AuthenticationType.BASICAUTH.equals(authenticationType)) {
@@ -162,8 +163,8 @@ public class PrometheusStorageFactory implements DataSourceFactory {
       if (!matcher.matches()) {
         throw new IllegalArgumentException(
             String.format(
-                "Disallowed hostname in the uri: %s. Validate with %s config",
-                config.get(URI), Settings.Key.DATASOURCES_URI_ALLOWHOSTS.getKeyValue()));
+                "Disallowed hostname in the uri. Validate with %s config",
+                Settings.Key.DATASOURCES_URI_ALLOWHOSTS.getKeyValue()));
       }
     }
   }

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactoryTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactoryTest.java
@@ -269,7 +269,7 @@ public class PrometheusStorageFactoryTest {
         exception
             .getMessage()
             .contains(
-                "Disallowed hostname in the uri: http://localhost.com:9090. "
+                "Disallowed hostname in the uri. "
                     + "Validate with plugins.query.datasources.uri.allowhosts config"));
   }
 

--- a/prometheus/src/test/resources/non_json_response.json
+++ b/prometheus/src/test/resources/non_json_response.json
@@ -1,0 +1,1 @@
+fadsfadsfasdfasdfadsfasdfadsfadsf


### PR DESCRIPTION
### Description
* For requests with security access exception, we are currently throwing 503 which is not recommended.
With this change, we are setting the status received from Opensearch Security Exception.
* All the prometheus errors are captured in PrometheusClientException and we are throwing 400 error to let customer fix the setup.
* Disabled redirects in okhttp client to block any ssrf issues.
* https://github.com/opensearch-project/sql/issues/2035 Issue for improving error response code.
* https://github.com/opensearch-project/sql/issues/2034 Issue for improving security integ tests framework to incorportate users with multiple permissions personas.

### Testing 
**Before Changes:**
POST _plugins/_ppl
{
"query" : "source=prometheus10.instance_cpu_time_ns"
}
<img width="803" alt="Screenshot 2023-08-28 at 8 33 11 AM" src="https://github.com/opensearch-project/sql/assets/99925918/3ebb7123-517f-4019-9b80-c4881836bfb0">

**After Changes:**
POST _plugins/_ppl
{
"query" : "source=prometheus10.instance_cpu_time_ns"
}
<img width="716" alt="Screenshot 2023-08-28 at 8 30 00 AM" src="https://github.com/opensearch-project/sql/assets/99925918/7f2afcfb-ee70-4cb8-8b83-581c5acbcac7">

Now the response code changes to 403.




### Backlog

* There are no existing unit tests for this RestPPLQueryAction.
* The current framework for integration tests with security plugin doesn't allow custom users with custom permissions. Its hard to replicate the scenario.
Created below backlog issue to handle this. 









 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).