### PR TITLE
Validate index refreshing state before cancel job

### DIFF
--- a/spark/src/main/antlr/SqlBaseLexer.g4
+++ b/spark/src/main/antlr/SqlBaseLexer.g4
@@ -69,6 +69,35 @@ lexer grammar SqlBaseLexer;
   public void markUnclosedComment() {
     has_unclosed_bracketed_comment = true;
   }
+
+  /**
+   * When greater than zero, it's in the middle of parsing ARRAY/MAP/STRUCT type.
+   */
+  public int complex_type_level_counter = 0;
+
+  /**
+   * Increase the counter by one when hits KEYWORD 'ARRAY', 'MAP', 'STRUCT'.
+   */
+  public void incComplexTypeLevelCounter() {
+    complex_type_level_counter++;
+  }
+
+  /**
+   * Decrease the counter by one when hits close tag '>' && the counter greater than zero
+   * which means we are in the middle of complex type parsing. Otherwise, it's a dangling
+   * GT token and we do nothing.
+   */
+  public void decComplexTypeLevelCounter() {
+    if (complex_type_level_counter > 0) complex_type_level_counter--;
+  }
+
+  /**
+   * If the counter is zero, it's a shift right operator. It can be closing tags of an complex
+   * type definition, such as MAP<INT, ARRAY<INT>>.
+   */
+  public boolean isShiftRightOperator() {
+    return complex_type_level_counter == 0 ? true : false;
+  }
 }
 
 SEMICOLON: ';';
@@ -100,7 +129,7 @@ ANTI: 'ANTI';
 ANY: 'ANY';
 ANY_VALUE: 'ANY_VALUE';
 ARCHIVE: 'ARCHIVE';
-ARRAY: 'ARRAY';
+ARRAY: 'ARRAY' {incComplexTypeLevelCounter();};
 AS: 'AS';
 ASC: 'ASC';
 AT: 'AT';
@@ -108,6 +137,7 @@ AUTHORIZATION: 'AUTHORIZATION';
 BETWEEN: 'BETWEEN';
 BIGINT: 'BIGINT';
 BINARY: 'BINARY';
+BINDING: 'BINDING';
 BOOLEAN: 'BOOLEAN';
 BOTH: 'BOTH';
 BUCKET: 'BUCKET';
@@ -137,6 +167,7 @@ COMMENT: 'COMMENT';
 COMMIT: 'COMMIT';
 COMPACT: 'COMPACT';
 COMPACTIONS: 'COMPACTIONS';
+COMPENSATION: 'COMPENSATION';
 COMPUTE: 'COMPUTE';
 CONCATENATE: 'CONCATENATE';
 CONSTRAINT: 'CONSTRAINT';
@@ -257,7 +288,7 @@ LOCKS: 'LOCKS';
 LOGICAL: 'LOGICAL';
 LONG: 'LONG';
 MACRO: 'MACRO';
-MAP: 'MAP';
+MAP: 'MAP' {incComplexTypeLevelCounter();};
 MATCHED: 'MATCHED';
 MERGE: 'MERGE';
 MICROSECOND: 'MICROSECOND';
@@ -298,8 +329,6 @@ OVERWRITE: 'OVERWRITE';
 PARTITION: 'PARTITION';
 PARTITIONED: 'PARTITIONED';
 PARTITIONS: 'PARTITIONS';
-PERCENTILE_CONT: 'PERCENTILE_CONT';
-PERCENTILE_DISC: 'PERCENTILE_DISC';
 PERCENTLIT: 'PERCENT';
 PIVOT: 'PIVOT';
 PLACING: 'PLACING';
@@ -362,7 +391,7 @@ STATISTICS: 'STATISTICS';
 STORED: 'STORED';
 STRATIFY: 'STRATIFY';
 STRING: 'STRING';
-STRUCT: 'STRUCT';
+STRUCT: 'STRUCT' {incComplexTypeLevelCounter();};
 SUBSTR: 'SUBSTR';
 SUBSTRING: 'SUBSTRING';
 SYNC: 'SYNC';
