### PR TITLE
Changed allowlist config to denylist ip config for datasource uri hosts

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'com.github.babbel:okhttp-aws-signer:1.0.2'
     api group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.12.1'
     api group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.12.1'
+    implementation "com.github.seancfoley:ipaddress:5.4.0"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.9.1'

--- a/common/src/main/java/org/opensearch/sql/common/interceptors/AwsSigningInterceptor.java
+++ b/common/src/main/java/org/opensearch/sql/common/interceptors/AwsSigningInterceptor.java
@@ -5,7 +5,7 @@
  *
  */
 
-package org.opensearch.sql.common.authinterceptors;
+package org.opensearch.sql.common.interceptors;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;

--- a/common/src/main/java/org/opensearch/sql/common/interceptors/BasicAuthenticationInterceptor.java
+++ b/common/src/main/java/org/opensearch/sql/common/interceptors/BasicAuthenticationInterceptor.java
@@ -5,7 +5,7 @@
  *
  */
 
-package org.opensearch.sql.common.authinterceptors;
+package org.opensearch.sql.common.interceptors;
 
 import java.io.IOException;
 import lombok.NonNull;

--- a/common/src/main/java/org/opensearch/sql/common/interceptors/URIValidatorInterceptor.java
+++ b/common/src/main/java/org/opensearch/sql/common/interceptors/URIValidatorInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.common.interceptors;
+
+import java.io.IOException;
+import java.util.List;
+import lombok.NonNull;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.common.utils.URIValidationUtils;
+
+public class URIValidatorInterceptor implements Interceptor {
+
+  private final List<String> denyHostList;
+
+  public URIValidatorInterceptor(@NonNull List<String> denyHostList) {
+    this.denyHostList = denyHostList;
+  }
+
+  @NotNull
+  @Override
+  public Response intercept(Interceptor.Chain chain) throws IOException {
+    Request request = chain.request();
+    String host = request.url().host();
+    boolean isValidHost = URIValidationUtils.validateURIHost(host, denyHostList);
+    if (isValidHost) {
+      return chain.proceed(request);
+    } else {
+      throw new IllegalArgumentException(
+          String.format(
+              "Disallowed hostname in the uri. Validate with %s config",
+              Settings.Key.DATASOURCES_URI_HOSTS_DENY_LIST.getKeyValue()));
+    }
+  }
+}

