### PR TITLE
Fix Integ test for datasource enabled setting with security plugin

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceEnabledIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceEnabledIT.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.datasource;
 
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
-import static org.opensearch.sql.legacy.TestsConstants.DATASOURCES;
 
 import lombok.SneakyThrows;
 import org.json.JSONObject;
@@ -25,31 +24,25 @@ public class DataSourceEnabledIT extends PPLIntegTestCase {
   }
 
   @Test
-  public void testDataSourceIndexIsCreatedByDefault() {
-    assertDataSourceCount(0);
-    assertSelectFromDataSourceReturnsDoesNotExist();
-    assertDataSourceIndexCreated(true);
-  }
-
-  @Test
-  public void testDataSourceIndexIsCreatedIfSettingIsEnabled() {
-    setDataSourcesEnabled("transient", true);
-    assertDataSourceCount(0);
-    assertSelectFromDataSourceReturnsDoesNotExist();
-    assertDataSourceIndexCreated(true);
-  }
-
-  @Test
-  public void testDataSourceIndexIsNotCreatedIfSettingIsDisabled() {
+  public void testAsyncQueryAPIFailureIfSettingIsDisabled() {
     setDataSourcesEnabled("transient", false);
     assertDataSourceCount(0);
     assertSelectFromDataSourceReturnsDoesNotExist();
-    assertDataSourceIndexCreated(false);
     assertAsyncQueryApiDisabled();
   }
 
   @Test
+  public void testDataSourceCreationWithDefaultSettings() {
+    createOpenSearchDataSource();
+    createIndex();
+    assertDataSourceCount(1);
+    assertSelectFromDataSourceReturnsSuccess();
+    assertSelectFromDummyIndexInValidDataSourceDataSourceReturnsDoesNotExist();
+  }
+
+  @Test
   public void testAfterPreviousEnable() {
+    setDataSourcesEnabled("transient", true);
     createOpenSearchDataSource();
     createIndex();
     assertDataSourceCount(1);
@@ -139,18 +132,6 @@ public class DataSourceEnabledIT extends PPLIntegTestCase {
     Assert.assertEquals(expected, jsonBody.getNumber("size"));
     Assert.assertEquals(expected, jsonBody.getNumber("total"));
     Assert.assertEquals(expected, jsonBody.getJSONArray("datarows").length());
-  }
-
-  @SneakyThrows
-  private void assertDataSourceIndexCreated(boolean expected) {
-    Request request = new Request("GET", "/" + DATASOURCES);
-    Response response = performRequest(request);
-    String responseBody = getResponseBody(response);
-    boolean indexDoesExist =
-        response.getStatusLine().getStatusCode() == 200
-            && responseBody.contains(DATASOURCES)
-            && responseBody.contains("mappings");
-    Assert.assertEquals(expected, indexDoesExist);
   }
 
   @SneakyThrows


### PR DESCRIPTION
### Description
The current check for .ql-datasources index creation is not feasible when security plugin is enabled due to restrictions on system index. Since there are other checks in place, I am removing the datasource index checks.
 
### Issues Resolved
https://github.com/opensearch-project/sql/issues/2848
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).