### PR TITLE
Pass down request context to data accessors

### DIFF
--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
@@ -6,7 +6,7 @@
 package org.opensearch.sql.spark.asyncquery;
 
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
-import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryRequest;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryResponse;
 
@@ -22,7 +22,8 @@ public interface AsyncQueryExecutorService {
    * @return {@link CreateAsyncQueryResponse}
    */
   CreateAsyncQueryResponse createAsyncQuery(
-      CreateAsyncQueryRequest createAsyncQueryRequest, RequestContext requestContext);
+      CreateAsyncQueryRequest createAsyncQueryRequest,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
   /**
    * Returns async query response for a given queryId.

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
@@ -18,7 +18,7 @@ import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
-import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
 import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
@@ -37,9 +37,10 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
 
   @Override
   public CreateAsyncQueryResponse createAsyncQuery(
-      CreateAsyncQueryRequest createAsyncQueryRequest, RequestContext requestContext) {
+      CreateAsyncQueryRequest createAsyncQueryRequest,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     SparkExecutionEngineConfig sparkExecutionEngineConfig =
-        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(requestContext);
+        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(asyncQueryRequestContext);
     DispatchQueryResponse dispatchQueryResponse =
         sparkQueryDispatcher.dispatch(
             DispatchQueryRequest.builder()
@@ -53,7 +54,8 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
                 .sparkSubmitParameterModifier(
                     sparkExecutionEngineConfig.getSparkSubmitParameterModifier())
                 .sessionId(createAsyncQueryRequest.getSessionId())
-                .build());
+                .build(),
+            asyncQueryRequestContext);
     asyncQueryJobMetadataStorageService.storeJobMetadata(
         AsyncQueryJobMetadata.builder()
             .queryId(dispatchQueryResponse.getQueryId())
@@ -65,7 +67,8 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
             .datasourceName(dispatchQueryResponse.getDatasourceName())
             .jobType(dispatchQueryResponse.getJobType())
             .indexName(dispatchQueryResponse.getIndexName())
-            .build());
+            .build(),
+        asyncQueryRequestContext);
     return new CreateAsyncQueryResponse(
         dispatchQueryResponse.getQueryId(), dispatchQueryResponse.getSessionId());
   }

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryJobMetadataStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryJobMetadataStorageService.java
@@ -9,10 +9,13 @@ package org.opensearch.sql.spark.asyncquery;
 
 import java.util.Optional;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 
 public interface AsyncQueryJobMetadataStorageService {
 
-  void storeJobMetadata(AsyncQueryJobMetadata asyncQueryJobMetadata);
+  void storeJobMetadata(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
   Optional<AsyncQueryJobMetadata> getJobMetadata(String jobId);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/OpenSearchAsyncQueryJobMetadataStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/OpenSearchAsyncQueryJobMetadataStorageService.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.statestore.OpenSearchStateStoreUtil;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.execution.xcontent.AsyncQueryJobMetadataXContentSerializer;
@@ -28,7 +29,9 @@ public class OpenSearchAsyncQueryJobMetadataStorageService
       LogManager.getLogger(OpenSearchAsyncQueryJobMetadataStorageService.class);
 
   @Override
-  public void storeJobMetadata(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  public void storeJobMetadata(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     stateStore.create(
         mapIdToDocumentId(asyncQueryJobMetadata.getId()),
         asyncQueryJobMetadata,

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/AsyncQueryRequestContext.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/AsyncQueryRequestContext.java
@@ -6,6 +6,6 @@
 package org.opensearch.sql.spark.asyncquery.model;
 
 /** Context interface to provide additional request related information */
-public interface RequestContext {
+public interface AsyncQueryRequestContext {
   Object getAttribute(String name);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/NullAsyncQueryRequestContext.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/asyncquery/model/NullAsyncQueryRequestContext.java
@@ -6,7 +6,7 @@
 package org.opensearch.sql.spark.asyncquery.model;
 
 /** An implementation of RequestContext for where context is not required */
-public class NullRequestContext implements RequestContext {
+public class NullAsyncQueryRequestContext implements AsyncQueryRequestContext {
   @Override
   public Object getAttribute(String name) {
     return null;

--- a/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/client/EMRServerlessClientFactoryImpl.java
@@ -13,7 +13,7 @@ import com.amazonaws.services.emrserverless.AWSEMRServerlessClientBuilder;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import lombok.RequiredArgsConstructor;
-import org.opensearch.sql.spark.asyncquery.model.NullRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.NullAsyncQueryRequestContext;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
 
@@ -34,7 +34,7 @@ public class EMRServerlessClientFactoryImpl implements EMRServerlessClientFactor
   public EMRServerlessClient getClient() {
     SparkExecutionEngineConfig sparkExecutionEngineConfig =
         this.sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(
-            new NullRequestContext());
+            new NullAsyncQueryRequestContext());
     validateSparkExecutionEngineConfig(sparkExecutionEngineConfig);
     if (isNewClientCreationRequired(sparkExecutionEngineConfig.getRegion())) {
       region = sparkExecutionEngineConfig.getRegion();

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplier.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplier.java
@@ -1,6 +1,6 @@
 package org.opensearch.sql.spark.config;
 
-import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 
 /** Interface for extracting and providing SparkExecutionEngineConfig */
 public interface SparkExecutionEngineConfigSupplier {
@@ -10,5 +10,6 @@ public interface SparkExecutionEngineConfigSupplier {
    *
    * @return {@link SparkExecutionEngineConfig}.
    */
-  SparkExecutionEngineConfig getSparkExecutionEngineConfig(RequestContext requestContext);
+  SparkExecutionEngineConfig getSparkExecutionEngineConfig(
+      AsyncQueryRequestContext asyncQueryRequestContext);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImpl.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImpl.java
@@ -9,7 +9,7 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.sql.common.setting.Settings;
-import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 
 @AllArgsConstructor
 public class SparkExecutionEngineConfigSupplierImpl implements SparkExecutionEngineConfigSupplier {
@@ -17,7 +17,8 @@ public class SparkExecutionEngineConfigSupplierImpl implements SparkExecutionEng
   private Settings settings;
 
   @Override
-  public SparkExecutionEngineConfig getSparkExecutionEngineConfig(RequestContext requestContext) {
+  public SparkExecutionEngineConfig getSparkExecutionEngineConfig(
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     ClusterName clusterName = settings.getSettingValue(CLUSTER_NAME);
     return getBuilderFromSettingsIfAvailable().clusterName(clusterName.value()).build();
   }

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
@@ -72,7 +73,8 @@ public class IndexDMLHandler extends AsyncQueryHandler {
               dataSourceMetadata,
               JobRunState.SUCCESS.toString(),
               StringUtils.EMPTY,
-              getElapsedTimeSince(startTime));
+              getElapsedTimeSince(startTime),
+              context.getAsyncQueryRequestContext());
       return DispatchQueryResponse.builder()
           .queryId(asyncQueryId)
           .jobId(DML_QUERY_JOB_ID)
@@ -89,7 +91,8 @@ public class IndexDMLHandler extends AsyncQueryHandler {
               dataSourceMetadata,
               JobRunState.FAILED.toString(),
               e.getMessage(),
-              getElapsedTimeSince(startTime));
+              getElapsedTimeSince(startTime),
+              context.getAsyncQueryRequestContext());
       return DispatchQueryResponse.builder()
           .queryId(asyncQueryId)
           .jobId(DML_QUERY_JOB_ID)
@@ -106,7 +109,8 @@ public class IndexDMLHandler extends AsyncQueryHandler {
       DataSourceMetadata dataSourceMetadata,
       String status,
       String error,
-      long queryRunTime) {
+      long queryRunTime,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     IndexDMLResult indexDMLResult =
         IndexDMLResult.builder()
             .queryId(queryId)
@@ -116,7 +120,7 @@ public class IndexDMLHandler extends AsyncQueryHandler {
             .queryRunTime(queryRunTime)
             .updateTime(System.currentTimeMillis())
             .build();
-    indexDMLResultStorageService.createIndexDMLResult(indexDMLResult);
+    indexDMLResultStorageService.createIndexDMLResult(indexDMLResult, asyncQueryRequestContext);
     return queryId;
   }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -111,14 +111,16 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
                       .acceptModifier(dispatchQueryRequest.getSparkSubmitParameterModifier()),
                   tags,
                   dataSourceMetadata.getResultIndex(),
-                  dataSourceMetadata.getName()));
+                  dataSourceMetadata.getName()),
+              context.getAsyncQueryRequestContext());
       MetricUtils.incrementNumericalMetric(MetricName.EMR_INTERACTIVE_QUERY_JOBS_CREATION_COUNT);
     }
     session.submit(
         new QueryRequest(
             context.getQueryId(),
             dispatchQueryRequest.getLangType(),
-            dispatchQueryRequest.getQuery()));
+            dispatchQueryRequest.getQuery()),
+        context.getAsyncQueryRequestContext());
     return DispatchQueryResponse.builder()
         .queryId(context.getQueryId())
         .jobId(session.getSessionModel().getJobId())

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
@@ -37,7 +38,9 @@ public class SparkQueryDispatcher {
   private final QueryHandlerFactory queryHandlerFactory;
   private final QueryIdProvider queryIdProvider;
 
-  public DispatchQueryResponse dispatch(DispatchQueryRequest dispatchQueryRequest) {
+  public DispatchQueryResponse dispatch(
+      DispatchQueryRequest dispatchQueryRequest,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     DataSourceMetadata dataSourceMetadata =
         this.dataSourceService.verifyDataSourceAccessAndGetRawMetadata(
             dispatchQueryRequest.getDatasource());
@@ -48,13 +51,16 @@ public class SparkQueryDispatcher {
       DispatchQueryContext context =
           getDefaultDispatchContextBuilder(dispatchQueryRequest, dataSourceMetadata)
               .indexQueryDetails(indexQueryDetails)
+              .asyncQueryRequestContext(asyncQueryRequestContext)
               .build();
 
       return getQueryHandlerForFlintExtensionQuery(indexQueryDetails)
           .submit(dispatchQueryRequest, context);
     } else {
       DispatchQueryContext context =
-          getDefaultDispatchContextBuilder(dispatchQueryRequest, dataSourceMetadata).build();
+          getDefaultDispatchContextBuilder(dispatchQueryRequest, dataSourceMetadata)
+              .asyncQueryRequestContext(asyncQueryRequestContext)
+              .build();
       return getDefaultAsyncQueryHandler().submit(dispatchQueryRequest, context);
     }
   }

--- a/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryContext.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryContext.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 
 @Getter
 @Builder
@@ -17,4 +18,5 @@ public class DispatchQueryContext {
   private final DataSourceMetadata dataSourceMetadata;
   private final Map<String, String> tags;
   private final IndexQueryDetails indexQueryDetails;
+  private final AsyncQueryRequestContext asyncQueryRequestContext;
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/Session.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/Session.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.spark.execution.session;
 
 import java.util.Optional;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.statement.QueryRequest;
 import org.opensearch.sql.spark.execution.statement.Statement;
 import org.opensearch.sql.spark.execution.statement.StatementId;
@@ -13,7 +14,8 @@ import org.opensearch.sql.spark.execution.statement.StatementId;
 /** Session define the statement execution context. Each session is binding to one Spark Job. */
 public interface Session {
   /** open session. */
-  void open(CreateSessionRequest createSessionRequest);
+  void open(
+      CreateSessionRequest createSessionRequest, AsyncQueryRequestContext asyncQueryRequestContext);
 
   /** close session. */
   void close();
@@ -22,9 +24,10 @@ public interface Session {
    * submit {@link QueryRequest}.
    *
    * @param request {@link QueryRequest}
+   * @param asyncQueryRequestContext {@link AsyncQueryRequestContext}
    * @return {@link StatementId}
    */
-  StatementId submit(QueryRequest request);
+  StatementId submit(QueryRequest request, AsyncQueryRequestContext asyncQueryRequestContext);
 
   /**
    * get {@link Statement}.

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/session/SessionManager.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/session/SessionManager.java
@@ -9,6 +9,7 @@ import static org.opensearch.sql.spark.execution.session.SessionId.newSessionId;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statestore.SessionStorageService;
 import org.opensearch.sql.spark.execution.statestore.StatementStorageService;
@@ -26,7 +27,8 @@ public class SessionManager {
   private final EMRServerlessClientFactory emrServerlessClientFactory;
   private final SessionConfigSupplier sessionConfigSupplier;
 
-  public Session createSession(CreateSessionRequest request) {
+  public Session createSession(
+      CreateSessionRequest request, AsyncQueryRequestContext asyncQueryRequestContext) {
     InteractiveSession session =
         InteractiveSession.builder()
             .sessionId(newSessionId(request.getDatasourceName()))
@@ -34,7 +36,7 @@ public class SessionManager {
             .statementStorageService(statementStorageService)
             .serverlessClient(emrServerlessClientFactory.getClient())
             .build();
-    session.open(request);
+    session.open(request, asyncQueryRequestContext);
     return session;
   }
 

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statement/Statement.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statement/Statement.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.index.engine.DocumentMissingException;
 import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.session.SessionId;
 import org.opensearch.sql.spark.execution.statestore.StatementStorageService;
 import org.opensearch.sql.spark.rest.model.LangType;
@@ -34,6 +35,7 @@ public class Statement {
   private final String datasourceName;
   private final String query;
   private final String queryId;
+  private final AsyncQueryRequestContext asyncQueryRequestContext;
   private final StatementStorageService statementStorageService;
 
   @Setter private StatementModel statementModel;
@@ -52,7 +54,8 @@ public class Statement {
               datasourceName,
               query,
               queryId);
-      statementModel = statementStorageService.createStatement(statementModel);
+      statementModel =
+          statementStorageService.createStatement(statementModel, asyncQueryRequestContext);
     } catch (VersionConflictEngineException e) {
       String errorMsg = "statement already exist. " + statementId;
       LOG.error(errorMsg);

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchSessionStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchSessionStorageService.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.spark.execution.statestore;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.session.SessionModel;
 import org.opensearch.sql.spark.execution.session.SessionState;
 import org.opensearch.sql.spark.execution.xcontent.SessionModelXContentSerializer;
@@ -18,7 +19,8 @@ public class OpenSearchSessionStorageService implements SessionStorageService {
   private final SessionModelXContentSerializer serializer;
 
   @Override
-  public SessionModel createSession(SessionModel sessionModel) {
+  public SessionModel createSession(
+      SessionModel sessionModel, AsyncQueryRequestContext asyncQueryRequestContext) {
     return stateStore.create(
         sessionModel.getId(),
         sessionModel,

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStatementStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStatementStorageService.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.spark.execution.statestore;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.statement.StatementModel;
 import org.opensearch.sql.spark.execution.statement.StatementState;
 import org.opensearch.sql.spark.execution.xcontent.StatementModelXContentSerializer;
@@ -18,7 +19,8 @@ public class OpenSearchStatementStorageService implements StatementStorageServic
   private final StatementModelXContentSerializer serializer;
 
   @Override
-  public StatementModel createStatement(StatementModel statementModel) {
+  public StatementModel createStatement(
+      StatementModel statementModel, AsyncQueryRequestContext asyncQueryRequestContext) {
     return stateStore.create(
         statementModel.getId(),
         statementModel,

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/SessionStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/SessionStorageService.java
@@ -6,13 +6,15 @@
 package org.opensearch.sql.spark.execution.statestore;
 
 import java.util.Optional;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.session.SessionModel;
 import org.opensearch.sql.spark.execution.session.SessionState;
 
 /** Interface for accessing {@link SessionModel} data storage. */
 public interface SessionStorageService {
 
-  SessionModel createSession(SessionModel sessionModel);
+  SessionModel createSession(
+      SessionModel sessionModel, AsyncQueryRequestContext asyncQueryRequestContext);
 
   Optional<SessionModel> getSession(String id, String datasourceName);
 

--- a/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StatementStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/execution/statestore/StatementStorageService.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.spark.execution.statestore;
 
 import java.util.Optional;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.statement.StatementModel;
 import org.opensearch.sql.spark.execution.statement.StatementState;
 
@@ -15,7 +16,8 @@ import org.opensearch.sql.spark.execution.statement.StatementState;
  */
 public interface StatementStorageService {
 
-  StatementModel createStatement(StatementModel statementModel);
+  StatementModel createStatement(
+      StatementModel statementModel, AsyncQueryRequestContext asyncQueryRequestContext);
 
   StatementModel updateStatementState(
       StatementModel oldStatementModel, StatementState statementState);

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/IndexDMLResultStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/IndexDMLResultStorageService.java
@@ -5,11 +5,13 @@
 
 package org.opensearch.sql.spark.flint;
 
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.IndexDMLResult;
 
 /**
  * Abstraction over the IndexDMLResult storage. It stores the result of IndexDML query execution.
  */
 public interface IndexDMLResultStorageService {
-  IndexDMLResult createIndexDMLResult(IndexDMLResult result);
+  IndexDMLResult createIndexDMLResult(
+      IndexDMLResult result, AsyncQueryRequestContext asyncQueryRequestContext);
 }

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/OpenSearchIndexDMLResultStorageService.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/OpenSearchIndexDMLResultStorageService.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.spark.flint;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.IndexDMLResult;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 
@@ -18,7 +19,8 @@ public class OpenSearchIndexDMLResultStorageService implements IndexDMLResultSto
   private final StateStore stateStore;
 
   @Override
-  public IndexDMLResult createIndexDMLResult(IndexDMLResult result) {
+  public IndexDMLResult createIndexDMLResult(
+      IndexDMLResult result, AsyncQueryRequestContext asyncQueryRequestContexts) {
     DataSourceMetadata dataSourceMetadata =
         dataSourceService.getDataSourceMetadata(result.getDatasourceName());
     return stateStore.create(

--- a/spark/src/main/java/org/opensearch/sql/spark/transport/TransportCreateAsyncQueryRequestAction.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/transport/TransportCreateAsyncQueryRequestAction.java
@@ -18,7 +18,7 @@ import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorService;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorServiceImpl;
-import org.opensearch.sql.spark.asyncquery.model.NullRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.NullAsyncQueryRequestContext;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryRequest;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryResponse;
 import org.opensearch.sql.spark.transport.model.CreateAsyncQueryActionRequest;
@@ -66,7 +66,7 @@ public class TransportCreateAsyncQueryRequestAction
       CreateAsyncQueryRequest createAsyncQueryRequest = request.getCreateAsyncQueryRequest();
       CreateAsyncQueryResponse createAsyncQueryResponse =
           asyncQueryExecutorService.createAsyncQuery(
-              createAsyncQueryRequest, new NullRequestContext());
+              createAsyncQueryRequest, new NullAsyncQueryRequestContext());
       String responseContent =
           new JsonResponseFormatter<CreateAsyncQueryResponse>(JsonResponseFormatter.Style.PRETTY) {
             @Override

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.spark.asyncquery;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -31,7 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
-import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.config.OpenSearchSparkSubmitParameterModifier;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
@@ -53,7 +54,7 @@ public class AsyncQueryExecutorServiceImplTest {
 
   @Mock private SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier;
   @Mock private SparkSubmitParameterModifier sparkSubmitParameterModifier;
-  @Mock private RequestContext requestContext;
+  @Mock private AsyncQueryRequestContext asyncQueryRequestContext;
   private final String QUERY_ID = "QUERY_ID";
 
   @BeforeEach
@@ -89,7 +90,7 @@ public class AsyncQueryExecutorServiceImplTest {
             .clusterName(TEST_CLUSTER_NAME)
             .sparkSubmitParameterModifier(sparkSubmitParameterModifier)
             .build();
-    when(sparkQueryDispatcher.dispatch(expectedDispatchQueryRequest))
+    when(sparkQueryDispatcher.dispatch(expectedDispatchQueryRequest, asyncQueryRequestContext))
         .thenReturn(
             DispatchQueryResponse.builder()
                 .queryId(QUERY_ID)
@@ -98,15 +99,16 @@ public class AsyncQueryExecutorServiceImplTest {
                 .build());
 
     CreateAsyncQueryResponse createAsyncQueryResponse =
-        jobExecutorService.createAsyncQuery(createAsyncQueryRequest, requestContext);
+        jobExecutorService.createAsyncQuery(createAsyncQueryRequest, asyncQueryRequestContext);
 
     verify(asyncQueryJobMetadataStorageService, times(1))
-        .storeJobMetadata(getAsyncQueryJobMetadata());
+        .storeJobMetadata(getAsyncQueryJobMetadata(), asyncQueryRequestContext);
     verify(sparkExecutionEngineConfigSupplier, times(1))
-        .getSparkExecutionEngineConfig(requestContext);
+        .getSparkExecutionEngineConfig(asyncQueryRequestContext);
     verify(sparkExecutionEngineConfigSupplier, times(1))
-        .getSparkExecutionEngineConfig(requestContext);
-    verify(sparkQueryDispatcher, times(1)).dispatch(expectedDispatchQueryRequest);
+        .getSparkExecutionEngineConfig(asyncQueryRequestContext);
+    verify(sparkQueryDispatcher, times(1))
+        .dispatch(expectedDispatchQueryRequest, asyncQueryRequestContext);
     Assertions.assertEquals(QUERY_ID, createAsyncQueryResponse.getQueryId());
   }
 
@@ -124,7 +126,7 @@ public class AsyncQueryExecutorServiceImplTest {
                 .sparkSubmitParameterModifier(modifier)
                 .clusterName(TEST_CLUSTER_NAME)
                 .build());
-    when(sparkQueryDispatcher.dispatch(any()))
+    when(sparkQueryDispatcher.dispatch(any(), any()))
         .thenReturn(
             DispatchQueryResponse.builder()
                 .queryId(QUERY_ID)
@@ -135,11 +137,12 @@ public class AsyncQueryExecutorServiceImplTest {
     jobExecutorService.createAsyncQuery(
         new CreateAsyncQueryRequest(
             "select * from my_glue.default.http_logs", "my_glue", LangType.SQL),
-        requestContext);
+        asyncQueryRequestContext);
 
     verify(sparkQueryDispatcher, times(1))
         .dispatch(
-            argThat(actualReq -> actualReq.getSparkSubmitParameterModifier().equals(modifier)));
+            argThat(actualReq -> actualReq.getSparkSubmitParameterModifier().equals(modifier)),
+            eq(asyncQueryRequestContext));
   }
 
   @Test
@@ -165,6 +168,7 @@ public class AsyncQueryExecutorServiceImplTest {
     JSONObject jobResult = new JSONObject();
     jobResult.put("status", JobRunState.PENDING.toString());
     when(sparkQueryDispatcher.getQueryResponse(getAsyncQueryJobMetadata())).thenReturn(jobResult);
+
     AsyncQueryExecutionResponse asyncQueryExecutionResponse =
         jobExecutorService.getAsyncQueryResults(EMR_JOB_ID);
 

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceSpec.java
@@ -52,7 +52,7 @@ import org.opensearch.sql.datasources.storage.OpenSearchDataSourceMetadataStorag
 import org.opensearch.sql.legacy.esdomain.LocalClusterState;
 import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
-import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.client.StartJobRequest;
@@ -104,7 +104,7 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
   protected StateStore stateStore;
   protected SessionStorageService sessionStorageService;
   protected StatementStorageService statementStorageService;
-  protected RequestContext requestContext;
+  protected AsyncQueryRequestContext asyncQueryRequestContext;
 
   @Override
   protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -342,7 +342,8 @@ public class AsyncQueryExecutorServiceSpec extends OpenSearchIntegTestCase {
     }
   }
 
-  public SparkExecutionEngineConfig sparkExecutionEngineConfig(RequestContext requestContext) {
+  public SparkExecutionEngineConfig sparkExecutionEngineConfig(
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     return SparkExecutionEngineConfig.builder()
         .applicationId("appId")
         .region("us-west-2")

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
@@ -24,10 +24,10 @@ import org.opensearch.sql.executor.pagination.Cursor;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.sql.protocol.response.format.ResponseFormatter;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryResult;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
-import org.opensearch.sql.spark.asyncquery.model.NullRequestContext;
-import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.NullAsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.execution.statement.StatementModel;
 import org.opensearch.sql.spark.execution.statement.StatementState;
@@ -40,7 +40,7 @@ import org.opensearch.sql.spark.rest.model.LangType;
 import org.opensearch.sql.spark.transport.format.AsyncQueryResultResponseFormatter;
 
 public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
-  RequestContext requestContext = new NullRequestContext();
+  AsyncQueryRequestContext asyncQueryRequestContext = new NullAsyncQueryRequestContext();
 
   /** Mock Flint index and index state */
   private final FlintDatasetMock mockIndex =
@@ -440,7 +440,7 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
       this.createQueryResponse =
           queryService.createAsyncQuery(
               new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
-              requestContext);
+              asyncQueryRequestContext);
     }
 
     AssertionHelper withInteraction(Interaction interaction) {

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
@@ -77,7 +77,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -146,7 +146,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -228,7 +228,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -292,7 +292,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               assertEquals(
@@ -358,7 +358,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               assertEquals(
@@ -433,7 +433,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -508,7 +508,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -577,7 +577,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -639,7 +639,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -703,7 +703,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -767,7 +767,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -828,7 +828,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -887,7 +887,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -954,7 +954,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -1019,7 +1019,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -1085,7 +1085,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.getQuery(), MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -136,7 +136,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               assertNotNull(response.getQueryId());
               assertTrue(clusterService.state().routingTable().hasIndex(mockDS.indexName));
@@ -187,7 +187,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2.fetch result.
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -227,7 +227,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -264,7 +264,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(mockDS.query, MYGLUE_DATASOURCE, LangType.SQL, null),
-            requestContext);
+            asyncQueryRequestContext);
 
     // 2.fetch result.
     AsyncQueryExecutionResponse asyncQueryResults =
@@ -307,7 +307,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               assertNotNull(response.getQueryId());
               assertTrue(clusterService.state().routingTable().hasIndex(mockDS.indexName));
@@ -367,7 +367,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2.fetch result.
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -414,7 +414,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -460,7 +460,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               assertEquals(
@@ -511,7 +511,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
@@ -559,7 +559,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               assertEquals(
@@ -606,7 +606,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               assertEquals(
@@ -661,7 +661,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
                   asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
@@ -706,7 +706,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(mockDS.query, MYGLUE_DATASOURCE, LangType.SQL, null),
-            requestContext);
+            asyncQueryRequestContext);
 
     // 2.fetch result.
     AsyncQueryExecutionResponse asyncQueryResults =
@@ -754,7 +754,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
@@ -784,7 +784,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
-            requestContext);
+            asyncQueryRequestContext);
     assertNull(response.getSessionId());
   }
 
@@ -813,7 +813,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
             () ->
                 asyncQueryExecutorService.createAsyncQuery(
                     new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
-                    requestContext));
+                    asyncQueryRequestContext));
     assertEquals("domain concurrent refresh job can not exceed 1", exception.getMessage());
   }
 
@@ -840,7 +840,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
             () ->
                 asyncQueryExecutorService.createAsyncQuery(
                     new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
-                    requestContext));
+                    asyncQueryRequestContext));
     assertEquals("domain concurrent refresh job can not exceed 1", exception.getMessage());
   }
 
@@ -863,7 +863,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     CreateAsyncQueryResponse asyncQueryResponse =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
-            requestContext);
+            asyncQueryRequestContext);
     assertNotNull(asyncQueryResponse.getSessionId());
   }
 
@@ -896,7 +896,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               CreateAsyncQueryResponse response =
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(query, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
 
               // 2. cancel query
               IllegalArgumentException exception =
@@ -940,7 +940,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.refreshQuery, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
               // mock index state.
               flintIndexJob.refreshing();
 
@@ -985,7 +985,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.createAsyncQuery(
                       new CreateAsyncQueryRequest(
                           mockDS.refreshQuery, MYS3_DATASOURCE, LangType.SQL, null),
-                      requestContext);
+                      asyncQueryRequestContext);
               // mock index state.
               flintIndexJob.active();
 
@@ -1032,7 +1032,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                 MYS3_DATASOURCE,
                 LangType.SQL,
                 null),
-            requestContext);
+            asyncQueryRequestContext);
     // mock index state.
     flintIndexJob.refreshing();
 

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
@@ -172,7 +172,7 @@ public class IndexQuerySpecVacuumTest extends AsyncQueryExecutorServiceSpec {
     CreateAsyncQueryResponse response =
         asyncQueryExecutorService.createAsyncQuery(
             new CreateAsyncQueryRequest(mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
-            requestContext);
+            asyncQueryRequestContext);
 
     return asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
   }

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/OpenSearchAsyncQueryJobMetadataStorageServiceTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/OpenSearchAsyncQueryJobMetadataStorageServiceTest.java
@@ -14,6 +14,8 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.NullAsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.execution.xcontent.AsyncQueryJobMetadataXContentSerializer;
 import org.opensearch.sql.spark.utils.IDUtils;
