### PR TITLE
Remove direct ClusterState access in LocalClusterState

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/LocalClusterState.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/esdomain/LocalClusterState.java
@@ -5,22 +5,19 @@
 
 package org.opensearch.sql.legacy.esdomain;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.concurrent.TimeUnit;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.support.IndicesOptions;
-import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.index.IndexNotFoundException;
@@ -39,12 +36,10 @@ import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
  *       across the plugin, ex. in rewriter, pretty formatter etc.
  * </ol>
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LocalClusterState {
 
   private static final Logger LOG = LogManager.getLogger();
-
-  private static final Function<String, Predicate<String>> ALL_FIELDS =
-      (anyIndex -> (anyField -> true));
 
   /** Singleton instance */
   private static LocalClusterState INSTANCE;
@@ -52,17 +47,9 @@ public class LocalClusterState {
   /** Current cluster state on local node */
   private ClusterService clusterService;
 
+  private Client client;
+
   private OpenSearchSettings pluginSettings;
-
-  /** Index name expression resolver to get concrete index name */
-  private IndexNameExpressionResolver resolver;
-
-  /**
-   * Thread-safe mapping cache to save the computation of sourceAsMap() which is not lightweight as
-   * thought Array cannot be used as key because hashCode() always return reference address, so
-   * either use wrapper or List.
-   */
-  private final Cache<List<String>, IndexMappings> cache;
 
   /** Latest setting value for each registered key. Thread-safe is required. */
   private final Map<String, Object> latestSettings = new ConcurrentHashMap<>();
@@ -79,25 +66,33 @@ public class LocalClusterState {
     INSTANCE = instance;
   }
 
-  public void setClusterService(ClusterService clusterService) {
+  /**
+   * Sets the ClusterService used to receive ClusterSetting update notifications.
+   *
+   * @param clusterService The non-null cluster service instance.
+   */
+  public void setClusterService(@NonNull ClusterService clusterService) {
     this.clusterService = clusterService;
-
-    clusterService.addListener(
-        event -> {
-          if (event.metadataChanged()) {
-            // State in cluster service is already changed to event.state() before listener fired
-            if (LOG.isDebugEnabled()) {
-              LOG.debug(
-                  "Metadata in cluster state changed: {}",
-                  new IndexMappings(clusterService.state().metadata()));
-            }
-            cache.invalidateAll();
-          }
-        });
   }
 
-  public void setPluginSettings(OpenSearchSettings settings) {
+  /**
+   * Sets the Client used to interact with OpenSearch core.
+   *
+   * @param client The non-null client instance
+   */
+  public void setClient(@NonNull Client client) {
+    this.client = client;
+  }
+
+  /**
+   * Sets the plugin's settings.
+   *
+   * @param settings The non-null plugin settings instance
+   */
+  public void setPluginSettings(@NonNull OpenSearchSettings settings) {
+
     this.pluginSettings = settings;
+
     for (Setting<?> setting : settings.getSettings()) {
       clusterService
           .getClusterSettings()
@@ -112,14 +107,6 @@ public class LocalClusterState {
     }
   }
 
-  public void setResolver(IndexNameExpressionResolver resolver) {
-    this.resolver = resolver;
-  }
-
-  private LocalClusterState() {
-    cache = CacheBuilder.newBuilder().maximumSize(100).build();
-  }
-
   /**
    * Get plugin setting value by key. Return default value if not configured explicitly.
    *
@@ -132,39 +119,31 @@ public class LocalClusterState {
     return (T) latestSettings.getOrDefault(key.getKeyValue(), pluginSettings.getSettingValue(key));
   }
 
-  /** Get field mappings by index expressions. All types and fields are included in response. */
-  public IndexMappings getFieldMappings(String[] indices) {
-    return getFieldMappings(indices, ALL_FIELDS);
-  }
-
   /**
-   * Get field mappings by index expressions, type and field filter. Because
-   * IndexMetaData/MappingMetaData is hard to convert to FieldMappingMetaData, custom mapping domain
-   * objects are being used here. In future, it should be moved to domain model layer for all
-   * OpenSearch specific knowledge.
-   *
-   * <p>Note that cluster state may be change inside OpenSearch so it's possible to read different
-   * state in 2 accesses to ClusterService.state() here.
+   * Get field mappings by index expressions. Because IndexMetaData/MappingMetaData is hard to
+   * convert to FieldMappingMetaData, custom mapping domain objects are being used here. In future,
+   * it should be moved to domain model layer for all OpenSearch specific knowledge.
    *
    * @param indices index name expression
-   * @param fieldFilter field filter predicate
    * @return index mapping(s)
    */
-  private IndexMappings getFieldMappings(
-      String[] indices, Function<String, Predicate<String>> fieldFilter) {
-    Objects.requireNonNull(clusterService, "Cluster service is null");
-    Objects.requireNonNull(resolver, "Index name expression resolver is null");
+  public IndexMappings getFieldMappings(String[] indices) {
+    Objects.requireNonNull(client, "Client is null");
 
     try {
-      ClusterState state = clusterService.state();
-      String[] concreteIndices = resolveIndexExpression(state, indices);
 
-      IndexMappings mappings;
-      if (fieldFilter == ALL_FIELDS) {
-        mappings = findMappingsInCache(state, concreteIndices);
-      } else {
-        mappings = findMappings(state, concreteIndices, fieldFilter);
-      }
+      Map<String, MappingMetadata> mappingMetadata =
+          client
+              .admin()
+              .indices()
+              .prepareGetMappings(indices)
+              .setLocal(true)
+              .setIndicesOptions(IndicesOptions.strictExpandOpen())
+              .execute()
+              .actionGet(0, TimeUnit.NANOSECONDS)
+              .mappings();
+
+      IndexMappings mappings = new IndexMappings(mappingMetadata);
 
       LOG.debug("Found mappings: {}", mappings);
       return mappings;
@@ -174,37 +153,5 @@ public class LocalClusterState {
       throw new IllegalStateException(
           "Failed to read mapping in cluster state for indices=" + Arrays.toString(indices), e);
     }
-  }
-
-  private String[] resolveIndexExpression(ClusterState state, String[] indices) {
-    String[] concreteIndices =
-        resolver.concreteIndexNames(state, IndicesOptions.strictExpandOpen(), true, indices);
-
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(
-          "Resolved index expression {} to concrete index names {}",
-          Arrays.toString(indices),
-          Arrays.toString(concreteIndices));
-    }
-    return concreteIndices;
-  }
-
-  private IndexMappings findMappings(
-      ClusterState state, String[] indices, Function<String, Predicate<String>> fieldFilter)
-      throws IOException {
-    LOG.debug("Cache didn't help. Load and parse mapping in cluster state");
-    return new IndexMappings(state.metadata().findMappings(indices, fieldFilter));
-  }
-
-  private IndexMappings findMappingsInCache(ClusterState state, String[] indices)
-      throws ExecutionException {
-    LOG.debug("Looking for mapping in cache: {}", cache.asMap());
-    return cache.get(sortToList(indices), () -> findMappings(state, indices, ALL_FIELDS));
-  }
-
-  private <T> List<T> sortToList(T[] array) {
-    // Mostly array has single element
-    Arrays.sort(array);
-    return Arrays.asList(array);
   }
 }

--- a/legacy/src/test/java/org/opensearch/sql/legacy/util/CheckScriptContents.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/util/CheckScriptContents.java
@@ -8,7 +8,7 @@ package org.opensearch.sql.legacy.util;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -24,17 +24,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.mockito.stubbing.Answer;
+import lombok.SneakyThrows;
+import org.mockito.Mockito;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
 import org.opensearch.client.IndicesAdminClient;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
-import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.xcontent.XContentType;
@@ -214,45 +212,28 @@ public class CheckScriptContents {
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, mappings);
   }
 
+  @SneakyThrows
   public static void mockLocalClusterState(String mappings) {
-    LocalClusterState.state().setClusterService(mockClusterService(mappings));
-    LocalClusterState.state().setResolver(mockIndexNameExpressionResolver());
+
+    Client client = Mockito.mock(Client.class, Mockito.RETURNS_DEEP_STUBS);
+
+    when(client
+            .admin()
+            .indices()
+            .prepareGetMappings(any(String[].class))
+            .setLocal(anyBoolean())
+            .setIndicesOptions(any())
+            .execute()
+            .actionGet(anyLong(), any())
+            .mappings())
+        .thenReturn(
+            Map.of(
+                TestsConstants.TEST_INDEX_BANK,
+                IndexMetadata.fromXContent(createParser(mappings)).mapping()));
+
+    LocalClusterState.state().setClusterService(mock(ClusterService.class));
     LocalClusterState.state().setPluginSettings(mockPluginSettings());
-  }
-
-  public static ClusterService mockClusterService(String mappings) {
-    ClusterService mockService = mock(ClusterService.class);
-    ClusterState mockState = mock(ClusterState.class);
-    Metadata mockMetaData = mock(Metadata.class);
-
-    when(mockService.state()).thenReturn(mockState);
-    when(mockState.metadata()).thenReturn(mockMetaData);
-    try {
-      when(mockMetaData.findMappings(any(), any()))
-          .thenReturn(
-              Map.of(
-                  TestsConstants.TEST_INDEX_BANK,
-                  IndexMetadata.fromXContent(createParser(mappings)).mapping()));
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
-    return mockService;
-  }
-
-  public static IndexNameExpressionResolver mockIndexNameExpressionResolver() {
-    IndexNameExpressionResolver mockResolver = mock(IndexNameExpressionResolver.class);
-    when(mockResolver.concreteIndexNames(any(), any(), anyBoolean(), anyString()))
-        .thenAnswer(
-            (Answer<String[]>)
-                invocation -> {
-                  // Return index expression directly without resolving
-                  Object indexExprs = invocation.getArguments()[3];
-                  if (indexExprs instanceof String) {
-                    return new String[] {(String) indexExprs};
-                  }
-                  return (String[]) indexExprs;
-                });
-    return mockResolver;
+    LocalClusterState.state().setClient(client);
   }
 
   public static OpenSearchSettings mockPluginSettings() {

--- a/legacy/src/test/java/org/opensearch/sql/legacy/util/MultipleIndexClusterUtils.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/util/MultipleIndexClusterUtils.java
@@ -6,20 +6,24 @@
 package org.opensearch.sql.legacy.util;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.sql.legacy.util.CheckScriptContents.createParser;
-import static org.opensearch.sql.legacy.util.CheckScriptContents.mockIndexNameExpressionResolver;
 import static org.opensearch.sql.legacy.util.CheckScriptContents.mockPluginSettings;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.opensearch.cluster.ClusterState;
+import lombok.SneakyThrows;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
-import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.sql.legacy.esdomain.LocalClusterState;
 
@@ -152,29 +156,36 @@ public class MultipleIndexClusterUtils {
                     INDEX_ACCOUNT_2_MAPPING))));
   }
 
+  @SneakyThrows
   public static void mockLocalClusterState(Map<String, Map<String, MappingMetadata>> indexMapping) {
-    LocalClusterState.state().setClusterService(mockClusterService(indexMapping));
-    LocalClusterState.state().setResolver(mockIndexNameExpressionResolver());
+
+    Client client = Mockito.mock(Client.class, Mockito.RETURNS_DEEP_STUBS);
+
+    ThreadLocal<String> callerIndexExpression = new ThreadLocal<>();
+    ArgumentMatcher<Object> preserveIndexMappingsFromCaller =
+        arg -> {
+          callerIndexExpression.set((String) arg);
+          return true;
+        };
+    Answer<Map<String, MappingMetadata>> getIndexMappingsForCaller =
+        invoke -> {
+          return indexMapping.get(callerIndexExpression.get());
+        };
+
+    when(client
+            .admin()
+            .indices()
+            .prepareGetMappings((String[]) argThat(preserveIndexMappingsFromCaller))
+            .setLocal(anyBoolean())
+            .setIndicesOptions(any())
+            .execute()
+            .actionGet(anyLong(), any())
+            .mappings())
+        .thenAnswer(getIndexMappingsForCaller);
+
+    LocalClusterState.state().setClusterService(mock(ClusterService.class));
     LocalClusterState.state().setPluginSettings(mockPluginSettings());
-  }
-
-  public static ClusterService mockClusterService(
-      Map<String, Map<String, MappingMetadata>> indexMapping) {
-    ClusterService mockService = mock(ClusterService.class);
-    ClusterState mockState = mock(ClusterState.class);
-    Metadata mockMetaData = mock(Metadata.class);
-
-    when(mockService.state()).thenReturn(mockState);
-    when(mockState.metadata()).thenReturn(mockMetaData);
-    try {
-      for (var entry : indexMapping.entrySet()) {
-        when(mockMetaData.findMappings(eq(new String[] {entry.getKey()}), any()))
-            .thenReturn(entry.getValue());
-      }
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
-    return mockService;
+    LocalClusterState.state().setClient(client);
   }
 
   private static Map<String, MappingMetadata> buildIndexMapping(Map<String, String> indexMapping) {

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -129,7 +129,6 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
     Objects.requireNonNull(clusterService, "Cluster service is required");
     Objects.requireNonNull(pluginSettings, "Cluster settings is required");
 
-    LocalClusterState.state().setResolver(indexNameExpressionResolver);
     Metrics.getInstance().registerDefaultMetrics();
 
     return Arrays.asList(
@@ -202,6 +201,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
     dataSourceService.createDataSource(defaultOpenSearchDataSourceMetadata());
     LocalClusterState.state().setClusterService(clusterService);
     LocalClusterState.state().setPluginSettings((OpenSearchSettings) pluginSettings);
+    LocalClusterState.state().setClient(client);
     ModulesBuilder modules = new ModulesBuilder();
     modules.add(new OpenSearchPluginModule());
     modules.add(


### PR DESCRIPTION
### Description

This commit refactors the LocalClusterState singleton to instead access cluster state through the `org.opensearch.client.Client` abstract interface. 
 
### Issues Resolved

- https://github.com/opensearch-project/OpenSearch/issues/13274
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).