### PR TITLE
[Tests] Test utils update to fix IT tests for serverless

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/AggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/AggregationIT.java
@@ -9,14 +9,17 @@ import static org.opensearch.sql.legacy.TestsConstants.*;
 import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verify;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 import static org.opensearch.sql.util.MatcherUtils.verifySome;
 import static org.opensearch.sql.util.TestUtils.getResponseBody;
+import static org.opensearch.sql.util.TestUtils.roundOfResponse;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
@@ -396,8 +399,9 @@ public class AggregationIT extends SQLIntegTestCase {
   @Test
   public void testAvgDoublePushedDown() throws IOException {
     var response = executeQuery(String.format("SELECT avg(num3)" + " from %s", TEST_INDEX_CALCS));
+    JSONArray responseJSON = roundOfResponse(response.getJSONArray("datarows"));
     verifySchema(response, schema("avg(num3)", null, "double"));
-    verifyDataRows(response, rows(-6.12D));
+    verify(responseJSON, rows(-6.12D));
   }
 
   @Test
@@ -456,8 +460,9 @@ public class AggregationIT extends SQLIntegTestCase {
         executeQuery(
             String.format(
                 "SELECT avg(num3)" + " OVER(PARTITION BY datetime1) from %s", TEST_INDEX_CALCS));
+    JSONArray roundOfResponse = roundOfResponse(response.getJSONArray("datarows"));
     verifySchema(response, schema("avg(num3) OVER(PARTITION BY datetime1)", null, "double"));
-    verifySome(response.getJSONArray("datarows"), rows(-6.12D));
+    verifySome(roundOfResponse, rows(-6.12D));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/ScoreQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/ScoreQueryIT.java
@@ -8,7 +8,7 @@ package org.opensearch.sql.sql;
 import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
-import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataAddressRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
@@ -123,8 +123,7 @@ public class ScoreQueryIT extends SQLIntegTestCase {
                     TestsConstants.TEST_INDEX_ACCOUNT),
                 "jdbc"));
     verifySchema(result, schema("address", null, "text"), schema("_score", null, "float"));
-    verifyDataRows(
-        result, rows("154 Douglass Street", 650.1515), rows("565 Hall Street", 3.2507575));
+    verifyDataAddressRows(result, rows("154 Douglass Street"), rows("565 Hall Street"));
   }
 
   @Test
@@ -154,7 +153,8 @@ public class ScoreQueryIT extends SQLIntegTestCase {
                         + "where score(matchQuery(address, 'Powell')) order by _score desc limit 2",
                     TestsConstants.TEST_INDEX_ACCOUNT),
                 "jdbc"));
+
     verifySchema(result, schema("address", null, "text"), schema("_score", null, "float"));
-    verifyDataRows(result, rows("305 Powell Street", 6.501515));
+    verifyDataAddressRows(result, rows("305 Powell Street"));
   }
 }


### PR DESCRIPTION
### Description
1. Rounding difference between test results when run with different sources - added 2 digit precision round of for the failing tests. Sample test failure - 
```java.lang.AssertionError: 
Expected: (a collection containing [-6.12])
     but: a collection containing [-6.12] mismatches were: [was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>, was <[-6.119999999999999]>]
	at __randomizedtesting.SeedInfo.seed([B1A9C07A3606A61E:6E333FC43A7C1CD3]:0)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.opensearch.sql.util.MatcherUtils.verifySome(MatcherUtils.java:192)
	at org.opensearch.sql.sql.AggregationIT.testAvgDoubleInMemory(AggregationIT.java:461)
```
2. Score Differences between test results when run with different data sources if one of the data source contains multiple shards and OpenSearch assumes to be run against single shard - skipped asserting on score part of the address array in the response as results can be different for different data sources and is expected behavior.
```
java.lang.AssertionError: 
Expected: iterable with items [[305 Powell Street, 6.501515]] in any order
     but: not matched: <["305 Powell Street",4.414816]>
	at __randomizedtesting.SeedInfo.seed([B1A9C07A3606A61E:726F6D646D7EFC49]:0)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.opensearch.sql.util.MatcherUtils.verify(MatcherUtils.java:173)
	at org.opensearch.sql.util.MatcherUtils.verifyDataRows(MatcherUtils.java:149)
	at org.opensearch.sql.sql.ScoreQueryCloudNativeIT.scoreQueryDefaultBoostQueryTest(ScoreQueryIT.java:106)
```
3. Retrying the index creation without refresh policy in the request URL for tests when it is not supported by API. Tests shouldn't fail as it is expected behavior.
```
java.lang.IllegalStateException: Failed to perform request
	at __randomizedtesting.SeedInfo.seed([B1A9C07A3606A61E:D3800B42483A3073]:0)
	at org.opensearch.sql.util.TestUtils.performRequest(TestUtils.java:124)
	at org.opensearch.sql.sql.IdentifierIT$Index.addDocHelper(IdentifierIT.java:287)
	at org.opensearch.sql.sql.IdentifierIT.createIndexWithOneDoc(IdentifierIT.java:242)
	at org.opensearch.sql.sql.IdentifierIT.testIndexNames(IdentifierIT.java:34)

at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.opensearch.client.ResponseException: method [PUT], host [https://ruh7jos10anqd6bsp844.beta-us-east-1.aoss.amazonaws.com], URI [/logs/_doc/1?refresh=true], status line [HTTP/1.1 400 Bad Request]
{"error":{"root_cause":[{"type":"status_exception","reason":"true refresh policy is not supported."}],"type":"status_exception","reason":"true refresh policy is not supported."},"status":400}
	at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:376)
```

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).