### PR TITLE
Support two tables join PPL command

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
@@ -41,10 +41,6 @@ public class AnalysisContext {
     environment = new TypeEnvironment(environment);
   }
 
-  public void cleanFields() {
-    environment.clearAllFields();
-  }
-
   /**
    * Return current environment.
    *

--- a/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/AnalysisContext.java
@@ -41,6 +41,10 @@ public class AnalysisContext {
     environment = new TypeEnvironment(environment);
   }
 
+  public void cleanFields() {
+    environment.clearAllFields();
+  }
+
   /**
    * Return current environment.
    *

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionReferenceOptimizer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionReferenceOptimizer.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.analysis;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,12 @@ public class ExpressionReferenceOptimizer
       BuiltinFunctionRepository repository, LogicalPlan logicalPlan) {
     this.repository = repository;
     logicalPlan.accept(new ExpressionMapBuilder(), null);
+  }
+
+  public ExpressionReferenceOptimizer(
+      BuiltinFunctionRepository repository, LogicalPlan... logicalPlans) {
+    this.repository = repository;
+    Arrays.stream(logicalPlans).forEach(p -> p.accept(new ExpressionMapBuilder(), null));
   }
 
   public Expression optimize(Expression analyzed, AnalysisContext context) {

--- a/core/src/main/java/org/opensearch/sql/analysis/symbol/SymbolTable.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/symbol/SymbolTable.java
@@ -72,6 +72,21 @@ public class SymbolTable {
     Map<String, ExprType> table = tableByNamespace.get(symbol.getNamespace());
     ExprType type = null;
     if (table != null) {
+      // To handle the field named start with [index.], for example index1.field1,
+      // this is used by Join query.
+      if (symbol.getNamespace() == Namespace.FIELD_NAME) {
+        String[] parts = symbol.getName().split("\\.");
+        if (parts.length == 2) {
+          // extract the indexName
+          if (tableByNamespace.get(Namespace.INDEX_NAME) != null) {
+            String indexName = tableByNamespace.get(Namespace.INDEX_NAME).firstKey();
+            if (indexName != null && indexName.equals(parts[0])) {
+              type = table.get(parts[1]);
+              return Optional.ofNullable(type);
+            }
+          }
+        }
+      }
       type = table.get(symbol.getName());
     }
     return Optional.ofNullable(type);

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -47,6 +47,7 @@ import org.opensearch.sql.ast.tree.Eval;
 import org.opensearch.sql.ast.tree.FetchCursor;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
+import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.Limit;
 import org.opensearch.sql.ast.tree.ML;
@@ -106,6 +107,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitFilter(Filter node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitJoin(Join node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -48,6 +48,7 @@ import org.opensearch.sql.ast.tree.Dedupe;
 import org.opensearch.sql.ast.tree.Eval;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
+import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Limit;
 import org.opensearch.sql.ast.tree.Parse;
 import org.opensearch.sql.ast.tree.Project;
@@ -470,5 +471,13 @@ public class AstDSL {
       Literal pattern,
       java.util.Map<String, Literal> arguments) {
     return new Parse(parseMethod, sourceField, pattern, arguments, input);
+  }
+
+  public static Join join(
+      UnresolvedPlan left,
+      UnresolvedPlan right,
+      Join.JoinType joinType,
+      UnresolvedExpression condition) {
+    return new Join(left, right, joinType, condition);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Join.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Join.java
@@ -40,12 +40,12 @@ public class Join extends UnresolvedPlan {
   }
 
   public enum JoinType {
-    CROSS,
     INNER,
-    SEMI,
-    ANTI,
     LEFT,
     RIGHT,
+    SEMI,
+    ANTI,
+    CROSS,
     FULL
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Join.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Join.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class Join extends UnresolvedPlan {
+  private final UnresolvedPlan left;
+  private final UnresolvedPlan right;
+  private final JoinType joinType;
+  private final UnresolvedExpression joinCondition;
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    return this;
+  }
+
+  @Override
+  public List<UnresolvedPlan> getChild() {
+    return ImmutableList.of(left, right);
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitJoin(this, context);
+  }
+
+  public enum JoinType {
+    CROSS,
+    INNER,
+    SEMI,
+    ANTI,
+    LEFT,
+    RIGHT,
+    FULL
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -289,6 +289,10 @@ public enum BuiltinFunctionName {
     return Optional.ofNullable(ALL_NATIVE_FUNCTIONS.getOrDefault(FunctionName.of(str), null));
   }
 
+  public static BuiltinFunctionName of(FunctionName name) {
+    return ALL_NATIVE_FUNCTIONS.get(name);
+  }
+
   public static Optional<BuiltinFunctionName> ofAggregation(String functionName) {
     return Optional.ofNullable(
         AGGREGATION_FUNC_MAPPING.getOrDefault(functionName.toLowerCase(Locale.ROOT), null));

--- a/core/src/main/java/org/opensearch/sql/planner/DefaultImplementor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/DefaultImplementor.java
@@ -253,6 +253,7 @@ public class DefaultImplementor<C> extends LogicalPlanNodeVisitor<PhysicalPlan, 
   /** Return true if the reference can be evaluated in relation */
   private boolean canEvaluate(ReferenceExpression expr, LogicalPlan plan) {
     if (plan instanceof LogicalRelation relation) {
+      // TODO need fix, the attr() contains relation prefix: Index.Field
       return relation.getTable().getFieldTypes().containsKey(expr.getAttr());
     } else {
       throw new UnsupportedOperationException("Only relation can be used in join");

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalJoin.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalJoin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.logical;
+
+import com.google.common.collect.ImmutableList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.expression.Expression;
+
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@Getter
+public class LogicalJoin extends LogicalPlan {
+  private final LogicalPlan left;
+  private final LogicalPlan right;
+  private final Join.JoinType type;
+  private final Expression condition;
+
+  public LogicalJoin(
+      LogicalPlan left, LogicalPlan right, Join.JoinType type, Expression condition) {
+    super(ImmutableList.of(left, right));
+    this.left = left;
+    this.right = right;
+    this.type = type;
+    this.condition = condition;
+  }
+
+  @Override
+  public <R, C> R accept(LogicalPlanNodeVisitor<R, C> visitor, C context) {
+    return visitor.visitJoin(this, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanDSL.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanDSL.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.expression.Expression;
@@ -137,5 +138,14 @@ public class LogicalPlanDSL {
 
   public static LogicalPlan limit(LogicalPlan input, Integer limit, Integer offset) {
     return new LogicalLimit(input, limit, offset);
+  }
+
+  public LogicalPlan innerJoin(LogicalPlan left, LogicalPlan right, Expression condition) {
+    return join(left, right, Join.JoinType.INNER, condition);
+  }
+
+  public LogicalPlan join(
+      LogicalPlan left, LogicalPlan right, Join.JoinType joinType, Expression condition) {
+    return new LogicalJoin(left, right, joinType, condition);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitor.java
@@ -115,4 +115,8 @@ public abstract class LogicalPlanNodeVisitor<R, C> {
   public R visitCloseCursor(LogicalCloseCursor plan, C context) {
     return visitNode(plan, context);
   }
+
+  public R visitJoin(LogicalJoin plan, C context) {
+    return visitNode(plan, context);
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/PhysicalPlanNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/PhysicalPlanNodeVisitor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.planner.physical;
 
+import org.opensearch.sql.planner.physical.join.JoinOperator;
 import org.opensearch.sql.storage.TableScanOperator;
 import org.opensearch.sql.storage.write.TableWriteOperator;
 
@@ -97,6 +98,10 @@ public abstract class PhysicalPlanNodeVisitor<R, C> {
   }
 
   public R visitCursorClose(CursorCloseOperator node, C context) {
+    return visitNode(node, context);
+  }
+
+  public R visitJoin(JoinOperator node, C context) {
     return visitNode(node, context);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTable.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/datasource/DataSourceTable.java
@@ -47,7 +47,7 @@ public class DataSourceTable implements Table {
 
     @Override
     public PhysicalPlan visitRelation(LogicalRelation node, Object context) {
-      return new DataSourceTableScan(dataSourceService);
+      return new DataSourceTableScan(dataSourceService, node);
     }
   }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/DefaultHashedRelation.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/DefaultHashedRelation.java
@@ -1,0 +1,54 @@
+package org.opensearch.sql.planner.physical.join;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.sql.data.model.ExprValue;
+
+public class DefaultHashedRelation implements HashedRelation, Serializable {
+
+  private final Map<ExprValue, List<ExprValue>> map = new HashMap<>();
+  private int numKeys;
+  private int numValues;
+
+  @Override
+  public List<ExprValue> get(ExprValue key) {
+    return map.get(key);
+  }
+
+  @Override
+  public ExprValue getValue(ExprValue key) {
+    List<ExprValue> values = map.get(key);
+    return values != null && !values.isEmpty() ? values.getFirst() : null;
+  }
+
+  @Override
+  public boolean containsKey(ExprValue key) {
+    return map.containsKey(key);
+  }
+
+  @Override
+  public Iterator<ExprValue> keyIterator() {
+    return map.keySet().iterator();
+  }
+
+  @Override
+  public boolean isUniqueKey() {
+    return numKeys == numValues;
+  }
+
+  @Override
+  public void close() {
+    map.clear();
+  }
+
+  @Override
+  public void put(ExprValue key, ExprValue value) {
+    map.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    numKeys++;
+    numValues++;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/HashJoinOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/HashJoinOperator.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical.join;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+
+@RequiredArgsConstructor
+public class HashJoinOperator extends JoinOperator {
+  private final List<Expression> leftKeys;
+  private final List<Expression> rightKeys;
+  private final Join.JoinType joinType;
+  private final PhysicalPlan left;
+  private final PhysicalPlan right;
+  private final Optional<Expression> nonEquiCond;
+
+  private final ImmutableList.Builder<ExprValue> joinedBuilder = ImmutableList.builder();
+  private Iterator<ExprValue> joinedIterator;
+
+  @Override
+  public void open() {
+    // Build hash table from left
+    left.open();
+    Map<ExprValue, ExprValue> hashed = buildHashed();
+    // Set streamed side to right
+    right.open();
+    Iterator<ExprValue> streamed = right;
+
+    if (joinType == Join.JoinType.INNER) {
+      innerJoin(streamed, hashed);
+    } else if (joinType == Join.JoinType.LEFT) {
+      leftOuterJoin(streamed, hashed);
+    } else if (joinType == Join.JoinType.SEMI) {
+      semiJoin(streamed, hashed);
+    } else if (joinType == Join.JoinType.ANTI) {
+      antiJoin(streamed, hashed);
+    } else {
+      throw new IllegalArgumentException("Unsupported join type: " + joinType);
+    }
+  }
+
+  @Override
+  public void close() {
+    joinedIterator = null;
+    left.close();
+    right.close();
+  }
+
+  private void innerJoin(Iterator<ExprValue> streamed, Map<ExprValue, ExprValue> hashed) {
+    while (streamed.hasNext()) {
+      ExprValue rightRow = streamed.next();
+      for (Expression rightKey : rightKeys) {
+        ExprValue rightRowKey = rightKey.valueOf(rightRow.bindingTuples());
+        if (rightRowKey != null && hashed.containsKey(rightRowKey)) {
+          ExprValue leftRow = hashed.get(rightRowKey);
+          ExprValue joinedRow = combineExprTupleValue(leftRow, rightRow);
+          if (nonEquiCond.isPresent()) {
+            ExprValue conditionValue = nonEquiCond.get().valueOf(joinedRow.bindingTuples());
+            if (!(conditionValue.isNull() || conditionValue.isMissing())
+                && conditionValue.booleanValue()) {
+              joinedBuilder.add(joinedRow);
+            }
+          } else {
+            joinedBuilder.add(joinedRow);
+          }
+        }
+      }
+    }
+    joinedIterator = joinedBuilder.build().iterator();
+  }
+
+  private void leftOuterJoin(Iterator<ExprValue> streamed, Map<ExprValue, ExprValue> hashed) {
+    // Track matched keys to identify unmatched left rows later
+    Set<ExprValue> matchedKeys = new HashSet<>();
+
+    while (streamed.hasNext()) {
+      ExprValue rightRow = streamed.next();
+      for (Expression rightKey : rightKeys) {
+        ExprValue rightRowKey = rightKey.valueOf(rightRow.bindingTuples());
+        if (rightRowKey != null && hashed.containsKey(rightRowKey)) {
+          ExprValue leftRow = hashed.get(rightRowKey);
+          ExprValue joinedRow = combineExprTupleValue(leftRow, rightRow);
+          if (nonEquiCond.isPresent()) {
+            ExprValue conditionValue = nonEquiCond.get().valueOf(joinedRow.bindingTuples());
+            if (!(conditionValue.isNull() || conditionValue.isMissing())
+                && conditionValue.booleanValue()) {
+              joinedBuilder.add(joinedRow);
+              matchedKeys.add(rightRowKey);
+            }
+          } else {
+            joinedBuilder.add(joinedRow);
+            matchedKeys.add(rightRowKey);
+          }
+        }
+      }
+    }
+
+    // Add unmatched left rows with nulls for the right side
+    for (Map.Entry<ExprValue, ExprValue> entry : hashed.entrySet()) {
+      if (!matchedKeys.contains(entry.getKey())) {
+        ExprValue leftRow = entry.getValue();
+        ExprValue joinedRow = combineExprTupleValue(leftRow, ExprValueUtils.nullValue());
+        joinedBuilder.add(joinedRow);
+      }
+    }
+
+    joinedIterator = joinedBuilder.build().iterator();
+  }
+
+  private void semiJoin(Iterator<ExprValue> streamed, Map<ExprValue, ExprValue> hashed) {
+    Set<ExprValue> matchedKeys = new HashSet<>();
+
+    while (streamed.hasNext()) {
+      ExprValue rightRow = streamed.next();
+      for (Expression rightKey : rightKeys) {
+        ExprValue rightRowKey = rightKey.valueOf(rightRow.bindingTuples());
+        if (rightRowKey != null && hashed.containsKey(rightRowKey)) {
+          ExprValue leftRow = hashed.get(rightRowKey);
+          if (nonEquiCond.isPresent()) {
+            ExprValue joinedRow = combineExprTupleValue(leftRow, rightRow);
+            ExprValue conditionValue = nonEquiCond.get().valueOf(joinedRow.bindingTuples());
+            if (!(conditionValue.isNull() || conditionValue.isMissing())
+                && conditionValue.booleanValue()) {
+              matchedKeys.add(rightRowKey);
+            }
+          } else {
+            matchedKeys.add(rightRowKey);
+          }
+        }
+      }
+    }
+
+    // Add matched left rows to the result
+    for (ExprValue key : matchedKeys) {
+      joinedBuilder.add(hashed.get(key));
+    }
+
+    joinedIterator = joinedBuilder.build().iterator();
+  }
+
+  private void antiJoin(Iterator<ExprValue> streamed, Map<ExprValue, ExprValue> hashed) {
+    Set<ExprValue> matchedKeys = new HashSet<>();
+
+    while (streamed.hasNext()) {
+      ExprValue rightRow = streamed.next();
+      for (Expression rightKey : rightKeys) {
+        ExprValue rightRowKey = rightKey.valueOf(rightRow.bindingTuples());
+        if (rightRowKey != null && hashed.containsKey(rightRowKey)) {
+          ExprValue leftRow = hashed.get(rightRowKey);
+          if (nonEquiCond.isPresent()) {
+            ExprValue joinedRow = combineExprTupleValue(leftRow, rightRow);
+            ExprValue conditionValue = nonEquiCond.get().valueOf(joinedRow.bindingTuples());
+            if (!(conditionValue.isNull() || conditionValue.isMissing())
+                && conditionValue.booleanValue()) {
+              matchedKeys.add(rightRowKey);
+            }
+          } else {
+            matchedKeys.add(rightRowKey);
+          }
+        }
+      }
+    }
+
+    // Add unmatched left rows to the result
+    for (Map.Entry<ExprValue, ExprValue> entry : hashed.entrySet()) {
+      if (!matchedKeys.contains(entry.getKey())) {
+        joinedBuilder.add(entry.getValue());
+      }
+    }
+
+    joinedIterator = joinedBuilder.build().iterator();
+  }
+
+  private Map<ExprValue, ExprValue> buildHashed() {
+    ImmutableMap.Builder<ExprValue, ExprValue> leftTableBuilder = ImmutableMap.builder();
+    while (left.hasNext()) {
+      ExprValue row = left.next();
+      for (Expression leftKey : leftKeys) {
+        ExprValue rowKey = leftKey.valueOf(row.bindingTuples());
+        if (rowKey != null) {
+          leftTableBuilder.put(rowKey, row);
+          break;
+        }
+      }
+    }
+    return leftTableBuilder.build();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return joinedIterator != null && joinedIterator.hasNext();
+  }
+
+  @Override
+  public ExprValue next() {
+    return joinedIterator.next();
+  }
+
+  @Override
+  public List<PhysicalPlan> getChild() {
+    return ImmutableList.of(left, right);
+  }
+
+  private ExprTupleValue combineExprTupleValue(ExprValue left, ExprValue right) {
+    Map<String, ExprValue> combinedMap = left.tupleValue();
+    combinedMap.putAll(right.tupleValue());
+    return ExprTupleValue.fromExprValueMap(combinedMap);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/HashedRelation.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/HashedRelation.java
@@ -1,0 +1,32 @@
+package org.opensearch.sql.planner.physical.join;
+
+import java.util.Iterator;
+import java.util.List;
+import org.opensearch.sql.data.model.ExprValue;
+
+public interface HashedRelation {
+
+  /** Return matched rows. */
+  List<ExprValue> get(ExprValue key);
+
+  /**
+   * Return the single matched row. Only used in {@link DefaultHashedRelation#isUniqueKey()} is
+   * true.
+   */
+  ExprValue getValue(ExprValue key);
+
+  /** Whether the key exists. */
+  boolean containsKey(ExprValue key);
+
+  /** Return the key iterator. */
+  Iterator<ExprValue> keyIterator();
+
+  /** Whether the key is unique. */
+  boolean isUniqueKey();
+
+  /** Put the key-value pair into the relation. */
+  void put(ExprValue key, ExprValue value);
+
+  /** Release the resources */
+  void close();
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/JoinOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/JoinOperator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical.join;
+
+import java.util.List;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+import org.opensearch.sql.planner.physical.PhysicalPlanNodeVisitor;
+
+public abstract class JoinOperator extends PhysicalPlan {
+
+  @Override
+  public <R, C> R accept(PhysicalPlanNodeVisitor<R, C> visitor, C context) {
+    return visitor.visitJoin(this, context);
+  }
+
+  @Override
+  public abstract List<PhysicalPlan> getChild();
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/JoinOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/JoinOperator.java
@@ -5,7 +5,16 @@
 
 package org.opensearch.sql.planner.physical.join;
 
+import static org.opensearch.sql.data.type.ExprCoreType.UNDEFINED;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlanNodeVisitor;
 
@@ -18,4 +27,35 @@ public abstract class JoinOperator extends PhysicalPlan {
 
   @Override
   public abstract List<PhysicalPlan> getChild();
+
+  public abstract void innerJoin(Iterator<ExprValue> streamedSide);
+
+  public abstract void outerJoin(Iterator<ExprValue> streamedSide);
+
+  public abstract void semiJoin(Iterator<ExprValue> streamedSide);
+
+  public abstract void antiJoin(Iterator<ExprValue> streamedSide);
+
+  protected ExprTupleValue combineExprTupleValue(
+      BuildSide buildSide, ExprValue streamedRow, ExprValue buildRow) {
+    ExprValue left = buildSide == BuildSide.BuildLeft ? buildRow : streamedRow;
+    ExprValue right = buildSide == BuildSide.BuildLeft ? streamedRow : buildRow;
+    Map<String, ExprValue> leftTuple = left.type().equals(UNDEFINED) ? Map.of() : left.tupleValue();
+    Map<String, ExprValue> rightTuple =
+        right.type().equals(UNDEFINED) ? Map.of() : right.tupleValue();
+    Map<String, ExprValue> combinedMap = new LinkedHashMap<>(leftTuple);
+    combinedMap.putAll(rightTuple);
+    return ExprTupleValue.fromExprValueMap(combinedMap);
+  }
+
+  protected boolean sameType(Expression expr1, Expression expr2) {
+    ExprType type1 = expr1.type();
+    ExprType type2 = expr2.type();
+    return type1.isCompatible(type2);
+  }
+
+  public enum BuildSide {
+    BuildLeft,
+    BuildRight
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/JoinOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/JoinOperator.java
@@ -5,20 +5,54 @@
 
 package org.opensearch.sql.planner.physical.join;
 
-import static org.opensearch.sql.data.type.ExprCoreType.UNDEFINED;
-
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.data.model.ExprNullValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.planner.physical.PhysicalPlanNodeVisitor;
 
 public abstract class JoinOperator extends PhysicalPlan {
+  protected PhysicalPlan left;
+  protected PhysicalPlan right;
+  protected Join.JoinType joinType;
+
+  protected ExecutionEngine.Schema leftSchema;
+  protected ExecutionEngine.Schema rightSchema;
+  protected ExecutionEngine.Schema outputSchema;
+
+  JoinOperator(PhysicalPlan left, PhysicalPlan right, Join.JoinType joinType) {
+    this.left = left;
+    this.right = right;
+    this.joinType = joinType;
+    this.leftSchema = left.schema();
+    this.rightSchema = right.schema();
+    getOutputSchema();
+  }
+
+  private void getOutputSchema() {
+    switch (joinType) {
+      case INNER, LEFT, RIGHT, FULL -> { // merge left and right schemas
+        List<ExecutionEngine.Schema.Column> columns =
+            Stream.of(left.schema().getColumns(), right.schema().getColumns())
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+        this.outputSchema = new ExecutionEngine.Schema(columns);
+      }
+      case SEMI, ANTI -> outputSchema = left.schema(); // left schema only
+      default -> throw new UnsupportedOperationException("Unsupported Join Type " + joinType);
+    }
+  }
 
   @Override
   public <R, C> R accept(PhysicalPlanNodeVisitor<R, C> visitor, C context) {
@@ -40,12 +74,26 @@ public abstract class JoinOperator extends PhysicalPlan {
       BuildSide buildSide, ExprValue streamedRow, ExprValue buildRow) {
     ExprValue left = buildSide == BuildSide.BuildLeft ? buildRow : streamedRow;
     ExprValue right = buildSide == BuildSide.BuildLeft ? streamedRow : buildRow;
-    Map<String, ExprValue> leftTuple = left.type().equals(UNDEFINED) ? Map.of() : left.tupleValue();
-    Map<String, ExprValue> rightTuple =
-        right.type().equals(UNDEFINED) ? Map.of() : right.tupleValue();
+    Map<String, ExprValue> leftTuple = getExprTupleMapFromSchema(left, leftSchema);
+    Map<String, ExprValue> rightTuple = getExprTupleMapFromSchema(right, rightSchema);
     Map<String, ExprValue> combinedMap = new LinkedHashMap<>(leftTuple);
     combinedMap.putAll(rightTuple);
     return ExprTupleValue.fromExprValueMap(combinedMap);
+  }
+
+  private Map<String, ExprValue> getExprTupleMapFromSchema(
+      ExprValue row, ExecutionEngine.Schema schema) {
+    Map<String, ExprValue> map = new LinkedHashMap<>();
+    if (row.isNull()) {
+      schema.getColumns().forEach(col -> map.put(col.getAlias(), ExprNullValue.of()));
+    } else {
+      // replace to indexName.fieldName as tupleMap key in case the field names are same in join
+      // tables.
+      schema
+          .getColumns()
+          .forEach(col -> map.put(col.getAlias(), row.tupleValue().get(col.getName())));
+    }
+    return map;
   }
 
   protected boolean sameType(Expression expr1, Expression expr2) {

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/JoinPredicatesHelper.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/JoinPredicatesHelper.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical.join;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+
+@UtilityClass
+public class JoinPredicatesHelper {
+
+  private static boolean instanceOf(Expression function, BuiltinFunctionName functionName) {
+    return function instanceof FunctionExpression
+        && ((FunctionExpression) function).getFunctionName().equals(functionName.getName());
+  }
+
+  private static boolean isValidJoinPredicate(FunctionExpression predicate) {
+    BuiltinFunctionName builtinFunctionName = BuiltinFunctionName.of(predicate.getFunctionName());
+    switch (builtinFunctionName) {
+      case AND:
+      case OR:
+      case EQUAL:
+      case NOTEQUAL:
+      case LESS:
+      case LTE:
+      case GREATER:
+      case GTE:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static ImmutablePair<Expression, Expression> extractJoinKeys(
+      FunctionExpression predicate) {
+    if (isValidJoinPredicate(predicate)) {
+      throw new SemanticCheckException(
+          StringUtils.format(
+              "Join condition {} is an invalid function",
+              predicate.getFunctionName().getFunctionName()));
+    } else {
+      return ImmutablePair.of(
+          predicate.getArguments().getFirst(), predicate.getArguments().getLast());
+    }
+  }
+
+  public static List<Expression> splitConjunctivePredicates(Expression condition) {
+    if (JoinPredicatesHelper.isAnd(condition)) {
+      return Stream.concat(
+              splitConjunctivePredicates(((FunctionExpression) condition).getArguments().getFirst())
+                  .stream(),
+              splitConjunctivePredicates(((FunctionExpression) condition).getArguments().getLast())
+                  .stream())
+          .collect(Collectors.toList());
+    } else {
+      return ImmutableList.of(condition);
+    }
+  }
+
+  public static List<Expression> splitDisjunctivePredicates(Expression condition) {
+    if (JoinPredicatesHelper.isOr(condition)) {
+      return Stream.concat(
+              splitDisjunctivePredicates(((FunctionExpression) condition).getArguments().getFirst())
+                  .stream(),
+              splitDisjunctivePredicates(((FunctionExpression) condition).getArguments().getLast())
+                  .stream())
+          .collect(Collectors.toList());
+    } else {
+      return ImmutableList.of(condition);
+    }
+  }
+
+  public static <L, R> Pair<List<L>, List<R>> unzip(List<Pair<L, R>> pairs) {
+    List<L> leftList = new ArrayList<>();
+    List<R> rightList = new ArrayList<>();
+    for (Pair<L, R> pair : pairs) {
+      leftList.add(pair.getLeft());
+      rightList.add(pair.getRight());
+    }
+    return Pair.of(leftList, rightList);
+  }
+
+  public static boolean isAnd(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.AND);
+  }
+
+  public static boolean isOr(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.OR);
+  }
+
+  public static boolean isEqual(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.EQUAL);
+  }
+
+  public static boolean isNot(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.NOT);
+  }
+
+  public static boolean isXor(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.XOR);
+  }
+
+  public static boolean isNotEqual(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.NOTEQUAL);
+  }
+
+  public static boolean isLess(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.LESS);
+  }
+
+  public static boolean isLte(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.LTE);
+  }
+
+  public static boolean isGreater(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.GREATER);
+  }
+
+  public static boolean isGte(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.GTE);
+  }
+
+  public static boolean isLike(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.LIKE);
+  }
+
+  public static boolean isNotLike(Expression expression) {
+    return instanceOf(expression, BuiltinFunctionName.NOT_LIKE);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/NestedLoopJoinOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/NestedLoopJoinOperator.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical.join;
+
+import com.google.common.collect.ImmutableList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+
+@RequiredArgsConstructor
+public class NestedLoopJoinOperator extends JoinOperator {
+  private final PhysicalPlan left;
+  private final PhysicalPlan right;
+  private final Join.JoinType joinType;
+  private final Expression condition;
+
+  private final ImmutableList.Builder<ExprValue> joinedBuilder = ImmutableList.builder();
+  private Iterator<ExprValue> joinedIterator;
+  // Build side is left by default, set the smaller side as the build side in future TODO
+  private Iterator<ExprValue> buildSide;
+
+  @Override
+  public void open() {
+    left.open();
+    right.open();
+
+    // buildSide is left plan by default
+    buildSide = left;
+
+    if (joinType == Join.JoinType.INNER) {
+      List<ExprValue> cached = cacheStreamedSide(right);
+      innerJoin(cached);
+    } else if (joinType == Join.JoinType.LEFT) {
+      // build side is right plan and streamed side is left plan in left outer join.
+      buildSide = right;
+      List<ExprValue> cached = cacheStreamedSide(left);
+      outerJoin(cached);
+    } else if (joinType == Join.JoinType.RIGHT) {
+      List<ExprValue> cached = cacheStreamedSide(right);
+      outerJoin(cached);
+    } else if (joinType == Join.JoinType.SEMI) {
+      List<ExprValue> cached = cacheStreamedSide(right);
+      semiJoin(cached);
+    } else if (joinType == Join.JoinType.ANTI) {
+      List<ExprValue> cached = cacheStreamedSide(right);
+      antiJoin(cached);
+    } else {
+      // LeftOuter with BuildLeft
+      // RightOuter with BuildRight
+      // FullOuter
+      List<ExprValue> cached = cacheStreamedSide(right);
+      defaultJoin(cached);
+    }
+  }
+
+  /** Convert iterator to a list to allow multiple iterations */
+  private List<ExprValue> cacheStreamedSide(PhysicalPlan plan) {
+    ImmutableList.Builder<ExprValue> streamedBuilder = ImmutableList.builder();
+    plan.forEachRemaining(streamedBuilder::add);
+    return streamedBuilder.build();
+  }
+
+  @Override
+  public void close() {
+    joinedIterator = null;
+    left.close();
+    right.close();
+  }
+
+  private void innerJoin(List<ExprValue> cacheStreamedSide) {
+    Iterator<ExprValue> streamed = cacheStreamedSide.iterator();
+    while (streamed.hasNext()) {
+      ExprValue leftRow = buildSide.next();
+
+      for (ExprValue rightRow : cacheStreamedSide) {
+        ExprTupleValue joinedRow = combineExprTupleValue(leftRow, rightRow);
+        ExprValue conditionValue = condition.valueOf(joinedRow.bindingTuples());
+        if (!(conditionValue.isNull() || conditionValue.isMissing())
+            && (conditionValue.booleanValue())) {
+          joinedBuilder.add(joinedRow);
+        }
+      }
+    }
+    joinedIterator = joinedBuilder.build().iterator();
+  }
+
+  /** The implementation for LeftOuter with BuildRight, RightOuter with BuildLeft */
+  private void outerJoin(List<ExprValue> cacheStreamedSide) {
+    Set<ExprValue> matchedRows = new HashSet<>();
+
+    // Probe phase
+    for (ExprValue streamedRow : cacheStreamedSide) {
+      boolean matched = false;
+      while (buildSide.hasNext()) {
+        ExprValue buildRow = buildSide.next();
+        ExprTupleValue joinedRow =
+            combineExprTupleValue(
+                joinType == Join.JoinType.LEFT ? streamedRow : buildRow,
+                joinType == Join.JoinType.LEFT ? buildRow : streamedRow);
+        ExprValue conditionValue = condition.valueOf(joinedRow.bindingTuples());
+        if (!(conditionValue.isNull() || conditionValue.isMissing())
+            && conditionValue.booleanValue()) {
+          joinedBuilder.add(joinedRow);
+          matchedRows.add(streamedRow);
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        ExprTupleValue joinedRow =
+            combineExprTupleValue(
+                joinType == Join.JoinType.LEFT ? streamedRow : ExprValueUtils.nullValue(),
+                joinType == Join.JoinType.LEFT ? ExprValueUtils.nullValue() : streamedRow);
+        joinedBuilder.add(joinedRow);
+      }
+    }
+
+    // Add unmatched rows
+    if (joinType == Join.JoinType.LEFT) {
+      while (buildSide.hasNext()) {
+        ExprValue buildRow = buildSide.next();
+        if (!matchedRows.contains(buildRow)) {
+          ExprTupleValue joinedRow = combineExprTupleValue(ExprValueUtils.nullValue(), buildRow);
+          joinedBuilder.add(joinedRow);
+        }
+      }
+    } else if (joinType == Join.JoinType.RIGHT) {
+      for (ExprValue streamedRow : cacheStreamedSide) {
+        if (!matchedRows.contains(streamedRow)) {
+          ExprTupleValue joinedRow = combineExprTupleValue(streamedRow, ExprValueUtils.nullValue());
+          joinedBuilder.add(joinedRow);
+        }
+      }
+    }
+
+    joinedIterator = joinedBuilder.build().iterator();
+  }
+
+  private void semiJoin(List<ExprValue> cacheStreamedSide) {
+    Set<ExprValue> matchedRows = new HashSet<>();
+
+    // Probe phase
+    for (ExprValue streamedRow : cacheStreamedSide) {
+      while (buildSide.hasNext()) {
+        ExprValue buildRow = buildSide.next();
+        ExprTupleValue joinedRow = combineExprTupleValue(streamedRow, buildRow);
+        ExprValue conditionValue = condition.valueOf(joinedRow.bindingTuples());
+        if (!(conditionValue.isNull() || conditionValue.isMissing())
+            && conditionValue.booleanValue()) {
+          matchedRows.add(streamedRow);
+          break;
+        }
+      }
+    }
+
+    // Add matched rows
+    for (ExprValue row : matchedRows) {
+      joinedBuilder.add(row);
+    }
+
+    joinedIterator = joinedBuilder.build().iterator();
+  }
+
+  // Java
+  private void antiJoin(List<ExprValue> cacheStreamedSide) {
+    Set<ExprValue> matchedRows = new HashSet<>();
+
+    // Probe phase
+    for (ExprValue streamedRow : cacheStreamedSide) {
+      boolean matched = false;
+      while (buildSide.hasNext()) {
+        ExprValue buildRow = buildSide.next();
+        ExprTupleValue joinedRow = combineExprTupleValue(streamedRow, buildRow);
+        ExprValue conditionValue = condition.valueOf(joinedRow.bindingTuples());
+        if (!(conditionValue.isNull() || conditionValue.isMissing())
+            && conditionValue.booleanValue()) {
+          matchedRows.add(streamedRow);
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        matchedRows.add(streamedRow);
+      }
+    }
+
+    // Add unmatched rows
+    for (ExprValue row : cacheStreamedSide) {
+      if (!matchedRows.contains(row)) {
+        joinedBuilder.add(row);
+      }
+    }
+
+    joinedIterator = joinedBuilder.build().iterator();
+  }
+
+  private void defaultJoin(List<ExprValue> cacheStreamedSide) {}
+
+  @Override
+  public boolean hasNext() {
+    return joinedIterator != null && joinedIterator.hasNext();
+  }
+
+  @Override
+  public ExprValue next() {
+    return joinedIterator.next();
+  }
+
+  private ExprTupleValue combineExprTupleValue(ExprValue left, ExprValue right) {
+    Map<String, ExprValue> combinedMap = left.tupleValue();
+    combinedMap.putAll(right.tupleValue());
+    return ExprTupleValue.fromExprValueMap(combinedMap);
+  }
+
+  @Override
+  public List<PhysicalPlan> getChild() {
+    return ImmutableList.of(left, right);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/planner/physical/join/NestedLoopJoinOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/join/NestedLoopJoinOperator.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
@@ -30,13 +29,20 @@ import org.opensearch.sql.planner.physical.PhysicalPlan;
  * bigger ON bigger.field1 = smaller.field2 AND bigger.field3 = smaller.field4 The build side is
  * left (smaller), and the streamed side is right (bigger).
  */
-@RequiredArgsConstructor
 public class NestedLoopJoinOperator extends JoinOperator {
-  private final PhysicalPlan left;
-  private final PhysicalPlan right;
-  private final Join.JoinType joinType;
   private final BuildSide buildSide;
   private final Expression condition;
+
+  public NestedLoopJoinOperator(
+      PhysicalPlan left,
+      PhysicalPlan right,
+      Join.JoinType joinType,
+      BuildSide buildSide,
+      Expression condition) {
+    super(left, right, joinType);
+    this.buildSide = buildSide;
+    this.condition = condition;
+  }
 
   private final ImmutableList.Builder<ExprValue> joinedBuilder = ImmutableList.builder();
   private Iterator<ExprValue> joinedIterator;
@@ -67,10 +73,10 @@ public class NestedLoopJoinOperator extends JoinOperator {
 
   @Override
   public void close() {
-    joinedIterator = null;
-    cachedBuildSide = null;
     left.close();
     right.close();
+    joinedIterator = null;
+    cachedBuildSide = null;
   }
 
   /** The implementation for inner join: Inner with BuildRight */

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -1973,4 +1973,24 @@ class AnalyzerTest extends AnalyzerTestBase {
             AstDSL.alias("schema1.string_value", AstDSL.field("schema1.string_value")),
             AstDSL.alias("schema2.string_value", AstDSL.field("schema2.string_value"))));
   }
+
+  @Test
+  public void join_condition_is_ambiguous() {
+    SemanticCheckException exception =
+        assertThrows(
+            SemanticCheckException.class,
+            () ->
+                analyze(
+                    AstDSL.join(
+                        AstDSL.relation("schema1"),
+                        AstDSL.relation("schema2"),
+                        Join.JoinType.INNER,
+                        AstDSL.and(
+                            AstDSL.equalTo(
+                                AstDSL.field("schema1.integer_value"),
+                                AstDSL.field("schema2.integer_value")),
+                            AstDSL.equalTo(
+                                AstDSL.field("double_value"), AstDSL.field("double_value"))))));
+    assertEquals("Reference `double_value` is ambiguous", exception.getMessage());
+  }
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -177,7 +177,8 @@ public class AnalyzerTestBase {
   }
 
   protected void assertAnalyzeEqual(LogicalPlan expected, UnresolvedPlan unresolvedPlan) {
-    assertEquals(expected, analyze(unresolvedPlan));
+    LogicalPlan actual = analyze(unresolvedPlan);
+    assertEquals(expected, actual);
   }
 
   protected LogicalPlan analyze(UnresolvedPlan unresolvedPlan) {

--- a/core/src/test/java/org/opensearch/sql/config/TestConfig.java
+++ b/core/src/test/java/org/opensearch/sql/config/TestConfig.java
@@ -61,6 +61,17 @@ public class TestConfig {
           .put("comment.data", ExprCoreType.STRING)
           .build();
 
+  public static Map<String, ExprType> typeMapping2 =
+      new ImmutableMap.Builder<String, ExprType>()
+          .put("i_value", ExprCoreType.INTEGER)
+          .put("l_value", ExprCoreType.LONG)
+          .put("f_value", ExprCoreType.FLOAT)
+          .put("d_value", ExprCoreType.DOUBLE)
+          .put("msg", ExprCoreType.STRING)
+          .put("msg.info", ExprCoreType.STRING)
+          .put("msg.info.id", ExprCoreType.STRING)
+          .build();
+
   protected StorageEngine storageEngine() {
     return new StorageEngine() {
       @Override

--- a/core/src/test/java/org/opensearch/sql/planner/physical/HashJoinOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/HashJoinOperatorTest.java
@@ -11,12 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -26,759 +24,212 @@ import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
-import org.opensearch.sql.planner.physical.join.HashJoinOperator;
 import org.opensearch.sql.planner.physical.join.JoinOperator;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class HashJoinOperatorTest extends PhysicalPlanTestBase {
-  private final JoinOperator.BuildSide defaultBuildSide = JoinOperator.BuildSide.BuildRight;
+public class HashJoinOperatorTest extends JoinOperatorTestHelper {
+  private final Optional<Expression> emptyNonEquiCond = Optional.empty();
   private final Optional<Expression> defaultNonEquiCond =
       Optional.of(
           DSL.and(
-              DSL.equal(DSL.ref("host", STRING), DSL.literal("h1")),
-              DSL.lte(DSL.ref("id", INTEGER), DSL.literal(5))));
+              DSL.equal(DSL.ref("error_t.host", STRING), DSL.literal("h1")),
+              DSL.lte(DSL.ref("name_t.id", INTEGER), DSL.literal(5))));
 
   @Test
   public void inner_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.INNER,
-            defaultBuildSide,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(
+            Join.JoinType.INNER, JoinOperator.BuildSide.BuildRight, emptyNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(7, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10,
-                    "id",
-                    10,
-                    "name",
-                    "j")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6,
-                    "id",
-                    6,
-                    "name",
-                    "f")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8))));
+            error1_id1,
+            error1_id1_duplicated,
+            error2_id2,
+            error3_id3,
+            error6_id6,
+            error8_id8,
+            error10_id10));
   }
 
   @Test
-  public void inner_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
+  public void inner_join_side_reversed_test() {
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            Join.JoinType.INNER,
-            defaultBuildSide,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(
+            Join.JoinType.INNER, JoinOperator.BuildSide.BuildRight, emptyNonEquiCond, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(7, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    2,
-                    "name",
-                    "b",
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    6,
-                    "name",
-                    "f",
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    10,
-                    "name",
-                    "j",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10))));
+            id1_error1,
+            id1_error1_duplicated,
+            id2_error2,
+            id3_error3,
+            id6_error6,
+            id8_error8,
+            id10_error10));
   }
 
   @Test
   public void inner_join_with_non_equi_cond_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.INNER,
-            defaultBuildSide,
-            left,
-            right,
-            defaultNonEquiCond);
+        makeHashJoin(
+            Join.JoinType.INNER, JoinOperator.BuildSide.BuildRight, defaultNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(3, result.size());
-    assertThat(
-        result,
-        containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a"))));
+    assertThat(result, containsInAnyOrder(error1_id1, error1_id1_duplicated, error2_id2));
   }
 
   @Test
   public void left_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.LEFT,
-            defaultBuildSide,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(
+            Join.JoinType.LEFT, JoinOperator.BuildSide.BuildRight, emptyNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(9, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10,
-                    "id",
-                    10,
-                    "name",
-                    "j")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6,
-                    "id",
-                    6,
-                    "name",
-                    "f")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+            error1_id1,
+            error1_id1_duplicated,
+            error2_id2,
+            error3_id3,
+            error6_id6,
+            error8_id8,
+            error10_id10,
+            error12_null,
+            error13_null));
   }
 
   @Test
-  public void left_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
+  public void left_join_side_reversed_test() {
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            Join.JoinType.LEFT,
-            defaultBuildSide,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(Join.JoinType.LEFT, JoinOperator.BuildSide.BuildRight, emptyNonEquiCond, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(12, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    2,
-                    "name",
-                    "b",
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    6,
-                    "name",
-                    "f",
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    10,
-                    "name",
-                    "j",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+            id1_error1,
+            id1_error1_duplicated,
+            id2_error2,
+            id3_error3,
+            id6_error6,
+            id8_error8,
+            id10_error10,
+            id4_null,
+            id5_null,
+            id7_null,
+            id9_null,
+            id11_null));
   }
 
   @Test
   public void left_join_with_non_equi_cond_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.INNER,
-            defaultBuildSide,
-            left,
-            right,
-            defaultNonEquiCond);
-    List<ExprValue> result = execute(joinPlan);
-    result.forEach(System.out::println);
-    assertEquals(3, result.size());
-    assertThat(
-        result,
-        containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a"))));
-  }
-
-  @Test
-  public void right_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
-    PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.RIGHT,
-            JoinOperator.BuildSide.BuildLeft,
-            left,
-            right,
-            Optional.empty());
-    List<ExprValue> result = execute(joinPlan);
-    result.forEach(System.out::println);
-    assertEquals(12, result.size());
-    assertThat(
-        result,
-        containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6,
-                    "id",
-                    6,
-                    "name",
-                    "f")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10,
-                    "id",
-                    10,
-                    "name",
-                    "j")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
-  }
-
-  @Test
-  public void right_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
-    PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            Join.JoinType.RIGHT,
-            JoinOperator.BuildSide.BuildLeft,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(
+            Join.JoinType.LEFT, JoinOperator.BuildSide.BuildRight, defaultNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(9, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    2,
-                    "name",
-                    "b",
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    10,
-                    "name",
-                    "j",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    6,
-                    "name",
-                    "f",
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+            error1_id1,
+            error1_id1_duplicated,
+            error2_id2,
+            error3_null,
+            error6_null,
+            error8_null,
+            error10_null,
+            error12_null,
+            error13_null));
   }
 
   @Test
-  public void right_join_with_non_equi_cond_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
+  public void right_join_test() {
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.RIGHT,
-            JoinOperator.BuildSide.BuildLeft,
-            left,
-            right,
-            defaultNonEquiCond);
+        makeHashJoin(
+            Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft, emptyNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(12, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 3)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 8)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+            error1_id1,
+            error1_id1_duplicated,
+            error2_id2,
+            error3_id3,
+            error6_id6,
+            error8_id8,
+            error10_id10,
+            null_id4,
+            null_id5,
+            null_id7,
+            null_id9,
+            null_id11));
+  }
+
+  @Test
+  public void right_join_side_reversed_test() {
+    PhysicalPlan joinPlan =
+        makeHashJoin(Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft, emptyNonEquiCond, true);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(9, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            id1_error1,
+            id1_error1_duplicated,
+            id2_error2,
+            id3_error3,
+            id6_error6,
+            id8_error8,
+            id10_error10,
+            null_error12,
+            null_error13));
+  }
+
+  @Test
+  public void right_join_with_non_equi_cond_test() {
+    PhysicalPlan joinPlan =
+        makeHashJoin(
+            Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft, defaultNonEquiCond, false);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(12, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            error1_id1,
+            error1_id1_duplicated,
+            error2_id2,
+            null_id3,
+            null_id4,
+            null_id5,
+            null_id6,
+            null_id7,
+            null_id8,
+            null_id9,
+            null_id10,
+            null_id11));
   }
 
   @Test
   public void semi_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.SEMI,
