### PR TITLE
Refactor Flint Auth

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/auth/AuthenticationType.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/auth/AuthenticationType.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum AuthenticationType {
+  NOAUTH("noauth"),
   BASICAUTH("basicauth"),
   AWSSIGV4AUTH("awssigv4");
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
@@ -43,7 +43,6 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
-import org.opensearch.sql.datasources.auth.AuthenticationType;
 import org.opensearch.sql.datasources.encryptor.Encryptor;
 import org.opensearch.sql.datasources.exceptions.DataSourceNotFoundException;
 import org.opensearch.sql.datasources.service.DataSourceMetadataStorage;
@@ -252,26 +251,13 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
     }
   }
 
-  @SuppressWarnings("missingswitchdefault")
+  // Encrypt and Decrypt irrespective of auth type.If properties name ends in username, password,
+  // secret_key and access_key.
   private DataSourceMetadata encryptDecryptAuthenticationData(
       DataSourceMetadata dataSourceMetadata, Boolean isEncryption) {
     Map<String, String> propertiesMap = dataSourceMetadata.getProperties();
-    Optional<AuthenticationType> authTypeOptional =
-        propertiesMap.keySet().stream()
-            .filter(s -> s.endsWith("auth.type"))
-            .findFirst()
-            .map(propertiesMap::get)
-            .map(AuthenticationType::get);
-    if (authTypeOptional.isPresent()) {
-      switch (authTypeOptional.get()) {
-        case BASICAUTH:
-          handleBasicAuthPropertiesEncryptionDecryption(propertiesMap, isEncryption);
-          break;
-        case AWSSIGV4AUTH:
-          handleSigV4PropertiesEncryptionDecryption(propertiesMap, isEncryption);
-          break;
-      }
-    }
+    handleBasicAuthPropertiesEncryptionDecryption(propertiesMap, isEncryption);
+    handleSigV4PropertiesEncryptionDecryption(propertiesMap, isEncryption);
     return dataSourceMetadata;
   }
 

--- a/docs/user/ppl/admin/connectors/s3glue_connector.rst
+++ b/docs/user/ppl/admin/connectors/s3glue_connector.rst
@@ -39,9 +39,10 @@ Glue Connector Properties.
     * This parameters provides the Opensearch domain host information for glue connector. This opensearch instance is used for writing index data back and also
     * ``glue.indexstore.opensearch.uri`` [Required]
     * ``glue.indexstore.opensearch.auth`` [Required]
-        * Default value for auth is ``false``.
-    * ``glue.indexstore.opensearch.region`` [Required]
-        * Default value for auth is ``us-west-2``.
+        * Accepted values include ["noauth", "basicauth", "awssigv4"]
+        * Basic Auth required ``glue.indexstore.opensearch.auth.username`` and ``glue.indexstore.opensearch.auth.password``
+        * AWSSigV4 Auth requires ``glue.indexstore.opensearch.auth.region``  and ``glue.auth.role_arn``
+    * ``glue.indexstore.opensearch.region`` [Required for awssigv4 auth]
 
 Sample Glue dataSource configuration
 ========================================
@@ -55,11 +56,23 @@ Glue datasource configuration::
                 "glue.auth.type": "iam_role",
                 "glue.auth.role_arn": "role_arn",
                 "glue.indexstore.opensearch.uri": "http://localhost:9200",
-                "glue.indexstore.opensearch.auth" :"false",
-                "glue.indexstore.opensearch.region": "us-west-2"
+                "glue.indexstore.opensearch.auth" :"basicauth",
+                "glue.indexstore.opensearch.auth.username" :"username"
+                "glue.indexstore.opensearch.auth.password" :"password"
         }
     }]
 
