### PR TITLE
Add data source stats by type

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceMetadataStorage.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceMetadataStorage.java
@@ -8,6 +8,7 @@
 package org.opensearch.sql.datasources.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.opensearch.sql.datasource.model.DataSource;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
@@ -25,6 +26,8 @@ public interface DataSourceMetadataStorage {
    * @return list of {@link DataSourceMetadata}.
    */
   List<DataSourceMetadata> getDataSourceMetadata();
+
+  Map<String, Long> countDataSourcesPerConnector();
 
   /**
    * Gets {@link DataSourceMetadata} corresponding to the datasourceName from underlying storage.

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
@@ -252,6 +252,11 @@ public class StandaloneIT extends PPLIntegTestCase {
       }
 
       @Override
+      public Map<String, Long> countDataSourcesPerConnector() {
+        return Collections.emptyMap();
+      }
+
+      @Override
       public Optional<DataSourceMetadata> getDataSourceMetadata(String datasourceName) {
         return Optional.empty();
       }


### PR DESCRIPTION
### Description

* Add data_counts_by_connector_type metric into the plugins, exposed via /stats API

```
BUILD SUCCESSFUL in 19m 37s
172 actionable tasks: 115 executed, 57 up-to-date
```

Usage:

1. Empty state
```
curl localhost:9200/_plugins/_ppl/stats
{"active_data_sources_count":{} ... }
```
2. Create several data sources
```
curl --request POST \
  --url localhost:9200/_plugins/_query/_datasources \
  --header 'content-type: application/x-ndjson' \
  --data '{"name": "mys5","description": "","connector": "SPARK","allowedRoles": [],"properties": {"glue.auth.type": "iam_role","glue.auth.role_arn": "arn:aws:iam::123456:role/flint-opensearch-role","glue.indexstore.opensearch.uri": "http://localhost:9200","glue.indexstore.opensearch.auth": "noauth"}}'
``` 

3. Run stats API again
```
curl localhost:9200/_plugins/_ppl/stats
{"active_data_sources_count":{"OPENSEARCH":1,"S3GLUE":4}
```

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).