### PR TITLE
Setting in S3 Glue datasource for blocking new async queries

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactory.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactory.java
@@ -29,6 +29,8 @@ public class GlueDataSourceFactory implements DataSourceFactory {
       "glue.indexstore.opensearch.auth.password";
   public static final String GLUE_INDEX_STORE_OPENSEARCH_REGION =
       "glue.indexstore.opensearch.region";
+  public static final String GLUE_ASYNC_QUERY_ENABLED =
+      "glue.async_query.enabled";
 
   @Override
   public DataSourceType getDataSourceType() {

--- a/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
@@ -16,6 +16,7 @@ import org.opensearch.common.inject.Singleton;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelperImpl;
+import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
 import org.opensearch.sql.legacy.metrics.GaugeMetric;
 import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorService;
@@ -96,8 +97,10 @@ public class AsyncExecutorServiceModule extends AbstractModule {
   }
 
   @Provides
-  public DefaultLeaseManager defaultLeaseManager(Settings settings, StateStore stateStore) {
-    return new DefaultLeaseManager(settings, stateStore);
+  public DefaultLeaseManager defaultLeaseManager(Settings settings,
+                                                 StateStore stateStore,
+                                                 DataSourceServiceImpl dataSourceService) {
+    return new DefaultLeaseManager(settings, stateStore, dataSourceService);
   }
 
   @Provides

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
@@ -217,7 +217,7 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
             new FlintIndexMetadataReaderImpl(client),
             client,
             new SessionManager(stateStore, emrServerlessClientFactory, pluginSettings),
-            new DefaultLeaseManager(pluginSettings, stateStore),
+            new DefaultLeaseManager(pluginSettings, stateStore, this.dataSourceService),
             stateStore);
     return new AsyncQueryExecutorServiceImpl(
         asyncQueryJobMetadataStorageService,

--- a/spark/src/test/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManagerTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManagerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.spark.dispatcher.model.JobType;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
@@ -22,13 +23,15 @@ class DefaultLeaseManagerTest {
 
   @Mock private StateStore stateStore;
 
+  @Mock private DataSourceService dataSourceService;
+
   @Test
   public void concurrentSessionRuleOnlyApplyToInteractiveQuery() {
     assertTrue(
-        new DefaultLeaseManager.ConcurrentSessionRule(settings, stateStore)
+        new DefaultLeaseManager.ConcurrentSessionRule(settings, stateStore, dataSourceService)
             .test(new LeaseRequest(JobType.BATCH, "mys3")));
     assertTrue(
-        new DefaultLeaseManager.ConcurrentSessionRule(settings, stateStore)
+        new DefaultLeaseManager.ConcurrentSessionRule(settings, stateStore, dataSourceService)
             .test(new LeaseRequest(JobType.STREAMING, "mys3")));
   }
 


### PR DESCRIPTION
### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).