### PR TITLE
Fix locale for monthName/dayName function

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunction.java
@@ -1390,7 +1390,7 @@ public class DateTimeFunction {
    */
   private ExprValue exprDayName(ExprValue date) {
     return new ExprStringValue(
-        date.dateValue().getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.getDefault()));
+        date.dateValue().getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.ENGLISH));
   }
 
   /**
@@ -1656,7 +1656,7 @@ public class DateTimeFunction {
    */
   private ExprValue exprMonthName(ExprValue date) {
     return new ExprStringValue(
-        date.dateValue().getMonth().getDisplayName(TextStyle.FULL, Locale.getDefault()));
+        date.dateValue().getMonth().getDisplayName(TextStyle.FULL, Locale.ENGLISH));
   }
 
   private LocalDate parseDatePeriod(Integer period) {


### PR DESCRIPTION
### Description
The monthName/dayName function uses `Locale.getDefault` to get the display name, which may return different results in different env and cause a test error.

```
org.opensearch.sql.sql.DateTimeFunctionIT > testMonthName FAILED
    java.lang.AssertionError: 
    Expected: iterable with items [[September]] in any order
         but: not matched: <["九月"]>
        at __randomizedtesting.SeedInfo.seed([3027A175091234F:5336A188EBBE09E2]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.opensearch.sql.util.MatcherUtils.verify(MatcherUtils.java:173)
        at org.opensearch.sql.util.MatcherUtils.verifyDataRows(MatcherUtils.java:149)
        at org.opensearch.sql.sql.DateTimeFunctionIT.testMonthName(DateTimeFunctionIT.java:801)
```
 
### Issues Resolved
#2844 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).