### PR TITLE
Adds validation to allow only flint queries and sql SELECT queries to security lake type datasource

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -54,7 +54,9 @@ public class SparkQueryDispatcher {
             dispatchQueryRequest, asyncQueryRequestContext, dataSourceMetadata);
       }
 
-      List<String> validationErrors = SQLQueryUtils.validateSparkSqlQuery(dataSourceService.getDataSource(dispatchQueryRequest.getDatasource()), query);
+      List<String> validationErrors =
+          SQLQueryUtils.validateSparkSqlQuery(
+              dataSourceService.getDataSource(dispatchQueryRequest.getDatasource()), query);
       if (!validationErrors.isEmpty()) {
         throw new IllegalArgumentException(
             "Query is not allowed: " + String.join(", ", validationErrors));

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -54,7 +54,7 @@ public class SparkQueryDispatcher {
             dispatchQueryRequest, asyncQueryRequestContext, dataSourceMetadata);
       }
 
-      List<String> validationErrors = SQLQueryUtils.validateSparkSqlQuery(query);
+      List<String> validationErrors = SQLQueryUtils.validateSparkSqlQuery(dataSourceService.getDataSource(dispatchQueryRequest.getDatasource()), query);
       if (!validationErrors.isEmpty()) {
         throw new IllegalArgumentException(
             "Query is not allowed: " + String.join(", ", validationErrors));

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/utils/SQLQueryUtils.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/utils/SQLQueryUtils.java
@@ -84,11 +84,11 @@ public class SQLQueryUtils {
   }
 
   public static List<String> validateSparkSqlQuery(DataSource datasource, String sqlQuery) {
+    SqlBaseParser sqlBaseParser =
+        new SqlBaseParser(
+            new CommonTokenStream(new SqlBaseLexer(new CaseInsensitiveCharStream(sqlQuery))));
+    sqlBaseParser.addErrorListener(new SyntaxAnalysisErrorListener());
     try {
-      SqlBaseParser sqlBaseParser =
-          new SqlBaseParser(
-              new CommonTokenStream(new SqlBaseLexer(new CaseInsensitiveCharStream(sqlQuery))));
-      sqlBaseParser.addErrorListener(new SyntaxAnalysisErrorListener());
       SqlBaseValidatorVisitor sqlParserBaseVisitor = getSparkSqlValidatorVisitor(datasource);
       StatementContext statement = sqlBaseParser.statement();
       sqlParserBaseVisitor.visit(statement);
@@ -113,7 +113,7 @@ public class SQLQueryUtils {
   }
 
   /**
-   * A generic validator impl for Spark Sql Queries that supports accumulating validation errors on
+   * A base class extending SqlBaseParserBaseVisitor for validating Spark Sql Queries. The class supports accumulating validation errors on
    * visiting sql statement
    */
   @Getter
@@ -435,9 +435,5 @@ public class SQLQueryUtils {
     public String removeUnwantedQuotes(String input) {
       return input.replaceAll("^\"|\"$", "");
     }
-  }
-
-  private boolean isSelectQuery(String query) {
-    return query.trim().toUpperCase().startsWith("SELECT");
   }
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/utils/SQLQueryUtils.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/utils/SQLQueryUtils.java
@@ -113,8 +113,8 @@ public class SQLQueryUtils {
   }
 
   /**
-   * A base class extending SqlBaseParserBaseVisitor for validating Spark Sql Queries. The class supports accumulating validation errors on
-   * visiting sql statement
+   * A base class extending SqlBaseParserBaseVisitor for validating Spark Sql Queries. The class
+   * supports accumulating validation errors on visiting sql statement
    */
   @Getter
   private static class SqlBaseValidatorVisitor<T> extends SqlBaseParserBaseVisitor<T> {

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.spark.utils;
 
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -18,7 +19,11 @@ import java.util.List;
 import lombok.Getter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.datasource.model.DataSource;
+import org.opensearch.sql.datasource.model.DataSourceType;
 import org.opensearch.sql.spark.dispatcher.model.FullyQualifiedTableName;
 import org.opensearch.sql.spark.dispatcher.model.IndexQueryActionType;
 import org.opensearch.sql.spark.dispatcher.model.IndexQueryDetails;
@@ -404,15 +409,39 @@ public class SQLQueryUtilsTest {
 
   @Test
   void testValidateSparkSqlQuery_ValidQuery() {
+    DataSource  dataSource = Mockito.mock(DataSource.class);
+    Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.PROMETHEUS);
     String validQuery = "SELECT * FROM users WHERE age > 18";
-    List<String> errors = SQLQueryUtils.validateSparkSqlQuery(validQuery);
+    List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, validQuery);
     assertTrue(errors.isEmpty(), "Valid query should not produce any errors");
   }
 
   @Test
+  void testValidateSparkSqlQuery_SelectQuery_DataSourceSecurityLake() {
+    DataSource  dataSource = Mockito.mock(DataSource.class);
+    Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.SECURITY_LAKE);
+    String validQuery = "SELECT * FROM users WHERE age > 18";
+    List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, validQuery);
+    assertTrue(errors.isEmpty(), "Valid query should not produce any errors ");
+  }
+
+  @Test
+  void testValidateSparkSqlQuery_SelectQuery_DataSourceSecurityLake_ValidationFails() {
+    DataSource dataSource = Mockito.mock(DataSource.class);
+    Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.SECURITY_LAKE);
+    String validQuery = "REFRESH INDEX cv1 ON mys3.default.http_logs";
+    List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, validQuery);
+    assertFalse(errors.isEmpty(),
+            "Invalid query as Security Lake datasource supports only flint queries and SELECT sql queries. " +
+                    "Given query was REFRESH sql query");
+  }
+
+  @Test
   void testValidateSparkSqlQuery_InvalidQuery() {
+    DataSource  dataSource = Mockito.mock(DataSource.class);
+    Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.PROMETHEUS);
     String invalidQuery = "CREATE FUNCTION myUDF AS 'com.example.UDF'";
