### PR TITLE
Handle EMR Exceptions in FlintCancelJob Operation

### DIFF
--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -420,7 +420,7 @@ SQL query::
 
 
 plugins.query.executionengine.spark.session_inactivity_timeout_millis
-===============================
+=====================================================================
 
 Description
 -----------
@@ -456,7 +456,7 @@ SQL query::
 
 
 plugins.query.executionengine.spark.auto_index_management.enabled
-===============================
+=================================================================
 
 Description
 -----------
@@ -492,7 +492,7 @@ SQL query::
 
 
 plugins.query.executionengine.spark.session.index.ttl
-===============================
+=====================================================
 
 Description
 -----------
@@ -529,7 +529,7 @@ SQL query::
 
 
 plugins.query.executionengine.spark.result.index.ttl
-===============================
+====================================================
 
 Description
 -----------
@@ -565,7 +565,7 @@ SQL query::
     }
 
 plugins.query.executionengine.async_query.enabled
-===============================
+=================================================
 
 Description
 -----------
@@ -596,7 +596,7 @@ Request::
     }
 
 plugins.query.executionengine.spark.streamingjobs.housekeeper.interval
-===============================
+======================================================================
 
 Description
 -----------

--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceAPIsIT.java
@@ -11,7 +11,10 @@ import static org.opensearch.sql.datasources.utils.XContentParserUtils.ALLOWED_R
 import static org.opensearch.sql.datasources.utils.XContentParserUtils.DESCRIPTION_FIELD;
 import static org.opensearch.sql.datasources.utils.XContentParserUtils.NAME_FIELD;
 import static org.opensearch.sql.datasources.utils.XContentParserUtils.STATUS_FIELD;
