### PR TITLE
Cancel Async Query API

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
@@ -88,8 +88,7 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
         new Route(GET, BASE_DATASOURCE_ACTION_URL),
 
         /*
-         * GET datasources
-         * Request URL: GET
+         * PUT datasources
          * Request body:
          * Ref
          * [org.opensearch.sql.plugin.transport.datasource.model.UpdateDataSourceActionRequest]
@@ -100,8 +99,7 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
         new Route(PUT, BASE_DATASOURCE_ACTION_URL),
 
         /*
-         * GET datasources
-         * Request URL: GET
+         * DELETE datasources
          * Request body: Ref
          * [org.opensearch.sql.plugin.transport.datasource.model.DeleteDataSourceActionRequest]
          * Response body: Ref

--- a/docs/user/interfaces/asyncqueryinterface.rst
+++ b/docs/user/interfaces/asyncqueryinterface.rst
@@ -32,15 +32,12 @@ We make use of default aws credentials chain to make calls to the emr serverless
 have pass role permissions for emr-job-execution-role mentioned in the engine configuration.
 
 
-
 Async Query Creation API
 ======================================
 If security plugin is enabled, this API can only be invoked by users with permission ``cluster:admin/opensearch/ql/async_query/create``.
 
-HTTP URI: _plugins/_query/_async_query
+HTTP URI: _plugins/_async_query
 HTTP VERB: POST
-
-
 
 Sample Request::
 
@@ -57,23 +54,19 @@ Sample Response::
       "queryId": "00fd796ut1a7eg0q"
     }
 
+
 Async Query Result API
 ======================================
 If security plugin is enabled, this API can only be invoked by users with permission ``cluster:admin/opensearch/ql/async_query/result``.
 Async Query Creation and Result Query permissions are orthogonal, so any user with result api permissions and queryId can query the corresponding query results irrespective of the user who created the async query.
 
-
-HTTP URI: _plugins/_query/_async_query/{queryId}
+HTTP URI: _plugins/_async_query/{queryId}
 HTTP VERB: GET
-
 
 Sample Request BODY::
 
     curl --location --request GET 'http://localhost:9200/_plugins/_async_query/00fd796ut1a7eg0q' \
     --header 'Content-Type: application/json' \
-    --data '{
-        "query" : "select * from default.http_logs limit 1"
-    }'
 
 Sample Response if the Query is in Progress ::
 
@@ -106,3 +99,17 @@ Sample Response If the Query is successful ::
         "total": 1,
         "size": 1
     }
+
+
+Async Query Cancellation API
+======================================
+If security plugin is enabled, this API can only be invoked by users with permission ``cluster:admin/opensearch/ql/jobs/delete``.
+
+HTTP URI: _plugins/_async_query/{queryId}
+HTTP VERB: DELETE
+
+Sample Request Body ::
+
+    curl --location --request DELETE 'http://localhost:9200/_plugins/_async_query/00fdalrvgkbh2g0q' \
+    --header 'Content-Type: application/json' \
+

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
@@ -29,4 +29,12 @@ public interface AsyncQueryExecutorService {
    * @return {@link AsyncQueryExecutionResponse}
    */
   AsyncQueryExecutionResponse getAsyncQueryResults(String queryId);
+
+  /**
+   * Cancels running async query and returns the cancelled queryId.
+   *
+   * @param queryId queryId.
+   * @return {@link String} cancelledQueryId.
+   */
+  String cancelQuery(String queryId);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
@@ -95,6 +95,17 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
     throw new AsyncQueryNotFoundException(String.format("QueryId: %s not found", queryId));
   }
 
