### PR TITLE
Allow metadata fields in PPL query

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -356,8 +356,7 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
 
   @Override
   public Expression visitField(Field node, AnalysisContext context) {
-    String attr = node.getField().toString();
-    return visitIdentifier(attr, context);
+    return visitQualifiedName((QualifiedName) node.getField(), context);
   }
 
   @Override

--- a/docs/user/ppl/general/identifiers.rst
+++ b/docs/user/ppl/general/identifiers.rst
@@ -161,3 +161,28 @@ Query delimited multiple indices seperated by ``,``::
     | 5         |
     +-----------+
 
+Metadata Identifiers
+====================
+
+Description
+-----------
+
+One can also provide meta-field name(s) to retrieve reserved-fields (beginning with underscore) from OpenSearch documents. Meta-fields are not output
+as default field list (`search source=<index>`) and must be explicitly included to be returned.
+
+Examples
+---------
+
+Query metadata fields::
+
+    os> source=accounts | fields firstname, lastname, _index, _sort;
+    fetched rows / total rows = 4/4
+    +-------------+------------+----------+---------+
+    | firstname   | lastname   | _index   | _sort   |
+    |-------------+------------+----------+---------|
+    | Amber       | Duke       | accounts | -2      |
+    | Hattie      | Bond       | accounts | -2      |
+    | Nanette     | Bates      | accounts | -2      |
+    | Dale        | Adams      | accounts | -2      |
+    +-------------+------------+----------+---------+
+

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/FieldsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/FieldsCommandIT.java
@@ -68,4 +68,19 @@ public class FieldsCommandIT extends PPLIntegTestCase {
         rows("2018-08-19 00:00:00"),
         rows("2018-08-11 00:00:00"));
   }
+
+  @Test
+  public void testMetadataFields() throws IOException {
+    JSONObject result =
+        executeQuery(String.format("source=%s | fields firstname, _index", TEST_INDEX_ACCOUNT));
+    verifyColumn(result, columnName("firstname"), columnName("_index"));
+  }
+
+  @Test
+  public void testDelimitedMetadataFields() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format("source=%s | fields firstname, `_id`, `_index`", TEST_INDEX_ACCOUNT));
+    verifyColumn(result, columnName("firstname"), columnName("_id"), columnName("_index"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -98,4 +98,12 @@ public class WhereCommandIT extends PPLIntegTestCase {
                 TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifyDataRows(result, rows("Amber JOHnny"));
   }
+
+  @Test
+  public void testWhereWithMetadataFields() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format("source=%s | where _id='1' | fields firstname", TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Amber"));
+  }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -389,13 +389,16 @@ INTEGER_LITERAL:                    DEC_DIGIT+;
 DECIMAL_LITERAL:                    (DEC_DIGIT+)? '.' DEC_DIGIT+;
 
 fragment DATE_SUFFIX:               ([\-.][*0-9]+)+;
-fragment ID_LITERAL:                [@*A-Z]+?[*A-Z_\-0-9]*;
 fragment CLUSTER_PREFIX_LITERAL:    [*A-Z]+?[*A-Z_\-0-9]* COLON;
 ID_DATE_SUFFIX:                     CLUSTER_PREFIX_LITERAL? ID_LITERAL DATE_SUFFIX;
 DQUOTA_STRING:                      '"' ( '\\'. | '""' | ~('"'| '\\') )* '"';
 SQUOTA_STRING:                      '\'' ('\\'. | '\'\'' | ~('\'' | '\\'))* '\'';
 BQUOTA_STRING:                      '`' ( '\\'. | '``' | ~('`'|'\\'))* '`';
 fragment DEC_DIGIT:                 [0-9];
+
+// Identifiers cannot start with a single '_' since this an OpenSearch reserved
+// metadata field.  Two underscores (or more) is acceptable, such as '__field'.
+fragment ID_LITERAL:                ([@*A-Z_])+?[*A-Z_\-0-9]*;
 
 
 ERROR_RECOGNITION:                  .    -> channel(ERRORCHANNEL);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -533,6 +533,32 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
   }
 
   @Test
+  public void canBuildMetaDataFieldAsQualifiedName() {
+    assertEqual(
+        "source=test | fields _id, _index, _sort, _maxscore",
+        projectWithArg(
+            relation("test"),
+            defaultFieldsArgs(),
+            field("_id"),
+            field("_index"),
+            field("_sort"),
+            field("_maxscore")));
+  }
+
+  @Test
+  public void canBuildNonMetaDataFieldAsQualifiedName() {
+    assertEqual(
+        "source=test | fields id, __id, _routing, ___field",
+        projectWithArg(
+            relation("test"),
+            defaultFieldsArgs(),
+            field("id"),
+            field("__id"),
+            field("_routing"),
+            field("___field")));
+  }
+
+  @Test
   public void canBuildMatchRelevanceFunctionWithArguments() {
     assertEqual(
         "source=test | where match('message', 'test query', analyzer='keyword')",


### PR DESCRIPTION
### Description
OpenSearch reserved fields (_id, _index, _sort, _score, _max_score) are not allowed to be used in PPL clauses because the field format starting with underscore _ is not allowed.

- This ticket adds specific identifiers to the language, and opens up support for OpenSearch reserved identifiers.
- As an aside, identifiers with double underscore at the start (such as __myCoolField) is acceptable as an identifier.

https://github.com/opensearch-project/sql/pull/1456 had fixed the same problem for SQL query, but the issue still existed in PPL.
 
### Issues Resolved
Resolves https://github.com/opensearch-project/sql/issues/2788
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).