### PR TITLE
Bump bwc version to 2.15

### DIFF
--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, macos-latest ]
+        os: [ windows-latest ]
         java: [ 11, 17, 21 ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -106,11 +106,8 @@ jobs:
       matrix:
         entry:
           - { os: windows-latest, java: 11, os_build_args: -x doctest  -PbuildPlatform=windows }
-          - { os: macos-latest, java: 11}
           - { os: windows-latest, java: 17, os_build_args: -x doctest -PbuildPlatform=windows }
-          - { os: macos-latest, java: 17 }
           - { os: windows-latest, java: 21, os_build_args: -x doctest -PbuildPlatform=windows }
-          - { os: macos-latest, java: 21 }
     runs-on: ${{ matrix.entry.os }}
 
     steps:

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -44,7 +44,7 @@ apply plugin: 'java'
 apply plugin: 'io.freefair.lombok'
 apply plugin: 'com.wiredforcode.spawn'
 
-String baseVersion = "2.14.0"
+String baseVersion = "2.15.0"
 String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"


### PR DESCRIPTION
### Description
Bumps BWC version. Stops running CI checks on mac because artifacts are not available and those tests will always fail.
 
### Issues Resolved
CI not being green 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).