### PR TITLE
Bug fix, datasource API should be case sensitive

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
@@ -94,7 +94,8 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
       return Optional.empty();
     }
     // todo, in case docId == datasourceName, could read doc directly.
-    return searchInDataSourcesIndex(QueryBuilders.termQuery("name.keyword", datasourceName)).stream()
+    return searchInDataSourcesIndex(QueryBuilders.termQuery("name.keyword", datasourceName))
+        .stream()
         .findFirst()
         .map(x -> this.encryptDecryptAuthenticationData(x, false));
   }

--- a/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorage.java
@@ -93,7 +93,8 @@ public class OpenSearchDataSourceMetadataStorage implements DataSourceMetadataSt
       createDataSourcesIndex();
       return Optional.empty();
     }
-    return searchInDataSourcesIndex(QueryBuilders.termQuery("name", datasourceName)).stream()
+    // todo, in case docId == datasourceName, could read doc directly.
+    return searchInDataSourcesIndex(QueryBuilders.termQuery("name.keyword", datasourceName)).stream()
         .findFirst()
         .map(x -> this.encryptDecryptAuthenticationData(x, false));
   }

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -220,7 +220,7 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
     Response response = client().performRequest(createRequest);
     Assert.assertEquals(201, response.getStatusLine().getStatusCode());
     String createResponseString = getResponseBody(response);
-    Assert.assertEquals("Created DataSource with name Create_Prometheus", createResponseString);
+    Assert.assertEquals("\"Created DataSource with name Create_Prometheus\"", createResponseString);
     // Datasource is not immediately created. so introducing a sleep of 2s.
     Thread.sleep(2000);
 

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -196,9 +196,7 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
         dataSourceMetadataList.stream().anyMatch(ds -> ds.getName().equals("get_all_prometheus")));
   }
 
-  /**
-   * https://github.com/opensearch-project/sql/issues/2196
-   */
+  /** https://github.com/opensearch-project/sql/issues/2196 */
   @SneakyThrows
   @Test
   public void issue2196() {


### PR DESCRIPTION
### Description
1. Using name.keyword == datasource.name when search. which is case sensitive.
 
### Issues Resolved
#2196
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).