### PR TITLE
Add AsyncQueryRequestContext to FlintIndexMetadataService/FlintIndexS…

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
@@ -39,5 +39,5 @@ public interface AsyncQueryExecutorService {
    * @param queryId queryId.
    * @return {@link String} cancelledQueryId.
    */
-  String cancelQuery(String queryId);
+  String cancelQuery(String queryId, AsyncQueryRequestContext asyncQueryRequestContext);
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
@@ -106,11 +106,11 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
   }
 
   @Override
-  public String cancelQuery(String queryId) {
+  public String cancelQuery(String queryId, AsyncQueryRequestContext asyncQueryRequestContext) {
     Optional<AsyncQueryJobMetadata> asyncQueryJobMetadata =
         asyncQueryJobMetadataStorageService.getJobMetadata(queryId);
     if (asyncQueryJobMetadata.isPresent()) {
-      return sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata.get());
+      return sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata.get(), asyncQueryRequestContext);
     }
     throw new AsyncQueryNotFoundException(String.format("QueryId: %s not found", queryId));
   }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/AsyncQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/AsyncQueryHandler.java
@@ -12,6 +12,7 @@ import static org.opensearch.sql.spark.data.constants.SparkConstants.STATUS_FIEL
 import com.amazonaws.services.emrserverless.model.JobRunState;
 import org.json.JSONObject;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