-    List<String> errors = SQLQueryUtils.validateSparkSqlQuery(invalidQuery);
+    List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, invalidQuery);
     assertFalse(errors.isEmpty(), "Invalid query should produce errors");
     assertEquals(1, errors.size(), "Should have one error");
     assertEquals(

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.spark.utils;
 
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,7 +18,6 @@ import java.util.List;
 import lombok.Getter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.datasource.model.DataSource;
@@ -409,7 +407,7 @@ public class SQLQueryUtilsTest {
 
   @Test
   void testValidateSparkSqlQuery_ValidQuery() {
-    DataSource  dataSource = Mockito.mock(DataSource.class);
+    DataSource dataSource = Mockito.mock(DataSource.class);
     Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.PROMETHEUS);
     String validQuery = "DELETE FROM Customers WHERE CustomerName='Alfreds Futterkiste'";
     List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, validQuery);
@@ -418,7 +416,7 @@ public class SQLQueryUtilsTest {
 
   @Test
   void testValidateSparkSqlQuery_SelectQuery_DataSourceSecurityLake() {
-    DataSource  dataSource = Mockito.mock(DataSource.class);
+    DataSource dataSource = Mockito.mock(DataSource.class);
     Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.SECURITY_LAKE);
     String validQuery = "SELECT * FROM users WHERE age > 18";
     List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, validQuery);
@@ -431,14 +429,15 @@ public class SQLQueryUtilsTest {
     Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.SECURITY_LAKE);
     String validQuery = "REFRESH INDEX cv1 ON mys3.default.http_logs";
     List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, validQuery);
