### PR TITLE
Push down OpenSearch specific exception handling

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
@@ -16,7 +16,6 @@ import lombok.Builder;
 import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
 import org.opensearch.sql.spark.client.StartJobRequest;
@@ -53,29 +52,23 @@ public class InteractiveSession implements Session {
   public void open(
       CreateSessionRequest createSessionRequest,
       AsyncQueryRequestContext asyncQueryRequestContext) {
-    try {
-      // append session id;
-      createSessionRequest
-          .getSparkSubmitParameters()
-          .acceptModifier(
-              (parameters) -> {
-                parameters.sessionExecution(sessionId, createSessionRequest.getDatasourceName());
-              });
-      createSessionRequest.getTags().put(SESSION_ID_TAG_KEY, sessionId);
-      StartJobRequest startJobRequest = createSessionRequest.getStartJobRequest(sessionId);
-      String jobID = serverlessClient.startJobRun(startJobRequest);
-      String applicationId = startJobRequest.getApplicationId();
-      String accountId = createSessionRequest.getAccountId();
+    // append session id;
+    createSessionRequest
+        .getSparkSubmitParameters()
+        .acceptModifier(
+            (parameters) -> {
+              parameters.sessionExecution(sessionId, createSessionRequest.getDatasourceName());
+            });
+    createSessionRequest.getTags().put(SESSION_ID_TAG_KEY, sessionId);
+    StartJobRequest startJobRequest = createSessionRequest.getStartJobRequest(sessionId);
+    String jobID = serverlessClient.startJobRun(startJobRequest);
+    String applicationId = startJobRequest.getApplicationId();
+    String accountId = createSessionRequest.getAccountId();
 
-      sessionModel =
-          initInteractiveSession(
-              accountId, applicationId, jobID, sessionId, createSessionRequest.getDatasourceName());
-      sessionStorageService.createSession(sessionModel, asyncQueryRequestContext);
-    } catch (VersionConflictEngineException e) {
-      String errorMsg = "session already exist. " + sessionId;
-      LOG.error(errorMsg);
-      throw new IllegalStateException(errorMsg);
-    }
+    sessionModel =
+        initInteractiveSession(
+            accountId, applicationId, jobID, sessionId, createSessionRequest.getDatasourceName());
+    sessionStorageService.createSession(sessionModel, asyncQueryRequestContext);
   }
 
   /** todo. StatementSweeper will delete doc. */

--- a/async-query/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStatementStorageService.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStatementStorageService.java
@@ -7,6 +7,10 @@ package org.opensearch.sql.spark.execution.statestore;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.index.engine.DocumentMissingException;
+import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.statement.StatementModel;
 import org.opensearch.sql.spark.execution.statement.StatementState;
@@ -14,6 +18,7 @@ import org.opensearch.sql.spark.execution.xcontent.StatementModelXContentSeriali
 
 @RequiredArgsConstructor
 public class OpenSearchStatementStorageService implements StatementStorageService {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final StateStore stateStore;
   private final StatementModelXContentSerializer serializer;
@@ -21,11 +26,17 @@ public class OpenSearchStatementStorageService implements StatementStorageServic
   @Override
   public StatementModel createStatement(
       StatementModel statementModel, AsyncQueryRequestContext asyncQueryRequestContext) {
-    return stateStore.create(
-        statementModel.getId(),
-        statementModel,
-        StatementModel::copy,
-        OpenSearchStateStoreUtil.getIndexName(statementModel.getDatasourceName()));
+    try {
+      return stateStore.create(
+          statementModel.getId(),
+          statementModel,
+          StatementModel::copy,
+          OpenSearchStateStoreUtil.getIndexName(statementModel.getDatasourceName()));
+    } catch (VersionConflictEngineException e) {
+      String errorMsg = "statement already exist. " + statementModel.getStatementId();
+      LOG.error(errorMsg);
+      throw new IllegalStateException(errorMsg);
+    }
   }
 
   @Override
@@ -37,10 +48,29 @@ public class OpenSearchStatementStorageService implements StatementStorageServic
   @Override
   public StatementModel updateStatementState(
       StatementModel oldStatementModel, StatementState statementState) {
-    return stateStore.updateState(
-        oldStatementModel,
-        statementState,
-        StatementModel::copyWithState,
-        OpenSearchStateStoreUtil.getIndexName(oldStatementModel.getDatasourceName()));
+    try {
+      return stateStore.updateState(
+          oldStatementModel,
+          statementState,
+          StatementModel::copyWithState,
+          OpenSearchStateStoreUtil.getIndexName(oldStatementModel.getDatasourceName()));
+    } catch (DocumentMissingException e) {
+      String errorMsg =
+          String.format(
+              "cancel statement failed. no statement found. statement: %s.",
+              oldStatementModel.getStatementId());
+      LOG.error(errorMsg);
+      throw new IllegalStateException(errorMsg);
+    } catch (VersionConflictEngineException e) {
+      StatementModel statementModel =
+          getStatement(oldStatementModel.getId(), oldStatementModel.getDatasourceName())
+              .orElse(oldStatementModel);
+      String errorMsg =
+          String.format(
+              "cancel statement failed. current statementState: %s " + "statement: %s.",
+              statementModel.getStatementState(), statementModel.getStatementId());
+      LOG.error(errorMsg);
+      throw new IllegalStateException(errorMsg);
+    }
   }
 }


### PR DESCRIPTION
### Description
- Push down OpenSearch specific exception handling to reduce the dependency from `async-query-core` to `legacy`

### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [-] New functionality has been documented.
  - [-] New functionality has javadoc added
  - [-] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).