@@ -54,7 +55,9 @@ public abstract class AsyncQueryHandler {
   protected abstract JSONObject getResponseFromExecutor(
       AsyncQueryJobMetadata asyncQueryJobMetadata);
 
-  public abstract String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata);
+  public abstract String cancelJob(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
   public abstract DispatchQueryResponse submit(
       DispatchQueryRequest request, DispatchQueryContext context);

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
 import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
@@ -61,7 +62,9 @@ public class BatchQueryHandler extends AsyncQueryHandler {
   }
 
   @Override
-  public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  public String cancelJob(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     emrServerlessClient.cancelJobRun(
         asyncQueryJobMetadata.getApplicationId(), asyncQueryJobMetadata.getJobId(), false);
     return asyncQueryJobMetadata.getQueryId();

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
@@ -62,9 +62,11 @@ public class IndexDMLHandler extends AsyncQueryHandler {
     long startTime = System.currentTimeMillis();
     try {
       IndexQueryDetails indexDetails = context.getIndexQueryDetails();
-      FlintIndexMetadata indexMetadata = getFlintIndexMetadata(indexDetails);
+      FlintIndexMetadata indexMetadata =
+          getFlintIndexMetadata(indexDetails, context.getAsyncQueryRequestContext());
 
-      getIndexOp(dispatchQueryRequest, indexDetails).apply(indexMetadata);
+      getIndexOp(dispatchQueryRequest, indexDetails)
+          .apply(indexMetadata, context.getAsyncQueryRequestContext());
 
       String asyncQueryId =
           storeIndexDMLResult(
@@ -146,9 +148,11 @@ public class IndexDMLHandler extends AsyncQueryHandler {
     }
   }
 
-  private FlintIndexMetadata getFlintIndexMetadata(IndexQueryDetails indexDetails) {
+  private FlintIndexMetadata getFlintIndexMetadata(
+      IndexQueryDetails indexDetails, AsyncQueryRequestContext asyncQueryRequestContext) {
     Map<String, FlintIndexMetadata> indexMetadataMap =
-        flintIndexMetadataService.getFlintIndexMetadata(indexDetails.openSearchIndexName());
+        flintIndexMetadataService.getFlintIndexMetadata(
+            indexDetails.openSearchIndexName(), asyncQueryRequestContext);
     if (!indexMetadataMap.containsKey(indexDetails.openSearchIndexName())) {
       throw new IllegalStateException(
           String.format(
@@ -174,7 +178,9 @@ public class IndexDMLHandler extends AsyncQueryHandler {
   }
 
   @Override
-  public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  public String cancelJob(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     throw new IllegalArgumentException("can't cancel index DML query");
   }
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
@@ -71,7 +72,9 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
   }
 
   @Override
-  public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  public String cancelJob(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     String queryId = asyncQueryJobMetadata.getQueryId();
     getStatementByQueryId(
             asyncQueryJobMetadata.getSessionId(),

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/RefreshQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/RefreshQueryHandler.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.spark.dispatcher;
 import java.util.Map;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
@@ -51,10 +52,13 @@ public class RefreshQueryHandler extends BatchQueryHandler {
   }
 
   @Override
-  public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  public String cancelJob(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     String datasourceName = asyncQueryJobMetadata.getDatasourceName();
     Map<String, FlintIndexMetadata> indexMetadataMap =
-        flintIndexMetadataService.getFlintIndexMetadata(asyncQueryJobMetadata.getIndexName());
+        flintIndexMetadataService.getFlintIndexMetadata(
+            asyncQueryJobMetadata.getIndexName(), asyncQueryRequestContext);
     if (!indexMetadataMap.containsKey(asyncQueryJobMetadata.getIndexName())) {
       throw new IllegalStateException(
           String.format(
@@ -62,7 +66,7 @@ public class RefreshQueryHandler extends BatchQueryHandler {
     }
     FlintIndexMetadata indexMetadata = indexMetadataMap.get(asyncQueryJobMetadata.getIndexName());
     FlintIndexOp jobCancelOp = flintIndexOpFactory.getCancel(datasourceName);
-    jobCancelOp.apply(indexMetadata);
+    jobCancelOp.apply(indexMetadata, asyncQueryRequestContext);
     return asyncQueryJobMetadata.getQueryId();
   }
 

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -158,9 +158,11 @@ public class SparkQueryDispatcher {
         .getQueryResponse(asyncQueryJobMetadata);
   }
 
-  public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  public String cancelJob(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     return getAsyncQueryHandlerForExistingQuery(asyncQueryJobMetadata)
-        .cancelJob(asyncQueryJobMetadata);
+        .cancelJob(asyncQueryJobMetadata, asyncQueryRequestContext);
   }
 
   private AsyncQueryHandler getAsyncQueryHandlerForExistingQuery(

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/StreamingQueryHandler.java
@@ -12,6 +12,7 @@ import static org.opensearch.sql.spark.metrics.EmrMetrics.EMR_STREAMING_QUERY_JO
 import java.util.Map;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClient;
 import org.opensearch.sql.spark.client.StartJobRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
@@ -46,7 +47,9 @@ public class StreamingQueryHandler extends BatchQueryHandler {
   }
 
   @Override
-  public String cancelJob(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  public String cancelJob(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     throw new IllegalArgumentException(
         "can't cancel index DML query, using ALTER auto_refresh=off statement to stop job, using"
             + " VACUUM statement to stop job and delete data");

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/flint/FlintIndexMetadataService.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/flint/FlintIndexMetadataService.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.spark.flint;
 
 import java.util.Map;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
 
 /** Interface for FlintIndexMetadataReader */
@@ -15,16 +16,22 @@ public interface FlintIndexMetadataService {
    * Retrieves a map of {@link FlintIndexMetadata} instances matching the specified index pattern.
    *
    * @param indexPattern indexPattern.
+   * @param asyncQueryRequestContext request context passed to AsyncQueryExecutorService
    * @return A map of {@link FlintIndexMetadata} instances against indexName, each providing
    *     metadata access for a matched index. Returns an empty list if no indices match the pattern.
    */
-  Map<String, FlintIndexMetadata> getFlintIndexMetadata(String indexPattern);
+  Map<String, FlintIndexMetadata> getFlintIndexMetadata(
+      String indexPattern, AsyncQueryRequestContext asyncQueryRequestContext);
 
   /**
    * Performs validation and updates flint index to manual refresh.
    *
    * @param indexName indexName.
    * @param flintIndexOptions flintIndexOptions.
+   * @param asyncQueryRequestContext request context passed to AsyncQueryExecutorService
    */
-  void updateIndexToManualRefresh(String indexName, FlintIndexOptions flintIndexOptions);
+  void updateIndexToManualRefresh(
+      String indexName,
+      FlintIndexOptions flintIndexOptions,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/flint/FlintIndexStateModelService.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/flint/FlintIndexStateModelService.java
@@ -6,20 +6,58 @@
 package org.opensearch.sql.spark.flint;
 
 import java.util.Optional;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 
 /**
  * Abstraction over flint index state storage. Flint index state will maintain the status of each
  * flint index.
  */
 public interface FlintIndexStateModelService {
-  FlintIndexStateModel createFlintIndexStateModel(FlintIndexStateModel flintIndexStateModel);
 
-  Optional<FlintIndexStateModel> getFlintIndexStateModel(String id, String datasourceName);
+  /**
+   * Create Flint index state record
+   *
+   * @param flintIndexStateModel the model to be saved
+   * @param asyncQueryRequestContext the request context passed to AsyncQueryExecutorService
+   * @return saved model
+   */
+  FlintIndexStateModel createFlintIndexStateModel(
+      FlintIndexStateModel flintIndexStateModel, AsyncQueryRequestContext asyncQueryRequestContext);
 
+  /**
+   * Get Flint index state record
+   *
+   * @param id ID(latestId) of the Flint index state record
+   * @param datasourceName datasource name
+   * @param asyncQueryRequestContext the request context passed to AsyncQueryExecutorService
+   * @return retrieved model
+   */
+  Optional<FlintIndexStateModel> getFlintIndexStateModel(
+      String id, String datasourceName, AsyncQueryRequestContext asyncQueryRequestContext);
+
+  /**
+   * Update Flint index state record
+   *
+   * @param flintIndexStateModel the model to be updated
+   * @param flintIndexState new state
+   * @param datasourceName Datasource name
+   * @param asyncQueryRequestContext the request context passed to AsyncQueryExecutorService
+   * @return Updated model
+   */
   FlintIndexStateModel updateFlintIndexState(
       FlintIndexStateModel flintIndexStateModel,
       FlintIndexState flintIndexState,
-      String datasourceName);
+      String datasourceName,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
-  boolean deleteFlintIndexStateModel(String id, String datasourceName);
+  /**
+   * Delete Flint index state record
+   *
+   * @param id ID(latestId) of the Flint index state record
+   * @param datasourceName datasource name
+   * @param asyncQueryRequestContext the request context passed to AsyncQueryExecutorService
+   * @return true if deleted, otherwise false
+   */
+  boolean deleteFlintIndexStateModel(
+      String id, String datasourceName, AsyncQueryRequestContext asyncQueryRequestContext);
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpAlter.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpAlter.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.spark.flint.operation;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
@@ -48,11 +49,14 @@ public class FlintIndexOpAlter extends FlintIndexOp {
 
   @SneakyThrows
   @Override
-  void runOp(FlintIndexMetadata flintIndexMetadata, FlintIndexStateModel flintIndexStateModel) {
+  void runOp(
+      FlintIndexMetadata flintIndexMetadata,
+      FlintIndexStateModel flintIndexStateModel,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     LOG.debug(
         "Running alter index operation for index: {}", flintIndexMetadata.getOpensearchIndexName());
     this.flintIndexMetadataService.updateIndexToManualRefresh(
-        flintIndexMetadata.getOpensearchIndexName(), flintIndexOptions);
+        flintIndexMetadata.getOpensearchIndexName(), flintIndexOptions, asyncQueryRequestContext);
     cancelStreamingJob(flintIndexStateModel);
   }
 

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpCancel.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpCancel.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.spark.flint.operation;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
@@ -38,7 +39,10 @@ public class FlintIndexOpCancel extends FlintIndexOp {
   /** cancel EMR-S job, wait cancelled state upto 15s. */
   @SneakyThrows
   @Override
-  void runOp(FlintIndexMetadata flintIndexMetadata, FlintIndexStateModel flintIndexStateModel) {
+  void runOp(
+      FlintIndexMetadata flintIndexMetadata,
+      FlintIndexStateModel flintIndexStateModel,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     LOG.debug(
         "Performing drop index operation for index: {}",
         flintIndexMetadata.getOpensearchIndexName());

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpDrop.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpDrop.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.spark.flint.operation;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
 import org.opensearch.sql.spark.flint.FlintIndexState;
@@ -40,7 +41,10 @@ public class FlintIndexOpDrop extends FlintIndexOp {
   /** cancel EMR-S job, wait cancelled state upto 15s. */
   @SneakyThrows
   @Override
-  void runOp(FlintIndexMetadata flintIndexMetadata, FlintIndexStateModel flintIndexStateModel) {
+  void runOp(
+      FlintIndexMetadata flintIndexMetadata,
+      FlintIndexStateModel flintIndexStateModel,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     LOG.debug(
         "Performing drop index operation for index: {}",
         flintIndexMetadata.getOpensearchIndexName());

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpVacuum.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpVacuum.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.spark.flint.operation;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.flint.FlintIndexClient;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
@@ -42,7 +43,10 @@ public class FlintIndexOpVacuum extends FlintIndexOp {
   }
 
   @Override
-  public void runOp(FlintIndexMetadata flintIndexMetadata, FlintIndexStateModel flintIndex) {
+  public void runOp(
+      FlintIndexMetadata flintIndexMetadata,
+      FlintIndexStateModel flintIndex,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     LOG.info("Vacuuming Flint index {}", flintIndexMetadata.getOpensearchIndexName());
     flintIndexClient.deleteIndex(flintIndexMetadata.getOpensearchIndexName());
   }

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
@@ -206,7 +206,8 @@ public class AsyncQueryExecutorServiceImplTest {
 
     AsyncQueryNotFoundException asyncQueryNotFoundException =
         Assertions.assertThrows(
-            AsyncQueryNotFoundException.class, () -> jobExecutorService.cancelQuery(EMR_JOB_ID));
+            AsyncQueryNotFoundException.class,
+            () -> jobExecutorService.cancelQuery(EMR_JOB_ID, asyncQueryRequestContext));
 
     Assertions.assertEquals(
         "QueryId: " + EMR_JOB_ID + " not found", asyncQueryNotFoundException.getMessage());
@@ -218,9 +219,10 @@ public class AsyncQueryExecutorServiceImplTest {
   void testCancelJob() {
     when(asyncQueryJobMetadataStorageService.getJobMetadata(EMR_JOB_ID))
         .thenReturn(Optional.of(getAsyncQueryJobMetadata()));
-    when(sparkQueryDispatcher.cancelJob(getAsyncQueryJobMetadata())).thenReturn(EMR_JOB_ID);
+    when(sparkQueryDispatcher.cancelJob(getAsyncQueryJobMetadata(), asyncQueryRequestContext))
+        .thenReturn(EMR_JOB_ID);
 
-    String jobId = jobExecutorService.cancelQuery(EMR_JOB_ID);
+    String jobId = jobExecutorService.cancelQuery(EMR_JOB_ID, asyncQueryRequestContext);
 
     Assertions.assertEquals(EMR_JOB_ID, jobId);
     verifyNoInteractions(sparkExecutionEngineConfigSupplier);

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandlerTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandlerTest.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.spark.dispatcher;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.sql.datasource.model.DataSourceStatus.ACTIVE;
@@ -27,6 +28,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.datasource.model.DataSourceType;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.config.SparkSubmitParameterModifier;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryContext;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
@@ -50,6 +52,7 @@ class IndexDMLHandlerTest {
   @Mock private IndexDMLResultStorageService indexDMLResultStorageService;
   @Mock private FlintIndexOpFactory flintIndexOpFactory;
   @Mock private SparkSubmitParameterModifier sparkSubmitParameterModifier;
+  @Mock private AsyncQueryRequestContext asyncQueryRequestContext;
 
   @InjectMocks IndexDMLHandler indexDMLHandler;
 
@@ -82,8 +85,10 @@ class IndexDMLHandlerTest {
             .queryId(QUERY_ID)
             .dataSourceMetadata(metadata)
             .indexQueryDetails(indexQueryDetails)
+            .asyncQueryRequestContext(asyncQueryRequestContext)
             .build();
-    Mockito.when(flintIndexMetadataService.getFlintIndexMetadata(any()))
+    Mockito.when(
+            flintIndexMetadataService.getFlintIndexMetadata(any(), eq(asyncQueryRequestContext)))
         .thenReturn(new HashMap<>());
 
     DispatchQueryResponse dispatchQueryResponse =
@@ -107,10 +112,12 @@ class IndexDMLHandlerTest {
             .queryId(QUERY_ID)
             .dataSourceMetadata(metadata)
             .indexQueryDetails(indexQueryDetails)
+            .asyncQueryRequestContext(asyncQueryRequestContext)
             .build();
     HashMap<String, FlintIndexMetadata> flintMetadataMap = new HashMap<>();
     flintMetadataMap.put(indexQueryDetails.openSearchIndexName(), flintIndexMetadata);
-    when(flintIndexMetadataService.getFlintIndexMetadata(indexQueryDetails.openSearchIndexName()))
+    when(flintIndexMetadataService.getFlintIndexMetadata(
+            indexQueryDetails.openSearchIndexName(), asyncQueryRequestContext))
         .thenReturn(flintMetadataMap);
 
     indexDMLHandler.submit(dispatchQueryRequest, dispatchQueryContext);

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -871,7 +871,8 @@ public class SparkQueryDispatcherTest {
                 .withJobRunId(EMR_JOB_ID)
                 .withApplicationId(EMRS_APPLICATION_ID));
 
-    String queryId = sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata());
+    String queryId =
+        sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata(), asyncQueryRequestContext);
 
     Assertions.assertEquals(QUERY_ID, queryId);
   }
@@ -884,7 +885,8 @@ public class SparkQueryDispatcherTest {
 
     String queryId =
         sparkQueryDispatcher.cancelJob(
-            asyncQueryJobMetadataWithSessionId(MOCK_STATEMENT_ID, MOCK_SESSION_ID));
+            asyncQueryJobMetadataWithSessionId(MOCK_STATEMENT_ID, MOCK_SESSION_ID),
+            asyncQueryRequestContext);
 
     verifyNoInteractions(emrServerlessClient);
     verify(statement, times(1)).cancel();
@@ -900,7 +902,8 @@ public class SparkQueryDispatcherTest {
             IllegalArgumentException.class,
             () ->
                 sparkQueryDispatcher.cancelJob(
-                    asyncQueryJobMetadataWithSessionId(MOCK_STATEMENT_ID, "invalid")));
+                    asyncQueryJobMetadataWithSessionId(MOCK_STATEMENT_ID, "invalid"),
+                    asyncQueryRequestContext));
 
     verifyNoInteractions(emrServerlessClient);
     verifyNoInteractions(session);
@@ -916,7 +919,8 @@ public class SparkQueryDispatcherTest {
             IllegalArgumentException.class,
             () ->
                 sparkQueryDispatcher.cancelJob(
-                    asyncQueryJobMetadataWithSessionId("invalid", MOCK_SESSION_ID)));
+                    asyncQueryJobMetadataWithSessionId("invalid", MOCK_SESSION_ID),
+                    asyncQueryRequestContext));
 
     verifyNoInteractions(emrServerlessClient);
     verifyNoInteractions(statement);
@@ -933,7 +937,8 @@ public class SparkQueryDispatcherTest {
                 .withJobRunId(EMR_JOB_ID)
                 .withApplicationId(EMRS_APPLICATION_ID));
 
-    String queryId = sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata());
+    String queryId =
+        sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata(), asyncQueryRequestContext);
 
     Assertions.assertEquals(QUERY_ID, queryId);
   }

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpVacuumTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpVacuumTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.client.EMRServerlessClientFactory;
 import org.opensearch.sql.spark.flint.FlintIndexClient;
 import org.opensearch.sql.spark.flint.FlintIndexMetadata;
@@ -38,6 +39,7 @@ class FlintIndexOpVacuumTest {
   @Mock EMRServerlessClientFactory emrServerlessClientFactory;
   @Mock FlintIndexStateModel flintIndexStateModel;
   @Mock FlintIndexStateModel transitionedFlintIndexStateModel;
+  @Mock AsyncQueryRequestContext asyncQueryRequestContext;
 
   RuntimeException testException = new RuntimeException("Test Exception");
 
@@ -55,110 +57,154 @@ class FlintIndexOpVacuumTest {
 
   @Test
   public void testApplyWithEmptyLatestId() {
-    flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITHOUT_LATEST_ID);
+    flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITHOUT_LATEST_ID, asyncQueryRequestContext);
 
     verify(flintIndexClient).deleteIndex(INDEX_NAME);
   }
 
   @Test
   public void testApplyWithFlintIndexStateNotFound() {
-    when(flintIndexStateModelService.getFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME))
+    when(flintIndexStateModelService.getFlintIndexStateModel(
+            LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenReturn(Optional.empty());
 
     assertThrows(
         IllegalStateException.class,
-        () -> flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITH_LATEST_ID));
+        () ->
+            flintIndexOpVacuum.apply(
+                FLINT_INDEX_METADATA_WITH_LATEST_ID, asyncQueryRequestContext));
   }
 
   @Test
   public void testApplyWithNotDeletedState() {
-    when(flintIndexStateModelService.getFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME))
+    when(flintIndexStateModelService.getFlintIndexStateModel(
+            LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenReturn(Optional.of(flintIndexStateModel));
     when(flintIndexStateModel.getIndexState()).thenReturn(FlintIndexState.ACTIVE);
 
     assertThrows(
         IllegalStateException.class,
-        () -> flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITH_LATEST_ID));
+        () ->
+            flintIndexOpVacuum.apply(
+                FLINT_INDEX_METADATA_WITH_LATEST_ID, asyncQueryRequestContext));
   }
 
   @Test
   public void testApplyWithUpdateFlintIndexStateThrow() {
-    when(flintIndexStateModelService.getFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME))
+    when(flintIndexStateModelService.getFlintIndexStateModel(
+            LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenReturn(Optional.of(flintIndexStateModel));
     when(flintIndexStateModel.getIndexState()).thenReturn(FlintIndexState.DELETED);
     when(flintIndexStateModelService.updateFlintIndexState(
-            flintIndexStateModel, FlintIndexState.VACUUMING, DATASOURCE_NAME))
+            flintIndexStateModel,
+            FlintIndexState.VACUUMING,
+            DATASOURCE_NAME,
+            asyncQueryRequestContext))
         .thenThrow(testException);
 
     assertThrows(
         IllegalStateException.class,
-        () -> flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITH_LATEST_ID));
+        () ->
+            flintIndexOpVacuum.apply(
+                FLINT_INDEX_METADATA_WITH_LATEST_ID, asyncQueryRequestContext));
   }
 
   @Test
   public void testApplyWithRunOpThrow() {
-    when(flintIndexStateModelService.getFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME))
+    when(flintIndexStateModelService.getFlintIndexStateModel(
+            LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenReturn(Optional.of(flintIndexStateModel));
     when(flintIndexStateModel.getIndexState()).thenReturn(FlintIndexState.DELETED);
     when(flintIndexStateModelService.updateFlintIndexState(
-            flintIndexStateModel, FlintIndexState.VACUUMING, DATASOURCE_NAME))
+            flintIndexStateModel,
+            FlintIndexState.VACUUMING,
+            DATASOURCE_NAME,
+            asyncQueryRequestContext))
         .thenReturn(transitionedFlintIndexStateModel);
     doThrow(testException).when(flintIndexClient).deleteIndex(INDEX_NAME);
 
     assertThrows(
-        Exception.class, () -> flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITH_LATEST_ID));
+        Exception.class,
+        () ->
+            flintIndexOpVacuum.apply(
+                FLINT_INDEX_METADATA_WITH_LATEST_ID, asyncQueryRequestContext));
 
     verify(flintIndexStateModelService)
         .updateFlintIndexState(
-            transitionedFlintIndexStateModel, FlintIndexState.DELETED, DATASOURCE_NAME);
+            transitionedFlintIndexStateModel,
+            FlintIndexState.DELETED,
+            DATASOURCE_NAME,
+            asyncQueryRequestContext);
   }
 
   @Test
   public void testApplyWithRunOpThrowAndRollbackThrow() {
-    when(flintIndexStateModelService.getFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME))
+    when(flintIndexStateModelService.getFlintIndexStateModel(
+            LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenReturn(Optional.of(flintIndexStateModel));
     when(flintIndexStateModel.getIndexState()).thenReturn(FlintIndexState.DELETED);
     when(flintIndexStateModelService.updateFlintIndexState(
-            flintIndexStateModel, FlintIndexState.VACUUMING, DATASOURCE_NAME))
+            flintIndexStateModel,
+            FlintIndexState.VACUUMING,
+            DATASOURCE_NAME,
+            asyncQueryRequestContext))
         .thenReturn(transitionedFlintIndexStateModel);
     doThrow(testException).when(flintIndexClient).deleteIndex(INDEX_NAME);
     when(flintIndexStateModelService.updateFlintIndexState(
-            transitionedFlintIndexStateModel, FlintIndexState.DELETED, DATASOURCE_NAME))
+            transitionedFlintIndexStateModel,
+            FlintIndexState.DELETED,
+            DATASOURCE_NAME,
+            asyncQueryRequestContext))
         .thenThrow(testException);
 
     assertThrows(
-        Exception.class, () -> flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITH_LATEST_ID));
+        Exception.class,
+        () ->
+            flintIndexOpVacuum.apply(
+                FLINT_INDEX_METADATA_WITH_LATEST_ID, asyncQueryRequestContext));
   }
 
   @Test
   public void testApplyWithDeleteFlintIndexStateModelThrow() {
-    when(flintIndexStateModelService.getFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME))
+    when(flintIndexStateModelService.getFlintIndexStateModel(
+            LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenReturn(Optional.of(flintIndexStateModel));
     when(flintIndexStateModel.getIndexState()).thenReturn(FlintIndexState.DELETED);
     when(flintIndexStateModelService.updateFlintIndexState(
-            flintIndexStateModel, FlintIndexState.VACUUMING, DATASOURCE_NAME))
+            flintIndexStateModel,
+            FlintIndexState.VACUUMING,
+            DATASOURCE_NAME,
+            asyncQueryRequestContext))
         .thenReturn(transitionedFlintIndexStateModel);
-    when(flintIndexStateModelService.deleteFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME))
+    when(flintIndexStateModelService.deleteFlintIndexStateModel(
+            LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenThrow(testException);
 
     assertThrows(
         IllegalStateException.class,
-        () -> flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITH_LATEST_ID));
+        () ->
+            flintIndexOpVacuum.apply(
+                FLINT_INDEX_METADATA_WITH_LATEST_ID, asyncQueryRequestContext));
   }
 
   @Test
   public void testApplyHappyPath() {
-    when(flintIndexStateModelService.getFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME))
+    when(flintIndexStateModelService.getFlintIndexStateModel(
+            LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenReturn(Optional.of(flintIndexStateModel));
     when(flintIndexStateModel.getIndexState()).thenReturn(FlintIndexState.DELETED);
     when(flintIndexStateModelService.updateFlintIndexState(
-            flintIndexStateModel, FlintIndexState.VACUUMING, DATASOURCE_NAME))
+            flintIndexStateModel,
+            FlintIndexState.VACUUMING,
+            DATASOURCE_NAME,
+            asyncQueryRequestContext))
         .thenReturn(transitionedFlintIndexStateModel);
     when(transitionedFlintIndexStateModel.getLatestId()).thenReturn(LATEST_ID);
 
-    flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITH_LATEST_ID);
+    flintIndexOpVacuum.apply(FLINT_INDEX_METADATA_WITH_LATEST_ID, asyncQueryRequestContext);
 
-    verify(flintIndexStateModelService).deleteFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME);
+    verify(flintIndexStateModelService)
+        .deleteFlintIndexStateModel(LATEST_ID, DATASOURCE_NAME, asyncQueryRequestContext);
     verify(flintIndexClient).deleteIndex(INDEX_NAME);
   }
 }

--- a/async-query/src/main/java/org/opensearch/sql/spark/flint/FlintIndexMetadataServiceImpl.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/flint/FlintIndexMetadataServiceImpl.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.opensearch.client.Client;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
 
 /** Implementation of {@link FlintIndexMetadataService} */
@@ -49,7 +50,8 @@ public class FlintIndexMetadataServiceImpl implements FlintIndexMetadataService 
           Arrays.asList(AUTO_REFRESH, INCREMENTAL_REFRESH, WATERMARK_DELAY, CHECKPOINT_LOCATION));
 
   @Override
-  public Map<String, FlintIndexMetadata> getFlintIndexMetadata(String indexPattern) {
+  public Map<String, FlintIndexMetadata> getFlintIndexMetadata(
+      String indexPattern, AsyncQueryRequestContext asyncQueryRequestContext) {
     GetMappingsResponse mappingsResponse =
         client.admin().indices().prepareGetMappings().setIndices(indexPattern).get();
     Map<String, FlintIndexMetadata> indexMetadataMap = new HashMap<>();
@@ -73,7 +75,10 @@ public class FlintIndexMetadataServiceImpl implements FlintIndexMetadataService 
   }
 
   @Override
-  public void updateIndexToManualRefresh(String indexName, FlintIndexOptions flintIndexOptions) {
+  public void updateIndexToManualRefresh(
+      String indexName,
+      FlintIndexOptions flintIndexOptions,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     GetMappingsResponse mappingsResponse =
         client.admin().indices().prepareGetMappings().setIndices(indexName).get();
     Map<String, Object> flintMetadataMap =

--- a/async-query/src/main/java/org/opensearch/sql/spark/flint/OpenSearchFlintIndexStateModelService.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/flint/OpenSearchFlintIndexStateModelService.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.spark.flint;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.statestore.OpenSearchStateStoreUtil;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.execution.xcontent.FlintIndexStateModelXContentSerializer;
@@ -20,7 +21,8 @@ public class OpenSearchFlintIndexStateModelService implements FlintIndexStateMod
   public FlintIndexStateModel updateFlintIndexState(
       FlintIndexStateModel flintIndexStateModel,
       FlintIndexState flintIndexState,
-      String datasourceName) {
+      String datasourceName,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     return stateStore.updateState(
         flintIndexStateModel,
         flintIndexState,
@@ -29,14 +31,16 @@ public class OpenSearchFlintIndexStateModelService implements FlintIndexStateMod
   }
 
   @Override
-  public Optional<FlintIndexStateModel> getFlintIndexStateModel(String id, String datasourceName) {
+  public Optional<FlintIndexStateModel> getFlintIndexStateModel(
+      String id, String datasourceName, AsyncQueryRequestContext asyncQueryRequestContext) {
     return stateStore.get(
         id, serializer::fromXContent, OpenSearchStateStoreUtil.getIndexName(datasourceName));
   }
 
   @Override
   public FlintIndexStateModel createFlintIndexStateModel(
-      FlintIndexStateModel flintIndexStateModel) {
+      FlintIndexStateModel flintIndexStateModel,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     return stateStore.create(
         flintIndexStateModel.getId(),
         flintIndexStateModel,
@@ -45,7 +49,8 @@ public class OpenSearchFlintIndexStateModelService implements FlintIndexStateMod
   }
 
   @Override
-  public boolean deleteFlintIndexStateModel(String id, String datasourceName) {
+  public boolean deleteFlintIndexStateModel(
+      String id, String datasourceName, AsyncQueryRequestContext asyncQueryRequestContext) {
     return stateStore.delete(id, OpenSearchStateStoreUtil.getIndexName(datasourceName));
   }
 }

--- a/async-query/src/main/java/org/opensearch/sql/spark/transport/TransportCancelAsyncQueryRequestAction.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/transport/TransportCancelAsyncQueryRequestAction.java
@@ -13,6 +13,7 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorServiceImpl;
+import org.opensearch.sql.spark.asyncquery.model.NullAsyncQueryRequestContext;
 import org.opensearch.sql.spark.transport.model.CancelAsyncQueryActionRequest;
 import org.opensearch.sql.spark.transport.model.CancelAsyncQueryActionResponse;
 import org.opensearch.tasks.Task;
@@ -41,7 +42,9 @@ public class TransportCancelAsyncQueryRequestAction
       CancelAsyncQueryActionRequest request,
       ActionListener<CancelAsyncQueryActionResponse> listener) {
     try {
-      String jobId = asyncQueryExecutorService.cancelQuery(request.getQueryId());
+      String jobId =
+          asyncQueryExecutorService.cancelQuery(
+              request.getQueryId(), new NullAsyncQueryRequestContext());
       listener.onResponse(
           new CancelAsyncQueryActionResponse(
               String.format("Deleted async query with id: %s", jobId)));

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
@@ -71,7 +71,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     emrsClient.getJobRunResultCalled(1);
 
     // 3. cancel async query.
-    String cancelQueryId = asyncQueryExecutorService.cancelQuery(response.getQueryId());
+    String cancelQueryId =
+        asyncQueryExecutorService.cancelQuery(response.getQueryId(), asyncQueryRequestContext);
     assertEquals(response.getQueryId(), cancelQueryId);
     emrsClient.cancelJobRunCalled(1);
   }
@@ -163,7 +164,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
     assertEquals(StatementState.WAITING.getState(), asyncQueryResults.getStatus());
 
     // 3. cancel async query.
-    String cancelQueryId = asyncQueryExecutorService.cancelQuery(response.getQueryId());
+    String cancelQueryId =
+        asyncQueryExecutorService.cancelQuery(response.getQueryId(), asyncQueryRequestContext);
     assertEquals(response.getQueryId(), cancelQueryId);
   }
 

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -152,7 +152,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               IllegalArgumentException exception =
                   assertThrows(
                       IllegalArgumentException.class,
-                      () -> asyncQueryExecutorService.cancelQuery(response.getQueryId()));
+                      () ->
+                          asyncQueryExecutorService.cancelQuery(
+                              response.getQueryId(), asyncQueryRequestContext));
               assertEquals("can't cancel index DML query", exception.getMessage());
             });
   }
@@ -326,7 +328,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               IllegalArgumentException exception =
                   assertThrows(
                       IllegalArgumentException.class,
-                      () -> asyncQueryExecutorService.cancelQuery(response.getQueryId()));
+                      () ->
+                          asyncQueryExecutorService.cancelQuery(
+                              response.getQueryId(), asyncQueryRequestContext));
               assertEquals("can't cancel index DML query", exception.getMessage());
             });
   }
