### PR TITLE
Align vacuum statement semantics with Flint Spark

### DIFF
--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
@@ -132,18 +132,6 @@ public class IndexDMLHandler extends AsyncQueryHandler {
         flintIndexOpAlter.apply(indexMetadata);
         break;
       case VACUUM:
-        // Try to perform drop operation first
-        FlintIndexOp tryDropOp =
-            new FlintIndexOpDrop(
-                stateStore, dispatchQueryRequest.getDatasource(), emrServerlessClient);
-        try {
-          tryDropOp.apply(indexMetadata);
-        } catch (IllegalStateException e) {
-          // Drop failed possibly due to invalid initial state
-        }
-
-        // Continue to delete index data physically if state is DELETED
-        // which means previous transaction succeeds
         FlintIndexOp indexVacuumOp =
             new FlintIndexOpVacuum(stateStore, dispatchQueryRequest.getDatasource(), client);
         indexVacuumOp.apply(indexMetadata);


### PR DESCRIPTION
### Description

#### Background

The `VACUUM` statement, introduced as part of the Flint Spark extension in version 0.3, provides users with an API to delete logically unused Flint indexes. Within the SQL plugin, this functionality initially triggers a DROP operation on the index, thereby enhancing usability.

#### Problem Statement

However, the current implementation presents two issues:

1. Index refresh may not stop completely despite EMR-S job transitioned to `CANCELLED` state. This leads to the index recreated by subsequent bulk requests after being deleted by Vacuum operation.
2. There is a risk that users may unintentionally delete their index data in use due to incorrect expectations.

#### Changes

1. Align the semantic behavior with Flint Spark extension.
2. Users will now be required to execute a `DROP` operation followed by `VACUUM` when they want to remove a Flint index completely.

### Issues Resolved

https://github.com/opensearch-project/opensearch-spark/issues/104
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).