### PR TITLE
Add option to use LakeFormation in S3Glue data source.

### DIFF
--- a/datasources/src/main/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactory.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactory.java
@@ -29,6 +29,7 @@ public class GlueDataSourceFactory implements DataSourceFactory {
       "glue.indexstore.opensearch.auth.password";
   public static final String GLUE_INDEX_STORE_OPENSEARCH_REGION =
       "glue.indexstore.opensearch.region";
+  public static final String GLUE_LAKEFORMATION_ENABLED = "glue.lakeformation.enabled";
 
   @Override
   public DataSourceType getDataSourceType() {

--- a/docs/user/ppl/admin/connectors/s3glue_connector.rst
+++ b/docs/user/ppl/admin/connectors/s3glue_connector.rst
@@ -42,6 +42,7 @@ Glue Connector Properties.
         * Basic Auth required ``glue.indexstore.opensearch.auth.username`` and ``glue.indexstore.opensearch.auth.password``
         * AWSSigV4 Auth requires ``glue.indexstore.opensearch.auth.region``  and ``glue.auth.role_arn``
     * ``glue.indexstore.opensearch.region`` [Required for awssigv4 auth]
+* ``glue.lakeformation.enabled`` determines whether to enable lakeformation for queries. Default value is ``"false"`` if not specified
 
 Sample Glue dataSource configuration
 ========================================
@@ -56,7 +57,7 @@ Glue datasource configuration::
                 "glue.auth.role_arn": "role_arn",
                 "glue.indexstore.opensearch.uri": "http://localhost:9200",
                 "glue.indexstore.opensearch.auth" :"basicauth",
-                "glue.indexstore.opensearch.auth.username" :"username"
+                "glue.indexstore.opensearch.auth.username" :"username",
                 "glue.indexstore.opensearch.auth.password" :"password"
         },
         "resultIndex": "query_execution_result"
@@ -71,6 +72,7 @@ Glue datasource configuration::
                 "glue.indexstore.opensearch.uri": "http://adsasdf.amazonopensearch.com:9200",
                 "glue.indexstore.opensearch.auth" :"awssigv4",
                 "glue.indexstore.opensearch.auth.region" :"awssigv4",
+                "glue.lakeformation.enabled": "true"
         },
         "resultIndex": "query_execution_result"
     }]

--- a/docs/user/ppl/admin/connectors/s3glue_connector.rst
+++ b/docs/user/ppl/admin/connectors/s3glue_connector.rst
@@ -18,7 +18,7 @@ s3Glue connector provides a way to query s3 files using glue as metadata store a
 This page covers s3Glue datasource configuration and also how to query and s3Glue datasource.
 
 Required resources for s3 Glue Connector
-===================================
+========================================
 * ``EMRServerless Spark Execution Engine Config Setting``:  Since we execute s3Glue queries on top of spark execution engine, we require this configuration.
   More details: `ExecutionEngine Config <../../../interfaces/asyncqueryinterface.rst#id2>`_
 * ``S3``: This is where the data lies.

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
@@ -10,6 +10,7 @@ import static org.opensearch.sql.datasources.glue.GlueDataSourceFactory.GLUE_IND
 import static org.opensearch.sql.datasources.glue.GlueDataSourceFactory.GLUE_INDEX_STORE_OPENSEARCH_AUTH_USERNAME;
 import static org.opensearch.sql.datasources.glue.GlueDataSourceFactory.GLUE_INDEX_STORE_OPENSEARCH_REGION;
 import static org.opensearch.sql.datasources.glue.GlueDataSourceFactory.GLUE_INDEX_STORE_OPENSEARCH_URI;
+import static org.opensearch.sql.datasources.glue.GlueDataSourceFactory.GLUE_LAKEFORMATION_ENABLED;
 import static org.opensearch.sql.datasources.glue.GlueDataSourceFactory.GLUE_ROLE_ARN;
 import static org.opensearch.sql.spark.data.constants.SparkConstants.*;
 import static org.opensearch.sql.spark.execution.statestore.StateStore.DATASOURCE_TO_REQUEST_INDEX;
