### PR TITLE
[Backport 2.x] Provide a way to modify spark parameters (#2691)

### DIFF
--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.spark.asyncquery;
 
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
+import org.opensearch.sql.spark.asyncquery.model.RequestContext;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryRequest;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryResponse;
 
@@ -20,7 +21,8 @@ public interface AsyncQueryExecutorService {
    * @param createAsyncQueryRequest createAsyncQueryRequest.
    * @return {@link CreateAsyncQueryResponse}
    */
-  CreateAsyncQueryResponse createAsyncQuery(CreateAsyncQueryRequest createAsyncQueryRequest);
+  CreateAsyncQueryResponse createAsyncQuery(
+      CreateAsyncQueryRequest createAsyncQueryRequest, RequestContext requestContext);
 
   /**
    * Returns async query response for a given queryId.

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
@@ -18,6 +18,7 @@ import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.RequestContext;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
 import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
@@ -36,9 +37,9 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
 
   @Override
   public CreateAsyncQueryResponse createAsyncQuery(
-      CreateAsyncQueryRequest createAsyncQueryRequest) {
+      CreateAsyncQueryRequest createAsyncQueryRequest, RequestContext requestContext) {
     SparkExecutionEngineConfig sparkExecutionEngineConfig =
-        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig();
+        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(requestContext);
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             new DispatchQueryRequest(
@@ -48,7 +49,7 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
                 createAsyncQueryRequest.getLang(),
                 sparkExecutionEngineConfig.getExecutionRoleARN(),
                 sparkExecutionEngineConfig.getClusterName(),
-                sparkExecutionEngineConfig.getSparkSubmitParameters(),
+                sparkExecutionEngineConfig.getSparkSubmitParameterModifier(),
                 createAsyncQueryRequest.getSessionId()));
     asyncQueryJobMetadataStorageService.storeJobMetadata(
         AsyncQueryJobMetadata.builder()

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/NullRequestContext.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/NullRequestContext.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.asyncquery.model;
+
+/** An implementation of RequestContext for where context is not required */
+public class NullRequestContext implements RequestContext {
+  @Override
+  public Object getAttribute(String name) {
+    return null;
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/RequestContext.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/RequestContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.spark.asyncquery.model;
+
+/** Context interface to provide additional request related information */
+public interface RequestContext {
+  Object getAttribute(String name);
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParameters.java
@@ -21,11 +21,13 @@ import java.util.Map;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.datasources.auth.AuthenticationType;
+import org.opensearch.sql.spark.config.SparkSubmitParameterModifier;
 import org.opensearch.sql.spark.execution.statestore.OpenSearchStateStoreUtil;
 
 /** Define Spark Submit Parameters. */
@@ -40,7 +42,24 @@ public class SparkSubmitParameters {
   private final Map<String, String> config;
 
   /** Extra parameters to append finally */
-  private String extraParameters;
+  @Setter private String extraParameters;
+
+  public void setConfigItem(String key, String value) {
+    config.put(key, value);
+  }
+
+  public void deleteConfigItem(String key) {
+    config.remove(key);
+  }
+
+  public static Builder builder() {
+    return Builder.builder();
+  }
+
+  public SparkSubmitParameters acceptModifier(SparkSubmitParameterModifier modifier) {
+    modifier.modifyParameters(this);
+    return this;
+  }
 
   public static class Builder {
 
@@ -180,15 +199,14 @@ public class SparkSubmitParameters {
       return this;
     }
 
-    public Builder sessionExecution(String sessionId, String datasourceName) {
-      config.put(FLINT_JOB_REQUEST_INDEX, OpenSearchStateStoreUtil.getIndexName(datasourceName));
-      config.put(FLINT_JOB_SESSION_ID, sessionId);
-      return this;
-    }
-
     public SparkSubmitParameters build() {
       return new SparkSubmitParameters(className, config, extraParameters);
     }
+  }
+
+  public void sessionExecution(String sessionId, String datasourceName) {
+    config.put(FLINT_JOB_REQUEST_INDEX, OpenSearchStateStoreUtil.getIndexName(datasourceName));
+    config.put(FLINT_JOB_SESSION_ID, sessionId);
   }
 
   @Override

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImpl.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.emrserverless.AWSEMRServerlessClientBuilder;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.asyncquery.model.NullRequestContext;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
 
@@ -32,7 +33,8 @@ public class EMRServerlessClientFactoryImpl implements EMRServerlessClientFactor
   @Override
   public EMRServerlessClient getClient() {
     SparkExecutionEngineConfig sparkExecutionEngineConfig =
-        this.sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig();
+        this.sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(
+            new NullRequestContext());
     validateSparkExecutionEngineConfig(sparkExecutionEngineConfig);
     if (isNewClientCreationRequired(sparkExecutionEngineConfig.getRegion())) {
       region = sparkExecutionEngineConfig.getRegion();

--- a/spark/src/main/java/org/opensearch/sql/spark/config/OpenSearchSparkSubmitParameterModifier.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/OpenSearchSparkSubmitParameterModifier.java
@@ -1,0 +1,15 @@
+package org.opensearch.sql.spark.config;
+
+import lombok.AllArgsConstructor;
+import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
+
+@AllArgsConstructor
+public class OpenSearchSparkSubmitParameterModifier implements SparkSubmitParameterModifier {
+
+  private String extraParameters;
+
+  @Override
+  public void modifyParameters(SparkSubmitParameters parameters) {
+    parameters.setExtraParameters(this.extraParameters);
+  }
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfig.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfig.java
@@ -1,8 +1,8 @@
 package org.opensearch.sql.spark.config;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * POJO for spark Execution Engine Config. Interface between {@link
@@ -10,12 +10,12 @@ import lombok.NoArgsConstructor;
  * SparkExecutionEngineConfigSupplier}
  */
 @Data
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
 public class SparkExecutionEngineConfig {
   private String applicationId;
   private String region;
   private String executionRoleARN;
-  private String sparkSubmitParameters;
+  private SparkSubmitParameterModifier sparkSubmitParameterModifier;
   private String clusterName;
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplier.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplier.java
@@ -1,5 +1,7 @@
 package org.opensearch.sql.spark.config;
 
+import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+
 /** Interface for extracting and providing SparkExecutionEngineConfig */
 public interface SparkExecutionEngineConfigSupplier {
 
@@ -8,5 +10,5 @@ public interface SparkExecutionEngineConfigSupplier {
    *
    * @return {@link SparkExecutionEngineConfig}.
    */
-  SparkExecutionEngineConfig getSparkExecutionEngineConfig();
+  SparkExecutionEngineConfig getSparkExecutionEngineConfig(RequestContext requestContext);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImpl.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.spark.asyncquery.model.RequestContext;
 
 @AllArgsConstructor
 public class SparkExecutionEngineConfigSupplierImpl implements SparkExecutionEngineConfigSupplier {
@@ -16,27 +17,30 @@ public class SparkExecutionEngineConfigSupplierImpl implements SparkExecutionEng
   private Settings settings;
 
   @Override
-  public SparkExecutionEngineConfig getSparkExecutionEngineConfig() {
+  public SparkExecutionEngineConfig getSparkExecutionEngineConfig(RequestContext requestContext) {
+    ClusterName clusterName = settings.getSettingValue(CLUSTER_NAME);
+    return getBuilderFromSettingsIfAvailable().clusterName(clusterName.value()).build();
+  }
+
+  private SparkExecutionEngineConfig.SparkExecutionEngineConfigBuilder
+      getBuilderFromSettingsIfAvailable() {
     String sparkExecutionEngineConfigSettingString =
         this.settings.getSettingValue(SPARK_EXECUTION_ENGINE_CONFIG);
-    SparkExecutionEngineConfig sparkExecutionEngineConfig = new SparkExecutionEngineConfig();
     if (!StringUtils.isBlank(sparkExecutionEngineConfigSettingString)) {
-      SparkExecutionEngineConfigClusterSetting sparkExecutionEngineConfigClusterSetting =
+      SparkExecutionEngineConfigClusterSetting setting =
           AccessController.doPrivileged(
               (PrivilegedAction<SparkExecutionEngineConfigClusterSetting>)
                   () ->
                       SparkExecutionEngineConfigClusterSetting.toSparkExecutionEngineConfig(
                           sparkExecutionEngineConfigSettingString));
-      sparkExecutionEngineConfig.setApplicationId(
-          sparkExecutionEngineConfigClusterSetting.getApplicationId());
-      sparkExecutionEngineConfig.setExecutionRoleARN(
-          sparkExecutionEngineConfigClusterSetting.getExecutionRoleARN());
-      sparkExecutionEngineConfig.setSparkSubmitParameters(
-          sparkExecutionEngineConfigClusterSetting.getSparkSubmitParameters());
-      sparkExecutionEngineConfig.setRegion(sparkExecutionEngineConfigClusterSetting.getRegion());
+      return SparkExecutionEngineConfig.builder()
+          .applicationId(setting.getApplicationId())
+          .executionRoleARN(setting.getExecutionRoleARN())
+          .sparkSubmitParameterModifier(
+              new OpenSearchSparkSubmitParameterModifier(setting.getSparkSubmitParameters()))
+          .region(setting.getRegion());
+    } else {
+      return SparkExecutionEngineConfig.builder();
     }
-    ClusterName clusterName = settings.getSettingValue(CLUSTER_NAME);
-    sparkExecutionEngineConfig.setClusterName(clusterName.value());
-    return sparkExecutionEngineConfig;
   }
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkSubmitParameterModifier.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkSubmitParameterModifier.java
@@ -1,0 +1,11 @@
+package org.opensearch.sql.spark.config;
+
+import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
+
+/**
+ * Interface for extension point to allow modification of spark submit parameter. modifyParameter
+ * method is called after the default spark submit parameter is build.
+ */
+public interface SparkSubmitParameterModifier {
+  void modifyParameters(SparkSubmitParameters parameters);
+}

--- a/spark/src/main/java/org/opensearch/sql/spark/data/constants/SparkConstants.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/data/constants/SparkConstants.java
@@ -47,8 +47,10 @@ public class SparkConstants {
   public static final String SPARK_DRIVER_ENV_JAVA_HOME_KEY =
       "spark.emr-serverless.driverEnv.JAVA_HOME";
   public static final String SPARK_EXECUTOR_ENV_JAVA_HOME_KEY = "spark.executorEnv.JAVA_HOME";
+  // Used for logging/metrics in Spark (driver)
   public static final String SPARK_DRIVER_ENV_FLINT_CLUSTER_NAME_KEY =
       "spark.emr-serverless.driverEnv.FLINT_CLUSTER_NAME";
+  // Used for logging/metrics in Spark (executor)
   public static final String SPARK_EXECUTOR_ENV_FLINT_CLUSTER_NAME_KEY =
       "spark.executorEnv.FLINT_CLUSTER_NAME";
   public static final String FLINT_INDEX_STORE_HOST_KEY = "spark.datasource.flint.host";

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -81,12 +81,12 @@ public class BatchQueryHandler extends AsyncQueryHandler {
             clusterName + ":" + JobType.BATCH.getText(),
             dispatchQueryRequest.getApplicationId(),
             dispatchQueryRequest.getExecutionRoleARN(),
-            SparkSubmitParameters.Builder.builder()
+            SparkSubmitParameters.builder()
                 .clusterName(clusterName)
                 .dataSource(context.getDataSourceMetadata())
                 .query(dispatchQueryRequest.getQuery())
-                .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams())
                 .build()
+                .acceptModifier(dispatchQueryRequest.getSparkSubmitParameterModifier())
                 .toString(),
             tags,
             false,

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -102,11 +102,12 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
                   clusterName,
                   dispatchQueryRequest.getApplicationId(),
                   dispatchQueryRequest.getExecutionRoleARN(),
-                  SparkSubmitParameters.Builder.builder()
+                  SparkSubmitParameters.builder()
                       .className(FLINT_SESSION_CLASS_NAME)
                       .clusterName(clusterName)
                       .dataSource(dataSourceMetadata)
-                      .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams()),
+                      .build()
+                      .acceptModifier(dispatchQueryRequest.getSparkSubmitParameterModifier()),
                   tags,
                   dataSourceMetadata.getResultIndex(),
                   dataSourceMetadata.getName()));

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
@@ -69,13 +69,13 @@ public class StreamingQueryHandler extends BatchQueryHandler {
             jobName,
             dispatchQueryRequest.getApplicationId(),
             dispatchQueryRequest.getExecutionRoleARN(),
-            SparkSubmitParameters.Builder.builder()
+            SparkSubmitParameters.builder()
                 .clusterName(clusterName)
                 .dataSource(dataSourceMetadata)
                 .query(dispatchQueryRequest.getQuery())
                 .structuredStreaming(true)
-                .extraParameters(dispatchQueryRequest.getExtraSparkSubmitParams())
                 .build()
+                .acceptModifier(dispatchQueryRequest.getSparkSubmitParameterModifier())
                 .toString(),
             tags,
             indexQueryDetails.getFlintIndexOptions().autoRefresh(),

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryRequest.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.spark.dispatcher.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.config.SparkSubmitParameterModifier;
 import org.opensearch.sql.spark.rest.model.LangType;
 
 @AllArgsConstructor
@@ -21,8 +22,8 @@ public class DispatchQueryRequest {
   private final String executionRoleARN;
   private final String clusterName;
 
-  /** Optional extra Spark submit parameters to include in final request */
-  private String extraSparkSubmitParams;
+  /* extension point to modify or add spark submit parameter */
+  private final SparkSubmitParameterModifier sparkSubmitParameterModifier;
 
   /** Optional sessionId. */
   private String sessionId;

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/CreateSessionRequest.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/CreateSessionRequest.java
@@ -16,7 +16,7 @@ public class CreateSessionRequest {
   private final String clusterName;
   private final String applicationId;
   private final String executionRoleArn;
-  private final SparkSubmitParameters.Builder sparkSubmitParametersBuilder;
+  private final SparkSubmitParameters sparkSubmitParameters;
   private final Map<String, String> tags;
   private final String resultIndex;
   private final String datasourceName;
@@ -26,7 +26,7 @@ public class CreateSessionRequest {
         clusterName + ":" + JobType.INTERACTIVE.getText() + ":" + sessionId,
         applicationId,
         executionRoleArn,
-        sparkSubmitParametersBuilder.build().toString(),
+        sparkSubmitParameters.toString(),
         tags,
         resultIndex);
   }

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
@@ -53,7 +53,7 @@ public class InteractiveSession implements Session {
     try {
       // append session id;
       createSessionRequest
-          .getSparkSubmitParametersBuilder()
+          .getSparkSubmitParameters()
           .sessionExecution(sessionId.getSessionId(), createSessionRequest.getDatasourceName());
       createSessionRequest.getTags().put(SESSION_ID_TAG_KEY, sessionId.getSessionId());
       StartJobRequest startJobRequest =

--- a/spark/src/main/java/org/opensearch/sql/spark/transport/TransportCreateAsyncQueryRequestAction.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/transport/TransportCreateAsyncQueryRequestAction.java
@@ -18,6 +18,7 @@ import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorService;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorServiceImpl;
+import org.opensearch.sql.spark.asyncquery.model.NullRequestContext;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryRequest;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryResponse;
 import org.opensearch.sql.spark.transport.model.CreateAsyncQueryActionRequest;
@@ -64,7 +65,8 @@ public class TransportCreateAsyncQueryRequestAction
 
       CreateAsyncQueryRequest createAsyncQueryRequest = request.getCreateAsyncQueryRequest();
       CreateAsyncQueryResponse createAsyncQueryResponse =
-          asyncQueryExecutorService.createAsyncQuery(createAsyncQueryRequest);
+          asyncQueryExecutorService.createAsyncQuery(
+              createAsyncQueryRequest, new NullRequestContext());
       String responseContent =
           new JsonResponseFormatter<CreateAsyncQueryResponse>(JsonResponseFormatter.Style.PRETTY) {
             @Override

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
@@ -31,6 +31,8 @@ import org.opensearch.sql.datasource.model.DataSourceStatus;
 import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.datasources.exceptions.DatasourceDisabledException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
+import org.opensearch.sql.spark.asyncquery.model.NullRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.RequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.session.SessionId;
 import org.opensearch.sql.spark.execution.session.SessionState;
@@ -42,6 +44,7 @@ import org.opensearch.sql.spark.rest.model.CreateAsyncQueryResponse;
 import org.opensearch.sql.spark.rest.model.LangType;
 
 public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorServiceSpec {
+  RequestContext requestContext = new NullRequestContext();
 
   @Disabled("batch query is unsupported")
   public void withoutSessionCreateAsyncQueryThenGetResultThenCancel() {
@@ -56,7 +59,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertFalse(clusterService().state().routingTable().hasIndex(SPARK_REQUEST_BUFFER_INDEX_NAME));
     emrsClient.startJobRunCalled(1);
 
@@ -86,12 +90,14 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     emrsClient.startJobRunCalled(1);
 
     CreateAsyncQueryResponse resp2 =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     emrsClient.startJobRunCalled(2);
   }
 
@@ -105,7 +111,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     enableSession(false);
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     String params = emrsClient.getJobRequest().getSparkSubmitParams();
     assertNull(response.getSessionId());
     assertTrue(params.contains(String.format("--class %s", DEFAULT_CLASS_NAME)));
@@ -119,7 +126,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     enableSession(true);
     response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     params = emrsClient.getJobRequest().getSparkSubmitParams();
     assertTrue(params.contains(String.format("--class %s", FLINT_SESSION_CLASS_NAME)));
     assertTrue(
@@ -139,7 +147,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(response.getSessionId());
     Optional<StatementModel> statementModel =
         statementStorageService.getStatement(response.getQueryId(), MYS3_DATASOURCE);
@@ -171,14 +180,16 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse first =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(first.getSessionId());
 
     // 2. reuse session id
     CreateAsyncQueryResponse second =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(
-                "select 1", MYS3_DATASOURCE, LangType.SQL, first.getSessionId()));
+                "select 1", MYS3_DATASOURCE, LangType.SQL, first.getSessionId()),
+            requestContext);
 
     assertEquals(first.getSessionId(), second.getSessionId());
     assertNotEquals(first.getQueryId(), second.getQueryId());
@@ -220,7 +231,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     enableSession(false);
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
 
     assertEquals(120L, (long) emrsClient.getJobRequest().executionTimeout());
   }
@@ -236,7 +248,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     enableSession(true);
 
     asyncQueryExecutorService.createAsyncQuery(
-        new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+        new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+        requestContext);
     assertEquals(0L, (long) emrsClient.getJobRequest().executionTimeout());
   }
 
@@ -269,7 +282,7 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     enableSession(true);
 
     asyncQueryExecutorService.createAsyncQuery(
-        new CreateAsyncQueryRequest("select 1", "mybasicauth", LangType.SQL, null));
+        new CreateAsyncQueryRequest("select 1", "mybasicauth", LangType.SQL, null), requestContext);
     String params = emrsClient.getJobRequest().getSparkSubmitParams();
     assertTrue(params.contains(String.format("--conf spark.datasource.flint.auth=basic")));
     assertTrue(
@@ -291,7 +304,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("myselect 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("myselect 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(response.getSessionId());
     Optional<StatementModel> statementModel =
         statementStorageService.getStatement(response.getQueryId(), MYS3_DATASOURCE);
@@ -341,7 +355,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse first =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(first.getSessionId());
     setSessionState(first.getSessionId(), SessionState.RUNNING);
 
@@ -351,7 +366,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             ConcurrencyLimitExceededException.class,
             () ->
                 asyncQueryExecutorService.createAsyncQuery(
-                    new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null)));
+                    new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+                    requestContext));
     assertEquals("domain concurrent active session can not exceed 1", exception.getMessage());
   }
 
@@ -369,7 +385,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse first =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(first.getSessionId());
 
     // set sessionState to FAIL
@@ -379,7 +396,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     CreateAsyncQueryResponse second =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(
-                "select 1", MYS3_DATASOURCE, LangType.SQL, first.getSessionId()));
+                "select 1", MYS3_DATASOURCE, LangType.SQL, first.getSessionId()),
+            requestContext);
 
     assertNotEquals(first.getSessionId(), second.getSessionId());
 
@@ -390,7 +408,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     CreateAsyncQueryResponse third =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(
-                "select 1", MYS3_DATASOURCE, LangType.SQL, second.getSessionId()));
+                "select 1", MYS3_DATASOURCE, LangType.SQL, second.getSessionId()),
+            requestContext);
     assertNotEquals(second.getSessionId(), third.getSessionId());
   }
 
@@ -408,7 +427,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     CreateAsyncQueryResponse first =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(
-                "SHOW SCHEMAS IN " + MYS3_DATASOURCE, MYS3_DATASOURCE, LangType.SQL, null));
+                "SHOW SCHEMAS IN " + MYS3_DATASOURCE, MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(first.getSessionId());
 
     // set sessionState to RUNNING
@@ -421,7 +441,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
                 "SHOW SCHEMAS IN " + MYS3_DATASOURCE,
                 MYS3_DATASOURCE,
                 LangType.SQL,
-                first.getSessionId()));
+                first.getSessionId()),
+            requestContext);
 
     assertEquals(first.getSessionId(), second.getSessionId());
 
