### PR TITLE
Spark Execution Engine Config Refactor

### DIFF
--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfig.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfig.java
@@ -1,25 +1,21 @@
-/*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package org.opensearch.sql.spark.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.google.gson.Gson;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ * POJO for spark Execution Engine Config. Interface between {@link
+ * org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorService} and {@link
+ * SparkExecutionEngineConfigSupplier}
+ */
 @Data
-@JsonIgnoreProperties(ignoreUnknown = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class SparkExecutionEngineConfig {
   private String applicationId;
   private String region;
   private String executionRoleARN;
-
-  /** Additional Spark submit parameters to append to request. */
   private String sparkSubmitParameters;
-
-  public static SparkExecutionEngineConfig toSparkExecutionEngineConfig(String jsonString) {
-    return new Gson().fromJson(jsonString, SparkExecutionEngineConfig.class);
-  }
+  private String clusterName;
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigClusterSetting.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigClusterSetting.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.gson.Gson;
+import lombok.Data;
+
+/**
+ * This POJO is just for reading stringified json in `plugins.query.executionengine.spark.config`
+ * setting.
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SparkExecutionEngineConfigClusterSetting {
+  private String applicationId;
+  private String region;
+  private String executionRoleARN;
+
+  /** Additional Spark submit parameters to append to request. */
+  private String sparkSubmitParameters;
+
+  public static SparkExecutionEngineConfigClusterSetting toSparkExecutionEngineConfig(
+      String jsonString) {
+    return new Gson().fromJson(jsonString, SparkExecutionEngineConfigClusterSetting.class);
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplier.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplier.java
@@ -1,0 +1,12 @@
+package org.opensearch.sql.spark.config;
+
+/** Interface for extracting and providing SparkExecutionEngineConfig */
+public interface SparkExecutionEngineConfigSupplier {
+
+  /**
+   * Get SparkExecutionEngineConfig
+   *
+   * @return {@link SparkExecutionEngineConfig}.
+   */
+  SparkExecutionEngineConfig getSparkExecutionEngineConfig();
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImpl.java
@@ -1,0 +1,42 @@
+package org.opensearch.sql.spark.config;
+
+import static org.opensearch.sql.common.setting.Settings.Key.CLUSTER_NAME;
+import static org.opensearch.sql.common.setting.Settings.Key.SPARK_EXECUTION_ENGINE_CONFIG;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.sql.common.setting.Settings;
+
+@AllArgsConstructor
+public class SparkExecutionEngineConfigSupplierImpl implements SparkExecutionEngineConfigSupplier {
+
+  private Settings settings;
+
+  @Override
+  public SparkExecutionEngineConfig getSparkExecutionEngineConfig() {
+    String sparkExecutionEngineConfigSettingString =
+        this.settings.getSettingValue(SPARK_EXECUTION_ENGINE_CONFIG);
+    SparkExecutionEngineConfig sparkExecutionEngineConfig = new SparkExecutionEngineConfig();
+    if (!StringUtils.isBlank(sparkExecutionEngineConfigSettingString)) {
+      SparkExecutionEngineConfigClusterSetting sparkExecutionEngineConfigClusterSetting =
+          AccessController.doPrivileged(
+              (PrivilegedAction<SparkExecutionEngineConfigClusterSetting>)
+                  () ->
+                      SparkExecutionEngineConfigClusterSetting.toSparkExecutionEngineConfig(
+                          sparkExecutionEngineConfigSettingString));
+      sparkExecutionEngineConfig.setApplicationId(
+          sparkExecutionEngineConfigClusterSetting.getApplicationId());
+      sparkExecutionEngineConfig.setExecutionRoleARN(
+          sparkExecutionEngineConfigClusterSetting.getExecutionRoleARN());
+      sparkExecutionEngineConfig.setSparkSubmitParameters(
+          sparkExecutionEngineConfigClusterSetting.getSparkSubmitParameters());
+      sparkExecutionEngineConfig.setRegion(sparkExecutionEngineConfigClusterSetting.getRegion());
+    }
+    ClusterName clusterName = settings.getSettingValue(CLUSTER_NAME);
+    sparkExecutionEngineConfig.setClusterName(clusterName.value());
+    return sparkExecutionEngineConfig;
+  }
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigClusterSettingTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigClusterSettingTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
-public class SparkExecutionEngineConfigTest {
+public class SparkExecutionEngineConfigClusterSettingTest {
 
   @Test
   public void testToSparkExecutionEngineConfigWithoutAllFields() {
@@ -20,8 +20,8 @@ public class SparkExecutionEngineConfigTest {
             + "\"executionRoleARN\": \"role-1\","
             + "\"region\": \"us-west-1\""
             + "}";
-    SparkExecutionEngineConfig config =
-        SparkExecutionEngineConfig.toSparkExecutionEngineConfig(json);
+    SparkExecutionEngineConfigClusterSetting config =
+        SparkExecutionEngineConfigClusterSetting.toSparkExecutionEngineConfig(json);
 
     assertEquals("app-1", config.getApplicationId());
     assertEquals("role-1", config.getExecutionRoleARN());
@@ -38,8 +38,8 @@ public class SparkExecutionEngineConfigTest {
             + "\"region\": \"us-west-1\","
             + "\"sparkSubmitParameters\": \"--conf A=1\""
             + "}";
-    SparkExecutionEngineConfig config =
-        SparkExecutionEngineConfig.toSparkExecutionEngineConfig(json);
+    SparkExecutionEngineConfigClusterSetting config =
+        SparkExecutionEngineConfigClusterSetting.toSparkExecutionEngineConfig(json);
 
     assertEquals("app-1", config.getApplicationId());
     assertEquals("role-1", config.getExecutionRoleARN());

--- a/spark/src/test/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImplTest.java
@@ -1,0 +1,61 @@
+package org.opensearch.sql.spark.config;
+
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.spark.constants.TestConstants.TEST_CLUSTER_NAME;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.sql.common.setting.Settings;
+
+@ExtendWith(MockitoExtension.class)
+public class SparkExecutionEngineConfigSupplierImplTest {
+
+  @Mock private Settings settings;
+
+  @Test
+  void testGetSparkExecutionEngineConfig() {
+    SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier =
+        new SparkExecutionEngineConfigSupplierImpl(settings);
+    when(settings.getSettingValue(Settings.Key.SPARK_EXECUTION_ENGINE_CONFIG))
+        .thenReturn(
+            "{"
+                + "\"applicationId\": \"00fd775baqpu4g0p\","
+                + "\"executionRoleARN\": \"arn:aws:iam::270824043731:role/emr-job-execution-role\","
+                + "\"region\": \"eu-west-1\","
+                + "\"sparkSubmitParameters\": \"--conf spark.dynamicAllocation.enabled=false\""
+                + "}");
+    when(settings.getSettingValue(Settings.Key.CLUSTER_NAME))
+        .thenReturn(new ClusterName(TEST_CLUSTER_NAME));
+    SparkExecutionEngineConfig sparkExecutionEngineConfig =
+        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig();
+    Assertions.assertEquals("00fd775baqpu4g0p", sparkExecutionEngineConfig.getApplicationId());
+    Assertions.assertEquals(
+        "arn:aws:iam::270824043731:role/emr-job-execution-role",
+        sparkExecutionEngineConfig.getExecutionRoleARN());
+    Assertions.assertEquals("eu-west-1", sparkExecutionEngineConfig.getRegion());
+    Assertions.assertEquals(
+        "--conf spark.dynamicAllocation.enabled=false",
+        sparkExecutionEngineConfig.getSparkSubmitParameters());
+    Assertions.assertEquals(TEST_CLUSTER_NAME, sparkExecutionEngineConfig.getClusterName());
+  }
+
+  @Test
+  void testGetSparkExecutionEngineConfigWithNullSetting() {
+    SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier =
+        new SparkExecutionEngineConfigSupplierImpl(settings);
+    when(settings.getSettingValue(Settings.Key.SPARK_EXECUTION_ENGINE_CONFIG)).thenReturn(null);
+    when(settings.getSettingValue(Settings.Key.CLUSTER_NAME))
+        .thenReturn(new ClusterName(TEST_CLUSTER_NAME));
+    SparkExecutionEngineConfig sparkExecutionEngineConfig =
+        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig();
+    Assertions.assertNull(sparkExecutionEngineConfig.getApplicationId());
+    Assertions.assertNull(sparkExecutionEngineConfig.getExecutionRoleARN());
+    Assertions.assertNull(sparkExecutionEngineConfig.getRegion());
+    Assertions.assertNull(sparkExecutionEngineConfig.getSparkSubmitParameters());
+    Assertions.assertEquals(TEST_CLUSTER_NAME, sparkExecutionEngineConfig.getClusterName());
+  }
+}


### PR DESCRIPTION
### Description
* Refactoring for Spark Execution Engine Config Reading.
* `SparkExecutionEngineConfigClusterSetting` is the POJO class for reading `plugins.query.executionengine.spark.config` cluster setting.
*  `SparkExecutionEngineConfigSupplier` is the new interface responsible for providing the configuration to  `AsyncQueryExecutorService`.
* `SparkExecutionEngineConfig` is the Interface between AsyncQueryExecutorService and SparkExecutionEngineConfigSupplier.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).