@@ -901,7 +905,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               IllegalArgumentException exception =
                   assertThrows(
                       IllegalArgumentException.class,
-                      () -> asyncQueryExecutorService.cancelQuery(response.getQueryId()));
+                      () ->
+                          asyncQueryExecutorService.cancelQuery(
+                              response.getQueryId(), asyncQueryRequestContext));
               assertEquals(
                   "can't cancel index DML query, using ALTER auto_refresh=off statement to stop"
                       + " job, using VACUUM statement to stop job and delete data",
@@ -944,7 +950,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               flintIndexJob.refreshing();
 
               // 2. Cancel query
-              String cancelResponse = asyncQueryExecutorService.cancelQuery(response.getQueryId());
+              String cancelResponse =
+                  asyncQueryExecutorService.cancelQuery(
+                      response.getQueryId(), asyncQueryRequestContext);
 
               assertNotNull(cancelResponse);
               assertTrue(clusterService.state().routingTable().hasIndex(mockDS.indexName));
@@ -992,7 +1000,9 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               IllegalStateException illegalStateException =
                   Assertions.assertThrows(
                       IllegalStateException.class,
-                      () -> asyncQueryExecutorService.cancelQuery(response.getQueryId()));
+                      () ->
+                          asyncQueryExecutorService.cancelQuery(
+                              response.getQueryId(), asyncQueryRequestContext));
               Assertions.assertEquals(
                   "Transaction failed as flint index is not in a valid state.",
                   illegalStateException.getMessage());