-    assertFalse(errors.isEmpty(),
-            "Invalid query as Security Lake datasource supports only flint queries and SELECT sql queries. " +
-                    "Given query was REFRESH sql query");
+    assertFalse(
+        errors.isEmpty(),
+        "Invalid query as Security Lake datasource supports only flint queries and SELECT sql"
+            + " queries. Given query was REFRESH sql query");
   }
 
   @Test
   void testValidateSparkSqlQuery_InvalidQuery() {
-    DataSource  dataSource = Mockito.mock(DataSource.class);
+    DataSource dataSource = Mockito.mock(DataSource.class);
     Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.PROMETHEUS);
     String invalidQuery = "CREATE FUNCTION myUDF AS 'com.example.UDF'";
     List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, invalidQuery);

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
@@ -427,6 +427,30 @@ public class SQLQueryUtilsTest {
     assertTrue(errors.isEmpty(), "Valid query should not produce any errors ");
   }
 
+  @Test
+  void testValidateSparkSqlQuery_SelectQuery_DataSourceTypeNull() {
+    List<String> errors =
+        validateSparkSqlQueryForDataSourceType("SELECT * FROM users WHERE age > 18", null);
+
+    assertTrue(errors.isEmpty(), "Valid query should not produce any errors ");
+  }
+
+  @Test
+  void testValidateSparkSqlQuery_InvalidQuery_SyntaxCheckFailureSkippedWithoutValidationError() {
+    List<String> errors =
+        validateSparkSqlQueryForDataSourceType(
+            "SEECT * FROM users WHERE age > 18", DataSourceType.SECURITY_LAKE);
+
+    assertTrue(errors.isEmpty(), "Valid query should not produce any errors ");
+  }
+
+  @Test
+  void testValidateSparkSqlQuery_nullDatasource() {
+    List<String> errors =
+        SQLQueryUtils.validateSparkSqlQuery(null, "SELECT * FROM users WHERE age > 18");
+    assertTrue(errors.isEmpty(), "Valid query should not produce any errors ");
+  }
+
   private List<String> validateSparkSqlQueryForDataSourceType(
       String query, DataSourceType dataSourceType) {
     when(this.dataSource.getConnectorType()).thenReturn(dataSourceType);

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
@@ -411,7 +411,7 @@ public class SQLQueryUtilsTest {
   void testValidateSparkSqlQuery_ValidQuery() {
     DataSource  dataSource = Mockito.mock(DataSource.class);
     Mockito.when(dataSource.getConnectorType()).thenReturn(DataSourceType.PROMETHEUS);
-    String validQuery = "SELECT * FROM users WHERE age > 18";
+    String validQuery = "DELETE FROM Customers WHERE CustomerName='Alfreds Futterkiste'";
     List<String> errors = SQLQueryUtils.validateSparkSqlQuery(dataSource, validQuery);
     assertTrue(errors.isEmpty(), "Valid query should not produce any errors");
   }

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
@@ -7,6 +7,8 @@ package org.opensearch.sql.datasource.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -55,5 +57,18 @@ public class DataSourceType {
     } else {
       throw new IllegalArgumentException("No DataSourceType with name " + name + " found");
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DataSourceType that = (DataSourceType) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
@@ -8,7 +8,6 @@ package org.opensearch.sql.datasource.model;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
@@ -7,8 +7,6 @@ package org.opensearch.sql.datasource.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 

--- a/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
+++ b/core/src/main/java/org/opensearch/sql/datasource/model/DataSourceType.java
@@ -8,9 +8,12 @@ package org.opensearch.sql.datasource.model;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@EqualsAndHashCode
 public class DataSourceType {
   public static DataSourceType PROMETHEUS = new DataSourceType("PROMETHEUS");
   public static DataSourceType OPENSEARCH = new DataSourceType("OPENSEARCH");
@@ -56,18 +59,5 @@ public class DataSourceType {
     } else {
       throw new IllegalArgumentException("No DataSourceType with name " + name + " found");
     }
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    DataSourceType that = (DataSourceType) o;
-    return Objects.equals(name, that.name);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(name);
   }
 }


### PR DESCRIPTION

### Description
Adds validation to allow only flint queries and sql select queries to security lake type datasource

### Related Issues
Resolves #2907



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
