### PR TITLE
Add MacOS workflows back and fix the artifact not found issue

### DIFF
--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest ]
+        os: [ windows-latest, macos-13 ]
         java: [21]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -105,6 +105,7 @@ jobs:
       matrix:
         entry:
           - { os: windows-latest, java: 21, os_build_args: -x doctest -PbuildPlatform=windows }
+          - { os: macos-13, java: 21 }
     runs-on: ${{ matrix.entry.os }}
 
     steps:


### PR DESCRIPTION
### Description
MacOS build workflows were removed in https://github.com/opensearch-project/sql/pull/2662 because we don't have the M series artifacts. This PR addresses the artifact not found problem via replace `macos-latest` by `macos-13`.

`macos-13` is the MacOS version used in workflows of OpenSearch Core:
<img width="293" alt="Screenshot 2024-07-16 at 18 37 40" src="https://github.com/user-attachments/assets/8a3147bb-b43f-40f4-9de6-731ad45529bd">

 
### Issues Resolved
workflow failure
 
### Check List
- [-] New functionality includes testing.
  - [-] All tests pass, including unit test, integration test and doctest
- [-] New functionality has been documented.
  - [-] New functionality has javadoc added
  - [-] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).