### PR TITLE
Async Executor Service Depedencies Refactor

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlStatsAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlStatsAction.java
@@ -11,11 +11,14 @@ import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
@@ -24,6 +27,7 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.sql.common.utils.QueryContext;
 import org.opensearch.sql.legacy.executor.format.ErrorMessageFactory;
 import org.opensearch.sql.legacy.metrics.Metrics;
+import org.opensearch.threadpool.ThreadPool;
 
 /**
  * Currently this interface is for node level. Cluster level is coming up soon.
@@ -69,8 +73,11 @@ public class RestSqlStatsAction extends BaseRestHandler {
 
     try {
       return channel ->
-          channel.sendResponse(
-              new BytesRestResponse(RestStatus.OK, Metrics.getInstance().collectToJSON()));
+          schedule(
+              client,
+              () ->
+                  channel.sendResponse(
+                      new BytesRestResponse(RestStatus.OK, Metrics.getInstance().collectToJSON())));
     } catch (Exception e) {
       LOG.error("Failed during Query SQL STATS Action.", e);
 
@@ -90,5 +97,18 @@ public class RestSqlStatsAction extends BaseRestHandler {
         Arrays.asList(
             "sql", "flat", "separator", "_score", "_type", "_id", "newLine", "format", "sanitize"));
     return responseParams;
+  }
+
+  private void schedule(NodeClient client, Runnable task) {
+    ThreadPool threadPool = client.threadPool();
+    threadPool.schedule(withCurrentContext(task), new TimeValue(0), "sql-worker");
+  }
+
+  private Runnable withCurrentContext(final Runnable task) {
+    final Map<String, String> currentContext = ThreadContext.getImmutableContext();
+    return () -> {
+      ThreadContext.putAll(currentContext);
+      task.run();
+    };
   }
 }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLStatsAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLStatsAction.java
@@ -22,6 +22,7 @@ import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.sql.common.utils.QueryContext;
+import org.opensearch.sql.datasources.utils.Scheduler;
 import org.opensearch.sql.legacy.executor.format.ErrorMessageFactory;
 import org.opensearch.sql.legacy.metrics.Metrics;
 
@@ -67,8 +68,11 @@ public class RestPPLStatsAction extends BaseRestHandler {
 
     try {
       return channel ->
-          channel.sendResponse(
-              new BytesRestResponse(RestStatus.OK, Metrics.getInstance().collectToJSON()));
+          Scheduler.schedule(
+              client,
+              () ->
+                  channel.sendResponse(
+                      new BytesRestResponse(RestStatus.OK, Metrics.getInstance().collectToJSON())));
     } catch (Exception e) {
       LOG.error("Failed during Query PPL STATS Action.", e);
 

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClientFactory.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClientFactory.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.client;
+
+/** Factory interface for creating instances of {@link EMRServerlessClient}. */
+public interface EMRServerlessClientFactory {
+
+  /**
+   * Gets an instance of {@link EMRServerlessClient}.
+   *
+   * @return An {@link EMRServerlessClient} instance.
+   */
+  EMRServerlessClient getClient();
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.client;
+
+import static org.opensearch.sql.common.setting.Settings.Key.SPARK_EXECUTION_ENGINE_CONFIG;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.emrserverless.AWSEMRServerless;
+import com.amazonaws.services.emrserverless.AWSEMRServerlessClientBuilder;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
+import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
+
+/** Implementation of {@link EMRServerlessClientFactory}. */
+@RequiredArgsConstructor
+public class EMRServerlessClientFactoryImpl implements EMRServerlessClientFactory {
+
+  private final SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier;
+  private EMRServerlessClient emrServerlessClient;
+  private String region;
+
+  /**
+   * Gets an instance of {@link EMRServerlessClient}.
+   *
+   * @return An {@link EMRServerlessClient} instance.
+   */
+  @Override
+  public EMRServerlessClient getClient() {
+    SparkExecutionEngineConfig sparkExecutionEngineConfig =
+        this.sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig();
+    validateSparkExecutionEngineConfig(sparkExecutionEngineConfig);
+    if (isNewClientCreationRequired(sparkExecutionEngineConfig.getRegion())) {
+      region = sparkExecutionEngineConfig.getRegion();
+      this.emrServerlessClient = createEMRServerlessClient(this.region);
+    }
+    return this.emrServerlessClient;
+  }
+
+  private boolean isNewClientCreationRequired(String region) {
+    return !region.equals(this.region);
+  }
+
+  private void validateSparkExecutionEngineConfig(
+      SparkExecutionEngineConfig sparkExecutionEngineConfig) {
+    if (sparkExecutionEngineConfig == null || sparkExecutionEngineConfig.getRegion() == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Async Query APIs are disabled. Please configure %s in cluster settings to enable"
+                  + " them.",
+              SPARK_EXECUTION_ENGINE_CONFIG.getKeyValue()));
+    }
+  }
+
+  private EMRServerlessClient createEMRServerlessClient(String awsRegion) {
+    return AccessController.doPrivileged(
+        (PrivilegedAction<EMRServerlessClient>)
+            () -> {
+              AWSEMRServerless awsemrServerless =
+                  AWSEMRServerlessClientBuilder.standard()
+                      .withRegion(awsRegion)
+                      .withCredentials(new DefaultAWSCredentialsProviderChain())
+                      .build();
+              return new EmrServerlessClientImpl(awsemrServerless);
+            });
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/SessionManager.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/SessionManager.java
@@ -10,7 +10,7 @@ import static org.opensearch.sql.spark.execution.session.SessionId.newSessionId;
 
 import java.util.Optional;
 import org.opensearch.sql.common.setting.Settings;
-import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.utils.RealTimeProvider;
 
@@ -21,13 +21,15 @@ import org.opensearch.sql.spark.utils.RealTimeProvider;
  */
 public class SessionManager {
   private final StateStore stateStore;
-  private final EMRServerlessClient emrServerlessClient;
+  private final EMRServerlessClientFactory emrServerlessClientFactory;
   private Settings settings;
 
   public SessionManager(
-      StateStore stateStore, EMRServerlessClient emrServerlessClient, Settings settings) {
+      StateStore stateStore,
+      EMRServerlessClientFactory emrServerlessClientFactory,
+      Settings settings) {
     this.stateStore = stateStore;
-    this.emrServerlessClient = emrServerlessClient;
+    this.emrServerlessClientFactory = emrServerlessClientFactory;
     this.settings = settings;
   }
 
@@ -36,7 +38,7 @@ public class SessionManager {
         InteractiveSession.builder()
             .sessionId(newSessionId(request.getDatasourceName()))
             .stateStore(stateStore)
-            .serverlessClient(emrServerlessClient)
+            .serverlessClient(emrServerlessClientFactory.getClient())
             .build();
     session.open(request);
     return session;
@@ -68,7 +70,7 @@ public class SessionManager {
           InteractiveSession.builder()
               .sessionId(sid)
               .stateStore(stateStore)
-              .serverlessClient(emrServerlessClient)
+              .serverlessClient(emrServerlessClientFactory.getClient())
               .sessionModel(model.get())
               .sessionInactivityTimeoutMilli(
                   settings.getSettingValue(SESSION_INACTIVITY_TIMEOUT_MILLIS))

--- a/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.transport.config;
+
+import static org.opensearch.sql.spark.execution.statestore.StateStore.ALL_DATASOURCE;
+
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.AbstractModule;
+import org.opensearch.common.inject.Provides;
+import org.opensearch.common.inject.Singleton;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelperImpl;
+import org.opensearch.sql.legacy.metrics.GaugeMetric;
+import org.opensearch.sql.legacy.metrics.Metrics;
+import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorService;
+import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorServiceImpl;
+import org.opensearch.sql.spark.asyncquery.AsyncQueryJobMetadataStorageService;
+import org.opensearch.sql.spark.asyncquery.OpensearchAsyncQueryJobMetadataStorageService;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactoryImpl;
+import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
+import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplierImpl;
+import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
+import org.opensearch.sql.spark.execution.session.SessionManager;
+import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.flint.FlintIndexMetadataReaderImpl;
+import org.opensearch.sql.spark.leasemanager.DefaultLeaseManager;
+import org.opensearch.sql.spark.response.JobExecutionResponseReader;
+
+@RequiredArgsConstructor
+public class AsyncExecutorServiceModule extends AbstractModule {
+
+  @Override
+  protected void configure() {}
+
+  @Provides
+  public AsyncQueryExecutorService asyncQueryExecutorService(
+      AsyncQueryJobMetadataStorageService asyncQueryJobMetadataStorageService,
+      SparkQueryDispatcher sparkQueryDispatcher,
+      SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier) {
+    return new AsyncQueryExecutorServiceImpl(
+        asyncQueryJobMetadataStorageService,
+        sparkQueryDispatcher,
+        sparkExecutionEngineConfigSupplier);
+  }
+
+  @Provides
+  public AsyncQueryJobMetadataStorageService asyncQueryJobMetadataStorageService(
+      StateStore stateStore) {
+    return new OpensearchAsyncQueryJobMetadataStorageService(stateStore);
+  }
+
+  @Provides
+  @Singleton
+  public StateStore stateStore(NodeClient client, ClusterService clusterService) {
+    StateStore stateStore = new StateStore(client, clusterService);
+    registerStateStoreMetrics(stateStore);
+    return stateStore;
+  }
+
+  @Provides
+  public SparkQueryDispatcher sparkQueryDispatcher(
+      EMRServerlessClientFactory emrServerlessClientFactory,
+      DataSourceService dataSourceService,
+      DataSourceUserAuthorizationHelperImpl dataSourceUserAuthorizationHelper,
+      JobExecutionResponseReader jobExecutionResponseReader,
+      FlintIndexMetadataReaderImpl flintIndexMetadataReader,
+      NodeClient client,
+      SessionManager sessionManager,
+      DefaultLeaseManager defaultLeaseManager,
+      StateStore stateStore) {
+    return new SparkQueryDispatcher(
+        emrServerlessClientFactory,
+        dataSourceService,
+        dataSourceUserAuthorizationHelper,
+        jobExecutionResponseReader,
+        flintIndexMetadataReader,
+        client,
+        sessionManager,
+        defaultLeaseManager,
+        stateStore);
+  }
+
+  @Provides
+  public SessionManager sessionManager(
+      StateStore stateStore,
+      EMRServerlessClientFactory emrServerlessClientFactory,
+      Settings settings) {
+    return new SessionManager(stateStore, emrServerlessClientFactory, settings);
+  }
+
+  @Provides
+  public DefaultLeaseManager defaultLeaseManager(Settings settings, StateStore stateStore) {
+    return new DefaultLeaseManager(settings, stateStore);
+  }
+
+  @Provides
+  public EMRServerlessClientFactory createEMRServerlessClientFactory(
+      SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier) {
+    return new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
+  }
+
+  @Provides
+  public SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier(Settings settings) {
+    return new SparkExecutionEngineConfigSupplierImpl(settings);
+  }
+
+  @Provides
+  @Singleton
+  public FlintIndexMetadataReaderImpl flintIndexMetadataReader(NodeClient client) {
+    return new FlintIndexMetadataReaderImpl(client);
+  }
+
+  @Provides
+  public JobExecutionResponseReader jobExecutionResponseReader(NodeClient client) {
+    return new JobExecutionResponseReader(client);
+  }
+
+  @Provides
+  public DataSourceUserAuthorizationHelperImpl dataSourceUserAuthorizationHelper(
+      NodeClient client) {
+    return new DataSourceUserAuthorizationHelperImpl(client);
+  }
+
+  private void registerStateStoreMetrics(StateStore stateStore) {
+    GaugeMetric<Long> activeSessionMetric =
+        new GaugeMetric<>(
+            "active_async_query_sessions_count",
+            StateStore.activeSessionsCount(stateStore, ALL_DATASOURCE));
+    GaugeMetric<Long> activeStatementMetric =
+        new GaugeMetric<>(
+            "active_async_query_statements_count",
+            StateStore.activeStatementsCount(stateStore, ALL_DATASOURCE));
+    Metrics.getInstance().registerMetric(activeSessionMetric);
+    Metrics.getInstance().registerMetric(activeStatementMetric);
+  }
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
@@ -32,6 +32,7 @@ import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.session.SessionId;
 import org.opensearch.sql.spark.execution.session.SessionState;
 import org.opensearch.sql.spark.execution.statement.StatementModel;
@@ -46,8 +47,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Disabled("batch query is unsupported")
   public void withoutSessionCreateAsyncQueryThenGetResultThenCancel() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // disable session
     enableSession(false);
@@ -74,8 +76,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Disabled("batch query is unsupported")
   public void sessionLimitNotImpactBatchQuery() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // disable session
     enableSession(false);
@@ -96,8 +99,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Disabled("batch query is unsupported")
   public void createAsyncQueryCreateJobWithCorrectParameters() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     enableSession(false);
     CreateAsyncQueryResponse response =
@@ -129,8 +133,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void withSessionCreateAsyncQueryThenGetResultThenCancel() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // 1. create async query.
     CreateAsyncQueryResponse response =
@@ -156,8 +161,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void reuseSessionWhenCreateAsyncQuery() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -207,8 +213,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Disabled("batch query is unsupported")
   public void batchQueryHasTimeout() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     enableSession(false);
     CreateAsyncQueryResponse response =
@@ -221,8 +228,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void interactiveQueryNoTimeout() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -255,8 +263,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             properties,
             null));
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -274,8 +283,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void withSessionCreateAsyncQueryFailed() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -322,8 +332,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void createSessionMoreThanLimitFailed() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -351,8 +362,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void recreateSessionIfNotReady() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -388,8 +400,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void submitQueryWithDifferentDataSourceSessionWillCreateNewSession() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -426,8 +439,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void recreateSessionIfStale() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -480,8 +494,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void submitQueryInInvalidSessionWillCreateNewSession() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -516,8 +531,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             null));
 
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // enable session
     enableSession(true);
@@ -536,8 +552,9 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
   @Test
   public void concurrentSessionLimitIsDomainLevel() {
     LocalEMRSClient emrsClient = new LocalEMRSClient();
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(emrsClient);
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // only allow one session in domain.
     setSessionLimit(1);

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
@@ -187,20 +187,6 @@ public class AsyncQueryExecutorServiceImplTest {
   }
 
   @Test
-  void testGetAsyncQueryResultsWithDisabledExecutionEngine() {
-    AsyncQueryExecutorService asyncQueryExecutorService = new AsyncQueryExecutorServiceImpl();
-    IllegalArgumentException illegalArgumentException =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> asyncQueryExecutorService.getAsyncQueryResults(EMR_JOB_ID));
-    Assertions.assertEquals(
-        "Async Query APIs are disabled as plugins.query.executionengine.spark.config is not"
-            + " configured in cluster settings. Please configure the setting and restart the domain"
-            + " to enable Async Query APIs",
-        illegalArgumentException.getMessage());
-  }
-
-  @Test
   void testCancelJobWithJobNotFound() {
     when(asyncQueryJobMetadataStorageService.getJobMetadata(EMR_JOB_ID))
         .thenReturn(Optional.empty());

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
@@ -26,6 +26,7 @@ import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.sql.protocol.response.format.ResponseFormatter;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryResult;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statement.StatementModel;
 import org.opensearch.sql.spark.execution.statement.StatementState;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
@@ -411,9 +412,10 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
     private Interaction interaction;
 
     AssertionHelper(String query, LocalEMRSClient emrClient) {
+      EMRServerlessClientFactory emrServerlessClientFactory = () -> emrClient;
       this.queryService =
           createAsyncQueryExecutorService(
-              emrClient,
+              emrServerlessClientFactory,
               /*
                * Custom reader that intercepts get results call and inject extra steps defined in
                * current interaction. Intercept both get methods for different query handler which

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -12,6 +12,8 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
+import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.flint.FlintIndexState;
 import org.opensearch.sql.spark.flint.FlintIndexType;
 import org.opensearch.sql.spark.leasemanager.ConcurrencyLimitExceededException;
@@ -72,9 +74,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return new GetJobRunResult().withJobRun(new JobRun().withState("Cancelled"));
                     }
                   };
-
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -120,8 +128,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       throw new IllegalArgumentException("Job run is not in a cancellable state");
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -157,8 +172,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return new GetJobRunResult().withJobRun(new JobRun().withState("Running"));
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -193,9 +215,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return new GetJobRunResult().withJobRun(new JobRun().withState("Cancelled"));
                     }
                   };
-
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -248,8 +276,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       throw new IllegalArgumentException("Job run is not in a cancellable state");
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -290,8 +325,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return new GetJobRunResult().withJobRun(new JobRun().withState("Running"));
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -331,8 +373,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return new GetJobRunResult().withJobRun(new JobRun().withState("Cancelled"));
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -380,8 +429,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return null;
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -424,8 +480,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return null;
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -468,8 +531,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return null;
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -517,8 +587,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return null;
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -565,8 +642,15 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       return null;
                     }
                   };
+              EMRServerlessClientFactory emrServerlessClientFactory =
+                  new EMRServerlessClientFactory() {
+                    @Override
+                    public EMRServerlessClient getClient() {
+                      return emrsClient;
+                    }
+                  };
               AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrsClient);
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
 
               // Mock flint index
               mockDS.createIndex();
@@ -586,8 +670,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
   @Test
   public void concurrentRefreshJobLimitNotApplied() {
+    EMRServerlessClientFactory emrServerlessClientFactory = new LocalEMRServerlessClientFactory();
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(new LocalEMRSClient());
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     // Mock flint index
     COVERING.createIndex();
@@ -607,8 +692,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
   @Test
   public void concurrentRefreshJobLimitAppliedToDDLWithAuthRefresh() {
+    EMRServerlessClientFactory emrServerlessClientFactory = new LocalEMRServerlessClientFactory();
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(new LocalEMRSClient());
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     setConcurrentRefreshJob(1);
 
@@ -633,8 +719,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
   @Test
   public void concurrentRefreshJobLimitAppliedToRefresh() {
+    EMRServerlessClientFactory emrServerlessClientFactory = new LocalEMRServerlessClientFactory();
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(new LocalEMRSClient());
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     setConcurrentRefreshJob(1);
 
@@ -658,9 +745,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
   @Test
   public void concurrentRefreshJobLimitNotAppliedToDDL() {
     String query = "CREATE INDEX covering ON mys3.default.http_logs(l_orderkey, l_quantity)";
-
+    EMRServerlessClientFactory emrServerlessClientFactory = new LocalEMRServerlessClientFactory();
     AsyncQueryExecutorService asyncQueryExecutorService =
-        createAsyncQueryExecutorService(new LocalEMRSClient());
+        createAsyncQueryExecutorService(emrServerlessClientFactory);
 
     setConcurrentRefreshJob(1);
 

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImplTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.client;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
+import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
+import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
+import org.opensearch.sql.spark.constants.TestConstants;
+
+@ExtendWith(MockitoExtension.class)
+public class EMRServerlessClientFactoryImplTest {
+
+  @Mock private SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier;
+
+  @Test
+  public void testGetClient() {
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig())
+        .thenReturn(createSparkExecutionEngineConfig());
+    EMRServerlessClientFactory emrServerlessClientFactory =
+        new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
+    EMRServerlessClient emrserverlessClient = emrServerlessClientFactory.getClient();
+    Assertions.assertNotNull(emrserverlessClient);
+  }
+
+  @Test
+  public void testGetClientWithChangeInSetting() {
+    SparkExecutionEngineConfig sparkExecutionEngineConfig = createSparkExecutionEngineConfig();
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig())
+        .thenReturn(sparkExecutionEngineConfig);
+    EMRServerlessClientFactory emrServerlessClientFactory =
+        new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
+    EMRServerlessClient emrserverlessClient = emrServerlessClientFactory.getClient();
+    Assertions.assertNotNull(emrserverlessClient);
+
+    EMRServerlessClient emrServerlessClient1 = emrServerlessClientFactory.getClient();
+    Assertions.assertEquals(emrServerlessClient1, emrserverlessClient);
+
+    sparkExecutionEngineConfig.setRegion(TestConstants.US_WEST_REGION);
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig())
+        .thenReturn(sparkExecutionEngineConfig);
+    EMRServerlessClient emrServerlessClient2 = emrServerlessClientFactory.getClient();
+    Assertions.assertNotEquals(emrServerlessClient2, emrserverlessClient);
+    Assertions.assertNotEquals(emrServerlessClient2, emrServerlessClient1);
+  }
+
+  @Test
+  public void testGetClientWithException() {
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig()).thenReturn(null);
+    EMRServerlessClientFactory emrServerlessClientFactory =
+        new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, emrServerlessClientFactory::getClient);
+    Assertions.assertEquals(
+        "Async Query APIs are disabled. Please configure plugins.query.executionengine.spark.config"
+            + " in cluster settings to enable them.",
+        illegalArgumentException.getMessage());
+  }
+
+  @Test
+  public void testGetClientWithExceptionWithNullRegion() {
+    SparkExecutionEngineConfig sparkExecutionEngineConfig = new SparkExecutionEngineConfig();
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig())
+        .thenReturn(sparkExecutionEngineConfig);
+    EMRServerlessClientFactory emrServerlessClientFactory =
+        new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, emrServerlessClientFactory::getClient);
+    Assertions.assertEquals(
+        "Async Query APIs are disabled. Please configure plugins.query.executionengine.spark.config"
+            + " in cluster settings to enable them.",
+        illegalArgumentException.getMessage());
+  }
+
+  private SparkExecutionEngineConfig createSparkExecutionEngineConfig() {
+    SparkExecutionEngineConfig sparkExecutionEngineConfig = new SparkExecutionEngineConfig();
+    sparkExecutionEngineConfig.setRegion(TestConstants.US_EAST_REGION);
+    sparkExecutionEngineConfig.setExecutionRoleARN(TestConstants.EMRS_EXECUTION_ROLE);
+    sparkExecutionEngineConfig.setSparkSubmitParameters(
+        SparkSubmitParameters.Builder.builder().build().toString());
+    sparkExecutionEngineConfig.setClusterName(TestConstants.TEST_CLUSTER_NAME);
+    sparkExecutionEngineConfig.setApplicationId(TestConstants.EMRS_APPLICATION_ID);
+    return sparkExecutionEngineConfig;
+  }
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/constants/TestConstants.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/constants/TestConstants.java
@@ -21,4 +21,6 @@ public class TestConstants {
   public static final String ENTRY_POINT_START_JAR =
       "file:///home/hadoop/.ivy2/jars/org.opensearch_opensearch-spark-sql-application_2.12-0.1.0-SNAPSHOT.jar";
   public static final String DEFAULT_RESULT_INDEX = "query_execution_result_ds1";
+  public static final String US_EAST_REGION = "us-east-1";
+  public static final String US_WEST_REGION = "us-west-1";
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -62,6 +62,7 @@ import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelperImpl
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryId;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
@@ -82,6 +83,7 @@ import org.opensearch.sql.spark.rest.model.LangType;
 public class SparkQueryDispatcherTest {
 
   @Mock private EMRServerlessClient emrServerlessClient;
+  @Mock private EMRServerlessClientFactory emrServerlessClientFactory;
   @Mock private DataSourceService dataSourceService;
   @Mock private JobExecutionResponseReader jobExecutionResponseReader;
   @Mock private DataSourceUserAuthorizationHelperImpl dataSourceUserAuthorizationHelper;
@@ -112,7 +114,7 @@ public class SparkQueryDispatcherTest {
   void setUp() {
     sparkQueryDispatcher =
         new SparkQueryDispatcher(
-            emrServerlessClient,
+            emrServerlessClientFactory,
             dataSourceService,
             dataSourceUserAuthorizationHelper,
             jobExecutionResponseReader,
@@ -121,6 +123,7 @@ public class SparkQueryDispatcherTest {
             sessionManager,
             leaseManager,
             stateStore);
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
   }
 
   @Test

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/InteractiveSessionTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/InteractiveSessionTest.java
@@ -23,6 +23,7 @@ import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -117,8 +118,9 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void sessionManagerCreateSession() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
 
     TestSession testSession = testSession(session, stateStore);
@@ -127,7 +129,9 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void sessionManagerGetSession() {
-    SessionManager sessionManager = new SessionManager(stateStore, emrsClient, sessionSetting());
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    SessionManager sessionManager =
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting());
     Session session = sessionManager.createSession(createSessionRequest());
 
     Optional<Session> managerSession = sessionManager.getSession(session.getSessionId());
@@ -137,7 +141,9 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void sessionManagerGetSessionNotExist() {
-    SessionManager sessionManager = new SessionManager(stateStore, emrsClient, sessionSetting());
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    SessionManager sessionManager =
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting());
 
     Optional<Session> managerSession =
         sessionManager.getSession(SessionId.newSessionId("no-exist"));

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/SessionManagerTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/SessionManagerTest.java
@@ -14,17 +14,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.common.setting.Settings;
-import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 
 @ExtendWith(MockitoExtension.class)
 public class SessionManagerTest {
   @Mock private StateStore stateStore;
-  @Mock private EMRServerlessClient emrClient;
+
+  @Mock private EMRServerlessClientFactory emrServerlessClientFactory;
 
   @Test
   public void sessionEnable() {
-    Assertions.assertTrue(new SessionManager(stateStore, emrClient, sessionSetting()).isEnabled());
+    Assertions.assertTrue(
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting()).isEnabled());
   }
 
   public static org.opensearch.sql.common.setting.Settings sessionSetting() {

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/statement/StatementTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/statement/StatementTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryId;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.session.InteractiveSessionTest;
 import org.opensearch.sql.spark.execution.session.Session;
 import org.opensearch.sql.spark.execution.session.SessionId;
@@ -258,8 +259,9 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
   @Test
   public void submitStatementInRunningSession() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
 
     // App change state to running
@@ -271,8 +273,9 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
   @Test
   public void submitStatementInNotStartedState() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
 
     StatementId statementId = session.submit(queryRequest());
@@ -281,8 +284,9 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
   @Test
   public void failToSubmitStatementInDeadState() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
 
     updateSessionState(stateStore, DS_NAME).apply(session.getSessionModel(), SessionState.DEAD);
@@ -297,8 +301,9 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
   @Test
   public void failToSubmitStatementInFailState() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
 
     updateSessionState(stateStore, DS_NAME).apply(session.getSessionModel(), SessionState.FAIL);
@@ -313,8 +318,9 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
   @Test
   public void newStatementFieldAssert() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
     StatementId statementId = session.submit(queryRequest());
     Optional<Statement> statement = session.get(statementId);
@@ -331,8 +337,9 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
   @Test
   public void failToSubmitStatementInDeletedSession() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
 
     // other's delete session
@@ -347,8 +354,9 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
   @Test
   public void getStatementSuccess() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
     // App change state to running
     updateSessionState(stateStore, DS_NAME).apply(session.getSessionModel(), SessionState.RUNNING);
@@ -362,8 +370,9 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
   @Test
   public void getStatementNotExist() {
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     Session session =
-        new SessionManager(stateStore, emrsClient, sessionSetting())
+        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
             .createSession(createSessionRequest());
     // App change state to running
     updateSessionState(stateStore, DS_NAME).apply(session.getSessionModel(), SessionState.RUNNING);

--- a/spark/src/test/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModuleTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModuleTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.transport.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Injector;
+import org.opensearch.common.inject.ModulesBuilder;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.legacy.metrics.Metrics;
+import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorService;
+
+@ExtendWith(MockitoExtension.class)
+public class AsyncExecutorServiceModuleTest {
+
+  @Mock private NodeClient nodeClient;
+
+  @Mock private ClusterService clusterService;
+
+  @Mock private Settings settings;
+
+  @Mock private DataSourceService dataSourceService;
+
+  @Test
+  public void testAsyncQueryExecutorService() {
+    ModulesBuilder modulesBuilder = new ModulesBuilder();
+    modulesBuilder.add(new AsyncExecutorServiceModule());
+    modulesBuilder.add(
+        b -> {
+          b.bind(NodeClient.class).toInstance(nodeClient);
+          b.bind(org.opensearch.sql.common.setting.Settings.class).toInstance(settings);
+          b.bind(DataSourceService.class).toInstance(dataSourceService);
+          b.bind(ClusterService.class).toInstance(clusterService);
+        });
+    Injector injector = modulesBuilder.createInjector();
+    assertNotNull(injector.getInstance(AsyncQueryExecutorService.class));
+    assertNotNull(Metrics.getInstance().getMetric("active_async_query_sessions_count"));
+    assertNotNull(Metrics.getInstance().getMetric("active_async_query_statements_count"));
+  }
+}


### PR DESCRIPTION
### Description
* Restructured the instantiation of AsyncQueryExecutorService using the Guice framework.

* Substituted the usage of EMRServerlessClient with EMRServerlessClientFactory. This modification helps prevent unnecessary errors and warnings during the plugin bootstrapping phase, particularly when constructing EMRServerlessClient using SparkExecutionEngineConfig.

* Previously, updating the Spark execution engine cluster configuration necessitated a system restart. With the current implementation, the recreation of EMRServerlessClient upon any cluster setting update eliminates the need for a restart.

* statement count and session count metrics are blocking operations as they make calls to opensearch index. So, we are moving stats operations to thread pool instead of processing on Transport thread.
 
### Issues Resolved
* https://github.com/opensearch-project/sql/issues/2434
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).