+import static org.opensearch.sql.legacy.TestUtils.createIndexByRestClient;
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
+import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
+import static org.opensearch.sql.legacy.TestUtils.loadDataByRestClient;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
@@ -36,11 +39,6 @@ import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class DataSourceAPIsIT extends PPLIntegTestCase {
-
-  @Override
-  protected void init() throws Exception {
-    loadIndex(Index.DATASOURCES);
-  }
 
   @After
   public void cleanUp() throws IOException {
@@ -397,6 +395,16 @@ public class DataSourceAPIsIT extends PPLIntegTestCase {
   @SneakyThrows
   @Test
   public void testOldDataSourceModelLoadingThroughGetDataSourcesAPI() {
+    Index index = Index.DATASOURCES;
+    String indexName = index.getName();
+    String mapping = index.getMapping();
+    String dataSet = index.getDataSet();
+    if (!isIndexExist(client(), indexName)) {
+      createIndexByRestClient(client(), indexName, mapping);
+    }
+    loadDataByRestClient(client(), indexName, dataSet);
+    // waiting for loaded indices.
+    Thread.sleep(1000);
     // get datasource to validate the creation.
     Request getRequest = getFetchDataSourceRequest(null);
     Response getResponse = client().performRequest(getRequest);

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClient.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClient.java
@@ -41,5 +41,6 @@ public interface EMRServerlessClient {
    * @param jobId jobId.
    * @return {@link CancelJobRunResult}
    */
-  CancelJobRunResult cancelJobRun(String applicationId, String jobId);
+  CancelJobRunResult cancelJobRun(
+      String applicationId, String jobId, boolean allowExceptionPropagation);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -58,7 +58,7 @@ public class BatchQueryHandler extends AsyncQueryHandler {
   @Override
   public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
     emrServerlessClient.cancelJobRun(
-        asyncQueryJobMetadata.getApplicationId(), asyncQueryJobMetadata.getJobId());
+        asyncQueryJobMetadata.getApplicationId(), asyncQueryJobMetadata.getJobId(), false);
     return asyncQueryJobMetadata.getQueryId().getId();
   }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
@@ -80,7 +80,8 @@ public class InteractiveSession implements Session {
     if (model.isEmpty()) {
       throw new IllegalStateException("session does not exist. " + sessionModel.getSessionId());
     } else {
-      serverlessClient.cancelJobRun(sessionModel.getApplicationId(), sessionModel.getJobId());
+      serverlessClient.cancelJobRun(
+          sessionModel.getApplicationId(), sessionModel.getJobId(), false);
     }
   }
 

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
@@ -243,7 +243,8 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
     }
 
     @Override
-    public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
+    public CancelJobRunResult cancelJobRun(
+        String applicationId, String jobId, boolean allowExceptionPropagation) {
       cancelJobRunCalled++;
       return new CancelJobRunResult().withJobRunId(jobId);
     }

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
@@ -1,0 +1,1073 @@
+package org.opensearch.sql.spark.asyncquery;
+
+import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
+import com.amazonaws.services.emrserverless.model.GetJobRunResult;
+import com.amazonaws.services.emrserverless.model.JobRun;
+import com.amazonaws.services.emrserverless.model.ValidationException;
+import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
+import org.opensearch.sql.spark.asyncquery.model.MockFlintIndex;
+import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
+import org.opensearch.sql.spark.client.StartJobRequest;
+import org.opensearch.sql.spark.flint.FlintIndexState;
+import org.opensearch.sql.spark.flint.FlintIndexType;
+import org.opensearch.sql.spark.rest.model.CreateAsyncQueryRequest;
+import org.opensearch.sql.spark.rest.model.CreateAsyncQueryResponse;
+import org.opensearch.sql.spark.rest.model.LangType;
+
+public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
+
+  @Test
+  public void testAlterIndexQueryConvertingToManualRefresh() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false)");
+    MockFlintIndex ALTER_COVERING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_covering_index",
+            FlintIndexType.COVERING,
+            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false)");
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
+                + " incremental_refresh=false) ");
+    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(1);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryConvertingToManualRefreshWithNoIncrementalRefresh() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false)");
+    MockFlintIndex ALTER_COVERING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_covering_index",
+            FlintIndexType.COVERING,
+            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false)");
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false)");
+    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              existingOptions.put("checkpoint_location", "s3://checkpoint/location");
+              mockDS.updateIndexOptions(existingOptions, true);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(1);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryWithRedundantOperation() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false)");
+    MockFlintIndex ALTER_COVERING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_covering_index",
+            FlintIndexType.COVERING,
+            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false)");
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
+                + " incremental_refresh=false) ");
+    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public String startJobRun(StartJobRequest startJobRequest) {
+                      return "jobId";
+                    }
+
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+
+                    @Override
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
+                      super.cancelJobRun(applicationId, jobId, allowExceptionPropagation);
+                      throw new ValidationException("Job run is not in a cancellable state");
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessCientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessCientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "false");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(1);
+              emrsClient.getJobRunResultCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryConvertingToAutoRefresh() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=true,"
+                + " incremental_refresh=false)");
+    MockFlintIndex ALTER_COVERING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_covering_index",
+            FlintIndexType.COVERING,
+            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=true,"
+                + " incremental_refresh=false)");
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=true,"
+                + " incremental_refresh=false) ");
+    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient localEMRSClient = new LocalEMRSClient();
+              EMRServerlessClientFactory clientFactory = () -> localEMRSClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(clientFactory);
+
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "false");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              assertEquals(
+                  "RUNNING",
+                  asyncQueryExecutorService
+                      .getAsyncQueryResults(response.getQueryId())
+                      .getStatus());
+
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              localEMRSClient.startJobRunCalled(1);
+              localEMRSClient.getJobRunResultCalled(1);
+              localEMRSClient.cancelJobRunCalled(0);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryWithOutAnyAutoRefresh() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH ("
+                + " incremental_refresh=false)");
+    MockFlintIndex ALTER_COVERING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_covering_index",
+            FlintIndexType.COVERING,
+            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH ("
+                + " incremental_refresh=false)");
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (" + " incremental_refresh=false) ");
+    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient localEMRSClient = new LocalEMRSClient();
+              EMRServerlessClientFactory clientFactory = () -> localEMRSClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(clientFactory);
+
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "false");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              assertEquals(
+                  "RUNNING",
+                  asyncQueryExecutorService
+                      .getAsyncQueryResults(response.getQueryId())
+                      .getStatus());
+
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              localEMRSClient.startJobRunCalled(1);
+              localEMRSClient.getJobRunResultCalled(1);
+              localEMRSClient.cancelJobRunCalled(0);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryOfFullRefreshWithInvalidOptions() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false, checkpoint_location=\"s3://ckp/skp\")");
+    MockFlintIndex ALTER_COVERING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_covering_index",
+            FlintIndexType.COVERING,
+            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false, checkpoint_location=\"s3://ckp/skp\")");
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
+                + " incremental_refresh=false, checkpoint_location=\"s3://ckp/skp\") ");
+    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
+              assertEquals(
+                  "Altering to full refresh only allows: [auto_refresh, incremental_refresh]"
+                      + " options",
+                  asyncQueryExecutionResponse.getError());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("true", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryOfIncrementalRefreshWithInvalidOptions() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=true, output_mode=\"complete\")");
+    MockFlintIndex ALTER_COVERING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_covering_index",
+            FlintIndexType.COVERING,
+            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=true, output_mode=\"complete\")");
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
+                + " incremental_refresh=true, output_mode=\"complete\") ");
+    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
+              assertEquals(
+                  "Altering to incremental refresh only allows: [auto_refresh, incremental_refresh,"
+                      + " watermark_delay, checkpoint_location] options",
+                  asyncQueryExecutionResponse.getError());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("true", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryOfIncrementalRefreshWithInsufficientOptions() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=true)");
+    MockFlintIndex ALTER_COVERING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_covering_index",
+            FlintIndexType.COVERING,
+            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=true)");
+    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              existingOptions.put("incremental_refresh", "false");
+              mockDS.updateIndexOptions(existingOptions, true);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
+              assertEquals(
+                  "Conversion to incremental refresh index cannot proceed due to missing"
+                      + " attributes: checkpoint_location.",
+                  asyncQueryExecutionResponse.getError());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("true", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryOfIncrementalRefreshWithInsufficientOptionsForMV() {
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
+                + " incremental_refresh=true) ");
+    ImmutableList.of(ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              existingOptions.put("incremental_refresh", "false");
+              mockDS.updateIndexOptions(existingOptions, true);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
+              assertEquals(
+                  "Conversion to incremental refresh index cannot proceed due to missing"
+                      + " attributes: checkpoint_location, watermark_delay.",
+                  asyncQueryExecutionResponse.getError());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("true", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryOfIncrementalRefreshWithEmptyExistingOptionsForMV() {
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
+                + " incremental_refresh=true) ");
+    ImmutableList.of(ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              existingOptions.put("incremental_refresh", "false");
+              existingOptions.put("watermark_delay", "");
+              existingOptions.put("checkpoint_location", "");
+              mockDS.updateIndexOptions(existingOptions, true);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
+              assertEquals(
+                  "Conversion to incremental refresh index cannot proceed due to missing"
+                      + " attributes: checkpoint_location, watermark_delay.",
+                  asyncQueryExecutionResponse.getError());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("true", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryOfIncrementalRefresh() {
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
+                + " incremental_refresh=true) ");
+    ImmutableList.of(ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              existingOptions.put("incremental_refresh", "false");
+              existingOptions.put("watermark_delay", "watermark_delay");
+              existingOptions.put("checkpoint_location", "s3://checkpoint/location");
+              mockDS.updateIndexOptions(existingOptions, true);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.refreshing();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.getJobRunResultCalled(1);
+              emrsClient.cancelJobRunCalled(1);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+              Assertions.assertEquals("true", options.get("incremental_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryWithIncrementalRefreshAlreadyExisting() {
+    MockFlintIndex ALTER_MV =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_mv",
+            FlintIndexType.MATERIALIZED_VIEW,
+            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false) ");
+    ImmutableList.of(ALTER_MV)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              existingOptions.put("incremental_refresh", "true");
+              existingOptions.put("watermark_delay", "watermark_delay");
+              existingOptions.put("checkpoint_location", "s3://checkpoint/location");
+              mockDS.updateIndexOptions(existingOptions, true);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.refreshing();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.getJobRunResultCalled(1);
+              emrsClient.cancelJobRunCalled(1);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+              Assertions.assertEquals("true", options.get("incremental_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryWithInvalidInitialState() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false)");
+    ImmutableList.of(ALTER_SKIPPING)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.updating();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
+              assertEquals(
+                  "Transaction failed as flint index is not in a valid state.",
+                  asyncQueryExecutionResponse.getError());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(0);
+              flintIndexJob.assertState(FlintIndexState.UPDATING);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("true", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryWithValidationExceptionWithSuccess() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false)");
+    ImmutableList.of(ALTER_SKIPPING)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+
+                    @Override
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
+                      super.cancelJobRun(applicationId, jobId, allowExceptionPropagation);
+                      throw new ValidationException("Job run is not in a cancellable state");
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(1);
+              emrsClient.getJobRunResultCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryWithResourceNotFoundExceptionWithSuccess() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false)");
+    ImmutableList.of(ALTER_SKIPPING)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+
+                    @Override
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
+                      super.cancelJobRun(applicationId, jobId, allowExceptionPropagation);
+                      throw new ValidationException("Random validation exception");
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
+              assertEquals("Internal Server Error.", asyncQueryExecutionResponse.getError());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(1);
+              emrsClient.getJobRunResultCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+            });
+  }
+
+  @Test
+  public void testAlterIndexQueryWithUnknownError() {
+    MockFlintIndex ALTER_SKIPPING =
+        new MockFlintIndex(
+            client,
+            "flint_my_glue_mydb_http_logs_skipping_index",
+            FlintIndexType.SKIPPING,
+            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+                + " incremental_refresh=false)");
+    ImmutableList.of(ALTER_SKIPPING)
+        .forEach(
+            mockDS -> {
+              LocalEMRSClient emrsClient =
+                  new LocalEMRSClient() {
+                    @Override
+                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+                      super.getJobRunResult(applicationId, jobId);
+                      JobRun jobRun = new JobRun();
+                      jobRun.setState("cancelled");
+                      return new GetJobRunResult().withJobRun(jobRun);
+                    }
+
+                    @Override
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
+                      super.cancelJobRun(applicationId, jobId, allowExceptionPropagation);
+                      throw new IllegalArgumentException("Unknown Error");
+                    }
+                  };
+              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+              AsyncQueryExecutorService asyncQueryExecutorService =
+                  createAsyncQueryExecutorService(emrServerlessClientFactory);
+              // Mock flint index
+              mockDS.createIndex();
+              HashMap<String, Object> existingOptions = new HashMap<>();
+              existingOptions.put("auto_refresh", "true");
+              mockDS.updateIndexOptions(existingOptions, false);
+              // Mock index state
+              MockFlintSparkJob flintIndexJob =
+                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+              flintIndexJob.active();
+
+              // 1. alter index
+              CreateAsyncQueryResponse response =
+                  asyncQueryExecutorService.createAsyncQuery(
+                      new CreateAsyncQueryRequest(
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+
+              // 2. fetch result
+              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
+                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
+              assertEquals("Internal Server Error.", asyncQueryExecutionResponse.getError());
+              emrsClient.startJobRunCalled(0);
+              emrsClient.cancelJobRunCalled(1);
+              emrsClient.getJobRunResultCalled(0);
+              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              Map<String, Object> mappings = mockDS.getIndexMappings();
+              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+              Map<String, Object> options = (Map<String, Object>) meta.get("options");
+              Assertions.assertEquals("false", options.get("auto_refresh"));
+            });
+  }
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -8,9 +8,8 @@ package org.opensearch.sql.spark.asyncquery;
 import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
 import com.amazonaws.services.emrserverless.model.GetJobRunResult;
 import com.amazonaws.services.emrserverless.model.JobRun;
+import com.amazonaws.services.emrserverless.model.ValidationException;
 import com.google.common.collect.ImmutableList;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -18,7 +17,6 @@ import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintIndex;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
-import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.flint.FlintIndexState;
 import org.opensearch.sql.spark.flint.FlintIndexType;
 import org.opensearch.sql.spark.leasemanager.ConcurrencyLimitExceededException;
@@ -171,8 +169,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               LocalEMRSClient emrsClient =
                   new LocalEMRSClient() {
                     @Override
-                    public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
-                      throw new IllegalArgumentException("Job run is not in a cancellable state");
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
+                      throw new ValidationException("Job run is not in a cancellable state");
                     }
                   };
               EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
@@ -246,8 +245,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     LocalEMRSClient emrsClient =
         new LocalEMRSClient() {
           @Override
-          public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
-            throw new IllegalArgumentException("Job run is not in a cancellable state");
+          public CancelJobRunResult cancelJobRun(
+              String applicationId, String jobId, boolean allowExceptionPropagation) {
+            throw new ValidationException("Job run is not in a cancellable state");
           }
         };
     EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
@@ -339,8 +339,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               LocalEMRSClient emrsClient =
                   new LocalEMRSClient() {
                     @Override
-                    public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
-                      throw new IllegalArgumentException("Job run is not in a cancellable state");
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
+                      throw new ValidationException("Job run is not in a cancellable state");
                     }
                   };
               EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
@@ -613,7 +614,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               LocalEMRSClient emrsClient =
                   new LocalEMRSClient() {
                     @Override
-                    public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
                       Assert.fail("should not call cancelJobRun");
                       return null;
                     }
@@ -664,7 +666,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     LocalEMRSClient emrsClient =
         new LocalEMRSClient() {
           @Override
-          public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
+          public CancelJobRunResult cancelJobRun(
+              String applicationId, String jobId, boolean allowExceptionPropagation) {
             throw new IllegalArgumentException("Job run is not in a cancellable state");
           }
         };
@@ -687,10 +690,10 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     // 2.fetch result.
     AsyncQueryExecutionResponse asyncQueryResults =
         asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-    assertEquals("SUCCESS", asyncQueryResults.getStatus());
-    assertNull(asyncQueryResults.getError());
+    assertEquals("FAILED", asyncQueryResults.getStatus());
+    assertEquals("Internal Server Error.", asyncQueryResults.getError());
 
-    flintIndexJob.assertState(FlintIndexState.DELETED);
+    flintIndexJob.assertState(FlintIndexState.REFRESHING);
   }
 
   /**
@@ -706,7 +709,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               LocalEMRSClient emrsClient =
                   new LocalEMRSClient() {
                     @Override
-                    public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
                       Assert.fail("should not call cancelJobRun");
                       return null;
                     }
@@ -846,7 +850,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               LocalEMRSClient emrsClient =
                   new LocalEMRSClient() {
                     @Override
-                    public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
+                    public CancelJobRunResult cancelJobRun(
+                        String applicationId, String jobId, boolean allowExceptionPropagation) {
                       Assert.fail("should not call cancelJobRun");
                       return null;
                     }
@@ -1002,862 +1007,5 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     Assertions.assertThrows(
         IllegalStateException.class,
         () -> asyncQueryExecutorService.cancelQuery(response.getQueryId()));
-  }
-
-  @Test
-  public void testAlterIndexQueryConvertingToManualRefresh() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=false)");
-    MockFlintIndex ALTER_COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=false)");
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=false) ");
-    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              mockDS.updateIndexOptions(existingOptions, false);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(1);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryConvertingToManualRefreshWithNoIncrementalRefresh() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false)");
-    MockFlintIndex ALTER_COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false)");
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false)");
-    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              existingOptions.put("checkpoint_location", "s3://checkpoint/location");
-              mockDS.updateIndexOptions(existingOptions, true);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(1);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryWithRedundantOperation() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=false)");
-    MockFlintIndex ALTER_COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=false)");
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=false) ");
-    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public String startJobRun(StartJobRequest startJobRequest) {
-                      return "jobId";
-                    }
-
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-
-                    @Override
-                    public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
-                      super.cancelJobRun(applicationId, jobId);
-                      throw new IllegalArgumentException("JobId doesn't exist");
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessCientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessCientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "false");
-              mockDS.updateIndexOptions(existingOptions, false);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(1);
-              emrsClient.getJobRunResultCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryConvertingToAutoRefresh() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=true,"
-                + " incremental_refresh=false)");
-    MockFlintIndex ALTER_COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=true,"
-                + " incremental_refresh=false)");
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=true,"
-                + " incremental_refresh=false) ");
-    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient localEMRSClient = new LocalEMRSClient();
-              EMRServerlessClientFactory clientFactory = () -> localEMRSClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(clientFactory);
-
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "false");
-              mockDS.updateIndexOptions(existingOptions, false);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              assertEquals(
-                  "RUNNING",
-                  asyncQueryExecutorService
-                      .getAsyncQueryResults(response.getQueryId())
-                      .getStatus());
-
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              localEMRSClient.startJobRunCalled(1);
-              localEMRSClient.getJobRunResultCalled(1);
-              localEMRSClient.cancelJobRunCalled(0);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryWithOutAnyAutoRefresh() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH ("
-                + " incremental_refresh=false)");
-    MockFlintIndex ALTER_COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH ("
-                + " incremental_refresh=false)");
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (" + " incremental_refresh=false) ");
-    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient localEMRSClient = new LocalEMRSClient();
-              EMRServerlessClientFactory clientFactory = () -> localEMRSClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(clientFactory);
-
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "false");
-              mockDS.updateIndexOptions(existingOptions, false);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              assertEquals(
-                  "RUNNING",
-                  asyncQueryExecutorService
-                      .getAsyncQueryResults(response.getQueryId())
-                      .getStatus());
-
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              localEMRSClient.startJobRunCalled(1);
-              localEMRSClient.getJobRunResultCalled(1);
-              localEMRSClient.cancelJobRunCalled(0);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryOfFullRefreshWithInvalidOptions() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=false, checkpoint_location=\"s3://ckp/skp\")");
-    MockFlintIndex ALTER_COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=false, checkpoint_location=\"s3://ckp/skp\")");
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=false, checkpoint_location=\"s3://ckp/skp\") ");
-    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              mockDS.updateIndexOptions(existingOptions, false);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
-              assertEquals(
-                  "Altering to full refresh only allows: [auto_refresh, incremental_refresh]"
-                      + " options",
-                  asyncQueryExecutionResponse.getError());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryOfIncrementalRefreshWithInvalidOptions() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex ALTER_COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\") ");
-    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING, ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              mockDS.updateIndexOptions(existingOptions, false);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
-              assertEquals(
-                  "Altering to incremental refresh only allows: [auto_refresh, incremental_refresh,"
-                      + " watermark_delay, checkpoint_location] options",
-                  asyncQueryExecutionResponse.getError());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryOfIncrementalRefreshWithInsufficientOptions() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true)");
-    MockFlintIndex ALTER_COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true)");
-    ImmutableList.of(ALTER_SKIPPING, ALTER_COVERING)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              existingOptions.put("incremental_refresh", "false");
-              mockDS.updateIndexOptions(existingOptions, true);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
-              assertEquals(
-                  "Conversion to incremental refresh index cannot proceed due to missing"
-                      + " attributes: checkpoint_location.",
-                  asyncQueryExecutionResponse.getError());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryOfIncrementalRefreshWithInsufficientOptionsForMV() {
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true) ");
-    ImmutableList.of(ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              existingOptions.put("incremental_refresh", "false");
-              mockDS.updateIndexOptions(existingOptions, true);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
-              assertEquals(
-                  "Conversion to incremental refresh index cannot proceed due to missing"
-                      + " attributes: checkpoint_location, watermark_delay.",
-                  asyncQueryExecutionResponse.getError());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryOfIncrementalRefreshWithEmptyExistingOptionsForMV() {
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true) ");
-    ImmutableList.of(ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              existingOptions.put("incremental_refresh", "false");
-              existingOptions.put("watermark_delay", "");
-              existingOptions.put("checkpoint_location", "");
-              mockDS.updateIndexOptions(existingOptions, true);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
-              assertEquals(
-                  "Conversion to incremental refresh index cannot proceed due to missing"
-                      + " attributes: checkpoint_location, watermark_delay.",
-                  asyncQueryExecutionResponse.getError());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryOfIncrementalRefresh() {
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true) ");
-    ImmutableList.of(ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              existingOptions.put("incremental_refresh", "false");
-              existingOptions.put("watermark_delay", "watermark_delay");
-              existingOptions.put("checkpoint_location", "s3://checkpoint/location");
-              mockDS.updateIndexOptions(existingOptions, true);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.refreshing();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.getJobRunResultCalled(1);
-              emrsClient.cancelJobRunCalled(1);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-              Assertions.assertEquals("true", options.get("incremental_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryWithIncrementalRefreshAlreadyExisting() {
-    MockFlintIndex ALTER_MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false) ");
-    ImmutableList.of(ALTER_MV)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              existingOptions.put("incremental_refresh", "true");
-              existingOptions.put("watermark_delay", "watermark_delay");
-              existingOptions.put("checkpoint_location", "s3://checkpoint/location");
-              mockDS.updateIndexOptions(existingOptions, true);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.refreshing();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.getJobRunResultCalled(1);
-              emrsClient.cancelJobRunCalled(1);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-              Assertions.assertEquals("true", options.get("incremental_refresh"));
-            });
-  }
-
-  @Test
-  public void testAlterIndexQueryWithInvalidInitialState() {
-    MockFlintIndex ALTER_SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=false)");
-    ImmutableList.of(ALTER_SKIPPING)
-        .forEach(
-            mockDS -> {
-              LocalEMRSClient emrsClient =
-                  new LocalEMRSClient() {
-                    @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      super.getJobRunResult(applicationId, jobId);
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-                  };
-              EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-              AsyncQueryExecutorService asyncQueryExecutorService =
-                  createAsyncQueryExecutorService(emrServerlessClientFactory);
-              // Mock flint index
-              mockDS.createIndex();
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              mockDS.updateIndexOptions(existingOptions, false);
-              // Mock index state
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.updating();
-
-              // 1. alter index
-              CreateAsyncQueryResponse response =
-                  asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
-
-              // 2. fetch result
-              AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
-              assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
-              assertEquals(
-                  "Transaction failed as flint index is not in a valid state.",
-                  asyncQueryExecutionResponse.getError());
-              emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.UPDATING);
-              Map<String, Object> mappings = mockDS.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
@@ -19,6 +19,7 @@ import static org.opensearch.sql.spark.flint.FlintIndexType.SKIPPING;
 import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
 import com.amazonaws.services.emrserverless.model.GetJobRunResult;
 import com.amazonaws.services.emrserverless.model.JobRun;
+import com.amazonaws.services.emrserverless.model.ValidationException;
 import com.google.common.collect.Lists;
 import java.util.Base64;
 import java.util.List;
@@ -75,7 +76,7 @@ public class IndexQuerySpecVacuumTest extends AsyncQueryExecutorServiceSpec {
                 // Cancel EMR-S job, but not job running
                 Pair.<EMRApiCall, EMRApiCall>of(
                     () -> {
-                      throw new IllegalArgumentException("Job run is not in a cancellable state");
+                      throw new ValidationException("Job run is not in a cancellable state");
                     },
                     DEFAULT_OP)));
 
@@ -177,9 +178,10 @@ public class IndexQuerySpecVacuumTest extends AsyncQueryExecutorServiceSpec {
     LocalEMRSClient emrsClient =
         new LocalEMRSClient() {
           @Override
-          public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
+          public CancelJobRunResult cancelJobRun(
+              String applicationId, String jobId, boolean allowExceptionPropagation) {
             if (cancelJobRun == DEFAULT_OP) {
-              return super.cancelJobRun(applicationId, jobId);
+              return super.cancelJobRun(applicationId, jobId, allowExceptionPropagation);
             }
             return cancelJobRun.call();
           }

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/model/MockFlintIndex.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/model/MockFlintIndex.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.spark.asyncquery.model;
 
-import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -55,7 +54,7 @@ public class MockFlintIndex {
         .getSourceAsMap();
   }
 
-  public void updateIndexOptions(HashMap<String, Object> newOptions, Boolean replaceCompletely) {
+  public void updateIndexOptions(Map<String, Object> newOptions, Boolean replaceCompletely) {
     GetMappingsResponse mappingsResponse =
         client.admin().indices().prepareGetMappings().setIndices(indexName).get();
     Map<String, Object> flintMetadataMap =

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -742,7 +742,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testCancelJob() {
-    when(emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID))
+    when(emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID, false))
         .thenReturn(
             new CancelJobRunResult()
                 .withJobRunId(EMR_JOB_ID)
@@ -802,7 +802,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testCancelQueryWithNoSessionId() {
-    when(emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID))
+    when(emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID, false))
         .thenReturn(
             new CancelJobRunResult()
                 .withJobRunId(EMR_JOB_ID)

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/InteractiveSessionTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/InteractiveSessionTest.java
@@ -227,7 +227,8 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
     }
 
     @Override
-    public CancelJobRunResult cancelJobRun(String applicationId, String jobId) {
+    public CancelJobRunResult cancelJobRun(
+        String applicationId, String jobId, boolean allowExceptionPropagation) {
       cancelJobRunCalled++;
       return null;
     }


### PR DESCRIPTION
### Description
This PR handles different kinds of exception from EMRServerless when cancelling a job. There are frequent scenarios where the streaming job is already in cancelled state and resulting in error of ALTER INDEX command. This PR catches scenarios where the job is already in cancelled state and proceeds with the command execution.

* ResourceNotFoundException: When JobId is not present.
* ValidationException: When JobRun is not in a cancellable state.
* OtherExceptions.
 

* Fixed Datasources IT.
* Fixed Settings documentation: https://github.com/vamsi-amazon/sql/blob/emr-exception/docs/user/admin/settings.rst#pluginsqueryexecutionengineasync_queryenabled
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).