### PR TITLE
Fix SparkSubmitParameterModifier issue

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/parameter/SparkSubmitParametersBuilder.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/parameter/SparkSubmitParametersBuilder.java
@@ -154,7 +154,9 @@ public class SparkSubmitParametersBuilder {
   }
 
   public SparkSubmitParametersBuilder acceptModifier(SparkSubmitParameterModifier modifier) {
-    modifier.modifyParameters(this);
+    if (modifier != null) {
+      modifier.modifyParameters(this);
+    }
     return this;
   }
 

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/parameter/SparkSubmitParametersBuilderTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/parameter/SparkSubmitParametersBuilderTest.java
@@ -153,6 +153,11 @@ public class SparkSubmitParametersBuilderTest {
   }
 
   @Test
+  public void testAcceptNullModifier() {
+    sparkSubmitParametersBuilder.acceptModifier(null);
+  }
+
+  @Test
   public void testDataSource() {
     when(sparkParameterComposerCollection.isComposerRegistered(DataSourceType.S3GLUE))
         .thenReturn(true);


### PR DESCRIPTION
### Description
* Fix SparkSubmitParameterModifier issue.
  * It was causing null pointer exception when SparkSubmitParameterModifier was not set.
 
### Issues Resolved
n/a
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [-] New functionality has been documented.
  - [-] New functionality has javadoc added
  - [-] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).