### PR TITLE
Fix issue in testSourceMetricCommandWithTimestamp integ test with different timezones and locales.

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
@@ -98,6 +99,7 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @SneakyThrows
   public void testSourceMetricCommandWithTimestamp() {
     SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    format.setTimeZone(TimeZone.getTimeZone("UTC"));
     String query =
         "source=my_prometheus.prometheus_http_requests_total | where @timestamp > '"
             + format.format(new Date(System.currentTimeMillis() - 3600 * 1000))

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
-import java.util.TimeZone;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
@@ -98,11 +98,12 @@ public class PrometheusDataSourceCommandsIT extends PPLIntegTestCase {
   @Test
   @SneakyThrows
   public void testSourceMetricCommandWithTimestamp() {
-    SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    format.setTimeZone(TimeZone.getTimeZone("UTC"));
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    // Generate timestamp string for one hour less than the current time
+    String timestamp = LocalDateTime.now().minusHours(1).format(formatter);
     String query =
         "source=my_prometheus.prometheus_http_requests_total | where @timestamp > '"
-            + format.format(new Date(System.currentTimeMillis() - 3600 * 1000))
+            + timestamp
             + "'  | sort + @timestamp | head 5";
 
     JSONObject response = executeQuery(query);


### PR DESCRIPTION
### Description
[Describe what this change achieves]
Switched to LocalDateTime for better handling of timezone and locale.
It uses system timezone irrespective of timezone set in JVM using `-Dtests.locale=hi-IN -Dtests.timezone=America/Atka`. 

Error before fix.
```
timestamp:२०२४-०२-१६ १०:१७:४७ in unsupported format
```



 
 ### Testing
  Following commands worked without error.
 ```
 ./gradlew ':integ-test:integTest' --tests "org.opensearch.sql.ppl.PrometheusDataSourceCommandsIT.testSourceMetricCommandWithTimestamp" -Dtests.seed=1574D2ADC54025EE -Dtests.security.manager=false -Dtests.locale=ja-JP-u-ca-japanese-x-lvariant-JP -Dtests.timezone=VST
 ```
 
 
 ```
 ./gradlew ':integ-test:integTest' --tests "org.opensearch.sql.ppl.PrometheusDataSourceCommandsIT.testSourceMetricCommandWithTimestamp" -Dtests.seed=EE70DA8B4C47EEC -Dtests.security.manager=false -Dtests.locale=hi-IN -Dtests.timezone=America/Atka
 ```
### Issues Resolved
https://github.com/opensearch-project/sql/issues/1275
https://github.com/opensearch-project/sql/issues/2517
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).