### PR TITLE
Dedup running workflows on push action with auto-backport

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,7 @@ on:
       - '[1-9]+.[0-9x]+'
   push:
     branches-ignore:
+      - 'backport/**'
       - 'dependabot/**'
     paths:
       - '**/*.java'

--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches-ignore:
+      - 'backport/**'
       - 'dependabot/**'
     paths:
       - 'integ-test/**'

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches-ignore:
+      - 'backport/**'
       - 'dependabot/**'
     paths:
       - '**/*.java'


### PR DESCRIPTION
### Description
Backport PR raised by `opensearch-trigger-bot` (e.g. https://github.com/opensearch-project/sql/pull/2842) will trigger duplicated workflows which wastes CI resources.

<img width="831" alt="Screenshot 2024-07-19 at 10 57 42" src="https://github.com/user-attachments/assets/63d40c05-f4d1-40c2-983c-5f1d48724af6">

 
### Issues Resolved
n/a
 
### Check List
- [-] New functionality includes testing.
  - [-] All tests pass, including unit test, integration test and doctest
- [-] New functionality has been documented.
  - [-] New functionality has javadoc added
  - [-] New functionality has user manual doc added
- [-] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).