@@ -21,6 +22,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
@@ -116,6 +118,11 @@ public class SparkSubmitParameters {
         config.put(HIVE_METASTORE_GLUE_ARN_KEY, roleArn);
         config.put("spark.sql.catalog." + metadata.getName(), FLINT_DELEGATE_CATALOG);
         config.put(FLINT_DATA_SOURCE_KEY, metadata.getName());
+
+        final boolean lakeFormationEnabled =
+            BooleanUtils.toBoolean(metadata.getProperties().get(GLUE_LAKEFORMATION_ENABLED));
+        config.put(EMR_LAKEFORMATION_OPTION, Boolean.toString(lakeFormationEnabled));
+        config.put(FLINT_ACCELERATE_USING_COVERING_INDEX, Boolean.toString(!lakeFormationEnabled));
 
         setFlintIndexStoreHost(
             parseUri(

--- a/spark/src/main/java/org/opensearch/sql/spark/data/constants/SparkConstants.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/data/constants/SparkConstants.java
@@ -105,4 +105,9 @@ public class SparkConstants {
   public static final String SPARK_CATALOG_CATALOG_IMPL =
       "spark.sql.catalog.spark_catalog.catalog-impl";
   public static final String ICEBERG_GLUE_CATALOG = "org.apache.iceberg.aws.glue.GlueCatalog";
+
+  public static final String EMR_LAKEFORMATION_OPTION =
+      "spark.emr-serverless.lakeformation.enabled";
+  public static final String FLINT_ACCELERATE_USING_COVERING_INDEX =
+      "spark.flint.optimizer.covering.enabled";
 }


### PR DESCRIPTION
### Description
Enables OpenSearch users to use LakeFormation option when querying the S3Glue data source.
This is important because some Glue tables are managed by LakeFormation. The customer will need to pass in a property for LakeFormation in order to not break backwards compataibility.
 
Note that this feature is launching in EMR serverless next month, so an error is thrown. Adding it in now so it's in the next release which is in line with the launch of this feature on EMR serverless.

### Testing

Built locally with 2.13 as version and then copied over to cluster running 2.13.

__Validating that property is read and correct configuration is added to Spark config__
```shell
curl --request POST  --url http://localhost:9200/_plugins/_query/_datasources   --header 'content-type: application/x-ndjson'   --data '{"name": "mygdc","description": "","connector": "S3GLUE","allowedRoles": [],"properties": {"glue.auth.type": "iam_role","glue.auth.role_arn": "arn:aws:iam::xxxxxxxxxxxx:role/flint-opensearch-execution-role","glue.indexstore.opensearch.uri": "http://ec2-xx-xx-xx-xx.compute-1.amazonaws.com:9200","glue.indexstore.opensearch.auth": "noauth", "glue.lakeformation.enabled": "true"}}'
curl --request  POST   --url http://localhost:9200/_plugins/_async_query   --header 'content-type: application/x-ndjson'   --data '{"datasource": "mygdc","lang": "sql","query": "SELECT * FROM mygdc.amazon_security_lake_glue_db_us_east_1.amazon_security_lake_table_us_east_1_vpc_flow_2_0 LIMIT 1"}'
{
  "status": 500,
  "error": {
    "type": "RuntimeException",
    "reason": "There was internal problem at backend",
    "details": "Internal Server Error."
  }
cat ~/tmp/opensearch.log 
com.amazonaws.services.emrserverless.model.ValidationException: Lake Formation configuration can only be specified at the application level, not at job run level. (Service: AWSEMRServerless; Status Code: 400; Error Code: ValidationException; Request ID: 28566859-cdfc-45fa-bb0a-21ad69d0a88a; Proxy: null)
```

__Validating backwards compatibility__
```shell
curl --request POST   --url http://localhost:9200/_plugins/_query/_datasources   --header 'content-type: application/x-ndjson'   --data '{"name": "mygdc2","description": "","connector": "S3GLUE","allowedRoles": [],"properties": {"glue.auth.type": "iam_role","glue.auth.role_arn": "arn:aws:iam::xxxxxxxxxx:role/flint-opensearch-execution-role","glue.indexstore.opensearch.uri": "http://ec2-xx-xx-xx-xx.compute-1.amazonaws.com:9200","glue.indexstore.opensearch.auth": "noauth"}}'
curl --request  POST   --url http://localhost:9200/_plugins/_async_query   --header 'content-type: application/x-ndjson'   --data '{"datasource": "mygdc2","lang": "sql","query": "SELECT * FROM mygdc2.amazon_security_lake_glue_db_us_east_1.amazon_security_lake_table_us_east_1_vpc_flow_2_0 LIMIT 1"}'
{
  "queryId": "b1d5WnhqYkdoMm15Z2RjMg==",
  "sessionId": "eFhDVk85ZUZMMG15Z2RjMg=="
}
curl --request  GET --url http://localhost:9200/_plugins/_async_query/b1d5WnhqYkdoMm15Z2RjMg==
{
  "status": "SUCCESS",
   ...
}
```
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).