@@ -435,7 +456,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
                 "SHOW SCHEMAS IN " + MYGLUE_DATASOURCE,
                 MYGLUE_DATASOURCE,
                 LangType.SQL,
-                second.getSessionId()));
+                second.getSessionId()),
+            requestContext);
     assertNotEquals(second.getSessionId(), third.getSessionId());
   }
 
@@ -452,7 +474,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse first =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(first.getSessionId());
 
     // set sessionState to RUNNING
@@ -462,7 +485,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     CreateAsyncQueryResponse second =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(
-                "select 1", MYS3_DATASOURCE, LangType.SQL, first.getSessionId()));
+                "select 1", MYS3_DATASOURCE, LangType.SQL, first.getSessionId()),
+            requestContext);
 
     assertEquals(first.getSessionId(), second.getSessionId());
 
@@ -480,7 +504,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
       CreateAsyncQueryResponse third =
           asyncQueryExecutorService.createAsyncQuery(
               new CreateAsyncQueryRequest(
-                  "select 1", MYS3_DATASOURCE, LangType.SQL, second.getSessionId()));
+                  "select 1", MYS3_DATASOURCE, LangType.SQL, second.getSessionId()),
+              requestContext);
       assertNotEquals(second.getSessionId(), third.getSessionId());
     } finally {
       // set timeout setting to 0
@@ -509,7 +534,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     CreateAsyncQueryResponse asyncQuery =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(
-                "select 1", MYS3_DATASOURCE, LangType.SQL, invalidSessionId.getSessionId()));
+                "select 1", MYS3_DATASOURCE, LangType.SQL, invalidSessionId.getSessionId()),
+            requestContext);
     assertNotNull(asyncQuery.getSessionId());
     assertNotEquals(invalidSessionId.getSessionId(), asyncQuery.getSessionId());
   }
