### PR TITLE
Enable PPL lang and add datasource to async query API

### DIFF
--- a/docs/user/interfaces/asyncqueryinterface.rst
+++ b/docs/user/interfaces/asyncqueryinterface.rst
@@ -45,6 +45,7 @@ Sample Request::
     curl --location 'http://localhost:9200/_plugins/_async_query' \
     --header 'Content-Type: application/json' \
     --data '{
+        "datasource" : "my_glue",
         "lang" : "sql",
         "query" : "select * from my_glue.default.http_logs limit 10"
     }'

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -19,9 +19,8 @@ tasks.register('downloadG4Files', Exec) {
 
     executable 'curl'
 
-//    Need to add these back once the grammar issues with indexName and tableName is addressed in flint integration jar.
-//    args '-o', 'src/main/antlr/FlintSparkSqlExtensions.g4', 'https://raw.githubusercontent.com/opensearch-project/opensearch-spark/main/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4'
-//    args '-o', 'src/main/antlr/SparkSqlBase.g4', 'https://raw.githubusercontent.com/opensearch-project/opensearch-spark/main/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4'
+    args '-o', 'src/main/antlr/FlintSparkSqlExtensions.g4', 'https://raw.githubusercontent.com/opensearch-project/opensearch-spark/main/flint-spark-integration/src/main/antlr4/FlintSparkSqlExtensions.g4'
+    args '-o', 'src/main/antlr/SparkSqlBase.g4', 'https://raw.githubusercontent.com/opensearch-project/opensearch-spark/main/flint-spark-integration/src/main/antlr4/SparkSqlBase.g4'
     args '-o', 'src/main/antlr/SqlBaseParser.g4', 'https://raw.githubusercontent.com/apache/spark/master/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4'
     args '-o', 'src/main/antlr/SqlBaseLexer.g4', 'https://raw.githubusercontent.com/apache/spark/master/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4'
 }

--- a/spark/src/main/antlr/FlintSparkSqlExtensions.g4
+++ b/spark/src/main/antlr/FlintSparkSqlExtensions.g4
@@ -27,7 +27,8 @@ skippingIndexStatement
     ;
 
 createSkippingIndexStatement
-    : CREATE SKIPPING INDEX ON tableName
+    : CREATE SKIPPING INDEX (IF NOT EXISTS)?
+        ON tableName
         LEFT_PAREN indexColTypeList RIGHT_PAREN
         (WITH LEFT_PAREN propertyList RIGHT_PAREN)?
     ;
@@ -53,7 +54,8 @@ coveringIndexStatement
     ;
 
 createCoveringIndexStatement
-    : CREATE INDEX indexName ON tableName
+    : CREATE INDEX (IF NOT EXISTS)? indexName
+        ON tableName
         LEFT_PAREN indexColumns=multipartIdentifierPropertyList RIGHT_PAREN
         (WITH LEFT_PAREN propertyList RIGHT_PAREN)?
     ;

--- a/spark/src/main/antlr/SparkSqlBase.g4
+++ b/spark/src/main/antlr/SparkSqlBase.g4
@@ -158,14 +158,16 @@ CREATE: 'CREATE';
 DESC: 'DESC';
 DESCRIBE: 'DESCRIBE';
 DROP: 'DROP';
+EXISTS: 'EXISTS';
 FALSE: 'FALSE';
+IF: 'IF';
 INDEX: 'INDEX';
 INDEXES: 'INDEXES';
+NOT: 'NOT';
 ON: 'ON';
 PARTITION: 'PARTITION';
 REFRESH: 'REFRESH';
 SHOW: 'SHOW';
-STRING: 'STRING';
 TRUE: 'TRUE';
 WITH: 'WITH';
 
@@ -173,6 +175,13 @@ WITH: 'WITH';
 EQ  : '=' | '==';
 MINUS: '-';
 
