### PR TITLE
Percent encode opensearch index name

### DIFF
--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/IndexQueryDetails.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/IndexQueryDetails.java
@@ -8,7 +8,6 @@ package org.opensearch.sql.spark.dispatcher.model;
 import static org.apache.commons.lang3.StringUtils.strip;
 
 import java.util.Set;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
@@ -334,10 +334,16 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
     final FlintIndexType indexType;
     final String indexName;
     boolean isLegacy = false;
+    boolean isSpecialCharacter = false;
     String latestId;
 
     FlintDatasetMock isLegacy(boolean isLegacy) {
       this.isLegacy = isLegacy;
+      return this;
+    }
+
+    FlintDatasetMock isSpecialCharacter(boolean isSpecialCharacter) {
+      this.isSpecialCharacter = isSpecialCharacter;
       return this;
     }
 
@@ -348,6 +354,11 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
 
     public void createIndex() {
       String pathPrefix = isLegacy ? "flint-index-mappings" : "flint-index-mappings/0.1.1";
+      if (isSpecialCharacter) {
+        createIndexWithMappings(
+            indexName, loadMappings(pathPrefix + "/" + "flint_special_character_index.json"));
+        return;
+      }
       switch (indexType) {
         case SKIPPING:
           createIndexWithMappings(

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -59,10 +59,10 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
   public final FlintDatasetMock LEGACY_SPECIAL_CHARACTERS =
       new FlintDatasetMock(
-          "DROP SKIPPING INDEX ON mys3.default." + specialName,
-          REFRESH_SCI,
-          FlintIndexType.SKIPPING,
-          "flint_mys3_default_" + encodedName + "_skipping_index")
+              "DROP SKIPPING INDEX ON mys3.default." + specialName,
+              REFRESH_SCI,
+              FlintIndexType.SKIPPING,
+              "flint_mys3_default_" + encodedName + "_skipping_index")
           .isLegacy(true)
           .isSpecialCharacter(true);
 
@@ -82,10 +82,10 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
           .latestId("ZmxpbnRfbXlzM19kZWZhdWx0X2h0dHBfbG9nc19jb3ZlcmluZ19pbmRleA==");
   public final FlintDatasetMock MV =
       new FlintDatasetMock(
-          "DROP MATERIALIZED VIEW mys3.default.http_logs_metrics",
-          REFRESH_MV,
-          FlintIndexType.MATERIALIZED_VIEW,
-          "flint_mys3_default_http_logs_metrics")
+              "DROP MATERIALIZED VIEW mys3.default.http_logs_metrics",
+              REFRESH_MV,
+              FlintIndexType.MATERIALIZED_VIEW,
+              "flint_mys3_default_http_logs_metrics")
           .latestId("ZmxpbnRfbXlzM19kZWZhdWx0X2h0dHBfbG9nc19tZXRyaWNz");
   public final FlintDatasetMock SPECIAL_CHARACTERS =
       new FlintDatasetMock(
@@ -94,7 +94,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               FlintIndexType.SKIPPING,
               "flint_mys3_default_" + encodedName + "_skipping_index")
           .isSpecialCharacter(true)
-          .latestId("ZmxpbnRfbXlzM19kZWZhdWx0X3Rlc3QlMjAlMmMlM2ElMjIlMmIlMmYlNWMlN2MlM2YlMjMlM2UlM2Nfc2tpcHBpbmdfaW5kZXg=");
+          .latestId(
+              "ZmxpbnRfbXlzM19kZWZhdWx0X3Rlc3QlMjAlMmMlM2ElMjIlMmIlMmYlNWMlN2MlM2YlMjMlM2UlM2Nfc2tpcHBpbmdfaW5kZXg=");
 
   public final String CREATE_SI_AUTO =
       "CREATE SKIPPING INDEX ON mys3.default.http_logs"

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -87,7 +87,6 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
           FlintIndexType.MATERIALIZED_VIEW,
           "flint_mys3_default_http_logs_metrics")
           .latestId("ZmxpbnRfbXlzM19kZWZhdWx0X2h0dHBfbG9nc19tZXRyaWNz");
-
   public final FlintDatasetMock SPECIAL_CHARACTERS =
       new FlintDatasetMock(
               "DROP SKIPPING INDEX ON mys3.default." + specialName,
@@ -95,7 +94,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               FlintIndexType.SKIPPING,
               "flint_mys3_default_" + encodedName + "_skipping_index")
           .isSpecialCharacter(true)
-          .latestId("specialcharacterindexid");
+          .latestId("ZmxpbnRfbXlzM19kZWZhdWx0X3Rlc3QlMjAlMmMlM2ElMjIlMmIlMmYlNWMlN2MlM2YlMjMlM2UlM2Nfc2tpcHBpbmdfaW5kZXg=");
 
   public final String CREATE_SI_AUTO =
       "CREATE SKIPPING INDEX ON mys3.default.http_logs"

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
@@ -54,7 +54,12 @@ public class IndexQuerySpecVacuumTest extends AsyncQueryExecutorServiceSpec {
           mockDataset(
               "VACUUM MATERIALIZED VIEW mys3.default.http_logs_metrics",
               MATERIALIZED_VIEW,
-              "flint_mys3_default_http_logs_metrics"));
+              "flint_mys3_default_http_logs_metrics"),
+          mockDataset(
+              "VACUUM SKIPPING INDEX ON mys3.default.`test ,:\"+/\\|?#><`",
+              SKIPPING,
+              "flint_mys3_default_test%20%2c%3a%22%2b%2f%5c%7c%3f%23%3e%3c_skipping_index")
+              .isSpecialCharacter(true));
 
   @Test
   public void shouldVacuumIndexInRefreshingState() {

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
@@ -56,9 +56,9 @@ public class IndexQuerySpecVacuumTest extends AsyncQueryExecutorServiceSpec {
               MATERIALIZED_VIEW,
               "flint_mys3_default_http_logs_metrics"),
           mockDataset(
-              "VACUUM SKIPPING INDEX ON mys3.default.`test ,:\"+/\\|?#><`",
-              SKIPPING,
-              "flint_mys3_default_test%20%2c%3a%22%2b%2f%5c%7c%3f%23%3e%3c_skipping_index")
+                  "VACUUM SKIPPING INDEX ON mys3.default.`test ,:\"+/\\|?#><`",
+                  SKIPPING,
+                  "flint_mys3_default_test%20%2c%3a%22%2b%2f%5c%7c%3f%23%3e%3c_skipping_index")
               .isSpecialCharacter(true));
 
   @Test

