### PR TITLE
Datasource description

### DIFF
--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceMetadata.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceMetadata.java
@@ -11,25 +11,28 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.sql.datasource.DataSourceService;
 
 @Getter
 @Setter
 @AllArgsConstructor
-@NoArgsConstructor
 @EqualsAndHashCode
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DataSourceMetadata {
 
   @JsonProperty private String name;
+
+  @JsonProperty private String description;
 
   @JsonProperty
   @JsonFormat(with = JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
@@ -38,6 +41,24 @@ public class DataSourceMetadata {
   @JsonProperty private List<String> allowedRoles;
 
   @JsonProperty private Map<String, String> properties;
+
+  public DataSourceMetadata(
+      String name,
+      DataSourceType connector,
+      List<String> allowedRoles,
+      Map<String, String> properties) {
+    this.name = name;
+    this.connector = connector;
+    this.description = StringUtils.EMPTY;
+    this.properties = properties;
+    this.allowedRoles = allowedRoles;
+  }
+
+  public DataSourceMetadata() {
+    this.description = StringUtils.EMPTY;
+    this.allowedRoles = new ArrayList<>();
+    this.properties = new HashMap<>();
+  }
 
   /**
    * Default OpenSearch {@link DataSourceMetadata}. Which is used to register default OpenSearch

--- a/datasources/src/main/java/org/opensearch/sql/datasources/utils/XContentParserUtils.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/utils/XContentParserUtils.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -26,6 +27,7 @@ import org.opensearch.sql.datasource.model.DataSourceType;
 @UtilityClass
 public class XContentParserUtils {
   public static final String NAME_FIELD = "name";
+  public static final String DESCRIPTION_FIELD = "description";
   public static final String CONNECTOR_FIELD = "connector";
   public static final String PROPERTIES_FIELD = "properties";
   public static final String ALLOWED_ROLES_FIELD = "allowedRoles";
@@ -39,6 +41,7 @@ public class XContentParserUtils {
    */
   public static DataSourceMetadata toDataSourceMetadata(XContentParser parser) throws IOException {
     String name = null;
+    String description = StringUtils.EMPTY;
     DataSourceType connector = null;
     List<String> allowedRoles = new ArrayList<>();
     Map<String, String> properties = new HashMap<>();
@@ -49,6 +52,9 @@ public class XContentParserUtils {
       switch (fieldName) {
         case NAME_FIELD:
           name = parser.textOrNull();
+          break;
+        case DESCRIPTION_FIELD:
+          description = parser.textOrNull();
           break;
         case CONNECTOR_FIELD:
           connector = DataSourceType.fromString(parser.textOrNull());
@@ -74,7 +80,7 @@ public class XContentParserUtils {
     if (name == null || connector == null) {
       throw new IllegalArgumentException("name and connector are required fields.");
     }
-    return new DataSourceMetadata(name, connector, allowedRoles, properties);
+    return new DataSourceMetadata(name, description, connector, allowedRoles, properties);
   }
 
   /**
@@ -108,6 +114,7 @@ public class XContentParserUtils {
     XContentBuilder builder = XContentFactory.jsonBuilder();
     builder.startObject();
     builder.field(NAME_FIELD, metadata.getName());
+    builder.field(DESCRIPTION_FIELD, metadata.getDescription());
     builder.field(CONNECTOR_FIELD, metadata.getConnector().name());
     builder.field(ALLOWED_ROLES_FIELD, metadata.getAllowedRoles().toArray());
     builder.startObject(PROPERTIES_FIELD);

--- a/datasources/src/test/java/org/opensearch/sql/datasources/utils/XContentParserUtilsTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/utils/XContentParserUtilsTest.java
@@ -31,7 +31,7 @@ public class XContentParserUtilsTest {
     XContentBuilder contentBuilder = XContentParserUtils.convertToXContent(dataSourceMetadata);
     String contentString = BytesReference.bytes(contentBuilder).utf8ToString();
     Assertions.assertEquals(
-        "{\"name\":\"testDS\",\"connector\":\"PROMETHEUS\",\"allowedRoles\":[\"prometheus_access\"],\"properties\":{\"prometheus.uri\":\"https://localhost:9090\"}}",
+        "{\"name\":\"testDS\",\"description\":\"\",\"connector\":\"PROMETHEUS\",\"allowedRoles\":[\"prometheus_access\"],\"properties\":{\"prometheus.uri\":\"https://localhost:9090\"}}",
         contentString);
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -51,6 +51,7 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
     DataSourceMetadata createDSM =
         new DataSourceMetadata(
             "create_prometheus",
+            "Prometheus Creation for Integ test",
             DataSourceType.PROMETHEUS,
             ImmutableList.of(),
             ImmutableMap.of(
@@ -79,6 +80,7 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
         new Gson().fromJson(getResponseString, DataSourceMetadata.class);
     Assert.assertEquals(
         "https://localhost:9090", dataSourceMetadata.getProperties().get("prometheus.uri"));
+    Assert.assertEquals("Prometheus Creation for Integ test", dataSourceMetadata.getDescription());
   }
 
   @SneakyThrows
@@ -142,6 +144,7 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
         new Gson().fromJson(getResponseString, DataSourceMetadata.class);
     Assert.assertEquals(
         "https://randomtest.com:9090", dataSourceMetadata.getProperties().get("prometheus.uri"));
+    Assert.assertEquals("", dataSourceMetadata.getDescription());
   }
 
   @SneakyThrows

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -152,8 +152,8 @@ dependencies {
 
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.12.13'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.5.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.5.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${versions.mockito}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${versions.mockito}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
 }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -152,8 +152,8 @@ dependencies {
 
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.12.13'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.4.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.5.0'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.5.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
 }
 


### PR DESCRIPTION
### Description
* Added description field to datasource metadata.
* Removed restriction on all fields with prefix auth. Now only username, password, access_key, secret_key are the only fields removed from GET datasource API.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).