### PR TITLE
Support nested aggregation

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizer.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizer.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.optimizer.rule.EliminateNested;
 import org.opensearch.sql.planner.optimizer.rule.MergeFilterAndFilter;
 import org.opensearch.sql.planner.optimizer.rule.PushFilterUnderSort;
 import org.opensearch.sql.planner.optimizer.rule.read.CreateTableScanBuilder;
@@ -58,7 +59,11 @@ public class LogicalPlanOptimizer {
             TableScanPushDown.PUSH_DOWN_HIGHLIGHT,
             TableScanPushDown.PUSH_DOWN_NESTED,
             TableScanPushDown.PUSH_DOWN_PROJECT,
-            new CreateTableWriteBuilder()));
+            new CreateTableWriteBuilder(),
+            /*
+             * Phase 3: Transformations for others
+             */
+            new EliminateNested()));
   }
 
   /** Optimize {@link LogicalPlan}. */

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EliminateNested.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EliminateNested.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.optimizer.rule;
+
+import static com.facebook.presto.matching.Pattern.typeOf;
+import static org.opensearch.sql.planner.optimizer.pattern.Patterns.source;
+
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import org.opensearch.sql.planner.logical.LogicalAggregation;
+import org.opensearch.sql.planner.logical.LogicalNested;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.optimizer.Rule;
+
+/**
+ * Eliminate LogicalNested if its child is LogicalAggregation.<br>
+ * LogicalNested - LogicalAggregation - Child --> LogicalAggregation - Child<br>
+ * E.g. count(nested(foo.bar, foo))
+ */
+public class EliminateNested implements Rule<LogicalNested> {
+
+  private final Capture<LogicalAggregation> capture;
+
+  @Accessors(fluent = true)
+  @Getter
+  private final Pattern<LogicalNested> pattern;
+
+  public EliminateNested() {
+    this.capture = Capture.newCapture();
+    this.pattern =
+        typeOf(LogicalNested.class)
+            .with(source().matching(typeOf(LogicalAggregation.class).capturedAs(capture)));
+  }
+
+  @Override
+  public LogicalPlan apply(LogicalNested plan, Captures captures) {
+    return captures.get(capture);
+  }
+}

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -126,7 +126,7 @@ The aggregation could has expression as arguments::
     | M        | 202    |
     +----------+--------+
 
-COUNT Aggregations
+COUNT Aggregation
 ------------------
 
 Besides regular identifiers, ``COUNT`` aggregate function also accepts arguments such as ``*`` or literals like ``1``. The meaning of these different forms are as follows:
@@ -134,6 +134,30 @@ Besides regular identifiers, ``COUNT`` aggregate function also accepts arguments
 1. ``COUNT(field)`` will count only if given field (or expression) is not null or missing in the input rows.
 2. ``COUNT(*)`` will count the number of all its input rows.
 3. ``COUNT(1)`` is same as ``COUNT(*)`` because any non-null literal will count.
+
+NESTED Aggregation
+------------------
+The nested aggregation lets you aggregate on fields inside a nested object. You can use ``nested`` function to return a nested field, ref :ref:`nested function <nested_function_label>`.
+
+To understand why we need nested aggregations, read `Nested Aggregations DSL doc <https://opensearch.org/docs/latest/aggregations/bucket/nested/>`_ to get more details.
+
+The nested aggregation could be expression::
+
+    os> SELECT count(nested(message.info, message)) FROM nested;
+    fetched rows / total rows = 1/1
+    +----------------------------------------+
+    | count(nested(message.info, message))   |
+    |----------------------------------------|
+    | 2                                      |
+    +----------------------------------------+
+
+    os> SELECT count(nested(message.info)) FROM nested;
+    fetched rows / total rows = 1/1
+    +-------------------------------+
+    | count(nested(message.info))   |
+    |-------------------------------|
+    | 2                             |
+    +-------------------------------+
 
 Aggregation Functions
 =====================

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -4419,6 +4419,7 @@ Another example to show how to set custom values for the optional parameters::
     +-------------------------------------------+
 
 
