### PR TITLE
Fix compiling error by adding meta fields checker before 7DOT8 in legacy SQL

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/join/ElasticJoinExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/join/ElasticJoinExecutor.java
@@ -23,7 +23,6 @@ import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.search.SearchHit;
@@ -39,6 +38,7 @@ import org.opensearch.sql.legacy.query.join.JoinRequestBuilder;
 import org.opensearch.sql.legacy.query.join.NestedLoopsElasticRequestBuilder;
 import org.opensearch.sql.legacy.query.join.TableInJoinRequestBuilder;
 import org.opensearch.sql.legacy.query.planner.HashJoinQueryPlanRequestBuilder;
+import org.opensearch.sql.legacy.utils.Util;
 
 /** Created by Eliran on 15/9/2015. */
 public abstract class ElasticJoinExecutor implements ElasticHitsExecutor {
@@ -223,9 +223,7 @@ public abstract class ElasticJoinExecutor implements ElasticHitsExecutor {
     hit.getFields()
         .forEach(
             (fieldName, docField) ->
-                (MapperService.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
-                        ? metaFields
-                        : documentFields)
+                (Util.META_FIELDS_BEFORE_7DOT8.contains(fieldName) ? metaFields : documentFields)
                     .put(fieldName, docField));
     SearchHit searchHit = new SearchHit(docId, unmatchedId, documentFields, metaFields);
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/join/HashJoinElasticExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/join/HashJoinElasticExecutor.java
@@ -21,7 +21,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
@@ -32,6 +31,7 @@ import org.opensearch.sql.legacy.exception.SqlParseException;
 import org.opensearch.sql.legacy.query.join.HashJoinElasticRequestBuilder;
 import org.opensearch.sql.legacy.query.join.TableInJoinRequestBuilder;
 import org.opensearch.sql.legacy.query.maker.QueryMaker;
+import org.opensearch.sql.legacy.utils.Util;
 
 /** Created by Eliran on 22/8/2015. */
 public class HashJoinElasticExecutor extends ElasticJoinExecutor {
@@ -187,7 +187,7 @@ public class HashJoinElasticExecutor extends ElasticJoinExecutor {
                   .getFields()
                   .forEach(
                       (fieldName, docField) ->
-                          (MapperService.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
+                          (Util.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
                                   ? metaFields
                                   : documentFields)
                               .put(fieldName, docField));
@@ -261,7 +261,7 @@ public class HashJoinElasticExecutor extends ElasticJoinExecutor {
         hit.getFields()
             .forEach(
                 (fieldName, docField) ->
-                    (MapperService.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
+                    (Util.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
                             ? metaFields
                             : documentFields)
                         .put(fieldName, docField));

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/join/NestedLoopsElasticExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/join/NestedLoopsElasticExecutor.java
@@ -19,7 +19,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.sql.legacy.domain.Condition;
@@ -32,6 +31,7 @@ import org.opensearch.sql.legacy.query.join.BackOffRetryStrategy;
 import org.opensearch.sql.legacy.query.join.NestedLoopsElasticRequestBuilder;
 import org.opensearch.sql.legacy.query.join.TableInJoinRequestBuilder;
 import org.opensearch.sql.legacy.query.maker.Maker;
+import org.opensearch.sql.legacy.utils.Util;
 
 /** Created by Eliran on 15/9/2015. */
 public class NestedLoopsElasticExecutor extends ElasticJoinExecutor {
@@ -200,9 +200,7 @@ public class NestedLoopsElasticExecutor extends ElasticJoinExecutor {
         .getFields()
         .forEach(
             (fieldName, docField) ->
-                (MapperService.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
-                        ? metaFields
-                        : documentFields)
+                (Util.META_FIELDS_BEFORE_7DOT8.contains(fieldName) ? metaFields : documentFields)
                     .put(fieldName, docField));
     SearchHit searchHit =
         new SearchHit(

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/multi/MinusExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/multi/MinusExecutor.java
@@ -19,7 +19,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.document.DocumentField;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.sql.legacy.domain.Condition;
@@ -125,9 +124,7 @@ public class MinusExecutor implements ElasticHitsExecutor {
           .getFields()
           .forEach(
               (field, docField) ->
-                  (MapperService.META_FIELDS_BEFORE_7DOT8.contains(field)
-                          ? metaFields
-                          : documentFields)
+                  (Util.META_FIELDS_BEFORE_7DOT8.contains(field) ? metaFields : documentFields)
                       .put(field, docField));
       SearchHit searchHit = new SearchHit(currentId, currentId + "", documentFields, metaFields);
       searchHit.sourceRef(someHit.getSourceRef());
@@ -157,9 +154,7 @@ public class MinusExecutor implements ElasticHitsExecutor {
           .getFields()
           .forEach(
               (fieldName, docField) ->
-                  (MapperService.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
-                          ? metaFields
-                          : documentFields)
+                  (Util.META_FIELDS_BEFORE_7DOT8.contains(fieldName) ? metaFields : documentFields)
                       .put(fieldName, docField));
       SearchHit searchHit =
           new SearchHit(currentId, originalHit.getId(), documentFields, metaFields);

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/multi/UnionExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/multi/UnionExecutor.java
@@ -15,7 +15,6 @@ import org.apache.lucene.search.TotalHits.Relation;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.document.DocumentField;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.sql.legacy.executor.ElasticHitsExecutor;
@@ -60,9 +59,7 @@ public class UnionExecutor implements ElasticHitsExecutor {
       hit.getFields()
           .forEach(
               (fieldName, docField) ->
-                  (MapperService.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
-                          ? metaFields
-                          : documentFields)
+                  (Util.META_FIELDS_BEFORE_7DOT8.contains(fieldName) ? metaFields : documentFields)
                       .put(fieldName, docField));
       SearchHit searchHit = new SearchHit(currentId, hit.getId(), documentFields, metaFields);
       searchHit.sourceRef(hit.getSourceRef());

--- a/legacy/src/main/java/org/opensearch/sql/legacy/query/planner/physical/node/scroll/SearchHitRow.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/query/planner/physical/node/scroll/SearchHitRow.java
@@ -9,9 +9,9 @@ import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.Map;
 import org.opensearch.common.document.DocumentField;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.SearchHit;
 import org.opensearch.sql.legacy.query.planner.physical.Row;
+import org.opensearch.sql.legacy.utils.Util;
 
 /**
  *
@@ -146,9 +146,7 @@ class SearchHitRow implements Row<SearchHit> {
     hit.getFields()
         .forEach(
             (fieldName, docField) ->
-                (MapperService.META_FIELDS_BEFORE_7DOT8.contains(fieldName)
-                        ? metaFields
-                        : documentFields)
+                (Util.META_FIELDS_BEFORE_7DOT8.contains(fieldName) ? metaFields : documentFields)
                     .put(fieldName, docField));
     SearchHit combined =
         new SearchHit(

--- a/legacy/src/main/java/org/opensearch/sql/legacy/utils/Util.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/utils/Util.java
@@ -24,6 +24,8 @@ import com.alibaba.druid.sql.ast.statement.SQLUnionQuery;
 import com.alibaba.druid.sql.parser.ParserException;
 import com.alibaba.druid.sql.parser.SQLExprParser;
 import com.alibaba.druid.sql.parser.Token;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +42,19 @@ import org.opensearch.sql.legacy.parser.ElasticSqlExprParser;
 public class Util {
 
   public static final String NESTED_JOIN_TYPE = "NestedJoinType";
+
+  public static final Set<String> META_FIELDS_BEFORE_7DOT8 =
+      Collections.unmodifiableSet(
+          new HashSet<>(
+              Arrays.asList(
+                  "_id",
+                  "_ignored",
+                  "_index",
+                  "_routing",
+                  "_size",
+                  "_timestamp",
+                  "_ttl",
+                  "_type")));
 
   public static String joiner(List<KVValue> lists, String oper) {
 


### PR DESCRIPTION
### Description
Fix compiling error by adding meta fields checker before 7DOT8 in legacy SQL
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/2699
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).