@@ -439,8 +468,11 @@ NEQ : '<>';
 NEQJ: '!=';
 LT  : '<';
 LTE : '<=' | '!>';
-GT  : '>';
+GT  : '>' {decComplexTypeLevelCounter();};
 GTE : '>=' | '!<';
+SHIFT_LEFT: '<<';
+SHIFT_RIGHT: '>>' {isShiftRightOperator()}?;
+SHIFT_RIGHT_UNSIGNED: '>>>' {isShiftRightOperator()}?;
 
 PLUS: '+';
 MINUS: '-';

--- a/spark/src/main/antlr/SqlBaseParser.g4
+++ b/spark/src/main/antlr/SqlBaseParser.g4
@@ -77,7 +77,7 @@ statement
     | USE identifierReference                                          #use
     | USE namespace identifierReference                                #useNamespace
     | SET CATALOG (errorCapturingIdentifier | stringLit)                  #setCatalog
-    | CREATE namespace (IF NOT EXISTS)? identifierReference
+    | CREATE namespace (IF errorCapturingNot EXISTS)? identifierReference
         (commentSpec |
          locationSpec |
          (WITH (DBPROPERTIES | PROPERTIES) propertyList))*             #createNamespace
@@ -92,7 +92,7 @@ statement
     | createTableHeader (LEFT_PAREN createOrReplaceTableColTypeList RIGHT_PAREN)? tableProvider?
         createTableClauses
         (AS? query)?                                                   #createTable