@@ -1038,6 +1048,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
     // 2. Cancel query
     Assertions.assertThrows(
         IllegalStateException.class,
-        () -> asyncQueryExecutorService.cancelQuery(response.getQueryId()));
+        () ->
+            asyncQueryExecutorService.cancelQuery(response.getQueryId(), asyncQueryRequestContext));
   }
 }

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/model/MockFlintSparkJob.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/model/MockFlintSparkJob.java
@@ -18,6 +18,7 @@ public class MockFlintSparkJob {
   private FlintIndexStateModel stateModel;
   private FlintIndexStateModelService flintIndexStateModelService;
   private String datasource;
+  private AsyncQueryRequestContext asyncQueryRequestContext = new NullAsyncQueryRequestContext();
 
   public MockFlintSparkJob(
       FlintIndexStateModelService flintIndexStateModelService, String latestId, String datasource) {
@@ -34,12 +35,15 @@ public class MockFlintSparkJob {
             .lastUpdateTime(System.currentTimeMillis())
             .error("")
             .build();
-    stateModel = flintIndexStateModelService.createFlintIndexStateModel(stateModel);
+    stateModel =
+        flintIndexStateModelService.createFlintIndexStateModel(
+            stateModel, asyncQueryRequestContext);
   }
 
   public void transition(FlintIndexState newState) {
     stateModel =
-        flintIndexStateModelService.updateFlintIndexState(stateModel, newState, datasource);
+        flintIndexStateModelService.updateFlintIndexState(
+            stateModel, newState, datasource, asyncQueryRequestContext);
   }
 
   public void refreshing() {
@@ -68,7 +72,8 @@ public class MockFlintSparkJob {
 
   public void assertState(FlintIndexState expected) {
     Optional<FlintIndexStateModel> stateModelOpt =
-        flintIndexStateModelService.getFlintIndexStateModel(stateModel.getId(), datasource);
+        flintIndexStateModelService.getFlintIndexStateModel(
+            stateModel.getId(), datasource, asyncQueryRequestContext);
     assertTrue(stateModelOpt.isPresent());
     assertEquals(expected, stateModelOpt.get().getIndexState());
   }

--- a/async-query/src/test/java/org/opensearch/sql/spark/cluster/FlintStreamingJobHouseKeeperTaskTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/cluster/FlintStreamingJobHouseKeeperTaskTest.java
@@ -20,6 +20,7 @@ import org.opensearch.sql.datasource.model.DataSourceStatus;
 import org.opensearch.sql.legacy.metrics.MetricName;
 import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorServiceSpec;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintIndex;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
@@ -393,13 +394,16 @@ public class FlintStreamingJobHouseKeeperTaskTest extends AsyncQueryExecutorServ
     FlintIndexMetadataService flintIndexMetadataService =
         new FlintIndexMetadataService() {
           @Override
-          public Map<String, FlintIndexMetadata> getFlintIndexMetadata(String indexPattern) {
+          public Map<String, FlintIndexMetadata> getFlintIndexMetadata(
+              String indexPattern, AsyncQueryRequestContext asyncQueryRequestContext) {
             throw new RuntimeException("Couldn't fetch details from ElasticSearch");
           }
 
           @Override
           public void updateIndexToManualRefresh(
-              String indexName, FlintIndexOptions flintIndexOptions) {}
+              String indexName,
+              FlintIndexOptions flintIndexOptions,
+              AsyncQueryRequestContext asyncQueryRequestContext) {}
         };
     FlintStreamingJobHouseKeeperTask flintStreamingJobHouseKeeperTask =
         new FlintStreamingJobHouseKeeperTask(

--- a/async-query/src/test/java/org/opensearch/sql/spark/flint/FlintIndexMetadataServiceImplTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/flint/FlintIndexMetadataServiceImplTest.java
@@ -29,6 +29,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.dispatcher.model.FlintIndexOptions;
 import org.opensearch.sql.spark.dispatcher.model.FullyQualifiedTableName;
 import org.opensearch.sql.spark.dispatcher.model.IndexQueryActionType;
@@ -38,6 +39,8 @@ import org.opensearch.sql.spark.dispatcher.model.IndexQueryDetails;
 public class FlintIndexMetadataServiceImplTest {
   @Mock(answer = RETURNS_DEEP_STUBS)
   private Client client;
+
+  @Mock private AsyncQueryRequestContext asyncQueryRequestContext;
 
   @SneakyThrows
   @Test
@@ -56,8 +59,11 @@ public class FlintIndexMetadataServiceImplTest {
             .indexQueryActionType(IndexQueryActionType.DROP)
             .indexType(FlintIndexType.SKIPPING)
             .build();
+
     Map<String, FlintIndexMetadata> indexMetadataMap =
-        flintIndexMetadataService.getFlintIndexMetadata(indexQueryDetails.openSearchIndexName());
+        flintIndexMetadataService.getFlintIndexMetadata(
+            indexQueryDetails.openSearchIndexName(), asyncQueryRequestContext);
+
     Assertions.assertEquals(
         "00fhelvq7peuao0",
         indexMetadataMap.get(indexQueryDetails.openSearchIndexName()).getJobId());
@@ -80,8 +86,11 @@ public class FlintIndexMetadataServiceImplTest {
             .indexQueryActionType(IndexQueryActionType.DROP)
             .indexType(FlintIndexType.SKIPPING)
             .build();
+
     Map<String, FlintIndexMetadata> indexMetadataMap =
-        flintIndexMetadataService.getFlintIndexMetadata(indexQueryDetails.openSearchIndexName());
+        flintIndexMetadataService.getFlintIndexMetadata(
+            indexQueryDetails.openSearchIndexName(), asyncQueryRequestContext);
+
     FlintIndexMetadata metadata = indexMetadataMap.get(indexQueryDetails.openSearchIndexName());
     Assertions.assertEquals("00fhelvq7peuao0", metadata.getJobId());
   }
@@ -103,8 +112,11 @@ public class FlintIndexMetadataServiceImplTest {
             .indexType(FlintIndexType.COVERING)
             .build();
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
+
     Map<String, FlintIndexMetadata> indexMetadataMap =
-        flintIndexMetadataService.getFlintIndexMetadata(indexQueryDetails.openSearchIndexName());
+        flintIndexMetadataService.getFlintIndexMetadata(
+            indexQueryDetails.openSearchIndexName(), asyncQueryRequestContext);
+
     Assertions.assertEquals(
         "00fdmvv9hp8u0o0q",
         indexMetadataMap.get(indexQueryDetails.openSearchIndexName()).getJobId());
@@ -126,8 +138,11 @@ public class FlintIndexMetadataServiceImplTest {
             .indexQueryActionType(IndexQueryActionType.DROP)
             .indexType(FlintIndexType.COVERING)
             .build();
+
     Map<String, FlintIndexMetadata> flintIndexMetadataMap =
-        flintIndexMetadataService.getFlintIndexMetadata(indexQueryDetails.openSearchIndexName());
+        flintIndexMetadataService.getFlintIndexMetadata(
+            indexQueryDetails.openSearchIndexName(), asyncQueryRequestContext);
+
     Assertions.assertFalse(
         flintIndexMetadataMap.containsKey("flint_mys3_default_http_logs_cv1_index"));
   }
@@ -148,8 +163,10 @@ public class FlintIndexMetadataServiceImplTest {
     indexMappingsMap.put(indexName, mappings);
     mockNodeClientIndicesMappings("flint_mys3*", indexMappingsMap);
     FlintIndexMetadataService flintIndexMetadataService = new FlintIndexMetadataServiceImpl(client);
+
     Map<String, FlintIndexMetadata> flintIndexMetadataMap =
-        flintIndexMetadataService.getFlintIndexMetadata("flint_mys3*");
+        flintIndexMetadataService.getFlintIndexMetadata("flint_mys3*", asyncQueryRequestContext);
+
     Assertions.assertFalse(
         flintIndexMetadataMap.containsKey("flint_mys3_default_http_logs_cv1_index"));
     Assertions.assertTrue(

--- a/async-query/src/test/java/org/opensearch/sql/spark/flint/OpenSearchFlintIndexStateModelServiceTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/flint/OpenSearchFlintIndexStateModelServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.execution.xcontent.FlintIndexStateModelXContentSerializer;
 
@@ -30,6 +31,7 @@ public class OpenSearchFlintIndexStateModelServiceTest {
   @Mock FlintIndexState flintIndexState;
   @Mock FlintIndexStateModel responseFlintIndexStateModel;
   @Mock FlintIndexStateModelXContentSerializer flintIndexStateModelXContentSerializer;
+  @Mock AsyncQueryRequestContext asyncQueryRequestContext;
 
   @InjectMocks OpenSearchFlintIndexStateModelService openSearchFlintIndexStateModelService;
 
@@ -40,7 +42,7 @@ public class OpenSearchFlintIndexStateModelServiceTest {
 
     FlintIndexStateModel result =
         openSearchFlintIndexStateModelService.updateFlintIndexState(
-            flintIndexStateModel, flintIndexState, DATASOURCE);
+            flintIndexStateModel, flintIndexState, DATASOURCE, asyncQueryRequestContext);
 
     assertEquals(responseFlintIndexStateModel, result);
   }
@@ -51,7 +53,8 @@ public class OpenSearchFlintIndexStateModelServiceTest {
         .thenReturn(Optional.of(responseFlintIndexStateModel));
 
     Optional<FlintIndexStateModel> result =
-        openSearchFlintIndexStateModelService.getFlintIndexStateModel("ID", DATASOURCE);
+        openSearchFlintIndexStateModelService.getFlintIndexStateModel(
+            "ID", DATASOURCE, asyncQueryRequestContext);
 
     assertEquals(responseFlintIndexStateModel, result.get());
   }
@@ -63,7 +66,8 @@ public class OpenSearchFlintIndexStateModelServiceTest {
     when(flintIndexStateModel.getDatasourceName()).thenReturn(DATASOURCE);
 
     FlintIndexStateModel result =
-        openSearchFlintIndexStateModelService.createFlintIndexStateModel(flintIndexStateModel);
+        openSearchFlintIndexStateModelService.createFlintIndexStateModel(
+            flintIndexStateModel, asyncQueryRequestContext);
 
     assertEquals(responseFlintIndexStateModel, result);
   }
@@ -73,7 +77,8 @@ public class OpenSearchFlintIndexStateModelServiceTest {
     when(mockStateStore.delete(any(), any())).thenReturn(true);
 
     boolean result =
-        openSearchFlintIndexStateModelService.deleteFlintIndexStateModel(ID, DATASOURCE);
+        openSearchFlintIndexStateModelService.deleteFlintIndexStateModel(
+            ID, DATASOURCE, asyncQueryRequestContext);
 
     assertTrue(result);
   }


### PR DESCRIPTION

### Description
- Add AsyncQueryRequestContext to FlintIndexMetadataService/FlintIndexStateService
- The main changes are in FlintIndexMetadataService and FlintIndexStateService, and other changes are for reflecting the additional parameters.

### Related Issues
n/a

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [n/a] New functionality has a user manual doc added.
- [n/a] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [n/a] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