-            defaultBuildSide,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(
+            Join.JoinType.SEMI, JoinOperator.BuildSide.BuildRight, emptyNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(7, result.size());
@@ -803,19 +254,9 @@ public class HashJoinOperatorTest extends PhysicalPlanTestBase {
   }
 
   @Test
-  public void semi_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
+  public void semi_join_side_reversed_test() {
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            Join.JoinType.SEMI,
-            defaultBuildSide,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(Join.JoinType.SEMI, JoinOperator.BuildSide.BuildRight, emptyNonEquiCond, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(6, result.size());
@@ -826,23 +267,27 @@ public class HashJoinOperatorTest extends PhysicalPlanTestBase {
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")),
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")),
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 3)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 8))));
+            ExprValueUtils.tupleValue(
+                new LinkedHashMap<>() {
+                  {
+                    put("id", 3);
+                    put("name", null);
+                  }
+                }),
+            ExprValueUtils.tupleValue(
+                new LinkedHashMap<>() {
+                  {
+                    put("id", 8);
+                    put("name", null);
+                  }
+                })));
   }
 
   @Test
   public void semi_join_non_equi_cond_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.SEMI,
-            defaultBuildSide,
-            left,
-            right,
-            defaultNonEquiCond);
+        makeHashJoin(
+            Join.JoinType.SEMI, JoinOperator.BuildSide.BuildRight, defaultNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(3, result.size());
@@ -860,17 +305,9 @@ public class HashJoinOperatorTest extends PhysicalPlanTestBase {
 
   @Test
   public void anti_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.ANTI,
-            defaultBuildSide,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(
+            Join.JoinType.ANTI, JoinOperator.BuildSide.BuildRight, emptyNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(2, result.size());
@@ -886,19 +323,9 @@ public class HashJoinOperatorTest extends PhysicalPlanTestBase {
   }
 
   @Test
-  public void anti_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
+  public void anti_join_side_reversed_test() {
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            Join.JoinType.ANTI,
-            defaultBuildSide,
-            left,
-            right,
-            Optional.empty());
+        makeHashJoin(Join.JoinType.ANTI, JoinOperator.BuildSide.BuildRight, emptyNonEquiCond, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(5, result.size());
@@ -914,17 +341,9 @@ public class HashJoinOperatorTest extends PhysicalPlanTestBase {
 
   @Test
   public void anti_join_non_equi_cond_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        new HashJoinOperator(
-            ImmutableList.of(DSL.ref("errors", INTEGER)),
-            ImmutableList.of(DSL.ref("id", INTEGER)),
-            Join.JoinType.ANTI,
-            defaultBuildSide,
-            left,
-            right,
-            defaultNonEquiCond);
+        makeHashJoin(
+            Join.JoinType.ANTI, JoinOperator.BuildSide.BuildRight, defaultNonEquiCond, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(6, result.size());

--- a/core/src/test/java/org/opensearch/sql/planner/physical/JoinOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/JoinOperatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.planner.physical.join.NestedLoopJoinOperator;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class JoinOperatorTest extends PhysicalPlanTestBase {
+
+  public void nested_loop_join_test() {
+    PhysicalPlan left = testScan(compoundInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.INNER,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    assertEquals(7, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "ip",
+                    "209.160.24.63",
+                    "action",
+                    "GET",
+                    "response",
+                    404,
+                    "referer",
+                    "www.amazon.com"))));
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/physical/JoinOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/JoinOperatorTest.java
@@ -14,9 +14,11 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.expression.DSL;
@@ -26,8 +28,9 @@ import org.opensearch.sql.planner.physical.join.NestedLoopJoinOperator;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class JoinOperatorTest extends PhysicalPlanTestBase {
 
-  public void nested_loop_join_test() {
-    PhysicalPlan left = testScan(compoundInputs);
+  @Test
+  public void nested_loop_inner_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
     PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
         new NestedLoopJoinOperator(
@@ -36,19 +39,627 @@ public class JoinOperatorTest extends PhysicalPlanTestBase {
             Join.JoinType.INNER,
             DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
     List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
     assertEquals(7, result.size());
     assertThat(
         result,
         containsInAnyOrder(
             ExprValueUtils.tupleValue(
                 ImmutableMap.of(
-                    "ip",
-                    "209.160.24.63",
-                    "action",
-                    "GET",
-                    "response",
-                    404,
-                    "referer",
-                    "www.amazon.com"))));
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2,
+                    "id",
+                    2,
+                    "name",
+                    "b")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10,
+                    "id",
+                    10,
+                    "name",
+                    "j")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6,
+                    "id",
+                    6,
+                    "name",
+                    "f")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8))));
+  }
+
+  @Test
+  public void nested_loop_inner_join_test_2() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.INNER,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(7, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    2,
+                    "name",
+                    "b",
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    6,
+                    "name",
+                    "f",
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    10,
+                    "name",
+                    "j",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10))));
+  }
+
+  @Test
+  public void nested_loop_left_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.LEFT,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(9, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2,
+                    "id",
+                    2,
+                    "name",
+                    "b")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10,
+                    "id",
+                    10,
+                    "name",
+                    "j")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6,
+                    "id",
+                    6,
+                    "name",
+                    "f")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+  }
+
+  @Test
+  public void nested_loop_left_join_test_2() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.LEFT,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(12, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    2,
+                    "name",
+                    "b",
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    6,
+                    "name",
+                    "f",
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    10,
+                    "name",
+                    "j",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+  }
+
+  @Test
+  public void nested_loop_right_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.RIGHT,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(12, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2,
+                    "id",
+                    2,
+                    "name",
+                    "b")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6,
+                    "id",
+                    6,
+                    "name",
+                    "f")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10,
+                    "id",
+                    10,
+                    "name",
+                    "j")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+  }
+
+  @Test
+  public void nested_loop_right_join_test_2() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.RIGHT,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(9, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    2,
+                    "name",
+                    "b",
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    10,
+                    "name",
+                    "j",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    6,
+                    "name",
+                    "f",
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+  }
+
+  @Test
+  public void nested_loop_semi_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.SEMI,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(7, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-04"), "host", "h1", "errors", 1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-06"), "host", "h1", "errors", 1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-03"), "host", "h1", "errors", 2)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-07"), "host", "h1", "errors", 6)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-04"), "host", "h2", "errors", 10))));
+  }
+
+  @Test
+  public void nested_loop_semi_join_test_2() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.SEMI,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(6, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 2, "name", "b")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 3)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 8))));
+  }
+
+  @Test
+  public void nested_loop_anti_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.ANTI,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(2, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+  }
+
+  @Test
+  public void nested_loop_anti_join_test_2() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan =
+        new NestedLoopJoinOperator(
+            left,
+            right,
+            Join.JoinType.ANTI,
+            DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(5, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/JoinOperatorTestHelper.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/JoinOperatorTestHelper.java
@@ -1,0 +1,780 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical;
+
+import static org.opensearch.sql.data.type.ExprCoreType.DATE;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.executor.ExecutionEngine;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.planner.physical.join.HashJoinOperator;
+import org.opensearch.sql.planner.physical.join.JoinOperator;
+import org.opensearch.sql.planner.physical.join.NestedLoopJoinOperator;
+
+public class JoinOperatorTestHelper extends PhysicalPlanTestBase {
+
+  private final List<ExprValue> errorInputs =
+      new ImmutableList.Builder<ExprValue>()
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-03"), "host", "h1", "errors", 2)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-04"), "host", "h1", "errors", 1)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-04"), "host", "h2", "errors", 10)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-06"), "host", "h1", "errors", 1)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-07"), "host", "h1", "errors", 6)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13)))
+          .build();
+
+  private final List<ExprValue> nameInputs =
+      new ImmutableList.Builder<ExprValue>()
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 2, "name", "b")))
+          .add(
+              ExprValueUtils.tupleValue(
+                  new LinkedHashMap<>() {
+                    {
+                      put("id", 3);
+                      put("name", null);
+                    }
+                  }))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")))
+          .add(
+              ExprValueUtils.tupleValue(
+                  new LinkedHashMap<>() {
+                    {
+                      put("id", 8);
+                      put("name", null);
+                    }
+                  }))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k")))
+          .build();
+
+  private final List<ExprValue> sameNameInputs =
+      new ImmutableList.Builder<ExprValue>()
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 3, "name", "c")))
+          .add(
+              ExprValueUtils.tupleValue(
+                  new LinkedHashMap<>() {
+                    {
+                      put("id", 5);
+                      put("name", null);
+                    }
+                  }))
+          .add(
+              ExprValueUtils.tupleValue(
+                  new LinkedHashMap<>() {
+                    {
+                      put("id", 8);
+                      put("name", null);
+                    }
+                  }))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "jj")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "jjj")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 15, "name", "o")))
+          .add(
+              ExprValueUtils.tupleValue(
+                  new LinkedHashMap<>() {
+                    {
+                      put("id", 16);
+                      put("name", null);
+                    }
+                  }))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 17, "name", "q")))
+          .build();
+
+  private final ExecutionEngine.Schema errorSchema =
+      new ExecutionEngine.Schema(
+          List.of(
+              new ExecutionEngine.Schema.Column("day", "error_t.day", DATE),
+              new ExecutionEngine.Schema.Column("host", "error_t.host", STRING),
+              new ExecutionEngine.Schema.Column("errors", "error_t.errors", INTEGER)));
+
+  private final ExecutionEngine.Schema nameSchema =
+      new ExecutionEngine.Schema(
+          List.of(
+              new ExecutionEngine.Schema.Column("id", "name_t.id", INTEGER),
+              new ExecutionEngine.Schema.Column("name", "name_t.name", STRING)));
+
+  private final ExecutionEngine.Schema sameNameSchema =
+      new ExecutionEngine.Schema(
+          List.of(
+              new ExecutionEngine.Schema.Column("id", "name_t2.id", INTEGER),
+              new ExecutionEngine.Schema.Column("name", "name_t2.name", STRING)));
+
+  public PhysicalPlan makeNestedLoopJoin(
+      Join.JoinType joinType, JoinOperator.BuildSide buildSide, boolean reversed) {
+    PhysicalPlan left =
+        reversed
+            ? testTableScan("name_t", nameSchema, nameInputs)
+            : testTableScan("error_t", errorSchema, errorInputs);
+    PhysicalPlan right =
+        reversed
+            ? testTableScan("error_t", errorSchema, errorInputs)
+            : testTableScan("name_t", nameSchema, nameInputs);
+    return new NestedLoopJoinOperator(
+        left,
+        right,
+        joinType,
+        buildSide,
+        DSL.equal(DSL.ref("error_t.errors", INTEGER), DSL.ref("name_t.id", INTEGER)));
+  }
+
+  public PhysicalPlan makeNestedLoopJoinWithSameColumnNames(
+      Join.JoinType joinType, JoinOperator.BuildSide buildSide, boolean reversed) {
+    PhysicalPlan left =
+        reversed
+            ? testTableScan("name_t2", sameNameSchema, sameNameInputs)
+            : testTableScan("name_t", nameSchema, nameInputs);
+    PhysicalPlan right =
+        reversed
+            ? testTableScan("name_t", nameSchema, nameInputs)
+            : testTableScan("name_t2", sameNameSchema, sameNameInputs);
+    return new NestedLoopJoinOperator(
+        left,
+        right,
+        joinType,
+        buildSide,
+        DSL.equal(DSL.ref("name_t.id", INTEGER), DSL.ref("name_t2.id", INTEGER)));
+  }
+
+  public PhysicalPlan makeHashJoin(
+      Join.JoinType joinType,
+      JoinOperator.BuildSide buildSide,
+      Optional<Expression> nonEquiCond,
+      boolean reversed) {
+    PhysicalPlan left =
+        reversed
+            ? testTableScan("name_t", nameSchema, nameInputs)
+            : testTableScan("error_t", errorSchema, errorInputs);
+    PhysicalPlan right =
+        reversed
+            ? testTableScan("error_t", errorSchema, errorInputs)
+            : testTableScan("name_t", nameSchema, nameInputs);
+    List<Expression> leftKeys =
+        reversed
+            ? ImmutableList.of(DSL.ref("id", INTEGER))
+            : ImmutableList.of(DSL.ref("errors", INTEGER));
+
+    List<Expression> rightKeys =
+        reversed
+            ? ImmutableList.of(DSL.ref("errors", INTEGER))
+            : ImmutableList.of(DSL.ref("id", INTEGER));
+    return new HashJoinOperator(leftKeys, rightKeys, joinType, buildSide, left, right, nonEquiCond);
+  }
+
+  public PhysicalPlan makeHashJoinWithSameColumnNames(
+      Join.JoinType joinType,
+      JoinOperator.BuildSide buildSide,
+      Optional<Expression> nonEquiCond,
+      boolean reversed) {
+    PhysicalPlan left =
+        reversed
+            ? testTableScan("name_t", nameSchema, nameInputs)
+            : testTableScan("name_t2", sameNameSchema, sameNameInputs);
+    PhysicalPlan right =
+        reversed
+            ? testTableScan("name_t2", sameNameSchema, sameNameInputs)
+            : testTableScan("name_t", nameSchema, nameInputs);
+    List<Expression> leftKeys = ImmutableList.of(DSL.ref("id", INTEGER));
+
+    List<Expression> rightKeys = ImmutableList.of(DSL.ref("id", INTEGER));
+    return new HashJoinOperator(leftKeys, rightKeys, joinType, buildSide, left, right, nonEquiCond);
+  }
+
+  /** {day:DATE '2021-01-04',host:"h1",errors:1,id:1,name:"a"} */
+  protected ExprValue error1_id1 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "error_t.day",
+              new ExprDateValue("2021-01-04"),
+              "error_t.host",
+              "h1",
+              "error_t.errors",
+              1,
+              "name_t.id",
+              1,
+              "name_t.name",
+              "a"));
+
+  /** {day:DATE '2021-01-06',host:"h1",errors:1,id:1,name:"a"} */
+  protected ExprValue error1_id1_duplicated =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "error_t.day",
+              new ExprDateValue("2021-01-06"),
+              "error_t.host",
+              "h1",
+              "error_t.errors",
+              1,
+              "name_t.id",
+              1,
+              "name_t.name",
+              "a"));
+
+  /** {day:DATE '2021-01-03',host:"h1",errors:2,id:2,name:"b"} */
+  protected ExprValue error2_id2 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "error_t.day",
+              new ExprDateValue("2021-01-03"),
+              "error_t.host",
+              "h1",
+              "error_t.errors",
+              2,
+              "name_t.id",
+              2,
+              "name_t.name",
+              "b"));
+
+  /** {day:DATE '2021-01-03',host:"h2",errors:3,id:3,name:NULL} */
+  protected ExprValue error3_id3 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", new ExprDateValue("2021-01-03"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 3);
+              put("name_t.id", 3);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:DATE '2021-01-03',host:"h2",errors:3,id:NULL,name:NULL} */
+  protected ExprValue error3_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", new ExprDateValue("2021-01-03"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 3);
+              put("name_t.id", null);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:DATE '2021-01-07',host:"h1",errors:6,id:6,name:"f"} */
+  protected ExprValue error6_id6 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "error_t.day",
+              new ExprDateValue("2021-01-07"),
+              "error_t.host",
+              "h1",
+              "error_t.errors",
+              6,
+              "name_t.id",
+              6,
+              "name_t.name",
+              "f"));
+
+  /** {day:DATE '2021-01-07',host:"h1",errors:6,id:NULL,name:NULL} */
+  protected ExprValue error6_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", new ExprDateValue("2021-01-07"));
+              put("error_t.host", "h1");
+              put("error_t.errors", 6);
+              put("name_t.id", null);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:DATE '2021-01-07',host:"h2",errors:8,id:8,name:NULL} */
+  protected ExprValue error8_id8 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", new ExprDateValue("2021-01-07"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 8);
+              put("name_t.id", 8);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:DATE '2021-01-07',host:"h2",errors:8,id:NULL,name:NULL} */
+  protected ExprValue error8_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", new ExprDateValue("2021-01-07"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 8);
+              put("name_t.id", null);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:DATE '2021-01-04',host:"h2",errors:10,id:10,name:"j"} */
+  protected ExprValue error10_id10 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "error_t.day",
+              new ExprDateValue("2021-01-04"),
+              "error_t.host",
+              "h2",
+              "error_t.errors",
+              10,
+              "name_t.id",
+              10,
+              "name_t.name",
+              "j"));
+
+  /** {day:DATE '2021-01-04',host:"h2",errors:10,id:NULL,name:NULL} */
+  protected ExprValue error10_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", new ExprDateValue("2021-01-04"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 10);
+              put("name_t.id", null);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:DATE '2021-01-07',host:"h2",errors:12,id:NULL,name:NULL} */
+  protected ExprValue error12_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", new ExprDateValue("2021-01-07"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 12);
+              put("name_t.id", null);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:DATE '2021-01-08',host:"h1",errors:13,id:NULL,name:NULL} */
+  protected ExprValue error13_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", new ExprDateValue("2021-01-08"));
+              put("error_t.host", "h1");
+              put("error_t.errors", 13);
+              put("name_t.id", null);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {id:1,name:"a",day:DATE '2021-01-04',host:"h1",errors:1} */
+  protected ExprValue id1_error1 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id",
+              1,
+              "name_t.name",
+              "a",
+              "error_t.day",
+              new ExprDateValue("2021-01-04"),
+              "error_t.host",
+              "h1",
+              "error_t.errors",
+              1));
+
+  /** {id:1,name:"a",day:DATE '2021-01-06',host:"h1",errors:1} */
+  protected ExprValue id1_error1_duplicated =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id",
+              1,
+              "name_t.name",
+              "a",
+              "error_t.day",
+              new ExprDateValue("2021-01-06"),
+              "error_t.host",
+              "h1",
+              "error_t.errors",
+              1));
+
+  /** {id:2,name:"b",day:DATE '2021-01-03',host:"h1",errors:2} */
+  protected ExprValue id2_error2 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id",
+              2,
+              "name_t.name",
+              "b",
+              "error_t.day",
+              new ExprDateValue("2021-01-03"),
+              "error_t.host",
+              "h1",
+              "error_t.errors",
+              2));
+
+  /** {id:3,name:NULL,day:DATE '2021-01-03',host:"h2",errors:3} */
+  protected ExprValue id3_error3 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 3);
+              put("name_t.name", null);
+              put("error_t.day", new ExprDateValue("2021-01-03"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 3);
+            }
+          });
+
+  /** {id:4,name:"d",day:NULL,host:NULL,errors:NULL} */
+  protected ExprValue id4_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 4);
+              put("name_t.name", "d");
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+            }
+          });
+
+  /** {id:5,name:"e",day:NULL,host:NULL,errors:NULL} */
+  protected ExprValue id5_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 5);
+              put("name_t.name", "e");
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+            }
+          });
+
+  /** {id:6,name:"f",day:DATE '2021-01-07',host:"h1",errors:6} */
+  protected ExprValue id6_error6 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id",
+              6,
+              "name_t.name",
+              "f",
+              "error_t.day",
+              new ExprDateValue("2021-01-07"),
+              "error_t.host",
+              "h1",
+              "error_t.errors",
+              6));
+
+  /** {id:7,name:"g",day:NULL,host:NULL,errors:NULL} */
+  protected ExprValue id7_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 7);
+              put("name_t.name", "g");
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+            }
+          });
+
+  /** {id:8,name:NULL,day:DATE '2021-01-07',host:"h2",errors:8} */
+  protected ExprValue id8_error8 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 8);
+              put("name_t.name", null);
+              put("error_t.day", new ExprDateValue("2021-01-07"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 8);
+            }
+          });
+
+  /** {id:9,name:"i",day:NULL,host:NULL,errors:NULL} */
+  protected ExprValue id9_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 9);
+              put("name_t.name", "i");
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+            }
+          });
+
+  /** {id:10,name:"j",day:DATE '2021-01-04',host:"h2",errors:10} */
+  protected ExprValue id10_error10 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id",
+              10,
+              "name_t.name",
+              "j",
+              "error_t.day",
+              new ExprDateValue("2021-01-04"),
+              "error_t.host",
+              "h2",
+              "error_t.errors",
+              10));
+
+  /** {id:11,name:"k",day:NULL,host:NULL,errors:NULL} */
+  protected ExprValue id11_null =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 11);
+              put("name_t.name", "k");
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:3,name:NULL} */
+  protected ExprValue null_id3 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 3);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:4,name:"d"} */
+  protected ExprValue null_id4 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 4);
+              put("name_t.name", "d");
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:5,name:"e"} */
+  protected ExprValue null_id5 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 5);
+              put("name_t.name", "e");
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:6,name:"f"} */
+  protected ExprValue null_id6 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 6);
+              put("name_t.name", "f");
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:7,name:"g"} */
+  protected ExprValue null_id7 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 7);
+              put("name_t.name", "g");
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:8,name:NULL} */
+  protected ExprValue null_id8 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 8);
+              put("name_t.name", null);
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:9,name:"i"} */
+  protected ExprValue null_id9 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 9);
+              put("name_t.name", "i");
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:10,name:"j"} */
+  protected ExprValue null_id10 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 10);
+              put("name_t.name", "j");
+            }
+          });
+
+  /** {day:NULL,host:NULL,errors:NULL,id:11,name:"k"} */
+  protected ExprValue null_id11 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("error_t.day", null);
+              put("error_t.host", null);
+              put("error_t.errors", null);
+              put("name_t.id", 11);
+              put("name_t.name", "k");
+            }
+          });
+
+  /** {id:NULL,name:NULL,day:DATE '2021-01-07',host:"h2",errors:12} */
+  protected ExprValue null_error12 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", null);
+              put("name_t.name", null);
+              put("error_t.day", new ExprDateValue("2021-01-07"));
+              put("error_t.host", "h2");
+              put("error_t.errors", 12);
+            }
+          });
+
+  /** {id:NULL,name:NULL,day:DATE '2021-01-08',host:"h1",errors:13} */
+  protected ExprValue null_error13 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", null);
+              put("name_t.name", null);
+              put("error_t.day", new ExprDateValue("2021-01-08"));
+              put("error_t.host", "h1");
+              put("error_t.errors", 13);
+            }
+          });
+
+  /** {name_t.id:1,name_t.name:"a",name_t2.id:1,name_t2.name:"a"} */
+  ExprValue id1_same_id1 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id", 1, "name_t.name", "a", "name_t2.id", 1, "name_t2.name", "a"));
+
+  /** {name_t.id:3,name_t.name:NULL,name_t2.id:3,name_t2.name:"c"} */
+  ExprValue id3_same_id3 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 3);
+              put("name_t.name", null);
+              put("name_t2.id", 3);
+              put("name_t2.name", "c");
+            }
+          });
+
+  /** {name_t.id:5,name_t.name:"e",name_t2.id:5,name_t2.name:NULL} */
+  ExprValue id5_same_id5 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 5);
+              put("name_t.name", "e");
+              put("name_t2.id", 5);
+              put("name_t2.name", null);
+            }
+          });
+
+  /** {name_t.id:8,name_t.name:NULL,name_t2.id:8,name_t2.name:NULL} */
+  ExprValue id8_same_id8 =
+      ExprValueUtils.tupleValue(
+          new LinkedHashMap<>() {
+            {
+              put("name_t.id", 8);
+              put("name_t.name", null);
+              put("name_t2.id", 8);
+              put("name_t2.name", null);
+            }
+          });
+
+  /** {name_t.id:10,name_t.name:"j",name_t2.id:10,name_t2.name:"j"} */
+  ExprValue id10_same_id10 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id", 10, "name_t.name", "j", "name_t2.id", 10, "name_t2.name", "j"));
+
+  /** {name_t.id:10,name_t.name:"j",name_t2.id:10,name_t2.name:"jj"} */
+  ExprValue id10_same_id10_duplicated =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id", 10, "name_t.name", "j", "name_t2.id", 10, "name_t2.name", "jj"));
+
+  /** {name_t.id:10,name_t.name:"j",name_t2.id:10,name_t2.name:"jjj"} */
+  ExprValue id10_same_id10_duplicated2 =
+      ExprValueUtils.tupleValue(
+          ImmutableMap.of(
+              "name_t.id", 10, "name_t.name", "j", "name_t2.id", 10, "name_t2.name", "jjj"));
+}

