### PR TITLE
Add more metrics and handle emr exception message

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryAction.java
@@ -135,6 +135,7 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
 
   private RestChannelConsumer executePostRequest(RestRequest restRequest, NodeClient nodeClient)
       throws IOException {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_CREATION_REQ_COUNT);
     DataSourceMetadata dataSourceMetadata =
         XContentParserUtils.toDataSourceMetadata(restRequest.contentParser());
     return restChannel ->
@@ -163,6 +164,7 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
   }
 
   private RestChannelConsumer executeGetRequest(RestRequest restRequest, NodeClient nodeClient) {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_GET_REQ_COUNT);
     String dataSourceName = restRequest.param("dataSourceName");
     return restChannel ->
         Scheduler.schedule(
@@ -191,6 +193,7 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
 
   private RestChannelConsumer executeUpdateRequest(RestRequest restRequest, NodeClient nodeClient)
       throws IOException {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_PUT_REQ_COUNT);
     DataSourceMetadata dataSourceMetadata =
         XContentParserUtils.toDataSourceMetadata(restRequest.contentParser());
     return restChannel ->
@@ -220,6 +223,7 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
 
   private RestChannelConsumer executePatchRequest(RestRequest restRequest, NodeClient nodeClient)
       throws IOException {
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_PATCH_REQ_COUNT);
     Map<String, Object> dataSourceData = XContentParserUtils.toMap(restRequest.contentParser());
     return restChannel ->
         Scheduler.schedule(
@@ -247,7 +251,7 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
   }
 
   private RestChannelConsumer executeDeleteRequest(RestRequest restRequest, NodeClient nodeClient) {
-
+    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_DELETE_REQ_COUNT);
     String dataSourceName = restRequest.param("dataSourceName");
     return restChannel ->
         Scheduler.schedule(
@@ -276,8 +280,10 @@ public class RestDataSourceQueryAction extends BaseRestHandler {
 
   private void handleException(Exception e, RestChannel restChannel) {
     if (e instanceof DataSourceNotFoundException) {
+      MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_CUS);
       reportError(restChannel, e, NOT_FOUND);
     } else if (e instanceof OpenSearchException) {
+      MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_FAILED_REQ_COUNT_SYS);
       OpenSearchException exception = (OpenSearchException) e;
       reportError(restChannel, exception, exception.status());
     } else {

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceAction.java
@@ -20,8 +20,6 @@ import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasources.model.transport.CreateDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.CreateDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
-import org.opensearch.sql.legacy.metrics.MetricName;
-import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -62,7 +60,6 @@ public class TransportCreateDataSourceAction
       Task task,
       CreateDataSourceActionRequest request,
       ActionListener<CreateDataSourceActionResponse> actionListener) {
-    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_CREATION_REQ_COUNT);
     int dataSourceLimit = settings.getSettingValue(DATASOURCES_LIMIT);
     if (dataSourceService.getDataSourceMetadata(false).size() >= dataSourceLimit) {
       actionListener.onFailure(

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceAction.java
@@ -16,8 +16,6 @@ import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.model.transport.DeleteDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.DeleteDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
-import org.opensearch.sql.legacy.metrics.MetricName;
-import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
@@ -55,7 +53,6 @@ public class TransportDeleteDataSourceAction
       Task task,
       DeleteDataSourceActionRequest request,
       ActionListener<DeleteDataSourceActionResponse> actionListener) {
-    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_DELETE_REQ_COUNT);
     try {
       dataSourceService.deleteDataSource(request.getDataSourceName());
       actionListener.onResponse(

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceAction.java
@@ -18,8 +18,6 @@ import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasources.model.transport.GetDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.GetDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
-import org.opensearch.sql.legacy.metrics.MetricName;
-import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -58,7 +56,6 @@ public class TransportGetDataSourceAction
       Task task,
       GetDataSourceActionRequest request,
       ActionListener<GetDataSourceActionResponse> actionListener) {
-    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_GET_REQ_COUNT);
     try {
       String responseContent;
       if (request.getDataSourceName() == null) {

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceAction.java
@@ -19,8 +19,6 @@ import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.model.transport.PatchDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.PatchDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
-import org.opensearch.sql.legacy.metrics.MetricName;
-import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -59,7 +57,6 @@ public class TransportPatchDataSourceAction
       Task task,
       PatchDataSourceActionRequest request,
       ActionListener<PatchDataSourceActionResponse> actionListener) {
-    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_PATCH_REQ_COUNT);
     try {
       dataSourceService.patchDataSource(request.getDataSourceData());
       String responseContent =

--- a/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceAction.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceAction.java
@@ -18,8 +18,6 @@ import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.model.transport.UpdateDataSourceActionRequest;
 import org.opensearch.sql.datasources.model.transport.UpdateDataSourceActionResponse;
 import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
-import org.opensearch.sql.legacy.metrics.MetricName;
-import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -58,7 +56,6 @@ public class TransportUpdateDataSourceAction
       Task task,
       UpdateDataSourceActionRequest request,
       ActionListener<UpdateDataSourceActionResponse> actionListener) {
-    MetricUtils.incrementNumericalMetric(MetricName.DATASOURCE_PUT_REQ_COUNT);
     try {
       dataSourceService.updateDataSource(request.getDataSourceMetadata());
       String responseContent =

--- a/legacy/src/main/java/org/opensearch/sql/legacy/metrics/MetricName.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/metrics/MetricName.java
@@ -33,6 +33,15 @@ public enum MetricName {
   DATASOURCE_DELETE_REQ_COUNT("datasource_delete_request_count"),
   DATASOURCE_FAILED_REQ_COUNT_SYS("datasource_failed_request_count_syserr"),
   DATASOURCE_FAILED_REQ_COUNT_CUS("datasource_failed_request_count_cuserr"),
+  ASYNC_QUERY_CREATE_API_REQUEST_COUNT("async_query_create_api_request_count"),
+  ASYNC_QUERY_GET_API_REQUEST_COUNT("async_query_get_api_request_count"),
+  ASYNC_QUERY_CANCEL_API_REQUEST_COUNT("async_query_cancel_api_request_count"),
+  ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_SYS("async_query_get_api_failed_request_count_syserr"),
+  ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_CUS("async_query_get_api_failed_request_count_cuserr"),
+  ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_SYS("async_query_create_api_failed_request_count_syserr"),
+  ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_CUS("async_query_create_api_failed_request_count_cuserr"),
+  ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_SYS("async_query_cancel_api_failed_request_count_syserr"),
+  ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_CUS("async_query_cancel_api_failed_request_count_cuserr"),
   EMR_START_JOB_REQUEST_FAILURE_COUNT("emr_start_job_request_failure_count"),
   EMR_GET_JOB_RESULT_FAILURE_COUNT("emr_get_job_request_failure_count"),
   EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT("emr_cancel_job_request_failure_count"),
@@ -73,6 +82,15 @@ public enum MetricName {
           .add(EMR_INTERACTIVE_QUERY_JOBS_CREATION_COUNT)
           .add(EMR_STREAMING_QUERY_JOBS_CREATION_COUNT)
           .add(EMR_BATCH_QUERY_JOBS_CREATION_COUNT)
+          .add(ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_CUS)
+          .add(ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_SYS)
+          .add(ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_CUS)
+          .add(ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_SYS)
+          .add(ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_CUS)
+          .add(ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_SYS)
+          .add(ASYNC_QUERY_CREATE_API_REQUEST_COUNT)
+          .add(ASYNC_QUERY_GET_API_REQUEST_COUNT)
+          .add(ASYNC_QUERY_CANCEL_API_REQUEST_COUNT)
           .build();
 
   public boolean isNumerical() {

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
@@ -17,7 +17,6 @@ import com.amazonaws.services.emrserverless.model.JobDriver;
 import com.amazonaws.services.emrserverless.model.SparkSubmit;
 import com.amazonaws.services.emrserverless.model.StartJobRunRequest;
 import com.amazonaws.services.emrserverless.model.StartJobRunResult;
-import com.amazonaws.services.emrserverless.model.ValidationException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import org.apache.logging.log4j.LogManager;
@@ -29,6 +28,8 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
 
   private final AWSEMRServerless emrServerless;
   private static final Logger logger = LogManager.getLogger(EmrServerlessClientImpl.class);
+
+  private static final String GENERIC_INTERNAL_SERVER_ERROR_MESSAGE = "Internal Server Error.";
 
   public EmrServerlessClientImpl(AWSEMRServerless emrServerless) {
     this.emrServerless = emrServerless;
@@ -62,9 +63,10 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
                   try {
                     return emrServerless.startJobRun(request);
                   } catch (Throwable t) {
+                    logger.error("Error while making start job request to emr:", t);
                     MetricUtils.incrementNumericalMetric(
                         MetricName.EMR_START_JOB_REQUEST_FAILURE_COUNT);
-                    throw t;
+                    throw new RuntimeException(GENERIC_INTERNAL_SERVER_ERROR_MESSAGE);
                   }
                 });
     logger.info("Job Run ID: " + startJobRunResult.getJobRunId());
@@ -82,9 +84,10 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
                   try {
                     return emrServerless.getJobRun(request);
                   } catch (Throwable t) {
+                    logger.error("Error while making get job run request to emr:", t);
                     MetricUtils.incrementNumericalMetric(
                         MetricName.EMR_GET_JOB_RESULT_FAILURE_COUNT);
-                    throw t;
+                    throw new RuntimeException(GENERIC_INTERNAL_SERVER_ERROR_MESSAGE);
                   }
                 });
     logger.info("Job Run state: " + getJobRunResult.getJobRun().getState());
@@ -95,24 +98,20 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
   public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
     CancelJobRunRequest cancelJobRunRequest =
         new CancelJobRunRequest().withJobRunId(jobId).withApplicationId(applicationId);
-    try {
-      CancelJobRunResult cancelJobRunResult =
-          AccessController.doPrivileged(
-              (PrivilegedAction<CancelJobRunResult>)
-                  () -> {
-                    try {
-                      return emrServerless.cancelJobRun(cancelJobRunRequest);
-                    } catch (Throwable t) {
-                      MetricUtils.incrementNumericalMetric(
-                          MetricName.EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT);
-                      throw t;
-                    }
-                  });
-      logger.info(String.format("Job : %s cancelled", cancelJobRunResult.getJobRunId()));
-      return cancelJobRunResult;
-    } catch (ValidationException e) {
-      throw new IllegalArgumentException(
-          String.format("Couldn't cancel the queryId: %s due to %s", jobId, e.getMessage()));
-    }
+    CancelJobRunResult cancelJobRunResult =
+        AccessController.doPrivileged(
+            (PrivilegedAction<CancelJobRunResult>)
+                () -> {
+                  try {
+                    return emrServerless.cancelJobRun(cancelJobRunRequest);
+                  } catch (Throwable t) {
+                    logger.error("Error while making cancel job request to emr:", t);
+                    MetricUtils.incrementNumericalMetric(
+                        MetricName.EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT);
+                    throw new RuntimeException(GENERIC_INTERNAL_SERVER_ERROR_MESSAGE);
+                  }
+                });
+    logger.info(String.format("Job : %s cancelled", cancelJobRunResult.getJobRunId()));
+    return cancelJobRunResult;
   }
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/rest/RestAsyncQueryManagementAction.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/rest/RestAsyncQueryManagementAction.java
@@ -27,6 +27,8 @@ import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sql.datasources.exceptions.ErrorMessage;
 import org.opensearch.sql.datasources.utils.Scheduler;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.utils.MetricUtils;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryRequest;
 import org.opensearch.sql.spark.transport.TransportCancelAsyncQueryRequestAction;
 import org.opensearch.sql.spark.transport.TransportCreateAsyncQueryRequestAction;
@@ -110,6 +112,7 @@ public class RestAsyncQueryManagementAction extends BaseRestHandler {
 
   private RestChannelConsumer executePostRequest(RestRequest restRequest, NodeClient nodeClient)
       throws IOException {
+    MetricUtils.incrementNumericalMetric(MetricName.ASYNC_QUERY_CREATE_API_REQUEST_COUNT);
     CreateAsyncQueryRequest submitJobRequest =
         CreateAsyncQueryRequest.fromXContentParser(restRequest.contentParser());
     return restChannel ->
@@ -132,13 +135,14 @@ public class RestAsyncQueryManagementAction extends BaseRestHandler {
 
                       @Override
                       public void onFailure(Exception e) {
-                        handleException(e, restChannel);
+                        handleException(e, restChannel, restRequest.method());
                       }
                     }));
   }
 
   private RestChannelConsumer executeGetAsyncQueryResultRequest(
       RestRequest restRequest, NodeClient nodeClient) {
+    MetricUtils.incrementNumericalMetric(MetricName.ASYNC_QUERY_GET_API_REQUEST_COUNT);
     String queryId = restRequest.param("queryId");
     return restChannel ->
         Scheduler.schedule(
@@ -160,26 +164,31 @@ public class RestAsyncQueryManagementAction extends BaseRestHandler {
 
                       @Override
                       public void onFailure(Exception e) {
-                        handleException(e, restChannel);
+                        handleException(e, restChannel, restRequest.method());
                       }
                     }));
   }
 
-  private void handleException(Exception e, RestChannel restChannel) {
+  private void handleException(
+      Exception e, RestChannel restChannel, RestRequest.Method requestMethod) {
     if (e instanceof OpenSearchException) {
       OpenSearchException exception = (OpenSearchException) e;
       reportError(restChannel, exception, exception.status());
+      addCustomerErrorMetric(requestMethod);
     } else {
       LOG.error("Error happened during request handling", e);
       if (isClientError(e)) {
         reportError(restChannel, e, BAD_REQUEST);
+        addCustomerErrorMetric(requestMethod);
       } else {
         reportError(restChannel, e, SERVICE_UNAVAILABLE);
+        addSystemErrorMetric(requestMethod);
       }
     }
   }
 
   private RestChannelConsumer executeDeleteRequest(RestRequest restRequest, NodeClient nodeClient) {
+    MetricUtils.incrementNumericalMetric(MetricName.ASYNC_QUERY_CANCEL_API_REQUEST_COUNT);
     String queryId = restRequest.param("queryId");
     return restChannel ->
         Scheduler.schedule(
@@ -201,7 +210,7 @@ public class RestAsyncQueryManagementAction extends BaseRestHandler {
 
                       @Override
                       public void onFailure(Exception e) {
-                        handleException(e, restChannel);
+                        handleException(e, restChannel, restRequest.method());
                       }
                     }));
   }
@@ -213,5 +222,37 @@ public class RestAsyncQueryManagementAction extends BaseRestHandler {
 
   private static boolean isClientError(Exception e) {
     return e instanceof IllegalArgumentException || e instanceof IllegalStateException;
+  }
+
+  private void addSystemErrorMetric(RestRequest.Method requestMethod) {
+    switch (requestMethod) {
+      case POST:
+        MetricUtils.incrementNumericalMetric(
+            MetricName.ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_SYS);
+        break;
+      case GET:
+        MetricUtils.incrementNumericalMetric(MetricName.ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_SYS);
+        break;
+      case DELETE:
+        MetricUtils.incrementNumericalMetric(
+            MetricName.ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_SYS);
+        break;
+    }
+  }
+
+  private void addCustomerErrorMetric(RestRequest.Method requestMethod) {
+    switch (requestMethod) {
+      case POST:
+        MetricUtils.incrementNumericalMetric(
+            MetricName.ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_CUS);
+        break;
+      case GET:
+        MetricUtils.incrementNumericalMetric(MetricName.ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_CUS);
+        break;
+      case DELETE:
+        MetricUtils.incrementNumericalMetric(
+            MetricName.ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_CUS);
+        break;
+    }
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
@@ -88,21 +88,23 @@ public class EmrServerlessClientImplTest {
 
   @Test
   void testStartJobRunWithErrorMetric() {
-    doThrow(new RuntimeException()).when(emrServerless).startJobRun(any());
+    doThrow(new ValidationException("Couldn't start job")).when(emrServerless).startJobRun(any());
     EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
-    Assertions.assertThrows(
-        RuntimeException.class,
-        () ->
-            emrServerlessClient.startJobRun(
-                new StartJobRequest(
-                    QUERY,
-                    EMRS_JOB_NAME,
-                    EMRS_APPLICATION_ID,
-                    EMRS_EXECUTION_ROLE,
-                    SPARK_SUBMIT_PARAMETERS,
-                    new HashMap<>(),
-                    false,
-                    null)));
+    RuntimeException runtimeException =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () ->
+                emrServerlessClient.startJobRun(
+                    new StartJobRequest(
+                        QUERY,
+                        EMRS_JOB_NAME,
+                        EMRS_APPLICATION_ID,
+                        EMRS_EXECUTION_ROLE,
+                        SPARK_SUBMIT_PARAMETERS,
+                        new HashMap<>(),
+                        false,
+                        null)));
+    Assertions.assertEquals("Internal Server Error.", runtimeException.getMessage());
   }
 
   @Test
@@ -136,11 +138,13 @@ public class EmrServerlessClientImplTest {
 
   @Test
   void testGetJobRunStateWithErrorMetric() {
-    doThrow(new RuntimeException()).when(emrServerless).getJobRun(any());
+    doThrow(new ValidationException("Not a good job")).when(emrServerless).getJobRun(any());
     EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
-    Assertions.assertThrows(
-        RuntimeException.class,
-        () -> emrServerlessClient.getJobRunResult(EMRS_APPLICATION_ID, "123"));
+    RuntimeException runtimeException =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> emrServerlessClient.getJobRunResult(EMRS_APPLICATION_ID, "123"));
+    Assertions.assertEquals("Internal Server Error.", runtimeException.getMessage());
   }
 
   @Test
@@ -165,13 +169,10 @@ public class EmrServerlessClientImplTest {
   void testCancelJobRunWithValidationException() {
     doThrow(new ValidationException("Error")).when(emrServerless).cancelJobRun(any());
     EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
-    IllegalArgumentException illegalArgumentException =
+    RuntimeException runtimeException =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
+            RuntimeException.class,
             () -> emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID));
-    Assertions.assertEquals(
-        "Couldn't cancel the queryId: job-123xxx due to Error (Service: null; Status Code: 0; Error"
-            + " Code: null; Request ID: null; Proxy: null)",
-        illegalArgumentException.getMessage());
+    Assertions.assertEquals("Internal Server Error.", runtimeException.getMessage());
   }
 }


### PR DESCRIPTION
### Description


* Added below metrics.
```
ASYNC_QUERY_CREATE_API_REQUEST_COUNT("async_query_create_api_request_count"),
ASYNC_QUERY_GET_API_REQUEST_COUNT("async_query_get_api_request_count"),
ASYNC_QUERY_CANCEL_API_REQUEST_COUNT("async_query_cancel_api_request_count"),
ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_SYS("async_query_get_api_failed_request_count_syserr"),
ASYNC_QUERY_GET_API_FAILED_REQ_COUNT_CUS("async_query_get_api_failed_request_count_cuserr"),
ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_SYS("async_query_create_api_failed_request_count_syserr"),
ASYNC_QUERY_CREATE_API_FAILED_REQ_COUNT_CUS("async_query_create_api_failed_request_count_cuserr"),
ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_SYS("async_query_cancel_api_failed_request_count_syserr"),
ASYNC_QUERY_CANCEL_API_FAILED_REQ_COUNT_CUS("async_query_cancel_api_failed_request_count_cuserr"),
  ```
* Handled EMR Error Messages.
Rest Classes coverage is captured in this issue. https://github.com/opensearch-project/sql/issues/2410 
* Moved datasource metrics to REST Layer.
Stats API Result:
```
{
   "async_query_get_api_failed_request_count_cuserr":0,
   "emr_interactive_jobs_creation_count":0,
   "default_cursor_request_count":0,
   "async_query_create_api_failed_request_count_syserr":15,
   "async_query_cancel_api_failed_request_count_cuserr":0,
   "default_cursor_request_total":0,
   "ppl_failed_request_count_syserr":0,
   "datasource_failed_request_count_cuserr":0,
   "request_total":0,
   "datasource_failed_request_count_syserr":0,
   "datasource_delete_request_count":0,
   "failed_request_count_cb":0,
   "async_query_cancel_api_failed_request_count_syserr":5,
   "datasource_patch_request_count":0,
   "datasource_put_request_count":0,
   "ppl_failed_request_count_cuserr":0,
   "async_query_create_api_failed_request_count_cuserr":0,
   "active_async_query_sessions_count":0,
   "ppl_request_total":0,
   "emr_streaming_jobs_creation_count":0,
   "datasource_get_request_count":0,
   "circuit_breaker":0,
   "request_count":0,
   "async_query_get_api_failed_request_count_syserr":15,
   "emr_cancel_job_request_failure_count":0,
   "emr_batch_jobs_creation_count":0,
   "active_async_query_statements_count":0,
   "emr_get_job_request_failure_count":0,
   "async_query_create_api_request_count":15,
   "failed_request_count_cuserr":0,
   "async_query_get_api_request_count":15,
   "emr_start_job_request_failure_count":0,
   "ppl_request_count":0,
   "failed_request_count_syserr":0,
   "datasource_create_request_count":0,
   "async_query_cancel_api_request_count":5
}
```


### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).