@@ -26,6 +28,7 @@ public class OpenSearchAsyncQueryJobMetadataStorageServiceTest extends OpenSearc
   private static final String MOCK_RESULT_INDEX = "resultIndex";
   private static final String MOCK_QUERY_ID = "00fdo6u94n7abo0q";
   private OpenSearchAsyncQueryJobMetadataStorageService openSearchJobMetadataStorageService;
+  private AsyncQueryRequestContext asyncQueryRequestContext = new NullAsyncQueryRequestContext();
 
   @Before
   public void setup() {
@@ -46,7 +49,7 @@ public class OpenSearchAsyncQueryJobMetadataStorageServiceTest extends OpenSearc
             .datasourceName(DS_NAME)
             .build();
 
-    openSearchJobMetadataStorageService.storeJobMetadata(expected);
+    openSearchJobMetadataStorageService.storeJobMetadata(expected, asyncQueryRequestContext);
     Optional<AsyncQueryJobMetadata> actual =
         openSearchJobMetadataStorageService.getJobMetadata(expected.getQueryId());
 
@@ -68,7 +71,7 @@ public class OpenSearchAsyncQueryJobMetadataStorageServiceTest extends OpenSearc
             .datasourceName(DS_NAME)
             .build();
 
-    openSearchJobMetadataStorageService.storeJobMetadata(expected);
+    openSearchJobMetadataStorageService.storeJobMetadata(expected, asyncQueryRequestContext);
     Optional<AsyncQueryJobMetadata> actual =
         openSearchJobMetadataStorageService.getJobMetadata(expected.getQueryId());
 

--- a/spark/src/test/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImplTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplierImplTest.java
@@ -15,14 +15,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.sql.common.setting.Settings;
-import org.opensearch.sql.spark.asyncquery.model.RequestContext;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.asyncquery.model.SparkSubmitParameters;
 
 @ExtendWith(MockitoExtension.class)
 public class SparkExecutionEngineConfigSupplierImplTest {
 
   @Mock private Settings settings;
-  @Mock private RequestContext requestContext;
+  @Mock private AsyncQueryRequestContext asyncQueryRequestContext;
 
   @Test
   void testGetSparkExecutionEngineConfig() {
@@ -34,7 +34,7 @@ public class SparkExecutionEngineConfigSupplierImplTest {
         .thenReturn(new ClusterName(TEST_CLUSTER_NAME));
 
     SparkExecutionEngineConfig sparkExecutionEngineConfig =
-        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(requestContext);
+        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(asyncQueryRequestContext);
     SparkSubmitParameters parameters = SparkSubmitParameters.builder().build();
     sparkExecutionEngineConfig.getSparkSubmitParameterModifier().modifyParameters(parameters);
 
@@ -63,7 +63,7 @@ public class SparkExecutionEngineConfigSupplierImplTest {
         .thenReturn(new ClusterName(TEST_CLUSTER_NAME));
 
     SparkExecutionEngineConfig sparkExecutionEngineConfig =
-        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(requestContext);
+        sparkExecutionEngineConfigSupplier.getSparkExecutionEngineConfig(asyncQueryRequestContext);
 
     Assertions.assertNull(sparkExecutionEngineConfig.getApplicationId());
     Assertions.assertNull(sparkExecutionEngineConfig.getExecutionRoleARN());

--- a/spark/src/test/java/org/opensearch/sql/spark/execution/session/InteractiveSessionTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/execution/session/InteractiveSessionTest.java
@@ -18,6 +18,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.NullAsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.dispatcher.model.JobType;
@@ -43,6 +45,7 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
   private StatementStorageService statementStorageService;
   private SessionConfigSupplier sessionConfigSupplier = () -> 600000L;
   private SessionManager sessionManager;
+  private AsyncQueryRequestContext asyncQueryRequestContext = new NullAsyncQueryRequestContext();
 
   @Before
   public void setup() {
@@ -106,7 +109,7 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
             .statementStorageService(statementStorageService)
             .serverlessClient(emrsClient)
             .build();
-    session.open(createSessionRequest());
+    session.open(createSessionRequest(), asyncQueryRequestContext);
 
     InteractiveSession duplicateSession =
         InteractiveSession.builder()
@@ -117,7 +120,8 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
             .build();
     IllegalStateException exception =
         assertThrows(
-            IllegalStateException.class, () -> duplicateSession.open(createSessionRequest()));
+            IllegalStateException.class,
+            () -> duplicateSession.open(createSessionRequest(), asyncQueryRequestContext));
     assertEquals("session already exist. " + sessionId, exception.getMessage());
   }
 
@@ -131,7 +135,7 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
             .statementStorageService(statementStorageService)
             .serverlessClient(emrsClient)
             .build();
-    session.open(createSessionRequest());
+    session.open(createSessionRequest(), asyncQueryRequestContext);
 
     client().delete(new DeleteRequest(indexName, sessionId.getSessionId())).actionGet();
 
@@ -142,7 +146,8 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void sessionManagerCreateSession() {
-    Session session = sessionManager.createSession(createSessionRequest());
+    Session session =
+        sessionManager.createSession(createSessionRequest(), asyncQueryRequestContext);
 
     new SessionAssertions(session)
         .assertSessionState(NOT_STARTED)
@@ -152,7 +157,8 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
 
   @Test
   public void sessionManagerGetSession() {
-    Session session = sessionManager.createSession(createSessionRequest());
+    Session session =
+        sessionManager.createSession(createSessionRequest(), asyncQueryRequestContext);
 
     Optional<Session> managerSession = sessionManager.getSession(session.getSessionId());
     assertTrue(managerSession.isPresent());
@@ -192,7 +198,7 @@ public class InteractiveSessionTest extends OpenSearchIntegTestCase {
     }
 
     public SessionAssertions open(CreateSessionRequest req) {
-      session.open(req);
+      session.open(req, asyncQueryRequestContext);
       return this;
     }
 


### PR DESCRIPTION
### Description
- Pass down request context to data accessors to allow data accessors to use the information passed in the context.
- Renamed the class name to AsyncQueryRequestContext to make it more specific and avoid confusion.

### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).