--- a/core/src/test/java/org/opensearch/sql/planner/physical/NestedLoopJoinOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/NestedLoopJoinOperatorTest.java
@@ -1,0 +1,637 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.planner.physical;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.data.model.ExprDateValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.planner.physical.join.JoinOperator;
+import org.opensearch.sql.planner.physical.join.NestedLoopJoinOperator;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class NestedLoopJoinOperatorTest extends PhysicalPlanTestBase {
+  private final JoinOperator.BuildSide defaultBuildSide = JoinOperator.BuildSide.BuildRight;
+
+  private PhysicalPlan makeNestedLoopJoin(
+      PhysicalPlan left, PhysicalPlan right, Join.JoinType joinType) {
+    return makeNestedLoopJoin(left, right, joinType, defaultBuildSide);
+  }
+
+  private PhysicalPlan makeNestedLoopJoin(
+      PhysicalPlan left,
+      PhysicalPlan right,
+      Join.JoinType joinType,
+      JoinOperator.BuildSide buildSide) {
+    return new NestedLoopJoinOperator(
+        left,
+        right,
+        joinType,
+        buildSide,
+        DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
+  }
+
+  @Test
+  public void inner_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.INNER);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(7, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2,
+                    "id",
+                    2,
+                    "name",
+                    "b")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10,
+                    "id",
+                    10,
+                    "name",
+                    "j")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6,
+                    "id",
+                    6,
+                    "name",
+                    "f")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8))));
+  }
+
+  @Test
+  public void inner_join_side_exchange_test() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.INNER);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(7, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    2,
+                    "name",
+                    "b",
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    6,
+                    "name",
+                    "f",
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    10,
+                    "name",
+                    "j",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10))));
+  }
+
+  @Test
+  public void left_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.LEFT);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(9, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2,
+                    "id",
+                    2,
+                    "name",
+                    "b")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10,
+                    "id",
+                    10,
+                    "name",
+                    "j")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6,
+                    "id",
+                    6,
+                    "name",
+                    "f")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+  }
+
+  @Test
+  public void left_join_side_exchange_test() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.LEFT);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(12, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    2,
+                    "name",
+                    "b",
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    6,
+                    "name",
+                    "f",
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    10,
+                    "name",
+                    "j",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+  }
+
+  @Test
+  public void right_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(left, right, Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(12, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1,
+                    "id",
+                    1,
+                    "name",
+                    "a")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2,
+                    "id",
+                    2,
+                    "name",
+                    "b")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6,
+                    "id",
+                    6,
+                    "name",
+                    "f")),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10,
+                    "id",
+                    10,
+                    "name",
+                    "j")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+  }
+
+  @Test
+  public void right_join_side_exchange_test() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(left, right, Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(9, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    2,
+                    "name",
+                    "b",
+                    "day",
+                    new ExprDateValue("2021-01-03"),
+                    "host",
+                    "h1",
+                    "errors",
+                    2)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    10,
+                    "name",
+                    "j",
+                    "day",
+                    new ExprDateValue("2021-01-04"),
+                    "host",
+                    "h2",
+                    "errors",
+                    10)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    1,
+                    "name",
+                    "a",
+                    "day",
+                    new ExprDateValue("2021-01-06"),
+                    "host",
+                    "h1",
+                    "errors",
+                    1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id",
+                    6,
+                    "name",
+                    "f",
+                    "day",
+                    new ExprDateValue("2021-01-07"),
+                    "host",
+                    "h1",
+                    "errors",
+                    6)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+  }
+
+  @Test
+  public void semi_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.SEMI);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(7, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-04"), "host", "h1", "errors", 1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-06"), "host", "h1", "errors", 1)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-03"), "host", "h1", "errors", 2)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-07"), "host", "h1", "errors", 6)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-04"), "host", "h2", "errors", 10))));
+  }
+
+  @Test
+  public void semi_join_side_exchange_test() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.SEMI);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(6, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 2, "name", "b")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 3)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 8))));
+  }
+
+  @Test
+  public void anti_join_test() {
+    PhysicalPlan left = testScan(joinTestInputs);
+    PhysicalPlan right = testScan(countTestInputs);
+    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.ANTI);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(2, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+  }
+
+  @Test
+  public void anti_join_side_exchange_test() {
+    // Exchange the tables
+    PhysicalPlan left = testScan(countTestInputs);
+    PhysicalPlan right = testScan(joinTestInputs);
+    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.ANTI);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(5, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
+            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/planner/physical/NestedLoopJoinOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/NestedLoopJoinOperatorTest.java
@@ -8,12 +8,10 @@ package org.opensearch.sql.planner.physical;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,539 +19,143 @@ import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
-import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.planner.physical.join.JoinOperator;
-import org.opensearch.sql.planner.physical.join.NestedLoopJoinOperator;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class NestedLoopJoinOperatorTest extends PhysicalPlanTestBase {
-  private final JoinOperator.BuildSide defaultBuildSide = JoinOperator.BuildSide.BuildRight;
-
-  private PhysicalPlan makeNestedLoopJoin(
-      PhysicalPlan left, PhysicalPlan right, Join.JoinType joinType) {
-    return makeNestedLoopJoin(left, right, joinType, defaultBuildSide);
-  }
-
-  private PhysicalPlan makeNestedLoopJoin(
-      PhysicalPlan left,
-      PhysicalPlan right,
-      Join.JoinType joinType,
-      JoinOperator.BuildSide buildSide) {
-    return new NestedLoopJoinOperator(
-        left,
-        right,
-        joinType,
-        buildSide,
-        DSL.equal(DSL.ref("errors", INTEGER), DSL.ref("id", INTEGER)));
-  }
+public class NestedLoopJoinOperatorTest extends JoinOperatorTestHelper {
 
   @Test
   public void inner_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
-    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.INNER);
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(Join.JoinType.INNER, JoinOperator.BuildSide.BuildRight, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(7, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10,
-                    "id",
-                    10,
-                    "name",
-                    "j")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6,
-                    "id",
-                    6,
-                    "name",
-                    "f")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8))));
+            error1_id1,
+            error1_id1_duplicated,
+            error2_id2,
+            error3_id3,
+            error6_id6,
+            error8_id8,
+            error10_id10));
   }
 
   @Test
