### PR TITLE
bump aws-encryption-sdk-java to 1.71

### DIFF
--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
     implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
-    implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.0'
+    implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')


### PR DESCRIPTION
### Description
fix CVE-2023-33201 by changing jdk15on to jdk15to18
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).