### PR TITLE
Fix bug, using basic instead of basicauth

### DIFF
--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
@@ -31,6 +31,7 @@ import org.opensearch.sql.datasources.auth.AuthenticationType;
 public class SparkSubmitParameters {
   public static final String SPACE = " ";
   public static final String EQUALS = "=";
+  public static final String FLINT_BASIC_AUTH = "basic";
 
   private final String className;
   private final Map<String, String> config;
@@ -114,7 +115,7 @@ public class SparkSubmitParameters {
         Supplier<String> password,
         Supplier<String> region) {
       if (AuthenticationType.get(authType).equals(AuthenticationType.BASICAUTH)) {
-        config.put(FLINT_INDEX_STORE_AUTH_KEY, authType);
+        config.put(FLINT_INDEX_STORE_AUTH_KEY, FLINT_BASIC_AUTH);
         config.put(FLINT_INDEX_STORE_AUTH_USERNAME, userName.get());
         config.put(FLINT_INDEX_STORE_AUTH_PASSWORD, password.get());
       } else if (AuthenticationType.get(authType).equals(AuthenticationType.AWSSIGV4AUTH)) {

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -39,7 +39,7 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
     Statement statement = getStatementByQueryId(asyncQueryJobMetadata.getSessionId(), queryId);
     StatementState statementState = statement.getStatementState();
     result.put(STATUS_FIELD, statementState.getState());
-    result.put(ERROR_FIELD, "");
+    result.put(ERROR_FIELD, Optional.of(statement.getStatementModel().getError()).orElse(""));
     return result;
   }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/CreateSessionRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/CreateSessionRequest.java
@@ -21,14 +21,31 @@ public class CreateSessionRequest {
   private final String datasourceName;
 
   public StartJobRequest getStartJobRequest() {
-    return new StartJobRequest(
+    return new InteractiveSessionStartJobRequest(
         "select 1",
         jobName,
         applicationId,
         executionRoleArn,
         sparkSubmitParametersBuilder.build().toString(),
         tags,
-        false,
         resultIndex);
+  }
+
+  static class InteractiveSessionStartJobRequest extends StartJobRequest{
+    public InteractiveSessionStartJobRequest(String query, String jobName, String applicationId,
+                                             String executionRoleArn, String sparkSubmitParams,
+                                             Map<String, String> tags,
+                                             String resultIndex) {
+      super(query, jobName, applicationId, executionRoleArn, sparkSubmitParams, tags,
+          false, resultIndex);
+    }
+
+    /**
+     * Interactive query keep running.
+     */
+    @Override
+    public Long executionTimeout() {
+      return 0L;
+    }
   }
 }


### PR DESCRIPTION
### Description
1. Align with Flint auth conf, use basic instead of basicauth. https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md#basic-auth
2. Change Interactive timeout to 0.
3. Fetch error from statementDoc in case not result write to indexResult yet.
4. Add IT for (1), (2), (3)
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).