### PR TITLE
#2550 Allowing joins when index names start with a period

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/utils/StringUtils.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/utils/StringUtils.java
@@ -90,12 +90,26 @@ public class StringUtils {
    * @return A string whose each dot-separated field has been unquoted from back-ticks (if any)
    */
   public static String unquoteFullColumn(String text, String quote) {
+    boolean startsWithPeriod = false;
+    if (text.startsWith(quote + ".")) {
+      startsWithPeriod = true;
+      text = quote + text.substring(2);
+    }
     String[] strs = text.split("\\.");
     for (int i = 0; i < strs.length; i++) {
       String unquotedSubstr = unquoteSingleField(strs[i], quote);
       strs[i] = unquotedSubstr;
     }
-    return String.join(".", strs);
+    if (startsWithPeriod) {
+      String s = String.join(".", strs);
+      if (s.startsWith(quote)) {
+        return new StringBuilder(s).insert(1, ".").toString();
+      } else {
+        return "." + s;
+      }
+    } else {
+      return String.join(".", strs);
+    }
   }
 
   public static String unquoteFullColumn(String text) {

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/BackticksUnquoterTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/utils/BackticksUnquoterTest.java
@@ -23,20 +23,25 @@ public class BackticksUnquoterTest {
   public void assertNotQuotedStringShouldKeepTheSame() {
     assertThat(unquoteSingleField("identifier"), equalTo("identifier"));
     assertThat(unquoteFullColumn("identifier"), equalTo("identifier"));
+    assertThat(unquoteFullColumn(".identifier"), equalTo(".identifier"));
   }
 
   @Test
   public void assertStringWithOneBackTickShouldKeepTheSame() {
     assertThat(unquoteSingleField("`identifier"), equalTo("`identifier"));
     assertThat(unquoteFullColumn("`identifier"), equalTo("`identifier"));
+    assertThat(unquoteFullColumn("`.identifier"), equalTo("`.identifier"));
   }
 
   @Test
   public void assertBackticksQuotedStringShouldBeUnquoted() {
     assertThat("identifier", equalTo(unquoteSingleField("`identifier`")));
+    assertThat(".identifier", equalTo(unquoteSingleField("`.identifier`")));
 
     assertThat(
         "identifier1.identifier2", equalTo(unquoteFullColumn("`identifier1`.`identifier2`")));
     assertThat("identifier1.identifier2", equalTo(unquoteFullColumn("`identifier1`.identifier2")));
+    assertThat(
+        ".identifier1.identifier2", equalTo(unquoteFullColumn("`.identifier1`.`identifier2`")));
   }
 }


### PR DESCRIPTION
### Description
Allows for join operations on indexes whose names start with periods.

### Related Issues
Resolves #2550 

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
 - [X] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