@@ -542,7 +568,7 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
 
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", "TESTS3", LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", "TESTS3", LangType.SQL, null), requestContext);
     String params = emrsClient.getJobRequest().getSparkSubmitParams();
 
     assertNotNull(response.getSessionId());
@@ -564,7 +590,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     CreateAsyncQueryResponse first =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(first.getSessionId());
     setSessionState(first.getSessionId(), SessionState.RUNNING);
 
@@ -574,8 +601,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             ConcurrencyLimitExceededException.class,
             () ->
                 asyncQueryExecutorService.createAsyncQuery(
-                    new CreateAsyncQueryRequest(
-                        "select 1", MYGLUE_DATASOURCE, LangType.SQL, null)));
+                    new CreateAsyncQueryRequest("select 1", MYGLUE_DATASOURCE, LangType.SQL, null),
+                    requestContext));
     assertEquals("domain concurrent active session can not exceed 1", exception.getMessage());
   }
 
@@ -595,7 +622,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     // 1. create async query.
     try {
       asyncQueryExecutorService.createAsyncQuery(
-          new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null));
+          new CreateAsyncQueryRequest("select 1", MYS3_DATASOURCE, LangType.SQL, null),
+          requestContext);
       fail("It should have thrown DataSourceDisabledException");
     } catch (DatasourceDisabledException exception) {
       Assertions.assertEquals("Datasource mys3 is disabled.", exception.getMessage());

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
@@ -52,9 +52,11 @@ import org.opensearch.sql.datasources.storage.OpenSearchDataSourceMetadataStorag
 import org.opensearch.sql.legacy.esdomain.LocalClusterState;
 import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
+import org.opensearch.sql.spark.asyncquery.model.RequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.client.StartJobRequest;
+import org.opensearch.sql.spark.config.OpenSearchSparkSubmitParameterModifier;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.dispatcher.QueryHandlerFactory;
 import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
@@ -97,6 +99,7 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
   protected StateStore stateStore;
   protected SessionStorageService sessionStorageService;
   protected StatementStorageService statementStorageService;
+  protected RequestContext requestContext;
 
   @Override
   protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -332,8 +335,14 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
     }
   }
 