+    [{
+        "name" : "my_glue",
+        "connector": "s3glue",
+        "properties" : {
+                "glue.auth.type": "iam_role",
+                "glue.auth.role_arn": "role_arn",
+                "glue.indexstore.opensearch.uri": "http://adsasdf.amazonopensearch.com:9200",
+                "glue.indexstore.opensearch.auth" :"awssigv4",
+                "glue.indexstore.opensearch.auth.region" :"awssigv4",
+        }
+    }]
 
 Sample s3Glue datasource queries
 ================================

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactory.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactory.java
@@ -43,7 +43,6 @@ public class PrometheusStorageFactory implements DataSourceFactory {
   public static final String REGION = "prometheus.auth.region";
   public static final String ACCESS_KEY = "prometheus.auth.access_key";
   public static final String SECRET_KEY = "prometheus.auth.secret_key";
-  private static final Integer MAX_LENGTH_FOR_CONFIG_PROPERTY = 1000;
 
   private final Settings settings;
 

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/S3GlueSparkSubmitParameters.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/S3GlueSparkSubmitParameters.java
@@ -17,10 +17,8 @@ import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_CREDE
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_DEFAULT_AUTH;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_DEFAULT_HOST;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_DEFAULT_PORT;
-import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_DEFAULT_REGION;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_DEFAULT_SCHEME;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_INDEX_STORE_AUTH_KEY;
-import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_INDEX_STORE_AWSREGION_KEY;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_INDEX_STORE_HOST_KEY;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_INDEX_STORE_PORT_KEY;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_INDEX_STORE_SCHEME_KEY;
@@ -69,7 +67,6 @@ public class S3GlueSparkSubmitParameters {
     this.config.put(FLINT_INDEX_STORE_PORT_KEY, FLINT_DEFAULT_PORT);
     this.config.put(FLINT_INDEX_STORE_SCHEME_KEY, FLINT_DEFAULT_SCHEME);
     this.config.put(FLINT_INDEX_STORE_AUTH_KEY, FLINT_DEFAULT_AUTH);
-    this.config.put(FLINT_INDEX_STORE_AWSREGION_KEY, FLINT_DEFAULT_REGION);
     this.config.put(FLINT_CREDENTIALS_PROVIDER_KEY, EMR_ASSUME_ROLE_CREDENTIALS_PROVIDER);
     this.config.put(SPARK_SQL_EXTENSIONS_KEY, FLINT_SQL_EXTENSION);
     this.config.put(HIVE_METASTORE_CLASS_KEY, GLUE_HIVE_CATALOG_FACTORY_CLASS);

--- a/spark/src/main/java/org/opensearch/sql/spark/data/constants/SparkConstants.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/data/constants/SparkConstants.java
@@ -24,7 +24,7 @@ public class SparkConstants {
   public static final String FLINT_DEFAULT_HOST = "localhost";
   public static final String FLINT_DEFAULT_PORT = "9200";
   public static final String FLINT_DEFAULT_SCHEME = "http";
-  public static final String FLINT_DEFAULT_AUTH = "-1";
+  public static final String FLINT_DEFAULT_AUTH = "noauth";
   public static final String FLINT_DEFAULT_REGION = "us-west-2";
   public static final String DEFAULT_CLASS_NAME = "org.opensearch.sql.FlintJob";
   public static final String S3_AWS_CREDENTIALS_PROVIDER_KEY =
@@ -46,6 +46,10 @@ public class SparkConstants {
   public static final String FLINT_INDEX_STORE_PORT_KEY = "spark.datasource.flint.port";
   public static final String FLINT_INDEX_STORE_SCHEME_KEY = "spark.datasource.flint.scheme";
   public static final String FLINT_INDEX_STORE_AUTH_KEY = "spark.datasource.flint.auth";
+  public static final String FLINT_INDEX_STORE_AUTH_USERNAME =
+      "spark.datasource.flint.auth.username";
+  public static final String FLINT_INDEX_STORE_AUTH_PASSWORD =
+      "spark.datasource.flint.auth.password";
   public static final String FLINT_INDEX_STORE_AWSREGION_KEY = "spark.datasource.flint.region";
   public static final String FLINT_CREDENTIALS_PROVIDER_KEY =
       "spark.datasource.flint.customAWSCredentialsProvider";


### PR DESCRIPTION
### Description
* false is replaced with `noauth` for `glue.indexstore.opensearch.auth` property.
* Fixed few more bugs in indexstore parameters.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).