### PR TITLE
Correctly Set query status

### DIFF
--- a/docs/user/ppl/admin/connectors/s3glue_connector.rst
+++ b/docs/user/ppl/admin/connectors/s3glue_connector.rst
@@ -14,9 +14,17 @@ S3Glue Connector
 Introduction
 ============
 
+Properties in DataSource Configuration
+
+* name: A unique identifier for the data source within a domain.
+* connector: Currently supports the following connectors: s3glue, spark, prometheus, and opensearch.
+* resultIndex: Stores the results of queries executed on the data source. If unavailable, it defaults to .query_execution_result.
+
+Glue Connector
+========================================================
+
 s3Glue connector provides a way to query s3 files using glue as metadata store and spark as execution engine.
 This page covers s3Glue datasource configuration and also how to query and s3Glue datasource.
-
 
 Required resources for s3 Glue Connector
 ===================================
@@ -27,8 +35,6 @@ Required resources for s3 Glue Connector
 
 We currently only support emr-serverless as spark execution engine and Glue as metadata store. we will add more support in future.
 
-Glue Connector Properties in DataSource Configuration
-========================================================
 Glue Connector Properties.
 
 * ``glue.auth.type`` [Required]
@@ -59,7 +65,8 @@ Glue datasource configuration::
                 "glue.indexstore.opensearch.auth" :"basicauth",
                 "glue.indexstore.opensearch.auth.username" :"username"
                 "glue.indexstore.opensearch.auth.password" :"password"
-        }
+        },
+        "resultIndex": "query_execution_result"
     }]
 
     [{

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -82,7 +82,7 @@ public class SparkQueryDispatcher {
     if (result.has(DATA_FIELD)) {
       JSONObject items = result.getJSONObject(DATA_FIELD);
 
-      // If items have STATUS_FIELD, use it; otherwise, use jobState
+      // If items have STATUS_FIELD, use it; otherwise, mark failed
       String status = items.optString(STATUS_FIELD, JobRunState.FAILED.toString());
       result.put(STATUS_FIELD, status);
 

--- a/spark/src/main/java/org/opensearch/sql/spark/response/JobExecutionResponseReader.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/response/JobExecutionResponseReader.java
@@ -50,13 +50,12 @@ public class JobExecutionResponseReader {
     JSONObject data = new JSONObject();
     try {
       searchResponseActionFuture = client.search(searchRequest);
-    } catch (Exception e) {
+    } catch (IndexNotFoundException e) {
       // if there is no result index (e.g., EMR-S hasn't created the index yet), we return empty
       // json
-      if (e instanceof IndexNotFoundException) {
-        LOG.info(resultIndex + " is not created yet.");
-        return data;
-      }
+      LOG.info(resultIndex + " is not created yet.");
+      return data;
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
     SearchResponse searchResponse = searchResponseActionFuture.actionGet();

--- a/spark/src/test/java/org/opensearch/sql/spark/response/AsyncQueryExecutionResponseReaderTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/response/AsyncQueryExecutionResponseReaderTest.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.spark.response;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.opensearch.sql.spark.constants.TestConstants.EMR_JOB_ID;
@@ -24,6 +25,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 
@@ -90,5 +92,13 @@ public class AsyncQueryExecutionResponseReaderTest {
     assertThrows(
         RuntimeException.class,
         () -> jobExecutionResponseReader.getResultFromOpensearchIndex(EMR_JOB_ID, null));
+  }
+
+  @Test
+  public void testIndexNotFoundException() {
+    when(client.search(any())).thenThrow(IndexNotFoundException.class);
+    JobExecutionResponseReader jobExecutionResponseReader = new JobExecutionResponseReader(client);
+    assertTrue(
+        jobExecutionResponseReader.getResultFromOpensearchIndex(EMR_JOB_ID, "foo").isEmpty());
   }
 }


### PR DESCRIPTION
### Description
Previously, the query status was set to SUCCESS only when the EMR-S job status was 'SUCCESS'. However, for index queries, even when the EMR Job Run State is 'RUNNING', the result should indicate success. This PR addresses and resolves this inconsistency.

Tests done:
* Manual verification: Created a skipping index and confirmed the async query result is marked 'successful' instead of 'running'.
* Updated relevant unit tests.

### Issues Resolved
https://github.com/opensearch-project/sql/issues/2214
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).