-  public SparkExecutionEngineConfig sparkExecutionEngineConfig() {
-    return new SparkExecutionEngineConfig("appId", "us-west-2", "roleArn", "", "myCluster");
+  public SparkExecutionEngineConfig sparkExecutionEngineConfig(RequestContext requestContext) {
+    return SparkExecutionEngineConfig.builder()
+        .applicationId("appId")
+        .region("us-west-2")
+        .executionRoleARN("roleArn")
+        .sparkSubmitParameterModifier(new OpenSearchSparkSubmitParameterModifier(""))
+        .clusterName("myCluster")
+        .build();
   }
 
   public void enableSession(boolean enabled) {

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
@@ -26,6 +26,8 @@ import org.opensearch.sql.protocol.response.format.ResponseFormatter;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryResult;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
+import org.opensearch.sql.spark.asyncquery.model.NullRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.RequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statement.StatementModel;
 import org.opensearch.sql.spark.execution.statement.StatementState;
@@ -37,6 +39,7 @@ import org.opensearch.sql.spark.rest.model.LangType;
 import org.opensearch.sql.spark.transport.format.AsyncQueryResultResponseFormatter;
 
 public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
+  RequestContext requestContext = new NullRequestContext();
 
   /** Mock Flint index and index state */
   private final FlintDatasetMock mockIndex =
@@ -435,7 +438,8 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
               });
       this.createQueryResponse =
           queryService.createAsyncQuery(
-              new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null));
+              new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
+              requestContext);
     }
 
     AssertionHelper withInteraction(Interaction interaction) {

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
@@ -76,7 +76,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -144,7 +145,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -225,7 +227,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -288,7 +291,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               assertEquals(
@@ -353,7 +357,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               assertEquals(
@@ -427,7 +432,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -501,7 +507,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -569,7 +576,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -630,7 +638,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -693,7 +702,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -756,7 +766,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -816,7 +827,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -874,7 +886,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -940,7 +953,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -1004,7 +1018,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -1069,7 +1084,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -135,7 +135,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               assertNotNull(response.getQueryId());
               assertTrue(clusterService.state().routingTable().hasIndex(mockDS.indexName));
@@ -185,7 +186,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2.fetch result.
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -224,7 +226,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -260,7 +263,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     // 1.drop index
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest(mockDS.query, MYGLUE_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest(mockDS.query, MYGLUE_DATASOURCE, LangType.SQL, null),
+            requestContext);
 
     // 2.fetch result.
     AsyncQueryExecutionResponse asyncQueryResults =
@@ -302,7 +306,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               assertNotNull(response.getQueryId());
               assertTrue(clusterService.state().routingTable().hasIndex(mockDS.indexName));
@@ -361,7 +366,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2.fetch result.
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -407,7 +413,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -452,7 +459,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               assertEquals(
@@ -502,7 +510,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -549,7 +558,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               assertEquals(
@@ -595,7 +605,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               assertEquals(
@@ -649,7 +660,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
                   asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
@@ -693,7 +705,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     // 1.drop index
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest(mockDS.query, MYGLUE_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest(mockDS.query, MYGLUE_DATASOURCE, LangType.SQL, null),
+            requestContext);
 
     // 2.fetch result.
     AsyncQueryExecutionResponse asyncQueryResults =
@@ -740,7 +753,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -769,7 +783,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
             + "l_quantity) WITH (auto_refresh = true)";
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNull(response.getSessionId());
   }
 
@@ -797,7 +812,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
             ConcurrencyLimitExceededException.class,
             () ->
                 asyncQueryExecutorService.createAsyncQuery(
-                    new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null)));
+                    new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
+                    requestContext));
     assertEquals("domain concurrent refresh job can not exceed 1", exception.getMessage());
   }
 
