### PR TITLE
Change async query default setting

### DIFF
--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -506,7 +506,7 @@ To change the TTL to 60 days for example, execute the following command:
 SQL query::
 
     sh$ curl -sS -H 'Content-Type: application/json' -X PUT localhost:9200/_cluster/settings \
-    ... -d '{"transient":{"plugins.query.executionengine.spark.session.index.ttl":"30d"}}'
+    ... -d '{"transient":{"plugins.query.executionengine.spark.session.index.ttl":"60d"}}'
     {
         "acknowledged": true,
         "persistent": {},

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -318,9 +318,9 @@ plugins.query.executionengine.spark.session.limit
 Description
 -----------
 
-Each cluster can have maximum 100 sessions running in parallel by default. You can increase limit by this setting.
+Each cluster can have maximum 10 sessions running in parallel by default. You can increase limit by this setting.
 
-1. The default value is 100.
+1. The default value is 10.
 2. This setting is node scope.
 3. This setting can be updated dynamically.
 
@@ -355,9 +355,9 @@ plugins.query.executionengine.spark.refresh_job.limit
 Description
 -----------
 
-Each cluster can have maximum 20 datasources. You can increase limit by this setting.
+Each cluster can have maximum 5 refresh job running concurrently. You can increase limit by this setting.
 
-1. The default value is 20.
+1. The default value is 5.
 2. This setting is node scope.
 3. This setting can be updated dynamically.
 
@@ -499,9 +499,9 @@ Description
 This setting defines the time-to-live (TTL) for request indices when plugins.query.executionengine.spark.auto_index_management.enabled
 is true. By default, request indices older than 14 days are deleted.
 
-* Default Value: 14 days
+* Default Value: 30 days
 
-To change the TTL to 30 days for example, execute the following command:
+To change the TTL to 60 days for example, execute the following command:
 
 SQL query::
 
@@ -517,7 +517,7 @@ SQL query::
                         "spark": {
                             "session": {
                                 "index": {
-                                    "ttl": "30d"
+                                    "ttl": "60d"
                                 }
                             }
                         }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -147,21 +147,21 @@ public class OpenSearchSettings extends Settings {
   public static final Setting<?> SPARK_EXECUTION_SESSION_LIMIT_SETTING =
       Setting.intSetting(
           Key.SPARK_EXECUTION_SESSION_LIMIT.getKeyValue(),
-          100,
+          10,
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 
   public static final Setting<?> SPARK_EXECUTION_REFRESH_JOB_LIMIT_SETTING =
       Setting.intSetting(
           Key.SPARK_EXECUTION_REFRESH_JOB_LIMIT.getKeyValue(),
-          50,
+          5,
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 
   public static final Setting<TimeValue> SESSION_INDEX_TTL_SETTING =
       Setting.positiveTimeSetting(
           Key.SESSION_INDEX_TTL.getKeyValue(),
-          timeValueDays(14),
+          timeValueDays(30),
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 


### PR DESCRIPTION
### Description
* plugins.query.executionengine.spark.session.limit, 100 to 10
* plugins.query.executionengine.spark.refresh_job.limit, 20 to 5
* plugins.query.executionengine.spark.session.index.ttl, 14 day to 30 day
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/2471
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).