### PR TITLE
Always use snapshot version for security plugin download

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,9 @@ buildscript {
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
         }
+        //this variable for always downloading snapshot version of security plugin.
+        //need to figure out more elegant solution for integ tests with security.
+        opensearch_build_snapshot = opensearch_build + '-SNAPSHOT'
         if (isSnapshot) {
             // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT (opensearch_build)
             opensearch_build += "-SNAPSHOT"

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -64,7 +64,7 @@ ext {
 
     getSecurityPluginDownloadLink = { ->
         var repo = "https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/" +
-                   "opensearch-security/$opensearch_build/"
+                   "opensearch-security/$opensearch_build_snapshot/"
         var metadataFile = Paths.get(projectDir.toString(), "build", "maven-metadata.xml").toAbsolutePath().toFile()
         download.run {
             src repo + "maven-metadata.xml"


### PR DESCRIPTION
### Description

Build is failing when we run with snapshot=false. This is due to downloading non-snapshot version of security plugin.
As a temporary fix, we will always download snapshot version of security plugin irrespective of security plugin.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).