### PR TITLE
Query anonymization should work in fallback log

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -167,7 +167,7 @@ public class RestSqlAction extends BaseRestHandler {
               LOG.info(
                   "[{}] Request {} is not supported and falling back to old SQL engine",
                   QueryContext.getRequestId(),
-                  newSqlRequest.toAnonymousString(QueryDataAnonymizer::anonymizeData));
+                  newSqlRequest.toString(QueryDataAnonymizer::anonymizeData));
               LOG.info("Request Query: {}", QueryDataAnonymizer.anonymizeData(sqlRequest.getSql()));
               QueryAction queryAction = explainRequest(client, sqlRequest, format);
               executeSqlRequest(request, queryAction, client, restChannel);

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -167,7 +167,7 @@ public class RestSqlAction extends BaseRestHandler {
               LOG.info(
                   "[{}] Request {} is not supported and falling back to old SQL engine",
                   QueryContext.getRequestId(),
-                  newSqlRequest);
+                  newSqlRequest.toAnonymousString(QueryDataAnonymizer::anonymizeData));
               LOG.info("Request Query: {}", QueryDataAnonymizer.anonymizeData(sqlRequest.getSql()));
               QueryAction queryAction = explainRequest(client, sqlRequest, format);
               executeSqlRequest(request, queryAction, client, restChannel);

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/QueryDataAnonymizerTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/QueryDataAnonymizerTest.java
@@ -5,9 +5,11 @@
 
 package org.opensearch.sql.legacy.unittest.utils;
 
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.sql.legacy.utils.QueryDataAnonymizer;
+import org.opensearch.sql.sql.domain.SQLQueryRequest;
 
 public class QueryDataAnonymizerTest {
 
@@ -90,5 +92,21 @@ public class QueryDataAnonymizerTest {
         "( SELECT identifier, identifier FROM table "
             + "UNION SELECT identifier, identifier FROM table )";
     Assert.assertEquals(expectedQuery, QueryDataAnonymizer.anonymizeData(query));
+  }
+
+  @Test
+  public void test_to_anonymous_string_of_SQLQueryRequest() {
+    String query =
+        "SELECT a.account_number, a.firstname, a.lastname, e.id, e.name "
+            + "FROM accounts a JOIN employees e";
+    SQLQueryRequest request =
+        new SQLQueryRequest(null, query, "/_plugins/_sql", Map.of("pretty", "true"), null);
+    ;
+    String actualQuery = request.toAnonymousString(QueryDataAnonymizer::anonymizeData);
+    String expectedQuery =
+        "SQLQueryRequest(query=( SELECT identifier, identifier, identifier, identifier, identifier"
+            + " FROM table a JOIN table e ), path=/_plugins/_sql, format=jdbc,"
+            + " params={pretty=true}, sanitize=true, cursor=Optional.empty)";
+    Assert.assertEquals(expectedQuery, actualQuery);
   }
 }

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/QueryDataAnonymizerTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/QueryDataAnonymizerTest.java
@@ -101,7 +101,6 @@ public class QueryDataAnonymizerTest {
             + "FROM accounts a JOIN employees e";
     SQLQueryRequest request =
         new SQLQueryRequest(null, query, "/_plugins/_sql", Map.of("pretty", "true"), null);
-    ;
     String actualQuery = request.toAnonymousString(QueryDataAnonymizer::anonymizeData);
     String expectedQuery =
         "SQLQueryRequest(query=( SELECT identifier, identifier, identifier, identifier, identifier"

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/QueryDataAnonymizerTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/QueryDataAnonymizerTest.java
@@ -101,7 +101,7 @@ public class QueryDataAnonymizerTest {
             + "FROM accounts a JOIN employees e";
     SQLQueryRequest request =
         new SQLQueryRequest(null, query, "/_plugins/_sql", Map.of("pretty", "true"), null);
-    String actualQuery = request.toAnonymousString(QueryDataAnonymizer::anonymizeData);
+    String actualQuery = request.toString(QueryDataAnonymizer::anonymizeData);
     String expectedQuery =
         "SQLQueryRequest(query=( SELECT identifier, identifier, identifier, identifier, identifier"
             + " FROM table a JOIN table e ), path=/_plugins/_sql, format=jdbc,"

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -10,6 +10,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -147,5 +148,22 @@ public class SQLQueryRequest {
       return Boolean.parseBoolean(params.get(QUERY_PARAMS_SANITIZE));
     }
     return true;
+  }
+
+  public String toAnonymousString(Function<String, String> anonymizer) {
+    return "SQLQueryRequest("
+        + "query="
+        + anonymizer.apply(getQuery())
+        + ", path="
+        + path
+        + ", format="
+        + format
+        + ", params="
+        + params
+        + ", sanitize="
+        + sanitize
+        + ", cursor="
+        + getCursor()
+        + ')';
   }
 }

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -150,7 +150,8 @@ public class SQLQueryRequest {
     return true;
   }
 
