### PR TITLE
Datasource disable feature

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -108,7 +108,9 @@ jacocoTestCoverageVerification {
             excludes = [
                     'org.opensearch.sql.utils.MLCommonsConstants',
                     'org.opensearch.sql.utils.Constants',
-                    'org.opensearch.sql.datasource.model.*'
+                    'org.opensearch.sql.datasource.model.DataSource',
+                    'org.opensearch.sql.datasource.model.DataSourceStatus',
+                    'org.opensearch.sql.datasource.model.DataSourceType'
             ]
             limit {
                 counter = 'LINE'

--- a/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/DataSourceService.java
@@ -14,7 +14,8 @@ import org.opensearch.sql.datasource.model.DataSourceMetadata;
 public interface DataSourceService {
 
   /**
-   * Returns {@link DataSource} corresponding to the DataSource name.
+   * Returns {@link DataSource} corresponding to the DataSource name only if the datasource is
+   * active and authorized.
    *
    * @param dataSourceName Name of the {@link DataSource}.
    * @return {@link DataSource}.
@@ -39,15 +40,6 @@ public interface DataSourceService {
    * @return set of {@link DataSourceMetadata}.
    */
   DataSourceMetadata getDataSourceMetadata(String name);
-
-  /**
-   * Returns dataSourceMetadata object with specific name. The returned objects contain all the
-   * metadata information without any filtering.
-   *
-   * @param name name of the {@link DataSource}.
-   * @return set of {@link DataSourceMetadata}.
-   */
-  DataSourceMetadata getRawDataSourceMetadata(String name);
 
   /**
    * Register {@link DataSource} defined by {@link DataSourceMetadata}.
@@ -84,4 +76,12 @@ public interface DataSourceService {
    * @param dataSourceName name of the {@link DataSource}.
    */
   Boolean dataSourceExists(String dataSourceName);
+
+  /**
+   * Performs authorization and datasource status check and then returns RawDataSourceMetadata.
+   * Specifically for addressing use cases in SparkQueryDispatcher.
+   *
+   * @param dataSourceName of the {@link DataSource}
+   */
+  DataSourceMetadata verifyDataSourceAccessAndGetRawMetadata(String dataSourceName);
 }

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceStatus.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceStatus.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.datasource.model;
+
+/** Enum for capturing the current datasource status. */
+public enum DataSourceStatus {
+  ACTIVE("active"),
+  DISABLED("disabled");
+
+  private String text;
+
+  DataSourceStatus(String text) {
+    this.text = text;
+  }
+
+  public String getText() {
+    return this.text;
+  }
+
+  /**
+   * Get DataSourceStatus from text.
+   *
+   * @param text text.
+   * @return DataSourceStatus {@link DataSourceStatus}.
+   */
+  public static DataSourceStatus fromString(String text) {
+    for (DataSourceStatus dataSourceStatus : DataSourceStatus.values()) {
+      if (dataSourceStatus.text.equalsIgnoreCase(text)) {
+        return dataSourceStatus;
+      }
+    }
+    throw new IllegalArgumentException("No DataSourceStatus with text " + text + " found");
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.analysis.symbol.Namespace;
@@ -196,23 +195,15 @@ public class AnalyzerTestBase {
       return Stream.of(opensearchDataSource, prometheusDataSource)
           .map(
               ds ->
-                  new DataSourceMetadata(
-                      ds.getName(),
-                      StringUtils.EMPTY,
-                      ds.getConnectorType(),
-                      Collections.emptyList(),
-                      ImmutableMap.of(),
-                      null))
+                  new DataSourceMetadata.Builder()
+                      .setName(ds.getName())
+                      .setConnector(ds.getConnectorType())
+                      .build())
           .collect(Collectors.toSet());
     }
 
     @Override
     public DataSourceMetadata getDataSourceMetadata(String name) {
-      return null;
-    }
-
-    @Override
-    public DataSourceMetadata getRawDataSourceMetadata(String name) {
       return null;
     }
 
@@ -242,6 +233,11 @@ public class AnalyzerTestBase {
     @Override
     public Boolean dataSourceExists(String dataSourceName) {
       return dataSourceName.equals(DEFAULT_DATASOURCE_NAME) || dataSourceName.equals("prometheus");
+    }
+
+    @Override
+    public DataSourceMetadata verifyDataSourceAccessAndGetRawMetadata(String dataSourceName) {
+      return null;
     }
   }
 

--- a/core/src/test/java/org/opensearch/sql/datasource/model/DataSourceMetadataTest.java
+++ b/core/src/test/java/org/opensearch/sql/datasource/model/DataSourceMetadataTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.datasource.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.opensearch.sql.datasource.model.DataSourceStatus.ACTIVE;
+import static org.opensearch.sql.datasource.model.DataSourceType.PROMETHEUS;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+
+public class DataSourceMetadataTest {
+
+  @Test
+  public void testBuilderAndGetterMethods() {
+    List<String> allowedRoles = Arrays.asList("role1", "role2");
+    Map<String, String> properties = new HashMap<>();
+    properties.put("key", "value");
+
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("test")
+            .setDescription("test description")
+            .setConnector(DataSourceType.OPENSEARCH)
+            .setAllowedRoles(allowedRoles)
+            .setProperties(properties)
+            .setResultIndex("query_execution_result_test123")
+            .setDataSourceStatus(ACTIVE)
+            .build();
+
+    assertEquals("test", metadata.getName());
+    assertEquals("test description", metadata.getDescription());
+    assertEquals(DataSourceType.OPENSEARCH, metadata.getConnector());
+    assertEquals(allowedRoles, metadata.getAllowedRoles());
+    assertEquals(properties, metadata.getProperties());
+    assertEquals("query_execution_result_test123", metadata.getResultIndex());
+    assertEquals(ACTIVE, metadata.getStatus());
+  }
+
+  @Test
+  public void testDefaultDataSourceMetadata() {
+    DataSourceMetadata defaultMetadata = DataSourceMetadata.defaultOpenSearchDataSourceMetadata();
+    assertNotNull(defaultMetadata);
+    assertEquals(DataSourceType.OPENSEARCH, defaultMetadata.getConnector());
+    assertTrue(defaultMetadata.getAllowedRoles().isEmpty());
+    assertTrue(defaultMetadata.getProperties().isEmpty());
+  }
+
+  @Test
+  public void testNameValidation() {
+    try {
+      new DataSourceMetadata.Builder().setName("Invalid$$$Name").setConnector(PROMETHEUS).build();
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "DataSource Name: Invalid$$$Name contains illegal characters. Allowed characters:"
+              + " a-zA-Z0-9_-*@.",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testResultIndexValidation() {
+    try {
+      new DataSourceMetadata.Builder()
+          .setName("test")
+          .setConnector(PROMETHEUS)
+          .setResultIndex("invalid_result_index")
+          .build();
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertEquals(DataSourceMetadata.INVALID_RESULT_INDEX_PREFIX, e.getMessage());
+    }
+  }
+
+  @Test
+  public void testMissingAttributes() {
+    try {
+      new DataSourceMetadata.Builder().build();
+      fail("Should have thrown an IllegalArgumentException due to missing attributes");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("name"));
+      assertTrue(e.getMessage().contains("connector"));
+    }
+  }
+
+  @Test
+  public void testFillAttributes() {
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder().setName("test").setConnector(PROMETHEUS).build();
+
+    assertEquals("test", metadata.getName());
+    assertEquals(PROMETHEUS, metadata.getConnector());
+    assertTrue(metadata.getDescription().isEmpty());
+    assertTrue(metadata.getAllowedRoles().isEmpty());
+    assertTrue(metadata.getProperties().isEmpty());
+    assertEquals("query_execution_result_test", metadata.getResultIndex());
+    assertEquals(ACTIVE, metadata.getStatus());
+  }
+
+  @Test
+  public void testLengthyResultIndexName() {
+    try {
+      new DataSourceMetadata.Builder()
+          .setName("test")
+          .setConnector(PROMETHEUS)
+          .setResultIndex("query_execution_result_" + RandomStringUtils.randomAlphanumeric(300))
+          .build();
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "Result index name size must contains less than 255 characters.Result index name has"
+              + " invalid character. Valid characters are a-z, 0-9, -(hyphen) and _(underscore).",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testInbuiltLengthyResultIndexName() {
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName(RandomStringUtils.randomAlphabetic(250))
+            .setConnector(PROMETHEUS)
+            .build();
+    assertEquals(255, dataSourceMetadata.getResultIndex().length());
+  }
+
+  @Test
+  public void testCopyFromAnotherMetadata() {
+    List<String> allowedRoles = Arrays.asList("role1", "role2");
+    Map<String, String> properties = new HashMap<>();
+    properties.put("key", "value");
+
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("test")
+            .setDescription("test description")
+            .setConnector(DataSourceType.OPENSEARCH)
+            .setAllowedRoles(allowedRoles)
+            .setProperties(properties)
+            .setResultIndex("query_execution_result_test123")
+            .setDataSourceStatus(ACTIVE)
+            .build();
+    DataSourceMetadata copiedMetadata = new DataSourceMetadata.Builder(metadata).build();
+    assertEquals(metadata.getResultIndex(), copiedMetadata.getResultIndex());
+    assertEquals(metadata.getProperties(), copiedMetadata.getProperties());
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScanTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/datasource/DataSourceTableScanTest.java
@@ -13,12 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,13 +59,11 @@ public class DataSourceTableScanTest {
         dataSourceSet.stream()
             .map(
                 dataSource ->
-                    new DataSourceMetadata(
-                        dataSource.getName(),
-                        StringUtils.EMPTY,
-                        dataSource.getConnectorType(),
-                        Collections.emptyList(),
-                        ImmutableMap.of(),
-                        null))
+                    new DataSourceMetadata.Builder()
+                        .setName(dataSource.getName())
+                        .setConnector(dataSource.getConnectorType())
+                        .setProperties(ImmutableMap.of("prometheus.uri", "localhost:9200"))
+                        .build())
             .collect(Collectors.toSet());
     when(dataSourceService.getDataSourceMetadata(false)).thenReturn(dataSourceMetadata);
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/DataSourceNotFoundException.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/DataSourceNotFoundException.java
@@ -8,7 +8,7 @@
 package org.opensearch.sql.datasources.exceptions;
 
 /** DataSourceNotFoundException. */
-public class DataSourceNotFoundException extends RuntimeException {
+public class DataSourceNotFoundException extends DataSourceClientException {
   public DataSourceNotFoundException(String message) {
     super(message);
   }

--- a/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/DatasourceDisabledException.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/exceptions/DatasourceDisabledException.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.datasources.exceptions;
+
+/** Exception for taking actions on a disabled datasource. */
+public class DatasourceDisabledException extends DataSourceClientException {
+  public DatasourceDisabledException(String message) {
+    super(message);
+  }
+}

--- a/datasources/src/main/resources/datasources-index-mapping.yml
+++ b/datasources/src/main/resources/datasources-index-mapping.yml
@@ -17,3 +17,5 @@ properties:
     type: keyword
   resultIndex:
     type: keyword
+  status:
+    type: keyword

--- a/datasources/src/test/java/org/opensearch/sql/datasources/auth/DataSourceUserAuthorizationHelperImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/auth/DataSourceUserAuthorizationHelperImplTest.java
@@ -7,7 +7,6 @@ package org.opensearch.sql.datasources.auth;
 
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT;
 
-import java.util.HashMap;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -102,11 +101,10 @@ public class DataSourceUserAuthorizationHelperImplTest {
   }
 
   private DataSourceMetadata dataSourceMetadata() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("test");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-    dataSourceMetadata.setAllowedRoles(List.of("prometheus_access"));
-    dataSourceMetadata.setProperties(new HashMap<>());
-    return dataSourceMetadata;
+    return new DataSourceMetadata.Builder()
+        .setName("test")
+        .setAllowedRoles(List.of("prometheus_access"))
+        .setConnector(DataSourceType.PROMETHEUS)
+        .build();
   }
 }

--- a/datasources/src/test/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactoryTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactoryTest.java
@@ -35,17 +35,18 @@ public class GlueDataSourceFactoryTest {
         .thenReturn(Collections.emptyList());
     GlueDataSourceFactory glueDatasourceFactory = new GlueDataSourceFactory(settings);
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
     HashMap<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put("glue.auth.role_arn", "role_arn");
     properties.put("glue.indexstore.opensearch.uri", "http://localhost:9200");
     properties.put("glue.indexstore.opensearch.auth", "noauth");
     properties.put("glue.indexstore.opensearch.region", "us-west-2");
-
-    metadata.setName("my_glue");
-    metadata.setConnector(DataSourceType.S3GLUE);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("my_glue")
+            .setConnector(DataSourceType.S3GLUE)
+            .setProperties(properties)
+            .build();
     DataSource dataSource = glueDatasourceFactory.createDataSource(metadata);
     Assertions.assertEquals(DataSourceType.S3GLUE, dataSource.getConnectorType());
     UnsupportedOperationException unsupportedOperationException =
@@ -66,7 +67,6 @@ public class GlueDataSourceFactoryTest {
         .thenReturn(Collections.emptyList());
     GlueDataSourceFactory glueDatasourceFactory = new GlueDataSourceFactory(settings);
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
     HashMap<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put("glue.auth.role_arn", "role_arn");
@@ -75,10 +75,12 @@ public class GlueDataSourceFactoryTest {
     properties.put("glue.indexstore.opensearch.auth.username", "username");
     properties.put("glue.indexstore.opensearch.auth.password", "password");
     properties.put("glue.indexstore.opensearch.region", "us-west-2");
-
-    metadata.setName("my_glue");
-    metadata.setConnector(DataSourceType.S3GLUE);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("my_glue")
+            .setConnector(DataSourceType.S3GLUE)
+            .setProperties(properties)
+            .build();
     DataSource dataSource = glueDatasourceFactory.createDataSource(metadata);
     Assertions.assertEquals(DataSourceType.S3GLUE, dataSource.getConnectorType());
     UnsupportedOperationException unsupportedOperationException =
@@ -99,17 +101,18 @@ public class GlueDataSourceFactoryTest {
         .thenReturn(Collections.emptyList());
     GlueDataSourceFactory glueDatasourceFactory = new GlueDataSourceFactory(settings);
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
     HashMap<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put("glue.auth.role_arn", "role_arn");
     properties.put("glue.indexstore.opensearch.uri", "http://localhost:9200");
     properties.put("glue.indexstore.opensearch.auth", "awssigv4");
     properties.put("glue.indexstore.opensearch.region", "us-west-2");
-
-    metadata.setName("my_glue");
-    metadata.setConnector(DataSourceType.S3GLUE);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("my_glue")
+            .setConnector(DataSourceType.S3GLUE)
+            .setProperties(properties)
+            .build();
     DataSource dataSource = glueDatasourceFactory.createDataSource(metadata);
     Assertions.assertEquals(DataSourceType.S3GLUE, dataSource.getConnectorType());
     UnsupportedOperationException unsupportedOperationException =
@@ -128,16 +131,19 @@ public class GlueDataSourceFactoryTest {
   void testCreateGLueDatSourceWithBasicAuthForIndexStoreAndMissingFields() {
     GlueDataSourceFactory glueDatasourceFactory = new GlueDataSourceFactory(settings);
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
     HashMap<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put("glue.auth.role_arn", "role_arn");
     properties.put("glue.indexstore.opensearch.uri", "http://localhost:9200");
     properties.put("glue.indexstore.opensearch.auth", "basicauth");
 
-    metadata.setName("my_glue");
-    metadata.setConnector(DataSourceType.S3GLUE);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("my_glue")
+            .setConnector(DataSourceType.S3GLUE)
+            .setProperties(properties)
+            .build();
+
     IllegalArgumentException illegalArgumentException =
         Assertions.assertThrows(
             IllegalArgumentException.class, () -> glueDatasourceFactory.createDataSource(metadata));
@@ -154,7 +160,6 @@ public class GlueDataSourceFactoryTest {
         .thenReturn(List.of("127.0.0.0/8"));
     GlueDataSourceFactory glueDatasourceFactory = new GlueDataSourceFactory(settings);
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
     HashMap<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put("glue.auth.role_arn", "role_arn");
@@ -162,9 +167,12 @@ public class GlueDataSourceFactoryTest {
     properties.put("glue.indexstore.opensearch.auth", "noauth");
     properties.put("glue.indexstore.opensearch.region", "us-west-2");
 
-    metadata.setName("my_glue");
-    metadata.setConnector(DataSourceType.S3GLUE);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("my_glue")
+            .setConnector(DataSourceType.S3GLUE)
+            .setProperties(properties)
+            .build();
     IllegalArgumentException illegalArgumentException =
         Assertions.assertThrows(
             IllegalArgumentException.class, () -> glueDatasourceFactory.createDataSource(metadata));
@@ -181,7 +189,6 @@ public class GlueDataSourceFactoryTest {
         .thenReturn(List.of("127.0.0.0/8"));
     GlueDataSourceFactory glueDatasourceFactory = new GlueDataSourceFactory(settings);
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
     HashMap<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put("glue.auth.role_arn", "role_arn");
@@ -191,9 +198,12 @@ public class GlueDataSourceFactoryTest {
     properties.put("glue.indexstore.opensearch.auth", "noauth");
     properties.put("glue.indexstore.opensearch.region", "us-west-2");
 
-    metadata.setName("my_glue");
-    metadata.setConnector(DataSourceType.S3GLUE);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("my_glue")
+            .setConnector(DataSourceType.S3GLUE)
+            .setProperties(properties)
+            .build();
     IllegalArgumentException illegalArgumentException =
         Assertions.assertThrows(
             IllegalArgumentException.class, () -> glueDatasourceFactory.createDataSource(metadata));

--- a/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImplTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -46,11 +45,7 @@ class DataSourceLoaderCacheImplTest {
   void testGetOrLoadDataSource() {
     DataSourceLoaderCache dataSourceLoaderCache =
         new DataSourceLoaderCacheImpl(Collections.singleton(dataSourceFactory));
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
-    dataSourceMetadata.setConnector(DataSourceType.OPENSEARCH);
-    dataSourceMetadata.setAllowedRoles(Collections.emptyList());
-    dataSourceMetadata.setProperties(ImmutableMap.of());
+    DataSourceMetadata dataSourceMetadata = getMetadata();
     DataSource dataSource = dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
     verify(dataSourceFactory, times(1)).createDataSource(dataSourceMetadata);
     Assertions.assertEquals(
@@ -65,18 +60,19 @@ class DataSourceLoaderCacheImplTest {
     DataSourceMetadata dataSourceMetadata = getMetadata();
     dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
     dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
-    dataSourceMetadata.setAllowedRoles(List.of("testDS_access"));
+    dataSourceMetadata =
+        new DataSourceMetadata.Builder(dataSourceMetadata)
+            .setAllowedRoles(List.of("testDS_access"))
+            .build();
     dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
     dataSourceLoaderCache.getOrLoadDataSource(dataSourceMetadata);
-    verify(dataSourceFactory, times(2)).createDataSource(dataSourceMetadata);
+    verify(dataSourceFactory, times(2)).createDataSource(any());
   }
 
   private DataSourceMetadata getMetadata() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
-    dataSourceMetadata.setConnector(DataSourceType.OPENSEARCH);
-    dataSourceMetadata.setAllowedRoles(Collections.emptyList());
-    dataSourceMetadata.setProperties(ImmutableMap.of());
-    return dataSourceMetadata;
+    return new DataSourceMetadata.Builder()
+        .setName("testDS")
+        .setConnector(DataSourceType.OPENSEARCH)
+        .build();
   }
 }

--- a/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
@@ -501,8 +501,8 @@ public class OpenSearchDataSourceMetadataStorageTest {
     Mockito.when(encryptor.encrypt("access_key")).thenReturn("access_key");
     Mockito.when(client.update(ArgumentMatchers.any()))
         .thenThrow(new DocumentMissingException(ShardId.fromString("[2][2]"), "testDS"));
-    DataSourceMetadata dataSourceMetadata = getDataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder(getDataSourceMetadata()).setName("testDS").build();
 
     DataSourceNotFoundException dataSourceNotFoundException =
         Assertions.assertThrows(
@@ -526,8 +526,8 @@ public class OpenSearchDataSourceMetadataStorageTest {
     Mockito.when(encryptor.encrypt("access_key")).thenReturn("access_key");
     Mockito.when(client.update(ArgumentMatchers.any()))
         .thenThrow(new RuntimeException("error message"));
-    DataSourceMetadata dataSourceMetadata = getDataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder(getDataSourceMetadata()).setName("testDS").build();
 
     RuntimeException runtimeException =
         Assertions.assertThrows(
@@ -599,74 +599,82 @@ public class OpenSearchDataSourceMetadataStorageTest {
   }
 
   private String getBasicDataSourceMetadataString() throws JsonProcessingException {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-    dataSourceMetadata.setAllowedRoles(Collections.singletonList("prometheus_access"));
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.type", "basicauth");
     properties.put("prometheus.auth.username", "username");
     properties.put("prometheus.auth.uri", "https://localhost:9090");
     properties.put("prometheus.auth.password", "password");
-    dataSourceMetadata.setProperties(properties);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("testDS")
+            .setProperties(properties)
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setAllowedRoles(Collections.singletonList("prometheus_access"))
+            .build();
     ObjectMapper objectMapper = new ObjectMapper();
     return objectMapper.writeValueAsString(dataSourceMetadata);
   }
 
   private String getAWSSigv4DataSourceMetadataString() throws JsonProcessingException {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-    dataSourceMetadata.setAllowedRoles(Collections.singletonList("prometheus_access"));
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.type", "awssigv4");
     properties.put("prometheus.auth.secret_key", "secret_key");
     properties.put("prometheus.auth.uri", "https://localhost:9090");
     properties.put("prometheus.auth.access_key", "access_key");
-    dataSourceMetadata.setProperties(properties);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("testDS")
+            .setProperties(properties)
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setAllowedRoles(Collections.singletonList("prometheus_access"))
+            .build();
     ObjectMapper objectMapper = new ObjectMapper();
     return objectMapper.writeValueAsString(dataSourceMetadata);
   }
 
   private String getDataSourceMetadataStringWithBasicAuthentication()
       throws JsonProcessingException {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-    dataSourceMetadata.setAllowedRoles(Collections.singletonList("prometheus_access"));
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.uri", "https://localhost:9090");
     properties.put("prometheus.auth.type", "basicauth");
     properties.put("prometheus.auth.username", "username");
     properties.put("prometheus.auth.password", "password");
-    dataSourceMetadata.setProperties(properties);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("testDS")
+            .setProperties(properties)
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setAllowedRoles(Collections.singletonList("prometheus_access"))
+            .build();
     ObjectMapper objectMapper = new ObjectMapper();
     return objectMapper.writeValueAsString(dataSourceMetadata);
   }
 
   private String getDataSourceMetadataStringWithNoAuthentication() throws JsonProcessingException {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-    dataSourceMetadata.setAllowedRoles(Collections.singletonList("prometheus_access"));
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.uri", "https://localhost:9090");
-    dataSourceMetadata.setProperties(properties);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("testDS")
+            .setProperties(properties)
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setAllowedRoles(Collections.singletonList("prometheus_access"))
+            .build();
     ObjectMapper objectMapper = new ObjectMapper();
     return objectMapper.writeValueAsString(dataSourceMetadata);
   }
 
   private DataSourceMetadata getDataSourceMetadata() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("testDS");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-    dataSourceMetadata.setAllowedRoles(Collections.singletonList("prometheus_access"));
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.type", "awssigv4");
     properties.put("prometheus.auth.secret_key", "secret_key");
     properties.put("prometheus.auth.uri", "https://localhost:9090");
     properties.put("prometheus.auth.access_key", "access_key");
-    dataSourceMetadata.setProperties(properties);
-    return dataSourceMetadata;
+    return new DataSourceMetadata.Builder()
+        .setName("testDS")
+        .setProperties(properties)
+        .setConnector(DataSourceType.PROMETHEUS)
+        .setAllowedRoles(Collections.singletonList("prometheus_access"))
+        .build();
   }
 }

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceActionTest.java
@@ -71,9 +71,11 @@ public class TransportCreateDataSourceActionTest {
 
   @Test
   public void testDoExecute() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("test_datasource");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("test_datasource")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .build();
     CreateDataSourceActionRequest request = new CreateDataSourceActionRequest(dataSourceMetadata);
 
     action.doExecute(task, request, actionListener);
@@ -88,9 +90,11 @@ public class TransportCreateDataSourceActionTest {
 
   @Test
   public void testDoExecuteWithException() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("test_datasource");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("test_datasource")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .build();
     doThrow(new RuntimeException("Error"))
         .when(dataSourceService)
         .createDataSource(dataSourceMetadata);
@@ -105,9 +109,11 @@ public class TransportCreateDataSourceActionTest {
 
   @Test
   public void testDataSourcesLimit() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("test_datasource");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("test_datasource")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .build();
     CreateDataSourceActionRequest request = new CreateDataSourceActionRequest(dataSourceMetadata);
     when(dataSourceService.getDataSourceMetadata(false).size()).thenReturn(1);
     when(settings.getSettingValue(DATASOURCES_LIMIT)).thenReturn(1);

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceActionTest.java
@@ -68,9 +68,11 @@ public class TransportGetDataSourceActionTest {
 
   @Test
   public void testDoExecute() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("test_datasource");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("test_datasource")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .build();
     GetDataSourceActionRequest request = new GetDataSourceActionRequest("test_datasource");
     when(dataSourceService.getDataSourceMetadata("test_datasource")).thenReturn(dataSourceMetadata);
 
@@ -97,10 +99,11 @@ public class TransportGetDataSourceActionTest {
 
   @Test
   public void testDoExecuteForGetAllDataSources() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("test_datasource");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("test_datasource")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .build();
     GetDataSourceActionRequest request = new GetDataSourceActionRequest();
     when(dataSourceService.getDataSourceMetadata(false))
         .thenReturn(Collections.singleton(dataSourceMetadata));

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceActionTest.java
@@ -62,9 +62,11 @@ public class TransportUpdateDataSourceActionTest {
 
   @Test
   public void testDoExecute() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("test_datasource");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("test_datasource")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .build();
     UpdateDataSourceActionRequest request = new UpdateDataSourceActionRequest(dataSourceMetadata);
 
     action.doExecute(task, request, actionListener);
@@ -80,9 +82,12 @@ public class TransportUpdateDataSourceActionTest {
 
   @Test
   public void testDoExecuteWithException() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("test_datasource");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
+    DataSourceMetadata dataSourceMetadata =
+        new DataSourceMetadata.Builder()
+            .setName("test_datasource")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .build();
+
     doThrow(new RuntimeException("Error"))
         .when(dataSourceService)
         .updateDataSource(dataSourceMetadata);

--- a/docs/user/ppl/admin/datasources.rst
+++ b/docs/user/ppl/admin/datasources.rst
@@ -39,7 +39,8 @@ Example Prometheus Datasource Definition ::
             "prometheus.auth.username" : "admin",
             "prometheus.auth.password" : "admin"
         },
-        "allowedRoles" : ["prometheus_access"]
+        "allowedRoles" : ["prometheus_access"],
+        "status" : "ACTIVE|DISABLED"
     }
 Datasource configuration Restrictions.
 
@@ -51,6 +52,8 @@ Datasource configuration Restrictions.
 * Allowed Connectors.
     * ``prometheus`` [More details: `Prometheus Connector <connectors/prometheus_connector.rst>`_]
 * All the allowed config parameters in ``properties`` are defined in individual connector pages mentioned above.
+* From version 2.13, we have introduced a new optional field ``status`` which can be used to enable and disable a datasource.When a datasource is disabled, it blocks new queries, resulting in 400 errors for any attempts made on it. By default when a datasource is created, status is ACTIVE.
+
 
 Datasource configuration APIs
 ======================================
@@ -196,3 +199,16 @@ Moving from keystore datasource configuration
 =============================================
 * In versions prior to 2.7, the plugins.query.federation.datasources.config key store setting was used to configure datasources, but it has been deprecated and will be removed in version 3.0.
 * To port previously configured datasources from the keystore, users can use the `create datasource` REST API mentioned in the above section.
+
+Disabling a datasource to block new queries
+=============================================
+* We can disable a datasource using PATCH or PUT API. Below is the example request for disabling a datasource named "my_prometheus" using PATCH API. ::
+
+    PATCH https://localhost:9200/_plugins/_query/_datasources
+    content-type: application/json
+    Authorization: Basic {{username}} {{password}}
+
+    {
+        "name" : "my_prometheus",
+        "status" : "disabled"
+    }

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -5,11 +5,14 @@
 
 package org.opensearch.sql.datasource;
 
+import static org.opensearch.sql.datasource.model.DataSourceStatus.ACTIVE;
+import static org.opensearch.sql.datasource.model.DataSourceStatus.DISABLED;
+import static org.opensearch.sql.datasources.utils.XContentParserUtils.ALLOWED_ROLES_FIELD;
 import static org.opensearch.sql.datasources.utils.XContentParserUtils.DESCRIPTION_FIELD;
 import static org.opensearch.sql.datasources.utils.XContentParserUtils.NAME_FIELD;
+import static org.opensearch.sql.datasources.utils.XContentParserUtils.STATUS_FIELD;
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -21,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -34,6 +36,11 @@ import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class DataSourceAPIsIT extends PPLIntegTestCase {
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.DATASOURCES);
+  }
 
   @After
   public void cleanUp() throws IOException {
@@ -68,21 +75,21 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
   public void createDataSourceAPITest() {
     // create datasource
     DataSourceMetadata createDSM =
-        new DataSourceMetadata(
-            "create_prometheus",
-            "Prometheus Creation for Integ test",
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of(
-                "prometheus.uri",
-                "https://localhost:9090",
-                "prometheus.auth.type",
-                "basicauth",
-                "prometheus.auth.username",
-                "username",
-                "prometheus.auth.password",
-                "password"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName("create_prometheus")
+            .setDescription("Prometheus Creation for Integ test")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(
+                ImmutableMap.of(
+                    "prometheus.uri",
+                    "https://localhost:9090",
+                    "prometheus.auth.type",
+                    "basicauth",
+                    "prometheus.auth.username",
+                    "username",
+                    "prometheus.auth.password",
+                    "password"))
+            .build();
     Request createRequest = getCreateDataSourceRequest(createDSM);
     Response response = client().performRequest(createRequest);
     Assert.assertEquals(201, response.getStatusLine().getStatusCode());
@@ -104,6 +111,7 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
         "basicauth", dataSourceMetadata.getProperties().get("prometheus.auth.type"));
     Assert.assertNull(dataSourceMetadata.getProperties().get("prometheus.auth.username"));
     Assert.assertNull(dataSourceMetadata.getProperties().get("prometheus.auth.password"));
+    Assert.assertEquals(ACTIVE, dataSourceMetadata.getStatus());
     Assert.assertEquals("Prometheus Creation for Integ test", dataSourceMetadata.getDescription());
   }
 
@@ -112,13 +120,11 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
   public void updateDataSourceAPITest() {
     // create datasource
     DataSourceMetadata createDSM =
-        new DataSourceMetadata(
-            "update_prometheus",
-            StringUtils.EMPTY,
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of("prometheus.uri", "https://localhost:9090"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName("update_prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(ImmutableMap.of("prometheus.uri", "https://localhost:9090"))
+            .build();
     Request createRequest = getCreateDataSourceRequest(createDSM);
     client().performRequest(createRequest);
     // Datasource is not immediately created. so introducing a sleep of 2s.
@@ -126,13 +132,11 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
 
     // update datasource
     DataSourceMetadata updateDSM =
-        new DataSourceMetadata(
-            "update_prometheus",
-            StringUtils.EMPTY,
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of("prometheus.uri", "https://randomtest.com:9090"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName("update_prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(ImmutableMap.of("prometheus.uri", "https://randomtest.com:9090"))
+            .build();
     Request updateRequest = getUpdateDataSourceRequest(updateDSM);
     Response updateResponse = client().performRequest(updateRequest);
     Assert.assertEquals(200, updateResponse.getStatusLine().getStatusCode());
@@ -186,13 +190,11 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
 
     // create datasource for deletion
     DataSourceMetadata createDSM =
-        new DataSourceMetadata(
-            "delete_prometheus",
-            StringUtils.EMPTY,
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of("prometheus.uri", "https://localhost:9090"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName("delete_prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(ImmutableMap.of("prometheus.uri", "https://localhost:9090"))
+            .build();
     Request createRequest = getCreateDataSourceRequest(createDSM);
     client().performRequest(createRequest);
     // Datasource is not immediately created. so introducing a sleep of 2s.
@@ -226,13 +228,11 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
   public void getAllDataSourceTest() {
     // create datasource for deletion
     DataSourceMetadata createDSM =
-        new DataSourceMetadata(
-            "get_all_prometheus",
-            StringUtils.EMPTY,
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of("prometheus.uri", "https://localhost:9090"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName("get_all_prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(ImmutableMap.of("prometheus.uri", "https://localhost:9090"))
+            .build();
     Request createRequest = getCreateDataSourceRequest(createDSM);
     client().performRequest(createRequest);
     // Datasource is not immediately created. so introducing a sleep of 2s.
@@ -255,21 +255,21 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
   public void issue2196() {
     // create datasource
     DataSourceMetadata createDSM =
-        new DataSourceMetadata(
-            "Create_Prometheus",
-            "Prometheus Creation for Integ test",
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of(
-                "prometheus.uri",
-                "https://localhost:9090",
-                "prometheus.auth.type",
-                "basicauth",
-                "prometheus.auth.username",
-                "username",
-                "prometheus.auth.password",
-                "password"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName("Create_Prometheus")
+            .setDescription("Prometheus Creation for Integ test")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(
+                ImmutableMap.of(
+                    "prometheus.uri",
+                    "https://localhost:9090",
+                    "prometheus.auth.type",
+                    "basicauth",
+                    "prometheus.auth.username",
+                    "username",
+                    "prometheus.auth.password",
+                    "password"))
+            .build();
     Request createRequest = getCreateDataSourceRequest(createDSM);
     Response response = client().performRequest(createRequest);
     Assert.assertEquals(201, response.getStatusLine().getStatusCode());
@@ -317,21 +317,109 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
         errorMessage.get("error").getAsJsonObject().get("details").getAsString());
   }
 
+  @SneakyThrows
+  @Test
+  public void patchDataSourceAPITest() {
+    // create datasource
+    DataSourceMetadata createDSM =
+        new DataSourceMetadata.Builder()
+            .setName("patch_prometheus")
+            .setDescription("Prometheus Creation for Integ test")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(
+                ImmutableMap.of(
+                    "prometheus.uri",
+                    "https://localhost:9090",
+                    "prometheus.auth.type",
+                    "basicauth",
+                    "prometheus.auth.username",
+                    "username",
+                    "prometheus.auth.password",
+                    "password"))
+            .setAllowedRoles(List.of("role1", "role2"))
+            .build();
+    Request createRequest = getCreateDataSourceRequest(createDSM);
+    Response response = client().performRequest(createRequest);
+    Assert.assertEquals(201, response.getStatusLine().getStatusCode());
+    String createResponseString = getResponseBody(response);
+    Assert.assertEquals("\"Created DataSource with name patch_prometheus\"", createResponseString);
+    // Datasource is not immediately created. so introducing a sleep of 2s.
+    Thread.sleep(2000);
+
+    // patch datasource
+    Map<String, Object> updateDS =
+        new HashMap<>(
+            Map.of(
+                NAME_FIELD,
+                "patch_prometheus",
+                DESCRIPTION_FIELD,
+                "test",
+                STATUS_FIELD,
+                "disabled",
+                ALLOWED_ROLES_FIELD,
+                List.of("role3", "role4")));
+
+    Request patchRequest = getPatchDataSourceRequest(updateDS);
+    Response patchResponse = client().performRequest(patchRequest);
+    Assert.assertEquals(200, patchResponse.getStatusLine().getStatusCode());
+    String patchResponseString = getResponseBody(patchResponse);
+    Assert.assertEquals("\"Updated DataSource with name patch_prometheus\"", patchResponseString);
+
+    // Datasource is not immediately updated. so introducing a sleep of 2s.
+    Thread.sleep(2000);
+
+    // get datasource to validate the creation.
+    Request getRequest = getFetchDataSourceRequest("patch_prometheus");
+    Response getResponse = client().performRequest(getRequest);
+    Assert.assertEquals(200, getResponse.getStatusLine().getStatusCode());
+    String getResponseString = getResponseBody(getResponse);
+    DataSourceMetadata dataSourceMetadata =
+        new Gson().fromJson(getResponseString, DataSourceMetadata.class);
+    Assert.assertEquals(
+        "https://localhost:9090", dataSourceMetadata.getProperties().get("prometheus.uri"));
+    Assert.assertEquals(
+        "basicauth", dataSourceMetadata.getProperties().get("prometheus.auth.type"));
+    Assert.assertNull(dataSourceMetadata.getProperties().get("prometheus.auth.username"));
+    Assert.assertNull(dataSourceMetadata.getProperties().get("prometheus.auth.password"));
+    Assert.assertEquals(DISABLED, dataSourceMetadata.getStatus());
+    Assert.assertEquals(List.of("role3", "role4"), dataSourceMetadata.getAllowedRoles());
+    Assert.assertEquals("test", dataSourceMetadata.getDescription());
+  }
+
+  @SneakyThrows
+  @Test
+  public void testOldDataSourceModelLoadingThroughGetDataSourcesAPI() {
+    // get datasource to validate the creation.
+    Request getRequest = getFetchDataSourceRequest(null);
+    Response getResponse = client().performRequest(getRequest);
+    Assert.assertEquals(200, getResponse.getStatusLine().getStatusCode());
+    String getResponseString = getResponseBody(getResponse);
+    Type listType = new TypeToken<List<DataSourceMetadata>>() {}.getType();
+    List<DataSourceMetadata> dataSourceMetadataList =
+        new Gson().fromJson(getResponseString, listType);
+    Assert.assertTrue(
+        dataSourceMetadataList.stream()
+            .anyMatch(
+                dataSourceMetadata ->
+                    dataSourceMetadata.getName().equals("old_prometheus")
+                        && dataSourceMetadata.getStatus().equals(ACTIVE)));
+  }
+
   public DataSourceMetadata mockDataSourceMetadata(String name) {
-    return new DataSourceMetadata(
-        name,
-        "Prometheus Creation for Integ test",
-        DataSourceType.PROMETHEUS,
-        ImmutableList.of(),
-        ImmutableMap.of(
-            "prometheus.uri",
-            "https://localhost:9090",
-            "prometheus.auth.type",
-            "basicauth",
-            "prometheus.auth.username",
-            "username",
-            "prometheus.auth.password",
-            "password"),
-        null);
+    return new DataSourceMetadata.Builder()
+        .setName(name)
+        .setDescription("Prometheus Creation for Integ test")
+        .setConnector(DataSourceType.PROMETHEUS)
+        .setProperties(
+            ImmutableMap.of(
+                "prometheus.uri",
+                "https://localhost:9090",
+                "prometheus.auth.type",
+                "basicauth",
+                "prometheus.auth.username",
+                "username",
+                "prometheus.auth.password",
+                "password"))
+        .build();
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/InformationSchemaCommandIT.java
@@ -12,10 +12,8 @@ import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
@@ -43,13 +41,11 @@ public class InformationSchemaCommandIT extends PPLIntegTestCase {
   @Override
   protected void init() throws InterruptedException, IOException {
     DataSourceMetadata createDSM =
-        new DataSourceMetadata(
-            "my_prometheus",
-            StringUtils.EMPTY,
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of("prometheus.uri", "http://localhost:9090"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName("my_prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(ImmutableMap.of("prometheus.uri", "http://localhost:9090"))
+            .build();
     Request createRequest = getCreateDataSourceRequest(createDSM);
     Response response = client().performRequest(createRequest);
     Assert.assertEquals(201, response.getStatusLine().getStatusCode());

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ShowDataSourcesCommandIT.java
@@ -12,10 +12,8 @@ import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
@@ -43,13 +41,11 @@ public class ShowDataSourcesCommandIT extends PPLIntegTestCase {
   @Override
   protected void init() throws InterruptedException, IOException {
     DataSourceMetadata createDSM =
-        new DataSourceMetadata(
-            "my_prometheus",
-            StringUtils.EMPTY,
-            DataSourceType.PROMETHEUS,
-            ImmutableList.of(),
-            ImmutableMap.of("prometheus.uri", "http://localhost:9090"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName("my_prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(ImmutableMap.of("prometheus.uri", "http://localhost:9090"))
+            .build();
     Request createRequest = getCreateDataSourceRequest(createDSM);
     Response response = client().performRequest(createRequest);
     Assert.assertEquals(201, response.getStatusLine().getStatusCode());

--- a/integ-test/src/test/resources/datasources.json
+++ b/integ-test/src/test/resources/datasources.json
@@ -1,2 +1,2 @@
-{"index":{"_id":"my_prometheus"}}
-{ "name" : "my_prometheus", "connector": "prometheus", "properties" : { "prometheus.uri" : "http://localhost:9090"}}
+{"index":{"_id":"old_prometheus"}}
+{ "name" : "old_prometheus", "connector": "prometheus", "properties" : { "prometheus.uri" : "http://localhost:9090"}}

--- a/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactoryTest.java
+++ b/prometheus/src/test/java/org/opensearch/sql/prometheus/storage/PrometheusStorageFactoryTest.java
@@ -181,10 +181,12 @@ public class PrometheusStorageFactoryTest {
     properties.put("prometheus.auth.username", "admin");
     properties.put("prometheus.auth.password", "admin");
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
-    metadata.setName("prometheus");
-    metadata.setConnector(DataSourceType.PROMETHEUS);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(properties)
+            .build();
 
     DataSource dataSource = new PrometheusStorageFactory(settings).createDataSource(metadata);
     Assertions.assertTrue(dataSource.getStorageEngine() instanceof PrometheusStorageEngine);
@@ -200,10 +202,12 @@ public class PrometheusStorageFactoryTest {
     properties.put("prometheus.auth.username", "admin");
     properties.put("prometheus.auth.password", "admin");
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
-    metadata.setName("prometheus");
-    metadata.setConnector(DataSourceType.PROMETHEUS);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(properties)
+            .build();
 
     DataSource dataSource = new PrometheusStorageFactory(settings).createDataSource(metadata);
     Assertions.assertTrue(dataSource.getStorageEngine() instanceof PrometheusStorageEngine);
@@ -219,10 +223,12 @@ public class PrometheusStorageFactoryTest {
     properties.put("prometheus.auth.username", "admin");
     properties.put("prometheus.auth.password", "admin");
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
-    metadata.setName("prometheus");
-    metadata.setConnector(DataSourceType.PROMETHEUS);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("prometheus")
+            .setConnector(DataSourceType.PROMETHEUS)
+            .setProperties(properties)
+            .build();
 
     PrometheusStorageFactory prometheusStorageFactory = new PrometheusStorageFactory(settings);
     RuntimeException exception =

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -60,8 +60,8 @@ public class SparkQueryDispatcher {
   public DispatchQueryResponse dispatch(DispatchQueryRequest dispatchQueryRequest) {
     EMRServerlessClient emrServerlessClient = emrServerlessClientFactory.getClient();
     DataSourceMetadata dataSourceMetadata =
-        this.dataSourceService.getRawDataSourceMetadata(dispatchQueryRequest.getDatasource());
-    dataSourceUserAuthorizationHelper.authorizeDataSource(dataSourceMetadata);
+        this.dataSourceService.verifyDataSourceAccessAndGetRawMetadata(
+            dispatchQueryRequest.getDatasource());
     AsyncQueryHandler asyncQueryHandler =
         sessionManager.isEnabled()
             ? new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader, leaseManager)

--- a/spark/src/main/java/org/opensearch/sql/spark/rest/RestAsyncQueryManagementAction.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/rest/RestAsyncQueryManagementAction.java
@@ -26,7 +26,7 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
-import org.opensearch.sql.datasources.exceptions.DataSourceNotFoundException;
+import org.opensearch.sql.datasources.exceptions.DataSourceClientException;
 import org.opensearch.sql.datasources.exceptions.ErrorMessage;
 import org.opensearch.sql.datasources.utils.Scheduler;
 import org.opensearch.sql.legacy.metrics.MetricName;
@@ -235,7 +235,7 @@ public class RestAsyncQueryManagementAction extends BaseRestHandler {
   private static boolean isClientError(Exception e) {
     return e instanceof IllegalArgumentException
         || e instanceof IllegalStateException
-        || e instanceof DataSourceNotFoundException
+        || e instanceof DataSourceClientException
         || e instanceof AsyncQueryNotFoundException
         || e instanceof IllegalAccessException;
   }

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
@@ -17,7 +17,6 @@ import com.amazonaws.services.emrserverless.model.GetJobRunResult;
 import com.amazonaws.services.emrserverless.model.JobRun;
 import com.amazonaws.services.emrserverless.model.JobRunState;
 import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
@@ -30,7 +29,6 @@ import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -119,38 +117,36 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
         .get();
     dataSourceService = createDataSourceService();
     DataSourceMetadata dm =
-        new DataSourceMetadata(
-            DATASOURCE,
-            StringUtils.EMPTY,
-            DataSourceType.S3GLUE,
-            ImmutableList.of(),
-            ImmutableMap.of(
-                "glue.auth.type",
-                "iam_role",
-                "glue.auth.role_arn",
-                "arn:aws:iam::924196221507:role/FlintOpensearchServiceRole",
-                "glue.indexstore.opensearch.uri",
-                "http://localhost:9200",
-                "glue.indexstore.opensearch.auth",
-                "noauth"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName(DATASOURCE)
+            .setConnector(DataSourceType.S3GLUE)
+            .setProperties(
+                ImmutableMap.of(
+                    "glue.auth.type",
+                    "iam_role",
+                    "glue.auth.role_arn",
+                    "arn:aws:iam::924196221507:role/FlintOpensearchServiceRole",
+                    "glue.indexstore.opensearch.uri",
+                    "http://localhost:9200",
+                    "glue.indexstore.opensearch.auth",
+                    "noauth"))
+            .build();
     dataSourceService.createDataSource(dm);
     DataSourceMetadata otherDm =
-        new DataSourceMetadata(
-            DSOTHER,
-            StringUtils.EMPTY,
-            DataSourceType.S3GLUE,
-            ImmutableList.of(),
-            ImmutableMap.of(
-                "glue.auth.type",
-                "iam_role",
-                "glue.auth.role_arn",
-                "arn:aws:iam::924196221507:role/FlintOpensearchServiceRole",
-                "glue.indexstore.opensearch.uri",
-                "http://localhost:9200",
-                "glue.indexstore.opensearch.auth",
-                "noauth"),
-            null);
+        new DataSourceMetadata.Builder()
+            .setName(DSOTHER)
+            .setConnector(DataSourceType.S3GLUE)
+            .setProperties(
+                ImmutableMap.of(
+                    "glue.auth.type",
+                    "iam_role",
+                    "glue.auth.role_arn",
+                    "arn:aws:iam::924196221507:role/FlintOpensearchServiceRole",
+                    "glue.indexstore.opensearch.uri",
+                    "http://localhost:9200",
+                    "glue.indexstore.opensearch.auth",
+                    "noauth"))
+            .build();
     dataSourceService.createDataSource(otherDm);
     stateStore = new StateStore(client, clusterService);
     createIndexWithMappings(dm.getResultIndex(), loadResultIndexMappings());

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -150,11 +150,12 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             false,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -195,11 +196,11 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             false,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadataWithBasicAuth();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -238,11 +239,12 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             false,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadataWithNoAuth();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -269,8 +271,9 @@ public class SparkQueryDispatcherTest {
     doReturn(new StatementId(MOCK_STATEMENT_ID)).when(session).submit(any());
     when(session.getSessionModel().getJobId()).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse = sparkQueryDispatcher.dispatch(queryRequest);
 
     verifyNoInteractions(emrServerlessClient);
@@ -293,8 +296,9 @@ public class SparkQueryDispatcherTest {
     when(session.getSessionModel().getJobId()).thenReturn(EMR_JOB_ID);
     when(session.isOperationalForDataSource(any())).thenReturn(true);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse = sparkQueryDispatcher.dispatch(queryRequest);
 
     verifyNoInteractions(emrServerlessClient);
@@ -311,8 +315,9 @@ public class SparkQueryDispatcherTest {
     doReturn(true).when(sessionManager).isEnabled();
     doThrow(RuntimeException.class).when(sessionManager).createSession(any());
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     Assertions.assertThrows(
         RuntimeException.class, () -> sparkQueryDispatcher.dispatch(queryRequest));
 
@@ -347,11 +352,13 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             true,
-            null);
+            "query_execution_result_my_glue");
+
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -391,11 +398,11 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             false,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -435,11 +442,12 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             false,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -483,11 +491,12 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             true,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -531,11 +540,12 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             true,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -575,11 +585,12 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             false,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -619,11 +630,12 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             false,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -663,11 +675,12 @@ public class SparkQueryDispatcherTest {
             sparkSubmitParameters,
             tags,
             false,
-            null);
+            "query_execution_result_my_glue");
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -685,7 +698,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchWithWrongURI() {
-    when(dataSourceService.getRawDataSourceMetadata("my_glue"))
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
         .thenReturn(constructMyGlueDataSourceMetadataWithBadURISyntax());
     String query = "select * from my_glue.default.http_logs";
     IllegalArgumentException illegalArgumentException =
@@ -707,7 +720,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchWithUnSupportedDataSourceType() {
-    when(dataSourceService.getRawDataSourceMetadata("my_prometheus"))
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_prometheus"))
         .thenReturn(constructPrometheusDataSourceType());
     String query = "select * from my_prometheus.default.http_logs";
     UnsupportedOperationException unsupportedOperationException =
@@ -894,8 +907,8 @@ public class SparkQueryDispatcherTest {
   @Test
   void testDispatchQueryWithExtraSparkSubmitParameters() {
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
-    when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
-    doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
+        .thenReturn(dataSourceMetadata);
 
     String extraParameters = "--conf spark.dynamicAllocation.enabled=false";
     DispatchQueryRequest[] requests = {
@@ -973,9 +986,7 @@ public class SparkQueryDispatcherTest {
   }
 
   private DataSourceMetadata constructMyGlueDataSourceMetadata() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("my_glue");
-    dataSourceMetadata.setConnector(DataSourceType.S3GLUE);
+
     Map<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put(
@@ -985,14 +996,14 @@ public class SparkQueryDispatcherTest {
         "https://search-flint-dp-benchmark-cf5crj5mj2kfzvgwdeynkxnefy.eu-west-1.es.amazonaws.com");
     properties.put("glue.indexstore.opensearch.auth", "awssigv4");
     properties.put("glue.indexstore.opensearch.region", "eu-west-1");
-    dataSourceMetadata.setProperties(properties);
-    return dataSourceMetadata;
+    return new DataSourceMetadata.Builder()
+        .setName("my_glue")
+        .setConnector(DataSourceType.S3GLUE)
+        .setProperties(properties)
+        .build();
   }
 
   private DataSourceMetadata constructMyGlueDataSourceMetadataWithBasicAuth() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("my_glue");
-    dataSourceMetadata.setConnector(DataSourceType.S3GLUE);
     Map<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put(
@@ -1003,14 +1014,14 @@ public class SparkQueryDispatcherTest {
     properties.put("glue.indexstore.opensearch.auth", "basicauth");
     properties.put("glue.indexstore.opensearch.auth.username", "username");
     properties.put("glue.indexstore.opensearch.auth.password", "password");
-    dataSourceMetadata.setProperties(properties);
-    return dataSourceMetadata;
+    return new DataSourceMetadata.Builder()
+        .setName("my_glue")
+        .setConnector(DataSourceType.S3GLUE)
+        .setProperties(properties)
+        .build();
   }
 
   private DataSourceMetadata constructMyGlueDataSourceMetadataWithNoAuth() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("my_glue");
-    dataSourceMetadata.setConnector(DataSourceType.S3GLUE);
     Map<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put(
@@ -1019,14 +1030,14 @@ public class SparkQueryDispatcherTest {
         "glue.indexstore.opensearch.uri",
         "https://search-flint-dp-benchmark-cf5crj5mj2kfzvgwdeynkxnefy.eu-west-1.es.amazonaws.com");
     properties.put("glue.indexstore.opensearch.auth", "noauth");
-    dataSourceMetadata.setProperties(properties);
-    return dataSourceMetadata;
+    return new DataSourceMetadata.Builder()
+        .setName("my_glue")
+        .setConnector(DataSourceType.S3GLUE)
+        .setProperties(properties)
+        .build();
   }
 
   private DataSourceMetadata constructMyGlueDataSourceMetadataWithBadURISyntax() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("my_glue");
-    dataSourceMetadata.setConnector(DataSourceType.S3GLUE);
     Map<String, String> properties = new HashMap<>();
     properties.put("glue.auth.type", "iam_role");
     properties.put(
@@ -1034,17 +1045,18 @@ public class SparkQueryDispatcherTest {
     properties.put("glue.indexstore.opensearch.uri", "http://localhost:9090? param");
     properties.put("glue.indexstore.opensearch.auth", "awssigv4");
     properties.put("glue.indexstore.opensearch.region", "eu-west-1");
-    dataSourceMetadata.setProperties(properties);
-    return dataSourceMetadata;
+    return new DataSourceMetadata.Builder()
+        .setName("my_glue")
+        .setConnector(DataSourceType.S3GLUE)
+        .setProperties(properties)
+        .build();
   }
 
   private DataSourceMetadata constructPrometheusDataSourceType() {
-    DataSourceMetadata dataSourceMetadata = new DataSourceMetadata();
-    dataSourceMetadata.setName("my_prometheus");
-    dataSourceMetadata.setConnector(DataSourceType.PROMETHEUS);
-    Map<String, String> properties = new HashMap<>();
-    dataSourceMetadata.setProperties(properties);
-    return dataSourceMetadata;
+    return new DataSourceMetadata.Builder()
+        .setName("my_prometheus")
+        .setConnector(DataSourceType.PROMETHEUS)
+        .build();
   }
 
   private DispatchQueryRequest constructDispatchQueryRequest(

--- a/spark/src/test/java/org/opensearch/sql/spark/storage/SparkStorageFactoryTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/storage/SparkStorageFactoryTest.java
@@ -146,10 +146,12 @@ public class SparkStorageFactoryTest {
     properties.put("spark.datasource.flint.auth", "false");
     properties.put("spark.datasource.flint.region", "us-west-2");
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
-    metadata.setName("spark");
-    metadata.setConnector(DataSourceType.SPARK);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("spark")
+            .setConnector(DataSourceType.SPARK)
+            .setProperties(properties)
+            .build();
 
     DataSource dataSource = new SparkStorageFactory(client, settings).createDataSource(metadata);
     Assertions.assertTrue(dataSource.getStorageEngine() instanceof SparkStorageEngine);
@@ -167,10 +169,12 @@ public class SparkStorageFactoryTest {
     properties.put("emr.auth.region", "region");
     properties.put("spark.datasource.flint.integration", "s3://spark/flint-spark-integration.jar");
 
-    DataSourceMetadata metadata = new DataSourceMetadata();
-    metadata.setName("spark");
-    metadata.setConnector(DataSourceType.SPARK);
-    metadata.setProperties(properties);
+    DataSourceMetadata metadata =
+        new DataSourceMetadata.Builder()
+            .setName("spark")
+            .setConnector(DataSourceType.SPARK)
+            .setProperties(properties)
+            .build();
 
     DataSource dataSource = new SparkStorageFactory(client, settings).createDataSource(metadata);
     Assertions.assertTrue(dataSource.getStorageEngine() instanceof SparkStorageEngine);


### PR DESCRIPTION
### Description
* This PR introduces a new field status to datasource. This helps in disabling/enabling a datasource.
* Since status is a new column, there won't be any issues with old datasources already registered. But, a datasource registered in 2.13 won't work in 2.12.
* By default, If user doesn't supply any status, the datasource status would be `ACTIVE`.
* A disabled datasource won't accept any new queries.  This applies to all kinds of datasources.
* Also included refactoring related to DataSourceMetadata.
* Documentation Link: https://github.com/vamsi-amazon/sql/blob/datasource-disable-feature/docs/user/ppl/admin/datasources.rst#disabling-a-datasource-to-block-new-queries

### Sample Request for disabling a datasource 
```
PATCH {{baseUrl}}/_plugins/_query/_datasources
content-type: application/json

{
    "name" : "mys3",
    "status" : "disabled"
}
```
Response
```
Updated DataSource with name mys3
```

### Sample Async Query on disabled S3 datasource
```
POST {{baseUrl}}/_plugins/_async_query
content-type: application/json

{
    "lang" : "sql",
    "datasource" : "mys3",
    "query" : "create index clientip_year4 on s3.default.http_logs (clientip, year) WITH (auto_refresh=true)"
}
```
Response
```
{
  "status": 400,
  "error": {
    "type": "DatasourceDisabledException",
    "reason": "Invalid Request",
    "details": "Datasource mys3 is disabled."
  }
}
```
### Sample Query on disabled prometheus datasource.
```
POST http://localhost:9200/_plugins/_ppl
content-type: application/json
{
  "query" : "source=my_prometheus_old.information_schema.tables"
}
```
Response
```
{
  "error": {
    "reason": "Invalid Query",
    "details": "Datasource my_prometheus_old is disabled.",
    "type": "DatasourceDisabledException"
  },
  "status": 400
}
```



### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).