### PR TITLE
Submit long running job only when auto_refresh = false

### DIFF
--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
@@ -155,9 +155,10 @@ public class SparkSubmitParameters {
       }
     }
 
-    public Builder structuredStreaming() {
-      config.put("spark.flint.job.type", "streaming");
-
+    public Builder structuredStreaming(Boolean isStructuredStreaming) {
+      if (isStructuredStreaming) {
+        config.put("spark.flint.job.type", "streaming");
+      }
       return this;
     }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -123,7 +123,7 @@ public class SparkQueryDispatcher {
                 .dataSource(
                     dataSourceService.getRawDataSourceMetadata(
                         dispatchQueryRequest.getDatasource()))
-                .structuredStreaming()
+                .structuredStreaming(indexDetails.getAutoRefresh())
                 .build()
                 .toString(),
             tags,

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -127,7 +127,7 @@ public class SparkQueryDispatcher {
                 .build()
                 .toString(),
             tags,
-            true);
+            indexDetails.getAutoRefresh());
     return startJobRequest;
   }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/IndexDetails.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/IndexDetails.java
@@ -12,4 +12,6 @@ import lombok.Data;
 public class IndexDetails {
   private String indexName;
   private FullyQualifiedTableName fullyQualifiedTableName;
+  // by default, auto_refresh = false;
+  private Boolean autoRefresh = false;
 }


### PR DESCRIPTION
### Description
* Submit long running job only when auto_refresh = false
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/2206
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).