+
+STRING
+    : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''
+    | '"' ( ~('"'|'\\') | ('\\' .) )* '"'
+    | 'R\'' (~'\'')* '\''
+    | 'R"'(~'"')* '"'
+    ;
 
 INTEGER_VALUE
     : DIGIT+

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
@@ -69,6 +69,7 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
             new DispatchQueryRequest(
                 sparkExecutionEngineConfig.getApplicationId(),
                 createAsyncQueryRequest.getQuery(),
+                createAsyncQueryRequest.getDatasource(),
                 createAsyncQueryRequest.getLang(),
                 sparkExecutionEngineConfig.getExecutionRoleARN(),
                 clusterName.value()));

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryRequest.java
@@ -12,6 +12,7 @@ import org.opensearch.sql.spark.rest.model.LangType;
 public class DispatchQueryRequest {
   private final String applicationId;
   private final String query;
+  private final String datasource;
   private final LangType langType;
   private final String executionRoleARN;
   private final String clusterName;

--- a/spark/src/main/java/org/opensearch/sql/spark/rest/model/CreateAsyncQueryRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/rest/model/CreateAsyncQueryRequest.java
@@ -8,21 +8,28 @@ package org.opensearch.sql.spark.rest.model;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.apache.commons.lang3.Validate;
 import org.opensearch.core.xcontent.XContentParser;
 
 @Data
-@AllArgsConstructor
 public class CreateAsyncQueryRequest {
 
   private String query;
+  private String datasource;
   private LangType lang;
+
+  public CreateAsyncQueryRequest(String query, String datasource, LangType lang) {
+    this.query = Validate.notNull(query, "Query can't be null");
+    this.datasource = Validate.notNull(datasource, "Datasource can't be null");
+    this.lang = Validate.notNull(lang, "lang can't be null");
+  }
 
   public static CreateAsyncQueryRequest fromXContentParser(XContentParser parser)
       throws IOException {
     String query = null;
     LangType lang = null;
+    String datasource = null;
     ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
     while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
       String fieldName = parser.currentName();
@@ -30,14 +37,14 @@ public class CreateAsyncQueryRequest {
       if (fieldName.equals("query")) {
         query = parser.textOrNull();
       } else if (fieldName.equals("lang")) {
-        lang = LangType.fromString(parser.textOrNull());
+        String langString = parser.textOrNull();
+        lang = LangType.fromString(langString);
+      } else if (fieldName.equals("datasource")) {
+        datasource = parser.textOrNull();
       } else {
         throw new IllegalArgumentException("Unknown field: " + fieldName);
       }
     }
-    if (lang == null || query == null) {
-      throw new IllegalArgumentException("lang and query are required fields.");
-    }
-    return new CreateAsyncQueryRequest(query, lang);
+    return new CreateAsyncQueryRequest(query, datasource, lang);
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
@@ -48,7 +48,8 @@ public class AsyncQueryExecutorServiceImplTest {
         new AsyncQueryExecutorServiceImpl(
             asyncQueryJobMetadataStorageService, sparkQueryDispatcher, settings);
     CreateAsyncQueryRequest createAsyncQueryRequest =
-        new CreateAsyncQueryRequest("select * from my_glue.default.http_logs", LangType.SQL);
+        new CreateAsyncQueryRequest(
+            "select * from my_glue.default.http_logs", "my_glue", LangType.SQL);
     when(settings.getSettingValue(Settings.Key.SPARK_EXECUTION_ENGINE_CONFIG))
         .thenReturn(
             "{\"applicationId\":\"00fd775baqpu4g0p\",\"executionRoleARN\":\"arn:aws:iam::270824043731:role/emr-job-execution-role\",\"region\":\"eu-west-1\"}");
@@ -58,6 +59,7 @@ public class AsyncQueryExecutorServiceImplTest {
             new DispatchQueryRequest(
                 "00fd775baqpu4g0p",
                 "select * from my_glue.default.http_logs",
+                "my_glue",
                 LangType.SQL,
                 "arn:aws:iam::270824043731:role/emr-job-execution-role",
                 TEST_CLUSTER_NAME)))
@@ -73,6 +75,7 @@ public class AsyncQueryExecutorServiceImplTest {
             new DispatchQueryRequest(
                 "00fd775baqpu4g0p",
                 "select * from my_glue.default.http_logs",
+                "my_glue",
                 LangType.SQL,
                 "arn:aws:iam::270824043731:role/emr-job-execution-role",
                 TEST_CLUSTER_NAME));

--- a/spark/src/test/java/org/opensearch/sql/spark/transport/TransportCreateAsyncQueryRequestActionTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/transport/TransportCreateAsyncQueryRequestActionTest.java
@@ -57,7 +57,7 @@ public class TransportCreateAsyncQueryRequestActionTest {
   @Test
   public void testDoExecute() {
     CreateAsyncQueryRequest createAsyncQueryRequest =
-        new CreateAsyncQueryRequest("source = my_glue.default.alb_logs", LangType.SQL);
+        new CreateAsyncQueryRequest("source = my_glue.default.alb_logs", "my_glue", LangType.SQL);
     CreateAsyncQueryActionRequest request =
         new CreateAsyncQueryActionRequest(createAsyncQueryRequest);
     when(jobExecutorService.createAsyncQuery(createAsyncQueryRequest))
@@ -73,7 +73,7 @@ public class TransportCreateAsyncQueryRequestActionTest {
   @Test
   public void testDoExecuteWithException() {
     CreateAsyncQueryRequest createAsyncQueryRequest =
-        new CreateAsyncQueryRequest("source = my_glue.default.alb_logs", LangType.SQL);
+        new CreateAsyncQueryRequest("source = my_glue.default.alb_logs", "my_glue", LangType.SQL);
     CreateAsyncQueryActionRequest request =
         new CreateAsyncQueryActionRequest(createAsyncQueryRequest);
     doThrow(new RuntimeException("Error"))


### PR DESCRIPTION
### Description
* Added PPL lang to Async Query API.
* Added datasource to request model.
* Removed table and schema tags in non Index Queries.
* Updated Spark Grammar For Indices.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).