### PR TITLE
CVE-2024-6345 fix

### DIFF
--- a/doctest/requirements.txt
+++ b/doctest/requirements.txt
@@ -1,1 +1,2 @@
 zc.customdoctests==1.0.1
+setuptools>=70.0.0


### PR DESCRIPTION
### Description
Upgrade setuptools version to 70.0.0
```
pip install -r requirements.txt

pip show setuptools

# setuptools version no less than 70.0.0
Name: setuptools
Version: 72.1.0
Summary: Easily download, build, install, upgrade, and uninstall Python packages
Home-page:
Author:
Author-email: Python Packaging Authority <distutils-sig@python.org>
License:
Location: /Users/qianheng/Library/Python/3.9/lib/python/site-packages
Requires:
Required-by: zc.customdoctests
```

### Related Issues
Resolves #2846 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