+.. _nested_function_label:
 NESTED
 ------
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NestedIT.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
 public class NestedIT extends SQLIntegTestCase {
@@ -75,20 +74,18 @@ public class NestedIT extends SQLIntegTestCase {
         rows("zz", "bb", 6));
   }
 
-  // Has to be tested with JSON format when https://github.com/opensearch-project/sql/issues/1317
-  // gets resolved
-  @Disabled // TODO fix me when aggregation is supported
+  @Test
   public void nested_function_in_an_aggregate_function_in_select_test() {
     String query =
-        "SELECT sum(nested(message.dayOfWeek)) FROM " + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
+        "SELECT sum(nested(message.dayOfWeek, message)) FROM "
+            + TEST_INDEX_NESTED_TYPE_WITHOUT_ARRAYS;
     JSONObject result = executeJdbcRequest(query);
     verifyDataRows(result, rows(14));
   }
 
-  // TODO Enable me when nested aggregation is supported
-  @Disabled
+  @Test
   public void nested_function_with_arrays_in_an_aggregate_function_in_select_test() {
-    String query = "SELECT sum(nested(message.dayOfWeek)) FROM " + TEST_INDEX_NESTED_TYPE;
+    String query = "SELECT sum(nested(message.dayOfWeek, message)) FROM " + TEST_INDEX_NESTED_TYPE;
     JSONObject result = executeJdbcRequest(query);
     verifyDataRows(result, rows(19));
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/MetricParserHelper.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/MetricParserHelper.java
@@ -21,6 +21,7 @@ import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.bucket.nested.InternalNested;
 import org.opensearch.sql.common.utils.StringUtils;
 
 /** Parse multiple metrics in one bucket. */
@@ -44,6 +45,9 @@ public class MetricParserHelper {
   public Map<String, Object> parse(Aggregations aggregations) {
     Map<String, Object> resultMap = new HashMap<>();
     for (Aggregation aggregation : aggregations) {
+      if (aggregation instanceof InternalNested) {
+        aggregation = ((InternalNested) aggregation).getAggregations().asList().getFirst();
+      }
       if (metricParserMap.containsKey(aggregation.getName())) {
         resultMap.putAll(metricParserMap.get(aggregation.getName()).parse(aggregation));
       } else {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -155,7 +155,8 @@ public class OpenSearchIndex implements Table {
   @Override
   public PhysicalPlan implement(LogicalPlan plan) {
     // TODO: Leave it here to avoid impact Prometheus and AD operators. Need to move to Planner.
-    return plan.accept(new OpenSearchDefaultImplementor(client), null);
+    PhysicalPlan pp = plan.accept(new OpenSearchDefaultImplementor(client), null);
+    return pp;
   }
 
   @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/AggregationBuilderHelper.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/AggregationBuilderHelper.java
@@ -9,13 +9,17 @@ import static java.util.Collections.emptyMap;
 import static org.opensearch.script.Script.DEFAULT_SCRIPT_TYPE;
 import static org.opensearch.sql.opensearch.storage.script.ExpressionScriptEngine.EXPRESSION_LANG_NAME;
 
+import java.util.List;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.script.Script;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
 
@@ -25,18 +29,59 @@ public class AggregationBuilderHelper {
 
   private final ExpressionSerializer serializer;
 
+  /** Build Composite Builder from Expression. */
+  public <T> T buildComposite(
+      Expression expression, Function<String, T> fieldBuilder, Function<Script, T> scriptBuilder) {
+    if (expression instanceof ReferenceExpression) {
+      String fieldName = ((ReferenceExpression) expression).getAttr();
+      return fieldBuilder.apply(
+          OpenSearchTextType.convertTextToKeyword(fieldName, expression.type()));
+    } else if (expression instanceof FunctionExpression
+        || expression instanceof LiteralExpression) {
+      return scriptBuilder.apply(
+          new Script(
+              DEFAULT_SCRIPT_TYPE,
+              EXPRESSION_LANG_NAME,
+              serializer.serialize(expression),
+              emptyMap()));
+    } else {
+      throw new IllegalStateException(
+          String.format("bucket aggregation doesn't support " + "expression %s", expression));
+    }
+  }
+
   /**
    * Build AggregationBuilder from Expression.
    *
    * @param expression Expression
    * @return AggregationBuilder
    */
-  public <T> T build(
-      Expression expression, Function<String, T> fieldBuilder, Function<Script, T> scriptBuilder) {
+  public AggregationBuilder build(
+      Expression expression,
+      Function<String, AggregationBuilder> fieldBuilder,
+      Function<Script, AggregationBuilder> scriptBuilder) {
     if (expression instanceof ReferenceExpression) {
       String fieldName = ((ReferenceExpression) expression).getAttr();
       return fieldBuilder.apply(
           OpenSearchTextType.convertTextToKeyword(fieldName, expression.type()));
+    } else if (expression instanceof FunctionExpression
+        && ((FunctionExpression) expression)
+            .getFunctionName()
+            .equals(BuiltinFunctionName.NESTED.getName())) {
+      List<Expression> args = ((FunctionExpression) expression).getArguments();
+      // NestedAnalyzer has validated the number of arguments.
+      // Here we can safety invoke args.getFirst().
+      String fieldName = ((ReferenceExpression) args.getFirst()).getAttr();
+      if (fieldName.contains("*")) {
+        throw new IllegalArgumentException("Nested aggregation doesn't support multiple fields");
+      }
+      String path =
+          args.size() == 2
+              ? ((ReferenceExpression) args.get(1)).getAttr()
+              : fieldName.substring(0, fieldName.lastIndexOf("."));
+      AggregationBuilder subAgg =
+          fieldBuilder.apply(OpenSearchTextType.convertTextToKeyword(fieldName, expression.type()));
+      return AggregationBuilders.nested(path + "_nested", path).subAggregation(subAgg);
     } else if (expression instanceof FunctionExpression
         || expression instanceof LiteralExpression) {
       return scriptBuilder.apply(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilder.java
@@ -68,7 +68,8 @@ public class BucketAggregationBuilder {
       if (List.of(TIMESTAMP, TIME, DATE).contains(expr.getDelegated().type())) {
         sourceBuilder.userValuetypeHint(ValueType.LONG);
       }
-      return helper.build(expr.getDelegated(), sourceBuilder::field, sourceBuilder::script);
+      return helper.buildComposite(
+          expr.getDelegated(), sourceBuilder::field, sourceBuilder::script);
     }
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/AggregationResponseUtils.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/AggregationResponseUtils.java
@@ -26,6 +26,8 @@ import org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregat
 import org.opensearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
 import org.opensearch.search.aggregations.bucket.histogram.ParsedHistogram;
+import org.opensearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.nested.ParsedNested;
 import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
 import org.opensearch.search.aggregations.bucket.terms.LongTerms;
 import org.opensearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
@@ -87,6 +89,8 @@ public class AggregationResponseUtils {
               .put(
                   TopHitsAggregationBuilder.NAME,
                   (p, c) -> ParsedTopHits.fromXContent(p, (String) c))
+              .put(
+                  NestedAggregationBuilder.NAME, (p, c) -> ParsedNested.fromXContent(p, (String) c))
               .build()
               .entrySet()
               .stream()


### PR DESCRIPTION
### Description
Support nested aggregation. With this PR, follow SQL are able to exectue a nested aggregation query.
```SQL
SELECT min(nested(pages.load_time, pages)) FROM logs WHERE response = 200;
```
And it equals the DSL
```
GET logs/_search
{
  "query": {
    "match": { "response": "200" }
  },
  "aggs": {
    "pages": {
      "nested": {
        "path": "pages"
      },
      "aggs": {
        "min_load_time": { "min": { "field": "pages.load_time" } }
      }
    }
  }
}
```
 
### Issues Resolved
PR resolves https://github.com/opensearch-project/sql/issues/2813 and https://github.com/opensearch-project/sql/issues/2529, and partly resolves https://github.com/opensearch-project/sql/issues/2739 since nested function hasn't supported in PPL yet.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).