### PR TITLE
add concurrent limit on datasource and sessions

### DIFF
--- a/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
+++ b/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
@@ -34,6 +34,7 @@ public abstract class Settings {
     QUERY_SIZE_LIMIT("plugins.query.size_limit"),
     ENCYRPTION_MASTER_KEY("plugins.query.datasources.encryption.masterkey"),
     DATASOURCES_URI_HOSTS_DENY_LIST("plugins.query.datasources.uri.hosts.denylist"),
+    DATASOURCES_LIMIT("plugins.query.datasources.limit"),
 
     METRICS_ROLLING_WINDOW("plugins.query.metrics.rolling_window"),
     METRICS_ROLLING_INTERVAL("plugins.query.metrics.rolling_interval"),

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
     implementation project(':core')
     implementation project(':protocol')
+    implementation project(':opensearch')
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
@@ -35,7 +36,7 @@ dependencies {
 test {
     useJUnitPlatform()
     testLogging {
-        events "passed", "skipped", "failed"
+        events "skipped", "failed"
         exceptionFormat "full"
     }
 }

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -348,12 +348,12 @@ SQL query::
     }
 
 plugins.query.executionengine.spark.session.limit
-===================================================
+==================================================
 
 Description
 -----------
 
-Each datasource can have maximum 100 sessions running in parallel by default. You can increase limit by this setting.
+Each cluster can have maximum 100 sessions running in parallel by default. You can increase limit by this setting.
 
 1. The default value is 100.
 2. This setting is node scope.
@@ -377,6 +377,39 @@ SQL query::
                   "limit": "200"
                 }
               }
+            }
+          }
+        }
+      }
+    }
+
+
+plugins.query.datasources.limit
+===============================
+
+Description
+-----------
+
+Each cluster can have maximum 20 datasources. You can increase limit by this setting.
+
+1. The default value is 20.
+2. This setting is node scope.
+3. This setting can be updated dynamically.
+
+You can update the setting with a new value like this.
+
+SQL query::
+
+    sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings \
+    ... -d '{"transient":{"plugins.query.datasources.limit":25}}'
+    {
+      "acknowledged": true,
+      "persistent": {},
+      "transient": {
+        "plugins": {
+          "query": {
+            "datasources": {
+              "limit": "25"
             }
           }
         }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -149,6 +149,13 @@ public class OpenSearchSettings extends Settings {
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 
+  public static final Setting<?> DATASOURCES_LIMIT_SETTING =
+      Setting.intSetting(
+          Key.DATASOURCES_LIMIT.getKeyValue(),
+          20,
+          Setting.Property.NodeScope,
+          Setting.Property.Dynamic);
+
   /** Construct OpenSearchSetting. The OpenSearchSetting must be singleton. */
   @SuppressWarnings("unchecked")
   public OpenSearchSettings(ClusterSettings clusterSettings) {
@@ -231,6 +238,12 @@ public class OpenSearchSettings extends Settings {
         Key.SPARK_EXECUTION_SESSION_LIMIT,
         SPARK_EXECUTION_SESSION_LIMIT_SETTING,
         new Updater(Key.SPARK_EXECUTION_SESSION_LIMIT));
+    register(
+        settingBuilder,
+        clusterSettings,
+        Key.DATASOURCES_LIMIT,
+        DATASOURCES_LIMIT_SETTING,
+        new Updater(Key.DATASOURCES_LIMIT));
     registerNonDynamicSettings(
         settingBuilder, clusterSettings, Key.CLUSTER_NAME, ClusterName.CLUSTER_NAME_SETTING);
     defaultSettings = settingBuilder.build();
@@ -298,6 +311,7 @@ public class OpenSearchSettings extends Settings {
         .add(SPARK_EXECUTION_ENGINE_CONFIG)
         .add(SPARK_EXECUTION_SESSION_ENABLED_SETTING)
         .add(SPARK_EXECUTION_SESSION_LIMIT_SETTING)
+        .add(DATASOURCES_LIMIT_SETTING)
         .build();
   }
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -96,6 +96,7 @@ import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
 import org.opensearch.sql.spark.execution.session.SessionManager;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataReaderImpl;
+import org.opensearch.sql.spark.leasemanager.DefaultLeaseManager;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 import org.opensearch.sql.spark.rest.RestAsyncQueryManagementAction;
 import org.opensearch.sql.spark.storage.SparkStorageFactory;
@@ -245,7 +246,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
         });
 
     injector = modules.createInjector();
-    return ImmutableList.of(dataSourceService, asyncQueryExecutorService);
+    return ImmutableList.of(dataSourceService, asyncQueryExecutorService, pluginSettings);
   }
 
   @Override
@@ -320,7 +321,8 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
             jobExecutionResponseReader,
             new FlintIndexMetadataReaderImpl(client),
             client,
-            new SessionManager(stateStore, emrServerlessClient, pluginSettings));
+            new SessionManager(stateStore, emrServerlessClient, pluginSettings),
+            new DefaultLeaseManager(pluginSettings, stateStore));
     return new AsyncQueryExecutorServiceImpl(
         asyncQueryJobMetadataStorageService,
         sparkQueryDispatcher,

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/AsyncQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/AsyncQueryHandler.java
@@ -12,6 +12,9 @@ import static org.opensearch.sql.spark.data.constants.SparkConstants.STATUS_FIEL
 import com.amazonaws.services.emrserverless.model.JobRunState;
 import org.json.JSONObject;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
 
 /** Process async query request. */
 public abstract class AsyncQueryHandler {
@@ -45,5 +48,8 @@ public abstract class AsyncQueryHandler {
   protected abstract JSONObject getResponseFromExecutor(
       AsyncQueryJobMetadata asyncQueryJobMetadata);
 
-  abstract String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata);
+  public abstract String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata);
+
+  public abstract DispatchQueryResponse submit(
+      DispatchQueryRequest request, DispatchQueryContext context);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -7,12 +7,21 @@ package org.opensearch.sql.spark.dispatcher;
 
 import static org.opensearch.sql.spark.data.constants.SparkConstants.ERROR_FIELD;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.STATUS_FIELD;
+import static org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher.JOB_TYPE_TAG_KEY;
 
 import com.amazonaws.services.emrserverless.model.GetJobRunResult;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.StartJobRequest;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
+import org.opensearch.sql.spark.dispatcher.model.JobType;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
 @RequiredArgsConstructor
@@ -46,5 +55,32 @@ public class BatchQueryHandler extends AsyncQueryHandler {
     emrServerlessClient.cancelJobRun(
         asyncQueryJobMetadata.getApplicationId(), asyncQueryJobMetadata.getJobId());
     return asyncQueryJobMetadata.getQueryId().getId();
+  }
+
+  @Override
+  public DispatchQueryResponse submit(
+      DispatchQueryRequest dispatchQueryRequest, DispatchQueryContext context) {
+    String jobName = dispatchQueryRequest.getClusterName() + ":" + "non-index-query";
+    Map<String, String> tags = context.getTags();
+    DataSourceMetadata dataSourceMetadata = context.getDataSourceMetadata();
+
+    tags.put(JOB_TYPE_TAG_KEY, JobType.BATCH.getText());
+    StartJobRequest startJobRequest =
+        new StartJobRequest(
+            dispatchQueryRequest.getQuery(),
+            jobName,
+            dispatchQueryRequest.getApplicationId(),
+            dispatchQueryRequest.getExecutionRoleARN(),
+            SparkSubmitParameters.Builder.builder()
+                .dataSource(context.getDataSourceMetadata())
+                .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams())
+                .build()
+                .toString(),
+            tags,
+            false,
+            dataSourceMetadata.getResultIndex());
+    String jobId = emrServerlessClient.startJobRun(startJobRequest);
+    return new DispatchQueryResponse(
+        context.getQueryId(), jobId, false, dataSourceMetadata.getResultIndex(), null);
   }
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -6,24 +6,38 @@
 package org.opensearch.sql.spark.dispatcher;
 
 import static org.opensearch.sql.spark.data.constants.SparkConstants.ERROR_FIELD;
