### PR TITLE
Change emr job names based on the query type

### DIFF
--- a/spark/src/main/antlr/SqlBaseParser.g4
+++ b/spark/src/main/antlr/SqlBaseParser.g4
@@ -989,7 +989,7 @@ primaryExpression
     | CASE whenClause+ (ELSE elseExpression=expression)? END                                   #searchedCase
     | CASE value=expression whenClause+ (ELSE elseExpression=expression)? END                  #simpleCase
     | name=(CAST | TRY_CAST) LEFT_PAREN expression AS dataType RIGHT_PAREN                     #cast
-    | primaryExpression collateClause                                                          #collate
+    | primaryExpression collateClause                                                      #collate
     | primaryExpression DOUBLE_COLON dataType                                                  #castByColon
     | STRUCT LEFT_PAREN (argument+=namedExpression (COMMA argument+=namedExpression)*)? RIGHT_PAREN #struct
     | FIRST LEFT_PAREN expression (IGNORE NULLS)? RIGHT_PAREN                                  #first
@@ -1096,7 +1096,7 @@ colPosition
     ;
 
 collateClause
-    : COLLATE collationName=stringLit
+    : COLLATE collationName=identifier
     ;
 
 type

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.emrserverless.model.StartJobRunRequest;
 import com.amazonaws.services.emrserverless.model.StartJobRunResult;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.legacy.metrics.MetricName;
@@ -28,6 +29,8 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
 
   private final AWSEMRServerless emrServerless;
   private static final Logger logger = LogManager.getLogger(EmrServerlessClientImpl.class);
+
+  private static final int MAX_JOB_NAME_LENGTH = 255;
 
   private static final String GENERIC_INTERNAL_SERVER_ERROR_MESSAGE = "Internal Server Error.";
 
@@ -43,7 +46,7 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
             : startJobRequest.getResultIndex();
     StartJobRunRequest request =
         new StartJobRunRequest()