--- a/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
+++ b/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
@@ -31,7 +31,7 @@ public abstract class Settings {
     QUERY_MEMORY_LIMIT("plugins.query.memory_limit"),
     QUERY_SIZE_LIMIT("plugins.query.size_limit"),
     ENCYRPTION_MASTER_KEY("plugins.query.datasources.encryption.masterkey"),
-    DATASOURCES_URI_ALLOWHOSTS("plugins.query.datasources.uri.allowhosts"),
+    DATASOURCES_URI_HOSTS_DENY_LIST("plugins.query.datasources.uri.hosts.denylist"),
 
     METRICS_ROLLING_WINDOW("plugins.query.metrics.rolling_window"),
     METRICS_ROLLING_INTERVAL("plugins.query.metrics.rolling_interval"),

--- a/common/src/main/java/org/opensearch/sql/common/utils/URIValidationUtils.java
+++ b/common/src/main/java/org/opensearch/sql/common/utils/URIValidationUtils.java
@@ -1,0 +1,22 @@
+package org.opensearch.sql.common.utils;
+
+import inet.ipaddr.IPAddressString;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+/** Utility Class for URI host validation. */
+public class URIValidationUtils {
+
+  public static boolean validateURIHost(String host, List<String> denyHostList)
+      throws UnknownHostException {
+    IPAddressString ipStr = new IPAddressString(InetAddress.getByName(host).getHostAddress());
+    for (String denyHost : denyHostList) {
+      IPAddressString denyHostStr = new IPAddressString(denyHost);
+      if (denyHostStr.contains(ipStr)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/common/src/test/java/org/opensearch/sql/common/interceptors/AwsSigningInterceptorTest.java
+++ b/common/src/test/java/org/opensearch/sql/common/interceptors/AwsSigningInterceptorTest.java
@@ -5,7 +5,7 @@
  *
  */
 
-package org.opensearch.sql.common.authinterceptors;
+package org.opensearch.sql.common.interceptors;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSSessionCredentials;

--- a/common/src/test/java/org/opensearch/sql/common/interceptors/BasicAuthenticationInterceptorTest.java
+++ b/common/src/test/java/org/opensearch/sql/common/interceptors/BasicAuthenticationInterceptorTest.java
@@ -5,7 +5,7 @@
  *
  */
 
-package org.opensearch.sql.common.authinterceptors;
+package org.opensearch.sql.common.interceptors;
 
 import java.util.Collections;
 import lombok.SneakyThrows;

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
     implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
+    implementation group: 'commons-validator', name: 'commons-validator', version: '1.7'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')

--- a/datasources/src/main/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtils.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtils.java
@@ -1,0 +1,68 @@
+package org.opensearch.sql.datasources.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.validator.routines.DomainValidator;
+import org.opensearch.sql.common.utils.URIValidationUtils;
+
+/** Common Validation methods for all datasource connectors. */
+@UtilityClass
+public class DatasourceValidationUtils {
+
+  public static final int MAX_LENGTH_FOR_CONFIG_PROPERTY = 1000;
+
+  public static void validateHost(String uriString, List<String> denyHostList)
+      throws URISyntaxException, UnknownHostException {
+    validateDomain(uriString);
+    if (!URIValidationUtils.validateURIHost(new URI(uriString).getHost(), denyHostList)) {
+      throw new IllegalArgumentException(
+          "Disallowed hostname in the uri. "
+              + "Validate with plugins.query.datasources.uri.hosts.denylist config");
+    }
+    ;
+  }
+
+  public static void validateLengthAndRequiredFields(
+      Map<String, String> config, Set<String> fields) {
+    Set<String> missingFields = new HashSet<>();
+    Set<String> invalidLengthFields = new HashSet<>();
+    for (String field : fields) {
+      if (!config.containsKey(field)) {
+        missingFields.add(field);
+      } else if (config.get(field).length() > MAX_LENGTH_FOR_CONFIG_PROPERTY) {
+        invalidLengthFields.add(field);
+      }
+    }
+    StringBuilder errorStringBuilder = new StringBuilder();
+    if (missingFields.size() > 0) {
+      errorStringBuilder.append(
+          String.format(
+              "Missing %s fields in the Prometheus connector properties.", missingFields));
+    }
+
+    if (invalidLengthFields.size() > 0) {
+      errorStringBuilder.append(
+          String.format("Fields %s exceeds more than 1000 characters.", invalidLengthFields));
+    }
+    if (errorStringBuilder.length() > 0) {
+      throw new IllegalArgumentException(errorStringBuilder.toString());
+    }
+  }
+
+  private static void validateDomain(String uriString) throws URISyntaxException {
+    URI uri = new URI(uriString);
+    String host = uri.getHost();
+    if (host == null
+        || (!(DomainValidator.getInstance().isValid(host)
+            || DomainValidator.getInstance().isValidLocalTld(host)))) {
+      throw new IllegalArgumentException(
+          String.format("Invalid hostname in the uri: %s", uriString));
+    }
+  }
+}

--- a/datasources/src/test/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtilsTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtilsTest.java
@@ -1,0 +1,94 @@
+package org.opensearch.sql.datasources.utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DatasourceValidationUtilsTest {
+
+  @SneakyThrows
+  @Test
+  public void testValidateHost() {
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DatasourceValidationUtils.validateHost(
+                    "http://localhost:9090", Collections.singletonList("127.0.0.0/8")));
+    Assertions.assertEquals(
+        "Disallowed hostname in the uri. Validate with plugins.query.datasources.uri.hosts.denylist"
+            + " config",
+        illegalArgumentException.getMessage());
+  }
+
+  @SneakyThrows
+  @Test
+  public void testValidateHostWithSuccess() {
+    Assertions.assertDoesNotThrow(
+        () ->
+            DatasourceValidationUtils.validateHost(
+                "http://localhost:9090", Collections.singletonList("192.168.0.0/8")));
+  }
+
+  @SneakyThrows
+  @Test
+  public void testValidateHostWithInvalidDomain() {
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DatasourceValidationUtils.validateHost(
+                    "http:://prometheus:9090", Collections.singletonList("127.0.0.0/8")));
+    Assertions.assertEquals(
+        "Invalid hostname in the uri: http:://prometheus:9090",
+        illegalArgumentException.getMessage());
+  }
+
+  @Test
+  public void testValidateLengthAndRequiredFieldsWithAbsentField() {
+    HashMap<String, String> config = new HashMap<>();
+    config.put("s3.uri", "test");
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DatasourceValidationUtils.validateLengthAndRequiredFields(
+                    config, Set.of("s3.uri", "s3.auth.type")));
+    Assertions.assertEquals(
+        "Missing [s3.auth.type] fields in the Prometheus connector properties.",
+        illegalArgumentException.getMessage());
+  }
+
+  @Test
+  public void testValidateLengthAndRequiredFieldsWithInvalidLength() {
+    HashMap<String, String> config = new HashMap<>();
+    config.put("s3.uri", RandomStringUtils.random(1001));
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DatasourceValidationUtils.validateLengthAndRequiredFields(
+                    config, Set.of("s3.uri", "s3.auth.type")));
+    Assertions.assertEquals(
+        "Missing [s3.auth.type] fields in the Prometheus connector properties.Fields "
+            + "[s3.uri] exceeds more than 1000 characters.",
+        illegalArgumentException.getMessage());
+  }
+
+  @Test
+  public void testValidateLengthAndRequiredFieldsWithSuccess() {
+    HashMap<String, String> config = new HashMap<>();
+    config.put("s3.uri", "test");
+    Assertions.assertDoesNotThrow(
+        () ->
+            DatasourceValidationUtils.validateLengthAndRequiredFields(
+                config, Collections.emptySet()));
+  }
+}

--- a/docs/user/ppl/admin/datasources.rst
+++ b/docs/user/ppl/admin/datasources.rst
@@ -140,15 +140,11 @@ Master Key config for encrypting credential information
     # Print the master key
     print("Generated master key:", master_key)
 
-Datasource Allow Hosts Config
+Datasource URI Hosts Deny Lists Config
 ========================================================
-* In the OpenSearch configuration file (opensearch.yml), the parameter "plugins.query.datasources.uri.allowhosts" can be utilized to control the permitted hosts within the datasource URI configuration.
-* By default, the value is set to `.*`, which allows any domain to be accepted.
-* For instance, if you set the value to `dummy.*.com`, the following URIs are some examples that would be allowed in the datasource configuration:
-   - https://dummy.prometheus.com:9080
-   - http://dummy.prometheus.com
-
-Note: The mentioned URIs are just examples to illustrate the concept.
+* In the OpenSearch configuration file (opensearch.yml), the parameter "plugins.query.datasources.uri.hosts.denylist" can be utilized to control the permitted host ips within the datasource URI configuration.
+* By default, the value is set to empty list, which allows any domain to be accepted.
+* For instance, if you set the value to `127.0.0.0/8`, ppl plugins will deny all the query requests where the datasource URI resolves to the ip range from `127.0.0.0` to `127.255.255.255`
 
 
 Using a datasource in PPL command

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -12,10 +12,12 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.cluster.ClusterName;
@@ -119,10 +121,11 @@ public class OpenSearchSettings extends Settings {
           Setting.Property.Final,
           Setting.Property.Filtered);
 
-  public static final Setting<String> DATASOURCE_URI_ALLOW_HOSTS =
-      Setting.simpleString(
-          Key.DATASOURCES_URI_ALLOWHOSTS.getKeyValue(),
-          ".*",
+  public static final Setting<List<String>> DATASOURCE_URI_HOSTS_DENY_LIST =
+      Setting.listSetting(
+          Key.DATASOURCES_URI_HOSTS_DENY_LIST.getKeyValue(),
+          Collections.emptyList(),
+          Function.identity(),
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 
@@ -187,9 +190,9 @@ public class OpenSearchSettings extends Settings {
     register(
         settingBuilder,
         clusterSettings,
-        Key.DATASOURCES_URI_ALLOWHOSTS,
-        DATASOURCE_URI_ALLOW_HOSTS,
-        new Updater(Key.DATASOURCES_URI_ALLOWHOSTS));
+        Key.DATASOURCES_URI_HOSTS_DENY_LIST,
+        DATASOURCE_URI_HOSTS_DENY_LIST,
+        new Updater(Key.DATASOURCES_URI_HOSTS_DENY_LIST));
     registerNonDynamicSettings(
         settingBuilder, clusterSettings, Key.CLUSTER_NAME, ClusterName.CLUSTER_NAME_SETTING);
     defaultSettings = settingBuilder.build();
@@ -253,7 +256,7 @@ public class OpenSearchSettings extends Settings {
         .add(QUERY_SIZE_LIMIT_SETTING)
         .add(METRICS_ROLLING_WINDOW_SETTING)
         .add(METRICS_ROLLING_INTERVAL_SETTING)
-        .add(DATASOURCE_URI_ALLOW_HOSTS)
+        .add(DATASOURCE_URI_HOSTS_DENY_LIST)
         .build();
   }
 

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -23,8 +23,6 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
     implementation group: 'org.json', name: 'json', version: '20230227'
-    // https://mvnrepository.com/artifact/commons-validator/commons-validator
-    implementation group: 'commons-validator', name: 'commons-validator', version: '1.7'
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
@@ -128,9 +128,7 @@ public class PrometheusClientImpl implements PrometheusClient {
       }
     } else {
       throw new PrometheusClientException(
-          String.format(
-              "Request to Prometheus is Unsuccessful with : %s",
-              Objects.requireNonNull(response.body(), "Response body can't be null").string()));
+          String.format("Request to Prometheus is Unsuccessful with code : %s", response.code()));
     }
   }
 }

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactory.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactory.java
@@ -11,24 +11,23 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import okhttp3.OkHttpClient;
-import org.apache.commons.validator.routines.DomainValidator;
-import org.opensearch.sql.common.authinterceptors.AwsSigningInterceptor;
-import org.opensearch.sql.common.authinterceptors.BasicAuthenticationInterceptor;
+import org.opensearch.sql.common.interceptors.AwsSigningInterceptor;
+import org.opensearch.sql.common.interceptors.BasicAuthenticationInterceptor;
+import org.opensearch.sql.common.interceptors.URIValidatorInterceptor;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasource.model.DataSource;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.datasources.auth.AuthenticationType;
+import org.opensearch.sql.datasources.utils.DatasourceValidationUtils;
 import org.opensearch.sql.prometheus.client.PrometheusClient;
 import org.opensearch.sql.prometheus.client.PrometheusClientImpl;
 import org.opensearch.sql.storage.DataSourceFactory;