+import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_SESSION_CLASS_NAME;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.STATUS_FIELD;
+import static org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher.JOB_TYPE_TAG_KEY;
 
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
+import org.opensearch.sql.spark.dispatcher.model.JobType;
+import org.opensearch.sql.spark.execution.session.CreateSessionRequest;
 import org.opensearch.sql.spark.execution.session.Session;
 import org.opensearch.sql.spark.execution.session.SessionId;
 import org.opensearch.sql.spark.execution.session.SessionManager;
+import org.opensearch.sql.spark.execution.statement.QueryRequest;
 import org.opensearch.sql.spark.execution.statement.Statement;
 import org.opensearch.sql.spark.execution.statement.StatementId;
 import org.opensearch.sql.spark.execution.statement.StatementState;
+import org.opensearch.sql.spark.leasemanager.LeaseManager;
+import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
 @RequiredArgsConstructor
 public class InteractiveQueryHandler extends AsyncQueryHandler {
   private final SessionManager sessionManager;
   private final JobExecutionResponseReader jobExecutionResponseReader;
+  private final LeaseManager leaseManager;
 
   @Override
   protected JSONObject getResponseFromResultIndex(AsyncQueryJobMetadata asyncQueryJobMetadata) {
@@ -48,6 +62,56 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
     String queryId = asyncQueryJobMetadata.getQueryId().getId();
     getStatementByQueryId(asyncQueryJobMetadata.getSessionId(), queryId).cancel();
     return queryId;
+  }
+
+  @Override
+  public DispatchQueryResponse submit(
+      DispatchQueryRequest dispatchQueryRequest, DispatchQueryContext context) {
+    Session session = null;
+    String jobName = dispatchQueryRequest.getClusterName() + ":" + "non-index-query";
+    Map<String, String> tags = context.getTags();
+    DataSourceMetadata dataSourceMetadata = context.getDataSourceMetadata();
+
+    // todo, manage lease lifecycle
+    leaseManager.borrow(
+        new LeaseRequest(JobType.INTERACTIVE, dispatchQueryRequest.getDatasource()));
+
+    if (dispatchQueryRequest.getSessionId() != null) {
+      // get session from request
+      SessionId sessionId = new SessionId(dispatchQueryRequest.getSessionId());
+      Optional<Session> createdSession = sessionManager.getSession(sessionId);
+      if (createdSession.isPresent()) {
+        session = createdSession.get();
+      }
+    }
+    if (session == null || !session.isReady()) {
+      // create session if not exist or session dead/fail
+      tags.put(JOB_TYPE_TAG_KEY, JobType.INTERACTIVE.getText());
+      session =
+          sessionManager.createSession(
+              new CreateSessionRequest(
+                  jobName,
+                  dispatchQueryRequest.getApplicationId(),
+                  dispatchQueryRequest.getExecutionRoleARN(),
+                  SparkSubmitParameters.Builder.builder()
+                      .className(FLINT_SESSION_CLASS_NAME)
+                      .dataSource(dataSourceMetadata)
+                      .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams()),
+                  tags,
+                  dataSourceMetadata.getResultIndex(),
+                  dataSourceMetadata.getName()));
+    }
+    session.submit(
+        new QueryRequest(
+            context.getQueryId(),
+            dispatchQueryRequest.getLangType(),
+            dispatchQueryRequest.getQuery()));
+    return new DispatchQueryResponse(
+        context.getQueryId(),
+        session.getSessionModel().getJobId(),
+        false,
+        dataSourceMetadata.getResultIndex(),
+        session.getSessionId().getSessionId());
   }
 
   private Statement getStatementByQueryId(String sid, String qid) {

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -7,7 +7,6 @@ package org.opensearch.sql.spark.dispatcher;
 
 import static org.opensearch.sql.spark.data.constants.SparkConstants.DATA_FIELD;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.ERROR_FIELD;
-import static org.opensearch.sql.spark.data.constants.SparkConstants.FLINT_SESSION_CLASS_NAME;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.STATUS_FIELD;
 
 import com.amazonaws.services.emrserverless.model.JobRunState;
@@ -15,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,17 +31,16 @@ import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelperImpl;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryId;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
-import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
-import org.opensearch.sql.spark.client.StartJobRequest;
-import org.opensearch.sql.spark.dispatcher.model.*;
-import org.opensearch.sql.spark.execution.session.CreateSessionRequest;
-import org.opensearch.sql.spark.execution.session.Session;
-import org.opensearch.sql.spark.execution.session.SessionId;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
+import org.opensearch.sql.spark.dispatcher.model.IndexQueryActionType;
+import org.opensearch.sql.spark.dispatcher.model.IndexQueryDetails;
 import org.opensearch.sql.spark.execution.session.SessionManager;
-import org.opensearch.sql.spark.execution.statement.QueryRequest;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataReader;
+import org.opensearch.sql.spark.leasemanager.LeaseManager;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 import org.opensearch.sql.spark.rest.model.LangType;
 import org.opensearch.sql.spark.utils.SQLQueryUtils;
@@ -72,19 +69,49 @@ public class SparkQueryDispatcher {
 
   private SessionManager sessionManager;
 
+  private LeaseManager leaseManager;
+
   public DispatchQueryResponse dispatch(DispatchQueryRequest dispatchQueryRequest) {
-    if (LangType.SQL.equals(dispatchQueryRequest.getLangType())) {
-      return handleSQLQuery(dispatchQueryRequest);
-    } else {
-      // Since we don't need any extra handling for PPL, we are treating it as normal dispatch
-      // Query.
-      return handleNonIndexQuery(dispatchQueryRequest);
+    DataSourceMetadata dataSourceMetadata =
+        this.dataSourceService.getRawDataSourceMetadata(dispatchQueryRequest.getDatasource());
+    dataSourceUserAuthorizationHelper.authorizeDataSource(dataSourceMetadata);
+
+    AsyncQueryHandler asyncQueryHandler =
+        sessionManager.isEnabled()
+            ? new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader, leaseManager)
+            : new BatchQueryHandler(emrServerlessClient, jobExecutionResponseReader);
+    DispatchQueryContext.DispatchQueryContextBuilder contextBuilder =
+        DispatchQueryContext.builder()
+            .dataSourceMetadata(dataSourceMetadata)
+            .tags(getDefaultTagsForJobSubmission(dispatchQueryRequest))
+            .queryId(AsyncQueryId.newAsyncQueryId(dataSourceMetadata.getName()));
+
+    // override asyncQueryHandler with specific.
+    if (LangType.SQL.equals(dispatchQueryRequest.getLangType())
+        && SQLQueryUtils.isFlintExtensionQuery(dispatchQueryRequest.getQuery())) {
+      IndexQueryDetails indexQueryDetails =
+          SQLQueryUtils.extractIndexDetails(dispatchQueryRequest.getQuery());
+      fillMissingDetails(dispatchQueryRequest, indexQueryDetails);
+      contextBuilder.indexQueryDetails(indexQueryDetails);
+
+      if (IndexQueryActionType.DROP.equals(indexQueryDetails.getIndexQueryActionType())) {
+        // todo, fix in DROP INDEX PR.
+        return handleDropIndexQuery(dispatchQueryRequest, indexQueryDetails);
+      } else if (IndexQueryActionType.CREATE.equals(indexQueryDetails.getIndexQueryActionType())
+          && indexQueryDetails.isAutoRefresh()) {
+        asyncQueryHandler =
+            new StreamingQueryHandler(emrServerlessClient, jobExecutionResponseReader);
+      } else if (IndexQueryActionType.REFRESH.equals(indexQueryDetails.getIndexQueryActionType())) {
+        // manual refresh should be handled by batch handler
+        asyncQueryHandler = new BatchQueryHandler(emrServerlessClient, jobExecutionResponseReader);
+      }
     }
+    return asyncQueryHandler.submit(dispatchQueryRequest, contextBuilder.build());
   }
 
   public JSONObject getQueryResponse(AsyncQueryJobMetadata asyncQueryJobMetadata) {
     if (asyncQueryJobMetadata.getSessionId() != null) {
-      return new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader)
+      return new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader, leaseManager)
           .getQueryResponse(asyncQueryJobMetadata);
     } else {
       return new BatchQueryHandler(emrServerlessClient, jobExecutionResponseReader)
@@ -94,30 +121,11 @@ public class SparkQueryDispatcher {
 
   public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
     if (asyncQueryJobMetadata.getSessionId() != null) {
-      return new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader)
+      return new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader, leaseManager)
           .cancelJob(asyncQueryJobMetadata);
     } else {
       return new BatchQueryHandler(emrServerlessClient, jobExecutionResponseReader)
           .cancelJob(asyncQueryJobMetadata);
-    }
-  }
-
-  private DispatchQueryResponse handleSQLQuery(DispatchQueryRequest dispatchQueryRequest) {
-    if (SQLQueryUtils.isFlintExtensionQuery(dispatchQueryRequest.getQuery())) {
-      IndexQueryDetails indexQueryDetails =
-          SQLQueryUtils.extractIndexDetails(dispatchQueryRequest.getQuery());
-      fillMissingDetails(dispatchQueryRequest, indexQueryDetails);
-
-      // TODO: refactor this code properly.
-      if (IndexQueryActionType.DROP.equals(indexQueryDetails.getIndexQueryActionType())) {
-        return handleDropIndexQuery(dispatchQueryRequest, indexQueryDetails);
-      } else if (IndexQueryActionType.CREATE.equals(indexQueryDetails.getIndexQueryActionType())) {
-        return handleStreamingQueries(dispatchQueryRequest, indexQueryDetails);
-      } else {
-        return handleFlintNonStreamingQueries(dispatchQueryRequest, indexQueryDetails);
-      }
-    } else {
-      return handleNonIndexQuery(dispatchQueryRequest);
     }
   }
 