@@ -823,7 +839,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
             ConcurrencyLimitExceededException.class,
             () ->
                 asyncQueryExecutorService.createAsyncQuery(
-                    new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null)));
+                    new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
+                    requestContext));
     assertEquals("domain concurrent refresh job can not exceed 1", exception.getMessage());
   }
 
@@ -845,7 +862,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
     CreateAsyncQueryResponse asyncQueryResponse =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
     assertNotNull(asyncQueryResponse.getSessionId());
   }
 
@@ -877,7 +895,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               // 1. submit create / refresh index query
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
-                      new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null));
+                      new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
 
               // 2. cancel query
               IllegalArgumentException exception =
@@ -920,7 +939,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.refreshQuery, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.refreshQuery, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
               // mock index state.
               flintIndexJob.refreshing();
 
@@ -964,7 +984,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
-                          mockDS.refreshQuery, MYS3_DATASOURCE, LangType.SQL, null));
+                          mockDS.refreshQuery, MYS3_DATASOURCE, LangType.SQL, null),
+                      requestContext);
               // mock index state.
               flintIndexJob.active();
 
@@ -1010,7 +1031,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                 "REFRESH INDEX covering_corrupted ON my_glue.mydb.http_logs",
                 MYS3_DATASOURCE,
                 LangType.SQL,
-                null));
+                null),
+            requestContext);
     // mock index state.
     flintIndexJob.refreshing();
 

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
@@ -171,7 +171,8 @@ public class IndexQuerySpecVacuumTest extends AsyncQueryExecutorServiceSpec {
     // Vacuum index
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
-            new CreateAsyncQueryRequest(mockDS.query, MYS3_DATASOURCE, LangType.SQL, null));
+            new CreateAsyncQueryRequest(mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
+            requestContext);
 
     return asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
   }

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParametersTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/model/SparkSubmitParametersTest.java
@@ -5,8 +5,11 @@
 
 package org.opensearch.sql.spark.asyncquery.model;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opensearch.sql.spark.data.constants.SparkConstants.HADOOP_CATALOG_CREDENTIALS_PROVIDER_FACTORY_KEY;