-    | CREATE TABLE (IF NOT EXISTS)? target=tableIdentifier
+    | CREATE TABLE (IF errorCapturingNot EXISTS)? target=tableIdentifier
         LIKE source=tableIdentifier
         (tableProvider |
         rowFormat |
@@ -141,7 +141,7 @@ statement
         SET SERDE stringLit (WITH SERDEPROPERTIES propertyList)?       #setTableSerDe
     | ALTER TABLE identifierReference (partitionSpec)?
         SET SERDEPROPERTIES propertyList                               #setTableSerDe
-    | ALTER (TABLE | VIEW) identifierReference ADD (IF NOT EXISTS)?
+    | ALTER (TABLE | VIEW) identifierReference ADD (IF errorCapturingNot EXISTS)?
         partitionSpecLocation+                                         #addTablePartition
     | ALTER TABLE identifierReference
         from=partitionSpec RENAME TO to=partitionSpec                  #renameTablePartition
@@ -153,9 +153,10 @@ statement
     | DROP TABLE (IF EXISTS)? identifierReference PURGE?               #dropTable
     | DROP VIEW (IF EXISTS)? identifierReference                       #dropView
     | CREATE (OR REPLACE)? (GLOBAL? TEMPORARY)?
-        VIEW (IF NOT EXISTS)? identifierReference
+        VIEW (IF errorCapturingNot EXISTS)? identifierReference
         identifierCommentList?
         (commentSpec |
+         schemaBinding |
          (PARTITIONED ON identifierList) |
          (TBLPROPERTIES propertyList))*
         AS query                                                       #createView
@@ -163,7 +164,8 @@ statement
         tableIdentifier (LEFT_PAREN colTypeList RIGHT_PAREN)? tableProvider
         (OPTIONS propertyList)?                                        #createTempViewUsing
     | ALTER VIEW identifierReference AS? query                         #alterViewQuery
-    | CREATE (OR REPLACE)? TEMPORARY? FUNCTION (IF NOT EXISTS)?
+    | ALTER VIEW identifierReference schemaBinding                     #alterViewSchemaBinding
+    | CREATE (OR REPLACE)? TEMPORARY? FUNCTION (IF errorCapturingNot EXISTS)?
         identifierReference AS className=stringLit
         (USING resource (COMMA resource)*)?                            #createFunction
     | DROP TEMPORARY? FUNCTION (IF EXISTS)? identifierReference        #dropFunction
@@ -224,7 +226,7 @@ statement
     | SET .*?                                                          #setConfiguration
     | RESET configKey                                                  #resetQuotedConfiguration
     | RESET .*?                                                        #resetConfiguration
-    | CREATE INDEX (IF NOT EXISTS)? identifier ON TABLE?
+    | CREATE INDEX (IF errorCapturingNot EXISTS)? identifier ON TABLE?
         identifierReference (USING indexType=identifier)?
         LEFT_PAREN columns=multipartIdentifierPropertyList RIGHT_PAREN
         (OPTIONS options=propertyList)?                                #createIndex
@@ -315,7 +317,7 @@ unsupportedHiveNativeCommands
     ;
 
 createTableHeader
-    : CREATE TEMPORARY? EXTERNAL? TABLE (IF NOT EXISTS)? identifierReference
+    : CREATE TEMPORARY? EXTERNAL? TABLE (IF errorCapturingNot EXISTS)? identifierReference
     ;
 
 replaceTableHeader
@@ -342,6 +344,10 @@ locationSpec
     : LOCATION stringLit
     ;
 
+schemaBinding
+    : WITH SCHEMA (BINDING | COMPENSATION | EVOLUTION | TYPE EVOLUTION)
+    ;
+
 commentSpec
     : COMMENT stringLit
     ;
@@ -351,8 +357,8 @@ query
     ;
 
 insertInto
-    : INSERT OVERWRITE TABLE? identifierReference (partitionSpec (IF NOT EXISTS)?)?  ((BY NAME) | identifierList)? #insertOverwriteTable
-    | INSERT INTO TABLE? identifierReference partitionSpec? (IF NOT EXISTS)? ((BY NAME) | identifierList)?   #insertIntoTable
+    : INSERT OVERWRITE TABLE? identifierReference (partitionSpec (IF errorCapturingNot EXISTS)?)?  ((BY NAME) | identifierList)? #insertOverwriteTable
+    | INSERT INTO TABLE? identifierReference partitionSpec? (IF errorCapturingNot EXISTS)? ((BY NAME) | identifierList)?   #insertIntoTable
     | INSERT INTO TABLE? identifierReference REPLACE whereClause                                             #insertIntoReplaceWhere
     | INSERT OVERWRITE LOCAL? DIRECTORY path=stringLit rowFormat? createFileFormat?                     #insertOverwriteHiveDir
     | INSERT OVERWRITE LOCAL? DIRECTORY (path=stringLit)? tableProvider (OPTIONS options=propertyList)? #insertOverwriteDir
@@ -389,6 +395,7 @@ describeFuncName
     | comparisonOperator
     | arithmeticOperator
     | predicateOperator
+    | shiftOperator
     | BANG
     ;
 
@@ -588,11 +595,11 @@ matchedClause
     : WHEN MATCHED (AND matchedCond=booleanExpression)? THEN matchedAction
     ;
 notMatchedClause
-    : WHEN NOT MATCHED (BY TARGET)? (AND notMatchedCond=booleanExpression)? THEN notMatchedAction
+    : WHEN errorCapturingNot MATCHED (BY TARGET)? (AND notMatchedCond=booleanExpression)? THEN notMatchedAction
     ;
 
 notMatchedBySourceClause
-    : WHEN NOT MATCHED BY SOURCE (AND notMatchedBySourceCond=booleanExpression)? THEN notMatchedBySourceAction
+    : WHEN errorCapturingNot MATCHED BY SOURCE (AND notMatchedBySourceCond=booleanExpression)? THEN notMatchedBySourceAction
     ;
 
 matchedAction
@@ -838,9 +845,11 @@ tableArgumentPartitioning
     : ((WITH SINGLE PARTITION)
         | ((PARTITION | DISTRIBUTE) BY
             (((LEFT_PAREN partition+=expression (COMMA partition+=expression)* RIGHT_PAREN))
+            | (expression (COMMA invalidMultiPartitionExpression=expression)+)
             | partition+=expression)))
       ((ORDER | SORT) BY
         (((LEFT_PAREN sortItem (COMMA sortItem)* RIGHT_PAREN)
+        | (sortItem (COMMA invalidMultiSortItem=sortItem)+)
         | sortItem)))?
     ;
 
@@ -956,15 +965,20 @@ booleanExpression
     ;
 
 predicate
-    : NOT? kind=BETWEEN lower=valueExpression AND upper=valueExpression
-    | NOT? kind=IN LEFT_PAREN expression (COMMA expression)* RIGHT_PAREN
-    | NOT? kind=IN LEFT_PAREN query RIGHT_PAREN
-    | NOT? kind=RLIKE pattern=valueExpression
-    | NOT? kind=(LIKE | ILIKE) quantifier=(ANY | SOME | ALL) (LEFT_PAREN RIGHT_PAREN | LEFT_PAREN expression (COMMA expression)* RIGHT_PAREN)
-    | NOT? kind=(LIKE | ILIKE) pattern=valueExpression (ESCAPE escapeChar=stringLit)?
-    | IS NOT? kind=NULL
-    | IS NOT? kind=(TRUE | FALSE | UNKNOWN)
-    | IS NOT? kind=DISTINCT FROM right=valueExpression
+    : errorCapturingNot? kind=BETWEEN lower=valueExpression AND upper=valueExpression
+    | errorCapturingNot? kind=IN LEFT_PAREN expression (COMMA expression)* RIGHT_PAREN
+    | errorCapturingNot? kind=IN LEFT_PAREN query RIGHT_PAREN
+    | errorCapturingNot? kind=RLIKE pattern=valueExpression
+    | errorCapturingNot? kind=(LIKE | ILIKE) quantifier=(ANY | SOME | ALL) (LEFT_PAREN RIGHT_PAREN | LEFT_PAREN expression (COMMA expression)* RIGHT_PAREN)
+    | errorCapturingNot? kind=(LIKE | ILIKE) pattern=valueExpression (ESCAPE escapeChar=stringLit)?
+    | IS errorCapturingNot? kind=NULL
+    | IS errorCapturingNot? kind=(TRUE | FALSE | UNKNOWN)
+    | IS errorCapturingNot? kind=DISTINCT FROM right=valueExpression
+    ;
+
+errorCapturingNot
+    : NOT
+    | BANG
     ;
 
 valueExpression
@@ -972,10 +986,17 @@ valueExpression
     | operator=(MINUS | PLUS | TILDE) valueExpression                                        #arithmeticUnary
     | left=valueExpression operator=(ASTERISK | SLASH | PERCENT | DIV) right=valueExpression #arithmeticBinary
     | left=valueExpression operator=(PLUS | MINUS | CONCAT_PIPE) right=valueExpression       #arithmeticBinary
+    | left=valueExpression shiftOperator right=valueExpression                               #shiftExpression
     | left=valueExpression operator=AMPERSAND right=valueExpression                          #arithmeticBinary
     | left=valueExpression operator=HAT right=valueExpression                                #arithmeticBinary
     | left=valueExpression operator=PIPE right=valueExpression                               #arithmeticBinary
     | left=valueExpression comparisonOperator right=valueExpression                          #comparison
+    ;
+
+shiftOperator
+    : SHIFT_LEFT
+    | SHIFT_RIGHT
+    | SHIFT_RIGHT_UNSIGNED
     ;
 
 datetimeUnit
@@ -1143,7 +1164,7 @@ qualifiedColTypeWithPosition
     ;
 
 colDefinitionDescriptorWithPosition
-    : NOT NULL
+    : errorCapturingNot NULL
     | defaultExpression
     | commentSpec
     | colPosition
@@ -1162,7 +1183,7 @@ colTypeList
     ;
 
 colType
-    : colName=errorCapturingIdentifier dataType (NOT NULL)? commentSpec?
+    : colName=errorCapturingIdentifier dataType (errorCapturingNot NULL)? commentSpec?
     ;
 
 createOrReplaceTableColTypeList
@@ -1174,7 +1195,7 @@ createOrReplaceTableColType
     ;
 
 colDefinitionOption
-    : NOT NULL
+    : errorCapturingNot NULL
     | defaultExpression
     | generationExpression
     | commentSpec
@@ -1189,7 +1210,7 @@ complexColTypeList
     ;
 
 complexColType
-    : errorCapturingIdentifier COLON? dataType (NOT NULL)? commentSpec?
+    : errorCapturingIdentifier COLON? dataType (errorCapturingNot NULL)? commentSpec?
     ;
 
 whenClause
@@ -1296,7 +1317,7 @@ alterColumnAction
     : TYPE dataType
     | commentSpec
     | colPosition
-    | setOrDrop=(SET | DROP) NOT NULL
+    | setOrDrop=(SET | DROP) errorCapturingNot NULL
     | SET defaultExpression
     | dropDefault=DROP DEFAULT
     ;
@@ -1343,6 +1364,7 @@ ansiNonReserved
     | BIGINT
     | BINARY
     | BINARY_HEX
+    | BINDING
     | BOOLEAN
     | BUCKET
     | BUCKETS
@@ -1365,6 +1387,7 @@ ansiNonReserved
     | COMMIT
     | COMPACT
     | COMPACTIONS
+    | COMPENSATION
     | COMPUTE
     | CONCATENATE
     | COST
@@ -1643,6 +1666,7 @@ nonReserved
     | BIGINT
     | BINARY
     | BINARY_HEX
+    | BINDING
     | BOOLEAN
     | BOTH
     | BUCKET
@@ -1672,6 +1696,7 @@ nonReserved
     | COMMIT
     | COMPACT
     | COMPACTIONS
+    | COMPENSATION
     | COMPUTE
     | CONCATENATE
     | CONSTRAINT
@@ -1824,8 +1849,6 @@ nonReserved
     | PARTITION
     | PARTITIONED
     | PARTITIONS
-    | PERCENTILE_CONT
-    | PERCENTILE_DISC
     | PERCENTLIT
     | PIVOT
     | PLACING

--- a/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOp.java
+++ b/spark/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOp.java
@@ -80,6 +80,7 @@ public abstract class FlintIndexOp {
 
   private void takeActionWithoutOCC(FlintIndexMetadata metadata) {
     // take action without occ.
+    // indexState should be REFRESHING to allow for cancel streaming job.
     FlintIndexStateModel fakeModel =
         FlintIndexStateModel.builder()
             .indexState(FlintIndexState.REFRESHING)
@@ -90,6 +91,7 @@ public abstract class FlintIndexOp {
             .lastUpdateTime(System.currentTimeMillis())
             .error("")
             .build();
+    initialFlintIndexStateModel = fakeModel;
     runOp(metadata, fakeModel);
   }
 

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
@@ -7,8 +7,6 @@ import com.amazonaws.services.emrserverless.model.ValidationException;
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
@@ -13,7 +13,6 @@ import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintIndex;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
-import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.flint.FlintIndexState;
 import org.opensearch.sql.spark.flint.FlintIndexType;
 import org.opensearch.sql.spark.rest.model.CreateAsyncQueryRequest;
@@ -1006,8 +1005,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(1);
               emrsClient.getJobRunResultCalled(0);
-              // TODO: such error will set index state to initial state, REFRESHING, inconsistent with
-              // auto_refresh setting "false"
+              // TODO: such error will set index state to initial state, REFRESHING, inconsistent
+              // with auto_refresh setting "false"
               flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
@@ -1074,8 +1073,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(1);
               emrsClient.getJobRunResultCalled(0);
-              // TODO: such error will set index state to initial state, REFRESHING, inconsistent with
-              // auto_refresh setting "false"
+              // TODO: such error will set index state to initial state, REFRESHING, inconsistent
+              // with auto_refresh setting "false"
               flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");

--- a/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
+++ b/spark/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
@@ -7,6 +7,8 @@ import com.amazonaws.services.emrserverless.model.ValidationException;
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
@@ -70,7 +72,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -139,7 +141,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -196,13 +198,6 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                     }
 
                     @Override
-                    public GetJobRunResult getJobRunResult(String applicationId, String jobId) {
-                      JobRun jobRun = new JobRun();
-                      jobRun.setState("cancelled");
-                      return new GetJobRunResult().withJobRun(jobRun);
-                    }
-
-                    @Override
                     public CancelJobRunResult cancelJobRun(
                         String applicationId, String jobId, boolean allowExceptionPropagation) {
                       super.cancelJobRun(applicationId, jobId, allowExceptionPropagation);
@@ -235,7 +230,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
               assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
               emrsClient.startJobRunCalled(0);
-              emrsClient.cancelJobRunCalled(1);
+              emrsClient.cancelJobRunCalled(0);
               emrsClient.getJobRunResultCalled(0);
               flintIndexJob.assertState(FlintIndexState.ACTIVE);
               Map<String, Object> mappings = mockDS.getIndexMappings();
@@ -301,7 +296,6 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                       .getAsyncQueryResults(response.getQueryId())
                       .getStatus());
 
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
               localEMRSClient.startJobRunCalled(1);
               localEMRSClient.getJobRunResultCalled(1);
               localEMRSClient.cancelJobRunCalled(0);
@@ -368,6 +362,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                       .getStatus());
 
               flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              // IndexDMLHandler can handle alter queries that explicitly set auto_refresh to false.
+              // Other alter queries are handled by StreamingQueryHandler, which starts a job.
               localEMRSClient.startJobRunCalled(1);
               localEMRSClient.getJobRunResultCalled(1);
               localEMRSClient.cancelJobRunCalled(0);
@@ -426,7 +422,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -445,7 +441,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutionResponse.getError());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
               Map<String, Object> options = (Map<String, Object>) meta.get("options");
