### PR TITLE
Removed Domain Validation

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtils.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtils.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.experimental.UtilityClass;
-import org.apache.commons.validator.routines.DomainValidator;
 import org.opensearch.sql.common.utils.URIValidationUtils;
 
 /** Common Validation methods for all datasource connectors. */
@@ -19,7 +18,6 @@ public class DatasourceValidationUtils {
 
   public static void validateHost(String uriString, List<String> denyHostList)
       throws URISyntaxException, UnknownHostException {
-    validateDomain(uriString);
     if (!URIValidationUtils.validateURIHost(new URI(uriString).getHost(), denyHostList)) {
       throw new IllegalArgumentException(
           "Disallowed hostname in the uri. "
@@ -52,17 +50,6 @@ public class DatasourceValidationUtils {
     }
     if (errorStringBuilder.length() > 0) {
       throw new IllegalArgumentException(errorStringBuilder.toString());
-    }
-  }
-
-  private static void validateDomain(String uriString) throws URISyntaxException {
-    URI uri = new URI(uriString);
-    String host = uri.getHost();
-    if (host == null
-        || (!(DomainValidator.getInstance().isValid(host)
-            || DomainValidator.getInstance().isValidLocalTld(host)))) {
-      throw new IllegalArgumentException(
-          String.format("Invalid hostname in the uri: %s", uriString));
     }
   }
 }

--- a/datasources/src/test/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtilsTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtilsTest.java
@@ -37,20 +37,6 @@ public class DatasourceValidationUtilsTest {
                 "http://localhost:9090", Collections.singletonList("192.168.0.0/8")));
   }
 
-  @SneakyThrows
-  @Test
-  public void testValidateHostWithInvalidDomain() {
-    IllegalArgumentException illegalArgumentException =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                DatasourceValidationUtils.validateHost(
-                    "http:://prometheus:9090", Collections.singletonList("127.0.0.0/8")));
-    Assertions.assertEquals(
-        "Invalid hostname in the uri: http:://prometheus:9090",
-        illegalArgumentException.getMessage());
-  }
-
   @Test
   public void testValidateLengthAndRequiredFieldsWithAbsentField() {
     HashMap<String, String> config = new HashMap<>();

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -112,26 +112,6 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
     // Datasource is not immediately updated. so introducing a sleep of 2s.
     Thread.sleep(2000);
 
-    // update datasource with invalid URI
-    updateDSM =
-        new DataSourceMetadata(
-            "update_prometheus",
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of("prometheus.uri", "https://randomtest:9090"));
-    final Request illFormedUpdateRequest = getUpdateDataSourceRequest(updateDSM);
-    ResponseException updateResponseException =
-        Assert.assertThrows(
-            ResponseException.class, () -> client().performRequest(illFormedUpdateRequest));
-    Assert.assertEquals(400, updateResponseException.getResponse().getStatusLine().getStatusCode());
-    updateResponseString = getResponseBody(updateResponseException.getResponse());
-    JsonObject errorMessage = new Gson().fromJson(updateResponseString, JsonObject.class);
-    Assert.assertEquals(
-        "Invalid hostname in the uri: https://randomtest:9090",
-        errorMessage.get("error").getAsJsonObject().get("details").getAsString());
-
-    Thread.sleep(2000);
-
     // get datasource to validate the modification.
     // get datasource
     Request getRequest = getFetchDataSourceRequest("update_prometheus");

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactoryTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactoryTest.java
@@ -210,50 +210,6 @@ public class PrometheusStorageFactoryTest {
   }
 
   @Test
-  void createDataSourceWithInvalidHostname() {
-    HashMap<String, String> properties = new HashMap<>();
-    properties.put("prometheus.uri", "http://dummyprometheus:9090");
-    properties.put("prometheus.auth.type", "basicauth");
-    properties.put("prometheus.auth.username", "admin");
-    properties.put("prometheus.auth.password", "admin");
-
-    DataSourceMetadata metadata = new DataSourceMetadata();
-    metadata.setName("prometheus");
-    metadata.setConnector(DataSourceType.PROMETHEUS);
-    metadata.setProperties(properties);
-
-    PrometheusStorageFactory prometheusStorageFactory = new PrometheusStorageFactory(settings);
-    RuntimeException exception =
-        Assertions.assertThrows(
-            RuntimeException.class, () -> prometheusStorageFactory.createDataSource(metadata));
-    Assertions.assertTrue(
-        exception
-            .getMessage()
-            .contains("Invalid hostname in the uri: http://dummyprometheus:9090"));
-  }
-
-  @Test
-  void createDataSourceWithInvalidIp() {
-    HashMap<String, String> properties = new HashMap<>();
-    properties.put("prometheus.uri", "http://231.54.11.987:9090");
-    properties.put("prometheus.auth.type", "basicauth");
-    properties.put("prometheus.auth.username", "admin");
-    properties.put("prometheus.auth.password", "admin");
-
-    DataSourceMetadata metadata = new DataSourceMetadata();
-    metadata.setName("prometheus");
-    metadata.setConnector(DataSourceType.PROMETHEUS);
-    metadata.setProperties(properties);
-
-    PrometheusStorageFactory prometheusStorageFactory = new PrometheusStorageFactory(settings);
-    RuntimeException exception =
-        Assertions.assertThrows(
-            RuntimeException.class, () -> prometheusStorageFactory.createDataSource(metadata));
-    Assertions.assertTrue(
-        exception.getMessage().contains("Invalid hostname in the uri: http://231.54.11.987:9090"));
-  }
-
-  @Test
   void createDataSourceWithHostnameNotMatchingWithAllowHostsConfig() {
     when(settings.getSettingValue(Settings.Key.DATASOURCES_URI_HOSTS_DENY_LIST))
         .thenReturn(Collections.singletonList("127.0.0.0/8"));


### PR DESCRIPTION
### Description
* Currently in datasource uri validation, we validate domain which is excessively restrictive and hampering ease of use in case of docker and using ips in prometheus URL. This PR addresses this problem by removing the restriction. 

* We can always avoid ssrf issue by specifying the host denylist `plugins.query.datasources.uri.hosts.denylist` 

Manual Testing
```
curl --location 'localhost:9200/_plugins/_query/_datasources/' \
--header 'Content-Type: application/json' \
--data '{
  "name": "my_prometheus3",
  "connector": "PROMETHEUS",
  "allowedRoles": [],
  "properties": {
    "prometheus.uri": "http://10.0.0.1:9090"
  }
}'
```
This call worked which used to not function earlier.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).