### PR TITLE
Bump json and wiremock version to fix CVEs

### DIFF
--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -89,7 +89,7 @@ dependencies {
         }
     }
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
-    compile group: 'org.json', name: 'json', version:'20230227'
+    compile group: 'org.json', name: 'json', version:'20231013'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     compile group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     compile project(':sql')

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
-    compile group: 'org.json', name: 'json', version:'20230227'
+    compile group: 'org.json', name: 'json', version:'20231013'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     compile group: 'org.opensearch', name:'opensearch-ml-client', version: '1.3.4.0-SNAPSHOT'
 

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     compile group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     compile group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
-    compile group: 'org.json', name: 'json', version: '20230227'
+    compile group: 'org.json', name: 'json', version: '20231013'
     compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
     compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.17.1'

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -51,11 +51,11 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.3.1')
-    testImplementation('com.github.tomakehurst:wiremock:3.0.0-beta-7')
+    testImplementation('org.wiremock:wiremock:3.4.0')
     testImplementation('org.mockito:mockito-core:2.23.0')
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.3.1')
     testImplementation('org.junit-pioneer:junit-pioneer:0.3.0')
-    testImplementation('org.eclipse.jetty:jetty-server:11.0.14')
+    testImplementation('org.eclipse.jetty:jetty-server:11.0.20')
 
     // Enforce wiremock to use latest guava
     testImplementation('com.google.guava:guava:32.0.1-jre')

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     compile "org.antlr:antlr4-runtime:4.7.1"
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
-    compile group: 'org.json', name: 'json', version:'20230227'
+    compile group: 'org.json', name: 'json', version:'20231013'
     compile group: 'org.springframework', name: 'spring-context', version: "${spring_version}"
     compile group: 'org.springframework', name: 'spring-beans', version: "${spring_version}"
     compile project(':common')


### PR DESCRIPTION
### Description
Fix following CVEs by bumping json and wiremock version
* CVE-2023-51074
* CVE-2023-36479
* CVE-2023-36478
* CVE-2023-40167
* CVE-2023-5072
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).