### PR TITLE
Check for existence of security plugin

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -76,7 +76,8 @@ ext {
         return repo + "opensearch-security-${securitySnapshotVersion}.zip"
     }
 
-    File downloadedSecurityPlugin = null
+    var projectAbsPath = projectDir.getAbsolutePath()
+    File downloadedSecurityPlugin = Paths.get(projectAbsPath, 'bin', 'opensearch-security-snapshot.zip').toFile()
 
     configureSecurityPlugin = { OpenSearchCluster cluster ->
 
@@ -89,15 +90,14 @@ ext {
             }
         }
 
-        var projectAbsPath = projectDir.getAbsolutePath()
-
         // add a check to avoid re-downloading multiple times during single test run
-        if (downloadedSecurityPlugin == null) {
-            downloadedSecurityPlugin = Paths.get(projectAbsPath, 'bin', 'opensearch-security-snapshot.zip').toFile()
+        if (!downloadedSecurityPlugin.exists()) {
             download.run {
                 src getSecurityPluginDownloadLink()
                 dest downloadedSecurityPlugin
             }
+        } else {
+            println "Security Plugin File Already Exists"
         }
 
         // Config below including files are copied from security demo configuration


### PR DESCRIPTION
### Description
Security Plugin zip is downloaded even when the file is already downloaded in the prior run.
Added a check to stop downloading multiple times.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).