### PR TITLE
Temp use of older nodejs version before moving to Almalinux8

### DIFF
--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         java: [21]
-
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution

--- a/.github/workflows/sql-pitest.yml
+++ b/.github/workflows/sql-pitest.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         java:
           - 21
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -29,6 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         java: [21]
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution

--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         java:
           - 21
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution


### PR DESCRIPTION
### Description

As we are using the AL2 image for OS plugin for linux now.
We need to fall back with older nodejs versions until AL2 deprecation next year.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4834

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).