### PR TITLE
Create Result Index immediately after datasource creation.

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
@@ -276,8 +276,10 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
 
   private void handleException(Exception e, RestChannel restChannel) {
     if (e instanceof DataSourceNotFoundException) {
+      MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_CUS);
       reportError(restChannel, e, NOT_FOUND);
     } else if (e instanceof OpenSearchException) {
+      MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_SYS);
       OpenSearchException exception = (OpenSearchException) e;
       reportError(restChannel, exception, exception.status());
     } else {

--- a/legacy/src/main/java/org/opensearch/sql/legacy/metrics/MetricName.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/metrics/MetricName.java
@@ -33,6 +33,12 @@ public enum MetricName {
   DATASOURCE_DELETE_REQ_COUNT("datasource_delete_request_count"),
   DATASOURCE_FAILED_REQ_COUNT_SYS("datasource_failed_request_count_syserr"),
   DATASOURCE_FAILED_REQ_COUNT_CUS("datasource_failed_request_count_cuserr"),
+  ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_SYS("async_query_get_api_failed_request_count_syserr"),
+  ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_CUS("async_query_get_api_failed_request_count_cuserr"),
+  ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_SYS("async_query_create_api_failed_request_count_syserr"),
+  ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_CUS("async_query_create_api_failed_request_count_cuserr"),
+  ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_SYS("async_query_cancel_api_failed_request_count_syserr"),
+  ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_CUS("async_query_cancel_api_failed_request_count_cuserr"),
   EMR_START_JOB_REQUEST_FAILURE_COUNT("emr_start_job_request_failure_count"),
   EMR_GET_JOB_RESULT_FAILURE_COUNT("emr_get_job_request_failure_count"),
   EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT("emr_cancel_job_request_failure_count"),
@@ -73,6 +79,12 @@ public enum MetricName {
           .add(EMR_INTERACTIVE_QUERY_JOBS_CREATION_COUNT)
           .add(EMR_STREAMING_QUERY_JOBS_CREATION_COUNT)
           .add(EMR_BATCH_QUERY_JOBS_CREATION_COUNT)
+          .add(ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_CUS)
+          .add(ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_SYS)
+          .add(ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_CUS)
+          .add(ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_SYS)
+          .add(ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_CUS)
+          .add(ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_SYS)
           .build();
 
   public boolean isNumerical() {

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
@@ -17,7 +17,6 @@ import com.amazonaws.services.emrserverless.model.JobDriver;
 import com.amazonaws.services.emrserverless.model.SparkSubmit;
 import com.amazonaws.services.emrserverless.model.StartJobRunRequest;
 import com.amazonaws.services.emrserverless.model.StartJobRunResult;
-import com.amazonaws.services.emrserverless.model.ValidationException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import org.apache.logging.log4j.LogManager;
@@ -29,6 +28,8 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
 
   private final AWSEMRServerless emrServerless;
   private static final Logger logger = LogManager.getLogger(EmrServerlessClientImpl.class);
+
+  private static final String GENERIC_INTERNAL_SERVER_ERROR_MESSAGE = "Internal Server Error.";
 
   public EmrServerlessClientImpl(AWSEMRServerless emrServerless) {
     this.emrServerless = emrServerless;
@@ -62,9 +63,10 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
                   try {
                     return emrServerless.startJobRun(request);
                   } catch (Throwable t) {
+                    logger.error("Error while making start job request to emr:", t);
                     MetricUtils.incrementNumericalMetric(
                         MetricName.EMR_START_JOB_REQUEST_FAILURE_COUNT);
-                    throw t;
+                    throw new RuntimeException(GENERIC_INTERNAL_SERVER_ERROR_MESSAGE);
                   }
                 });
     logger.info("Job Run ID: " + startJobRunResult.getJobRunId());
@@ -82,9 +84,10 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
                   try {
                     return emrServerless.getJobRun(request);
                   } catch (Throwable t) {
+                    logger.error("Error while making get job run request to emr:", t);
                     MetricUtils.incrementNumericalMetric(
                         MetricName.EMR_GET_JOB_RESULT_FAILURE_COUNT);
-                    throw t;
+                    throw new RuntimeException(GENERIC_INTERNAL_SERVER_ERROR_MESSAGE);
                   }
                 });
     logger.info("Job Run state: " + getJobRunResult.getJobRun().getState());
@@ -95,24 +98,20 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
   public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
     CancelJobRunRequest cancelJobRunRequest =
         new CancelJobRunRequest().withJobRunId(jobId).withApplicationId(applicationId);
-    try {
-      CancelJobRunResult cancelJobRunResult =
-          AccessController.doPrivileged(
-              (PrivilegedAction<CancelJobRunResult>)
-                  () -> {
-                    try {
-                      return emrServerless.cancelJobRun(cancelJobRunRequest);
-                    } catch (Throwable t) {
-                      MetricUtils.incrementNumericalMetric(
-                          MetricName.EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT);
-                      throw t;
-                    }
-                  });
-      logger.info(String.format("Job : %s cancelled", cancelJobRunResult.getJobRunId()));
-      return cancelJobRunResult;
-    } catch (ValidationException e) {
-      throw new IllegalArgumentException(
-          String.format("Couldn't cancel the queryId: %s due to %s", jobId, e.getMessage()));
-    }
+    CancelJobRunResult cancelJobRunResult =
+        AccessController.doPrivileged(
+            (PrivilegedAction<CancelJobRunResult>)
+                () -> {
+                  try {
+                    return emrServerless.cancelJobRun(cancelJobRunRequest);
+                  } catch (Throwable t) {
+                    logger.error("Error while making cancel job request to emr:", t);
+                    MetricUtils.incrementNumericalMetric(
+                        MetricName.EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT);
+                    throw new RuntimeException(GENERIC_INTERNAL_SERVER_ERROR_MESSAGE);
+                  }
+                });
+    logger.info(String.format("Job : %s cancelled", cancelJobRunResult.getJobRunId()));
+    return cancelJobRunResult;
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
@@ -88,21 +88,23 @@ public class EmrServerlessClientImplTest {
 
   @Test
   void testStartJobRunWithErrorMetric() {
-    doThrow(new RuntimeException()).when(emrServerless).startJobRun(any());
+    doThrow(new ValidationException("Couldn't start job")).when(emrServerless).startJobRun(any());
     EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
-    Assertions.assertThrows(
-        RuntimeException.class,
-        () ->
-            emrServerlessClient.startJobRun(
-                new StartJobRequest(
-                    QUERY,
-                    EMRS_JOB_NAME,
-                    EMRS_APPLICATION_ID,
-                    EMRS_EXECUTION_ROLE,
-                    SPARK_SUBMIT_PARAMETERS,
-                    new HashMap<>(),
-                    false,
-                    null)));
+    RuntimeException runtimeException =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () ->
+                emrServerlessClient.startJobRun(
+                    new StartJobRequest(
+                        QUERY,
+                        EMRS_JOB_NAME,
+                        EMRS_APPLICATION_ID,
+                        EMRS_EXECUTION_ROLE,
+                        SPARK_SUBMIT_PARAMETERS,
+                        new HashMap<>(),
+                        false,
+                        null)));
+    Assertions.assertEquals("Internal Server Error.", runtimeException.getMessage());
   }
 
   @Test
@@ -136,11 +138,13 @@ public class EmrServerlessClientImplTest {
 
   @Test
   void testGetJobRunStateWithErrorMetric() {
-    doThrow(new RuntimeException()).when(emrServerless).getJobRun(any());
+    doThrow(new ValidationException("Not a good job")).when(emrServerless).getJobRun(any());
     EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
-    Assertions.assertThrows(
-        RuntimeException.class,
-        () -> emrServerlessClient.getJobRunResult(EMRS_APPLICATION_ID, "123"));
+    RuntimeException runtimeException =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> emrServerlessClient.getJobRunResult(EMRS_APPLICATION_ID, "123"));
+    Assertions.assertEquals("Internal Server Error.", runtimeException.getMessage());
   }
 
   @Test
@@ -165,13 +169,10 @@ public class EmrServerlessClientImplTest {
   void testCancelJobRunWithValidationException() {
     doThrow(new ValidationException("Error")).when(emrServerless).cancelJobRun(any());
     EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
-    IllegalArgumentException illegalArgumentException =
+    RuntimeException runtimeException =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
+            RuntimeException.class,
             () -> emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID));
-    Assertions.assertEquals(
-        "Couldn't cancel the queryId: job-123xxx due to Error (Service: null; Status Code: 0; Error"
-            + " Code: null; Request ID: null; Proxy: null)",
-        illegalArgumentException.getMessage());
+    Assertions.assertEquals("Internal Server Error.", runtimeException.getMessage());
   }
 }


### PR DESCRIPTION
### Description
* Create Result Index after create and update datasource calls.
* This would fix the below issue listed.
* Picked Mappings Yaml File from here: https://github.com/opensearch-project/opensearch-spark/blob/e5e3f873dae0db68e2a14fe903647bb394f25481/spark-sql-application/src/main/scala/org/apache/spark/sql/FlintJobExecutor.scala#L228
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/2268
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).