### PR TITLE
Add AsyncQueryRequestContext to update/get in StatementStorageService

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorService.java
@@ -31,7 +31,8 @@ public interface AsyncQueryExecutorService {
    * @param queryId queryId.
    * @return {@link AsyncQueryExecutionResponse}
    */
-  AsyncQueryExecutionResponse getAsyncQueryResults(String queryId);
+  AsyncQueryExecutionResponse getAsyncQueryResults(
+      String queryId, AsyncQueryRequestContext asyncQueryRequestContext);
 
   /**
    * Cancels running async query and returns the cancelled queryId.

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
@@ -74,12 +74,14 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
   }
 
   @Override
-  public AsyncQueryExecutionResponse getAsyncQueryResults(String queryId) {
+  public AsyncQueryExecutionResponse getAsyncQueryResults(
+      String queryId, AsyncQueryRequestContext asyncQueryRequestContext) {
     Optional<AsyncQueryJobMetadata> jobMetadata =
         asyncQueryJobMetadataStorageService.getJobMetadata(queryId);
     if (jobMetadata.isPresent()) {
       String sessionId = jobMetadata.get().getSessionId();
-      JSONObject jsonObject = sparkQueryDispatcher.getQueryResponse(jobMetadata.get());
+      JSONObject jsonObject =
+          sparkQueryDispatcher.getQueryResponse(jobMetadata.get(), asyncQueryRequestContext);
       if (JobRunState.SUCCESS.toString().equals(jsonObject.getString(STATUS_FIELD))) {
         DefaultSparkSqlFunctionResponseHandle sparkSqlFunctionResponseHandle =
             new DefaultSparkSqlFunctionResponseHandle(jsonObject);

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/AsyncQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/AsyncQueryHandler.java
@@ -21,8 +21,10 @@ import org.opensearch.sql.spark.execution.statement.StatementState;
 /** Process async query request. */
 public abstract class AsyncQueryHandler {
 
-  public JSONObject getQueryResponse(AsyncQueryJobMetadata asyncQueryJobMetadata) {
-    JSONObject result = getResponseFromResultIndex(asyncQueryJobMetadata);
+  public JSONObject getQueryResponse(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
+    JSONObject result = getResponseFromResultIndex(asyncQueryJobMetadata, asyncQueryRequestContext);
     if (result.has(DATA_FIELD)) {
       JSONObject items = result.getJSONObject(DATA_FIELD);
 
@@ -35,7 +37,8 @@ public abstract class AsyncQueryHandler {
       result.put(ERROR_FIELD, error);
       return result;
     } else {
-      JSONObject statement = getResponseFromExecutor(asyncQueryJobMetadata);
+      JSONObject statement =
+          getResponseFromExecutor(asyncQueryJobMetadata, asyncQueryRequestContext);
 
       // Consider statement still running if state is success but query result unavailable
       if (isSuccessState(statement)) {
@@ -50,10 +53,12 @@ public abstract class AsyncQueryHandler {
   }
 
   protected abstract JSONObject getResponseFromResultIndex(
-      AsyncQueryJobMetadata asyncQueryJobMetadata);
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
   protected abstract JSONObject getResponseFromExecutor(
-      AsyncQueryJobMetadata asyncQueryJobMetadata);
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
   public abstract String cancelJob(
       AsyncQueryJobMetadata asyncQueryJobMetadata,

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -41,7 +41,9 @@ public class BatchQueryHandler extends AsyncQueryHandler {
   protected final SparkSubmitParametersBuilderProvider sparkSubmitParametersBuilderProvider;
 
   @Override
-  protected JSONObject getResponseFromResultIndex(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  protected JSONObject getResponseFromResultIndex(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     // either empty json when the result is not available or data with status
     // Fetch from Result Index
     return jobExecutionResponseReader.getResultWithJobId(
@@ -49,7 +51,9 @@ public class BatchQueryHandler extends AsyncQueryHandler {
   }
 
   @Override
-  protected JSONObject getResponseFromExecutor(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  protected JSONObject getResponseFromExecutor(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     JSONObject result = new JSONObject();
     // make call to EMR Serverless when related result index documents are not available
     GetJobRunResult getJobRunResult =

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
@@ -162,14 +162,18 @@ public class IndexDMLHandler extends AsyncQueryHandler {
   }
 
   @Override
-  protected JSONObject getResponseFromResultIndex(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  protected JSONObject getResponseFromResultIndex(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     String queryId = asyncQueryJobMetadata.getQueryId();
     return jobExecutionResponseReader.getResultWithQueryId(
         queryId, asyncQueryJobMetadata.getResultIndex());
   }
 
   @Override
-  protected JSONObject getResponseFromExecutor(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  protected JSONObject getResponseFromExecutor(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     // Consider statement still running if result doc created in submit() is not available yet
     JSONObject result = new JSONObject();
     result.put(STATUS_FIELD, StatementState.RUNNING.getState());

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -50,21 +50,26 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
   protected final SparkSubmitParametersBuilderProvider sparkSubmitParametersBuilderProvider;
 
   @Override
-  protected JSONObject getResponseFromResultIndex(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  protected JSONObject getResponseFromResultIndex(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     String queryId = asyncQueryJobMetadata.getQueryId();
     return jobExecutionResponseReader.getResultWithQueryId(
         queryId, asyncQueryJobMetadata.getResultIndex());
   }
 
   @Override
-  protected JSONObject getResponseFromExecutor(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  protected JSONObject getResponseFromExecutor(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     JSONObject result = new JSONObject();
     String queryId = asyncQueryJobMetadata.getQueryId();
     Statement statement =
         getStatementByQueryId(
             asyncQueryJobMetadata.getSessionId(),
             queryId,
-            asyncQueryJobMetadata.getDatasourceName());
+            asyncQueryJobMetadata.getDatasourceName(),
+            asyncQueryRequestContext);
     StatementState statementState = statement.getStatementState();
     result.put(STATUS_FIELD, statementState.getState());
     result.put(ERROR_FIELD, Optional.of(statement.getStatementModel().getError()).orElse(""));
@@ -79,7 +84,8 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
     getStatementByQueryId(
             asyncQueryJobMetadata.getSessionId(),
             queryId,
-            asyncQueryJobMetadata.getDatasourceName())
+            asyncQueryJobMetadata.getDatasourceName(),
+            asyncQueryRequestContext)
         .cancel();
     return queryId;
   }
@@ -148,12 +154,16 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
         .build();
   }
 
-  private Statement getStatementByQueryId(String sessionId, String queryId, String datasourceName) {
+  private Statement getStatementByQueryId(
+      String sessionId,
+      String queryId,
+      String datasourceName,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     Optional<Session> session = sessionManager.getSession(sessionId, datasourceName);
     if (session.isPresent()) {
       // todo, statementId == jobId if statement running in session.
       StatementId statementId = new StatementId(queryId);
-      Optional<Statement> statement = session.get().get(statementId);
+      Optional<Statement> statement = session.get().get(statementId, asyncQueryRequestContext);
       if (statement.isPresent()) {
         return statement.get();
       } else {

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -157,9 +157,11 @@ public class SparkQueryDispatcher {
                 && !indexQueryDetails.getFlintIndexOptions().autoRefresh()));
   }
 
-  public JSONObject getQueryResponse(AsyncQueryJobMetadata asyncQueryJobMetadata) {
+  public JSONObject getQueryResponse(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     return getAsyncQueryHandlerForExistingQuery(asyncQueryJobMetadata)
-        .getQueryResponse(asyncQueryJobMetadata);
+        .getQueryResponse(asyncQueryJobMetadata, asyncQueryRequestContext);
   }
 
   public String cancelJob(

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/execution/session/InteractiveSession.java
@@ -121,9 +121,10 @@ public class InteractiveSession implements Session {
   }
 
   @Override
-  public Optional<Statement> get(StatementId stID) {
+  public Optional<Statement> get(
+      StatementId stID, AsyncQueryRequestContext asyncQueryRequestContext) {
     return statementStorageService
-        .getStatement(stID.getId(), sessionModel.getDatasourceName())
+        .getStatement(stID.getId(), sessionModel.getDatasourceName(), asyncQueryRequestContext)
         .map(
             model ->
                 Statement.builder()
@@ -137,6 +138,7 @@ public class InteractiveSession implements Session {
                     .queryId(model.getQueryId())
                     .statementStorageService(statementStorageService)
                     .statementModel(model)
+                    .asyncQueryRequestContext(asyncQueryRequestContext)
                     .build());
   }
 

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/execution/session/Session.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/execution/session/Session.java
@@ -35,7 +35,7 @@ public interface Session {
    * @param stID {@link StatementId}
    * @return {@link Statement}
    */
-  Optional<Statement> get(StatementId stID);
+  Optional<Statement> get(StatementId stID, AsyncQueryRequestContext asyncQueryRequestContext);
 
   SessionModel getSessionModel();
 

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/execution/statement/Statement.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/execution/statement/Statement.java
@@ -70,7 +70,8 @@ public class Statement {
       throw new IllegalStateException(errorMsg);
     }
     this.statementModel =
-        statementStorageService.updateStatementState(statementModel, StatementState.CANCELLED);
+        statementStorageService.updateStatementState(
+            statementModel, StatementState.CANCELLED, asyncQueryRequestContext);
   }
 
   public StatementState getStatementState() {

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/execution/statestore/StatementStorageService.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/execution/statestore/StatementStorageService.java
@@ -20,7 +20,10 @@ public interface StatementStorageService {
       StatementModel statementModel, AsyncQueryRequestContext asyncQueryRequestContext);
 
   StatementModel updateStatementState(
-      StatementModel oldStatementModel, StatementState statementState);
+      StatementModel oldStatementModel,
+      StatementState statementState,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
-  Optional<StatementModel> getStatement(String id, String datasourceName);
+  Optional<StatementModel> getStatement(
+      String id, String datasourceName, AsyncQueryRequestContext asyncQueryRequestContext);
 }

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryCoreIntegTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryCoreIntegTest.java
@@ -377,7 +377,8 @@ public class AsyncQueryCoreIntegTest {
     when(jobExecutionResponseReader.getResultWithQueryId(QUERY_ID, RESULT_INDEX))
         .thenReturn(result);
 
-    AsyncQueryExecutionResponse response = asyncQueryExecutorService.getAsyncQueryResults(QUERY_ID);
+    AsyncQueryExecutionResponse response =
+        asyncQueryExecutorService.getAsyncQueryResults(QUERY_ID, asyncQueryRequestContext);
 
     assertEquals("SUCCESS", response.getStatus());
     assertEquals(SESSION_ID, response.getSessionId());
@@ -395,7 +396,8 @@ public class AsyncQueryCoreIntegTest {
     when(jobExecutionResponseReader.getResultWithQueryId(QUERY_ID, RESULT_INDEX))
         .thenReturn(result);
 
-    AsyncQueryExecutionResponse response = asyncQueryExecutorService.getAsyncQueryResults(QUERY_ID);
+    AsyncQueryExecutionResponse response =
+        asyncQueryExecutorService.getAsyncQueryResults(QUERY_ID, asyncQueryRequestContext);
 
     assertEquals("SUCCESS", response.getStatus());
     assertNull(response.getSessionId());
@@ -413,7 +415,8 @@ public class AsyncQueryCoreIntegTest {
     JSONObject result = getValidExecutionResponse();
     when(jobExecutionResponseReader.getResultWithJobId(JOB_ID, RESULT_INDEX)).thenReturn(result);
 
-    AsyncQueryExecutionResponse response = asyncQueryExecutorService.getAsyncQueryResults(QUERY_ID);
+    AsyncQueryExecutionResponse response =
+        asyncQueryExecutorService.getAsyncQueryResults(QUERY_ID, asyncQueryRequestContext);
 
     assertEquals("SUCCESS", response.getStatus());
     assertNull(response.getSessionId());
@@ -428,13 +431,15 @@ public class AsyncQueryCoreIntegTest {
     final StatementModel statementModel = givenStatementExists();
     StatementModel canceledStatementModel =
         StatementModel.copyWithState(statementModel, StatementState.CANCELLED, ImmutableMap.of());
-    when(statementStorageService.updateStatementState(statementModel, StatementState.CANCELLED))
+    when(statementStorageService.updateStatementState(
+            statementModel, StatementState.CANCELLED, asyncQueryRequestContext))
         .thenReturn(canceledStatementModel);
 
     String result = asyncQueryExecutorService.cancelQuery(QUERY_ID, asyncQueryRequestContext);
 
     assertEquals(QUERY_ID, result);
-    verify(statementStorageService).updateStatementState(statementModel, StatementState.CANCELLED);
+    verify(statementStorageService)
+        .updateStatementState(statementModel, StatementState.CANCELLED, asyncQueryRequestContext);
   }
 
   @Test
@@ -596,7 +601,7 @@ public class AsyncQueryCoreIntegTest {
             .statementId(new StatementId(QUERY_ID))
             .statementState(StatementState.RUNNING)
             .build();
-    when(statementStorageService.getStatement(QUERY_ID, DATASOURCE_NAME))
+    when(statementStorageService.getStatement(QUERY_ID, DATASOURCE_NAME, asyncQueryRequestContext))
         .thenReturn(Optional.of(statementModel));
     return statementModel;
   }

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
@@ -152,7 +152,7 @@ public class AsyncQueryExecutorServiceImplTest {
     AsyncQueryNotFoundException asyncQueryNotFoundException =
         Assertions.assertThrows(
             AsyncQueryNotFoundException.class,
-            () -> jobExecutorService.getAsyncQueryResults(EMR_JOB_ID));
+            () -> jobExecutorService.getAsyncQueryResults(EMR_JOB_ID, asyncQueryRequestContext));
 
     Assertions.assertEquals(
         "QueryId: " + EMR_JOB_ID + " not found", asyncQueryNotFoundException.getMessage());
@@ -166,10 +166,12 @@ public class AsyncQueryExecutorServiceImplTest {
         .thenReturn(Optional.of(getAsyncQueryJobMetadata()));
     JSONObject jobResult = new JSONObject();
     jobResult.put("status", JobRunState.PENDING.toString());
-    when(sparkQueryDispatcher.getQueryResponse(getAsyncQueryJobMetadata())).thenReturn(jobResult);
+    when(sparkQueryDispatcher.getQueryResponse(
+            getAsyncQueryJobMetadata(), asyncQueryRequestContext))
+        .thenReturn(jobResult);
 
     AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-        jobExecutorService.getAsyncQueryResults(EMR_JOB_ID);
+        jobExecutorService.getAsyncQueryResults(EMR_JOB_ID, asyncQueryRequestContext);
 
     Assertions.assertNull(asyncQueryExecutionResponse.getResults());
     Assertions.assertNull(asyncQueryExecutionResponse.getSchema());
@@ -183,10 +185,12 @@ public class AsyncQueryExecutorServiceImplTest {
         .thenReturn(Optional.of(getAsyncQueryJobMetadata()));
     JSONObject jobResult = new JSONObject(getJson("select_query_response.json"));
     jobResult.put("status", JobRunState.SUCCESS.toString());
-    when(sparkQueryDispatcher.getQueryResponse(getAsyncQueryJobMetadata())).thenReturn(jobResult);
+    when(sparkQueryDispatcher.getQueryResponse(
+            getAsyncQueryJobMetadata(), asyncQueryRequestContext))
+        .thenReturn(jobResult);
 
     AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-        jobExecutorService.getAsyncQueryResults(EMR_JOB_ID);
+        jobExecutorService.getAsyncQueryResults(EMR_JOB_ID, asyncQueryRequestContext);
 
     Assertions.assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
     Assertions.assertEquals(1, asyncQueryExecutionResponse.getSchema().getColumns().size());

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandlerTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandlerTest.java
@@ -66,7 +66,9 @@ class IndexDMLHandlerTest {
 
   @Test
   public void getResponseFromExecutor() {
-    JSONObject result = new IndexDMLHandler(null, null, null, null).getResponseFromExecutor(null);
+    JSONObject result =
+        new IndexDMLHandler(null, null, null, null)
+            .getResponseFromExecutor(null, asyncQueryRequestContext);
 
     assertEquals("running", result.getString(STATUS_FIELD));
     assertEquals("", result.getString(ERROR_FIELD));

--- a/async-query/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStatementStorageService.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/execution/statestore/OpenSearchStatementStorageService.java
@@ -40,14 +40,17 @@ public class OpenSearchStatementStorageService implements StatementStorageServic
   }
 
   @Override
-  public Optional<StatementModel> getStatement(String id, String datasourceName) {
+  public Optional<StatementModel> getStatement(
+      String id, String datasourceName, AsyncQueryRequestContext asyncQueryRequestContext) {
     return stateStore.get(
         id, serializer::fromXContent, OpenSearchStateStoreUtil.getIndexName(datasourceName));
   }
 
   @Override
   public StatementModel updateStatementState(
-      StatementModel oldStatementModel, StatementState statementState) {
+      StatementModel oldStatementModel,
+      StatementState statementState,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
     try {
       return stateStore.updateState(
           oldStatementModel,
@@ -63,7 +66,10 @@ public class OpenSearchStatementStorageService implements StatementStorageServic
       throw new IllegalStateException(errorMsg);
     } catch (VersionConflictEngineException e) {
       StatementModel statementModel =
-          getStatement(oldStatementModel.getId(), oldStatementModel.getDatasourceName())
+          getStatement(
+                  oldStatementModel.getId(),
+                  oldStatementModel.getDatasourceName(),
+                  asyncQueryRequestContext)
               .orElse(oldStatementModel);
       String errorMsg =
           String.format(

--- a/async-query/src/main/java/org/opensearch/sql/spark/transport/TransportGetAsyncQueryResultAction.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/transport/TransportGetAsyncQueryResultAction.java
@@ -16,6 +16,7 @@ import org.opensearch.sql.protocol.response.format.ResponseFormatter;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorService;
 import org.opensearch.sql.spark.asyncquery.AsyncQueryExecutorServiceImpl;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
+import org.opensearch.sql.spark.asyncquery.model.NullAsyncQueryRequestContext;
 import org.opensearch.sql.spark.transport.format.AsyncQueryResultResponseFormatter;
 import org.opensearch.sql.spark.transport.model.AsyncQueryResult;
 import org.opensearch.sql.spark.transport.model.GetAsyncQueryResultActionRequest;
@@ -50,7 +51,7 @@ public class TransportGetAsyncQueryResultAction
     try {
       String jobId = request.getQueryId();
       AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-          asyncQueryExecutorService.getAsyncQueryResults(jobId);
+          asyncQueryExecutorService.getAsyncQueryResults(jobId, new NullAsyncQueryRequestContext());
       ResponseFormatter<AsyncQueryResult> formatter =
           new AsyncQueryResultResponseFormatter(JsonResponseFormatter.Style.PRETTY);
       String responseContent =

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplSpecTest.java
@@ -66,7 +66,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
 
     // 2. fetch async query result.
     AsyncQueryExecutionResponse asyncQueryResults =
-        asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+        asyncQueryExecutorService.getAsyncQueryResults(
+            response.getQueryId(), asyncQueryRequestContext);
     assertEquals("RUNNING", asyncQueryResults.getStatus());
     emrsClient.getJobRunResultCalled(1);
 
@@ -152,13 +153,15 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             asyncQueryRequestContext);
     assertNotNull(response.getSessionId());
     Optional<StatementModel> statementModel =
-        statementStorageService.getStatement(response.getQueryId(), MYS3_DATASOURCE);
+        statementStorageService.getStatement(
+            response.getQueryId(), MYS3_DATASOURCE, asyncQueryRequestContext);
     assertTrue(statementModel.isPresent());
     assertEquals(StatementState.WAITING, statementModel.get().getStatementState());
 
     // 2. fetch async query result.
     AsyncQueryExecutionResponse asyncQueryResults =
-        asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+        asyncQueryExecutorService.getAsyncQueryResults(
+            response.getQueryId(), asyncQueryRequestContext);
     assertEquals("", asyncQueryResults.getError());
     assertTrue(Strings.isEmpty(asyncQueryResults.getError()));
     assertEquals(StatementState.WAITING.getState(), asyncQueryResults.getStatus());
@@ -211,13 +214,15 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
                 .must(QueryBuilders.termQuery(SESSION_ID, first.getSessionId()))));
 
     Optional<StatementModel> firstModel =
-        statementStorageService.getStatement(first.getQueryId(), MYS3_DATASOURCE);
+        statementStorageService.getStatement(
+            first.getQueryId(), MYS3_DATASOURCE, asyncQueryRequestContext);
     assertTrue(firstModel.isPresent());
     assertEquals(StatementState.WAITING, firstModel.get().getStatementState());
     assertEquals(first.getQueryId(), firstModel.get().getStatementId().getId());
     assertEquals(first.getQueryId(), firstModel.get().getQueryId());
     Optional<StatementModel> secondModel =
-        statementStorageService.getStatement(second.getQueryId(), MYS3_DATASOURCE);
+        statementStorageService.getStatement(
+            second.getQueryId(), MYS3_DATASOURCE, asyncQueryRequestContext);
     assertEquals(StatementState.WAITING, secondModel.get().getStatementState());
     assertEquals(second.getQueryId(), secondModel.get().getStatementId().getId());
     assertEquals(second.getQueryId(), secondModel.get().getQueryId());
@@ -311,7 +316,8 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             asyncQueryRequestContext);
     assertNotNull(response.getSessionId());
     Optional<StatementModel> statementModel =
-        statementStorageService.getStatement(response.getQueryId(), MYS3_DATASOURCE);
+        statementStorageService.getStatement(
+            response.getQueryId(), MYS3_DATASOURCE, asyncQueryRequestContext);
     assertTrue(statementModel.isPresent());
     assertEquals(StatementState.WAITING, statementModel.get().getStatementState());
 
@@ -334,10 +340,12 @@ public class AsyncQueryExecutorServiceImplSpecTest extends AsyncQueryExecutorSer
             .error("mock error")
             .metadata(submitted.getMetadata())
             .build();
-    statementStorageService.updateStatementState(mocked, StatementState.FAILED);
+    statementStorageService.updateStatementState(
+        mocked, StatementState.FAILED, asyncQueryRequestContext);
 
     AsyncQueryExecutionResponse asyncQueryResults =
-        asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+        asyncQueryExecutorService.getAsyncQueryResults(
+            response.getQueryId(), asyncQueryRequestContext);
     assertEquals(StatementState.FAILED.getState(), asyncQueryResults.getStatus());
     assertEquals("mock error", asyncQueryResults.getError());
   }

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
@@ -450,7 +450,8 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
 
     AssertionHelper assertQueryResults(String status, List<ExprValue> data) {
       AsyncQueryExecutionResponse results =
-          queryService.getAsyncQueryResults(createQueryResponse.getQueryId());
+          queryService.getAsyncQueryResults(
+              createQueryResponse.getQueryId(), asyncQueryRequestContext);
       assertEquals(status, results.getStatus());
       assertEquals(data, results.getResults());
       return this;
@@ -458,7 +459,8 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
 
     AssertionHelper assertFormattedQueryResults(String expected) {
       AsyncQueryExecutionResponse results =
-          queryService.getAsyncQueryResults(createQueryResponse.getQueryId());
+          queryService.getAsyncQueryResults(
+              createQueryResponse.getQueryId(), asyncQueryRequestContext);
 
       ResponseFormatter<AsyncQueryResult> formatter =
           new AsyncQueryResultResponseFormatter(JsonResponseFormatter.Style.COMPACT);
@@ -515,8 +517,11 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
 
     /** Simulate EMR-S updates query_execution_request with state */
     void emrJobUpdateStatementState(StatementState newState) {
-      StatementModel stmt = statementStorageService.getStatement(queryId, MYS3_DATASOURCE).get();
-      statementStorageService.updateStatementState(stmt, newState);
+      StatementModel stmt =
+          statementStorageService
+              .getStatement(queryId, MYS3_DATASOURCE, asyncQueryRequestContext)
+              .get();
+      statementStorageService.updateStatementState(stmt, newState, asyncQueryRequestContext);
     }
 
     void emrJobUpdateJobState(JobRunState jobState) {

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecAlterTest.java
@@ -86,7 +86,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(1);
@@ -155,7 +156,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(1);
@@ -237,7 +239,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(1);
@@ -303,7 +306,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               assertEquals(
                   "RUNNING",
                   asyncQueryExecutorService
-                      .getAsyncQueryResults(response.getQueryId())
+                      .getAsyncQueryResults(response.getQueryId(), asyncQueryRequestContext)
                       .getStatus());
 
               flintIndexJob.assertState(FlintIndexState.ACTIVE);
@@ -369,7 +372,7 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
               assertEquals(
                   "RUNNING",
                   asyncQueryExecutorService
-                      .getAsyncQueryResults(response.getQueryId())
+                      .getAsyncQueryResults(response.getQueryId(), asyncQueryRequestContext)
                       .getStatus());
 
               flintIndexJob.assertState(FlintIndexState.ACTIVE);
@@ -442,7 +445,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals(
                   "Altering to full refresh only allows: [auto_refresh, incremental_refresh]"
@@ -517,7 +521,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals(
                   "Altering to incremental refresh only allows: [auto_refresh, incremental_refresh,"
@@ -586,7 +591,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals(
                   "Conversion to incremental refresh index cannot proceed due to missing"
@@ -648,7 +654,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals(
                   "Conversion to incremental refresh index cannot proceed due to missing"
@@ -712,7 +719,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals(
                   "Conversion to incremental refresh index cannot proceed due to missing"
@@ -776,7 +784,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
               emrsClient.startJobRunCalled(0);
               emrsClient.getJobRunResultCalled(1);
@@ -837,7 +846,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
               emrsClient.startJobRunCalled(0);
               emrsClient.getJobRunResultCalled(1);
@@ -896,7 +906,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals(
                   "Transaction failed as flint index is not in a valid state.",
@@ -963,7 +974,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
               emrsClient.startJobRunCalled(0);
               emrsClient.cancelJobRunCalled(1);
@@ -1028,7 +1040,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals("Internal Server Error.", asyncQueryExecutionResponse.getError());
               emrsClient.startJobRunCalled(0);
@@ -1094,7 +1107,8 @@ public class IndexQuerySpecAlterTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals("Internal Server Error.", asyncQueryExecutionResponse.getError());
               emrsClient.startJobRunCalled(0);

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecTest.java
@@ -143,7 +143,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
               // 2.fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryResults.getStatus());
               assertNull(asyncQueryResults.getError());
               emrsClient.cancelJobRunCalled(1);
@@ -193,7 +194,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
               // 2.fetch result.
               AsyncQueryExecutionResponse asyncQueryResults =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryResults.getStatus());
               assertNull(asyncQueryResults.getError());
             });
@@ -233,7 +235,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryResults.getStatus());
               assertEquals("Cancel job operation timed out.", asyncQueryResults.getError());
             });
@@ -270,7 +273,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
     // 2.fetch result.
     AsyncQueryExecutionResponse asyncQueryResults =
-        asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+        asyncQueryExecutorService.getAsyncQueryResults(
+            response.getQueryId(), asyncQueryRequestContext);
     assertEquals("SUCCESS", asyncQueryResults.getStatus());
     assertNull(asyncQueryResults.getError());
   }
@@ -319,7 +323,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
               // 2.fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryResults.getStatus());
               assertNull(asyncQueryResults.getError());
               emrsClient.cancelJobRunCalled(1);
@@ -375,7 +380,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
               // 2.fetch result.
               AsyncQueryExecutionResponse asyncQueryResults =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryResults.getStatus());
               assertNull(asyncQueryResults.getError());
 
@@ -422,7 +428,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryResults.getStatus());
               assertEquals("Cancel job operation timed out.", asyncQueryResults.getError());
               flintIndexJob.assertState(FlintIndexState.REFRESHING);
@@ -470,7 +477,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               assertEquals(
                   "SUCCESS",
                   asyncQueryExecutorService
-                      .getAsyncQueryResults(response.getQueryId())
+                      .getAsyncQueryResults(response.getQueryId(), asyncQueryRequestContext)
                       .getStatus());
 
               flintIndexJob.assertState(FlintIndexState.DELETED);
@@ -519,7 +526,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
               flintIndexJob.assertState(FlintIndexState.DELETED);
               emrsClient.startJobRunCalled(0);
@@ -569,7 +577,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               assertEquals(
                   "SUCCESS",
                   asyncQueryExecutorService
-                      .getAsyncQueryResults(response.getQueryId())
+                      .getAsyncQueryResults(response.getQueryId(), asyncQueryRequestContext)
                       .getStatus());
 
               flintIndexJob.assertState(FlintIndexState.DELETED);
@@ -616,7 +624,7 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
               assertEquals(
                   "SUCCESS",
                   asyncQueryExecutorService
-                      .getAsyncQueryResults(response.getQueryId())
+                      .getAsyncQueryResults(response.getQueryId(), asyncQueryRequestContext)
                       .getStatus());
 
               flintIndexJob.assertState(FlintIndexState.DELETED);
@@ -668,7 +676,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
                       asyncQueryRequestContext);
 
               AsyncQueryExecutionResponse asyncQueryExecutionResponse =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               // 2. fetch result
               assertEquals("FAILED", asyncQueryExecutionResponse.getStatus());
               assertEquals(
@@ -714,7 +723,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
     // 2.fetch result.
     AsyncQueryExecutionResponse asyncQueryResults =
-        asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+        asyncQueryExecutorService.getAsyncQueryResults(
+            response.getQueryId(), asyncQueryRequestContext);
     assertEquals("FAILED", asyncQueryResults.getStatus());
     assertEquals("Internal Server Error.", asyncQueryResults.getError());
 
@@ -762,7 +772,8 @@ public class IndexQuerySpecTest extends AsyncQueryExecutorServiceSpec {
 
               // 2. fetch result
               AsyncQueryExecutionResponse asyncQueryResults =
-                  asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+                  asyncQueryExecutorService.getAsyncQueryResults(
+                      response.getQueryId(), asyncQueryRequestContext);
               assertEquals("FAILED", asyncQueryResults.getStatus());
               assertTrue(asyncQueryResults.getError().contains("no state found"));
             });

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/IndexQuerySpecVacuumTest.java
@@ -174,7 +174,8 @@ public class IndexQuerySpecVacuumTest extends AsyncQueryExecutorServiceSpec {
             new CreateAsyncQueryRequest(mockDS.query, MYS3_DATASOURCE, LangType.SQL, null),
             asyncQueryRequestContext);
 
-    return asyncQueryExecutorService.getAsyncQueryResults(response.getQueryId());
+    return asyncQueryExecutorService.getAsyncQueryResults(
+        response.getQueryId(), asyncQueryRequestContext);
   }
 
   private boolean flintIndexExists(String flintIndexName) {

--- a/async-query/src/test/java/org/opensearch/sql/spark/execution/statement/StatementTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/execution/statement/StatementTest.java
@@ -144,7 +144,8 @@ public class StatementTest extends OpenSearchIntegTestCase {
     st.open();
 
     StatementModel running =
-        statementStorageService.updateStatementState(st.getStatementModel(), CANCELLED);
+        statementStorageService.updateStatementState(
+            st.getStatementModel(), CANCELLED, asyncQueryRequestContext);
 
     assertEquals(StatementState.CANCELLED, running.getStatementState());
     IllegalStateException exception = assertThrows(IllegalStateException.class, st::cancel);
@@ -265,7 +266,7 @@ public class StatementTest extends OpenSearchIntegTestCase {
     Session session =
         sessionManager.createSession(createSessionRequest(), asyncQueryRequestContext);
     StatementId statementId = session.submit(queryRequest(), asyncQueryRequestContext);
-    Optional<Statement> statement = session.get(statementId);
+    Optional<Statement> statement = session.get(statementId, asyncQueryRequestContext);
 
     assertTrue(statement.isPresent());
     assertEquals(session.getSessionId(), statement.get().getSessionId());
@@ -301,7 +302,7 @@ public class StatementTest extends OpenSearchIntegTestCase {
     sessionStorageService.updateSessionState(session.getSessionModel(), SessionState.RUNNING);
     StatementId statementId = session.submit(queryRequest(), asyncQueryRequestContext);
 
-    Optional<Statement> statement = session.get(statementId);
+    Optional<Statement> statement = session.get(statementId, asyncQueryRequestContext);
     assertTrue(statement.isPresent());
     assertEquals(WAITING, statement.get().getStatementState());
     assertEquals(statementId, statement.get().getStatementId());
@@ -314,7 +315,8 @@ public class StatementTest extends OpenSearchIntegTestCase {
     // App change state to running
     sessionStorageService.updateSessionState(session.getSessionModel(), SessionState.RUNNING);
 
-    Optional<Statement> statement = session.get(StatementId.newStatementId("not-exist-id"));
+    Optional<Statement> statement =
+        session.get(StatementId.newStatementId("not-exist-id"), asyncQueryRequestContext);
     assertFalse(statement.isPresent());
   }
 
@@ -332,7 +334,8 @@ public class StatementTest extends OpenSearchIntegTestCase {
       assertEquals(expected, st.getStatementModel().getStatementState());
 
       Optional<StatementModel> model =
-          statementStorageService.getStatement(st.getStatementId().getId(), TEST_DATASOURCE_NAME);
+          statementStorageService.getStatement(
+              st.getStatementId().getId(), TEST_DATASOURCE_NAME, st.getAsyncQueryRequestContext());
       assertTrue(model.isPresent());
       assertEquals(expected, model.get().getStatementState());
 
@@ -343,7 +346,8 @@ public class StatementTest extends OpenSearchIntegTestCase {
       assertEquals(expected, st.getStatementModel().getStatementId());
 
       Optional<StatementModel> model =
-          statementStorageService.getStatement(st.getStatementId().getId(), TEST_DATASOURCE_NAME);
+          statementStorageService.getStatement(
+              st.getStatementId().getId(), TEST_DATASOURCE_NAME, st.getAsyncQueryRequestContext());
       assertTrue(model.isPresent());
       assertEquals(expected, model.get().getStatementId());
       return this;
@@ -361,7 +365,8 @@ public class StatementTest extends OpenSearchIntegTestCase {
 
     public TestStatement run() {
       StatementModel model =
-          statementStorageService.updateStatementState(st.getStatementModel(), RUNNING);
+          statementStorageService.updateStatementState(
+              st.getStatementModel(), RUNNING, st.getAsyncQueryRequestContext());
       st.setStatementModel(model);
       return this;
     }


### PR DESCRIPTION
### Description
- Add AsyncQueryRequestContext to update/get in StatementStorageService
- Passing through the AsyncQueryRequestContext from AsyncQueryExecutorService to Statement. Other changes are to pass down the parameter.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [n/a] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [n/a] New functionality has a user manual doc added.
- [n/a] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [n/a] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
