### PR TITLE
Exclude integ-test and download task when built offline

### DIFF
--- a/async-query-core/build.gradle
+++ b/async-query-core/build.gradle
@@ -38,8 +38,11 @@ configurations {
     }
 }
 
-// Make sure the downloadG4File task runs before the generateGrammarSource task
-generateGrammarSource.dependsOn downloadG4Files
+// skip download in case of offline build
+if (!gradle.startParameter.offline) {
+    // Make sure the downloadG4File task runs before the generateGrammarSource task
+    generateGrammarSource.dependsOn downloadG4Files
+}
 
 dependencies {
     antlr "org.antlr:antlr4:4.7.1"

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,12 +9,10 @@ rootProject.name = 'opensearch-sql'
 include 'opensearch-sql-plugin'
 project(':opensearch-sql-plugin').projectDir = file('plugin')
 include 'ppl'
-include 'integ-test'
 include 'common'
 include 'opensearch'
 include 'core'
 include 'protocol'
-include 'doctest'
 include 'legacy'
 include 'sql'
 include 'prometheus'
@@ -23,3 +21,9 @@ include 'datasources'
 include 'spark'
 include 'async-query-core'
 include 'async-query'
+
+// exclude integ-test/doctest in case of offline build since they need downloads
+if (!gradle.startParameter.offline) {
+    include 'integ-test'
+    include 'doctest'
+}


### PR DESCRIPTION
### Description
- Exclude integ-test, doctest and download task when built offline
- This is to make `async-query-core` module buildable in offline environment (it still requires Gradle cache)
- When built with `--offline` option, `integ-test` and `doctest` will be excluded, and also download of .g4 files are skipped. Even if we specify target such as `:async-query-core:shadowJar`, some downloads were done during preparation, and build failed even though `async-query-core` module does not depend on `integ-test`.
 
### Issues Resolved
n/a
 
### Check List
- [n/a] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [n/a] New functionality has javadoc added
  - [n/a] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).