### PR TITLE
Push down sort through eval

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizer.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizer.java
@@ -48,6 +48,7 @@ public class LogicalPlanOptimizer {
             new MergeFilterAndFilter(),
             new PushFilterUnderSort(),
             EvalPushDown.PUSH_DOWN_LIMIT,
+            EvalPushDown.PUSH_DOWN_SORT,
             /*
              * Phase 2: Transformations that rely on data source push down capability
              */

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
@@ -89,6 +89,19 @@ public class ExplainIT extends PPLIntegTestCase {
                 + "| fields ageMinus"));
   }
 
+  @Test
+  public void testSortPushDownThroughEvalExplain() throws Exception {
+    String expected = loadFromFile("expectedOutput/ppl/explain_limit_push.json");
+
+    assertJsonEquals(
+        expected,
+        explainQueryToString(
+            "source=opensearch-sql_test_index_account"
+                + "| eval newAge = age"
+                + "| sort newAge"
+                + "| fields newAge"));
+  }
+
   String loadFromFile(String filename) throws Exception {
     URI uri = Resources.getResource(filename).toURI();
     return new String(Files.readAllBytes(Paths.get(uri)));

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_sort_push_through_eval.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_sort_push_through_eval.json
@@ -1,0 +1,27 @@
+{
+  "root": {
+    "name": "ProjectOperator",
+    "description": {
+      "fields": "[newAge]"
+    },
+    "children": [
+      {
+        "name": "EvalOperator",
+        "description": {
+          "expressions": {
+            "newAge": "age"
+          }
+        },
+        "children": [
+          {
+            "name": "OpenSearchIndexScan",
+            "description": {
+              "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, searchDone=false)"
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description
Add a rule EvalPushDown.PUSH_DOWN_SORT, this rule will push down limit under eval. Thus, sort has chance to be pushed down into TableScanBuilder later.

For now, it only supports push specific sort and eval, which has restriction:
1. The expression in sort and replaced expression are both ReferenceExpression.
2. No internal reference in eval.

As described in this RFC #2864 , we may have chance to extend it.

### Related Issues
Resolves #2904
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