-  public void inner_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
-    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.INNER);
+  public void inner_join_side_reversed_test() {
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(Join.JoinType.INNER, JoinOperator.BuildSide.BuildRight, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(7, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    2,
-                    "name",
-                    "b",
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    6,
-                    "name",
-                    "f",
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    10,
-                    "name",
-                    "j",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10))));
+            id1_error1,
+            id1_error1_duplicated,
+            id2_error2,
+            id3_error3,
+            id6_error6,
+            id8_error8,
+            id10_error10));
   }
 
   @Test
   public void left_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
-    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.LEFT);
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(Join.JoinType.LEFT, JoinOperator.BuildSide.BuildRight, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(9, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10,
-                    "id",
-                    10,
-                    "name",
-                    "j")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6,
-                    "id",
-                    6,
-                    "name",
-                    "f")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+            error1_id1,
+            error1_id1_duplicated,
+            error2_id2,
+            error3_id3,
+            error6_id6,
+            error8_id8,
+            error10_id10,
+            error12_null,
+            error13_null));
   }
 
   @Test
-  public void left_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
-    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.LEFT);
+  public void left_join_side_reversed_test() {
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(Join.JoinType.LEFT, JoinOperator.BuildSide.BuildRight, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(12, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    2,
-                    "name",
-                    "b",
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    6,
-                    "name",
-                    "f",
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    10,
-                    "name",
-                    "j",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+            id1_error1,
+            id1_error1_duplicated,
+            id2_error2,
+            id3_error3,
+            id6_error6,
+            id8_error8,
+            id10_error10,
+            id4_null,
+            id5_null,
+            id7_null,
+            id9_null,
+            id11_null));
   }
 
   @Test
   public void right_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
     PhysicalPlan joinPlan =