@@ -501,7 +497,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -520,7 +516,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutionResponse.getError());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
               Map<String, Object> options = (Map<String, Object>) meta.get("options");
@@ -570,7 +566,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -589,7 +585,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutionResponse.getError());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
               Map<String, Object> options = (Map<String, Object>) meta.get("options");
@@ -632,7 +628,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -651,7 +647,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutionResponse.getError());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
               Map<String, Object> options = (Map<String, Object>) meta.get("options");
@@ -696,7 +692,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -715,7 +711,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
                   asyncQueryExecutionResponse.getError());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
               Map<String, Object> options = (Map<String, Object>) meta.get("options");
@@ -947,7 +943,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -1012,7 +1008,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -1029,7 +1025,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(1);
               emrsClient.getJobRunResultCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
               Map<String, Object> options = (Map<String, Object>) meta.get("options");
@@ -1078,7 +1074,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               MockFlintSparkJob flintIndexJob =
                   new MockFlintSparkJob(
                       flintIndexStateModelService, mockDS.getLatestId(), MYS3_DATASOURCE);
-              flintIndexJob.active();
+              flintIndexJob.refreshing();
 
               // 1. alter index
               CreateAsyncQueryResponse response =
@@ -1095,7 +1091,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(1);
               emrsClient.getJobRunResultCalled(0);
-              flintIndexJob.assertState(FlintIndexState.ACTIVE);
+              flintIndexJob.assertState(FlintIndexState.REFRESHING);
               Map<String, Object> mappings = mockDS.getIndexMappings();
               Map<String, Object> meta = (HashMap<String, Object>) mappings.get("_meta");
               Map<String, Object> options = (Map<String, Object>) meta.get("options");


### PR DESCRIPTION
### Description
Validate index state when cancelling job. Only cancel when index is refreshing.
Updated behavior of several test cases (please see comments in code)
 
### Issues Resolved
* #2689 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).