### PR TITLE
Remove MacOS from workflow

### DIFF
--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, macos-latest ]
+        os: [ windows-latest ]
         java: [ 11, 17, 21 ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -105,11 +105,8 @@ jobs:
       matrix:
         entry:
           - { os: windows-latest, java: 11, os_build_args: -x doctest  -PbuildPlatform=windows }
-          - { os: macos-latest, java: 11}
           - { os: windows-latest, java: 17, os_build_args: -x doctest -PbuildPlatform=windows }
-          - { os: macos-latest, java: 17 }
           - { os: windows-latest, java: 21, os_build_args: -x doctest -PbuildPlatform=windows }
-          - { os: macos-latest, java: 21 }
     runs-on: ${{ matrix.entry.os }}
 
     steps:


### PR DESCRIPTION
### Description
- Remove MacOS from workflow in 2.x branch
- Main branch don't have MacOS build workflows (removed earlier in https://github.com/opensearch-project/sql/pull/2662)
 
### Issues Resolved
- workflow failure
 
### Check List
- [-] New functionality includes testing.
  - [-] All tests pass, including unit test, integration test and doctest
- [-] New functionality has been documented.
  - [-] New functionality has javadoc added
  - [-] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).