### PR TITLE
Fixed integ test delete myindex issue and wipe All indices with security plugin.

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceEnabledIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/datasource/DataSourceEnabledIT.java
@@ -7,8 +7,10 @@ package org.opensearch.sql.datasource;
 
 import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
 
+import java.io.IOException;
 import lombok.SneakyThrows;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.client.Request;
@@ -18,9 +20,9 @@ import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class DataSourceEnabledIT extends PPLIntegTestCase {
 
-  @Override
-  protected boolean preserveClusterUponCompletion() {
-    return false;
+  @After
+  public void cleanUp() throws IOException {
+    wipeAllClusterSettings();
   }
 
   @Test
@@ -39,6 +41,7 @@ public class DataSourceEnabledIT extends PPLIntegTestCase {
     assertSelectFromDataSourceReturnsSuccess();
     assertSelectFromDummyIndexInValidDataSourceDataSourceReturnsDoesNotExist();
     deleteSelfDataSourceCreated();
+    deleteIndex();
   }
 
   @Test
@@ -55,6 +58,7 @@ public class DataSourceEnabledIT extends PPLIntegTestCase {
     assertAsyncQueryApiDisabled();
     setDataSourcesEnabled("transient", true);
     deleteSelfDataSourceCreated();
+    deleteIndex();
   }
 
   @SneakyThrows
@@ -94,6 +98,12 @@ public class DataSourceEnabledIT extends PPLIntegTestCase {
 
   private void createIndex() {
     Request request = new Request("PUT", "/myindex");
+    Response response = performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  private void deleteIndex() {
+    Request request = new Request("DELETE", "/myindex");
     Response response = performRequest(request);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
   }


### PR DESCRIPTION

### Description
Fixed integ tests issues with datasourceEnabledITs.



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/sql/issues/2848

Tested using remote test cluster with docker.

```
 docker pull opensearchstaging/opensearch:2.16.0.10131 && docker run -it -p 9200:9200 -e "discovery.type=single-node" -e 'OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!' opensearchstaging/opensearch:2.16.0.10131  -e "plugins.query.datasources.encryption.masterkey:99c6daa59300876ffbb6191f"
 ```
 
 ```
 ./gradlew integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Duser=admin -Dpassword=myStrongPassword123! -Dhttps=true
 ```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