-        makeNestedLoopJoin(left, right, Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft);
+        makeNestedLoopJoin(Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(12, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1,
-                    "id",
-                    1,
-                    "name",
-                    "a")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2,
-                    "id",
-                    2,
-                    "name",
-                    "b")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3, "id", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6,
-                    "id",
-                    6,
-                    "name",
-                    "f")),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8, "id", 8)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10,
-                    "id",
-                    10,
-                    "name",
-                    "j")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+            error1_id1,
+            error1_id1_duplicated,
+            error2_id2,
+            error3_id3,
+            error6_id6,
+            error8_id8,
+            error10_id10,
+            null_id4,
+            null_id5,
+            null_id7,
+            null_id9,
+            null_id11));
   }
 
   @Test
-  public void right_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
+  public void right_join_side_reversed_test() {
     PhysicalPlan joinPlan =
-        makeNestedLoopJoin(left, right, Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft);
+        makeNestedLoopJoin(Join.JoinType.RIGHT, JoinOperator.BuildSide.BuildLeft, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(9, result.size());
     assertThat(
         result,
         containsInAnyOrder(
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    2,
-                    "name",
-                    "b",
-                    "day",
-                    new ExprDateValue("2021-01-03"),
-                    "host",
-                    "h1",
-                    "errors",
-                    2)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 3, "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    10,
-                    "name",
-                    "j",
-                    "day",
-                    new ExprDateValue("2021-01-04"),
-                    "host",
-                    "h2",
-                    "errors",
-                    10)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    1,
-                    "name",
-                    "a",
-                    "day",
-                    new ExprDateValue("2021-01-06"),
-                    "host",
-                    "h1",
-                    "errors",
-                    1)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id",
-                    6,
-                    "name",
-                    "f",
-                    "day",
-                    new ExprDateValue("2021-01-07"),
-                    "host",
-                    "h1",
-                    "errors",
-                    6)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "id", 8, "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)),
-            ExprValueUtils.tupleValue(
-                ImmutableMap.of(
-                    "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13))));
+            id1_error1,
+            id1_error1_duplicated,
+            id2_error2,
+            id3_error3,
+            id6_error6,
+            id8_error8,
+            id10_error10,
+            null_error12,
+            null_error13));
   }
 
   @Test
   public void semi_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
