### PR TITLE
Added session, statement, emrjob metrics to sql stats api

### DIFF
--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation project(':core')
     implementation project(':protocol')
     implementation project(':opensearch')
+    implementation project(':legacy')
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"

--- a/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
@@ -34,6 +34,8 @@ import org.opensearch.sql.datasources.model.transport.*;
 import org.opensearch.sql.datasources.transport.*;
 import org.opensearch.sql.datasources.utils.Scheduler;
 import org.opensearch.sql.datasources.utils.XContentParserUtils;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 
 public class RestDataSourceQueryAction extends BaseRestHandler {
 
@@ -133,7 +135,6 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
 
   private RestChannelConsumer executePostRequest(RestRequest restRequest, NodeClient nodeClient)
       throws IOException {
-
     DataSourceMetadata dataSourceMetadata =
         XContentParserUtils.toDataSourceMetadata(restRequest.contentParser());
     return restChannel ->
@@ -282,8 +283,10 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
     } else {
       LOG.error("Error happened during request handling", e);
       if (isClientError(e)) {
+        MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_CUS);
         reportError(restChannel, e, BAD_REQUEST);
       } else {
+        MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_SYS);
         reportError(restChannel, e, SERVICE_UNAVAILABLE);
       }
     }

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceAction.java
@@ -20,6 +20,8 @@ import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasources.model.transport.CreateDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.CreateDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -60,6 +62,7 @@ public class TransportCreateDataSourceAction
       Task task,
       CreateDataSourceActionRequest request,
       ActionListener<CreateDataSourceActionResponse> actionListener) {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_CREATION_REQ_COUNT);
     int dataSourceLimit = settings.getSettingValue(DATASOURCES_LIMIT);
     if (dataSourceService.getDataSourceMetadata(false).size() >= dataSourceLimit) {
       actionListener.onFailure(

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceAction.java
@@ -16,6 +16,8 @@ import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.model.transport.DeleteDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.DeleteDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -53,6 +55,7 @@ public class TransportDeleteDataSourceAction
       Task task,
       DeleteDataSourceActionRequest request,
       ActionListener<DeleteDataSourceActionResponse> actionListener) {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_DELETE_REQ_COUNT);
     try {
       dataSourceService.deleteDataSource(request.getDataSourceName());
       actionListener.onResponse(

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceAction.java
@@ -18,6 +18,8 @@ import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasources.model.transport.GetDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.GetDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -56,6 +58,7 @@ public class TransportGetDataSourceAction
       Task task,
       GetDataSourceActionRequest request,
       ActionListener<GetDataSourceActionResponse> actionListener) {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_GET_REQ_COUNT);
     try {
       String responseContent;
       if (request.getDataSourceName() == null) {

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceAction.java
@@ -19,6 +19,8 @@ import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.model.transport.PatchDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.PatchDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -57,6 +59,7 @@ public class TransportPatchDataSourceAction
       Task task,
       PatchDataSourceActionRequest request,
       ActionListener<PatchDataSourceActionResponse> actionListener) {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_PATCH_REQ_COUNT);
     try {
       dataSourceService.patchDataSource(request.getDataSourceData());
       String responseContent =

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceAction.java
@@ -18,6 +18,8 @@ import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.model.transport.UpdateDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.UpdateDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -56,6 +58,7 @@ public class TransportUpdateDataSourceAction
       Task task,
       UpdateDataSourceActionRequest request,
       ActionListener<UpdateDataSourceActionResponse> actionListener) {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_PUT_REQ_COUNT);
     try {
       dataSourceService.updateDataSource(request.getDataSourceMetadata());
       String responseContent =

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceActionTest.java
@@ -1,7 +1,9 @@
 package org.opensearch.sql.datasources.transport;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -21,11 +23,14 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.datasources.model.transport.CreateDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.CreateDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.esdomain.LocalClusterState;
+import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -56,6 +61,12 @@ public class TransportCreateDataSourceActionTest {
             transportService, new ActionFilters(new HashSet<>()), dataSourceService, settings);
     when(dataSourceService.getDataSourceMetadata(false).size()).thenReturn(1);
     when(settings.getSettingValue(DATASOURCES_LIMIT)).thenReturn(20);
+    // Required for metrics initialization
+    doReturn(emptyList()).when(settings).getSettings();
+    when(settings.getSettingValue(Settings.Key.METRICS_ROLLING_INTERVAL)).thenReturn(3600L);
+    when(settings.getSettingValue(Settings.Key.METRICS_ROLLING_WINDOW)).thenReturn(600L);
+    LocalClusterState.state().setPluginSettings(settings);
+    Metrics.getInstance().registerDefaultMetrics();
   }
 
   @Test

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceActionTest.java
@@ -1,8 +1,11 @@
 package org.opensearch.sql.datasources.transport;
 
+import static java.util.Collections.emptyList;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
 import org.junit.jupiter.api.Assertions;
@@ -16,9 +19,13 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasources.model.transport.DeleteDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.DeleteDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.esdomain.LocalClusterState;
+import org.opensearch.sql.legacy.metrics.Metrics;
+import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -31,6 +38,8 @@ public class TransportDeleteDataSourceActionTest {
   @Mock private Task task;
   @Mock private ActionListener<DeleteDataSourceActionResponse> actionListener;
 
+  @Mock private OpenSearchSettings settings;
+
   @Captor
   private ArgumentCaptor<DeleteDataSourceActionResponse>
       deleteDataSourceActionResponseArgumentCaptor;
@@ -42,6 +51,12 @@ public class TransportDeleteDataSourceActionTest {
     action =
         new TransportDeleteDataSourceAction(
             transportService, new ActionFilters(new HashSet<>()), dataSourceService);
+    // Required for metrics initialization
+    doReturn(emptyList()).when(settings).getSettings();
+    when(settings.getSettingValue(Settings.Key.METRICS_ROLLING_INTERVAL)).thenReturn(3600L);
+    when(settings.getSettingValue(Settings.Key.METRICS_ROLLING_WINDOW)).thenReturn(600L);
+    LocalClusterState.state().setPluginSettings(settings);
+    Metrics.getInstance().registerDefaultMetrics();
   }
 
   @Test

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceActionTest.java
@@ -1,5 +1,6 @@
 package org.opensearch.sql.datasources.transport;
 
+import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.*;
 import static org.opensearch.sql.datasources.utils.XContentParserUtils.*;
 
@@ -17,9 +18,13 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasources.model.transport.PatchDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.PatchDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.legacy.esdomain.LocalClusterState;
+import org.opensearch.sql.legacy.metrics.Metrics;
+import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -36,12 +41,19 @@ public class TransportPatchDataSourceActionTest {
   private ArgumentCaptor<PatchDataSourceActionResponse> patchDataSourceActionResponseArgumentCaptor;
 
   @Captor private ArgumentCaptor<Exception> exceptionArgumentCaptor;
+  @Mock private OpenSearchSettings settings;
 
   @BeforeEach
   public void setUp() {
     action =
         new TransportPatchDataSourceAction(
             transportService, new ActionFilters(new HashSet<>()), dataSourceService);
+    // Required for metrics initialization
+    doReturn(emptyList()).when(settings).getSettings();
+    when(settings.getSettingValue(Settings.Key.METRICS_ROLLING_INTERVAL)).thenReturn(3600L);
+    when(settings.getSettingValue(Settings.Key.METRICS_ROLLING_WINDOW)).thenReturn(600L);
+    LocalClusterState.state().setPluginSettings(settings);
+    Metrics.getInstance().registerDefaultMetrics();
   }
 
   @Test

--- a/legacy/src/main/java/org/opensearch/sql/legacy/metrics/MetricFactory.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/metrics/MetricFactory.java
@@ -27,6 +27,19 @@ public class MetricFactory {
       case PPL_REQ_COUNT_TOTAL:
       case PPL_FAILED_REQ_COUNT_CUS:
       case PPL_FAILED_REQ_COUNT_SYS:
+      case DATASOURCE_CREATION_REQ_COUNT:
+      case DATASOURCE_GET_REQ_COUNT:
+      case DATASOURCE_PUT_REQ_COUNT:
+      case DATASOURCE_PATCH_REQ_COUNT:
+      case DATASOURCE_DELETE_REQ_COUNT:
+      case DATASOURCE_FAILED_REQ_COUNT_SYS:
+      case DATASOURCE_FAILED_REQ_COUNT_CUS:
+      case EMR_GET_JOB_RESULT_FAILURE_COUNT:
+      case EMR_START_JOB_REQUEST_FAILURE_COUNT:
+      case EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT:
+      case EMR_BATCH_QUERY_JOBS_CREATION_COUNT:
+      case EMR_STREAMING_QUERY_JOBS_CREATION_COUNT:
+      case EMR_INTERACTIVE_QUERY_JOBS_CREATION_COUNT:
         return new NumericMetric<>(name.getName(), new RollingCounter());
       default:
         return new NumericMetric<>(name.getName(), new BasicCounter());

--- a/legacy/src/main/java/org/opensearch/sql/legacy/metrics/MetricName.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/metrics/MetricName.java
@@ -26,9 +26,19 @@ public enum MetricName {
   PPL_REQ_COUNT_TOTAL("ppl_request_count"),
   PPL_FAILED_REQ_COUNT_SYS("ppl_failed_request_count_syserr"),
   PPL_FAILED_REQ_COUNT_CUS("ppl_failed_request_count_cuserr"),
-  DATASOURCE_REQ_COUNT("datasource_request_count"),
+  DATASOURCE_CREATION_REQ_COUNT("datasource_create_request_count"),
+  DATASOURCE_GET_REQ_COUNT("datasource_get_request_count"),
+  DATASOURCE_PUT_REQ_COUNT("datasource_put_request_count"),
+  DATASOURCE_PATCH_REQ_COUNT("datasource_patch_request_count"),
+  DATASOURCE_DELETE_REQ_COUNT("datasource_delete_request_count"),
   DATASOURCE_FAILED_REQ_COUNT_SYS("datasource_failed_request_count_syserr"),
-  DATASOURCE_FAILED_REQ_COUNT_CUS("datasource_failed_request_count_cuserr");
+  DATASOURCE_FAILED_REQ_COUNT_CUS("datasource_failed_request_count_cuserr"),
+  EMR_START_JOB_REQUEST_FAILURE_COUNT("emr_start_job_request_failure_count"),
+  EMR_GET_JOB_RESULT_FAILURE_COUNT("emr_get_job_request_failure_count"),
+  EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT("emr_cancel_job_request_failure_count"),
+  EMR_STREAMING_QUERY_JOBS_CREATION_COUNT("emr_streaming_jobs_creation_count"),
+  EMR_INTERACTIVE_QUERY_JOBS_CREATION_COUNT("emr_interactive_jobs_creation_count"),
+  EMR_BATCH_QUERY_JOBS_CREATION_COUNT("emr_batch_jobs_creation_count");
 
   private String name;
 
@@ -50,6 +60,19 @@ public enum MetricName {
           .add(PPL_REQ_COUNT_TOTAL)
           .add(PPL_FAILED_REQ_COUNT_SYS)
           .add(PPL_FAILED_REQ_COUNT_CUS)
+          .add(DATASOURCE_CREATION_REQ_COUNT)
+          .add(DATASOURCE_DELETE_REQ_COUNT)
+          .add(DATASOURCE_FAILED_REQ_COUNT_CUS)
+          .add(DATASOURCE_GET_REQ_COUNT)
+          .add(DATASOURCE_PATCH_REQ_COUNT)
+          .add(DATASOURCE_FAILED_REQ_COUNT_SYS)
+          .add(DATASOURCE_PUT_REQ_COUNT)
+          .add(EMR_GET_JOB_RESULT_FAILURE_COUNT)
+          .add(EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT)
+          .add(EMR_START_JOB_REQUEST_FAILURE_COUNT)
+          .add(EMR_INTERACTIVE_QUERY_JOBS_CREATION_COUNT)
+          .add(EMR_STREAMING_QUERY_JOBS_CREATION_COUNT)
+          .add(EMR_BATCH_QUERY_JOBS_CREATION_COUNT)
           .build();
 
   public boolean isNumerical() {

--- a/legacy/src/main/java/org/opensearch/sql/legacy/utils/MetricUtils.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/utils/MetricUtils.java
@@ -1,0 +1,22 @@
+package org.opensearch.sql.legacy.utils;
+
+import lombok.experimental.UtilityClass;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.metrics.Metrics;
+
+/** Utility to add metrics. */
+@UtilityClass
+public class MetricUtils {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  public static void incrementNumericalMetric(MetricName metricName) {
+    try {
+      Metrics.getInstance().getNumericalMetric(metricName).increment();
+    } catch (Throwable throwable) {
+      LOG.error("Error while adding metric: {}", throwable.getMessage());
+    }
+  }
+}

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     api project(':core')
     implementation project(':protocol')
     implementation project(':datasources')
+    implementation project(':legacy')
 
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation group: 'org.json', name: 'json', version: '20231013'

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
@@ -85,6 +87,7 @@ public class BatchQueryHandler extends AsyncQueryHandler {
             false,
             dataSourceMetadata.getResultIndex());
     String jobId = emrServerlessClient.startJobRun(startJobRequest);
+    MetricUtils.incrementNumericalMetric(MetricName.EMR_BATCH_QUERY_JOBS_CREATION_COUNT);
     return new DispatchQueryResponse(
         context.getQueryId(), jobId, dataSourceMetadata.getResultIndex(), null);
   }

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
@@ -100,6 +102,7 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
                   tags,
                   dataSourceMetadata.getResultIndex(),
                   dataSourceMetadata.getName()));
+      MetricUtils.incrementNumericalMetric(MetricName.EMR_INTERACTIVE_QUERY_JOBS_CREATION_COUNT);
     }
     session.submit(
         new QueryRequest(

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
@@ -10,6 +10,8 @@ import static org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher.JOB_TYPE_
 
 import java.util.Map;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryId;
 import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
@@ -63,6 +65,7 @@ public class StreamingQueryHandler extends BatchQueryHandler {
             indexQueryDetails.isAutoRefresh(),
             dataSourceMetadata.getResultIndex());
     String jobId = emrServerlessClient.startJobRun(startJobRequest);
+    MetricUtils.incrementNumericalMetric(MetricName.EMR_STREAMING_QUERY_JOBS_CREATION_COUNT);
     return new DispatchQueryResponse(
         AsyncQueryId.newAsyncQueryId(dataSourceMetadata.getName()),
         jobId,

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
@@ -343,4 +343,18 @@ public class StateStore {
                         SessionModel.TYPE, FlintIndexStateModel.FLINT_INDEX_DOC_TYPE))
                 .must(QueryBuilders.termQuery(STATE, FlintIndexState.REFRESHING.getState())));
   }
+
+  public static Supplier<Long> activeStatementsCount(StateStore stateStore, String datasourceName) {
+    return () ->
+        stateStore.count(
+            DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName),
+            QueryBuilders.boolQuery()
+                .must(
+                    QueryBuilders.termQuery(StatementModel.TYPE, StatementModel.STATEMENT_DOC_TYPE))
+                .should(
+                    QueryBuilders.termsQuery(
+                        StatementModel.STATEMENT_STATE,
+                        StatementState.RUNNING.getState(),
+                        StatementState.WAITING.getState())));
+  }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
@@ -4,7 +4,9 @@
 
 package org.opensearch.sql.spark.client;
 
+import static java.util.Collections.emptyList;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.opensearch.sql.spark.constants.TestConstants.EMRS_APPLICATION_ID;
@@ -22,14 +24,30 @@ import com.amazonaws.services.emrserverless.model.StartJobRunResult;
 import com.amazonaws.services.emrserverless.model.ValidationException;
 import java.util.HashMap;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.legacy.esdomain.LocalClusterState;
+import org.opensearch.sql.legacy.metrics.Metrics;
+import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
 
 @ExtendWith(MockitoExtension.class)
 public class EmrServerlessClientImplTest {
   @Mock private AWSEMRServerless emrServerless;
+
+  @Mock private OpenSearchSettings settings;
+
+  @BeforeEach
+  public void setUp() {
+    doReturn(emptyList()).when(settings).getSettings();
+    when(settings.getSettingValue(Settings.Key.METRICS_ROLLING_INTERVAL)).thenReturn(3600L);
+    when(settings.getSettingValue(Settings.Key.METRICS_ROLLING_WINDOW)).thenReturn(600L);
+    LocalClusterState.state().setPluginSettings(settings);
+    Metrics.getInstance().registerDefaultMetrics();
+  }
 
   @Test
   void testStartJobRun() {
@@ -47,6 +65,25 @@ public class EmrServerlessClientImplTest {
             new HashMap<>(),
             false,
             null));
+  }
+
+  @Test
+  void testStartJobRunWithErrorMetric() {
+    doThrow(new RuntimeException()).when(emrServerless).startJobRun(any());
+    EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () ->
+            emrServerlessClient.startJobRun(
+                new StartJobRequest(
+                    QUERY,
+                    EMRS_JOB_NAME,
+                    EMRS_APPLICATION_ID,
+                    EMRS_EXECUTION_ROLE,
+                    SPARK_SUBMIT_PARAMETERS,
+                    new HashMap<>(),
+                    false,
+                    null)));
   }
 
   @Test
@@ -79,6 +116,15 @@ public class EmrServerlessClientImplTest {
   }
 
   @Test
+  void testGetJobRunStateWithErrorMetric() {
+    doThrow(new RuntimeException()).when(emrServerless).getJobRun(any());
+    EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> emrServerlessClient.getJobRunResult(EMRS_APPLICATION_ID, "123"));
+  }
+
+  @Test
   void testCancelJobRun() {
     when(emrServerless.cancelJobRun(any()))
         .thenReturn(new CancelJobRunResult().withJobRunId(EMR_JOB_ID));
@@ -86,6 +132,14 @@ public class EmrServerlessClientImplTest {
     CancelJobRunResult cancelJobRunResult =
         emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID);
     Assertions.assertEquals(EMR_JOB_ID, cancelJobRunResult.getJobRunId());
+  }
+
+  @Test
+  void testCancelJobRunWithErrorMetric() {
+    doThrow(new RuntimeException()).when(emrServerless).cancelJobRun(any());
+    EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
+    Assertions.assertThrows(
+        RuntimeException.class, () -> emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, "123"));
   }
 
   @Test


### PR DESCRIPTION
### Description
Added new metrics to stats API.
Below are the list of new metrics.
```
  DATASOURCE_CREATION_REQ_COUNT("datasource_create_request_count"),
  DATASOURCE_GET_REQ_COUNT("datasource_get_request_count"),
  DATASOURCE_PUT_REQ_COUNT("datasource_put_request_count"),
  DATASOURCE_PATCH_REQ_COUNT("datasource_patch_request_count"),
  DATASOURCE_DELETE_REQ_COUNT("datasource_delete_request_count"),
  DATASOURCE_FAILED_REQ_COUNT_SYS("datasource_failed_request_count_syserr"),
  DATASOURCE_FAILED_REQ_COUNT_CUS("datasource_failed_request_count_cuserr"),
  EMR_START_JOB_REQUEST_FAILURE_COUNT("emr_start_job_request_failure_count"),
  EMR_GET_JOB_RESULT_FAILURE_COUNT("emr_get_job_request_failure_count"),
  EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT("emr_cancel_job_request_failure_count"),
  EMR_STREAMING_QUERY_JOBS_CREATION_COUNT("emr_streaming_jobs_creation_count"),
  EMR_INTERACTIVE_QUERY_JOBS_CREATION_COUNT("emr_interactive_jobs_creation_count"),
  EMR_BATCH_QUERY_JOBS_CREATION_COUNT("emr_batch_jobs_creation_count"),
  ACTIVE_ASYNC_QUERY_SESSION_COUNT("active_async_query_session_count"),
  ACTIVE_ASYNC_QUERY_STATEMENT_COUNT("active_async_query_statement_count");
```
Basic Testing of stats API
```
{
emr_interactive_jobs_creation_count: 0,
default_cursor_request_count: 0,
default_cursor_request_total: 0,
ppl_failed_request_count_syserr: 0,
datasource_failed_request_count_cuserr: 0,
request_total: 0,
datasource_failed_request_count_syserr: 0,
datasource_delete_request_count: 0,
active_async_query_statement_count: 0,
failed_request_count_cb: 0,
datasource_patch_request_count: 0,
datasource_put_request_count: 0,
ppl_failed_request_count_cuserr: 0,
ppl_request_total: 0,
emr_streaming_jobs_creation_count: 0,
active_async_query_session_count: 0,
datasource_get_request_count: 0,
circuit_breaker: 0,
request_count: 0,
emr_cancel_job_request_failure_count: 0,
emr_batch_jobs_creation_count: 0,
emr_get_job_request_failure_count: 0,
failed_request_count_cuserr: 0,
emr_start_job_request_failure_count: 0,
ppl_request_count: 0,
failed_request_count_syserr: 0,
datasource_create_request_count: 0
}
```




 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).