### PR TITLE
[WIP][Prometheus] PrometheusClient use Labels API for "describe" resultset

### DIFF
--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClient.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClient.java
@@ -20,5 +20,7 @@ public interface PrometheusClient {
 
   Map<String, List<MetricMetadata>> getAllMetrics() throws IOException;
 
+  List<String> getAllSeriesLabels() throws IOException;
+
   JSONArray queryExemplars(String query, Long start, Long end) throws IOException;
 }

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
@@ -84,6 +84,17 @@ public class PrometheusClientImpl implements PrometheusClient {
   }
 
   @Override
+  public List<String> getAllSeriesLabels() throws IOException {
+    String queryUrl =
+        String.format("%s/api/v1/label/__name__/values", uri.toString().replaceAll("/$", ""));
+    logger.debug("queryUrl: " + queryUrl);
+    Request request = new Request.Builder().url(queryUrl).build();
+    Response response = this.okHttpClient.newCall(request).execute();
+    JSONObject jsonObject = readResponse(response);
+    return toListOfLabels(jsonObject.getJSONArray("data"));
+  }
+
+  @Override
   public JSONArray queryExemplars(String query, Long start, Long end) throws IOException {
     String queryUrl =
         String.format(

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/request/system/PrometheusListSeriesLabelsRequest.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/request/system/PrometheusListSeriesLabelsRequest.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *  * Copyright OpenSearch Contributors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.sql.prometheus.request.system;
+
+import static org.opensearch.sql.data.model.ExprValueUtils.stringValue;
+
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.sql.DataSourceSchemaName;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.prometheus.client.PrometheusClient;
+
+@RequiredArgsConstructor
+public class PrometheusListSeriesLabelsRequest implements PrometheusSystemRequest {
+
+  private final PrometheusClient prometheusClient;
+
+  private final DataSourceSchemaName dataSourceSchemaName;
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  @Override
+  public List<ExprValue> search() {
+    return AccessController.doPrivileged(
+        (PrivilegedAction<List<ExprValue>>)
+            () -> {
+              try {
+                List<String> result = prometheusClient.getAllSeriesLabels();
+                return result.stream()
+                    .map(
+                        label -> {
+                          return row(label, "gauge", "", "");
+                        })
+                    .collect(Collectors.toList());
+              } catch (IOException e) {
+                LOG.error(
+                    "Error while fetching metric list for from prometheus: {}", e.getMessage());
+                throw new RuntimeException(
+                    String.format(
+                        "Error while fetching metric list " + "for from prometheus: %s",
+                        e.getMessage()));
+              }
+            });
+  }
+
+  private ExprTupleValue row(String metricName, String tableType, String unit, String help) {
+    LinkedHashMap<String, ExprValue> valueMap = new LinkedHashMap<>();
+    valueMap.put("TABLE_CATALOG", stringValue(dataSourceSchemaName.getDataSourceName()));
+    valueMap.put("TABLE_SCHEMA", stringValue("default"));
+    valueMap.put("TABLE_NAME", stringValue(metricName));
+    valueMap.put("TABLE_TYPE", stringValue(tableType));
+    valueMap.put("UNIT", stringValue(unit));
+    valueMap.put("REMARKS", stringValue(help));
+    return new ExprTupleValue(valueMap);
+  }
+}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/client/PrometheusClientImplTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/client/PrometheusClientImplTest.java
@@ -168,6 +168,28 @@ public class PrometheusClientImplTest {
 
   @Test
   @SneakyThrows
+  void testGetSeriesLabels() {
+    MockResponse mockResponse =
+        new MockResponse()
+            .addHeader("Content-Type", "application/json; charset=utf-8")
+            .setBody(getJson("all_series_labels_response.json"));
+    mockWebServer.enqueue(mockResponse);
+    List<String> response = prometheusClient.getAllSeriesLabels();
+    List<String> expected =
+        new ArrayList<>() {
+          {
+            add("go_gc_duration_seconds");
+            add("test_usage");
+          }
+        };
+
+    assertEquals(expected, response);
+    RecordedRequest recordedRequest = mockWebServer.takeRequest();
+    verifyGetAllSeriesLabelsCall(recordedRequest);
+  }
+
+  @Test
+  @SneakyThrows
   void testQueryExemplars() {
     MockResponse mockResponse =
         new MockResponse()
@@ -202,6 +224,13 @@ public class PrometheusClientImplTest {
     assertNotNull(httpUrl);
     assertEquals("/api/v1/labels", httpUrl.encodedPath());
     assertEquals(METRIC_NAME, httpUrl.queryParameter("match[]"));
+  }
+
+  private void verifyGetAllSeriesLabelsCall(RecordedRequest recordedRequest) {
+    HttpUrl httpUrl = recordedRequest.getRequestUrl();
+    assertEquals("GET", recordedRequest.getMethod());
+    assertNotNull(httpUrl);
+    assertEquals("/api/v1/label/__name__/values", httpUrl.encodedPath());
   }
 
   private void verifyGetAllMetricsCall(RecordedRequest recordedRequest) {

--- a/prometheus/src/test/resources/all_series_labels_response.json
+++ b/prometheus/src/test/resources/all_series_labels_response.json
@@ -1,0 +1,7 @@
+{
+  "status": "success",
+  "data": [
+    "go_gc_duration_seconds",
+    "test_usage"
+  ]
+}


### PR DESCRIPTION
### Description
Modify PrometheusClient to use Prometheus Labels API for PPL "describe" results, instead of Prometheus "metadata" API.


Prometheus series will only produce a "metadata" record if the Prometheus server actively scrapes the configured metrics source server.

In the case of backfilling via `promtool tsdb create-blocks-from`, this scraping event does not occur.  In the case of development or test environment, this scraping event may never occur.

All series are exposed by the Prometheus Labels API, via  endpoint `/api/v1/label/__name__/values`.   Prometheus naming conventions can be used to determine the "unit" and "type" of each series.   This is the expected internal behaviour of the Prometheus service itself.

Use case : 
Script-generated backfill files are created, with content similar to :
```
# HELP test metric
# TYPE test gauge
test_usage{instance="2"} 8.723671517308066 1640995200
# EOF
 ```

Upon ingestion of this backfill via the cli `promtool tsdb create-blocks-from /tmp/test_usage_backfill.txt`, the series is visible in the Promethus Web UI (http://localhost:9090) via the "metrics browser".
Yet the series is not visible in the Metadata API (`/api/v1/metdata`).

This result is irrespective of any configuration in `prometheus.yml` for scraping, relabeling, or other configuration feautres.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).