@@ -135,151 +143,10 @@ public class SparkQueryDispatcher {
     }
   }
 
-  private DispatchQueryResponse handleStreamingQueries(
-      DispatchQueryRequest dispatchQueryRequest, IndexQueryDetails indexQueryDetails) {
-    DataSourceMetadata dataSourceMetadata =
-        this.dataSourceService.getRawDataSourceMetadata(dispatchQueryRequest.getDatasource());
-    dataSourceUserAuthorizationHelper.authorizeDataSource(dataSourceMetadata);
-    String jobName = dispatchQueryRequest.getClusterName() + ":" + "index-query";
-    Map<String, String> tags = getDefaultTagsForJobSubmission(dispatchQueryRequest);
-    tags.put(INDEX_TAG_KEY, indexQueryDetails.openSearchIndexName());
-    if (indexQueryDetails.isAutoRefresh()) {
-      tags.put(JOB_TYPE_TAG_KEY, JobType.STREAMING.getText());
-    }
-    StartJobRequest startJobRequest =
-        new StartJobRequest(
-            dispatchQueryRequest.getQuery(),
-            jobName,
-            dispatchQueryRequest.getApplicationId(),
-            dispatchQueryRequest.getExecutionRoleARN(),
-            SparkSubmitParameters.Builder.builder()
-                .dataSource(
-                    dataSourceService.getRawDataSourceMetadata(
-                        dispatchQueryRequest.getDatasource()))
-                .structuredStreaming(indexQueryDetails.isAutoRefresh())
-                .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams())
-                .build()
-                .toString(),
-            tags,
-            indexQueryDetails.isAutoRefresh(),
-            dataSourceMetadata.getResultIndex());
-    String jobId = emrServerlessClient.startJobRun(startJobRequest);
-    return new DispatchQueryResponse(
-        AsyncQueryId.newAsyncQueryId(dataSourceMetadata.getName()),
-        jobId,
-        false,
-        dataSourceMetadata.getResultIndex(),
-        null);
-  }
-
-  private DispatchQueryResponse handleFlintNonStreamingQueries(
-      DispatchQueryRequest dispatchQueryRequest, IndexQueryDetails indexQueryDetails) {
-    DataSourceMetadata dataSourceMetadata =
-        this.dataSourceService.getRawDataSourceMetadata(dispatchQueryRequest.getDatasource());
-    dataSourceUserAuthorizationHelper.authorizeDataSource(dataSourceMetadata);
-    String jobName = dispatchQueryRequest.getClusterName() + ":" + "index-query";
-    Map<String, String> tags = getDefaultTagsForJobSubmission(dispatchQueryRequest);
-    StartJobRequest startJobRequest =
-        new StartJobRequest(
-            dispatchQueryRequest.getQuery(),
-            jobName,
-            dispatchQueryRequest.getApplicationId(),
-            dispatchQueryRequest.getExecutionRoleARN(),
-            SparkSubmitParameters.Builder.builder()
-                .dataSource(
-                    dataSourceService.getRawDataSourceMetadata(
-                        dispatchQueryRequest.getDatasource()))
-                .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams())
-                .build()
-                .toString(),
-            tags,
-            indexQueryDetails.isAutoRefresh(),
-            dataSourceMetadata.getResultIndex());
-    String jobId = emrServerlessClient.startJobRun(startJobRequest);
-    return new DispatchQueryResponse(
-        AsyncQueryId.newAsyncQueryId(dataSourceMetadata.getName()),
-        jobId,
-        false,
-        dataSourceMetadata.getResultIndex(),
-        null);
-  }
-
-  private DispatchQueryResponse handleNonIndexQuery(DispatchQueryRequest dispatchQueryRequest) {
-    DataSourceMetadata dataSourceMetadata =
-        this.dataSourceService.getRawDataSourceMetadata(dispatchQueryRequest.getDatasource());
-    AsyncQueryId queryId = AsyncQueryId.newAsyncQueryId(dataSourceMetadata.getName());
-    dataSourceUserAuthorizationHelper.authorizeDataSource(dataSourceMetadata);
-    String jobName = dispatchQueryRequest.getClusterName() + ":" + "non-index-query";
-    Map<String, String> tags = getDefaultTagsForJobSubmission(dispatchQueryRequest);
-
-    if (sessionManager.isEnabled()) {
-      Session session = null;
-
-      if (dispatchQueryRequest.getSessionId() != null) {
-        // get session from request
-        SessionId sessionId = new SessionId(dispatchQueryRequest.getSessionId());
-        Optional<Session> createdSession = sessionManager.getSession(sessionId);
-        if (createdSession.isPresent()) {
-          session = createdSession.get();
-        }
-      }
-      if (session == null || !session.isReady()) {
-        // create session if not exist or session dead/fail
-        tags.put(JOB_TYPE_TAG_KEY, JobType.INTERACTIVE.getText());
-        session =
-            sessionManager.createSession(
-                new CreateSessionRequest(
-                    jobName,
-                    dispatchQueryRequest.getApplicationId(),
-                    dispatchQueryRequest.getExecutionRoleARN(),
-                    SparkSubmitParameters.Builder.builder()
-                        .className(FLINT_SESSION_CLASS_NAME)
-                        .dataSource(
-                            dataSourceService.getRawDataSourceMetadata(
-                                dispatchQueryRequest.getDatasource()))
-                        .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams()),
-                    tags,
-                    dataSourceMetadata.getResultIndex(),
-                    dataSourceMetadata.getName()));
-      }
-      session.submit(
-          new QueryRequest(
-              queryId, dispatchQueryRequest.getLangType(), dispatchQueryRequest.getQuery()));
-      return new DispatchQueryResponse(
-          queryId,
-          session.getSessionModel().getJobId(),
-          false,
-          dataSourceMetadata.getResultIndex(),
-          session.getSessionId().getSessionId());
-    } else {
-      tags.put(JOB_TYPE_TAG_KEY, JobType.BATCH.getText());
-      StartJobRequest startJobRequest =
-          new StartJobRequest(
-              dispatchQueryRequest.getQuery(),
-              jobName,
-              dispatchQueryRequest.getApplicationId(),
-              dispatchQueryRequest.getExecutionRoleARN(),
-              SparkSubmitParameters.Builder.builder()
-                  .dataSource(
-                      dataSourceService.getRawDataSourceMetadata(
-                          dispatchQueryRequest.getDatasource()))
-                  .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams())
-                  .build()
-                  .toString(),
-              tags,
-              false,
-              dataSourceMetadata.getResultIndex());
-      String jobId = emrServerlessClient.startJobRun(startJobRequest);
-      return new DispatchQueryResponse(
-          queryId, jobId, false, dataSourceMetadata.getResultIndex(), null);
-    }
-  }
-
   private DispatchQueryResponse handleDropIndexQuery(
       DispatchQueryRequest dispatchQueryRequest, IndexQueryDetails indexQueryDetails) {
     DataSourceMetadata dataSourceMetadata =
         this.dataSourceService.getRawDataSourceMetadata(dispatchQueryRequest.getDatasource());
-    dataSourceUserAuthorizationHelper.authorizeDataSource(dataSourceMetadata);
     FlintIndexMetadata indexMetadata =
         flintIndexMetadataReader.getFlintIndexMetadata(indexQueryDetails);
     // if index is created without auto refresh. there is no job to cancel.

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.dispatcher;
+
+import static org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher.INDEX_TAG_KEY;
+import static org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher.JOB_TYPE_TAG_KEY;
+
+import java.util.Map;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryId;
+import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
+import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.StartJobRequest;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
+import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
+import org.opensearch.sql.spark.dispatcher.model.IndexQueryDetails;
+import org.opensearch.sql.spark.dispatcher.model.JobType;
+import org.opensearch.sql.spark.response.JobExecutionResponseReader;
+
+/** Handle Streaming Query. */
+public class StreamingQueryHandler extends BatchQueryHandler {
+  private final EMRServerlessClient emrServerlessClient;
+
+  public StreamingQueryHandler(
+      EMRServerlessClient emrServerlessClient,
+      JobExecutionResponseReader jobExecutionResponseReader) {
+    super(emrServerlessClient, jobExecutionResponseReader);
+    this.emrServerlessClient = emrServerlessClient;
+  }
+
+  @Override
+  public DispatchQueryResponse submit(
+      DispatchQueryRequest dispatchQueryRequest, DispatchQueryContext context) {
+    String jobName = dispatchQueryRequest.getClusterName() + ":" + "index-query";
+    IndexQueryDetails indexQueryDetails = context.getIndexQueryDetails();
+    Map<String, String> tags = context.getTags();
+    tags.put(INDEX_TAG_KEY, indexQueryDetails.openSearchIndexName());
+    DataSourceMetadata dataSourceMetadata = context.getDataSourceMetadata();
+    tags.put(JOB_TYPE_TAG_KEY, JobType.STREAMING.getText());
+    StartJobRequest startJobRequest =
+        new StartJobRequest(
+            dispatchQueryRequest.getQuery(),
+            jobName,
+            dispatchQueryRequest.getApplicationId(),
+            dispatchQueryRequest.getExecutionRoleARN(),
+            SparkSubmitParameters.Builder.builder()
+                .dataSource(dataSourceMetadata)
+                .structuredStreaming(true)
+                .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams())
+                .build()
+                .toString(),
+            tags,
+            indexQueryDetails.isAutoRefresh(),
+            dataSourceMetadata.getResultIndex());
+    String jobId = emrServerlessClient.startJobRun(startJobRequest);
+    return new DispatchQueryResponse(
+        AsyncQueryId.newAsyncQueryId(dataSourceMetadata.getName()),
+        jobId,
+        false,
+        dataSourceMetadata.getResultIndex(),
+        null);
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryContext.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryContext.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.dispatcher.model;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryId;
+
+@Getter
+@Builder
+public class DispatchQueryContext {
+  private final AsyncQueryId queryId;
+  private final DataSourceMetadata dataSourceMetadata;
+  private final Map<String, String> tags;
+  private final IndexQueryDetails indexQueryDetails;
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/SessionManager.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/SessionManager.java
@@ -6,11 +6,8 @@
 package org.opensearch.sql.spark.execution.session;
 
 import static org.opensearch.sql.common.setting.Settings.Key.SPARK_EXECUTION_SESSION_ENABLED;
-import static org.opensearch.sql.common.setting.Settings.Key.SPARK_EXECUTION_SESSION_LIMIT;
 import static org.opensearch.sql.spark.execution.session.SessionId.newSessionId;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.activeSessionsCount;
 
-import java.util.Locale;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.common.setting.Settings;
@@ -29,15 +26,6 @@ public class SessionManager {
   private final Settings settings;
 
   public Session createSession(CreateSessionRequest request) {
-    int sessionMaxLimit = sessionMaxLimit();
-    if (activeSessionsCount(stateStore, request.getDatasourceName()).get() >= sessionMaxLimit) {
-      String errorMsg =
-          String.format(
-              Locale.ROOT,
-              "The maximum number of active sessions can be " + "supported is %d",
-              sessionMaxLimit);
-      throw new IllegalArgumentException(errorMsg);
-    }
     InteractiveSession session =
         InteractiveSession.builder()
             .sessionId(newSessionId(request.getDatasourceName()))
@@ -66,9 +54,5 @@ public class SessionManager {
 
   public boolean isEnabled() {
     return settings.getSettingValue(SPARK_EXECUTION_SESSION_ENABLED);
-  }
-
-  public int sessionMaxLimit() {
-    return settings.getSettingValue(SPARK_EXECUTION_SESSION_LIMIT);
   }
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
@@ -63,6 +63,7 @@ public class StateStore {
       datasourceName ->
           String.format(
               "%s_%s", SPARK_REQUEST_BUFFER_INDEX_NAME, datasourceName.toLowerCase(Locale.ROOT));
+  public static String ALL_DATASOURCE = "*";
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -192,9 +193,6 @@ public class StateStore {
   }
 
   private long count(String indexName, QueryBuilder query) {
-    if (!this.clusterService.state().routingTable().hasIndex(indexName)) {
-      return 0;
-    }
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     searchSourceBuilder.query(query);
     searchSourceBuilder.size(0);
@@ -301,7 +299,6 @@ public class StateStore {
                 .must(
                     QueryBuilders.termQuery(
                         SessionModel.SESSION_TYPE, SessionType.INTERACTIVE.getSessionType()))
-                .must(QueryBuilders.termQuery(SessionModel.DATASOURCE_NAME, datasourceName))
                 .must(
                     QueryBuilders.termQuery(
                         SessionModel.SESSION_STATE, SessionState.RUNNING.getSessionState())));

--- a/spark/src/main/java/org/opensearch/sql/spark/leasemanager/ConcurrencyLimitExceededException.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/leasemanager/ConcurrencyLimitExceededException.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.leasemanager;
+
+/** Concurrency limit exceeded. */
+public class ConcurrencyLimitExceededException extends RuntimeException {
+  public ConcurrencyLimitExceededException(String message) {
+    super(message);
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManager.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManager.java
@@ -12,7 +12,6 @@ import static org.opensearch.sql.spark.execution.statestore.StateStore.activeSes
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.spark.dispatcher.model.JobType;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
@@ -49,7 +48,6 @@ public class DefaultLeaseManager implements LeaseManager {
     String description();
   }
 
-  @RequiredArgsConstructor
   public class ConcurrentSessionRule implements Rule<LeaseRequest> {
     @Override
     public String description() {

--- a/spark/src/main/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManager.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManager.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.leasemanager;
+
+import static org.opensearch.sql.common.setting.Settings.Key.SPARK_EXECUTION_SESSION_LIMIT;
+import static org.opensearch.sql.spark.execution.statestore.StateStore.ALL_DATASOURCE;
+import static org.opensearch.sql.spark.execution.statestore.StateStore.activeSessionsCount;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.spark.dispatcher.model.JobType;
+import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
+
+/**
+ * Default Lease Manager
+ * <li>QueryHandler borrow lease before execute the query.
+ * <li>LeaseManagerService check request against domain level concurrent limit.
+ * <li>LeaseManagerService running on data node and check limit based on cluster settings.
+ */
+public class DefaultLeaseManager implements LeaseManager {
+
+  private final List<Rule<LeaseRequest>> concurrentLimitRules;
+  private final Settings settings;
+  private final StateStore stateStore;
+
+  public DefaultLeaseManager(Settings settings, StateStore stateStore) {
+    this.settings = settings;
+    this.stateStore = stateStore;
+    this.concurrentLimitRules = Arrays.asList(new ConcurrentSessionRule());
+  }
+
+  @Override
+  public void borrow(LeaseRequest request) {
+    for (Rule<LeaseRequest> rule : concurrentLimitRules) {
+      if (!rule.test(request)) {
+        throw new ConcurrencyLimitExceededException(rule.description());
+      }
+    }
+  }
+
+  interface Rule<T> extends Predicate<T> {
+    String description();
+  }
+
+  @RequiredArgsConstructor
+  public class ConcurrentSessionRule implements Rule<LeaseRequest> {
+    @Override
+    public String description() {
+      return String.format("domain concurrent active session can not exceed %d", sessionMaxLimit());
+    }
+
+    @Override
+    public boolean test(LeaseRequest leaseRequest) {
+      if (leaseRequest.getJobType() != JobType.INTERACTIVE) {
+        return true;
+      }
+      return activeSessionsCount(stateStore, ALL_DATASOURCE).get() < sessionMaxLimit();
+    }
+
+    public int sessionMaxLimit() {
+      return settings.getSettingValue(SPARK_EXECUTION_SESSION_LIMIT);
+    }
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/leasemanager/LeaseManager.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/leasemanager/LeaseManager.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.leasemanager;
+
+import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
+
+/** Lease manager */
+public interface LeaseManager {
+
+  /**
+   * Borrow from LeaseManager. If no exception, lease successfully.
+   *
+   * @throws ConcurrencyLimitExceededException
+   */
+  void borrow(LeaseRequest request);
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/leasemanager/model/LeaseRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/leasemanager/model/LeaseRequest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.leasemanager.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.dispatcher.model.JobType;
+
+/** Lease Request. */
+@Getter
+@RequiredArgsConstructor
+public class LeaseRequest {
+  private final JobType jobType;
+  private final String datasourceName;
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -74,6 +74,7 @@ import org.opensearch.sql.spark.execution.statement.StatementState;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataReader;
 import org.opensearch.sql.spark.flint.FlintIndexType;
+import org.opensearch.sql.spark.leasemanager.LeaseManager;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 import org.opensearch.sql.spark.rest.model.LangType;
 
@@ -92,6 +93,8 @@ public class SparkQueryDispatcherTest {
   @Mock private FlintIndexMetadata flintIndexMetadata;
 
   @Mock private SessionManager sessionManager;
+
+  @Mock private LeaseManager leaseManager;
 
   @Mock(answer = RETURNS_DEEP_STUBS)
   private Session session;
@@ -115,7 +118,8 @@ public class SparkQueryDispatcherTest {
             jobExecutionResponseReader,
             flintIndexMetadataReader,
             openSearchClient,
-            sessionManager);
+            sessionManager,
+            leaseManager);
   }
 
   @Test
@@ -636,6 +640,7 @@ public class SparkQueryDispatcherTest {
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
+    tags.put(JOB_TYPE_TAG_KEY, JobType.BATCH.getText());
     String query = "SHOW MATERIALIZED VIEW IN mys3.default";
     String sparkSubmitParameters =
         constructExpectedSparkSubmitParameterString(
@@ -672,7 +677,7 @@ public class SparkQueryDispatcherTest {
     StartJobRequest expected =
         new StartJobRequest(
             query,
-            "TEST_CLUSTER:index-query",
+            "TEST_CLUSTER:non-index-query",
             EMRS_APPLICATION_ID,
             EMRS_EXECUTION_ROLE,
             sparkSubmitParameters,
@@ -690,6 +695,7 @@ public class SparkQueryDispatcherTest {
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
+    tags.put(JOB_TYPE_TAG_KEY, JobType.BATCH.getText());
     String query = "REFRESH SKIPPING INDEX ON my_glue.default.http_logs";
     String sparkSubmitParameters =
         constructExpectedSparkSubmitParameterString(
@@ -702,7 +708,7 @@ public class SparkQueryDispatcherTest {
     when(emrServerlessClient.startJobRun(
             new StartJobRequest(
                 query,
-                "TEST_CLUSTER:index-query",
+                "TEST_CLUSTER:non-index-query",
                 EMRS_APPLICATION_ID,
                 EMRS_EXECUTION_ROLE,
                 sparkSubmitParameters,
@@ -726,7 +732,7 @@ public class SparkQueryDispatcherTest {
     StartJobRequest expected =
         new StartJobRequest(
             query,
-            "TEST_CLUSTER:index-query",
+            "TEST_CLUSTER:non-index-query",
             EMRS_APPLICATION_ID,
             EMRS_EXECUTION_ROLE,
             sparkSubmitParameters,
@@ -744,6 +750,7 @@ public class SparkQueryDispatcherTest {
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
+    tags.put(JOB_TYPE_TAG_KEY, JobType.BATCH.getText());
     String query = "DESCRIBE SKIPPING INDEX ON mys3.default.http_logs";
     String sparkSubmitParameters =
         constructExpectedSparkSubmitParameterString(
@@ -780,7 +787,7 @@ public class SparkQueryDispatcherTest {
     StartJobRequest expected =
         new StartJobRequest(
             query,
-            "TEST_CLUSTER:index-query",
+            "TEST_CLUSTER:non-index-query",
             EMRS_APPLICATION_ID,
             EMRS_EXECUTION_ROLE,
             sparkSubmitParameters,
@@ -977,15 +984,6 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testGetQueryResponseWithSuccess() {
-    SparkQueryDispatcher sparkQueryDispatcher =
-        new SparkQueryDispatcher(
-            emrServerlessClient,
-            dataSourceService,
-            dataSourceUserAuthorizationHelper,
-            jobExecutionResponseReader,
-            flintIndexMetadataReader,
-            openSearchClient,
-            sessionManager);
     JSONObject queryResult = new JSONObject();
     Map<String, Object> resultMap = new HashMap<>();
     resultMap.put(STATUS_FIELD, "SUCCESS");
@@ -1013,16 +1011,6 @@ public class SparkQueryDispatcherTest {
   // todo. refactor query process logic in plugin.
   @Test
   void testGetQueryResponseOfDropIndex() {
-    SparkQueryDispatcher sparkQueryDispatcher =
-        new SparkQueryDispatcher(
-            emrServerlessClient,
-            dataSourceService,
-            dataSourceUserAuthorizationHelper,
-            jobExecutionResponseReader,
-            flintIndexMetadataReader,
-            openSearchClient,
-            sessionManager);
-
     String jobId =
         new SparkQueryDispatcher.DropIndexResult(JobRunState.SUCCESS.toString()).toJobId();
 

--- a/spark/src/test/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManagerTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManagerTest.java
@@ -5,15 +5,23 @@
 
 package org.opensearch.sql.spark.leasemanager;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.spark.dispatcher.model.JobType;
+import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultLeaseManagerTest {
+  @Mock private Settings settings;
+
+  @Mock private StateStore stateStore;
 
   @Test
-  public void concurrentSessionRuleOnlyApplyToInteractiveQuery() {}
+  public void concurrentSessionRuleOnlyApplyToInteractiveQuery() {
+    new DefaultLeaseManager(settings, stateStore).borrow(new LeaseRequest(JobType.BATCH, "mys3"));
+  }
 }


### PR DESCRIPTION
### Description
1. add cluster level datasource limit.
2. add cluster level session limit.
3. move query process to handler based on query type. Todo, will add drop index will be address in https://github.com/opensearch-project/sql/pull/2386.
4. add LeaseManager, currently, it only limit the concurrent session in cluster.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/2379
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).