### PR TITLE
Bug Fix: Escape query in spark submit parameter

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     api group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     api group: 'org.apache.logging.log4j', name: 'log4j-core', version:"${versions.log4j}"
     api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    api group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
     implementation 'com.github.babbel:okhttp-aws-signer:1.0.2'
     api group: 'com.amazonaws', name: 'aws-java-sdk-core', version: "${aws_java_sdk_version}"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -48,6 +48,7 @@ pitest {
 dependencies {
     api group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    api group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     api group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'org.json', name: 'json', version:'20231013'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     // add geo module as dependency. https://github.com/opensearch-project/OpenSearch/pull/4180/.
     implementation group: 'org.opensearch.plugin', name: 'geo', version: "${opensearch_version}"

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.text.StringEscapeUtils;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.datasources.auth.AuthenticationType;
@@ -85,8 +86,13 @@ public class SparkSubmitParameters {
       return this;
     }
 
+    /**
+     * For query in spark submit parameters to be parsed correctly, escape
+     * the characters in the query, then wrap the query with double quotes.
+     */
     public Builder query(String query) {
-      String wrappedQuery = "\"" + query + "\""; // Wrap the query with double quotes
+      String escapedQuery = StringEscapeUtils.escapeJava(query);
+      String wrappedQuery = "\"" + escapedQuery + "\"";
       config.put(FLINT_JOB_QUERY, wrappedQuery);
       return this;
     }

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
@@ -87,8 +87,8 @@ public class SparkSubmitParameters {
     }
 
     /**
-     * For query in spark submit parameters to be parsed correctly, escape
-     * the characters in the query, then wrap the query with double quotes.
+     * For query in spark submit parameters to be parsed correctly, escape the characters in the
+     * query, then wrap the query with double quotes.
      */
     public Builder query(String query) {
       String escapedQuery = StringEscapeUtils.escapeJava(query);

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParametersTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParametersTest.java
@@ -30,8 +30,17 @@ public class SparkSubmitParametersTest {
 
   @Test
   public void testBuildQueryString() {
-    String query = "SHOW tables LIKE \"%\";";
-    String params = SparkSubmitParameters.Builder.builder().query(query).build().toString();
-    assertTrue(params.contains(query));
+    String rawQuery = "SHOW tables LIKE \"%\";";
+    String expectedQueryInParams = "\"SHOW tables LIKE \\\"%\\\";\"";
+    String params = SparkSubmitParameters.Builder.builder().query(rawQuery).build().toString();
+    assertTrue(params.contains(expectedQueryInParams));
+  }
+
+  @Test
+  public void testBuildQueryStringNestedQuote() {
+    String rawQuery = "SELECT '\"1\"'";
+    String expectedQueryInParams = "\"SELECT '\\\"1\\\"'\"";
+    String params = SparkSubmitParameters.Builder.builder().query(rawQuery).build().toString();
+    assertTrue(params.contains(expectedQueryInParams));
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParametersTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParametersTest.java
@@ -43,4 +43,12 @@ public class SparkSubmitParametersTest {
     String params = SparkSubmitParameters.Builder.builder().query(rawQuery).build().toString();
     assertTrue(params.contains(expectedQueryInParams));
   }
+
+  @Test
+  public void testBuildQueryStringSpecialCharacter() {
+    String rawQuery = "SELECT '{\"test ,:+\\\"inner\\\"/\\|?#><\"}'";
+    String expectedQueryInParams = "SELECT '{\\\"test ,:+\\\\\\\"inner\\\\\\\"/\\\\|?#><\\\"}'";
+    String params = SparkSubmitParameters.Builder.builder().query(rawQuery).build().toString();
+    assertTrue(params.contains(expectedQueryInParams));
+  }
 }


### PR DESCRIPTION
### Description
Fix EMR spark submit parameter for batch FlintJob parsing issue when query contains quotes.

Ideally would like to test start job run in https://github.com/opensearch-project/sql/blob/main/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java as well, but the AWSEMRServerless is mocked.

Manually ran end to end test connecting to a real EMR-S application for queries with nested quotes.
Example query:
```
CREATE INDEX test_cv
ON mys3.default.http_logs (`status`, `day`, `size`, `request` )
WITH (index_settings = '{"number_of_shards": 1 ,"number_of_replicas":1}', auto_refresh = true, checkpoint_location = 's3://test/')
```
This creates the index successfully.

The following tests special characters in a string get passed correctly.
```
CREATE INDEX test_special
ON mys3.default.http_logs (`status`, `day`, `size`, `request` )
WITH (index_settings = '{"number_of_shards": 1 ,"test ,:+\"inner\"/\|?#><":1}', auto_refresh = true, checkpoint_location = 's3://test/')
```
Checking the logs, we see this printed as expected:
```
24/03/23 16:36:10 INFO FlintSpark: Creating Flint index FlintSparkCoveringIndex(test_special,mys3.default.http_logs,Map(status -> int, day -> int, size -> int, request -> string),None,FlintSparkIndexOptions(Map(index_settings -> {"number_of_shards": 1 ,"test ,:+\"inner\"/\|?#><":1}, auto_refresh -> true, checkpoint_location -> s3://test/)),None) with ignoreIfExists false
```
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).