### PR TITLE
Prevent arn changes in Patch datasources API

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/PatchDataSourceActionRequest.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/PatchDataSourceActionRequest.java
@@ -8,7 +8,9 @@
 package org.opensearch.sql.datasources.model.transport;
 
 import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
-import static org.opensearch.sql.datasources.utils.XContentParserUtils.*;
+import static org.opensearch.sql.datasources.utils.XContentParserUtils.CONNECTOR_FIELD;
+import static org.opensearch.sql.datasources.utils.XContentParserUtils.NAME_FIELD;
+import static org.opensearch.sql.datasources.utils.XContentParserUtils.PROPERTIES_FIELD;
 
 import java.io.IOException;
 import java.util.Map;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/PatchDataSourceActionRequest.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/PatchDataSourceActionRequest.java
@@ -41,12 +41,12 @@ public class PatchDataSourceActionRequest extends ActionRequest {
       ActionRequestValidationException exception = new ActionRequestValidationException();
       exception.addValidationError("Not allowed to update connector for datasource");
       return exception;
-    } else if (((Map<String, String>)this.dataSourceData.get(PROPERTIES_FIELD)).keySet().stream().anyMatch(key -> key.endsWith("role_arn"))) {
+    } else if (((Map<String, String>) this.dataSourceData.get(PROPERTIES_FIELD))
+        .keySet().stream().anyMatch(key -> key.endsWith("role_arn"))) {
       ActionRequestValidationException exception = new ActionRequestValidationException();
-      exception.addValidationError(
-              "Not allowed to update role_arn");
+      exception.addValidationError("Not allowed to update role_arn");
       return exception;
-    }else {
+    } else {
       return null;
     }
   }

--- a/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/PatchDataSourceActionRequest.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/model/transport/PatchDataSourceActionRequest.java
@@ -8,8 +8,7 @@
 package org.opensearch.sql.datasources.model.transport;
 
 import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
-import static org.opensearch.sql.datasources.utils.XContentParserUtils.CONNECTOR_FIELD;
-import static org.opensearch.sql.datasources.utils.XContentParserUtils.NAME_FIELD;
+import static org.opensearch.sql.datasources.utils.XContentParserUtils.*;
 
 import java.io.IOException;
 import java.util.Map;
@@ -42,7 +41,12 @@ public class PatchDataSourceActionRequest extends ActionRequest {
       ActionRequestValidationException exception = new ActionRequestValidationException();
       exception.addValidationError("Not allowed to update connector for datasource");
       return exception;
-    } else {
+    } else if (((Map<String, String>)this.dataSourceData.get(PROPERTIES_FIELD)).keySet().stream().anyMatch(key -> key.endsWith("role_arn"))) {
+      ActionRequestValidationException exception = new ActionRequestValidationException();
+      exception.addValidationError(
+              "Not allowed to update role_arn");
+      return exception;
+    }else {
       return null;
     }
   }

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceActionTest.java
@@ -1,5 +1,6 @@
 package org.opensearch.sql.datasources.transport;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.opensearch.sql.datasources.utils.XContentParserUtils.*;
 
@@ -15,6 +16,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.datasources.model.transport.PatchDataSourceActionRequest;
@@ -75,5 +77,12 @@ public class TransportPatchDataSourceActionTest {
     Exception exception = exceptionArgumentCaptor.getValue();
     Assertions.assertTrue(exception instanceof RuntimeException);
     Assertions.assertEquals("Error", exception.getMessage());
+  }
+
+  @Test
+  public void testValidateFailsWhenPatchingRoleArn() {
+      PatchDataSourceActionRequest request = new PatchDataSourceActionRequest(Map.of(NAME_FIELD, "test", PROPERTIES_FIELD, Map.of("glue.auth.role_arn", "test_arn")));
+      assertNotNull(request.validate());
+      assertTrue(request.validate().getMessage().contains("Not allowed to update role_arn"));
   }
 }

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceActionTest.java
@@ -16,7 +16,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.datasources.model.transport.PatchDataSourceActionRequest;
@@ -81,8 +80,10 @@ public class TransportPatchDataSourceActionTest {
 
   @Test
   public void testValidateFailsWhenPatchingRoleArn() {
-      PatchDataSourceActionRequest request = new PatchDataSourceActionRequest(Map.of(NAME_FIELD, "test", PROPERTIES_FIELD, Map.of("glue.auth.role_arn", "test_arn")));
-      assertNotNull(request.validate());
-      assertTrue(request.validate().getMessage().contains("Not allowed to update role_arn"));
+    PatchDataSourceActionRequest request =
+        new PatchDataSourceActionRequest(
+            Map.of(NAME_FIELD, "test", PROPERTIES_FIELD, Map.of("glue.auth.role_arn", "test_arn")));
+    assertNotNull(request.validate());
+    assertTrue(request.validate().getMessage().contains("Not allowed to update role_arn"));
   }
 }


### PR DESCRIPTION
### Description
Prevent arn changes in Patch datasources API 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).