-            .withName(startJobRequest.getJobName())
+            .withName(StringUtils.truncate(startJobRequest.getJobName(), MAX_JOB_NAME_LENGTH))
             .withApplicationId(startJobRequest.getApplicationId())
             .withExecutionRoleArn(startJobRequest.getExecutionRoleArn())
             .withTags(startJobRequest.getTags())

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -68,7 +68,6 @@ public class BatchQueryHandler extends AsyncQueryHandler {
     leaseManager.borrow(new LeaseRequest(JobType.BATCH, dispatchQueryRequest.getDatasource()));
 
     String clusterName = dispatchQueryRequest.getClusterName();
-    String jobName = clusterName + ":" + "non-index-query";
     Map<String, String> tags = context.getTags();
     DataSourceMetadata dataSourceMetadata = context.getDataSourceMetadata();
 
@@ -76,7 +75,7 @@ public class BatchQueryHandler extends AsyncQueryHandler {
     StartJobRequest startJobRequest =
         new StartJobRequest(
             dispatchQueryRequest.getQuery(),
-            jobName,
+            clusterName + ":" + JobType.BATCH.getText(),
             dispatchQueryRequest.getApplicationId(),
             dispatchQueryRequest.getExecutionRoleARN(),
             SparkSubmitParameters.Builder.builder()

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
@@ -15,9 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.opensearch.client.Client;
-import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
-import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelperImpl;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryId;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
@@ -43,10 +41,6 @@ public class IndexDMLHandler extends AsyncQueryHandler {
   public static final String DROP_INDEX_JOB_ID = "dropIndexJobId";
 
   private final EMRServerlessClient emrServerlessClient;
-
-  private final DataSourceService dataSourceService;
-
-  private final DataSourceUserAuthorizationHelperImpl dataSourceUserAuthorizationHelper;
 
   private final JobExecutionResponseReader jobExecutionResponseReader;
 

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -71,7 +71,6 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
       DispatchQueryRequest dispatchQueryRequest, DispatchQueryContext context) {
     Session session = null;
     String clusterName = dispatchQueryRequest.getClusterName();
-    String jobName = clusterName + ":" + "non-index-query";
     Map<String, String> tags = context.getTags();
     DataSourceMetadata dataSourceMetadata = context.getDataSourceMetadata();
 
@@ -94,7 +93,7 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
       session =
           sessionManager.createSession(
               new CreateSessionRequest(
-                  jobName,
+                  clusterName,
                   dispatchQueryRequest.getApplicationId(),
                   dispatchQueryRequest.getExecutionRoleARN(),
                   SparkSubmitParameters.Builder.builder()

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -127,8 +127,6 @@ public class SparkQueryDispatcher {
   private IndexDMLHandler createIndexDMLHandler(EMRServerlessClient emrServerlessClient) {
     return new IndexDMLHandler(
         emrServerlessClient,
-        dataSourceService,
-        dataSourceUserAuthorizationHelper,
         jobExecutionResponseReader,
         flintIndexMetadataReader,
         client,

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
@@ -44,12 +44,17 @@ public class StreamingQueryHandler extends BatchQueryHandler {
     leaseManager.borrow(new LeaseRequest(JobType.STREAMING, dispatchQueryRequest.getDatasource()));
 
     String clusterName = dispatchQueryRequest.getClusterName();
-    String jobName = clusterName + ":" + "index-query";
     IndexQueryDetails indexQueryDetails = context.getIndexQueryDetails();
     Map<String, String> tags = context.getTags();
     tags.put(INDEX_TAG_KEY, indexQueryDetails.openSearchIndexName());
     DataSourceMetadata dataSourceMetadata = context.getDataSourceMetadata();
     tags.put(JOB_TYPE_TAG_KEY, JobType.STREAMING.getText());
+    String jobName =
+        clusterName
+            + ":"
+            + JobType.STREAMING.getText()
+            + ":"
+            + indexQueryDetails.openSearchIndexName();
     StartJobRequest startJobRequest =
         new StartJobRequest(
             dispatchQueryRequest.getQuery(),

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/CreateSessionRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/CreateSessionRequest.java
@@ -9,10 +9,11 @@ import java.util.Map;
 import lombok.Data;
 import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 import org.opensearch.sql.spark.client.StartJobRequest;
+import org.opensearch.sql.spark.dispatcher.model.JobType;
 
 @Data
 public class CreateSessionRequest {
-  private final String jobName;
+  private final String clusterName;
   private final String applicationId;
   private final String executionRoleArn;
   private final SparkSubmitParameters.Builder sparkSubmitParametersBuilder;
@@ -20,10 +21,10 @@ public class CreateSessionRequest {
   private final String resultIndex;
   private final String datasourceName;
 
-  public StartJobRequest getStartJobRequest() {
+  public StartJobRequest getStartJobRequest(String sessionId) {
     return new InteractiveSessionStartJobRequest(
         "select 1",
-        jobName,
+        clusterName + ":" + JobType.INTERACTIVE.getText() + ":" + sessionId,
         applicationId,
         executionRoleArn,
         sparkSubmitParametersBuilder.build().toString(),

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.execution.statement.QueryRequest;
 import org.opensearch.sql.spark.execution.statement.Statement;
 import org.opensearch.sql.spark.execution.statement.StatementId;
@@ -55,8 +56,10 @@ public class InteractiveSession implements Session {
           .getSparkSubmitParametersBuilder()
           .sessionExecution(sessionId.getSessionId(), createSessionRequest.getDatasourceName());
       createSessionRequest.getTags().put(SESSION_ID_TAG_KEY, sessionId.getSessionId());
-      String jobID = serverlessClient.startJobRun(createSessionRequest.getStartJobRequest());
-      String applicationId = createSessionRequest.getStartJobRequest().getApplicationId();
+      StartJobRequest startJobRequest =
+          createSessionRequest.getStartJobRequest(sessionId.getSessionId());
+      String jobID = serverlessClient.startJobRun(startJobRequest);
+      String applicationId = startJobRequest.getApplicationId();
 
       sessionModel =
           initInteractiveSession(

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
@@ -29,6 +29,7 @@ import com.amazonaws.services.emrserverless.model.StartJobRunResult;
 import com.amazonaws.services.emrserverless.model.ValidationException;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -174,5 +175,26 @@ public class EmrServerlessClientImplTest {
             RuntimeException.class,
             () -> emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID));
     Assertions.assertEquals("Internal Server Error.", runtimeException.getMessage());
+  }
+
+  @Test
+  void testStartJobRunWithLongJobName() {
+    StartJobRunResult response = new StartJobRunResult();
+    when(emrServerless.startJobRun(any())).thenReturn(response);
+
+    EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
+    emrServerlessClient.startJobRun(
+        new StartJobRequest(
+            QUERY,
+            RandomStringUtils.random(300),
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            SPARK_SUBMIT_PARAMETERS,
+            new HashMap<>(),
+            false,
+            DEFAULT_RESULT_INDEX));
+    verify(emrServerless, times(1)).startJobRun(startJobRunRequestArgumentCaptor.capture());
+    StartJobRunRequest startJobRunRequest = startJobRunRequestArgumentCaptor.getValue();
+    Assertions.assertEquals(255, startJobRunRequest.getName().length());
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandlerTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandlerTest.java
@@ -16,7 +16,7 @@ class IndexDMLHandlerTest {
   @Test
   public void getResponseFromExecutor() {
     JSONObject result =
-        new IndexDMLHandler(null, null, null, null, null, null, null).getResponseFromExecutor(null);
+        new IndexDMLHandler(null, null, null, null, null).getResponseFromExecutor(null);
 
     assertEquals("running", result.getString(STATUS_FIELD));
     assertEquals("", result.getString(ERROR_FIELD));

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -141,17 +141,17 @@ public class SparkQueryDispatcherTest {
                 put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
               }
             });
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:non-index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                false,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:batch",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            false,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -165,16 +165,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:non-index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            false,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -196,17 +186,17 @@ public class SparkQueryDispatcherTest {
                 put(FLINT_INDEX_STORE_AUTH_PASSWORD, "password");
               }
             });
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:non-index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                false,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:batch",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            false,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadataWithBasicAuth();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -220,16 +210,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:non-index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            false,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -249,17 +229,17 @@ public class SparkQueryDispatcherTest {
               {
               }
             });
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:non-index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                false,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:batch",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            false,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadataWithNoAuth();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -273,16 +253,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:non-index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            false,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -368,17 +338,17 @@ public class SparkQueryDispatcherTest {
                     put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
                   }
                 }));
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                true,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:streaming:flint_my_glue_default_http_logs_elb_and_requesturi_index",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            true,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -392,16 +362,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            true,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -422,17 +382,17 @@ public class SparkQueryDispatcherTest {
                 put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
               }
             });
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:non-index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                false,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:batch",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            false,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -446,16 +406,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:non-index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            false,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -476,17 +426,17 @@ public class SparkQueryDispatcherTest {
                 put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
               }
             });
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:non-index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                false,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:batch",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            false,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -500,16 +450,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:non-index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            false,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -534,17 +474,17 @@ public class SparkQueryDispatcherTest {
                     put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
                   }
                 }));
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                true,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:streaming:flint_my_glue_default_http_logs_elb_and_requesturi_index",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            true,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -558,16 +498,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            true,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -592,17 +522,17 @@ public class SparkQueryDispatcherTest {
                     put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
                   }
                 }));
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                true,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:streaming:flint_mv_1",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            true,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -616,16 +546,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            true,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -646,17 +566,17 @@ public class SparkQueryDispatcherTest {
                 put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
               }
             });
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                false,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:batch",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            false,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -670,16 +590,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:non-index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            false,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -700,17 +610,17 @@ public class SparkQueryDispatcherTest {
                 put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
               }
             });
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:non-index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                false,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:batch",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            false,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -724,16 +634,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:non-index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            false,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);
@@ -754,17 +654,17 @@ public class SparkQueryDispatcherTest {
                 put(FLINT_INDEX_STORE_AWSREGION_KEY, "eu-west-1");
               }
             });
