### PR TITLE
Fix SparkExecutionEngineConfigClusterSetting deserialize issue

### DIFF
--- a/async-query/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigClusterSetting.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigClusterSetting.java
@@ -6,9 +6,9 @@
 package org.opensearch.sql.spark.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.gson.Gson;
 import lombok.Builder;
 import lombok.Data;
-import org.opensearch.sql.utils.SerializeUtils;
 
 /**
  * This POJO is just for reading stringified json in `plugins.query.executionengine.spark.config`
@@ -29,7 +29,6 @@ public class SparkExecutionEngineConfigClusterSetting {
 
   public static SparkExecutionEngineConfigClusterSetting toSparkExecutionEngineConfig(
       String jsonString) {
-    return SerializeUtils.buildGson()
-        .fromJson(jsonString, SparkExecutionEngineConfigClusterSetting.class);
+    return new Gson().fromJson(jsonString, SparkExecutionEngineConfigClusterSetting.class);
   }
 }


### PR DESCRIPTION
### Description
- Fix SparkExecutionEngineConfigClusterSetting deserialize issue
- GSON could use NoArgsConstructor / AllArgsConstructor when TypeAdapter is used to build GSON instance. 
- Fixed this back to default GSON since this class does not require custom handling.
 
### Issues Resolved
n/a
 
### Check List
- [n/a] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [n/a] New functionality has been documented.
  - [n/a] New functionality has javadoc added
  - [n/a] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).