### PR TITLE
Separate build and validateAndBuild method in DataSourceMetadata

### DIFF
--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceMetadata.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceMetadata.java
@@ -128,10 +128,14 @@ public class DataSourceMetadata {
       return this;
     }
 
-    public DataSourceMetadata build() {
+    public DataSourceMetadata validateAndBuild() {
       validateMissingAttributes();
       validateName();
       validateCustomResultIndex();
+      return build();
+    }
+
+    public DataSourceMetadata build() {
       fillNullAttributes();
       return new DataSourceMetadata(this);
     }
@@ -239,6 +243,6 @@ public class DataSourceMetadata {
         .setConnector(DataSourceType.OPENSEARCH)
         .setAllowedRoles(Collections.emptyList())
         .setProperties(ImmutableMap.of())
-        .build();
+        .validateAndBuild();
   }
 }

--- a/core/src/test/java/org/opensearch/sql/datasource/model/DataSourceMetadataTest.java
+++ b/core/src/test/java/org/opensearch/sql/datasource/model/DataSourceMetadataTest.java
@@ -36,7 +36,7 @@ public class DataSourceMetadataTest {
             .setProperties(properties)
             .setResultIndex("query_execution_result_test123")
             .setDataSourceStatus(ACTIVE)
-            .build();
+            .validateAndBuild();
 
     assertEquals("test", metadata.getName());
     assertEquals("test description", metadata.getDescription());
@@ -59,7 +59,10 @@ public class DataSourceMetadataTest {
   @Test
   public void testNameValidation() {
     try {
-      new DataSourceMetadata.Builder().setName("Invalid$$$Name").setConnector(PROMETHEUS).build();
+      new DataSourceMetadata.Builder()
+          .setName("Invalid$$$Name")
+          .setConnector(PROMETHEUS)
+          .validateAndBuild();
       fail("Should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -76,7 +79,7 @@ public class DataSourceMetadataTest {
           .setName("test")
           .setConnector(PROMETHEUS)
           .setResultIndex("invalid_result_index")
-          .build();
+          .validateAndBuild();
       fail("Should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       assertEquals(DataSourceMetadata.INVALID_RESULT_INDEX_PREFIX, e.getMessage());
@@ -86,7 +89,7 @@ public class DataSourceMetadataTest {
   @Test
   public void testMissingAttributes() {
     try {
-      new DataSourceMetadata.Builder().build();
+      new DataSourceMetadata.Builder().validateAndBuild();
       fail("Should have thrown an IllegalArgumentException due to missing attributes");
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("name"));
@@ -97,7 +100,10 @@ public class DataSourceMetadataTest {
   @Test
   public void testFillAttributes() {
     DataSourceMetadata metadata =
-        new DataSourceMetadata.Builder().setName("test").setConnector(PROMETHEUS).build();
+        new DataSourceMetadata.Builder()
+            .setName("test")
+            .setConnector(PROMETHEUS)
+            .validateAndBuild();
 
     assertEquals("test", metadata.getName());
     assertEquals(PROMETHEUS, metadata.getConnector());
@@ -115,7 +121,7 @@ public class DataSourceMetadataTest {
           .setName("test")
           .setConnector(PROMETHEUS)
           .setResultIndex("query_execution_result_" + RandomStringUtils.randomAlphanumeric(300))
-          .build();
+          .validateAndBuild();
       fail("Should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -131,7 +137,7 @@ public class DataSourceMetadataTest {
         new DataSourceMetadata.Builder()
             .setName(RandomStringUtils.randomAlphabetic(250))
             .setConnector(PROMETHEUS)
-            .build();
+            .validateAndBuild();
     assertEquals(255, dataSourceMetadata.getResultIndex().length());
   }
 
@@ -150,8 +156,8 @@ public class DataSourceMetadataTest {
             .setProperties(properties)
             .setResultIndex("query_execution_result_test123")
             .setDataSourceStatus(ACTIVE)
-            .build();
-    DataSourceMetadata copiedMetadata = new DataSourceMetadata.Builder(metadata).build();
+            .validateAndBuild();
+    DataSourceMetadata copiedMetadata = new DataSourceMetadata.Builder(metadata).validateAndBuild();
     assertEquals(metadata.getResultIndex(), copiedMetadata.getResultIndex());
     assertEquals(metadata.getProperties(), copiedMetadata.getProperties());
   }

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceServiceImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceServiceImpl.java
@@ -167,7 +167,7 @@ public class DataSourceServiceImpl implements DataSourceService {
           break;
       }
     }
-    return metadataBuilder.build();
+    return metadataBuilder.validateAndBuild();
   }
 
   private DataSourceMetadata getRawDataSourceMetadata(String dataSourceName) {
@@ -199,6 +199,8 @@ public class DataSourceServiceImpl implements DataSourceService {
             entry ->
                 CONFIDENTIAL_AUTH_KEYS.stream()
                     .anyMatch(confidentialKey -> entry.getKey().endsWith(confidentialKey)));
-    return new DataSourceMetadata.Builder(dataSourceMetadata).setProperties(safeProperties).build();
+    return new DataSourceMetadata.Builder(dataSourceMetadata)
+        .setProperties(safeProperties)
+        .validateAndBuild();
   }
 }

--- a/datasources/src/main/java/org/opensearch/sql/datasources/utils/XContentParserUtils.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/utils/XContentParserUtils.java
@@ -97,7 +97,7 @@ public class XContentParserUtils {
         .setAllowedRoles(allowedRoles)
         .setResultIndex(resultIndex)
         .setDataSourceStatus(status)
-        .build();
+        .validateAndBuild();
   }
 
   public static Map<String, Object> toMap(XContentParser parser) throws IOException {


### PR DESCRIPTION
### Description
* Separate build and validateAndBuild method in DataSourceMetadata to let internally build special DataSourceMetadata.
 * The validation doesn't allow datasource name starting from `_`(underscore) 
 
### Issues Resolved
n/a

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).