### PR TITLE
Enable session by default

### DIFF
--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -317,9 +317,9 @@ plugins.query.executionengine.spark.session.enabled
 Description
 -----------
 
-By default, execution engine is executed in job mode. You can enable session mode by this setting.
+By default, execution engine is executed in session mode. You can disable session mode by this setting.
 
-1. The default value is false.
+1. The default value is true.
 2. This setting is node scope.
 3. This setting can be updated dynamically.
 
@@ -328,7 +328,7 @@ You can update the setting with a new value like this.
 SQL query::
 
     sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings \
-    ... -d '{"transient":{"plugins.query.executionengine.spark.session.enabled":"true"}}'
+    ... -d '{"transient":{"plugins.query.executionengine.spark.session.enabled":"false"}}'
     {
       "acknowledged": true,
       "persistent": {},
@@ -338,7 +338,7 @@ SQL query::
             "executionengine": {
               "spark": {
                 "session": {
-                  "enabled": "true"
+                  "enabled": "false"
                 }
               }
             }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -138,7 +138,7 @@ public class OpenSearchSettings extends Settings {
   public static final Setting<?> SPARK_EXECUTION_SESSION_ENABLED_SETTING =
       Setting.boolSetting(
           Key.SPARK_EXECUTION_SESSION_ENABLED.getKeyValue(),
-          false,
+          true,
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
@@ -60,7 +60,9 @@ public class StateStore {
   public static String SETTINGS_FILE_NAME = "query_execution_request_settings.yml";
   public static String MAPPING_FILE_NAME = "query_execution_request_mapping.yml";
   public static Function<String, String> DATASOURCE_TO_REQUEST_INDEX =
-      datasourceName -> String.format("%s_%s", SPARK_REQUEST_BUFFER_INDEX_NAME, datasourceName);
+      datasourceName ->
+          String.format(
+              "%s_%s", SPARK_REQUEST_BUFFER_INDEX_NAME, datasourceName.toLowerCase(Locale.ROOT));
 
   private static final Logger LOG = LogManager.getLogger();
 


### PR DESCRIPTION
### Description
1.  enable session support by default. update setting doc.
2. bug fix - lowercase datasource name when create request indices.
3. disable flaky test.
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).