### PR TITLE
Push down limit through eval

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizer.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizer.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.optimizer.rule.EvalPushDown;
 import org.opensearch.sql.planner.optimizer.rule.MergeFilterAndFilter;
 import org.opensearch.sql.planner.optimizer.rule.PushFilterUnderSort;
 import org.opensearch.sql.planner.optimizer.rule.read.CreateTableScanBuilder;
@@ -46,6 +47,7 @@ public class LogicalPlanOptimizer {
              */
             new MergeFilterAndFilter(),
             new PushFilterUnderSort(),
+            EvalPushDown.PUSH_DOWN_LIMIT,
             /*
              * Phase 2: Transformations that rely on data source push down capability
              */

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/pattern/Patterns.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/pattern/Patterns.java
@@ -12,6 +12,7 @@ import com.facebook.presto.matching.PropertyPattern;
 import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
+import org.opensearch.sql.planner.logical.LogicalEval;
 import org.opensearch.sql.planner.logical.LogicalFilter;
 import org.opensearch.sql.planner.logical.LogicalHighlight;
 import org.opensearch.sql.planner.logical.LogicalLimit;
@@ -61,6 +62,10 @@ public class Patterns {
   /** Logical project operator with a given pattern on inner field. */
   public static <T extends LogicalPlan> Pattern<LogicalProject> project(Pattern<T> pattern) {
     return Pattern.typeOf(LogicalProject.class).with(source(pattern));
+  }
+
+  public static <T extends LogicalPlan> Pattern<LogicalEval> eval(Pattern<T> pattern) {
+    return Pattern.typeOf(LogicalEval.class).with(source(pattern));
   }
 
   /** Pattern for {@link TableScanBuilder} and capture it meanwhile. */

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/pattern/Patterns.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/pattern/Patterns.java
@@ -64,8 +64,8 @@ public class Patterns {
     return Pattern.typeOf(LogicalProject.class).with(source(pattern));
   }
 
-  public static <T extends LogicalPlan> Pattern<LogicalEval> eval(Pattern<T> pattern) {
-    return Pattern.typeOf(LogicalEval.class).with(source(pattern));
+  public static Pattern<LogicalEval> evalCapture() {
+    return Pattern.typeOf(LogicalEval.class).capturedAs(Capture.newCapture());
   }
 
   /** Pattern for {@link TableScanBuilder} and capture it meanwhile. */

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EvalPushDown.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EvalPushDown.java
@@ -23,20 +23,20 @@ import org.opensearch.sql.planner.logical.LogicalLimit;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.optimizer.Rule;
 
-/**
- */
+/** */
 public class EvalPushDown<T extends LogicalPlan> implements Rule<T> {
-
 
   // TODO: Add more rules to push down sort and project
   /** Push down optimize rule for limit operator. Transform `limit -> eval` to `eval -> limit` */
   public static final Rule<LogicalLimit> PUSH_DOWN_LIMIT =
-          match(limit(typeOf(LogicalEval.class).capturedAs(Capture.newCapture()))).apply((limit, logicalEval) -> {
-            List<LogicalPlan> child = logicalEval.getChild();
-            limit.replaceChildPlans(child);
-            logicalEval.replaceChildPlans(List.of(limit));
-            return logicalEval;
-          });
+      match(limit(typeOf(LogicalEval.class).capturedAs(Capture.newCapture())))
+          .apply(
+              (limit, logicalEval) -> {
+                List<LogicalPlan> child = logicalEval.getChild();
+                limit.replaceChildPlans(child);
+                logicalEval.replaceChildPlans(List.of(limit));
+                return logicalEval;
+              });
 
   private final Capture<LogicalEval> capture;
 
@@ -47,9 +47,10 @@ public class EvalPushDown<T extends LogicalPlan> implements Rule<T> {
   private final BiFunction<T, LogicalEval, LogicalPlan> pushDownFunction;
 
   @SuppressWarnings("unchecked")
-  public EvalPushDown(WithPattern<T> pattern, BiFunction<T, LogicalEval, LogicalPlan> pushDownFunction) {
+  public EvalPushDown(
+      WithPattern<T> pattern, BiFunction<T, LogicalEval, LogicalPlan> pushDownFunction) {
     this.pattern = pattern;
-    this.capture =  ((CapturePattern<LogicalEval>) pattern.getPattern()).capture();
+    this.capture = ((CapturePattern<LogicalEval>) pattern.getPattern()).capture();
     this.pushDownFunction = pushDownFunction;
   }
 
@@ -63,7 +64,8 @@ public class EvalPushDown<T extends LogicalPlan> implements Rule<T> {
 
     private WithPattern<T> pattern;
 
-    public static <T extends LogicalPlan> EvalPushDown.EvalPushDownBuilder<T> match(Pattern<T> pattern) {
+    public static <T extends LogicalPlan> EvalPushDown.EvalPushDownBuilder<T> match(
+        Pattern<T> pattern) {
       EvalPushDown.EvalPushDownBuilder<T> builder = new EvalPushDown.EvalPushDownBuilder<>();
       builder.pattern = (WithPattern<T>) pattern;
       return builder;

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EvalPushDown.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EvalPushDown.java
@@ -23,7 +23,11 @@ import org.opensearch.sql.planner.logical.LogicalLimit;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.optimizer.Rule;
 
-/** */
+/**
+ * Rule template for all rules related to push down logical plans under eval, so these plans can
+ * avoid blocking by eval and may have chances to be pushed down into table scan by rules in {@link
+ * org.opensearch.sql.planner.optimizer.rule.read.TableScanPushDown}.
+ */
 public class EvalPushDown<T extends LogicalPlan> implements Rule<T> {
 
   // TODO: Add more rules to push down sort and project

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EvalPushDown.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EvalPushDown.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.sql.planner.optimizer.rule;
 
-import static com.facebook.presto.matching.Pattern.typeOf;
+import static org.opensearch.sql.planner.optimizer.pattern.Patterns.evalCapture;
 import static org.opensearch.sql.planner.optimizer.pattern.Patterns.limit;
 import static org.opensearch.sql.planner.optimizer.rule.EvalPushDown.EvalPushDownBuilder.match;
 
@@ -29,7 +29,7 @@ public class EvalPushDown<T extends LogicalPlan> implements Rule<T> {
   // TODO: Add more rules to push down sort and project
   /** Push down optimize rule for limit operator. Transform `limit -> eval` to `eval -> limit` */
   public static final Rule<LogicalLimit> PUSH_DOWN_LIMIT =
-      match(limit(typeOf(LogicalEval.class).capturedAs(Capture.newCapture())))
+      match(limit(evalCapture()))
           .apply(
               (limit, logicalEval) -> {
                 List<LogicalPlan> child = logicalEval.getChild();

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EvalPushDown.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/rule/EvalPushDown.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.optimizer.rule;
+
+import static com.facebook.presto.matching.Pattern.typeOf;
+import static org.opensearch.sql.planner.optimizer.pattern.Patterns.limit;
+import static org.opensearch.sql.planner.optimizer.rule.EvalPushDown.EvalPushDownBuilder.match;
+
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.matching.pattern.CapturePattern;
+import com.facebook.presto.matching.pattern.WithPattern;
+import java.util.List;
+import java.util.function.BiFunction;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import org.opensearch.sql.planner.logical.LogicalEval;
+import org.opensearch.sql.planner.logical.LogicalLimit;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.optimizer.Rule;
+
+/**
+ */
+public class EvalPushDown<T extends LogicalPlan> implements Rule<T> {
+
+
+  // TODO: Add more rules to push down sort and project
+  /** Push down optimize rule for limit operator. Transform `limit -> eval` to `eval -> limit` */
+  public static final Rule<LogicalLimit> PUSH_DOWN_LIMIT =
+          match(limit(typeOf(LogicalEval.class).capturedAs(Capture.newCapture()))).apply((limit, logicalEval) -> {
+            List<LogicalPlan> child = logicalEval.getChild();
+            limit.replaceChildPlans(child);
+            logicalEval.replaceChildPlans(List.of(limit));
+            return logicalEval;
+          });
+
+  private final Capture<LogicalEval> capture;
+
+  @Accessors(fluent = true)
+  @Getter
+  private final Pattern<T> pattern;
+
+  private final BiFunction<T, LogicalEval, LogicalPlan> pushDownFunction;
+
+  @SuppressWarnings("unchecked")
+  public EvalPushDown(WithPattern<T> pattern, BiFunction<T, LogicalEval, LogicalPlan> pushDownFunction) {
+    this.pattern = pattern;
+    this.capture =  ((CapturePattern<LogicalEval>) pattern.getPattern()).capture();
+    this.pushDownFunction = pushDownFunction;
+  }
+
+  @Override
+  public LogicalPlan apply(T plan, Captures captures) {
+    LogicalEval logicalEval = captures.get(capture);
+    return pushDownFunction.apply(plan, logicalEval);
+  }
+
+  static class EvalPushDownBuilder<T extends LogicalPlan> {
+
+    private WithPattern<T> pattern;
+
+    public static <T extends LogicalPlan> EvalPushDown.EvalPushDownBuilder<T> match(Pattern<T> pattern) {
+      EvalPushDown.EvalPushDownBuilder<T> builder = new EvalPushDown.EvalPushDownBuilder<>();
+      builder.pattern = (WithPattern<T>) pattern;
+      return builder;
+    }
+
+    public EvalPushDown<T> apply(BiFunction<T, LogicalEval, LogicalPlan> pushDownFunction) {
+      return new EvalPushDown<>(pattern, pushDownFunction);
+    }
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizerTest.java
@@ -350,38 +350,22 @@ class LogicalPlanOptimizerTest {
   /** Limit - Eval --> Eval - Limit. */
   @Test
   void push_limit_under_eval() {
-    Pair<ReferenceExpression, Expression> evalExpr = Pair.of(DSL.ref("name1", STRING), DSL.ref("name", STRING));
+    Pair<ReferenceExpression, Expression> evalExpr =
+        Pair.of(DSL.ref("name1", STRING), DSL.ref("name", STRING));
     assertEquals(
-        eval(
-            limit(tableScanBuilder, 10, 5),
-            evalExpr),
-        optimize(
-            limit(
-                eval(
-                    relation("schema", table),
-                    evalExpr),
-                10,
-                5
-                )));
+        eval(limit(tableScanBuilder, 10, 5), evalExpr),
+        optimize(limit(eval(relation("schema", table), evalExpr), 10, 5)));
   }
 
   /** Limit - Eval - Scan --> Eval - Scan. */
   @Test
   void push_limit_through_eval_into_scan() {
     when(tableScanBuilder.pushDownLimit(any())).thenReturn(true);
-    Pair<ReferenceExpression, Expression> evalExpr = Pair.of(DSL.ref("name1", STRING), DSL.ref("name", STRING));
+    Pair<ReferenceExpression, Expression> evalExpr =
+        Pair.of(DSL.ref("name1", STRING), DSL.ref("name", STRING));
     assertEquals(
-        eval(
-            tableScanBuilder,
-            evalExpr),
-        optimize(
-            limit(
-                eval(
-                    relation("schema", table),
-                    evalExpr),
-                10,
-                5
-            )));
+        eval(tableScanBuilder, evalExpr),
+        optimize(limit(eval(relation("schema", table), evalExpr), 10, 5)));
   }
 
   private LogicalPlan optimize(LogicalPlan plan) {

--- a/core/src/test/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizerTest.java
@@ -15,6 +15,7 @@ import static org.opensearch.sql.data.model.ExprValueUtils.integerValue;
 import static org.opensearch.sql.data.model.ExprValueUtils.longValue;
 import static org.opensearch.sql.data.type.ExprCoreType.*;
 import static org.opensearch.sql.planner.logical.LogicalPlanDSL.aggregation;
+import static org.opensearch.sql.planner.logical.LogicalPlanDSL.eval;
 import static org.opensearch.sql.planner.logical.LogicalPlanDSL.filter;
 import static org.opensearch.sql.planner.logical.LogicalPlanDSL.highlight;
 import static org.opensearch.sql.planner.logical.LogicalPlanDSL.limit;
@@ -43,6 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.planner.logical.LogicalPaginate;
@@ -343,6 +345,43 @@ class LogicalPlanOptimizerTest {
     // `optimized` structure: LogicalProject -> TableScanBuilder
     // LogicalRelation replaced by a TableScanBuilder instance
     assertEquals(project(tableScanBuilder), optimized);
+  }
+
+  /** Limit - Eval --> Eval - Limit. */
+  @Test
+  void push_limit_under_eval() {
+    Pair<ReferenceExpression, Expression> evalExpr = Pair.of(DSL.ref("name1", STRING), DSL.ref("name", STRING));
+    assertEquals(
+        eval(
+            limit(tableScanBuilder, 10, 5),
+            evalExpr),
+        optimize(
+            limit(
+                eval(
+                    relation("schema", table),
+                    evalExpr),
+                10,
+                5
+                )));
+  }
+
+  /** Limit - Eval - Scan --> Eval - Scan. */
+  @Test
+  void push_limit_through_eval_into_scan() {
+    when(tableScanBuilder.pushDownLimit(any())).thenReturn(true);
+    Pair<ReferenceExpression, Expression> evalExpr = Pair.of(DSL.ref("name1", STRING), DSL.ref("name", STRING));
+    assertEquals(
+        eval(
+            tableScanBuilder,
+            evalExpr),
+        optimize(
+            limit(
+                eval(
+                    relation("schema", table),
+                    evalExpr),
+                10,
+                5
+            )));
   }
 
   private LogicalPlan optimize(LogicalPlan plan) {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
@@ -76,6 +76,19 @@ public class ExplainIT extends PPLIntegTestCase {
                 + "| fields age"));
   }
 
+  @Test
+  public void testLimitPushDownExplain() throws Exception {
+    String expected = loadFromFile("expectedOutput/ppl/explain_limit_push.json");
+
+    assertJsonEquals(
+        expected,
+        explainQueryToString(
+            "source=opensearch-sql_test_index_account"
+                + "| eval ageMinus = age - 30 "
+                + "| head 5 "
+                + "| fields ageMinus"));
+  }
+
   String loadFromFile(String filename) throws Exception {
     URI uri = Resources.getResource(filename).toURI();
     return new String(Files.readAllBytes(Paths.get(uri)));

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_push.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_push.json
@@ -1,0 +1,27 @@
+{
+  "root": {
+    "name": "ProjectOperator",
+    "description": {
+      "fields": "[ageMinus]"
+    },
+    "children": [
+      {
+        "name": "EvalOperator",
+        "description": {
+          "expressions": {
+            "ageMinus": "-(age, 30)"
+          }
+        },
+        "children": [
+          {
+            "name": "OpenSearchIndexScan",
+            "description": {
+              "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\"}, searchDone=false)"
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description
Add a rule EvalPushDown.PUSH_DOWN_LIMIT, this rule will push down limit under eval. Thus, limit has chance to be pushed down into TableScanBuilder later.

e.g.
```
POST _plugins/_ppl/_explain
{
  "query": """
    source=opensearch_dashboards_sample_data_flights |  eval FlightMin = FlightTimeMin | head 5 | fields  FlightMin
  """
}

# Before optimization
{
  "root": {
    "name": "ProjectOperator",
    "description": {
      "fields": "[FlightMin]"
    },
    "children": [
      {
        "name": "LimitOperator",
        "description": {
          "limit": 5,
          "offset": 0
        },
        "children": [
          {
            "name": "EvalOperator",
            "description": {
              "expressions": {
                "FlightMin": "FlightTimeMin"
              }
            },
            "children": [
              {
                "name": "OpenSearchIndexScan",
                "description": {
                  "request": """OpenSearchQueryRequest(indexName=opensearch_dashboards_sample_data_flights, 

sourceBuilder={"from":0,"size":200,"timeout":"1m"}, searchDone=false)"""
                },
                "children": []
              }
            ]
          }
        ]
      }
    ]
  }
}

# After optimization
{
  "root": {
    "name": "ProjectOperator",
    "description": {
      "fields": "[FlightMin]"
    },
    "children": [
      {
        "name": "EvalOperator",
        "description": {
          "expressions": {
            "FlightMin": "FlightTimeMin"
          }
        },
        "children": [
          {
            "name": "OpenSearchIndexScan",
            "description": {
              "request": """OpenSearchQueryRequest(indexName=opensearch_dashboards_sample_data_flights, 

sourceBuilder={"from":0,"size":5,"timeout":"1m"}, searchDone=false)"""
            },
            "children": []
          }
        ]
      }
    ]
  }
}

```

Note: Also added TODOs in this PR to implement rules PUSH_DOWN_SORT and PUSH_DOWN_PROJECT as follow-ups, which are more complex due to expression replacement.


### Related Issues
Resolves [#2903](https://github.com/opensearch-project/sql/issues/2903)


### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