+  @Override
+  public String cancelQuery(String queryId) {
+    Optional<AsyncQueryJobMetadata> asyncQueryJobMetadata =
+        asyncQueryJobMetadataStorageService.getJobMetadata(queryId);
+    if (asyncQueryJobMetadata.isPresent()) {
+      return sparkQueryDispatcher.cancelJob(
+          asyncQueryJobMetadata.get().getApplicationId(), queryId);
+    }
+    throw new AsyncQueryNotFoundException(String.format("QueryId: %s not found", queryId));
+  }
+
   private void validateSparkExecutionEngineSettings() {
     if (!isSparkJobExecutionEnabled) {
       throw new IllegalArgumentException(

--- a/spark/src/main/java/org/opensearch/sql/spark/client/SparkJobClient.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/SparkJobClient.java
@@ -7,6 +7,7 @@
 
 package org.opensearch.sql.spark.client;
 
+import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
 import com.amazonaws.services.emrserverless.model.GetJobRunResult;
 
 public interface SparkJobClient {
@@ -19,4 +20,6 @@ public interface SparkJobClient {
       String sparkSubmitParams);
 
   GetJobRunResult getJobRunResult(String applicationId, String jobId);
+
+  CancelJobRunResult cancelJobRun(String applicationId, String jobId);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -15,6 +15,7 @@ import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_INDEX
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_INDEX_STORE_SCHEME_KEY;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.HIVE_METASTORE_GLUE_ARN_KEY;
 
+import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
 import com.amazonaws.services.emrserverless.model.GetJobRunResult;
 import com.amazonaws.services.emrserverless.model.JobRunState;
 import java.net.URI;
@@ -62,6 +63,11 @@ public class SparkQueryDispatcher {
     }
     result.put("status", getJobRunResult.getJobRun().getState());
     return result;
+  }
+
+  public String cancelJob(String applicationId, String jobId) {
+    CancelJobRunResult cancelJobRunResult = sparkJobClient.cancelJobRun(applicationId, jobId);
+    return cancelJobRunResult.getJobRunId();
   }
 
   // TODO: Analyze given query

--- a/spark/src/main/java/org/opensearch/sql/spark/rest/RestAsyncQueryManagementAction.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/rest/RestAsyncQueryManagementAction.java
@@ -194,7 +194,7 @@ public class RestAsyncQueryManagementAction extends BaseRestHandler {
                           CancelAsyncQueryActionResponse cancelAsyncQueryActionResponse) {
                         restChannel.sendResponse(
                             new BytesRestResponse(
-                                RestStatus.OK,
+                                RestStatus.NO_CONTENT,
                                 "application/json; charset=UTF-8",
                                 cancelAsyncQueryActionResponse.getResult()));
                       }

--- a/spark/src/main/java/org/opensearch/sql/spark/transport/model/CancelAsyncQueryActionRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/transport/model/CancelAsyncQueryActionRequest.java
@@ -9,11 +9,13 @@ package org.opensearch.sql.spark.transport.model;
 
 import java.io.IOException;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
 
 @AllArgsConstructor
+@Getter
 public class CancelAsyncQueryActionRequest extends ActionRequest {
 
   private String queryId;

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
@@ -5,17 +5,22 @@
 package org.opensearch.sql.spark.client;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.opensearch.sql.spark.constants.TestConstants.EMRS_APPLICATION_ID;
 import static org.opensearch.sql.spark.constants.TestConstants.EMRS_EXECUTION_ROLE;
 import static org.opensearch.sql.spark.constants.TestConstants.EMRS_JOB_NAME;
+import static org.opensearch.sql.spark.constants.TestConstants.EMR_JOB_ID;
 import static org.opensearch.sql.spark.constants.TestConstants.QUERY;
 import static org.opensearch.sql.spark.constants.TestConstants.SPARK_SUBMIT_PARAMETERS;
 
 import com.amazonaws.services.emrserverless.AWSEMRServerless;
+import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
 import com.amazonaws.services.emrserverless.model.GetJobRunResult;
 import com.amazonaws.services.emrserverless.model.JobRun;
 import com.amazonaws.services.emrserverless.model.StartJobRunResult;
+import com.amazonaws.services.emrserverless.model.ValidationException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -44,5 +49,29 @@ public class EmrServerlessClientImplTest {
     when(emrServerless.getJobRun(any())).thenReturn(response);
     EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
     emrServerlessClient.getJobRunResult(EMRS_APPLICATION_ID, "123");
+  }
+
+  @Test
+  void testCancelJobRun() {
+    when(emrServerless.cancelJobRun(any()))
+        .thenReturn(new CancelJobRunResult().withJobRunId(EMR_JOB_ID));
+    EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
+    CancelJobRunResult cancelJobRunResult =
+        emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID);
+    Assertions.assertEquals(EMR_JOB_ID, cancelJobRunResult.getJobRunId());
+  }
+
+  @Test
+  void testCancelJobRunWithValidationException() {
+    doThrow(new ValidationException("Error")).when(emrServerless).cancelJobRun(any());
+    EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID));
+    Assertions.assertEquals(
+        "Couldn't cancel the queryId: job-123xxx due to Error (Service: null; Status Code: 0; Error"
+            + " Code: null; Request ID: null; Proxy: null)",
+        illegalArgumentException.getMessage());
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/transport/TransportCancelAsyncQueryRequestActionTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/transport/TransportCancelAsyncQueryRequestActionTest.java
@@ -7,6 +7,10 @@
 
 package org.opensearch.sql.spark.transport;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.spark.constants.TestConstants.EMR_JOB_ID;
+
 import java.util.HashSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +23,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorServiceImpl;
 import org.opensearch.sql.spark.transport.model.CancelAsyncQueryActionRequest;
 import org.opensearch.sql.spark.transport.model.CancelAsyncQueryActionResponse;
 import org.opensearch.tasks.Task;
@@ -32,24 +37,40 @@ public class TransportCancelAsyncQueryRequestActionTest {
   @Mock private Task task;
   @Mock private ActionListener<CancelAsyncQueryActionResponse> actionListener;
 
+  @Mock private AsyncQueryExecutorServiceImpl asyncQueryExecutorService;
+
   @Captor
   private ArgumentCaptor<CancelAsyncQueryActionResponse> deleteJobActionResponseArgumentCaptor;
+
+  @Captor private ArgumentCaptor<Exception> exceptionArgumentCaptor;
 
   @BeforeEach
   public void setUp() {
     action =
         new TransportCancelAsyncQueryRequestAction(
-            transportService, new ActionFilters(new HashSet<>()));
+            transportService, new ActionFilters(new HashSet<>()), asyncQueryExecutorService);
   }
 
   @Test
   public void testDoExecute() {
-    CancelAsyncQueryActionRequest request = new CancelAsyncQueryActionRequest("jobId");
-
+    CancelAsyncQueryActionRequest request = new CancelAsyncQueryActionRequest(EMR_JOB_ID);
+    when(asyncQueryExecutorService.cancelQuery(EMR_JOB_ID)).thenReturn(EMR_JOB_ID);
     action.doExecute(task, request, actionListener);
     Mockito.verify(actionListener).onResponse(deleteJobActionResponseArgumentCaptor.capture());
     CancelAsyncQueryActionResponse cancelAsyncQueryActionResponse =
         deleteJobActionResponseArgumentCaptor.getValue();
-    Assertions.assertEquals("deleted_job", cancelAsyncQueryActionResponse.getResult());
+    Assertions.assertEquals(
+        "Deleted async query with id: " + EMR_JOB_ID, cancelAsyncQueryActionResponse.getResult());
+  }
+
+  @Test
+  public void testDoExecuteWithException() {
+    CancelAsyncQueryActionRequest request = new CancelAsyncQueryActionRequest(EMR_JOB_ID);
+    doThrow(new RuntimeException("Error")).when(asyncQueryExecutorService).cancelQuery(EMR_JOB_ID);
+    action.doExecute(task, request, actionListener);
+    Mockito.verify(actionListener).onFailure(exceptionArgumentCaptor.capture());
+    Exception exception = exceptionArgumentCaptor.getValue();
+    Assertions.assertTrue(exception instanceof RuntimeException);
+    Assertions.assertEquals("Error", exception.getMessage());
   }
 }


### PR DESCRIPTION
### Description
* This PR covers Cancel Async Query API.
* Throws error incase of already successful async query and cancels a query which is IN_PROGRESS/QUEUED/RUNNING.
* Only unit tests are covered since there is not integration test setup.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).