### PR TITLE
Backport/backport 2644, 2658, 2657, and 2665 to 2.x

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -79,10 +79,9 @@ import org.opensearch.sql.plugin.transport.TransportPPLQueryAction;
 import org.opensearch.sql.plugin.transport.TransportPPLQueryResponse;
 import org.opensearch.sql.prometheus.storage.PrometheusStorageFactory;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorService;
-import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.cluster.ClusterManagerEventListener;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataServiceImpl;
+import org.opensearch.sql.spark.flint.operation.FlintIndexOpFactory;
 import org.opensearch.sql.spark.rest.RestAsyncQueryManagementAction;
 import org.opensearch.sql.spark.transport.TransportCancelAsyncQueryRequestAction;
 import org.opensearch.sql.spark.transport.TransportCreateAsyncQueryRequestAction;
@@ -227,8 +226,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
             environment.settings(),
             dataSourceService,
             injector.getInstance(FlintIndexMetadataServiceImpl.class),
-            injector.getInstance(StateStore.class),
-            injector.getInstance(EMRServerlessClientFactory.class));
+            injector.getInstance(FlintIndexOpFactory.class));
     return ImmutableList.of(
         dataSourceService,
         injector.getInstance(AsyncQueryExecutorService.class),

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -30,8 +30,8 @@ import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
 @RequiredArgsConstructor
 public class BatchQueryHandler extends AsyncQueryHandler {
-  private final EMRServerlessClient emrServerlessClient;
-  private final JobExecutionResponseReader jobExecutionResponseReader;
+  protected final EMRServerlessClient emrServerlessClient;
+  protected final JobExecutionResponseReader jobExecutionResponseReader;
   protected final LeaseManager leaseManager;
 
   @Override

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -28,6 +28,10 @@ import org.opensearch.sql.spark.leasemanager.LeaseManager;
 import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
+/**
+ * The handler for batch query. With batch query, queries are executed as single batch. The queries
+ * are sent along with job execution request ({@link StartJobRequest}) to spark.
+ */
 @RequiredArgsConstructor
 public class BatchQueryHandler extends AsyncQueryHandler {
   protected final EMRServerlessClient emrServerlessClient;

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
@@ -31,7 +31,12 @@ import org.opensearch.sql.spark.flint.operation.FlintIndexOp;
 import org.opensearch.sql.spark.flint.operation.FlintIndexOpFactory;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
-/** Handle Index DML query. includes * DROP * ALT? */
+/**
+ * The handler for Index DML (Data Manipulation Language) query. Handles DROP/ALTER/VACUUM operation
+ * for flint indices. It will stop streaming query job as needed (e.g. when the flint index is
+ * automatically updated by a streaming query, the streaming query is stopped when the index is
+ * dropped)
+ */
 @RequiredArgsConstructor
 public class IndexDMLHandler extends AsyncQueryHandler {
   private static final Logger LOG = LogManager.getLogger();

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -35,6 +35,12 @@ import org.opensearch.sql.spark.leasemanager.LeaseManager;
 import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
+/**
+ * The handler for interactive query. With interactive query, a session will be first established
+ * and then the session will be reused for the following queries(statements). Session is an
+ * abstraction of spark job, and once the job is started, the job will continuously poll the
+ * statements and execute query specified in it.
+ */
 @RequiredArgsConstructor
 public class InteractiveQueryHandler extends AsyncQueryHandler {
   private final SessionManager sessionManager;

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/QueryHandlerFactory.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/QueryHandlerFactory.java
@@ -6,11 +6,11 @@
 package org.opensearch.sql.spark.dispatcher;
 
 import lombok.RequiredArgsConstructor;
-import org.opensearch.client.Client;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.session.SessionManager;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
+import org.opensearch.sql.spark.flint.IndexDMLResultStorageService;
+import org.opensearch.sql.spark.flint.operation.FlintIndexOpFactory;
 import org.opensearch.sql.spark.leasemanager.LeaseManager;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
@@ -19,10 +19,10 @@ public class QueryHandlerFactory {
 
   private final JobExecutionResponseReader jobExecutionResponseReader;
   private final FlintIndexMetadataService flintIndexMetadataService;
-  private final Client client;
   private final SessionManager sessionManager;
   private final LeaseManager leaseManager;
-  private final StateStore stateStore;
+  private final IndexDMLResultStorageService indexDMLResultStorageService;
+  private final FlintIndexOpFactory flintIndexOpFactory;
   private final EMRServerlessClientFactory emrServerlessClientFactory;
 
   public RefreshQueryHandler getRefreshQueryHandler() {
@@ -30,8 +30,8 @@ public class QueryHandlerFactory {
         emrServerlessClientFactory.getClient(),
         jobExecutionResponseReader,
         flintIndexMetadataService,
-        stateStore,
-        leaseManager);
+        leaseManager,
+        flintIndexOpFactory);
   }
 
   public StreamingQueryHandler getStreamingQueryHandler() {
@@ -50,10 +50,9 @@ public class QueryHandlerFactory {
 
   public IndexDMLHandler getIndexDMLHandler() {
     return new IndexDMLHandler(
-        emrServerlessClientFactory.getClient(),
         jobExecutionResponseReader,
         flintIndexMetadataService,
-        stateStore,
-        client);
+        indexDMLResultStorageService,
+        flintIndexOpFactory);
   }
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/RefreshQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/RefreshQueryHandler.java
@@ -20,7 +20,10 @@ import org.opensearch.sql.spark.flint.operation.FlintIndexOpFactory;
 import org.opensearch.sql.spark.leasemanager.LeaseManager;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
-/** Handle Refresh Query. */
+/**
+ * The handler for refresh query. Refresh query is one time query request to refresh(update) flint
+ * index, and new job is submitted to Spark.
+ */
 public class RefreshQueryHandler extends BatchQueryHandler {
 
   private final FlintIndexMetadataService flintIndexMetadataService;

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
@@ -28,14 +28,12 @@ import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
 /** Handle Streaming Query. */
 public class StreamingQueryHandler extends BatchQueryHandler {
-  private final EMRServerlessClient emrServerlessClient;
 
   public StreamingQueryHandler(
       EMRServerlessClient emrServerlessClient,
       JobExecutionResponseReader jobExecutionResponseReader,
       LeaseManager leaseManager) {
     super(emrServerlessClient, jobExecutionResponseReader, leaseManager);
-    this.emrServerlessClient = emrServerlessClient;
   }
 
   @Override

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
@@ -26,7 +26,10 @@ import org.opensearch.sql.spark.leasemanager.LeaseManager;
 import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 
-/** Handle Streaming Query. */
+/**
+ * The handler for streaming query. Streaming query is a job to continuously update flint index.
+ * Once started, the job can be stopped by IndexDML query.
+ */
 public class StreamingQueryHandler extends BatchQueryHandler {
 
   public StreamingQueryHandler(

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statement/Statement.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statement/Statement.java
@@ -6,9 +6,6 @@
 package org.opensearch.sql.spark.execution.statement;
 
 import static org.opensearch.sql.spark.execution.statement.StatementModel.submitStatement;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.createStatement;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.getStatement;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.updateStatementState;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.index.engine.DocumentMissingException;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.sql.spark.execution.session.SessionId;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.execution.statestore.StatementStorageService;
 import org.opensearch.sql.spark.rest.model.LangType;
 
 /** Statement represent query to execute in session. One statement map to one session. */
@@ -35,7 +32,7 @@ public class Statement {
   private final String datasourceName;
   private final String query;
   private final String queryId;
-  private final StateStore stateStore;
+  private final StatementStorageService statementStorageService;
 
   @Setter private StatementModel statementModel;
 
@@ -52,7 +49,7 @@ public class Statement {
               datasourceName,
               query,
               queryId);
-      statementModel = createStatement(stateStore, datasourceName).apply(statementModel);
+      statementModel = statementStorageService.createStatement(statementModel, datasourceName);
     } catch (VersionConflictEngineException e) {
       String errorMsg = "statement already exist. " + statementId;
       LOG.error(errorMsg);
@@ -76,8 +73,8 @@ public class Statement {
     }
     try {
       this.statementModel =
-          updateStatementState(stateStore, statementModel.getDatasourceName())
-              .apply(this.statementModel, StatementState.CANCELLED);
+          statementStorageService.updateStatementState(
+              statementModel, StatementState.CANCELLED, statementModel.getDatasourceName());
     } catch (DocumentMissingException e) {
       String errorMsg =
           String.format("cancel statement failed. no statement found. statement: %s.", statementId);
@@ -85,8 +82,8 @@ public class Statement {
       throw new IllegalStateException(errorMsg);
     } catch (VersionConflictEngineException e) {
       this.statementModel =
-          getStatement(stateStore, statementModel.getDatasourceName())
-              .apply(statementModel.getId())
+          statementStorageService
+              .getStatement(statementModel.getId(), statementModel.getDatasourceName())
               .orElse(this.statementModel);
       String errorMsg =
           String.format(

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchSessionStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchSessionStorageService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.execution.statestore;
+
+import static org.opensearch.sql.spark.execution.statestore.StateStore.DATASOURCE_TO_REQUEST_INDEX;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.execution.session.SessionModel;
+import org.opensearch.sql.spark.execution.session.SessionState;
+
+@RequiredArgsConstructor
+public class OpenSearchSessionStorageService implements SessionStorageService {
+
+  private final StateStore stateStore;
+
+  @Override
+  public SessionModel createSession(SessionModel sessionModel, String datasourceName) {
+    return stateStore.create(
+        sessionModel, SessionModel::of, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
+  }
+
+  @Override
+  public Optional<SessionModel> getSession(String id, String datasourceName) {
+    return stateStore.get(
+        id, SessionModel::fromXContent, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
+  }
+
+  @Override
+  public SessionModel updateSessionState(
+      SessionModel sessionModel, SessionState sessionState, String datasourceName) {
+    return stateStore.updateState(
+        sessionModel,
+        sessionState,
+        SessionModel::copyWithState,
+        DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStateStoreUtil.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStateStoreUtil.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.execution.statestore;
+
+import static org.opensearch.sql.spark.data.constants.SparkConstants.SPARK_REQUEST_BUFFER_INDEX_NAME;
+
+import java.util.Locale;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class OpenSearchStateStoreUtil {
+
+  public static String getIndexName(String datasourceName) {
+    return String.format(
+        "%s_%s", SPARK_REQUEST_BUFFER_INDEX_NAME, datasourceName.toLowerCase(Locale.ROOT));
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStatementStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStatementStorageService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.execution.statestore;
+
+import static org.opensearch.sql.spark.execution.statestore.StateStore.DATASOURCE_TO_REQUEST_INDEX;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.execution.statement.StatementModel;
+import org.opensearch.sql.spark.execution.statement.StatementState;
+
+@RequiredArgsConstructor
+public class OpenSearchStatementStorageService implements StatementStorageService {
+
+  private final StateStore stateStore;
+
+  @Override
+  public StatementModel createStatement(StatementModel statementModel, String datasourceName) {
+    return stateStore.create(
+        statementModel, StatementModel::copy, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
+  }
+
+  @Override
+  public Optional<StatementModel> getStatement(String id, String datasourceName) {
+    return stateStore.get(
+        id, StatementModel::fromXContent, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
+  }
+
+  @Override
+  public StatementModel updateStatementState(
+      StatementModel oldStatementModel, StatementState statementState, String datasourceName) {
+    return stateStore.updateState(
+        oldStatementModel,
+        statementState,
+        StatementModel::copyWithState,
+        DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/SessionStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/SessionStorageService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.execution.statestore;
+
+import java.util.Optional;
+import org.opensearch.sql.spark.execution.session.SessionModel;
+import org.opensearch.sql.spark.execution.session.SessionState;
+
+/** Interface for accessing {@link SessionModel} data storage. */
+public interface SessionStorageService {
+
+  SessionModel createSession(SessionModel sessionModel, String datasourceName);
+
+  Optional<SessionModel> getSession(String id, String datasourceName);
+
+  SessionModel updateSessionState(
+      SessionModel sessionModel, SessionState sessionState, String datasourceName);
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
@@ -49,7 +49,6 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
-import org.opensearch.sql.spark.dispatcher.model.IndexDMLResult;
 import org.opensearch.sql.spark.execution.session.SessionModel;
 import org.opensearch.sql.spark.execution.session.SessionState;
 import org.opensearch.sql.spark.execution.session.SessionType;
@@ -250,55 +249,6 @@ public class StateStore {
     return IOUtils.toString(fileStream, StandardCharsets.UTF_8);
   }
 
-  /** Helper Functions */
-  public static Function<StatementModel, StatementModel> createStatement(
-      StateStore stateStore, String datasourceName) {
-    return (st) ->
-        stateStore.create(
-            st, StatementModel::copy, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  public static Function<String, Optional<StatementModel>> getStatement(
-      StateStore stateStore, String datasourceName) {
-    return (docId) ->
-        stateStore.get(
-            docId, StatementModel::fromXContent, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  public static BiFunction<StatementModel, StatementState, StatementModel> updateStatementState(
-      StateStore stateStore, String datasourceName) {
-    return (old, state) ->
-        stateStore.updateState(
-            old,
-            state,
-            StatementModel::copyWithState,
-            DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  public static Function<SessionModel, SessionModel> createSession(
-      StateStore stateStore, String datasourceName) {
-    return (session) ->
-        stateStore.create(
-            session, SessionModel::of, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  public static Function<String, Optional<SessionModel>> getSession(
-      StateStore stateStore, String datasourceName) {
-    return (docId) ->
-        stateStore.get(
-            docId, SessionModel::fromXContent, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  public static BiFunction<SessionModel, SessionState, SessionModel> updateSessionState(
-      StateStore stateStore, String datasourceName) {
-    return (old, state) ->
-        stateStore.updateState(
-            old,
-            state,
-            SessionModel::copyWithState,
-            DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
   public static Function<AsyncQueryJobMetadata, AsyncQueryJobMetadata> createJobMetaData(
       StateStore stateStore, String datasourceName) {
     return (jobMetadata) ->
@@ -339,37 +289,6 @@ public class StateStore {
             state,
             FlintIndexStateModel::copyWithState,
             DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  public static Function<String, Optional<FlintIndexStateModel>> getFlintIndexState(
-      StateStore stateStore, String datasourceName) {
-    return (docId) ->
-        stateStore.get(
-            docId,
-            FlintIndexStateModel::fromXContent,
-            DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  public static Function<FlintIndexStateModel, FlintIndexStateModel> createFlintIndexState(
-      StateStore stateStore, String datasourceName) {
-    return (st) ->
-        stateStore.create(
-            st, FlintIndexStateModel::copy, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  /**
-   * @param stateStore index state store
-   * @param datasourceName data source name
-   * @return function that accepts index state doc ID and perform the deletion
-   */
-  public static Function<String, Boolean> deleteFlintIndexState(
-      StateStore stateStore, String datasourceName) {
-    return (docId) -> stateStore.delete(docId, DATASOURCE_TO_REQUEST_INDEX.apply(datasourceName));
-  }
-
-  public static Function<IndexDMLResult, IndexDMLResult> createIndexDMLResult(
-      StateStore stateStore, String indexName) {
-    return (result) -> stateStore.create(result, IndexDMLResult::copy, indexName);
   }
 
   public static Supplier<Long> activeRefreshJobCount(StateStore stateStore, String datasourceName) {

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StatementStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StatementStorageService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.execution.statestore;
+
+import java.util.Optional;
+import org.opensearch.sql.spark.execution.statement.StatementModel;
+import org.opensearch.sql.spark.execution.statement.StatementState;
+
+/**
+ * Interface for accessing {@link StatementModel} data storage. {@link StatementModel} is an
+ * abstraction over the query request within a Session.
+ */
+public interface StatementStorageService {
+
+  StatementModel createStatement(StatementModel statementModel, String datasourceName);
+
+  StatementModel updateStatementState(
+      StatementModel oldStatementModel, StatementState statementState, String datasourceName);
+
+  Optional<StatementModel> getStatement(String id, String datasourceName);
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/FlintIndexStateModelService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/FlintIndexStateModelService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.flint;
+
+import java.util.Optional;
+
+/**
+ * Abstraction over flint index state storage. Flint index state will maintain the status of each
+ * flint index.
+ */
+public interface FlintIndexStateModelService {
+  FlintIndexStateModel createFlintIndexStateModel(
+      FlintIndexStateModel flintIndexStateModel, String datasourceName);
+
+  Optional<FlintIndexStateModel> getFlintIndexStateModel(String id, String datasourceName);
+
+  FlintIndexStateModel updateFlintIndexState(
+      FlintIndexStateModel flintIndexStateModel,
+      FlintIndexState flintIndexState,
+      String datasourceName);
+
+  boolean deleteFlintIndexStateModel(String id, String datasourceName);
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/IndexDMLResultStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/IndexDMLResultStorageService.java
@@ -7,6 +7,9 @@ package org.opensearch.sql.spark.flint;
 
 import org.opensearch.sql.spark.dispatcher.model.IndexDMLResult;
 
+/**
+ * Abstraction over the IndexDMLResult storage. It stores the result of IndexDML query execution.
+ */
 public interface IndexDMLResultStorageService {
   IndexDMLResult createIndexDMLResult(IndexDMLResult result, String datasourceName);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/IndexDMLResultStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/IndexDMLResultStorageService.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.flint;
+
+import org.opensearch.sql.spark.dispatcher.model.IndexDMLResult;
+
+public interface IndexDMLResultStorageService {
+  IndexDMLResult createIndexDMLResult(IndexDMLResult result, String datasourceName);
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/OpenSearchFlintIndexStateModelService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/OpenSearchFlintIndexStateModelService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.flint;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.execution.statestore.OpenSearchStateStoreUtil;
+import org.opensearch.sql.spark.execution.statestore.StateStore;
+
+@RequiredArgsConstructor
+public class OpenSearchFlintIndexStateModelService implements FlintIndexStateModelService {
+  private final StateStore stateStore;
+
+  @Override
+  public FlintIndexStateModel updateFlintIndexState(
+      FlintIndexStateModel flintIndexStateModel,
+      FlintIndexState flintIndexState,
+      String datasourceName) {
+    return stateStore.updateState(
+        flintIndexStateModel,
+        flintIndexState,
+        FlintIndexStateModel::copyWithState,
+        OpenSearchStateStoreUtil.getIndexName(datasourceName));
+  }
+
+  @Override
+  public Optional<FlintIndexStateModel> getFlintIndexStateModel(String id, String datasourceName) {
+    return stateStore.get(
+        id,
+        FlintIndexStateModel::fromXContent,
+        OpenSearchStateStoreUtil.getIndexName(datasourceName));
+  }
+
+  @Override
+  public FlintIndexStateModel createFlintIndexStateModel(
+      FlintIndexStateModel flintIndexStateModel, String datasourceName) {
+    return stateStore.create(
+        flintIndexStateModel,
+        FlintIndexStateModel::copy,
+        OpenSearchStateStoreUtil.getIndexName(datasourceName));
+  }
+
+  @Override
+  public boolean deleteFlintIndexStateModel(String id, String datasourceName) {
+    return stateStore.delete(id, OpenSearchStateStoreUtil.getIndexName(datasourceName));
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/OpenSearchIndexDMLResultStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/OpenSearchIndexDMLResultStorageService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.flint;
+
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.spark.dispatcher.model.IndexDMLResult;
+import org.opensearch.sql.spark.execution.statestore.StateStore;
+
+@RequiredArgsConstructor
+public class OpenSearchIndexDMLResultStorageService implements IndexDMLResultStorageService {
+
+  private final DataSourceService dataSourceService;
+  private final StateStore stateStore;
+
+  @Override
+  public IndexDMLResult createIndexDMLResult(IndexDMLResult result, String datasourceName) {
+    DataSourceMetadata dataSourceMetadata = dataSourceService.getDataSourceMetadata(datasourceName);
+    return stateStore.create(result, IndexDMLResult::copy, dataSourceMetadata.getResultIndex());
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOp.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOp.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
@@ -33,6 +34,7 @@ public abstract class FlintIndexOp {
 
   private final StateStore stateStore;
   private final String datasourceName;
+  private final EMRServerlessClientFactory emrServerlessClientFactory;
 
   /** Apply operation on {@link FlintIndexMetadata} */
   public void apply(FlintIndexMetadata metadata) {
@@ -140,11 +142,11 @@ public abstract class FlintIndexOp {
   /***
    * Common operation between AlterOff and Drop. So moved to FlintIndexOp.
    */
-  public void cancelStreamingJob(
-      EMRServerlessClient emrServerlessClient, FlintIndexStateModel flintIndexStateModel)
+  public void cancelStreamingJob(FlintIndexStateModel flintIndexStateModel)
       throws InterruptedException, TimeoutException {
     String applicationId = flintIndexStateModel.getApplicationId();
     String jobId = flintIndexStateModel.getJobId();
+    EMRServerlessClient emrServerlessClient = emrServerlessClientFactory.getClient();
     try {
       emrServerlessClient.cancelJobRun(
           flintIndexStateModel.getApplicationId(), flintIndexStateModel.getJobId(), true);

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpAlter.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpAlter.java
@@ -10,11 +10,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
 import org.opensearch.sql.spark.flint.FlintIndexState;
 import org.opensearch.sql.spark.flint.FlintIndexStateModel;
+import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
 
 /**
  * Index Operation for Altering the flint index. Only handles alter operation when
@@ -27,11 +27,11 @@ public class FlintIndexOpAlter extends FlintIndexOp {
 
   public FlintIndexOpAlter(
       FlintIndexOptions flintIndexOptions,
-      StateStore stateStore,
+      FlintIndexStateModelService flintIndexStateModelService,
       String datasourceName,
       EMRServerlessClientFactory emrServerlessClientFactory,
       FlintIndexMetadataService flintIndexMetadataService) {
-    super(stateStore, datasourceName, emrServerlessClientFactory);
+    super(flintIndexStateModelService, datasourceName, emrServerlessClientFactory);
     this.flintIndexMetadataService = flintIndexMetadataService;
     this.flintIndexOptions = flintIndexOptions;
   }

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpAlter.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpAlter.java
@@ -8,7 +8,7 @@ package org.opensearch.sql.spark.flint.operation;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
@@ -22,7 +22,6 @@ import org.opensearch.sql.spark.flint.FlintIndexStateModel;
  */
 public class FlintIndexOpAlter extends FlintIndexOp {
   private static final Logger LOG = LogManager.getLogger(FlintIndexOpAlter.class);
-  private final EMRServerlessClient emrServerlessClient;
   private final FlintIndexMetadataService flintIndexMetadataService;
   private final FlintIndexOptions flintIndexOptions;
 
@@ -30,10 +29,9 @@ public class FlintIndexOpAlter extends FlintIndexOp {
       FlintIndexOptions flintIndexOptions,
       StateStore stateStore,
       String datasourceName,
-      EMRServerlessClient emrServerlessClient,
+      EMRServerlessClientFactory emrServerlessClientFactory,
       FlintIndexMetadataService flintIndexMetadataService) {
-    super(stateStore, datasourceName);
-    this.emrServerlessClient = emrServerlessClient;
+    super(stateStore, datasourceName, emrServerlessClientFactory);
     this.flintIndexMetadataService = flintIndexMetadataService;
     this.flintIndexOptions = flintIndexOptions;
   }
@@ -55,7 +53,7 @@ public class FlintIndexOpAlter extends FlintIndexOp {
         "Running alter index operation for index: {}", flintIndexMetadata.getOpensearchIndexName());
     this.flintIndexMetadataService.updateIndexToManualRefresh(
         flintIndexMetadata.getOpensearchIndexName(), flintIndexOptions);
-    cancelStreamingJob(emrServerlessClient, flintIndexStateModel);
+    cancelStreamingJob(flintIndexStateModel);
   }
 
   @Override

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpCancel.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpCancel.java
@@ -9,20 +9,20 @@ import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
 import org.opensearch.sql.spark.flint.FlintIndexStateModel;
+import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
 
 /** Cancel refreshing job for refresh query when user clicks cancel button on UI. */
 public class FlintIndexOpCancel extends FlintIndexOp {
   private static final Logger LOG = LogManager.getLogger();
 
   public FlintIndexOpCancel(
-      StateStore stateStore,
+      FlintIndexStateModelService flintIndexStateModelService,
       String datasourceName,
       EMRServerlessClientFactory emrServerlessClientFactory) {
-    super(stateStore, datasourceName, emrServerlessClientFactory);
+    super(flintIndexStateModelService, datasourceName, emrServerlessClientFactory);
   }
 
   // Only in refreshing state, the job is cancellable in case of REFRESH query.

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpCancel.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpCancel.java
@@ -8,7 +8,7 @@ package org.opensearch.sql.spark.flint.operation;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
@@ -18,12 +18,11 @@ import org.opensearch.sql.spark.flint.FlintIndexStateModel;
 public class FlintIndexOpCancel extends FlintIndexOp {
   private static final Logger LOG = LogManager.getLogger();
 
-  private final EMRServerlessClient emrServerlessClient;
-
   public FlintIndexOpCancel(
-      StateStore stateStore, String datasourceName, EMRServerlessClient emrServerlessClient) {
-    super(stateStore, datasourceName);
-    this.emrServerlessClient = emrServerlessClient;
+      StateStore stateStore,
+      String datasourceName,
+      EMRServerlessClientFactory emrServerlessClientFactory) {
+    super(stateStore, datasourceName, emrServerlessClientFactory);
   }
 
   // Only in refreshing state, the job is cancellable in case of REFRESH query.
@@ -43,7 +42,7 @@ public class FlintIndexOpCancel extends FlintIndexOp {
     LOG.debug(
         "Performing drop index operation for index: {}",
         flintIndexMetadata.getOpensearchIndexName());
-    cancelStreamingJob(emrServerlessClient, flintIndexStateModel);
+    cancelStreamingJob(flintIndexStateModel);
   }
 
   @Override

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpDrop.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpDrop.java
@@ -8,7 +8,7 @@ package org.opensearch.sql.spark.flint.operation;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
@@ -17,12 +17,11 @@ import org.opensearch.sql.spark.flint.FlintIndexStateModel;
 public class FlintIndexOpDrop extends FlintIndexOp {
   private static final Logger LOG = LogManager.getLogger();
 
-  private final EMRServerlessClient emrServerlessClient;
-
   public FlintIndexOpDrop(
-      StateStore stateStore, String datasourceName, EMRServerlessClient emrServerlessClient) {
-    super(stateStore, datasourceName);
-    this.emrServerlessClient = emrServerlessClient;
+      StateStore stateStore,
+      String datasourceName,
+      EMRServerlessClientFactory emrServerlessClientFactory) {
+    super(stateStore, datasourceName, emrServerlessClientFactory);
   }
 
   public boolean validate(FlintIndexState state) {
@@ -44,7 +43,7 @@ public class FlintIndexOpDrop extends FlintIndexOp {
     LOG.debug(
         "Performing drop index operation for index: {}",
         flintIndexMetadata.getOpensearchIndexName());
-    cancelStreamingJob(emrServerlessClient, flintIndexStateModel);
+    cancelStreamingJob(flintIndexStateModel);
   }
 
   @Override

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpDrop.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpDrop.java
@@ -9,19 +9,20 @@ import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
 import org.opensearch.sql.spark.flint.FlintIndexStateModel;
+import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
 
+/** Operation to drop Flint index */
 public class FlintIndexOpDrop extends FlintIndexOp {
   private static final Logger LOG = LogManager.getLogger();
 
   public FlintIndexOpDrop(
-      StateStore stateStore,
+      FlintIndexStateModelService flintIndexStateModelService,
       String datasourceName,
       EMRServerlessClientFactory emrServerlessClientFactory) {
-    super(stateStore, datasourceName, emrServerlessClientFactory);
+    super(flintIndexStateModelService, datasourceName, emrServerlessClientFactory);
   }
 
   public boolean validate(FlintIndexState state) {

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpFactory.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpFactory.java
@@ -9,34 +9,37 @@ import lombok.RequiredArgsConstructor;
 import org.opensearch.client.Client;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
+import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
 
 @RequiredArgsConstructor
 public class FlintIndexOpFactory {
-  private final StateStore stateStore;
+  private final FlintIndexStateModelService flintIndexStateModelService;
   private final Client client;
   private final FlintIndexMetadataService flintIndexMetadataService;
   private final EMRServerlessClientFactory emrServerlessClientFactory;
 
   public FlintIndexOpDrop getDrop(String datasource) {
-    return new FlintIndexOpDrop(stateStore, datasource, emrServerlessClientFactory);
+    return new FlintIndexOpDrop(
+        flintIndexStateModelService, datasource, emrServerlessClientFactory);
   }
 
   public FlintIndexOpAlter getAlter(FlintIndexOptions flintIndexOptions, String datasource) {
     return new FlintIndexOpAlter(
         flintIndexOptions,
-        stateStore,
+        flintIndexStateModelService,
         datasource,
         emrServerlessClientFactory,
         flintIndexMetadataService);
   }
 
   public FlintIndexOpVacuum getVacuum(String datasource) {
-    return new FlintIndexOpVacuum(stateStore, datasource, client, emrServerlessClientFactory);
+    return new FlintIndexOpVacuum(
+        flintIndexStateModelService, datasource, client, emrServerlessClientFactory);
   }
 
   public FlintIndexOpCancel getCancel(String datasource) {
-    return new FlintIndexOpCancel(stateStore, datasource, emrServerlessClientFactory);
+    return new FlintIndexOpCancel(
+        flintIndexStateModelService, datasource, emrServerlessClientFactory);
   }
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpFactory.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.flint.operation;
+
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.Client;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
+import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
+import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
+
+@RequiredArgsConstructor
+public class FlintIndexOpFactory {
+  private final StateStore stateStore;
+  private final Client client;
+  private final FlintIndexMetadataService flintIndexMetadataService;
+  private final EMRServerlessClientFactory emrServerlessClientFactory;
+
+  public FlintIndexOpDrop getDrop(String datasource) {
+    return new FlintIndexOpDrop(stateStore, datasource, emrServerlessClientFactory);
+  }
+
+  public FlintIndexOpAlter getAlter(FlintIndexOptions flintIndexOptions, String datasource) {
+    return new FlintIndexOpAlter(
+        flintIndexOptions,
+        stateStore,
+        datasource,
+        emrServerlessClientFactory,
+        flintIndexMetadataService);
+  }
+
+  public FlintIndexOpVacuum getVacuum(String datasource) {
+    return new FlintIndexOpVacuum(stateStore, datasource, client, emrServerlessClientFactory);
+  }
+
+  public FlintIndexOpCancel getCancel(String datasource) {
+    return new FlintIndexOpCancel(stateStore, datasource, emrServerlessClientFactory);
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpVacuum.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpVacuum.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.Client;
+import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
@@ -23,8 +24,12 @@ public class FlintIndexOpVacuum extends FlintIndexOp {
   /** OpenSearch client. */
   private final Client client;
 
-  public FlintIndexOpVacuum(StateStore stateStore, String datasourceName, Client client) {
-    super(stateStore, datasourceName);
+  public FlintIndexOpVacuum(
+      StateStore stateStore,
+      String datasourceName,
+      Client client,
+      EMRServerlessClientFactory emrServerlessClientFactory) {
+    super(stateStore, datasourceName, emrServerlessClientFactory);
     this.client = client;
   }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpVacuum.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpVacuum.java
@@ -11,10 +11,10 @@ import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.Client;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
 import org.opensearch.sql.spark.flint.FlintIndexStateModel;
+import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
 
 /** Flint index vacuum operation. */
 public class FlintIndexOpVacuum extends FlintIndexOp {
@@ -25,11 +25,11 @@ public class FlintIndexOpVacuum extends FlintIndexOp {
   private final Client client;
 
   public FlintIndexOpVacuum(
-      StateStore stateStore,
+      FlintIndexStateModelService flintIndexStateModelService,
       String datasourceName,
       Client client,
       EMRServerlessClientFactory emrServerlessClientFactory) {
-    super(stateStore, datasourceName, emrServerlessClientFactory);
+    super(flintIndexStateModelService, datasourceName, emrServerlessClientFactory);
     this.client = client;
   }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
@@ -30,7 +30,9 @@ import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
 import org.opensearch.sql.spark.execution.session.SessionManager;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataServiceImpl;
+import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
 import org.opensearch.sql.spark.flint.IndexDMLResultStorageService;
+import org.opensearch.sql.spark.flint.OpenSearchFlintIndexStateModelService;
 import org.opensearch.sql.spark.flint.OpenSearchIndexDMLResultStorageService;
 import org.opensearch.sql.spark.flint.operation.FlintIndexOpFactory;
 import org.opensearch.sql.spark.leasemanager.DefaultLeaseManager;
@@ -96,12 +98,17 @@ public class AsyncExecutorServiceModule extends AbstractModule {
 
   @Provides
   public FlintIndexOpFactory flintIndexOpFactory(
-      StateStore stateStore,
+      FlintIndexStateModelService flintIndexStateModelService,
       NodeClient client,
       FlintIndexMetadataServiceImpl flintIndexMetadataService,
       EMRServerlessClientFactory emrServerlessClientFactory) {
     return new FlintIndexOpFactory(
-        stateStore, client, flintIndexMetadataService, emrServerlessClientFactory);
+        flintIndexStateModelService, client, flintIndexMetadataService, emrServerlessClientFactory);
+  }
+
+  @Provides
+  public FlintIndexStateModelService flintIndexStateModelService(StateStore stateStore) {
+    return new OpenSearchFlintIndexStateModelService(stateStore);
   }
 
   @Provides

--- a/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/transport/config/AsyncExecutorServiceModule.java
@@ -28,7 +28,11 @@ import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplierImpl;
 import org.opensearch.sql.spark.dispatcher.QueryHandlerFactory;
 import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
 import org.opensearch.sql.spark.execution.session.SessionManager;
+import org.opensearch.sql.spark.execution.statestore.OpenSearchSessionStorageService;
+import org.opensearch.sql.spark.execution.statestore.OpenSearchStatementStorageService;
+import org.opensearch.sql.spark.execution.statestore.SessionStorageService;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.execution.statestore.StatementStorageService;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataServiceImpl;
 import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
 import org.opensearch.sql.spark.flint.IndexDMLResultStorageService;
@@ -119,10 +123,22 @@ public class AsyncExecutorServiceModule extends AbstractModule {
 
   @Provides
   public SessionManager sessionManager(
-      StateStore stateStore,
+      SessionStorageService sessionStorageService,
+      StatementStorageService statementStorageService,
       EMRServerlessClientFactory emrServerlessClientFactory,
       Settings settings) {
-    return new SessionManager(stateStore, emrServerlessClientFactory, settings);
+    return new SessionManager(
+        sessionStorageService, statementStorageService, emrServerlessClientFactory, settings);
+  }
+
+  @Provides
+  public SessionStorageService sessionStorageService(StateStore stateStore) {
+    return new OpenSearchSessionStorageService(stateStore);
+  }
+
+  @Provides
+  public StatementStorageService statementStorageService(StateStore stateStore) {
+    return new OpenSearchStatementStorageService(stateStore);
   }
 
   @Provides

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
@@ -13,8 +13,6 @@ import static org.opensearch.sql.spark.data.constants.SparkConstants.SPARK_REQUE
 import static org.opensearch.sql.spark.execution.session.SessionModel.SESSION_DOC_TYPE;
 import static org.opensearch.sql.spark.execution.statement.StatementModel.SESSION_ID;
 import static org.opensearch.sql.spark.execution.statement.StatementModel.STATEMENT_DOC_TYPE;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.getStatement;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.updateStatementState;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
@@ -144,7 +142,7 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
     assertNotNull(response.getSessionId());
     Optional<StatementModel> statementModel =
-        getStatement(stateStore, MYS3_DATASOURCE).apply(response.getQueryId());
+        statementStorageService.getStatement(response.getQueryId(), MYS3_DATASOURCE);
     assertTrue(statementModel.isPresent());
     assertEquals(StatementState.WAITING, statementModel.get().getStatementState());
 
@@ -199,13 +197,13 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
                 .must(QueryBuilders.termQuery(SESSION_ID, first.getSessionId()))));
 
     Optional<StatementModel> firstModel =
-        getStatement(stateStore, MYS3_DATASOURCE).apply(first.getQueryId());
+        statementStorageService.getStatement(first.getQueryId(), MYS3_DATASOURCE);
     assertTrue(firstModel.isPresent());
     assertEquals(StatementState.WAITING, firstModel.get().getStatementState());
     assertEquals(first.getQueryId(), firstModel.get().getStatementId().getId());
     assertEquals(first.getQueryId(), firstModel.get().getQueryId());
     Optional<StatementModel> secondModel =
-        getStatement(stateStore, MYS3_DATASOURCE).apply(second.getQueryId());
+        statementStorageService.getStatement(second.getQueryId(), MYS3_DATASOURCE);
     assertEquals(StatementState.WAITING, secondModel.get().getStatementState());
     assertEquals(second.getQueryId(), secondModel.get().getStatementId().getId());
     assertEquals(second.getQueryId(), secondModel.get().getQueryId());
@@ -295,7 +293,7 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             new CreateAsyncQueryRequest("myselect 1", MYS3_DATASOURCE, LangType.SQL, null));
     assertNotNull(response.getSessionId());
     Optional<StatementModel> statementModel =
-        getStatement(stateStore, MYS3_DATASOURCE).apply(response.getQueryId());
+        statementStorageService.getStatement(response.getQueryId(), MYS3_DATASOURCE);
     assertTrue(statementModel.isPresent());
     assertEquals(StatementState.WAITING, statementModel.get().getStatementState());
 
@@ -319,7 +317,7 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             .seqNo(submitted.getSeqNo())
             .primaryTerm(submitted.getPrimaryTerm())
             .build();
-    updateStatementState(stateStore, MYS3_DATASOURCE).apply(mocked, StatementState.FAILED);
+    statementStorageService.updateStatementState(mocked, StatementState.FAILED, MYS3_DATASOURCE);
 
     AsyncQueryExecutionResponse asyncQueryResults =
         asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
@@ -8,9 +8,7 @@ package org.opensearch.sql.spark.asyncquery;
 import static org.opensearch.sql.opensearch.setting.OpenSearchSettings.DATASOURCE_URI_HOSTS_DENY_LIST;
 import static org.opensearch.sql.opensearch.setting.OpenSearchSettings.SPARK_EXECUTION_REFRESH_JOB_LIMIT_SETTING;
 import static org.opensearch.sql.opensearch.setting.OpenSearchSettings.SPARK_EXECUTION_SESSION_LIMIT_SETTING;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.DATASOURCE_TO_REQUEST_INDEX;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.getSession;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.updateSessionState;
+import static org.opensearch.sql.spark.execution.statestore.OpenSearchStateStoreUtil.getIndexName;
 
 import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
 import com.amazonaws.services.emrserverless.model.GetJobRunResult;
@@ -63,7 +61,11 @@ import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
 import org.opensearch.sql.spark.execution.session.SessionManager;
 import org.opensearch.sql.spark.execution.session.SessionModel;
 import org.opensearch.sql.spark.execution.session.SessionState;
+import org.opensearch.sql.spark.execution.statestore.OpenSearchSessionStorageService;
+import org.opensearch.sql.spark.execution.statestore.OpenSearchStatementStorageService;
+import org.opensearch.sql.spark.execution.statestore.SessionStorageService;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.execution.statestore.StatementStorageService;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataServiceImpl;
 import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
@@ -85,10 +87,12 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
   protected org.opensearch.sql.common.setting.Settings pluginSettings;
   protected NodeClient client;
   protected DataSourceServiceImpl dataSourceService;
-  protected StateStore stateStore;
   protected ClusterSettings clusterSettings;
   protected FlintIndexMetadataService flintIndexMetadataService;
   protected FlintIndexStateModelService flintIndexStateModelService;
+  protected StateStore stateStore;
+  protected SessionStorageService sessionStorageService;
+  protected StatementStorageService statementStorageService;
 
   @Override
   protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -159,6 +163,8 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
     createIndexWithMappings(otherDm.getResultIndex(), loadResultIndexMappings());
     flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     flintIndexStateModelService = new OpenSearchFlintIndexStateModelService(stateStore);
+    sessionStorageService = new OpenSearchSessionStorageService(stateStore);
+    statementStorageService = new OpenSearchStatementStorageService(stateStore);
   }
 
   protected FlintIndexOpFactory getFlintIndexOpFactory(
@@ -222,7 +228,11 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
         new QueryHandlerFactory(
             jobExecutionResponseReader,
             new FlintIndexMetadataServiceImpl(client),
-            new SessionManager(stateStore, emrServerlessClientFactory, pluginSettings),
+            new SessionManager(
+                sessionStorageService,
+                statementStorageService,
+                emrServerlessClientFactory,
+                pluginSettings),
             new DefaultLeaseManager(pluginSettings, stateStore),
             new OpenSearchIndexDMLResultStorageService(dataSourceService, stateStore),
             new FlintIndexOpFactory(
@@ -234,7 +244,11 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
     SparkQueryDispatcher sparkQueryDispatcher =
         new SparkQueryDispatcher(
             this.dataSourceService,
-            new SessionManager(stateStore, emrServerlessClientFactory, pluginSettings),
+            new SessionManager(
+                sessionStorageService,
+                statementStorageService,
+                emrServerlessClientFactory,
+                pluginSettings),
             queryHandlerFactory);
     return new AsyncQueryExecutorServiceImpl(
         asyncQueryJobMetadataStorageService,
@@ -341,7 +355,7 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
 
   int search(QueryBuilder query) {
     SearchRequest searchRequest = new SearchRequest();
-    searchRequest.indices(DATASOURCE_TO_REQUEST_INDEX.apply(MYS3_DATASOURCE));
+    searchRequest.indices(getIndexName(MYS3_DATASOURCE));
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     searchSourceBuilder.query(query);
     searchRequest.source(searchSourceBuilder);
@@ -351,9 +365,9 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
   }
 
   void setSessionState(String sessionId, SessionState sessionState) {
-    Optional<SessionModel> model = getSession(stateStore, MYS3_DATASOURCE).apply(sessionId);
+    Optional<SessionModel> model = sessionStorageService.getSession(sessionId, MYS3_DATASOURCE);
     SessionModel updated =
-        updateSessionState(stateStore, MYS3_DATASOURCE).apply(model.get(), sessionState);
+        sessionStorageService.updateSessionState(model.get(), sessionState, MYS3_DATASOURCE);
     assertEquals(sessionState, updated.getSessionState());
   }
 

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
@@ -53,7 +53,8 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
 
   @Before
   public void doSetUp() {
-    mockIndexState = new MockFlintSparkJob(stateStore, mockIndex.latestId, MYS3_DATASOURCE);
+    mockIndexState =
+        new MockFlintSparkJob(flintIndexStateModelService, mockIndex.latestId, MYS3_DATASOURCE);
   }
 
   @Test

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
@@ -8,7 +8,6 @@ package org.opensearch.sql.spark.asyncquery;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.WAIT_UNTIL;
 import static org.opensearch.sql.data.model.ExprValueUtils.tupleValue;
 import static org.opensearch.sql.datasource.model.DataSourceMetadata.DEFAULT_RESULT_INDEX;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.getStatement;
 
 import com.amazonaws.services.emrserverless.model.JobRunState;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +29,6 @@ import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statement.StatementModel;
 import org.opensearch.sql.spark.execution.statement.StatementState;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexType;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryRequest;
@@ -511,8 +509,8 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
 
     /** Simulate EMR-S updates query_execution_request with state */
     void emrJobUpdateStatementState(StatementState newState) {
-      StatementModel stmt = getStatement(stateStore, MYS3_DATASOURCE).apply(queryId).get();
-      StateStore.updateStatementState(stateStore, MYS3_DATASOURCE).apply(stmt, newState);
+      StatementModel stmt = statementStorageService.getStatement(queryId, MYS3_DATASOURCE).get();
+      statementStorageService.updateStatementState(stmt, newState, MYS3_DATASOURCE);
     }
 
     void emrJobUpdateJobState(JobRunState jobState) {

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
@@ -68,7 +68,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -135,7 +136,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, true);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -215,7 +217,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -277,7 +280,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -341,7 +345,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -414,7 +419,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -487,7 +493,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -554,7 +561,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, true);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -614,7 +622,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, true);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -676,7 +685,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, true);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -738,7 +748,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, true);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.refreshing();
 
               // 1. alter index
@@ -797,7 +808,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, true);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.refreshing();
 
               // 1. alter index
@@ -854,7 +866,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.updating();
 
               // 1. alter index
@@ -919,7 +932,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -982,7 +996,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index
@@ -1046,7 +1061,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               mockDS.updateIndexOptions(existingOptions, false);
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.getLatestId(), MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. alter index

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -294,7 +294,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
               flintIndexJob.refreshing();
 
               // 1.drop index
@@ -352,7 +353,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state in refresh state.
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
               flintIndexJob.refreshing();
 
               // 1.drop index
@@ -397,7 +399,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
               flintIndexJob.refreshing();
 
               // 1. drop index
@@ -441,7 +444,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
               flintIndexJob.refreshing();
 
               // 1. drop index
@@ -490,7 +494,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
               flintIndexJob.active();
 
               // 1. drop index
@@ -536,7 +541,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
               flintIndexJob.creating();
 
               // 1. drop index
@@ -582,7 +588,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
 
               // 1. drop index
               CreateAsyncQueryResponse response =
@@ -634,7 +641,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
               flintIndexJob.deleting();
 
               // 1. drop index
@@ -679,7 +687,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     mockDS.createIndex();
     // Mock index state in refresh state.
     MockFlintSparkJob flintIndexJob =
-        new MockFlintSparkJob(stateStore, mockDS.latestId, MYGLUE_DATASOURCE);
+        new MockFlintSparkJob(flintIndexStateModelService, mockDS.latestId, MYGLUE_DATASOURCE);
     flintIndexJob.refreshing();
 
     // 1.drop index
@@ -752,7 +760,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     COVERING.createIndex();
     // Mock index state
     MockFlintSparkJob flintIndexJob =
-        new MockFlintSparkJob(stateStore, COVERING.latestId, MYS3_DATASOURCE);
+        new MockFlintSparkJob(flintIndexStateModelService, COVERING.latestId, MYS3_DATASOURCE);
     flintIndexJob.refreshing();
 
     // query with auto refresh
@@ -777,7 +785,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     COVERING.createIndex();
     // Mock index state
     MockFlintSparkJob flintIndexJob =
-        new MockFlintSparkJob(stateStore, COVERING.latestId, MYS3_DATASOURCE);
+        new MockFlintSparkJob(flintIndexStateModelService, COVERING.latestId, MYS3_DATASOURCE);
     flintIndexJob.refreshing();
 
     // query with auto_refresh = true.
@@ -805,7 +813,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     COVERING.createIndex();
     // Mock index state
     MockFlintSparkJob flintIndexJob =
-        new MockFlintSparkJob(stateStore, COVERING.latestId, MYS3_DATASOURCE);
+        new MockFlintSparkJob(flintIndexStateModelService, COVERING.latestId, MYS3_DATASOURCE);
     flintIndexJob.refreshing();
 
     // query with auto_refresh = true.
@@ -832,7 +840,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     COVERING.createIndex();
     // Mock index state
     MockFlintSparkJob flintIndexJob =
-        new MockFlintSparkJob(stateStore, COVERING.latestId, MYS3_DATASOURCE);
+        new MockFlintSparkJob(flintIndexStateModelService, COVERING.latestId, MYS3_DATASOURCE);
     flintIndexJob.refreshing();
 
     CreateAsyncQueryResponse asyncQueryResponse =
@@ -905,7 +913,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
 
               // 1. Submit REFRESH statement
               CreateAsyncQueryResponse response =
@@ -948,7 +957,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               mockDS.createIndex();
               // Mock index state
               MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, mockDS.latestId, MYS3_DATASOURCE);
+                  new MockFlintSparkJob(
+                      flintIndexStateModelService, mockDS.latestId, MYS3_DATASOURCE);
 
               // 1. Submit REFRESH statement
               CreateAsyncQueryResponse response =
@@ -990,7 +1000,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     mockFlintIndex.createIndex();
     // Mock index state
     MockFlintSparkJob flintIndexJob =
-        new MockFlintSparkJob(stateStore, indexName + "_latest_id", MYS3_DATASOURCE);
+        new MockFlintSparkJob(
+            flintIndexStateModelService, indexName + "_latest_id", MYS3_DATASOURCE);
 
     // 1. Submit REFRESH statement
     CreateAsyncQueryResponse response =

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
@@ -164,7 +164,8 @@ public class IndexQuerySpecVacuumTest extends AsyncQueryExecutorServiceSpec {
     mockDS.createIndex();
 
     // Mock index state doc
-    MockFlintSparkJob flintIndexJob = new MockFlintSparkJob(stateStore, mockDS.latestId, "mys3");
+    MockFlintSparkJob flintIndexJob =
+        new MockFlintSparkJob(flintIndexStateModelService, mockDS.latestId, "mys3");
     flintIndexJob.transition(state);
 
     // Vacuum index

--- a/spark/src/test/java/org/opensearch/sql/spark/cluster/FlintStreamingJobHouseKeeperTaskTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/cluster/FlintStreamingJobHouseKeeperTaskTest.java
@@ -39,7 +39,8 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         INDEX -> {
           INDEX.createIndex();
           MockFlintSparkJob flintIndexJob =
-              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+              new MockFlintSparkJob(
+                  flintIndexStateModelService, INDEX.getLatestId(), MYGLUE_DATASOURCE);
           indexJobMapping.put(INDEX, flintIndexJob);
           HashMap<String, Object> existingOptions = new HashMap<>();
           existingOptions.put("auto_refresh", "true");
@@ -117,7 +118,8 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         INDEX -> {
           INDEX.createIndex();
           MockFlintSparkJob flintIndexJob =
-              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+              new MockFlintSparkJob(
+                  flintIndexStateModelService, INDEX.getLatestId(), MYGLUE_DATASOURCE);
           indexJobMapping.put(INDEX, flintIndexJob);
           HashMap<String, Object> existingOptions = new HashMap<>();
           existingOptions.put("auto_refresh", "true");
@@ -164,7 +166,8 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         INDEX -> {
           INDEX.createIndex();
           MockFlintSparkJob flintIndexJob =
-              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+              new MockFlintSparkJob(
+                  flintIndexStateModelService, INDEX.getLatestId(), MYGLUE_DATASOURCE);
           indexJobMapping.put(INDEX, flintIndexJob);
           HashMap<String, Object> existingOptions = new HashMap<>();
           existingOptions.put("auto_refresh", "true");
@@ -213,7 +216,8 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         INDEX -> {
           INDEX.createIndex();
           MockFlintSparkJob flintIndexJob =
-              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+              new MockFlintSparkJob(
+                  flintIndexStateModelService, INDEX.getLatestId(), MYGLUE_DATASOURCE);
           indexJobMapping.put(INDEX, flintIndexJob);
           HashMap<String, Object> existingOptions = new HashMap<>();
           existingOptions.put("auto_refresh", "true");
@@ -260,7 +264,8 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         INDEX -> {
           INDEX.createIndex();
           MockFlintSparkJob flintIndexJob =
-              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+              new MockFlintSparkJob(
+                  flintIndexStateModelService, INDEX.getLatestId(), MYGLUE_DATASOURCE);
           indexJobMapping.put(INDEX, flintIndexJob);
           HashMap<String, Object> existingOptions = new HashMap<>();
           existingOptions.put("auto_refresh", "true");
@@ -409,7 +414,8 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         INDEX -> {
           INDEX.createIndex();
           MockFlintSparkJob flintIndexJob =
-              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+              new MockFlintSparkJob(
+                  flintIndexStateModelService, INDEX.getLatestId(), MYGLUE_DATASOURCE);
           indexJobMapping.put(INDEX, flintIndexJob);
           HashMap<String, Object> existingOptions = new HashMap<>();
           existingOptions.put("auto_refresh", "true");
@@ -480,7 +486,8 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         INDEX -> {
           INDEX.createIndex();
           MockFlintSparkJob flintIndexJob =
-              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+              new MockFlintSparkJob(
+                  flintIndexStateModelService, INDEX.getLatestId(), MYGLUE_DATASOURCE);
           indexJobMapping.put(INDEX, flintIndexJob);
           HashMap<String, Object> existingOptions = new HashMap<>();
           existingOptions.put("auto_refresh", "true");

--- a/spark/src/test/java/org/opensearch/sql/spark/cluster/FlintStreamingJobHouseKeeperTaskTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/cluster/FlintStreamingJobHouseKeeperTaskTest.java
@@ -21,7 +21,6 @@ import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorServiceSpec;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintIndex;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
-import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
@@ -34,70 +33,40 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
   @Test
   @SneakyThrows
   public void testStreamingJobHouseKeeperWhenDataSourceDisabled() {
-    MockFlintIndex SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\") ");
+    ImmutableList<MockFlintIndex> mockFlintIndices = getMockFlintIndices();
     Map<MockFlintIndex, MockFlintSparkJob> indexJobMapping = new HashMap<>();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              INDEX.createIndex();
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
-              indexJobMapping.put(INDEX, flintIndexJob);
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              // Making Index Auto Refresh
-              INDEX.updateIndexOptions(existingOptions, false);
-              flintIndexJob.refreshing();
-            });
+    mockFlintIndices.forEach(
+        INDEX -> {
+          INDEX.createIndex();
+          MockFlintSparkJob flintIndexJob =
+              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+          indexJobMapping.put(INDEX, flintIndexJob);
+          HashMap<String, Object> existingOptions = new HashMap<>();
+          existingOptions.put("auto_refresh", "true");
+          // Making Index Auto Refresh
+          INDEX.updateIndexOptions(existingOptions, false);
+          flintIndexJob.refreshing();
+        });
     changeDataSourceStatus(MYGLUE_DATASOURCE, DISABLED);
-    LocalEMRSClient emrsClient =
-        new LocalEMRSClient() {
-          @Override
-          public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-            super.getJobRunResult(applicationId, jobId);
-            JobRun jobRun = new JobRun();
-            jobRun.setState("cancelled");
-            return new GetJobRunResult().withJobRun(jobRun);
-          }
-        };
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    LocalEMRSClient emrsClient = getCancelledLocalEmrsClient();
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
+
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.ACTIVE);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("false", options.get("auto_refresh"));
+        });
     emrsClient.cancelJobRunCalled(3);
     emrsClient.getJobRunResultCalled(3);
     emrsClient.startJobRunCalled(0);
@@ -108,64 +77,74 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
             .getValue());
   }
 
+  private ImmutableList<MockFlintIndex> getMockFlintIndices() {
+    return ImmutableList.of(getSkipping(), getCovering(), getMv());
+  }
+
+  private MockFlintIndex getMv() {
+    return new MockFlintIndex(
+        client,
+        "flint_my_glue_mydb_mv",
+        FlintIndexType.MATERIALIZED_VIEW,
+        "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
+            + " incremental_refresh=true, output_mode=\"complete\") ");
+  }
+
+  private MockFlintIndex getCovering() {
+    return new MockFlintIndex(
+        client,
+        "flint_my_glue_mydb_http_logs_covering_index",
+        FlintIndexType.COVERING,
+        "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+            + " incremental_refresh=true, output_mode=\"complete\")");
+  }
+
+  private MockFlintIndex getSkipping() {
+    return new MockFlintIndex(
+        client,
+        "flint_my_glue_mydb_http_logs_skipping_index",
+        FlintIndexType.SKIPPING,
+        "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
+            + " incremental_refresh=true, output_mode=\"complete\")");
+  }
+
   @Test
   @SneakyThrows
   public void testStreamingJobHouseKeeperWhenCancelJobGivesTimeout() {
-    MockFlintIndex SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\") ");
+    ImmutableList<MockFlintIndex> mockFlintIndices = getMockFlintIndices();
     Map<MockFlintIndex, MockFlintSparkJob> indexJobMapping = new HashMap<>();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              INDEX.createIndex();
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
-              indexJobMapping.put(INDEX, flintIndexJob);
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              // Making Index Auto Refresh
-              INDEX.updateIndexOptions(existingOptions, false);
-              flintIndexJob.refreshing();
-            });
+    mockFlintIndices.forEach(
+        INDEX -> {
+          INDEX.createIndex();
+          MockFlintSparkJob flintIndexJob =
+              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+          indexJobMapping.put(INDEX, flintIndexJob);
+          HashMap<String, Object> existingOptions = new HashMap<>();
+          existingOptions.put("auto_refresh", "true");
+          // Making Index Auto Refresh
+          INDEX.updateIndexOptions(existingOptions, false);
+          flintIndexJob.refreshing();
+        });
     changeDataSourceStatus(MYGLUE_DATASOURCE, DISABLED);
     LocalEMRSClient emrsClient = new LocalEMRSClient();
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.REFRESHING);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
+
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.REFRESHING);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("false", options.get("auto_refresh"));
+        });
     emrsClient.cancelJobRunCalled(3);
     emrsClient.getJobRunResultCalled(9);
     emrsClient.startJobRunCalled(0);
@@ -179,62 +158,41 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
   @Test
   @SneakyThrows
   public void testSimulateConcurrentJobHouseKeeperExecution() {
-    MockFlintIndex SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\") ");
+    ImmutableList<MockFlintIndex> mockFlintIndices = getMockFlintIndices();
     Map<MockFlintIndex, MockFlintSparkJob> indexJobMapping = new HashMap<>();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              INDEX.createIndex();
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
-              indexJobMapping.put(INDEX, flintIndexJob);
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              // Making Index Auto Refresh
-              INDEX.updateIndexOptions(existingOptions, false);
-              flintIndexJob.refreshing();
-            });
+    mockFlintIndices.forEach(
+        INDEX -> {
+          INDEX.createIndex();
+          MockFlintSparkJob flintIndexJob =
+              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+          indexJobMapping.put(INDEX, flintIndexJob);
+          HashMap<String, Object> existingOptions = new HashMap<>();
+          existingOptions.put("auto_refresh", "true");
+          // Making Index Auto Refresh
+          INDEX.updateIndexOptions(existingOptions, false);
+          flintIndexJob.refreshing();
+        });
     changeDataSourceStatus(MYGLUE_DATASOURCE, DISABLED);
     LocalEMRSClient emrsClient = new LocalEMRSClient();
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
     FlintStreamingJobHouseKeeperTask.isRunning.compareAndSet(false, true);
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.REFRESHING);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
+
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.REFRESHING);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("true", options.get("auto_refresh"));
+        });
     emrsClient.cancelJobRunCalled(0);
     emrsClient.getJobRunResultCalled(0);
     emrsClient.startJobRunCalled(0);
@@ -249,70 +207,40 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
   @SneakyThrows
   @Test
   public void testStreamingJobClearnerWhenDataSourceIsDeleted() {
-    MockFlintIndex SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\") ");
+    ImmutableList<MockFlintIndex> mockFlintIndices = getMockFlintIndices();
     Map<MockFlintIndex, MockFlintSparkJob> indexJobMapping = new HashMap<>();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              INDEX.createIndex();
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
-              indexJobMapping.put(INDEX, flintIndexJob);
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              // Making Index Auto Refresh
-              INDEX.updateIndexOptions(existingOptions, false);
-              flintIndexJob.refreshing();
-            });
+    mockFlintIndices.forEach(
+        INDEX -> {
+          INDEX.createIndex();
+          MockFlintSparkJob flintIndexJob =
+              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+          indexJobMapping.put(INDEX, flintIndexJob);
+          HashMap<String, Object> existingOptions = new HashMap<>();
+          existingOptions.put("auto_refresh", "true");
+          // Making Index Auto Refresh
+          INDEX.updateIndexOptions(existingOptions, false);
+          flintIndexJob.refreshing();
+        });
     this.dataSourceService.deleteDataSource(MYGLUE_DATASOURCE);
-    LocalEMRSClient emrsClient =
-        new LocalEMRSClient() {
-          @Override
-          public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-            super.getJobRunResult(applicationId, jobId);
-            JobRun jobRun = new JobRun();
-            jobRun.setState("cancelled");
-            return new GetJobRunResult().withJobRun(jobRun);
-          }
-        };
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    LocalEMRSClient emrsClient = getCancelledLocalEmrsClient();
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.DELETED);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
+
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.DELETED);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("true", options.get("auto_refresh"));
+        });
     emrsClient.cancelJobRunCalled(3);
     emrsClient.getJobRunResultCalled(3);
     emrsClient.startJobRunCalled(0);
@@ -326,69 +254,39 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
   @Test
   @SneakyThrows
   public void testStreamingJobHouseKeeperWhenDataSourceIsNeitherDisabledNorDeleted() {
-    MockFlintIndex SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\") ");
+    ImmutableList<MockFlintIndex> mockFlintIndices = getMockFlintIndices();
     Map<MockFlintIndex, MockFlintSparkJob> indexJobMapping = new HashMap<>();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              INDEX.createIndex();
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
-              indexJobMapping.put(INDEX, flintIndexJob);
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              // Making Index Auto Refresh
-              INDEX.updateIndexOptions(existingOptions, false);
-              flintIndexJob.refreshing();
-            });
-    LocalEMRSClient emrsClient =
-        new LocalEMRSClient() {
-          @Override
-          public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-            super.getJobRunResult(applicationId, jobId);
-            JobRun jobRun = new JobRun();
-            jobRun.setState("cancelled");
-            return new GetJobRunResult().withJobRun(jobRun);
-          }
-        };
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    mockFlintIndices.forEach(
+        INDEX -> {
+          INDEX.createIndex();
+          MockFlintSparkJob flintIndexJob =
+              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+          indexJobMapping.put(INDEX, flintIndexJob);
+          HashMap<String, Object> existingOptions = new HashMap<>();
+          existingOptions.put("auto_refresh", "true");
+          // Making Index Auto Refresh
+          INDEX.updateIndexOptions(existingOptions, false);
+          flintIndexJob.refreshing();
+        });
+    LocalEMRSClient emrsClient = getCancelledLocalEmrsClient();
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.REFRESHING);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
+
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.REFRESHING);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("true", options.get("auto_refresh"));
+        });
     emrsClient.cancelJobRunCalled(0);
     emrsClient.getJobRunResultCalled(0);
     emrsClient.startJobRunCalled(0);
@@ -413,14 +311,15 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
             return new GetJobRunResult().withJobRun(jobRun);
           }
         };
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
+
     emrsClient.getJobRunResultCalled(0);
     emrsClient.startJobRunCalled(0);
     emrsClient.cancelJobRunCalled(0);
@@ -438,24 +337,16 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         new MockFlintIndex(client(), indexName, FlintIndexType.COVERING, null);
     mockFlintIndex.createIndex();
     changeDataSourceStatus(MYGLUE_DATASOURCE, DISABLED);
-    LocalEMRSClient emrsClient =
-        new LocalEMRSClient() {
-          @Override
-          public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-            super.getJobRunResult(applicationId, jobId);
-            JobRun jobRun = new JobRun();
-            jobRun.setState("cancelled");
-            return new GetJobRunResult().withJobRun(jobRun);
-          }
-        };
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    LocalEMRSClient emrsClient = getCancelledLocalEmrsClient();
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
+
     emrsClient.getJobRunResultCalled(0);
     emrsClient.startJobRunCalled(0);
     emrsClient.cancelJobRunCalled(0);
@@ -479,7 +370,6 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
             return new GetJobRunResult().withJobRun(jobRun);
           }
         };
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
     FlintIndexMetadataService flintIndexMetadataService =
         new FlintIndexMetadataService() {
           @Override
@@ -493,10 +383,12 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
         };
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
+
     Assertions.assertFalse(FlintStreamingJobHouseKeeperTask.isRunning.get());
     emrsClient.getJobRunResultCalled(0);
     emrsClient.startJobRunCalled(0);
@@ -511,70 +403,40 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
   @Test
   @SneakyThrows
   public void testStreamingJobHouseKeeperMultipleTimesWhenDataSourceDisabled() {
-    MockFlintIndex SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\") ");
+    ImmutableList<MockFlintIndex> mockFlintIndices = getMockFlintIndices();
     Map<MockFlintIndex, MockFlintSparkJob> indexJobMapping = new HashMap<>();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              INDEX.createIndex();
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
-              indexJobMapping.put(INDEX, flintIndexJob);
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              // Making Index Auto Refresh
-              INDEX.updateIndexOptions(existingOptions, false);
-              flintIndexJob.refreshing();
-            });
+    mockFlintIndices.forEach(
+        INDEX -> {
+          INDEX.createIndex();
+          MockFlintSparkJob flintIndexJob =
+              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+          indexJobMapping.put(INDEX, flintIndexJob);
+          HashMap<String, Object> existingOptions = new HashMap<>();
+          existingOptions.put("auto_refresh", "true");
+          // Making Index Auto Refresh
+          INDEX.updateIndexOptions(existingOptions, false);
+          flintIndexJob.refreshing();
+        });
     changeDataSourceStatus(MYGLUE_DATASOURCE, DISABLED);
-    LocalEMRSClient emrsClient =
-        new LocalEMRSClient() {
-          @Override
-          public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-            super.getJobRunResult(applicationId, jobId);
-            JobRun jobRun = new JobRun();
-            jobRun.setState("cancelled");
-            return new GetJobRunResult().withJobRun(jobRun);
-          }
-        };
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    LocalEMRSClient emrsClient = getCancelledLocalEmrsClient();
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
+
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.ACTIVE);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("false", options.get("auto_refresh"));
+        });
     emrsClient.cancelJobRunCalled(3);
     emrsClient.getJobRunResultCalled(3);
     emrsClient.startJobRunCalled(0);
@@ -588,16 +450,15 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
     Thread thread2 = new Thread(flintStreamingJobHouseKeeperTask);
     thread2.start();
     thread2.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("false", options.get("auto_refresh"));
-            });
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.ACTIVE);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("false", options.get("auto_refresh"));
+        });
 
     // No New Calls and Errors
     emrsClient.cancelJobRunCalled(3);
@@ -613,70 +474,40 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
   @SneakyThrows
   @Test
   public void testRunStreamingJobHouseKeeperWhenDataSourceIsDeleted() {
-    MockFlintIndex SKIPPING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_skipping_index",
-            FlintIndexType.SKIPPING,
-            "ALTER SKIPPING INDEX ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex COVERING =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_http_logs_covering_index",
-            FlintIndexType.COVERING,
-            "ALTER INDEX covering ON my_glue.mydb.http_logs WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\")");
-    MockFlintIndex MV =
-        new MockFlintIndex(
-            client,
-            "flint_my_glue_mydb_mv",
-            FlintIndexType.MATERIALIZED_VIEW,
-            "ALTER MATERIALIZED VIEW my_glue.mydb.mv WITH (auto_refresh=false,"
-                + " incremental_refresh=true, output_mode=\"complete\") ");
+    ImmutableList<MockFlintIndex> mockFlintIndices = getMockFlintIndices();
     Map<MockFlintIndex, MockFlintSparkJob> indexJobMapping = new HashMap<>();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              INDEX.createIndex();
-              MockFlintSparkJob flintIndexJob =
-                  new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
-              indexJobMapping.put(INDEX, flintIndexJob);
-              HashMap<String, Object> existingOptions = new HashMap<>();
-              existingOptions.put("auto_refresh", "true");
-              // Making Index Auto Refresh
-              INDEX.updateIndexOptions(existingOptions, false);
-              flintIndexJob.refreshing();
-            });
+    mockFlintIndices.forEach(
+        INDEX -> {
+          INDEX.createIndex();
+          MockFlintSparkJob flintIndexJob =
+              new MockFlintSparkJob(stateStore, INDEX.getLatestId(), MYGLUE_DATASOURCE);
+          indexJobMapping.put(INDEX, flintIndexJob);
+          HashMap<String, Object> existingOptions = new HashMap<>();
+          existingOptions.put("auto_refresh", "true");
+          // Making Index Auto Refresh
+          INDEX.updateIndexOptions(existingOptions, false);
+          flintIndexJob.refreshing();
+        });
     this.dataSourceService.deleteDataSource(MYGLUE_DATASOURCE);
-    LocalEMRSClient emrsClient =
-        new LocalEMRSClient() {
-          @Override
-          public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-            super.getJobRunResult(applicationId, jobId);
-            JobRun jobRun = new JobRun();
-            jobRun.setState("cancelled");
-            return new GetJobRunResult().withJobRun(jobRun);
-          }
-        };
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    LocalEMRSClient emrsClient = getCancelledLocalEmrsClient();
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(
-            dataSourceService, flintIndexMetadataService, stateStore, emrServerlessClientFactory);
+            dataSourceService, flintIndexMetadataService, getFlintIndexOpFactory(() -> emrsClient));
+
     Thread thread = new Thread(flintStreamingJobHouseKeeperTask);
     thread.start();
     thread.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.DELETED);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
+
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.DELETED);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("true", options.get("auto_refresh"));
+        });
     emrsClient.cancelJobRunCalled(3);
     emrsClient.getJobRunResultCalled(3);
     emrsClient.startJobRunCalled(0);
@@ -690,16 +521,15 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
     Thread thread2 = new Thread(flintStreamingJobHouseKeeperTask);
     thread2.start();
     thread2.join();
-    ImmutableList.of(SKIPPING, COVERING, MV)
-        .forEach(
-            INDEX -> {
-              MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
-              flintIndexJob.assertState(FlintIndexState.DELETED);
-              Map<String, Object> mappings = INDEX.getIndexMappings();
-              Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
-              Map<String, Object> options = (Map<String, Object>) meta.get("options");
-              Assertions.assertEquals("true", options.get("auto_refresh"));
-            });
+    mockFlintIndices.forEach(
+        INDEX -> {
+          MockFlintSparkJob flintIndexJob = indexJobMapping.get(INDEX);
+          flintIndexJob.assertState(FlintIndexState.DELETED);
+          Map<String, Object> mappings = INDEX.getIndexMappings();
+          Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
+          Map<String, Object> options = (Map<String, Object>) meta.get("options");
+          Assertions.assertEquals("true", options.get("auto_refresh"));
+        });
     // No New Calls and Errors
     emrsClient.cancelJobRunCalled(3);
     emrsClient.getJobRunResultCalled(3);

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -54,7 +54,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.client.Client;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
@@ -72,8 +71,9 @@ import org.opensearch.sql.spark.execution.session.SessionManager;
 import org.opensearch.sql.spark.execution.statement.Statement;
 import org.opensearch.sql.spark.execution.statement.StatementId;
 import org.opensearch.sql.spark.execution.statement.StatementState;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadataService;
+import org.opensearch.sql.spark.flint.IndexDMLResultStorageService;
+import org.opensearch.sql.spark.flint.operation.FlintIndexOpFactory;
 import org.opensearch.sql.spark.leasemanager.LeaseManager;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
 import org.opensearch.sql.spark.rest.model.LangType;
@@ -86,21 +86,16 @@ public class SparkQueryDispatcherTest {
   @Mock private DataSourceService dataSourceService;
   @Mock private JobExecutionResponseReader jobExecutionResponseReader;
   @Mock private FlintIndexMetadataService flintIndexMetadataService;
-
-  @Mock(answer = RETURNS_DEEP_STUBS)
-  private Client openSearchClient;
-
   @Mock private SessionManager sessionManager;
-
   @Mock private LeaseManager leaseManager;
+  @Mock private IndexDMLResultStorageService indexDMLResultStorageService;
+  @Mock private FlintIndexOpFactory flintIndexOpFactory;
 
   @Mock(answer = RETURNS_DEEP_STUBS)
   private Session session;
 
   @Mock(answer = RETURNS_DEEP_STUBS)
   private Statement statement;
-
-  @Mock private StateStore stateStore;
 
   private SparkQueryDispatcher sparkQueryDispatcher;
 
@@ -114,13 +109,14 @@ public class SparkQueryDispatcherTest {
         new QueryHandlerFactory(
             jobExecutionResponseReader,
             flintIndexMetadataService,
-            openSearchClient,
             sessionManager,
             leaseManager,
-            stateStore,
+            indexDMLResultStorageService,
+            flintIndexOpFactory,
             emrServerlessClientFactory);
     sparkQueryDispatcher =
         new SparkQueryDispatcher(dataSourceService, sessionManager, queryHandlerFactory);
+    new SparkQueryDispatcher(dataSourceService, sessionManager, queryHandlerFactory);
   }
 
   @Test
@@ -405,7 +401,6 @@ public class SparkQueryDispatcherTest {
             tags,
             true,
             "query_execution_result_my_glue");
-
     when(emrServerlessClient.startJobRun(expected)).thenReturn(EMR_JOB_ID);
     DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
     when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata("my_glue"))
@@ -420,6 +415,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -513,6 +509,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -563,6 +560,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -613,6 +611,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -659,6 +658,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -751,6 +751,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -962,7 +963,9 @@ public class SparkQueryDispatcherTest {
     queryResult.put(DATA_FIELD, resultMap);
     when(jobExecutionResponseReader.getResultFromOpensearchIndex(EMR_JOB_ID, null))
         .thenReturn(queryResult);
+
     JSONObject result = sparkQueryDispatcher.getQueryResponse(asyncQueryJobMetadata());
+
     verify(jobExecutionResponseReader, times(1)).getResultFromOpensearchIndex(EMR_JOB_ID, null);
     Assertions.assertEquals(
         new HashSet<>(Arrays.asList(DATA_FIELD, STATUS_FIELD, ERROR_FIELD)), result.keySet());

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -301,6 +301,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -705,6 +706,7 @@ public class SparkQueryDispatcherTest {
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
                 TEST_CLUSTER_NAME));
+
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/InteractiveSessionTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/InteractiveSessionTest.java
@@ -5,14 +5,12 @@
 
 package org.opensearch.sql.spark.execution.session;
 
-import static org.opensearch.sql.spark.execution.session.InteractiveSessionTest.TestSession.testSession;
+import static org.opensearch.sql.spark.constants.TestConstants.TEST_CLUSTER_NAME;
+import static org.opensearch.sql.spark.constants.TestConstants.TEST_DATASOURCE_NAME;
 import static org.opensearch.sql.spark.execution.session.SessionManagerTest.sessionSetting;
 import static org.opensearch.sql.spark.execution.session.SessionState.NOT_STARTED;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.DATASOURCE_TO_REQUEST_INDEX;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.getSession;
+import static org.opensearch.sql.spark.execution.session.SessionTestUtil.createSessionRequest;
 
-import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
-import com.amazonaws.services.emrserverless.model.GetJobRunResult;
 import java.util.HashMap;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -21,30 +19,43 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.delete.DeleteRequest;
-import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
-import org.opensearch.sql.spark.client.EMRServerlessClient;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.dispatcher.model.JobType;
+import org.opensearch.sql.spark.execution.statestore.OpenSearchSessionStorageService;
+import org.opensearch.sql.spark.execution.statestore.OpenSearchStateStoreUtil;
+import org.opensearch.sql.spark.execution.statestore.OpenSearchStatementStorageService;
+import org.opensearch.sql.spark.execution.statestore.SessionStorageService;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.execution.statestore.StatementStorageService;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 /** mock-maker-inline does not work with OpenSearchTestCase. */
 public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
-  private static final String DS_NAME = "mys3";
-  private static final String indexName = DATASOURCE_TO_REQUEST_INDEX.apply(DS_NAME);
-  public static final String TEST_CLUSTER_NAME = "TEST_CLUSTER";
+  private static final String indexName =
+      OpenSearchStateStoreUtil.getIndexName(TEST_DATASOURCE_NAME);
 
   private TestEMRServerlessClient emrsClient;
   private StartJobRequest startJobRequest;
-  private StateStore stateStore;
+  private SessionStorageService sessionStorageService;
+  private StatementStorageService statementStorageService;
+  private SessionManager sessionManager;
 
   @Before
   public void setup() {
     emrsClient = new TestEMRServerlessClient();
     startJobRequest = new StartJobRequest("", "appId", "", "", new HashMap<>(), false, "");
-    stateStore = new StateStore(client(), clusterService());
+    StateStore stateStore = new StateStore(client(), clusterService());
+    sessionStorageService = new OpenSearchSessionStorageService(stateStore);
+    statementStorageService = new OpenSearchStatementStorageService(stateStore);
+    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
+    sessionManager =
+        new SessionManager(
+            sessionStorageService,
+            statementStorageService,
+            emrServerlessClientFactory,
+            sessionSetting());
   }
 
   @After
@@ -56,17 +67,17 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void openCloseSession() {
-    SessionId sessionId = SessionId.newSessionId(DS_NAME);
+    SessionId sessionId = SessionId.newSessionId(TEST_DATASOURCE_NAME);
     InteractiveSession session =
         InteractiveSession.builder()
             .sessionId(sessionId)
-            .stateStore(stateStore)
+            .statementStorageService(statementStorageService)
+            .sessionStorageService(sessionStorageService)
             .serverlessClient(emrsClient)
             .build();
 
-    // open session
-    TestSession testSession = testSession(session, stateStore);
-    testSession
+    SessionAssertions assertions = new SessionAssertions(session);
+    assertions
         .open(createSessionRequest())
         .assertSessionState(NOT_STARTED)
         .assertAppId("appId")
@@ -76,17 +87,18 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
         TEST_CLUSTER_NAME + ":" + JobType.INTERACTIVE.getText() + ":" + sessionId.getSessionId());
 
     // close session
-    testSession.close();
+    assertions.close();
     emrsClient.cancelJobRunCalled(1);
   }
 
   @Test
   public void openSessionFailedConflict() {
-    SessionId sessionId = SessionId.newSessionId(DS_NAME);
+    SessionId sessionId = SessionId.newSessionId(TEST_DATASOURCE_NAME);
     InteractiveSession session =
         InteractiveSession.builder()
             .sessionId(sessionId)
-            .stateStore(stateStore)
+            .sessionStorageService(sessionStorageService)
+            .statementStorageService(statementStorageService)
             .serverlessClient(emrsClient)
             .build();
     session.open(createSessionRequest());
@@ -94,7 +106,8 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
     InteractiveSession duplicateSession =
         InteractiveSession.builder()
             .sessionId(sessionId)
-            .stateStore(stateStore)
+            .sessionStorageService(sessionStorageService)
+            .statementStorageService(statementStorageService)
             .serverlessClient(emrsClient)
             .build();
     IllegalStateException exception =
@@ -105,11 +118,12 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void closeNotExistSession() {
-    SessionId sessionId = SessionId.newSessionId(DS_NAME);
+    SessionId sessionId = SessionId.newSessionId(TEST_DATASOURCE_NAME);
     InteractiveSession session =
         InteractiveSession.builder()
             .sessionId(sessionId)
-            .stateStore(stateStore)
+            .sessionStorageService(sessionStorageService)
+            .statementStorageService(statementStorageService)
             .serverlessClient(emrsClient)
             .build();
     session.open(createSessionRequest());
@@ -123,20 +137,16 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void sessionManagerCreateSession() {
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-    Session session =
-        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting())
-            .createSession(createSessionRequest());
+    Session session = sessionManager.createSession(createSessionRequest());
 
-    TestSession testSession = testSession(session, stateStore);
-    testSession.assertSessionState(NOT_STARTED).assertAppId("appId").assertJobId("jobId");
+    new SessionAssertions(session)
+        .assertSessionState(NOT_STARTED)
+        .assertAppId("appId")
+        .assertJobId("jobId");
   }
 
   @Test
   public void sessionManagerGetSession() {
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-    SessionManager sessionManager =
-        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting());
     Session session = sessionManager.createSession(createSessionRequest());
 
     Optional<Session> managerSession = sessionManager.getSession(session.getSessionId());
@@ -146,103 +156,44 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void sessionManagerGetSessionNotExist() {
-    EMRServerlessClientFactory emrServerlessClientFactory = () -> emrsClient;
-    SessionManager sessionManager =
-        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting());
-
     Optional<Session> managerSession =
         sessionManager.getSession(SessionId.newSessionId("no-exist"));
     assertTrue(managerSession.isEmpty());
   }
 
   @RequiredArgsConstructor
-  static class TestSession {
+  class SessionAssertions {
     private final Session session;
-    private final StateStore stateStore;
 
-    public static TestSession testSession(Session session, StateStore stateStore) {
-      return new TestSession(session, stateStore);
-    }
-
-    public TestSession assertSessionState(SessionState expected) {
+    public SessionAssertions assertSessionState(SessionState expected) {
       assertEquals(expected, session.getSessionModel().getSessionState());
 
       Optional<SessionModel> sessionStoreState =
-          getSession(stateStore, DS_NAME).apply(session.getSessionModel().getId());
+          sessionStorageService.getSession(session.getSessionModel().getId(), TEST_DATASOURCE_NAME);
       assertTrue(sessionStoreState.isPresent());
       assertEquals(expected, sessionStoreState.get().getSessionState());
 
       return this;
     }
 
-    public TestSession assertAppId(String expected) {
+    public SessionAssertions assertAppId(String expected) {
       assertEquals(expected, session.getSessionModel().getApplicationId());
       return this;
     }
 
-    public TestSession assertJobId(String expected) {
+    public SessionAssertions assertJobId(String expected) {
       assertEquals(expected, session.getSessionModel().getJobId());
       return this;
     }
 
-    public TestSession open(CreateSessionRequest req) {
+    public SessionAssertions open(CreateSessionRequest req) {
       session.open(req);
       return this;
     }
 
-    public TestSession close() {
+    public SessionAssertions close() {
       session.close();
       return this;
-    }
-  }
-
-  public static CreateSessionRequest createSessionRequest() {
-    return new CreateSessionRequest(
-        TEST_CLUSTER_NAME,
-        "appId",
-        "arn",
-        SparkSubmitParameters.Builder.builder(),
-        new HashMap<>(),
-        "resultIndex",
-        DS_NAME);
-  }
-
-  public static class TestEMRServerlessClient implements EMRServerlessClient {
-
-    private int startJobRunCalled = 0;
-    private int cancelJobRunCalled = 0;
-
-    private StartJobRequest startJobRequest;
-
-    @Override
-    public String startJobRun(StartJobRequest startJobRequest) {
-      this.startJobRequest = startJobRequest;
-      startJobRunCalled++;
-      return "jobId";
-    }
-
-    @Override
-    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-      return null;
-    }
-
-    @Override
-    public CancelJobRunResult cancelJobRun(
-        String applicationId, String jobId, boolean allowExceptionPropagation) {
-      cancelJobRunCalled++;
-      return null;
-    }
-
-    public void startJobRunCalled(int expectedTimes) {
-      assertEquals(expectedTimes, startJobRunCalled);
-    }
-
-    public void cancelJobRunCalled(int expectedTimes) {
-      assertEquals(expectedTimes, cancelJobRunCalled);
-    }
-
-    public void assertJobNameOfLastRequest(String expectedJobName) {
-      assertEquals(expectedJobName, startJobRequest.getJobName());
     }
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/SessionManagerTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/SessionManagerTest.java
@@ -15,18 +15,25 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
+import org.opensearch.sql.spark.execution.statestore.SessionStorageService;
+import org.opensearch.sql.spark.execution.statestore.StatementStorageService;
 
 @ExtendWith(MockitoExtension.class)
 public class SessionManagerTest {
-  @Mock private StateStore stateStore;
-
+  @Mock private SessionStorageService sessionStorageService;
+  @Mock private StatementStorageService statementStorageService;
   @Mock private EMRServerlessClientFactory emrServerlessClientFactory;
 
   @Test
   public void sessionEnable() {
-    Assertions.assertTrue(
-        new SessionManager(stateStore, emrServerlessClientFactory, sessionSetting()).isEnabled());
+    SessionManager sessionManager =
+        new SessionManager(
+            sessionStorageService,
+            statementStorageService,
+            emrServerlessClientFactory,
+            sessionSetting());
+
+    Assertions.assertTrue(sessionManager.isEnabled());
   }
 
   public static org.opensearch.sql.common.setting.Settings sessionSetting() {

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/SessionTestUtil.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/SessionTestUtil.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.execution.session;
+
+import static org.opensearch.sql.spark.constants.TestConstants.TEST_CLUSTER_NAME;
+import static org.opensearch.sql.spark.constants.TestConstants.TEST_DATASOURCE_NAME;
+
+import java.util.HashMap;
+import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
+
+public class SessionTestUtil {
+
+  public static CreateSessionRequest createSessionRequest() {
+    return new CreateSessionRequest(
+        TEST_CLUSTER_NAME,
+        "appId",
+        "arn",
+        SparkSubmitParameters.Builder.builder(),
+        new HashMap<>(),
+        "resultIndex",
+        TEST_DATASOURCE_NAME);
+  }
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/TestEMRServerlessClient.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/TestEMRServerlessClient.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.execution.session;
+
+import com.amazonaws.services.emrserverless.model.CancelJobRunResult;
+import com.amazonaws.services.emrserverless.model.GetJobRunResult;
+import org.junit.Assert;
+import org.opensearch.sql.spark.client.EMRServerlessClient;
+import org.opensearch.sql.spark.client.StartJobRequest;
+
+public class TestEMRServerlessClient implements EMRServerlessClient {
+
+  private int startJobRunCalled = 0;
+  private int cancelJobRunCalled = 0;
+
+  private StartJobRequest startJobRequest;
+
+  @Override
+  public String startJobRun(StartJobRequest startJobRequest) {
+    this.startJobRequest = startJobRequest;
+    startJobRunCalled++;
+    return "jobId";
+  }
+
+  @Override
+  public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
+    return null;
+  }
+
+  @Override
+  public CancelJobRunResult cancelJobRun(
+      String applicationId, String jobId, boolean allowExceptionPropagation) {
+    cancelJobRunCalled++;
+    return null;
+  }
+
+  public void startJobRunCalled(int expectedTimes) {
+    Assert.assertEquals(expectedTimes, startJobRunCalled);
+  }
+
+  public void cancelJobRunCalled(int expectedTimes) {
+    Assert.assertEquals(expectedTimes, cancelJobRunCalled);
+  }
+
+  public void assertJobNameOfLastRequest(String expectedJobName) {
+    Assert.assertEquals(expectedJobName, startJobRequest.getJobName());
+  }
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStateStoreUtilTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStateStoreUtilTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.execution.statestore;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class OpenSearchStateStoreUtilTest {
+
+  @Test
+  void getIndexName() {
+    String result = OpenSearchStateStoreUtil.getIndexName("DATASOURCE");
+
+    assertEquals(".query_execution_request_datasource", result);
+  }
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/flint/OpenSearchFlintIndexStateModelServiceTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/flint/OpenSearchFlintIndexStateModelServiceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.flint;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.spark.execution.statestore.StateStore;
+
+@ExtendWith(MockitoExtension.class)
+public class OpenSearchFlintIndexStateModelServiceTest {
+
+  public static final String DATASOURCE = "DATASOURCE";
+  public static final String ID = "ID";
+
+  @Mock StateStore mockStateStore;
+  @Mock FlintIndexStateModel flintIndexStateModel;
+  @Mock FlintIndexState flintIndexState;
+  @Mock FlintIndexStateModel responseFlintIndexStateModel;
+
+  @InjectMocks OpenSearchFlintIndexStateModelService openSearchFlintIndexStateModelService;
+
+  @Test
+  void updateFlintIndexState() {
+    when(mockStateStore.updateState(any(), any(), any(), any()))
+        .thenReturn(responseFlintIndexStateModel);
+
+    FlintIndexStateModel result =
+        openSearchFlintIndexStateModelService.updateFlintIndexState(
+            flintIndexStateModel, flintIndexState, DATASOURCE);
+
+    assertEquals(responseFlintIndexStateModel, result);
+  }
+
+  @Test
+  void getFlintIndexStateModel() {
+    when(mockStateStore.get(any(), any(), any()))
+        .thenReturn(Optional.of(responseFlintIndexStateModel));
+
+    Optional<FlintIndexStateModel> result =
+        openSearchFlintIndexStateModelService.getFlintIndexStateModel("ID", DATASOURCE);
+
+    assertEquals(responseFlintIndexStateModel, result.get());
+  }
+
+  @Test
+  void createFlintIndexStateModel() {
+    when(mockStateStore.create(any(), any(), any())).thenReturn(responseFlintIndexStateModel);
+
+    FlintIndexStateModel result =
+        openSearchFlintIndexStateModelService.createFlintIndexStateModel(
+            flintIndexStateModel, DATASOURCE);
+
+    assertEquals(responseFlintIndexStateModel, result);
+  }
+
+  @Test
+  void deleteFlintIndexStateModel() {
+    when(mockStateStore.delete(any(), any())).thenReturn(true);
+
+    boolean result =
+        openSearchFlintIndexStateModelService.deleteFlintIndexStateModel(ID, DATASOURCE);
+
+    assertTrue(result);
+  }
+}

--- a/spark/src/test/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpTest.java
@@ -1,10 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.flint.operation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.sql.spark.execution.statestore.StateStore.DATASOURCE_TO_REQUEST_INDEX;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
@@ -14,15 +18,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
-import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
 import org.opensearch.sql.spark.flint.FlintIndexStateModel;
+import org.opensearch.sql.spark.flint.FlintIndexStateModelService;
 
 @ExtendWith(MockitoExtension.class)
 public class FlintIndexOpTest {
 
-  @Mock private StateStore mockStateStore;
+  @Mock private FlintIndexStateModelService flintIndexStateModelService;
   @Mock private EMRServerlessClientFactory mockEmrServerlessClientFactory;
 
   @Test
@@ -40,12 +44,12 @@ public class FlintIndexOpTest {
             "",
             SequenceNumbers.UNASSIGNED_SEQ_NO,
             SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
-    when(mockStateStore.get(eq("latestId"), any(), eq(DATASOURCE_TO_REQUEST_INDEX.apply("myS3"))))
+    when(flintIndexStateModelService.getFlintIndexStateModel(eq("latestId"), any()))
         .thenReturn(Optional.of(fakeModel));
-    when(mockStateStore.updateState(any(), any(), any(), any()))
+    when(flintIndexStateModelService.updateFlintIndexState(any(), any(), any()))
         .thenThrow(new RuntimeException("Transitioning state failed"));
     FlintIndexOp flintIndexOp =
-        new TestFlintIndexOp(mockStateStore, "myS3", mockEmrServerlessClientFactory);
+        new TestFlintIndexOp(flintIndexStateModelService, "myS3", mockEmrServerlessClientFactory);
     IllegalStateException illegalStateException =
         Assertions.assertThrows(IllegalStateException.class, () -> flintIndexOp.apply(metadata));
     Assertions.assertEquals(
@@ -67,14 +71,14 @@ public class FlintIndexOpTest {
             "",
             SequenceNumbers.UNASSIGNED_SEQ_NO,
             SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
-    when(mockStateStore.get(eq("latestId"), any(), eq(DATASOURCE_TO_REQUEST_INDEX.apply("myS3"))))
+    when(flintIndexStateModelService.getFlintIndexStateModel(eq("latestId"), any()))
         .thenReturn(Optional.of(fakeModel));
-    when(mockStateStore.updateState(any(), any(), any(), any()))
+    when(flintIndexStateModelService.updateFlintIndexState(any(), any(), any()))
         .thenReturn(FlintIndexStateModel.copy(fakeModel, 1, 2))
         .thenThrow(new RuntimeException("Commit state failed"))
         .thenReturn(FlintIndexStateModel.copy(fakeModel, 1, 3));
     FlintIndexOp flintIndexOp =
-        new TestFlintIndexOp(mockStateStore, "myS3", mockEmrServerlessClientFactory);
+        new TestFlintIndexOp(flintIndexStateModelService, "myS3", mockEmrServerlessClientFactory);
     IllegalStateException illegalStateException =
         Assertions.assertThrows(IllegalStateException.class, () -> flintIndexOp.apply(metadata));
     Assertions.assertEquals(
@@ -96,14 +100,14 @@ public class FlintIndexOpTest {
             "",
             SequenceNumbers.UNASSIGNED_SEQ_NO,
             SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
-    when(mockStateStore.get(eq("latestId"), any(), eq(DATASOURCE_TO_REQUEST_INDEX.apply("myS3"))))
+    when(flintIndexStateModelService.getFlintIndexStateModel(eq("latestId"), any()))
         .thenReturn(Optional.of(fakeModel));
-    when(mockStateStore.updateState(any(), any(), any(), any()))
+    when(flintIndexStateModelService.updateFlintIndexState(any(), any(), any()))
         .thenReturn(FlintIndexStateModel.copy(fakeModel, 1, 2))
         .thenThrow(new RuntimeException("Commit state failed"))
         .thenThrow(new RuntimeException("Rollback failure"));
     FlintIndexOp flintIndexOp =
-        new TestFlintIndexOp(mockStateStore, "myS3", mockEmrServerlessClientFactory);
+        new TestFlintIndexOp(flintIndexStateModelService, "myS3", mockEmrServerlessClientFactory);
     IllegalStateException illegalStateException =
         Assertions.assertThrows(IllegalStateException.class, () -> flintIndexOp.apply(metadata));
     Assertions.assertEquals(
@@ -113,10 +117,10 @@ public class FlintIndexOpTest {
   static class TestFlintIndexOp extends FlintIndexOp {
 
     public TestFlintIndexOp(
-        StateStore stateStore,
+        FlintIndexStateModelService flintIndexStateModelService,
         String datasourceName,
         EMRServerlessClientFactory emrServerlessClientFactory) {
-      super(stateStore, datasourceName, emrServerlessClientFactory);
+      super(flintIndexStateModelService, datasourceName, emrServerlessClientFactory);
     }
 
     @Override


### PR DESCRIPTION
### Description
- Backport #2644, #2658, #2657, and #2665 to 2.x
- Those backports were failing since the depending changes were not backported to 2.x due to conflict.
- This PR backports them together.
- There is no code change from original PRs.
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).