### PR TITLE
[Backport 2.x] Refactor SparkQueryDispatcher (#2636)

### DIFF
--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/QueryHandlerFactory.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/QueryHandlerFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.dispatcher;
+
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.Client;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
+import org.opensearch.sql.spark.execution.session.SessionManager;
+import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
+import org.opensearch.sql.spark.leasemanager.LeaseManager;
+import org.opensearch.sql.spark.response.JobExecutionResponseReader;
+
+@RequiredArgsConstructor
+public class QueryHandlerFactory {
+
+  private final JobExecutionResponseReader jobExecutionResponseReader;
+  private final FlintIndexMetadataService flintIndexMetadataService;
+  private final Client client;
+  private final SessionManager sessionManager;
+  private final LeaseManager leaseManager;
+  private final StateStore stateStore;
+  private final EMRServerlessClientFactory emrServerlessClientFactory;
+
+  public RefreshQueryHandler getRefreshQueryHandler() {
+    return new RefreshQueryHandler(
+        emrServerlessClientFactory.getClient(),
+        jobExecutionResponseReader,
+        flintIndexMetadataService,
+        stateStore,
+        leaseManager);
+  }
+
+  public StreamingQueryHandler getStreamingQueryHandler() {
+    return new StreamingQueryHandler(
+        emrServerlessClientFactory.getClient(), jobExecutionResponseReader, leaseManager);
+  }
+
+  public BatchQueryHandler getBatchQueryHandler() {
+    return new BatchQueryHandler(
+        emrServerlessClientFactory.getClient(), jobExecutionResponseReader, leaseManager);
+  }
+
+  public InteractiveQueryHandler getInteractiveQueryHandler() {
+    return new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader, leaseManager);
+  }
+
+  public IndexDMLHandler getIndexDMLHandler() {
+    return new IndexDMLHandler(
+        emrServerlessClientFactory.getClient(),
+        jobExecutionResponseReader,
+        flintIndexMetadataService,
+        stateStore,
+        client);
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -8,14 +8,12 @@ package org.opensearch.sql.spark.dispatcher;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
-import org.opensearch.client.Client;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryId;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
-import org.opensearch.sql.spark.client.EMRServerlessClient;
-import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
@@ -23,10 +21,6 @@ import org.opensearch.sql.spark.dispatcher.model.IndexQueryActionType;
 import org.opensearch.sql.spark.dispatcher.model.IndexQueryDetails;
 import org.opensearch.sql.spark.dispatcher.model.JobType;
 import org.opensearch.sql.spark.execution.session.SessionManager;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
-import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
-import org.opensearch.sql.spark.leasemanager.LeaseManager;
-import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 import org.opensearch.sql.spark.rest.model.LangType;
 import org.opensearch.sql.spark.utils.SQLQueryUtils;
 
@@ -39,63 +33,67 @@ public class SparkQueryDispatcher {
   public static final String CLUSTER_NAME_TAG_KEY = "domain_ident";
   public static final String JOB_TYPE_TAG_KEY = "type";
 
-  private EMRServerlessClientFactory emrServerlessClientFactory;
-
-  private DataSourceService dataSourceService;
-
-  private JobExecutionResponseReader jobExecutionResponseReader;
-
-  private FlintIndexMetadataService flintIndexMetadataService;
-
-  private Client client;
-
-  private SessionManager sessionManager;
-
-  private LeaseManager leaseManager;
-
-  private StateStore stateStore;
+  private final DataSourceService dataSourceService;
+  private final SessionManager sessionManager;
+  private final QueryHandlerFactory queryHandlerFactory;
 
   public DispatchQueryResponse dispatch(DispatchQueryRequest dispatchQueryRequest) {
-    EMRServerlessClient emrServerlessClient = emrServerlessClientFactory.getClient();
     DataSourceMetadata dataSourceMetadata =
         this.dataSourceService.verifyDataSourceAccessAndGetRawMetadata(
             dispatchQueryRequest.getDatasource());
-    AsyncQueryHandler asyncQueryHandler =
-        sessionManager.isEnabled()
-            ? new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader, leaseManager)
-            : new BatchQueryHandler(emrServerlessClient, jobExecutionResponseReader, leaseManager);
-    DispatchQueryContext.DispatchQueryContextBuilder contextBuilder =
-        DispatchQueryContext.builder()
-            .dataSourceMetadata(dataSourceMetadata)
-            .tags(getDefaultTagsForJobSubmission(dispatchQueryRequest))
-            .queryId(AsyncQueryId.newAsyncQueryId(dataSourceMetadata.getName()));
 
-    // override asyncQueryHandler with specific.
     if (LangType.SQL.equals(dispatchQueryRequest.getLangType())
         && SQLQueryUtils.isFlintExtensionQuery(dispatchQueryRequest.getQuery())) {
-      IndexQueryDetails indexQueryDetails =
-          SQLQueryUtils.extractIndexDetails(dispatchQueryRequest.getQuery());
-      fillMissingDetails(dispatchQueryRequest, indexQueryDetails);
-      contextBuilder.indexQueryDetails(indexQueryDetails);
+      IndexQueryDetails indexQueryDetails = getIndexQueryDetails(dispatchQueryRequest);
+      DispatchQueryContext context =
+          getDefaultDispatchContextBuilder(dispatchQueryRequest, dataSourceMetadata)
+              .indexQueryDetails(indexQueryDetails)
+              .build();
 
-      if (isEligibleForIndexDMLHandling(indexQueryDetails)) {
-        asyncQueryHandler = createIndexDMLHandler(emrServerlessClient);
-      } else if (isEligibleForStreamingQuery(indexQueryDetails)) {
-        asyncQueryHandler =
-            new StreamingQueryHandler(
-                emrServerlessClient, jobExecutionResponseReader, leaseManager);
-      } else if (IndexQueryActionType.REFRESH.equals(indexQueryDetails.getIndexQueryActionType())) {
-        // manual refresh should be handled by batch handler
-        asyncQueryHandler =
-            new RefreshQueryHandler(
-                emrServerlessClient,
-                jobExecutionResponseReader,
-                flintIndexMetadataService,
-                stateStore,
-                leaseManager);
-      }
+      return getQueryHandlerForFlintExtensionQuery(indexQueryDetails)
+          .submit(dispatchQueryRequest, context);
+    } else {
+      DispatchQueryContext context =
+          getDefaultDispatchContextBuilder(dispatchQueryRequest, dataSourceMetadata).build();
+      return getDefaultAsyncQueryHandler().submit(dispatchQueryRequest, context);
     }
-    return asyncQueryHandler.submit(dispatchQueryRequest, contextBuilder.build());
+  }
+
+  private static DispatchQueryContext.DispatchQueryContextBuilder getDefaultDispatchContextBuilder(
+      DispatchQueryRequest dispatchQueryRequest, DataSourceMetadata dataSourceMetadata) {
+    return DispatchQueryContext.builder()
+        .dataSourceMetadata(dataSourceMetadata)
+        .tags(getDefaultTagsForJobSubmission(dispatchQueryRequest))
+        .queryId(AsyncQueryId.newAsyncQueryId(dataSourceMetadata.getName()));
+  }
+
+  private AsyncQueryHandler getQueryHandlerForFlintExtensionQuery(
+      IndexQueryDetails indexQueryDetails) {
+    if (isEligibleForIndexDMLHandling(indexQueryDetails)) {
+      return queryHandlerFactory.getIndexDMLHandler();
+    } else if (isEligibleForStreamingQuery(indexQueryDetails)) {
+      return queryHandlerFactory.getStreamingQueryHandler();
+    } else if (IndexQueryActionType.REFRESH.equals(indexQueryDetails.getIndexQueryActionType())) {
+      // manual refresh should be handled by batch handler
+      return queryHandlerFactory.getRefreshQueryHandler();
+    } else {
+      return getDefaultAsyncQueryHandler();
+    }
+  }
+
+  @NotNull
+  private AsyncQueryHandler getDefaultAsyncQueryHandler() {
+    return sessionManager.isEnabled()
+        ? queryHandlerFactory.getInteractiveQueryHandler()
+        : queryHandlerFactory.getBatchQueryHandler();
+  }
+
+  @NotNull
+  private static IndexQueryDetails getIndexQueryDetails(DispatchQueryRequest dispatchQueryRequest) {
+    IndexQueryDetails indexQueryDetails =
+        SQLQueryUtils.extractIndexDetails(dispatchQueryRequest.getQuery());
+    fillDatasourceName(dispatchQueryRequest, indexQueryDetails);
+    return indexQueryDetails;
   }
 
   private boolean isEligibleForStreamingQuery(IndexQueryDetails indexQueryDetails) {
@@ -119,58 +117,35 @@ public class SparkQueryDispatcher {
   }
 
   public JSONObject getQueryResponse(AsyncQueryJobMetadata asyncQueryJobMetadata) {
-    EMRServerlessClient emrServerlessClient = emrServerlessClientFactory.getClient();
-    if (asyncQueryJobMetadata.getSessionId() != null) {
-      return new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader, leaseManager)
-          .getQueryResponse(asyncQueryJobMetadata);
-    } else if (IndexDMLHandler.isIndexDMLQuery(asyncQueryJobMetadata.getJobId())) {
-      return createIndexDMLHandler(emrServerlessClient).getQueryResponse(asyncQueryJobMetadata);
-    } else {
-      return new BatchQueryHandler(emrServerlessClient, jobExecutionResponseReader, leaseManager)
-          .getQueryResponse(asyncQueryJobMetadata);
-    }
+    return getAsyncQueryHandlerForExistingQuery(asyncQueryJobMetadata)
+        .getQueryResponse(asyncQueryJobMetadata);
   }
 
   public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
-    EMRServerlessClient emrServerlessClient = emrServerlessClientFactory.getClient();
-    AsyncQueryHandler queryHandler;
-    if (asyncQueryJobMetadata.getSessionId() != null) {
-      queryHandler =
-          new InteractiveQueryHandler(sessionManager, jobExecutionResponseReader, leaseManager);
-    } else if (IndexDMLHandler.isIndexDMLQuery(asyncQueryJobMetadata.getJobId())) {
-      queryHandler = createIndexDMLHandler(emrServerlessClient);
-    } else if (asyncQueryJobMetadata.getJobType() == JobType.BATCH) {
-      queryHandler =
-          new RefreshQueryHandler(
-              emrServerlessClient,
-              jobExecutionResponseReader,
-              flintIndexMetadataService,
-              stateStore,
-              leaseManager);
-    } else if (asyncQueryJobMetadata.getJobType() == JobType.STREAMING) {
-      queryHandler =
-          new StreamingQueryHandler(emrServerlessClient, jobExecutionResponseReader, leaseManager);
-    } else {
-      queryHandler =
-          new BatchQueryHandler(emrServerlessClient, jobExecutionResponseReader, leaseManager);
-    }
-    return queryHandler.cancelJob(asyncQueryJobMetadata);
+    return getAsyncQueryHandlerForExistingQuery(asyncQueryJobMetadata)
+        .cancelJob(asyncQueryJobMetadata);
   }
 
-  private IndexDMLHandler createIndexDMLHandler(EMRServerlessClient emrServerlessClient) {
-    return new IndexDMLHandler(
-        emrServerlessClient,
-        jobExecutionResponseReader,
-        flintIndexMetadataService,
-        stateStore,
-        client);
+  private AsyncQueryHandler getAsyncQueryHandlerForExistingQuery(
+      AsyncQueryJobMetadata asyncQueryJobMetadata) {
+    if (asyncQueryJobMetadata.getSessionId() != null) {
+      return queryHandlerFactory.getInteractiveQueryHandler();
+    } else if (IndexDMLHandler.isIndexDMLQuery(asyncQueryJobMetadata.getJobId())) {
+      return queryHandlerFactory.getIndexDMLHandler();
+    } else if (asyncQueryJobMetadata.getJobType() == JobType.BATCH) {
+      return queryHandlerFactory.getRefreshQueryHandler();
+    } else if (asyncQueryJobMetadata.getJobType() == JobType.STREAMING) {
+      return queryHandlerFactory.getStreamingQueryHandler();
+    } else {
+      return queryHandlerFactory.getBatchQueryHandler();
+    }
   }
 
   // TODO: Revisit this logic.
   // Currently, Spark if datasource is not provided in query.
   // Spark Assumes the datasource to be catalog.
   // This is required to handle drop index case properly when datasource name is not provided.
-  private static void fillMissingDetails(
+  private static void fillDatasourceName(
       DispatchQueryRequest dispatchQueryRequest, IndexQueryDetails indexQueryDetails) {
     if (indexQueryDetails.getFullyQualifiedTableName() != null
         && indexQueryDetails.getFullyQualifiedTableName().getDatasourceName() == null) {

--- a/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
@@ -25,6 +25,7 @@ import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactoryImpl;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplierImpl;
+import org.opensearch.sql.spark.dispatcher.QueryHandlerFactory;
 import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
 import org.opensearch.sql.spark.execution.session.SessionManager;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
@@ -65,23 +66,29 @@ public class AsyncExecutorServiceModule extends AbstractModule {
 
   @Provides
   public SparkQueryDispatcher sparkQueryDispatcher(
-      EMRServerlessClientFactory emrServerlessClientFactory,
       DataSourceService dataSourceService,
+      SessionManager sessionManager,
+      QueryHandlerFactory queryHandlerFactory) {
+    return new SparkQueryDispatcher(dataSourceService, sessionManager, queryHandlerFactory);
+  }
+
+  @Provides
+  public QueryHandlerFactory queryhandlerFactory(
       JobExecutionResponseReader jobExecutionResponseReader,
       FlintIndexMetadataServiceImpl flintIndexMetadataReader,
       NodeClient client,
       SessionManager sessionManager,
       DefaultLeaseManager defaultLeaseManager,
-      StateStore stateStore) {
-    return new SparkQueryDispatcher(
-        emrServerlessClientFactory,
-        dataSourceService,
+      StateStore stateStore,
+      EMRServerlessClientFactory emrServerlessClientFactory) {
+    return new QueryHandlerFactory(
         jobExecutionResponseReader,
         flintIndexMetadataReader,
         client,
         sessionManager,
         defaultLeaseManager,
-        stateStore);
+        stateStore,
+        emrServerlessClientFactory);
   }
 
   @Provides

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -172,6 +172,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchSelectQueryWithLakeFormation() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -210,6 +211,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -110,21 +110,22 @@ public class SparkQueryDispatcherTest {
 
   @BeforeEach
   void setUp() {
-    sparkQueryDispatcher =
-        new SparkQueryDispatcher(
-            emrServerlessClientFactory,
-            dataSourceService,
+    QueryHandlerFactory queryHandlerFactory =
+        new QueryHandlerFactory(
             jobExecutionResponseReader,
             flintIndexMetadataService,
             openSearchClient,
             sessionManager,
             leaseManager,
-            stateStore);
-    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
+            stateStore,
+            emrServerlessClientFactory);
+    sparkQueryDispatcher =
+        new SparkQueryDispatcher(dataSourceService, sessionManager, queryHandlerFactory);
   }
 
   @Test
   void testDispatchSelectQuery() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -162,6 +163,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -216,6 +218,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchSelectQueryWithBasicAuthIndexStoreDatasource() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -244,6 +247,7 @@ public class SparkQueryDispatcherTest {
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadataWithBasicAuth();
     when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
         .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -253,6 +257,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -261,6 +266,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchSelectQueryWithNoAuthIndexStoreDatasource() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -369,6 +375,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchIndexQuery() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(INDEX_TAG_KEY, "flint_my_glue_default_http_logs_elb_and_requesturi_index");
@@ -419,6 +426,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchWithPPLQuery() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -446,6 +454,7 @@ public class SparkQueryDispatcherTest {
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
         .thenReturn(dataSourceMetadata);
+
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -455,6 +464,7 @@ public class SparkQueryDispatcherTest {
                 LangType.PPL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -463,6 +473,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchQueryWithoutATableAndDataSourceName() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -508,6 +519,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchIndexQueryWithoutADatasourceName() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(INDEX_TAG_KEY, "flint_my_glue_default_http_logs_elb_and_requesturi_index");
@@ -557,6 +569,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchMaterializedViewQuery() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(INDEX_TAG_KEY, "flint_mv_1");
@@ -606,6 +619,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchShowMVQuery() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -651,6 +665,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testRefreshIndexQuery() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -696,6 +711,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchDescribeIndexQuery() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     HashMap<String, String> tags = new HashMap<>();
     tags.put(DATASOURCE_TAG_KEY, "my_glue");
     tags.put(CLUSTER_NAME_TAG_KEY, TEST_CLUSTER_NAME);
@@ -744,6 +760,7 @@ public class SparkQueryDispatcherTest {
     when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
         .thenReturn(constructMyGlueDataSourceMetadataWithBadURISyntax());
     String query = "select * from my_glue.default.http_logs";
+
     IllegalArgumentException illegalArgumentException =
         Assertions.assertThrows(
             IllegalArgumentException.class,
@@ -756,6 +773,7 @@ public class SparkQueryDispatcherTest {
                         LangType.SQL,
                         EMRS_EXECUTION_ROLE,
                         TEST_CLUSTER_NAME)));
+
     Assertions.assertEquals(
         "Bad URI in indexstore configuration of the : my_glue datasoure.",
         illegalArgumentException.getMessage());
@@ -766,6 +784,7 @@ public class SparkQueryDispatcherTest {
     when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_prometheus"))
         .thenReturn(constructPrometheusDataSourceType());
     String query = "select * from my_prometheus.default.http_logs";
+
     UnsupportedOperationException unsupportedOperationException =
         Assertions.assertThrows(
             UnsupportedOperationException.class,
@@ -778,6 +797,7 @@ public class SparkQueryDispatcherTest {
                         LangType.SQL,
                         EMRS_EXECUTION_ROLE,
                         TEST_CLUSTER_NAME)));
+
     Assertions.assertEquals(
         "UnSupported datasource type for async queries:: PROMETHEUS",
         unsupportedOperationException.getMessage());
@@ -785,12 +805,15 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testCancelJob() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     when(emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID, false))
         .thenReturn(
             new CancelJobRunResult()
                 .withJobRunId(EMR_JOB_ID)
                 .withApplicationId(EMRS_APPLICATION_ID));
+
     String queryId = sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata());
+
     Assertions.assertEquals(QUERY_ID.getId(), queryId);
   }
 
@@ -845,24 +868,29 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testCancelQueryWithNoSessionId() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     when(emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID, false))
         .thenReturn(
             new CancelJobRunResult()
                 .withJobRunId(EMR_JOB_ID)
                 .withApplicationId(EMRS_APPLICATION_ID));
+
     String queryId = sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata());
+
     Assertions.assertEquals(QUERY_ID.getId(), queryId);
   }
 
   @Test
   void testGetQueryResponse() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     when(emrServerlessClient.getJobRunResult(EMRS_APPLICATION_ID, EMR_JOB_ID))
         .thenReturn(new GetJobRunResult().withJobRun(new JobRun().withState(JobRunState.PENDING)));
-
     // simulate result index is not created yet
     when(jobExecutionResponseReader.getResultFromOpensearchIndex(EMR_JOB_ID, null))
         .thenReturn(new JSONObject());
+
     JSONObject result = sparkQueryDispatcher.getQueryResponse(asyncQueryJobMetadata());
+
     Assertions.assertEquals("PENDING", result.get("status"));
   }
 
@@ -872,10 +900,10 @@ public class SparkQueryDispatcherTest {
     doReturn(Optional.of(statement)).when(session).get(any());
     when(statement.getStatementModel().getError()).thenReturn("mock error");
     doReturn(StatementState.WAITING).when(statement).getStatementState();
-
     doReturn(new JSONObject())
         .when(jobExecutionResponseReader)
         .getResultWithQueryId(eq(MOCK_STATEMENT_ID), any());
+
     JSONObject result =
         sparkQueryDispatcher.getQueryResponse(
             asyncQueryJobMetadataWithSessionId(MOCK_STATEMENT_ID, MOCK_SESSION_ID));
@@ -890,6 +918,7 @@ public class SparkQueryDispatcherTest {
     doReturn(new JSONObject())
         .when(jobExecutionResponseReader)
         .getResultWithQueryId(eq(MOCK_STATEMENT_ID), any());
+
     IllegalArgumentException exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
@@ -916,6 +945,7 @@ public class SparkQueryDispatcherTest {
             () ->
                 sparkQueryDispatcher.getQueryResponse(
                     asyncQueryJobMetadataWithSessionId(MOCK_STATEMENT_ID, MOCK_SESSION_ID)));
+
     verifyNoInteractions(emrServerlessClient);
     Assertions.assertEquals(
         "no statement found. " + new StatementId(MOCK_STATEMENT_ID), exception.getMessage());
@@ -949,6 +979,7 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchQueryWithExtraSparkSubmitParameters() {
+    when(emrServerlessClientFactory.getClient()).thenReturn(emrServerlessClient);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
         .thenReturn(dataSourceMetadata);


### PR DESCRIPTION
### Description
* Backport #2636 
* Automatic backport failed because of unit test failure due to change to the same class in different PR (#2624)
* For main branch, the same issue was solved in #2645
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).