-    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.SEMI);
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(Join.JoinType.SEMI, JoinOperator.BuildSide.BuildRight, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(7, result.size());
@@ -578,11 +180,9 @@ public class NestedLoopJoinOperatorTest extends PhysicalPlanTestBase {
   }
 
   @Test
-  public void semi_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
-    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.SEMI);
+  public void semi_join_side_reversed_test() {
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(Join.JoinType.SEMI, JoinOperator.BuildSide.BuildRight, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(6, result.size());
@@ -593,15 +193,26 @@ public class NestedLoopJoinOperatorTest extends PhysicalPlanTestBase {
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")),
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")),
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 3)),
-            ExprValueUtils.tupleValue(ImmutableMap.of("id", 8))));
+            ExprValueUtils.tupleValue(
+                new LinkedHashMap<>() {
+                  {
+                    put("id", 3);
+                    put("name", null);
+                  }
+                }),
+            ExprValueUtils.tupleValue(
+                new LinkedHashMap<>() {
+                  {
+                    put("id", 8);
+                    put("name", null);
+                  }
+                })));
   }
 
   @Test
   public void anti_join_test() {
-    PhysicalPlan left = testScan(joinTestInputs);
-    PhysicalPlan right = testScan(countTestInputs);
-    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.ANTI);
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(Join.JoinType.ANTI, JoinOperator.BuildSide.BuildRight, false);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(2, result.size());
@@ -617,11 +228,9 @@ public class NestedLoopJoinOperatorTest extends PhysicalPlanTestBase {
   }
 
   @Test
