### PR TITLE
[DOC] Remove the duplicated timestamp row in data type mapping table

### DIFF
--- a/docs/user/ppl/general/datatypes.rst
+++ b/docs/user/ppl/general/datatypes.rst
@@ -90,8 +90,6 @@ The table below list the mapping between OpenSearch Data Type, PPL Data Type and
 +-----------------+---------------+-----------+
 | ip              | ip            | VARCHAR   |
 +-----------------+---------------+-----------+
-| date            | timestamp     | TIMESTAMP |
-+-----------------+---------------+-----------+
 | binary          | binary        | VARBINARY |
 +-----------------+---------------+-----------+
 | object          | struct        | STRUCT    |


### PR DESCRIPTION
### Description
Remove a duplicated timestamp row in data type mapping table: L93 duplicates L89
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).