### PR TITLE
Fix grammar in log warnings.

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ResourceMonitorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ResourceMonitorIT.java
@@ -34,7 +34,7 @@ public class ResourceMonitorIT extends PPLIntegTestCase {
     assertEquals(500, exception.getResponse().getStatusLine().getStatusCode());
     assertThat(
         exception.getMessage(),
-        Matchers.containsString("resource is not enough to run the" + " query, quit."));
+        Matchers.containsString("insufficient resources to run the query, quit."));
 
     // update plugins.ppl.query.memory_limit to default value 85%
     updateClusterSettings(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/protector/ResourceMonitorPlan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/protector/ResourceMonitorPlan.java
@@ -44,7 +44,7 @@ public class ResourceMonitorPlan extends PhysicalPlan implements SerializablePla
   @Override
   public void open() {
     if (!this.monitor.isHealthy()) {
-      throw new IllegalStateException("resource is not enough to run the query, quit.");
+      throw new IllegalStateException("insufficient resources to run the query, quit.");
     }
     delegate.open();
   }
@@ -68,7 +68,7 @@ public class ResourceMonitorPlan extends PhysicalPlan implements SerializablePla
   public ExprValue next() {
     boolean shouldCheck = (++nextCallCount % NUMBER_OF_NEXT_CALL_TO_CHECK == 0);
     if (shouldCheck && !this.monitor.isHealthy()) {
-      throw new IllegalStateException("resource is not enough to load next row, quit.");
+      throw new IllegalStateException("insufficient resources to load next row, quit.");
     }
     return delegate.next();
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/OpenSearchMemoryHealthy.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/OpenSearchMemoryHealthy.java
@@ -36,7 +36,7 @@ public class OpenSearchMemoryHealthy {
     } else {
       log.warn("Memory usage:{} exceed limit:{}", memoryUsage, limitBytes);
       if (randomFail.shouldFail()) {
-        log.warn("Fast failure the current request");
+        log.warn("Fast failing the current request");
         throw new MemoryUsageExceedFastFailureException();
       } else {
         throw new MemoryUsageExceedException();

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/ResourceMonitorPlanTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/executor/ResourceMonitorPlanTest.java
@@ -47,7 +47,7 @@ class ResourceMonitorPlanTest {
 
     IllegalStateException exception =
         assertThrows(IllegalStateException.class, () -> monitorPlan.open());
-    assertEquals("resource is not enough to run the query, quit.", exception.getMessage());
+    assertEquals("insufficient resources to run the query, quit.", exception.getMessage());
   }
 
   @Test
@@ -79,7 +79,7 @@ class ResourceMonitorPlanTest {
 
     IllegalStateException exception =
         assertThrows(IllegalStateException.class, () -> monitorPlan.next());
-    assertEquals("resource is not enough to load next row, quit.", exception.getMessage());
+    assertEquals("insufficient resources to load next row, quit.", exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
### Description

I am running into this circuit breaker in https://github.com/opensearch-project/opensearch-api-specification/issues/468 and the logs contain some difficult to understand text. 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
