### PR TITLE
Add _primary preference only for segment replication enabled indices

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
@@ -225,10 +225,8 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
     searchSourceBuilder.query(query);
     searchSourceBuilder.size(DATASOURCE_QUERY_RESULT_SIZE);
     searchRequest.source(searchSourceBuilder);
-    if (state.isSegmentReplicationEnabled(DATASOURCE_INDEX_NAME)) {
-      // https://github.com/opensearch-project/sql/issues/1801.
-      searchRequest.preference("_primary");
-    }
+    // https://github.com/opensearch-project/sql/issues/1801.
+    searchRequest.preference("_primary_first");
     ActionFuture<SearchResponse> searchResponseActionFuture;
     try (ThreadContext.StoredContext ignored =
         client.threadPool().getThreadContext().stashContext()) {

--- a/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
@@ -32,7 +32,6 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -85,7 +84,7 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
       createDataSourcesIndex();
       return Collections.emptyList();
     }
-    return searchInDataSourcesIndex(this.clusterService.state(), QueryBuilders.matchAllQuery());
+    return searchInDataSourcesIndex(QueryBuilders.matchAllQuery());
   }
 
   @Override
@@ -94,7 +93,7 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
       createDataSourcesIndex();
       return Optional.empty();
     }
-    return searchInDataSourcesIndex(this.clusterService.state(), QueryBuilders.termQuery("name", datasourceName)).stream()
+    return searchInDataSourcesIndex(QueryBuilders.termQuery("name", datasourceName)).stream()
         .findFirst()
         .map(x -> this.encryptDecryptAuthenticationData(x, false));
   }
@@ -218,7 +217,7 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
     }
   }
 
-  private List<DataSourceMetadata> searchInDataSourcesIndex(ClusterState state, QueryBuilder query) {
+  private List<DataSourceMetadata> searchInDataSourcesIndex(QueryBuilder query) {
     SearchRequest searchRequest = new SearchRequest();
     searchRequest.indices(DATASOURCE_INDEX_NAME);
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();

--- a/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
@@ -106,39 +106,6 @@ public class OpenSearchDataSourceMetadataStorageTest {
 
   @SneakyThrows
   @Test
-  public void testGetDataSourceMetadataWithSegRepEnabled() {
-    Mockito.when(clusterService.state().routingTable().hasIndex(DATASOURCE_INDEX_NAME))
-            .thenReturn(true);
-    Mockito.when(clusterService.state().isSegmentReplicationEnabled(DATASOURCE_INDEX_NAME))
-            .thenReturn(true);
-    Mockito.when(client.search(ArgumentMatchers.any())).thenReturn(searchResponseActionFuture);
-    Mockito.when(searchResponseActionFuture.actionGet()).thenReturn(searchResponse);
-    Mockito.when(searchResponse.status()).thenReturn(RestStatus.OK);
-    Mockito.when(searchResponse.getHits())
-            .thenReturn(
-                    new SearchHits(
-                            new SearchHit[] {searchHit}, new TotalHits(21, TotalHits.Relation.EQUAL_TO), 1.0F));
-    Mockito.when(searchHit.getSourceAsString()).thenReturn(getBasicDataSourceMetadataString());
-    Mockito.when(encryptor.decrypt("password")).thenReturn("password");
-    Mockito.when(encryptor.decrypt("username")).thenReturn("username");
-
-    Optional<DataSourceMetadata> dataSourceMetadataOptional =
-            openSearchDataSourceMetadataStorage.getDataSourceMetadata(TEST_DATASOURCE_INDEX_NAME);
-
-    Assertions.assertFalse(dataSourceMetadataOptional.isEmpty());
-    DataSourceMetadata dataSourceMetadata = dataSourceMetadataOptional.get();
-    Assertions.assertEquals(TEST_DATASOURCE_INDEX_NAME, dataSourceMetadata.getName());
-    Assertions.assertEquals(DataSourceType.PROMETHEUS, dataSourceMetadata.getConnector());
-    Assertions.assertEquals(
-            "password", dataSourceMetadata.getProperties().get("prometheus.auth.password"));
-    Assertions.assertEquals(
-            "username", dataSourceMetadata.getProperties().get("prometheus.auth.username"));
-    Assertions.assertEquals(
-            "basicauth", dataSourceMetadata.getProperties().get("prometheus.auth.type"));
-  }
-
-  @SneakyThrows
-  @Test
   public void testGetDataSourceMetadataWith404SearchResponse() {
     Mockito.when(clusterService.state().routingTable().hasIndex(DATASOURCE_INDEX_NAME))
         .thenReturn(true);

--- a/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
@@ -32,6 +32,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.index.shard.ShardId;
@@ -101,6 +102,39 @@ public class OpenSearchDataSourceMetadataStorageTest {
         "username", dataSourceMetadata.getProperties().get("prometheus.auth.username"));
     Assertions.assertEquals(
         "basicauth", dataSourceMetadata.getProperties().get("prometheus.auth.type"));
+  }
+
+  @SneakyThrows
+  @Test
+  public void testGetDataSourceMetadataWithSegRepEnabled() {
+    Mockito.when(clusterService.state().routingTable().hasIndex(DATASOURCE_INDEX_NAME))
+            .thenReturn(true);
+    Mockito.when(clusterService.state().isSegmentReplicationEnabled(DATASOURCE_INDEX_NAME))
+            .thenReturn(true);
+    Mockito.when(client.search(ArgumentMatchers.any())).thenReturn(searchResponseActionFuture);
+    Mockito.when(searchResponseActionFuture.actionGet()).thenReturn(searchResponse);
+    Mockito.when(searchResponse.status()).thenReturn(RestStatus.OK);
+    Mockito.when(searchResponse.getHits())
+            .thenReturn(
+                    new SearchHits(
+                            new SearchHit[] {searchHit}, new TotalHits(21, TotalHits.Relation.EQUAL_TO), 1.0F));
+    Mockito.when(searchHit.getSourceAsString()).thenReturn(getBasicDataSourceMetadataString());
+    Mockito.when(encryptor.decrypt("password")).thenReturn("password");
+    Mockito.when(encryptor.decrypt("username")).thenReturn("username");
+
+    Optional<DataSourceMetadata> dataSourceMetadataOptional =
+            openSearchDataSourceMetadataStorage.getDataSourceMetadata(TEST_DATASOURCE_INDEX_NAME);
+
+    Assertions.assertFalse(dataSourceMetadataOptional.isEmpty());
+    DataSourceMetadata dataSourceMetadata = dataSourceMetadataOptional.get();
+    Assertions.assertEquals(TEST_DATASOURCE_INDEX_NAME, dataSourceMetadata.getName());
+    Assertions.assertEquals(DataSourceType.PROMETHEUS, dataSourceMetadata.getConnector());
+    Assertions.assertEquals(
+            "password", dataSourceMetadata.getProperties().get("prometheus.auth.password"));
+    Assertions.assertEquals(
+            "username", dataSourceMetadata.getProperties().get("prometheus.auth.username"));
+    Assertions.assertEquals(
+            "basicauth", dataSourceMetadata.getProperties().get("prometheus.auth.type"));
   }
 
   @SneakyThrows

--- a/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
@@ -32,7 +32,6 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.Client;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.index.shard.ShardId;


### PR DESCRIPTION
### Description
Adds _primary preference only for segment replication enabled indices. 
 
### Issues Resolved
#1801 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).