-  public String toAnonymousString(Function<String, String> anonymizer) {
+  /** A new toString() with anonymizer parameter to anonymize its query statement. */
+  public String toString(Function<String, String> anonymizer) {
     return "SQLQueryRequest("
         + "query="
         + anonymizer.apply(getQuery())

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -222,6 +222,16 @@ public class SQLQueryRequestTest {
     assertTrue(csvRequest.isSupported());
   }
 
+  @Test
+  public void test_to_string_with_anonymizer() {
+    SQLQueryRequest request = SQLQueryRequestBuilder.request("SELECT 1").build();
+    String actual = request.toString(s -> "***");
+    String expected =
+        "SQLQueryRequest(query=***, path=_plugins/_sql, format=jdbc, params={}, sanitize=true,"
+            + " cursor=Optional.empty)";
+    assertEquals(expected, actual);
+  }
+
   /** SQL query request build helper to improve test data setup readability. */
   private static class SQLQueryRequestBuilder {
     private String jsonContent;


### PR DESCRIPTION
### Description
Query anonymization is not working in the fallback log. `JOIN` query and other queries which trigger fallback to old engine are not anonymous in logs.
```
POST /_plugins/_sql
{
  "query" : """
  SELECT s.FlightNum, s.OriginCityName, d.DestCityName
    FROM opensearch_dashboards_sample_data_flights s
      JOIN opensearch_dashboards_sample_data_flights d
        ON s.DestCityName = d.OriginCityName
  """
}
```
> Request SQLQueryRequest(jsonContent={"query":"\n SELECT s.FlightNum, s.OriginCityName, d.DestCityName FROM opensearch_dashboards_sample_data_flights s JOIN opensearch_dashboards_sample_data_flights d ON s.DestCityName = d.OriginCityName\n "}, query=
**SELECT s.FlightNum, s.OriginCityName, d.DestCityName FROM opensearch_dashboards_sample_data_flights s JOIN opensearch_dashboards_sample_data_flights d ON s.DestCityName = d.OriginCityName**
, path=/_plugins/_sql, format=jdbc, params={pretty=true}, sanitize=true, cursor=Optional.empty) is not supported and falling back to old SQL engine

This PR resolves it by adding a new `toString()` method with a lambda function parameter anonymizer in `SQLQueryRequest` since `QueryDataAnonymizer` is in `org.opensearch.sql.legacy` package.

With this fixing, the new log show like
> Request SQLQueryRequest(query=**( SELECT identifier, identifier, identifier FROM table s JOIN table d ON identifier = identifier )**, path=/_plugins/_sql, format=jdbc, params={pretty=true}, sanitize=true, cursor=Optional.empty) is not supported and falling back to old SQL engine
 
### Issues Resolved
Resolves https://github.com/opensearch-project/sql/issues/2803
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- ~~[ ] New functionality has been documented.~~
  - ~~[ ] New functionality has javadoc added~~
  - ~~[ ] New functionality has user manual doc added~~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).