### PR TITLE
Provide auth.type and auth.role_arn paramters in GET Datasource API response.

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceServiceImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceServiceImpl.java
@@ -34,6 +34,8 @@ import org.opensearch.sql.storage.DataSourceFactory;
 public class DataSourceServiceImpl implements DataSourceService {
 
   private static String DATASOURCE_NAME_REGEX = "[@*A-Za-z]+?[*a-zA-Z_\\-0-9]*";
+  public static final Set<String> CONFIDENTIAL_AUTH_KEYS =
+      Set.of("auth.username", "auth.password", "auth.access_key", "auth.secret_key");
 
   private final DataSourceLoaderCache dataSourceLoaderCache;
 
@@ -159,7 +161,12 @@ public class DataSourceServiceImpl implements DataSourceService {
 
   private void removeAuthInfo(DataSourceMetadata dataSourceMetadata) {
     HashMap<String, String> safeProperties = new HashMap<>(dataSourceMetadata.getProperties());
-    safeProperties.entrySet().removeIf(entry -> entry.getKey().contains("auth"));
+    safeProperties
+        .entrySet()
+        .removeIf(
+            entry ->
+                CONFIDENTIAL_AUTH_KEYS.stream()
+                    .anyMatch(confidentialKey -> entry.getKey().endsWith(confidentialKey)));
     dataSourceMetadata.setProperties(safeProperties);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -85,6 +85,10 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
         new Gson().fromJson(getResponseString, DataSourceMetadata.class);
     Assert.assertEquals(
         "https://localhost:9090", dataSourceMetadata.getProperties().get("prometheus.uri"));
+    Assert.assertEquals(
+        "basicauth", dataSourceMetadata.getProperties().get("prometheus.auth.type"));
+    Assert.assertNull(dataSourceMetadata.getProperties().get("prometheus.auth.username"));
+    Assert.assertNull(dataSourceMetadata.getProperties().get("prometheus.auth.password"));
     Assert.assertEquals("Prometheus Creation for Integ test", dataSourceMetadata.getDescription());
   }
 
@@ -239,6 +243,10 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
         new Gson().fromJson(getResponseString, DataSourceMetadata.class);
     Assert.assertEquals(
         "https://localhost:9090", dataSourceMetadata.getProperties().get("prometheus.uri"));
+    Assert.assertEquals(
+        "basicauth", dataSourceMetadata.getProperties().get("prometheus.auth.type"));
+    Assert.assertNull(dataSourceMetadata.getProperties().get("prometheus.auth.username"));
+    Assert.assertNull(dataSourceMetadata.getProperties().get("prometheus.auth.password"));
     Assert.assertEquals("Prometheus Creation for Integ test", dataSourceMetadata.getDescription());
   }
 }


### PR DESCRIPTION
### Description
* Allow all auth parameters except for `auth.username`, `auth.password`, `auth.access_key` and `auth.secret_key` in datasource GET API results.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).