-    when(emrServerlessClient.startJobRun(
-            new StartJobRequest(
-                query,
-                "TEST_CLUSTER:index-query",
-                EMRS_APPLICATION_ID,
-                EMRS_EXECUTION_ROLE,
-                sparkSubmitParameters,
-                tags,
-                false,
-                any())))
-        .thenReturn(EMR_JOB_ID);
+    StartJobRequest expected =
+        new StartJobRequest(
+            query,
+            "TEST_CLUSTER:batch",
+            EMRS_APPLICATION_ID,
+            EMRS_EXECUTION_ROLE,
+            sparkSubmitParameters,
+            tags,
+            false,
+            null);
+    when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.getRawDataSourceMetadata("my_glue")).thenReturn(dataSourceMetadata);
     doNothing().when(dataSourceUserAuthorizationHelper).authorizeDataSource(dataSourceMetadata);
@@ -778,16 +678,6 @@ public class SparkQueryDispatcherTest {
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
-    StartJobRequest expected =
-        new StartJobRequest(
-            query,
-            "TEST_CLUSTER:non-index-query",
-            EMRS_APPLICATION_ID,
-            EMRS_EXECUTION_ROLE,
-            sparkSubmitParameters,
-            tags,
-            false,
-            null);
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
     verifyNoInteractions(flintIndexMetadataReader);

--- a/spark/src/test/java/org/opensearch/sql/spark/rest/model/CreateAsyncQueryRequestTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/rest/model/CreateAsyncQueryRequestTest.java
@@ -49,11 +49,10 @@ public class CreateAsyncQueryRequestTest {
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> CreateAsyncQueryRequest.fromXContentParser(xContentParser(request)));
-    Assertions.assertEquals(
-        "Error while parsing the request body: Duplicate field 'datasource'\n"
-            + " at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled);"
-            + " line: 3, column: 15]",
-        illegalArgumentException.getMessage());
+    Assertions.assertTrue(
+        illegalArgumentException
+            .getMessage()
+            .contains("Error while parsing the request body: Duplicate field 'datasource'"));
   }
 
   @Test


### PR DESCRIPTION
### Description
* Change EMR job names to following.
        * Batch Query: `clustername:batch`
        * Interactive Query: `clustername:interactive:sessionId`
        * Index Streaming Query: `clustername:streaming:flint_my_glue_default_http_logs_elb_and_requesturi_index`
* Truncating jobname if length of it is greater than 255 characters.
* SparkQueryDispatcherTest.java and CreateAsyncQueryRequestTest.java refactoring.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).