-  public void anti_join_side_exchange_test() {
-    // Exchange the tables
-    PhysicalPlan left = testScan(countTestInputs);
-    PhysicalPlan right = testScan(joinTestInputs);
-    PhysicalPlan joinPlan = makeNestedLoopJoin(left, right, Join.JoinType.ANTI);
+  public void anti_join_side_reversed_test() {
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoin(Join.JoinType.ANTI, JoinOperator.BuildSide.BuildRight, true);
     List<ExprValue> result = execute(joinPlan);
     result.forEach(System.out::println);
     assertEquals(5, result.size());
@@ -633,5 +242,29 @@ public class NestedLoopJoinOperatorTest extends PhysicalPlanTestBase {
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")),
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")),
             ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k"))));
+  }
+
+  // +-----------------------------------------+
+  // | Test join tables with same column names |
+  // +-----------------------------------------+
+
+  @Test
+  public void same_column_names_inner_join_test() {
+    PhysicalPlan joinPlan =
+        makeNestedLoopJoinWithSameColumnNames(
+            Join.JoinType.INNER, JoinOperator.BuildSide.BuildRight, false);
+    List<ExprValue> result = execute(joinPlan);
+    result.forEach(System.out::println);
+    assertEquals(7, result.size());
+    assertThat(
+        result,
+        containsInAnyOrder(
+            id1_same_id1,
+            id3_same_id3,
+            id5_same_id5,
+            id8_same_id8,
+            id10_same_id10,
+            id10_same_id10_duplicated,
+            id10_same_id10_duplicated2));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
@@ -20,67 +20,13 @@ import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.planner.SerializablePlan;
 
 public class PhysicalPlanTestBase {
-
-  protected static final List<ExprValue> countTestInputs =
-      new ImmutableList.Builder<ExprValue>()
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 2, "name", "b")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 3)))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 8)))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k")))
-          .build();
-
-  protected static final List<ExprValue> joinTestInputs =
-      new ImmutableList.Builder<ExprValue>()
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-03"), "host", "h1", "errors", 2)))
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)))
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-04"), "host", "h1", "errors", 1)))
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-04"), "host", "h2", "errors", 10)))
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-06"), "host", "h1", "errors", 1)))
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-07"), "host", "h1", "errors", 6)))
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)))
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)))
-          .add(
-              ExprValueUtils.tupleValue(
-                  ImmutableMap.of(
-                      "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13)))
-          .build();
 
   protected static final List<ExprValue> inputs =
       new ImmutableList.Builder<ExprValue>()
@@ -334,8 +280,15 @@ public class PhysicalPlanTestBase {
     return new TestScan(inputs);
   }
 
+  protected static PhysicalPlan testTableScan(
+      String relationName, ExecutionEngine.Schema schema, List<ExprValue> inputs) {
+    return new TestScan(inputs, relationName, schema);
+  }
+
   protected static class TestScan extends PhysicalPlan implements SerializablePlan {
     private final Iterator<ExprValue> iterator;
+    private ExecutionEngine.Schema schema;
+    private String relationName;
 
     public TestScan() {
       iterator = inputs.iterator();
@@ -343,6 +296,12 @@ public class PhysicalPlanTestBase {
 
     public TestScan(List<ExprValue> inputs) {
       iterator = inputs.iterator();
+    }
+
+    public TestScan(List<ExprValue> inputs, String relationName, ExecutionEngine.Schema schema) {
+      iterator = inputs.iterator();
+      this.relationName = relationName;
+      this.schema = schema;
     }
 
     @Override
@@ -363,6 +322,11 @@ public class PhysicalPlanTestBase {
     @Override
     public ExprValue next() {
       return iterator.next();
+    }
+
+    @Override
+    public ExecutionEngine.Schema schema() {
+      return this.schema;
     }
 
     @Override

--- a/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
@@ -29,17 +29,17 @@ public class PhysicalPlanTestBase {
 
   protected static final List<ExprValue> countTestInputs =
       new ImmutableList.Builder<ExprValue>()
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 2, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 3, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 8, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "testString", "asdf")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "testString", "asdf")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 2, "name", "b")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 3, "name", "c")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 8, "name", "h")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k")))
           .build();
 
   protected static final List<ExprValue> inputs =

--- a/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/PhysicalPlanTestBase.java
@@ -31,15 +31,55 @@ public class PhysicalPlanTestBase {
       new ImmutableList.Builder<ExprValue>()
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 1, "name", "a")))
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 2, "name", "b")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 3, "name", "c")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 3)))
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 4, "name", "d")))
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 5, "name", "e")))
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 6, "name", "f")))
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 7, "name", "g")))
-          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 8, "name", "h")))
+          .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 8)))
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 9, "name", "i")))
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 10, "name", "j")))
           .add(ExprValueUtils.tupleValue(ImmutableMap.of("id", 11, "name", "k")))
