### PR TITLE
Block execution engine settings in sql query settings API and add more unit tests

### DIFF
--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -328,7 +328,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-    sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings \
+    sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_cluster/settings \
     ... -d '{"transient":{"plugins.query.executionengine.spark.session.limit":200}}'
     {
       "acknowledged": true,
@@ -365,7 +365,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-    sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings \
+    sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_cluster/settings \
     ... -d '{"transient":{"plugins.query.executionengine.spark.refresh_job.limit":200}}'
     {
       "acknowledged": true,
@@ -402,7 +402,7 @@ You can update the setting with a new value like this.
 
 SQL query::
 
-    sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings \
+    sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_cluster/settings \
     ... -d '{"transient":{"plugins.query.datasources.limit":25}}'
     {
       "acknowledged": true,

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestQuerySettingsAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestQuerySettingsAction.java
@@ -39,6 +39,8 @@ public class RestQuerySettingsAction extends BaseRestHandler {
   private static final String LEGACY_SQL_SETTINGS_PREFIX = "opendistro.sql.";
   private static final String LEGACY_PPL_SETTINGS_PREFIX = "opendistro.ppl.";
   private static final String LEGACY_COMMON_SETTINGS_PREFIX = "opendistro.query.";
+  private static final String EXECUTION_ENGINE_SETTINGS_PREFIX = "plugins.query.executionengine";
+  public static final String DATASOURCES_SETTINGS_PREFIX = "plugins.query.datasources";
   private static final List<String> SETTINGS_PREFIX =
       ImmutableList.of(
           SQL_SETTINGS_PREFIX,
@@ -47,6 +49,9 @@ public class RestQuerySettingsAction extends BaseRestHandler {
           LEGACY_SQL_SETTINGS_PREFIX,
           LEGACY_PPL_SETTINGS_PREFIX,
           LEGACY_COMMON_SETTINGS_PREFIX);
+
+  private static final List<String> DENY_LIST_SETTINGS_PREFIX =
+      ImmutableList.of(EXECUTION_ENGINE_SETTINGS_PREFIX, DATASOURCES_SETTINGS_PREFIX);
 
   public static final String SETTINGS_API_ENDPOINT = "/_plugins/_query/settings";
   public static final String LEGACY_SQL_SETTINGS_API_ENDPOINT = "/_opendistro/_sql/settings";
@@ -133,6 +138,10 @@ public class RestQuerySettingsAction extends BaseRestHandler {
                 }
                 return true;
               });
+      // Applying DenyList Filter.
+      settingsBuilder
+          .keys()
+          .removeIf(key -> DENY_LIST_SETTINGS_PREFIX.stream().anyMatch(key::startsWith));
       return settingsBuilder.build();
     } catch (IOException e) {
       throw new OpenSearchGenerationException("Failed to generate [" + source + "]", e);

--- a/spark/src/test/java/org/opensearch/sql/spark/constants/TestConstants.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/constants/TestConstants.java
@@ -18,4 +18,7 @@ public class TestConstants {
   public static final String TEST_CLUSTER_NAME = "TEST_CLUSTER";
   public static final String MOCK_SESSION_ID = "s-0123456";
   public static final String MOCK_STATEMENT_ID = "st-0123456";
+  public static final String ENTRY_POINT_START_JAR =
+      "file:///home/hadoop/.ivy2/jars/org.opensearch_opensearch-spark-sql-application_2.12-0.1.0-SNAPSHOT.jar";
+  public static final String DEFAULT_RESULT_INDEX = "query_execution_result_ds1";
 }


### PR DESCRIPTION
### Description
Currently SQL Query Settings API acts as a backdoor for changing cluster settings specific to sql engine. We no longer require this for the new settings introduced for spark execution engine.  

New Settings Introduced.

```
plugins.query.datasources.encryption.masterkey
plugins.query.datasources.uri.hosts.denylist
plugins.query.executionengine.spark.config
plugins.query.executionengine.spark.session.limit
plugins.query.executionengine.spark.refresh_job.limit
plugins.query.executionengine.spark.session.index.ttl
plugins.query.executionengine.spark.result.index.ttl
plugins.query.executionengine.spark.auto_index_management.enabled
```

We also need to rethink the use cases of this API and deprecate if not required.[https://github.com/opensearch-project/sql/issues/2409]

This PR covers blocking execution engine settings.

Query Settings API Result before and after:
```
PUT {{baseUrl}}/_plugins/_query/settings
content-type: application/json

{
  "transient" : {
    "plugins.sql.enabled" : "false",
    "plugins.query.executionengine.spark.config" : "--conf spark.driverEnv.executors=2"
  }
}
```

```
{
  "acknowledged": true,
  "persistent": {},
  "transient": {
    "plugins": {
      "query": {
        "executionengine": {
          "spark": {
            "config": "--conf spark.driverEnv.executors=2"
          }
        }
      },
      "sql": {
        "enabled": "false"
      }
    }
  }
}
```
After the change.
```
PUT {{baseUrl}}/_plugins/_query/settings
content-type: application/json

{
  "transient" : {
    "plugins.sql.enabled" : "false",
    "plugins.query.executionengine.spark.config" : "--conf spark.driverEnv.executors=2",
    "plugins.query.datasources.uri.hosts.denylist": "127.001.1, 123.100.1"
  }
}
```
Response:
```
{
  "acknowledged": true,
  "persistent": {
    "plugins": {
      "sql": {
        "enabled": "false"
      }
    }
  },
  "transient": {}
}
```






 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/2382
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).