### PR TITLE
Add mvQuery attribute in IndexQueryDetails

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/model/IndexQueryDetails.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/model/IndexQueryDetails.java
@@ -31,6 +31,7 @@ public class IndexQueryDetails {
   // materialized view special case where
   // table name and mv name are combined.
   private String mvName;
+  private String mvQuery;
   private FlintIndexType indexType;
 
   private IndexQueryDetails() {}
@@ -70,6 +71,11 @@ public class IndexQueryDetails {
 
     public IndexQueryDetailsBuilder mvName(String mvName) {
       indexQueryDetails.mvName = mvName;
+      return this;
+    }
+
+    public IndexQueryDetailsBuilder mvQuery(String mvQuery) {
+      indexQueryDetails.mvQuery = mvQuery;
       return this;
     }
 

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/utils/SQLQueryUtils.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/utils/SQLQueryUtils.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.opensearch.sql.common.antlr.CaseInsensitiveCharStream;
 import org.opensearch.sql.common.antlr.SyntaxAnalysisErrorListener;
@@ -20,6 +21,7 @@ import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.spark.antlr.parser.FlintSparkSqlExtensionsBaseVisitor;
 import org.opensearch.sql.spark.antlr.parser.FlintSparkSqlExtensionsLexer;
 import org.opensearch.sql.spark.antlr.parser.FlintSparkSqlExtensionsParser;
+import org.opensearch.sql.spark.antlr.parser.FlintSparkSqlExtensionsParser.MaterializedViewQueryContext;
 import org.opensearch.sql.spark.antlr.parser.SqlBaseLexer;
 import org.opensearch.sql.spark.antlr.parser.SqlBaseParser;
 import org.opensearch.sql.spark.antlr.parser.SqlBaseParser.IdentifierReferenceContext;
@@ -351,6 +353,15 @@ public class SQLQueryUtils {
       indexQueryDetailsBuilder.mvName(ctx.mvName.getText());
       visitPropertyList(ctx.propertyList());
       return super.visitAlterMaterializedViewStatement(ctx);
+    }
+
+    @Override
+    public Void visitMaterializedViewQuery(MaterializedViewQueryContext ctx) {
+      int a = ctx.start.getStartIndex();
+      int b = ctx.stop.getStopIndex();
+      String query = ctx.start.getInputStream().getText(new Interval(a, b));
+      indexQueryDetailsBuilder.mvQuery(query);
+      return super.visitMaterializedViewQuery(ctx);
     }
 
     private String propertyKey(FlintSparkSqlExtensionsParser.PropertyKeyContext key) {


### PR DESCRIPTION
### Description
- Add mvQuery attribute in IndexQueryDetails
- This is needed to extract fullyQualifiedTableName from CREATE MATERIALIZED VIEW query. (first extract the query then extract tableNames from the extracted query)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
