### PR TITLE
Fixed 2.16 integ test failures (#2871)

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceEnabledIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceEnabledIT.java
@@ -38,6 +38,7 @@ public class DataSourceEnabledIT extends PPLIntegTestCase {
     assertDataSourceCount(1);
     assertSelectFromDataSourceReturnsSuccess();
     assertSelectFromDummyIndexInValidDataSourceDataSourceReturnsDoesNotExist();
+    deleteSelfDataSourceCreated();
   }
 
   @Test
@@ -52,6 +53,8 @@ public class DataSourceEnabledIT extends PPLIntegTestCase {
     assertDataSourceCount(0);
     assertSelectFromDataSourceReturnsDoesNotExist();
     assertAsyncQueryApiDisabled();
+    setDataSourcesEnabled("transient", true);
+    deleteSelfDataSourceCreated();
   }
 
   @SneakyThrows
@@ -141,5 +144,12 @@ public class DataSourceEnabledIT extends PPLIntegTestCase {
     } catch (ResponseException e) {
       return e.getResponse();
     }
+  }
+
+  @SneakyThrows
+  private void deleteSelfDataSourceCreated() {
+    Request deleteRequest = getDeleteDataSourceRequest("self");
+    Response deleteResponse = client().performRequest(deleteRequest);
+    Assert.assertEquals(204, deleteResponse.getStatusLine().getStatusCode());
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
@@ -188,7 +188,9 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
       String indexName = jsonObject.getString("index");
       try {
         // System index, mostly named .opensearch-xxx or .opendistro-xxx, are not allowed to delete
-        if (!indexName.startsWith(".opensearch") && !indexName.startsWith(".opendistro")) {
+        if (!indexName.startsWith(".opensearch")
+            && !indexName.startsWith(".opendistro")
+            && !indexName.startsWith(".ql")) {
           client.performRequest(new Request("DELETE", "/" + indexName));
         }
       } catch (Exception e) {


### PR DESCRIPTION
Signed-off-by: Vamsi Manohar <reddyvam@amazon.com>
(cherry picked from commit 103c4160ae2a129284ff5be70bac40951e0c6a18)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