+import static org.opensearch.sql.spark.data.constants.SparkConstants.SPARK_JARS_KEY;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +17,7 @@ public class SparkSubmitParametersTest {
 
   @Test
   public void testBuildWithoutExtraParameters() {
-    String params = SparkSubmitParameters.Builder.builder().build().toString();
+    String params = SparkSubmitParameters.builder().build().toString();
 
     assertNotNull(params);
   }
@@ -22,7 +25,7 @@ public class SparkSubmitParametersTest {
   @Test
   public void testBuildWithExtraParameters() {
     String params =
-        SparkSubmitParameters.Builder.builder().extraParameters("--conf A=1").build().toString();
+        SparkSubmitParameters.builder().extraParameters("--conf A=1").build().toString();
 
     // Assert the conf is included with a space
     assertTrue(params.endsWith(" --conf A=1"));
@@ -32,7 +35,7 @@ public class SparkSubmitParametersTest {
   public void testBuildQueryString() {
     String rawQuery = "SHOW tables LIKE \"%\";";
     String expectedQueryInParams = "\"SHOW tables LIKE \\\"%\\\";\"";
-    String params = SparkSubmitParameters.Builder.builder().query(rawQuery).build().toString();
+    String params = SparkSubmitParameters.builder().query(rawQuery).build().toString();
     assertTrue(params.contains(expectedQueryInParams));
   }
 
@@ -40,7 +43,7 @@ public class SparkSubmitParametersTest {
   public void testBuildQueryStringNestedQuote() {
     String rawQuery = "SELECT '\"1\"'";
     String expectedQueryInParams = "\"SELECT '\\\"1\\\"'\"";
-    String params = SparkSubmitParameters.Builder.builder().query(rawQuery).build().toString();
+    String params = SparkSubmitParameters.builder().query(rawQuery).build().toString();
     assertTrue(params.contains(expectedQueryInParams));
   }
 
@@ -48,7 +51,34 @@ public class SparkSubmitParametersTest {
   public void testBuildQueryStringSpecialCharacter() {
     String rawQuery = "SELECT '{\"test ,:+\\\"inner\\\"/\\|?#><\"}'";
     String expectedQueryInParams = "SELECT '{\\\"test ,:+\\\\\\\"inner\\\\\\\"/\\\\|?#><\\\"}'";
-    String params = SparkSubmitParameters.Builder.builder().query(rawQuery).build().toString();
+    String params = SparkSubmitParameters.builder().query(rawQuery).build().toString();
     assertTrue(params.contains(expectedQueryInParams));
+  }
+
+  @Test
+  public void testOverrideConfigItem() {
+    SparkSubmitParameters params = SparkSubmitParameters.builder().build();
+    params.setConfigItem(SPARK_JARS_KEY, "Overridden");
+    String result = params.toString();
+
+    assertTrue(result.contains(String.format("%s=Overridden", SPARK_JARS_KEY)));
+  }
+
+  @Test
+  public void testDeleteConfigItem() {
+    SparkSubmitParameters params = SparkSubmitParameters.builder().build();
+    params.deleteConfigItem(HADOOP_CATALOG_CREDENTIALS_PROVIDER_FACTORY_KEY);
+    String result = params.toString();
+
+    assertFalse(result.contains(HADOOP_CATALOG_CREDENTIALS_PROVIDER_FACTORY_KEY));
+  }
+
+  @Test
+  public void testAddConfigItem() {
+    SparkSubmitParameters params = SparkSubmitParameters.builder().build();
+    params.setConfigItem("AdditionalKey", "Value");
+    String result = params.toString();
+
+    assertTrue(result.contains("AdditionalKey=Value"));
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImplTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.spark.client;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Assertions;
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
 import org.opensearch.sql.spark.constants.TestConstants;
@@ -24,7 +24,7 @@ public class EMRServerlessClientFactoryImplTest {
 
   @Test
   public void testGetClient() {
-    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig())
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(any()))
         .thenReturn(createSparkExecutionEngineConfig());
     EMRServerlessClientFactory emrServerlessClientFactory =
         new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
@@ -35,7 +35,7 @@ public class EMRServerlessClientFactoryImplTest {
   @Test
   public void testGetClientWithChangeInSetting() {
     SparkExecutionEngineConfig sparkExecutionEngineConfig = createSparkExecutionEngineConfig();
-    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig())
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(any()))
         .thenReturn(sparkExecutionEngineConfig);
     EMRServerlessClientFactory emrServerlessClientFactory =
         new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
@@ -46,7 +46,7 @@ public class EMRServerlessClientFactoryImplTest {
     Assertions.assertEquals(emrServerlessClient1, emrserverlessClient);
 
     sparkExecutionEngineConfig.setRegion(TestConstants.US_WEST_REGION);
-    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig())
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(any()))
         .thenReturn(sparkExecutionEngineConfig);
     EMRServerlessClient emrServerlessClient2 = emrServerlessClientFactory.getClient();
     Assertions.assertNotEquals(emrServerlessClient2, emrserverlessClient);
@@ -55,7 +55,7 @@ public class EMRServerlessClientFactoryImplTest {
 
   @Test
   public void testGetClientWithException() {
-    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig()).thenReturn(null);
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(any())).thenReturn(null);
     EMRServerlessClientFactory emrServerlessClientFactory =
         new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
     IllegalArgumentException illegalArgumentException =
@@ -69,8 +69,9 @@ public class EMRServerlessClientFactoryImplTest {
 
   @Test
   public void testGetClientWithExceptionWithNullRegion() {
-    SparkExecutionEngineConfig sparkExecutionEngineConfig = new SparkExecutionEngineConfig();
-    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig())
+    SparkExecutionEngineConfig sparkExecutionEngineConfig =
+        SparkExecutionEngineConfig.builder().build();
+    when(sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(any()))
         .thenReturn(sparkExecutionEngineConfig);
     EMRServerlessClientFactory emrServerlessClientFactory =
         new EMRServerlessClientFactoryImpl(sparkExecutionEngineConfigSupplier);
@@ -84,13 +85,12 @@ public class EMRServerlessClientFactoryImplTest {
   }
 
   private SparkExecutionEngineConfig createSparkExecutionEngineConfig() {
-    SparkExecutionEngineConfig sparkExecutionEngineConfig = new SparkExecutionEngineConfig();
-    sparkExecutionEngineConfig.setRegion(TestConstants.US_EAST_REGION);
-    sparkExecutionEngineConfig.setExecutionRoleARN(TestConstants.EMRS_EXECUTION_ROLE);
-    sparkExecutionEngineConfig.setSparkSubmitParameters(
-        SparkSubmitParameters.Builder.builder().build().toString());
-    sparkExecutionEngineConfig.setClusterName(TestConstants.TEST_CLUSTER_NAME);
-    sparkExecutionEngineConfig.setApplicationId(TestConstants.EMRS_APPLICATION_ID);
-    return sparkExecutionEngineConfig;
+    return SparkExecutionEngineConfig.builder()
+        .region(TestConstants.US_EAST_REGION)
+        .executionRoleARN(TestConstants.EMRS_EXECUTION_ROLE)
+        .sparkSubmitParameterModifier((sparkSubmitParameters) -> {})
+        .clusterName(TestConstants.TEST_CLUSTER_NAME)
+        .applicationId(TestConstants.EMRS_APPLICATION_ID)
+        .build();
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
@@ -68,7 +68,7 @@ public class EmrServerlessClientImplTest {
     when(emrServerless.startJobRun(any())).thenReturn(response);
 
     EmrServerlessClientImpl emrServerlessClient = new EmrServerlessClientImpl(emrServerless);
-    String parameters = SparkSubmitParameters.Builder.builder().query(QUERY).build().toString();
+    String parameters = SparkSubmitParameters.builder().query(QUERY).build().toString();
 
     emrServerlessClient.startJobRun(
         new StartJobRequest(

--- a/spark/src/test/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImplTest.java
@@ -1,8 +1,13 @@
 package org.opensearch.sql.spark.config;
 
 import static org.mockito.Mockito.when;
+import static org.opensearch.sql.spark.constants.TestConstants.EMRS_APPLICATION_ID;
+import static org.opensearch.sql.spark.constants.TestConstants.EMRS_EXECUTION_ROLE;
+import static org.opensearch.sql.spark.constants.TestConstants.SPARK_SUBMIT_PARAMETERS;
 import static org.opensearch.sql.spark.constants.TestConstants.TEST_CLUSTER_NAME;
+import static org.opensearch.sql.spark.constants.TestConstants.US_WEST_REGION;
 
+import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,37 +15,43 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 
 @ExtendWith(MockitoExtension.class)
 public class SparkExecutionEngineConfigSupplierImplTest {
 
   @Mock private Settings settings;
+  @Mock private RequestContext requestContext;
 
   @Test
   void testGetSparkExecutionEngineConfig() {
     SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier =
         new SparkExecutionEngineConfigSupplierImpl(settings);
     when(settings.getSettingValue(Settings.Key.SPARK_EXECUTION_ENGINE_CONFIG))
-        .thenReturn(
-            "{"
-                + "\"applicationId\": \"00fd775baqpu4g0p\","
-                + "\"executionRoleARN\": \"arn:aws:iam::270824043731:role/emr-job-execution-role\","
-                + "\"region\": \"eu-west-1\","
-                + "\"sparkSubmitParameters\": \"--conf spark.dynamicAllocation.enabled=false\""
-                + "}");
+        .thenReturn(getConfigJson());
     when(settings.getSettingValue(Settings.Key.CLUSTER_NAME))
         .thenReturn(new ClusterName(TEST_CLUSTER_NAME));
+
     SparkExecutionEngineConfig sparkExecutionEngineConfig =
-        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig();
-    Assertions.assertEquals("00fd775baqpu4g0p", sparkExecutionEngineConfig.getApplicationId());
-    Assertions.assertEquals(
-        "arn:aws:iam::270824043731:role/emr-job-execution-role",
-        sparkExecutionEngineConfig.getExecutionRoleARN());
-    Assertions.assertEquals("eu-west-1", sparkExecutionEngineConfig.getRegion());
-    Assertions.assertEquals(
-        "--conf spark.dynamicAllocation.enabled=false",
-        sparkExecutionEngineConfig.getSparkSubmitParameters());
+        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(requestContext);
+    SparkSubmitParameters parameters = SparkSubmitParameters.builder().build();
+    sparkExecutionEngineConfig.getSparkSubmitParameterModifier().modifyParameters(parameters);
+
+    Assertions.assertEquals(EMRS_APPLICATION_ID, sparkExecutionEngineConfig.getApplicationId());
+    Assertions.assertEquals(EMRS_EXECUTION_ROLE, sparkExecutionEngineConfig.getExecutionRoleARN());
+    Assertions.assertEquals(US_WEST_REGION, sparkExecutionEngineConfig.getRegion());
     Assertions.assertEquals(TEST_CLUSTER_NAME, sparkExecutionEngineConfig.getClusterName());
+    Assertions.assertTrue(parameters.toString().contains(SPARK_SUBMIT_PARAMETERS));
+  }
+
+  String getConfigJson() {
+    return new JSONObject()
+        .put("applicationId", EMRS_APPLICATION_ID)
+        .put("executionRoleARN", EMRS_EXECUTION_ROLE)
+        .put("region", US_WEST_REGION)
+        .put("sparkSubmitParameters", SPARK_SUBMIT_PARAMETERS)
+        .toString();
   }
 
   @Test
@@ -50,12 +61,14 @@ public class SparkExecutionEngineConfigSupplierImplTest {
     when(settings.getSettingValue(Settings.Key.SPARK_EXECUTION_ENGINE_CONFIG)).thenReturn(null);
     when(settings.getSettingValue(Settings.Key.CLUSTER_NAME))
         .thenReturn(new ClusterName(TEST_CLUSTER_NAME));
+
     SparkExecutionEngineConfig sparkExecutionEngineConfig =
-        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig();
+        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(requestContext);
+
     Assertions.assertNull(sparkExecutionEngineConfig.getApplicationId());
     Assertions.assertNull(sparkExecutionEngineConfig.getExecutionRoleARN());
     Assertions.assertNull(sparkExecutionEngineConfig.getRegion());
-    Assertions.assertNull(sparkExecutionEngineConfig.getSparkSubmitParameters());
+    Assertions.assertNull(sparkExecutionEngineConfig.getSparkSubmitParameterModifier());
     Assertions.assertEquals(TEST_CLUSTER_NAME, sparkExecutionEngineConfig.getClusterName());
   }
 }

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandlerTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandlerTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
+import org.opensearch.sql.spark.config.SparkSubmitParameterModifier;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
@@ -46,6 +47,7 @@ class IndexDMLHandlerTest {
   @Mock private FlintIndexMetadataService flintIndexMetadataService;
   @Mock private IndexDMLResultStorageService indexDMLResultStorageService;
   @Mock private FlintIndexOpFactory flintIndexOpFactory;
+  @Mock private SparkSubmitParameterModifier sparkSubmitParameterModifier;
 
   @Test
   public void getResponseFromExecutor() {
@@ -70,7 +72,8 @@ class IndexDMLHandlerTest {
             "my_glue",
             LangType.SQL,
             EMRS_EXECUTION_ROLE,
-            TEST_CLUSTER_NAME);
+            TEST_CLUSTER_NAME,
+            sparkSubmitParameterModifier);
     DataSourceMetadata metadata =
         new DataSourceMetadata.Builder()
             .setName("mys3")
@@ -113,7 +116,8 @@ class IndexDMLHandlerTest {
             "my_glue",
             LangType.SQL,
             EMRS_EXECUTION_ROLE,
-            TEST_CLUSTER_NAME);
+            TEST_CLUSTER_NAME,
+            sparkSubmitParameterModifier);
     DataSourceMetadata metadata =
         new DataSourceMetadata.Builder()
             .setName("mys3")

--- a/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -62,6 +62,7 @@ import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.client.StartJobRequest;
+import org.opensearch.sql.spark.config.SparkSubmitParameterModifier;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
 import org.opensearch.sql.spark.dispatcher.model.JobType;
@@ -90,6 +91,7 @@ public class SparkQueryDispatcherTest {
   @Mock private LeaseManager leaseManager;
   @Mock private IndexDMLResultStorageService indexDMLResultStorageService;
   @Mock private FlintIndexOpFactory flintIndexOpFactory;
+  @Mock private SparkSubmitParameterModifier sparkSubmitParameterModifier;
 
   @Mock(answer = RETURNS_DEEP_STUBS)
   private Session session;
@@ -158,7 +160,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -206,8 +209,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
-
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
     Assertions.assertEquals(EMR_JOB_ID, dispatchQueryResponse.getJobId());
@@ -254,7 +257,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -300,7 +304,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -415,7 +420,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -462,7 +468,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.PPL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -509,7 +516,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -560,7 +568,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -611,7 +620,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -658,7 +668,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -705,7 +716,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -752,7 +764,8 @@ public class SparkQueryDispatcherTest {
                 "my_glue",
                 LangType.SQL,
                 EMRS_EXECUTION_ROLE,
-                TEST_CLUSTER_NAME));
+                TEST_CLUSTER_NAME,
+                sparkSubmitParameterModifier));
 
     verify(emrServerlessClient, times(1)).startJobRun(startJobRequestArgumentCaptor.capture());
     Assertions.assertEquals(expected, startJobRequestArgumentCaptor.getValue());
@@ -777,7 +790,8 @@ public class SparkQueryDispatcherTest {
                         "my_glue",
                         LangType.SQL,
                         EMRS_EXECUTION_ROLE,
-                        TEST_CLUSTER_NAME)));
+                        TEST_CLUSTER_NAME,
+                        sparkSubmitParameterModifier)));
 
     Assertions.assertEquals(
         "Bad URI in indexstore configuration of the : my_glue datasoure.",
@@ -801,7 +815,8 @@ public class SparkQueryDispatcherTest {
                         "my_prometheus",
                         LangType.SQL,
                         EMRS_EXECUTION_ROLE,
-                        TEST_CLUSTER_NAME)));
+                        TEST_CLUSTER_NAME,
+                        sparkSubmitParameterModifier)));
 
     Assertions.assertEquals(
         "UnSupported datasource type for async queries:: PROMETHEUS",
@@ -1183,7 +1198,7 @@ public class SparkQueryDispatcherTest {
         langType,
         EMRS_EXECUTION_ROLE,
         TEST_CLUSTER_NAME,
-        extraParameters,
+        (parameters) -> parameters.setExtraParameters(extraParameters),
         null);
   }
 
