### PR TITLE
Correct regular expression range

### DIFF
--- a/common/src/main/java/org/opensearch/sql/common/grok/GrokCompiler.java
+++ b/common/src/main/java/org/opensearch/sql/common/grok/GrokCompiler.java
@@ -29,7 +29,7 @@ import org.opensearch.sql.common.grok.exception.GrokException;
 public class GrokCompiler implements Serializable {
 
   // We don't want \n and commented line
-  private static final Pattern patternLinePattern = Pattern.compile("^([A-z0-9_]+)\\s+(.*)$");
+  private static final Pattern patternLinePattern = Pattern.compile("^([a-zA-Z0-9_]+)\\s+(.*)$");
 
   /** {@code Grok} patterns definitions. */
   private final Map<String, String> grokPatternDefinitions = new HashMap<>();

--- a/common/src/main/java/org/opensearch/sql/common/grok/GrokUtils.java
+++ b/common/src/main/java/org/opensearch/sql/common/grok/GrokUtils.java
@@ -24,8 +24,8 @@ public class GrokUtils {
       Pattern.compile(
           "%\\{"
               + "(?<name>"
-              + "(?<pattern>[A-z0-9]+)"
-              + "(?::(?<subname>[A-z0-9_:;,\\-\\/\\s\\.']+))?"
+              + "(?<pattern>[a-zA-Z0-9_]+)"
+              + "(?::(?<subname>[a-zA-Z0-9_:;,\\-\\/\\s\\.']+))?"
               + ")"
               + "(?:=(?<definition>"
               + "(?:"


### PR DESCRIPTION
### Description
Regular expression `[A-z]` also matches the characters: `` [ \ ] ^ _ ` ``. It may have overly permissive range risk. Correct it with `[a-zA-Z_]`.
 
### Issues Resolved
Resolves https://github.com/opensearch-project/sql/security/code-scanning/8
 
### Check List
- [-] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [-] New functionality has been documented.
  - [-] New functionality has javadoc added
  - [-] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).