### PR TITLE
Bump aws-java-sdk-core version to 1.12.651

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ buildscript {
         getPrometheusBinaryLocation = { ->
             return "https://github.com/prometheus/prometheus/releases/download/v${prometheus_binary_version}/prometheus-${prometheus_binary_version}."+ getOSFamilyType() + "-" + getArchType() + ".tar.gz"
         }
+        aws_java_sdk_version = "1.12.651"
     }
 
     repositories {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
     implementation 'com.github.babbel:okhttp-aws-signer:1.0.2'
-    api group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.12.545'
-    api group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.12.545'
+    api group: 'com.amazonaws', name: 'aws-java-sdk-core', version: "${aws_java_sdk_version}"
+    api group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: "${aws_java_sdk_version}"
     implementation "com.github.seancfoley:ipaddress:5.4.0"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -165,7 +165,7 @@ configurations.all {
     resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10"
     resolutionStrategy.force "joda-time:joda-time:2.10.12"
     resolutionStrategy.force "org.slf4j:slf4j-api:1.7.36"
-    resolutionStrategy.force "com.amazonaws:aws-java-sdk-core:1.12.545"
+    resolutionStrategy.force "com.amazonaws:aws-java-sdk-core:${aws_java_sdk_version}"
 }
 
 configurations {

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -49,8 +49,8 @@ dependencies {
 
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation group: 'org.json', name: 'json', version: '20231013'
-    api group: 'com.amazonaws', name: 'aws-java-sdk-emr', version: '1.12.545'
-    api group: 'com.amazonaws', name: 'aws-java-sdk-emrserverless', version: '1.12.545'
+    api group: 'com.amazonaws', name: 'aws-java-sdk-emr', version: "${aws_java_sdk_version}"
+    api group: 'com.amazonaws', name: 'aws-java-sdk-emrserverless', version: "${aws_java_sdk_version}"
     implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
     testImplementation(platform("org.junit:junit-bom:5.9.3"))


### PR DESCRIPTION
### Description
Bump aws-java-sdk-core version to 1.12.651
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/2473
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).