--- a/spark/src/test/java/org/opensearch/sql/spark/flint/IndexQueryDetailsTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/flint/IndexQueryDetailsTest.java
@@ -111,7 +111,8 @@ public class IndexQueryDetailsTest {
         "flint_mys3_default_test%20%2c%3a%22%2b%2f%5c%7c%3f%23%3e%3c_skipping_index",
         IndexQueryDetails.builder()
             .indexName("invalid")
-            .fullyQualifiedTableName(new FullyQualifiedTableName("mys3.default.`test ,:\"+/\\|?#><`"))
+            .fullyQualifiedTableName(
+                new FullyQualifiedTableName("mys3.default.`test ,:\"+/\\|?#><`"))
             .indexOptions(new FlintIndexOptions())
             .indexQueryActionType(IndexQueryActionType.DROP)
             .indexType(FlintIndexType.SKIPPING)

--- a/spark/src/test/java/org/opensearch/sql/spark/flint/IndexQueryDetailsTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/flint/IndexQueryDetailsTest.java
@@ -104,4 +104,18 @@ public class IndexQueryDetailsTest {
             .build()
             .openSearchIndexName());
   }
+
+  @Test
+  public void sanitizedIndexName() {
+    assertEquals(
+        "flint_mys3_default_test%20%2c%3a%22%2b%2f%5c%7c%3f%23%3e%3c_skipping_index",
+        IndexQueryDetails.builder()
+            .indexName("invalid")
+            .fullyQualifiedTableName(new FullyQualifiedTableName("mys3.default.`test ,:\"+/\\|?#><`"))
+            .indexOptions(new FlintIndexOptions())
+            .indexQueryActionType(IndexQueryActionType.DROP)
+            .indexType(FlintIndexType.SKIPPING)
+            .build()
+            .openSearchIndexName());
+  }
 }

--- a/spark/src/test/resources/flint-index-mappings/0.1.1/flint_special_character_index.json
+++ b/spark/src/test/resources/flint-index-mappings/0.1.1/flint_special_character_index.json
@@ -18,6 +18,6 @@
         "SERVERLESS_EMR_JOB_ID": "00fdmvv9hp8u0o0q"
       }
     },
-    "latestId": "specialcharacterindexid"
+    "latestId": "ZmxpbnRfbXlzM19kZWZhdWx0X3Rlc3QlMjAlMmMlM2ElMjIlMmIlMmYlNWMlN2MlM2YlMjMlM2UlM2Nfc2tpcHBpbmdfaW5kZXg="
   }
 }

--- a/spark/src/test/resources/flint-index-mappings/0.1.1/flint_special_character_index.json
+++ b/spark/src/test/resources/flint-index-mappings/0.1.1/flint_special_character_index.json
@@ -1,0 +1,23 @@
+{
+  "_meta": {
+    "kind": "skipping",
+    "indexedColumns": [
+      {
+        "columnType": "int",
+        "kind": "VALUE_SET",
+        "columnName": "status"
+      }
+    ],
+    "name": "flint_mys3_default_test%20%2c%3a%22%2b%2f%5c%7c%3f%23%3e%3c_skipping_index",
+    "options": {},
+    "source": "mys3.default.`test ,:\"+/\\|?#><`",
+    "version": "0.1.0",
+    "properties": {
+      "env": {
+        "SERVERLESS_EMR_VIRTUAL_CLUSTER_ID": "00fd777k3k3ls20p",
+        "SERVERLESS_EMR_JOB_ID": "00fdmvv9hp8u0o0q"
+      }
+    },
+    "latestId": "specialcharacterindexid"
+  }
+}

--- a/spark/src/test/resources/flint-index-mappings/flint_special_character_index.json
+++ b/spark/src/test/resources/flint-index-mappings/flint_special_character_index.json
@@ -1,0 +1,22 @@
+{
+  "_meta": {
+    "kind": "skipping",
+    "indexedColumns": [
+      {
+        "columnType": "int",
+        "kind": "VALUE_SET",
+        "columnName": "status"
+      }
+    ],
+    "name": "flint_mys3_default_test%20%2c%3a%22%2b%2f%5c%7c%3f%23%3e%3c_skipping_index",
+    "options": {},
+    "source": "mys3.default.`test ,:\"+/\\|?#><`",
+    "version": "0.1.0",
+    "properties": {
+      "env": {
+        "SERVERLESS_EMR_VIRTUAL_CLUSTER_ID": "00fd777k3k3ls20p",
+        "SERVERLESS_EMR_JOB_ID": "00fdmvv9hp8u0o0q"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Handle special characters when generating Flint index name by percent-encoding the invalid OpenSearch index name characters, since in some cases, sql queries (DROP, ALTER) are handled over here rather than forwarded to spark.
Same fix in opensearch-spark repo: https://github.com/opensearch-project/opensearch-spark/pull/215

 
### Issues Resolved
* https://github.com/opensearch-project/opensearch-spark/issues/192
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).