@@ -1195,7 +1210,7 @@ public class SparkQueryDispatcherTest {
         LangType.SQL,
         EMRS_EXECUTION_ROLE,
         TEST_CLUSTER_NAME,
-        null,
+        sparkSubmitParameterModifier,
         sessionId);
   }
 

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/SessionTestUtil.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/SessionTestUtil.java
@@ -18,7 +18,7 @@ public class SessionTestUtil {
         TEST_CLUSTER_NAME,
         "appId",
         "arn",
-        SparkSubmitParameters.Builder.builder(),
+        SparkSubmitParameters.builder().build(),
         new HashMap<>(),
         "resultIndex",
         TEST_DATASOURCE_NAME);

--- a/spark/src/test/java/org/opensearch/sql/spark/transport/TransportCreateAsyncQueryRequestActionTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/transport/TransportCreateAsyncQueryRequestActionTest.java
@@ -7,6 +7,8 @@
 
 package org.opensearch.sql.spark.transport;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -69,9 +71,11 @@ public class TransportCreateAsyncQueryRequestActionTest {
     CreateAsyncQueryActionRequest request =
         new CreateAsyncQueryActionRequest(createAsyncQueryRequest);
     when(pluginSettings.getSettingValue(Settings.Key.ASYNC_QUERY_ENABLED)).thenReturn(true);
-    when(jobExecutorService.createAsyncQuery(createAsyncQueryRequest))
+    when(jobExecutorService.createAsyncQuery(eq(createAsyncQueryRequest), any()))
         .thenReturn(new CreateAsyncQueryResponse("123", null));
+
     action.doExecute(task, request, actionListener);
+
     Mockito.verify(actionListener).onResponse(createJobActionResponseArgumentCaptor.capture());
     CreateAsyncQueryActionResponse createAsyncQueryActionResponse =
         createJobActionResponseArgumentCaptor.getValue();
@@ -87,9 +91,11 @@ public class TransportCreateAsyncQueryRequestActionTest {
     CreateAsyncQueryActionRequest request =
         new CreateAsyncQueryActionRequest(createAsyncQueryRequest);
     when(pluginSettings.getSettingValue(Settings.Key.ASYNC_QUERY_ENABLED)).thenReturn(true);
-    when(jobExecutorService.createAsyncQuery(createAsyncQueryRequest))
+    when(jobExecutorService.createAsyncQuery(eq(createAsyncQueryRequest), any()))
         .thenReturn(new CreateAsyncQueryResponse("123", MOCK_SESSION_ID));
+
     action.doExecute(task, request, actionListener);
+
     Mockito.verify(actionListener).onResponse(createJobActionResponseArgumentCaptor.capture());
     CreateAsyncQueryActionResponse createAsyncQueryActionResponse =
         createJobActionResponseArgumentCaptor.getValue();
@@ -107,9 +113,11 @@ public class TransportCreateAsyncQueryRequestActionTest {
     when(pluginSettings.getSettingValue(Settings.Key.ASYNC_QUERY_ENABLED)).thenReturn(true);
     doThrow(new RuntimeException("Error"))
         .when(jobExecutorService)
-        .createAsyncQuery(createAsyncQueryRequest);
+        .createAsyncQuery(eq(createAsyncQueryRequest), any());
+
     action.doExecute(task, request, actionListener);
-    verify(jobExecutorService, times(1)).createAsyncQuery(createAsyncQueryRequest);
+
+    verify(jobExecutorService, times(1)).createAsyncQuery(eq(createAsyncQueryRequest), any());
     Mockito.verify(actionListener).onFailure(exceptionArgumentCaptor.capture());
     Exception exception = exceptionArgumentCaptor.getValue();
     Assertions.assertTrue(exception instanceof RuntimeException);
@@ -123,8 +131,10 @@ public class TransportCreateAsyncQueryRequestActionTest {
     CreateAsyncQueryActionRequest request =
         new CreateAsyncQueryActionRequest(createAsyncQueryRequest);
     when(pluginSettings.getSettingValue(Settings.Key.ASYNC_QUERY_ENABLED)).thenReturn(false);
+
     action.doExecute(task, request, actionListener);
-    verify(jobExecutorService, never()).createAsyncQuery(createAsyncQueryRequest);
+
+    verify(jobExecutorService, never()).createAsyncQuery(eq(createAsyncQueryRequest), any());
     Mockito.verify(actionListener).onFailure(exceptionArgumentCaptor.capture());
     Exception exception = exceptionArgumentCaptor.getValue();
     Assertions.assertTrue(exception instanceof IllegalAccessException);


### PR DESCRIPTION
* Provide a way to modify spark parameters

Signed-off-by: Tomoyuki Morita <moritato@amazon.com>

* Address review comment

Signed-off-by: Tomoyuki Morita <moritato@amazon.com>

* Address review comment

Signed-off-by: Tomoyuki Morita <moritato@amazon.com>

* Address review comment

Signed-off-by: Tomoyuki Morita <moritato@amazon.com>

---------

Signed-off-by: Tomoyuki Morita <moritato@amazon.com>

(cherry picked from commit 5a2c199b64f1e02975b258e8711f3beb4c5d81ed)

### Description
- Backport #2691 to 2.x (automatic backport failed)
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).