### PR TITLE
Support common format geo point

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -20,6 +20,7 @@ import static org.opensearch.sql.legacy.TestUtils.getDogs2IndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getDogs3IndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getEmployeeNestedTypeIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getGameOfThronesIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getGeopointIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getJoinTypeIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getLocationIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getMappingFile;
@@ -724,7 +725,12 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         TestsConstants.TEST_INDEX_NESTED_WITH_NULLS,
         "multi_nested",
         getNestedTypeIndexMapping(),
-        "src/test/resources/nested_with_nulls.json");
+        "src/test/resources/nested_with_nulls.json"),
+    GEOPOINTS(
+        TestsConstants.TEST_INDEX_GEOPOINT,
+        "dates",
+        getGeopointIndexMapping(),
+        "src/test/resources/geopoints.json");
 
     private final String name;
     private final String type;

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
@@ -245,6 +245,11 @@ public class TestUtils {
     return getMappingFile(mappingFile);
   }
 
+  public static String getGeopointIndexMapping() {
+    String mappingFile = "geopoint_index_mapping.json";
+    return getMappingFile(mappingFile);
+  }
+
   public static void loadBulk(Client client, String jsonPath, String defaultIndex)
       throws Exception {
     System.out.println(String.format("Loading file %s into opensearch cluster", jsonPath));

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -57,6 +57,7 @@ public class TestsConstants {
   public static final String TEST_INDEX_WILDCARD = TEST_INDEX + "_wildcard";
   public static final String TEST_INDEX_MULTI_NESTED_TYPE = TEST_INDEX + "_multi_nested";
   public static final String TEST_INDEX_NESTED_WITH_NULLS = TEST_INDEX + "_nested_with_nulls";
+  public static final String TEST_INDEX_GEOPOINT = TEST_INDEX + "_geopoint";
   public static final String DATASOURCES = ".ql-datasources";
 
   public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";

--- a/integ-test/src/test/java/org/opensearch/sql/sql/GeopointFormatsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/GeopointFormatsIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.sql;
+
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+
+public class GeopointFormatsIT extends SQLIntegTestCase {
+
+  @Override
+  public void init() throws Exception {
+    loadIndex(Index.GEOPOINTS);
+  }
+
+  @Test
+  public void testReadingGeopoints() throws IOException {
+    String query = String.format("SELECT point FROM %s LIMIT 5", Index.GEOPOINTS.getName());
+    JSONObject result = executeJdbcRequest(query);
+    verifySchema(result, schema("point", null, "geo_point"));
+    verifyDataRows(
+        result,
+        rows(Map.of("lon", 74, "lat", 40.71)),
+        rows(Map.of("lon", 74, "lat", 40.71)),
+        rows(Map.of("lon", 74, "lat", 40.71)),
+        rows(Map.of("lon", 74, "lat", 40.71)),
+        rows(Map.of("lon", 74, "lat", 40.71)));
+  }
+
+  private static final double TOLERANCE = 1E-5;
+
+  public void testReadingGeoHash() throws IOException {
+    String query = String.format("SELECT point FROM %s WHERE _id='6'", Index.GEOPOINTS.getName());
+    JSONObject result = executeJdbcRequest(query);
+    verifySchema(result, schema("point", null, "geo_point"));
+    Pair<Double, Double> point = getGeoValue(result);
+    assertEquals(40.71, point.getLeft(), TOLERANCE);
+    assertEquals(74, point.getRight(), TOLERANCE);
+  }
+
+  private Pair<Double, Double> getGeoValue(JSONObject result) {
+    JSONObject geoRaw =
+        (JSONObject) ((JSONArray) ((JSONArray) result.get("datarows")).get(0)).get(0);
+    double lat = geoRaw.getDouble("lat");
+    double lon = geoRaw.getDouble("lon");
+    return Pair.of(lat, lon);
+  }
+}

--- a/integ-test/src/test/resources/geopoints.json
+++ b/integ-test/src/test/resources/geopoints.json
@@ -1,0 +1,12 @@
+{"index": {"_id": "1"}}
+{"point": {"lat": 40.71, "lon": 74.00}}
+{"index": {"_id": "2"}}
+{"point": "40.71,74.00"}
+{"index": {"_id": "3"}}
+{"point": [74.00, 40.71]}
+{"index": {"_id": "4"}}
+{"point": "POINT (74.00 40.71)"}
+{"index": {"_id": "5"}}
+{"point": {"type": "Point", "coordinates": [74.00, 40.71]}}
+{"index": {"_id": "6"}}
+{"point": "txhxegj0uyp3"}

--- a/integ-test/src/test/resources/indexDefinitions/geopoint_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/geopoint_index_mapping.json
@@ -1,0 +1,9 @@
+{
+  "mappings": {
+    "properties": {
+      "point": {
+        "type": "geo_point"
+      }
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -135,7 +135,6 @@ public class OpenSearchJsonContent implements Content {
             NamedXContentRegistry.EMPTY,
             DeprecationHandler.IGNORE_DEPRECATIONS,
             value.traverse())) {
-      assert parser.currentToken() == null;
       parser.nextToken();
       GeoPoint point = new GeoPoint();
       GeoUtils.parseGeoPoint(parser, point, true);
@@ -148,17 +147,5 @@ public class OpenSearchJsonContent implements Content {
   /** Getter for value. If value is array the whole array is returned. */
   private JsonNode value() {
     return value;
-  }
-
-  /** Get doubleValue from JsonNode if possible. */
-  private Double extractDoubleValue(JsonNode node) {
-    if (node.isTextual()) {
-      return Double.valueOf(node.textValue());
-    }
-    if (node.isNumber()) {
-      return node.doubleValue();
-    } else {
-      throw new IllegalStateException("node must be a number");
-    }
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -7,11 +7,19 @@ package org.opensearch.sql.opensearch.data.utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterators;
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.geo.GeoPoint;
+import org.opensearch.common.geo.GeoUtils;
+import org.opensearch.common.xcontent.json.JsonXContentParser;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 
 /** The Implementation of Content to represent {@link JsonNode}. */
 @RequiredArgsConstructor
@@ -122,25 +130,18 @@ public class OpenSearchJsonContent implements Content {
   @Override
   public Pair<Double, Double> geoValue() {
     final JsonNode value = value();
-    if (value.has("lat") && value.has("lon")) {
-      Double lat = 0d;
-      Double lon = 0d;
-      try {
-        lat = extractDoubleValue(value.get("lat"));
-      } catch (Exception exception) {
-        throw new IllegalStateException(
-            "latitude must be number value, but got value: " + value.get("lat"));
-      }
-      try {
-        lon = extractDoubleValue(value.get("lon"));
-      } catch (Exception exception) {
-        throw new IllegalStateException(
-            "longitude must be number value, but got value: " + value.get("lon"));
-      }
-      return Pair.of(lat, lon);
-    } else {
-      throw new IllegalStateException(
-          "geo point must in format of {\"lat\": number, \"lon\": number}");
+    try (XContentParser parser =
+        new JsonXContentParser(
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.IGNORE_DEPRECATIONS,
+            value.traverse())) {
+      assert parser.currentToken() == null;
+      parser.nextToken();
+      GeoPoint point = new GeoPoint();
+      GeoUtils.parseGeoPoint(parser, point, true);
+      return Pair.of(point.getLat(), point.getLon());
+    } catch (IOException ex) {
+      throw new OpenSearchParseException("error parsing geo point", ex);
     }
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -63,7 +63,6 @@ import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchBinaryType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDateType;
-import org.opensearch.sql.opensearch.data.type.OpenSearchGeoPointType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchIpType;
 import org.opensearch.sql.opensearch.data.utils.Content;
 import org.opensearch.sql.opensearch.data.utils.ObjectContent;
@@ -419,8 +418,7 @@ public class OpenSearchExprValueFactory {
       Content content, String prefix, ExprType type, boolean supportArrays) {
     if (type instanceof OpenSearchIpType
         || type instanceof OpenSearchBinaryType
-        || type instanceof OpenSearchDateType
-        || type instanceof OpenSearchGeoPointType) {
+        || type instanceof OpenSearchDateType) {
       return parse(content, prefix, Optional.of(type), supportArrays);
     } else if (content.isString()) {
       return parse(content, prefix, Optional.of(OpenSearchDataType.of(STRING)), supportArrays);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import lombok.Getter;
 import lombok.Setter;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.time.DateFormatters;
 import org.opensearch.common.time.FormatNames;
@@ -381,8 +382,11 @@ public class OpenSearchExprValueFactory {
     // an array in the [longitude, latitude] format.
     if (first.isNumber()) {
       double lon = first.doubleValue();
-      double lat = elements.next().doubleValue();
-      return new OpenSearchExprGeoPointValue(lat, lon);
+      var second = elements.next();
+      if (second.isNumber() == false) {
+        throw new OpenSearchParseException("lat must be a number, got " + second.objectValue());
+      }
+      return new OpenSearchExprGeoPointValue(second.doubleValue(), lon);
     }
 
     // there are multi points in doc

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContentTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContentTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.data.utils;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.opensearch.OpenSearchParseException;
+
+public class OpenSearchJsonContentTest {
+  @Test
+  public void testGetValueWithIOException() throws IOException {
+    JsonNode jsonNode = mock(JsonNode.class);
+    JsonParser jsonParser = mock(JsonParser.class);
+    when(jsonNode.traverse()).thenReturn(jsonParser);
+    when(jsonParser.nextToken()).thenThrow(new IOException());
+    OpenSearchJsonContent content = new OpenSearchJsonContent(jsonNode);
+    OpenSearchParseException exception =
+        assertThrows(OpenSearchParseException.class, content::geoValue);
+    assertTrue(exception.getMessage().contains("error parsing geo point"));
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.junit.jupiter.api.Test;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.geometry.utils.Geohash;
 import org.opensearch.sql.data.model.ExprCollectionValue;
 import org.opensearch.sql.data.model.ExprDateValue;
@@ -719,6 +720,27 @@ class OpenSearchExprValueFactoryTest {
     assertEquals(
         new OpenSearchExprGeoPointValue(42.60355556, -97.25263889),
         constructFromObject("geoV", "42.60355556,-97.25263889"));
+  }
+
+  @Test
+  public void constructGeoPointFromUnsupportedFormatShouldThrowException() {
+    OpenSearchParseException exception =
+        assertThrows(
+            OpenSearchParseException.class,
+            () -> tupleValue("{\"geoV\": [42.60355556, false]}").get("geoV"));
+    assertEquals("lat must be a number, got false", exception.getMessage());
+
+    exception =
+        assertThrows(
+            OpenSearchParseException.class,
+            () -> tupleValue("{\"geoV\":{\"lon\":-97.25263889}}").get("geoV"));
+    assertEquals("field [lat] missing", exception.getMessage());
+
+    exception =
+        assertThrows(
+            OpenSearchParseException.class,
+            () -> tupleValue("{\"geoV\":{\"lat\":true,\"lon\":-97.25263889}}").get("geoV"));
+    assertEquals("lat must be a number", exception.getMessage());
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -600,6 +600,18 @@ class OpenSearchExprValueFactoryTest {
   }
 
   @Test
+  public void constructArrayOfGeoPointsReturnsFirstIndex() {
+    assertEquals(
+        new OpenSearchExprGeoPointValue(42.60355556, -97.25263889),
+        tupleValue(
+                "{\"geoV\":["
+                    + "{\"lat\":42.60355556,\"lon\":-97.25263889},"
+                    + "{\"lat\":-33.6123556,\"lon\":66.287449}"
+                    + "]}")
+            .get("geoV"));
+  }
+
+  @Test
   public void constructArrayOfIPsReturnsFirstIndex() {
     assertEquals(
         new OpenSearchExprIpValue("192.168.0.1"),


### PR DESCRIPTION
### Description
Currently, we only support geo point in the format of an object with a latitude and longitude, this PR aims to expand our support to all common formats that are described in [OpenSearch doc](https://opensearch.org/docs/latest/field-types/supported-field-types/geo-point/).
 
### Issues Resolved
#1432 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).