+          .build();
+
+  protected static final List<ExprValue> joinTestInputs =
+      new ImmutableList.Builder<ExprValue>()
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-03"), "host", "h1", "errors", 2)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-03"), "host", "h2", "errors", 3)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-04"), "host", "h1", "errors", 1)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-04"), "host", "h2", "errors", 10)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-06"), "host", "h1", "errors", 1)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-07"), "host", "h1", "errors", 6)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 8)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-07"), "host", "h2", "errors", 12)))
+          .add(
+              ExprValueUtils.tupleValue(
+                  ImmutableMap.of(
+                      "day", new ExprDateValue("2021-01-08"), "host", "h1", "errors", 13)))
           .build();
 
   protected static final List<ExprValue> inputs =

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -36,6 +36,16 @@ KMEANS:                             'KMEANS';
 AD:                                 'AD';
 ML:                                 'ML';
 
+//Native JOIN KEYWORDS
+JOIN:                               'JOIN';
+ON:                                 'ON';
+INNER:                              'INNER';
+OUTER:                              'OUTER';
+FULL:                               'FULL';
+SEMI:                               'SEMI';
+ANTI:                               'ANTI';
+CROSS:                              'CROSS';
+
 // COMMAND ASSIST KEYWORDS
 AS:                                 'AS';
 BY:                                 'BY';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -166,14 +166,47 @@ mlArg
 
 // clauses
 fromClause
-   : SOURCE EQUAL tableSourceClause
-   | INDEX EQUAL tableSourceClause
-   | SOURCE EQUAL tableFunction
-   | INDEX EQUAL tableFunction
+   : (SOURCE | INDEX) EQUAL tableSourceClause
+   | (SOURCE | INDEX) EQUAL tableFunction
+   | (SOURCE | INDEX) EQUAL relation
    ;
 
 tableSourceClause
    : tableSource (COMMA tableSource)*
+   ;
+
+// TODO two-tables join only. Multi-tables join `relationExtension*` is unsupported in current implementation.
+relation
+   : tablePrimary relationExtension
+   ;
+
+tablePrimary
+   : tableSource (AS alias = qualifiedName)?
+   ;
+
+relationExtension
+   : joinSource
+   ;
+
+ // TODO joinCriteria could be none `(joinCriteria?)` for complex cases. It's unsupported in current implementation.
+ // TODO join hints `(hintStatement)?` is unsupported in current implementation.
+ // TODO directly tables jon only, join two plans is unsupported in current implementation.
+joinSource
+   : (joinType) JOIN right = tablePrimary joinCriteria
+   ;
+
+joinType
+   : INNER?
+   | CROSS
+   | LEFT OUTER?
+   | RIGHT OUTER?
+   | FULL OUTER?
+   | LEFT? SEMI
+   | LEFT? ANTI
+   ;
+
+joinCriteria
+   : ON logicalExpression
    ;
 
 renameClasue
@@ -925,4 +958,14 @@ keywordsCanBeId
    | SPARKLINE
    | C
    | DC
+   // JOIN
+   | ON
+   | INNER
+   | CROSS
+   | OUTER
+   | SEMI
+   | LEFT
+   | RIGHT
+   | FULL
+   | ANTI
    ;

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -166,9 +166,12 @@ mlArg
 
 // clauses
 fromClause
-   : (SOURCE | INDEX) EQUAL tableSourceClause
-   | (SOURCE | INDEX) EQUAL tableFunction
-   | (SOURCE | INDEX) EQUAL relation
+   : SOURCE EQUAL tableSourceClause
+   | INDEX EQUAL tableSourceClause
+   | SOURCE EQUAL tableFunction
+   | INDEX EQUAL tableFunction
+   | SOURCE EQUAL relation
+   | INDEX EQUAL relation
    ;
 
 tableSourceClause

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -362,18 +362,18 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
       joinType = Join.JoinType.INNER;
     } else if (joinCtx.joinType().INNER() != null) {
       joinType = Join.JoinType.INNER;
-    } else if (joinCtx.joinType().CROSS() != null) {
-      joinType = Join.JoinType.CROSS;
-    } else if (joinCtx.joinType().FULL() != null) {
-      joinType = Join.JoinType.FULL;
-    } else if (joinCtx.joinType().SEMI() != null) {
-      joinType = Join.JoinType.SEMI;
-    } else if (joinCtx.joinType().ANTI() != null) {
-      joinType = Join.JoinType.ANTI;
     } else if (joinCtx.joinType().LEFT() != null) {
       joinType = Join.JoinType.LEFT;
     } else if (joinCtx.joinType().RIGHT() != null) {
       joinType = Join.JoinType.RIGHT;
+    } else if (joinCtx.joinType().SEMI() != null) {
+      joinType = Join.JoinType.SEMI;
+    } else if (joinCtx.joinType().ANTI() != null) {
+      joinType = Join.JoinType.ANTI;
+    } else if (joinCtx.joinType().CROSS() != null) {
+      joinType = Join.JoinType.CROSS;
+    } else if (joinCtx.joinType().FULL() != null) {
+      joinType = Join.JoinType.FULL;
     } else {
       joinType = Join.JoinType.INNER;
     }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -69,6 +69,17 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
           .put("isnotnull", IS_NOT_NULL.getName().getFunctionName())
           .build();
 
+  @Override
+  public UnresolvedExpression visitMappingCompareExpr(
+      OpenSearchPPLParser.MappingCompareExprContext ctx) {
+    return new Compare(ctx.comparisonOperator().getText(), visit(ctx.left), visit(ctx.right));
+  }
+
+  @Override
+  public UnresolvedExpression visitMappingList(OpenSearchPPLParser.MappingListContext ctx) {
+    return super.visitMappingList(ctx);
+  }
+
   /** Eval clause. */
   @Override
   public UnresolvedExpression visitEvalClause(EvalClauseContext ctx) {

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -69,17 +69,6 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
           .put("isnotnull", IS_NOT_NULL.getName().getFunctionName())
           .build();
 
-  @Override
-  public UnresolvedExpression visitMappingCompareExpr(
-      OpenSearchPPLParser.MappingCompareExprContext ctx) {
-    return new Compare(ctx.comparisonOperator().getText(), visit(ctx.left), visit(ctx.right));
-  }
-
-  @Override
-  public UnresolvedExpression visitMappingList(OpenSearchPPLParser.MappingListContext ctx) {
-    return super.visitMappingList(ctx);
-  }
-
   /** Eval clause. */
   @Override
   public UnresolvedExpression visitEvalClause(EvalClauseContext ctx) {


### PR DESCRIPTION
### Description
This PR is the part 1 of supporting native join command. Check https://github.com/opensearch-project/sql/issues/2913 to get the whole implementation plan.
This PR includes
- In logical, support two-tables join PPL command with join type `inner join`, `left join`, `semi join` and `anti join`.
- In physical, support `hash` join operator for equi-join, `nested loop` join operator for non-equi-join

This PR not includes
- #2921
- #2922
- #2923
- #2924
- #2919

### Syntax introduced in this PR
```
source=t1 | [joinType] JOIN t2 ON joinCriteria

joinType: INNER | LEFT [OUTER] | [LEFT] SEMI | [LEFT] ANTI
```

For example:
```
source=websites
| inner join access_log on websites.id=access_log.site_id
| fields websites.id, websites.name, access_log.count, access_log.date

source=websites
| left outer join access_log on id=site_id
| fields id, name, count, date
```

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/2920 (part of https://github.com/opensearch-project/sql/issues/2913)

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