@@ -61,20 +60,24 @@ public class PrometheusStorageFactory implements DataSourceFactory {
 
   // Need to refactor to a separate Validator class.
   private void validateDataSourceConfigProperties(Map<String, String> dataSourceMetadataConfig)
-      throws URISyntaxException {
+      throws URISyntaxException, UnknownHostException {
     if (dataSourceMetadataConfig.get(AUTH_TYPE) != null) {
       AuthenticationType authenticationType =
           AuthenticationType.get(dataSourceMetadataConfig.get(AUTH_TYPE));
       if (AuthenticationType.BASICAUTH.equals(authenticationType)) {
-        validateMissingFields(dataSourceMetadataConfig, Set.of(URI, USERNAME, PASSWORD));
+        DatasourceValidationUtils.validateLengthAndRequiredFields(
+            dataSourceMetadataConfig, Set.of(URI, USERNAME, PASSWORD));
       } else if (AuthenticationType.AWSSIGV4AUTH.equals(authenticationType)) {
-        validateMissingFields(
+        DatasourceValidationUtils.validateLengthAndRequiredFields(
             dataSourceMetadataConfig, Set.of(URI, ACCESS_KEY, SECRET_KEY, REGION));
       }
     } else {
-      validateMissingFields(dataSourceMetadataConfig, Set.of(URI));
+      DatasourceValidationUtils.validateLengthAndRequiredFields(
+          dataSourceMetadataConfig, Set.of(URI));
     }
-    validateURI(dataSourceMetadataConfig);
+    DatasourceValidationUtils.validateHost(
+        dataSourceMetadataConfig.get(URI),
+        settings.getSettingValue(Settings.Key.DATASOURCES_URI_HOSTS_DENY_LIST));
   }
 
   StorageEngine getStorageEngine(Map<String, String> requiredConfig) {
@@ -87,7 +90,7 @@ public class PrometheusStorageFactory implements DataSourceFactory {
                     validateDataSourceConfigProperties(requiredConfig);
                     return new PrometheusClientImpl(
                         getHttpClient(requiredConfig), new URI(requiredConfig.get(URI)));
-                  } catch (URISyntaxException e) {
+                  } catch (URISyntaxException | UnknownHostException e) {
                     throw new IllegalArgumentException(
                         String.format("Invalid URI in prometheus properties: %s", e.getMessage()));
                   }
@@ -100,6 +103,9 @@ public class PrometheusStorageFactory implements DataSourceFactory {
     okHttpClient.callTimeout(1, TimeUnit.MINUTES);
     okHttpClient.connectTimeout(30, TimeUnit.SECONDS);
     okHttpClient.followRedirects(false);
+    okHttpClient.addInterceptor(
+        new URIValidatorInterceptor(
+            settings.getSettingValue(Settings.Key.DATASOURCES_URI_HOSTS_DENY_LIST)));
     if (config.get(AUTH_TYPE) != null) {
       AuthenticationType authenticationType = AuthenticationType.get(config.get(AUTH_TYPE));
       if (AuthenticationType.BASICAUTH.equals(authenticationType)) {
@@ -120,52 +126,5 @@ public class PrometheusStorageFactory implements DataSourceFactory {
       }
     }
     return okHttpClient.build();
-  }
-
-  private void validateMissingFields(Map<String, String> config, Set<String> fields) {
-    Set<String> missingFields = new HashSet<>();
-    Set<String> invalidLengthFields = new HashSet<>();
-    for (String field : fields) {
-      if (!config.containsKey(field)) {
-        missingFields.add(field);
-      } else if (config.get(field).length() > MAX_LENGTH_FOR_CONFIG_PROPERTY) {
-        invalidLengthFields.add(field);
-      }
-    }
-    StringBuilder errorStringBuilder = new StringBuilder();
-    if (missingFields.size() > 0) {
-      errorStringBuilder.append(
-          String.format(
-              "Missing %s fields in the Prometheus connector properties.", missingFields));
-    }
-
-    if (invalidLengthFields.size() > 0) {
-      errorStringBuilder.append(
-          String.format("Fields %s exceeds more than 1000 characters.", invalidLengthFields));
-    }
-    if (errorStringBuilder.length() > 0) {
-      throw new IllegalArgumentException(errorStringBuilder.toString());
-    }
-  }
-
-  private void validateURI(Map<String, String> config) throws URISyntaxException {
-    URI uri = new URI(config.get(URI));
-    String host = uri.getHost();
-    if (host == null
-        || (!(DomainValidator.getInstance().isValid(host)
-            || DomainValidator.getInstance().isValidLocalTld(host)))) {
-      throw new IllegalArgumentException(
-          String.format("Invalid hostname in the uri: %s", config.get(URI)));
-    } else {
-      Pattern allowHostsPattern =
-          Pattern.compile(settings.getSettingValue(Settings.Key.DATASOURCES_URI_ALLOWHOSTS));
-      Matcher matcher = allowHostsPattern.matcher(host);
-      if (!matcher.matches()) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Disallowed hostname in the uri. Validate with %s config",
-                Settings.Key.DATASOURCES_URI_ALLOWHOSTS.getKeyValue()));
-      }
-    }
   }
 }

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/client/PrometheusClientImplTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/client/PrometheusClientImplTest.java
@@ -114,10 +114,9 @@ public class PrometheusClientImplTest {
         assertThrows(
             PrometheusClientException.class,
             () -> prometheusClient.queryRange(QUERY, STARTTIME, ENDTIME, STEP));
-    assertTrue(
-        prometheusClientException
-            .getMessage()
-            .contains("Request to Prometheus is Unsuccessful with :"));
+    assertEquals(
+        "Request to Prometheus is Unsuccessful with code : 400",
+        prometheusClientException.getMessage());
     RecordedRequest recordedRequest = mockWebServer.takeRequest();
     verifyQueryRangeCall(recordedRequest);
   }


### PR DESCRIPTION
### Description
* Changed allowlist config to denylist of ips.
`plugins.query.datasources.uri.hosts.denylist` is the new property.
* Validating datasource URL in every interaction. So the datasource validation happens during datasource creation and datasource queries.

Current Process of Validation:
* Before interacting with any customer provided URI, we do dns resolution and validate the ip against the denylist provided in the config.
* The new config specifes denied IP CIDR blocks. For eg: `127.0.0.0/8`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).