### PR TITLE
Resolve Alias Issues in Legacy SQL with Filters

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -5,42 +5,10 @@
 
 package org.opensearch.sql.legacy;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static org.opensearch.sql.legacy.TestUtils.createIndexByRestClient;
-import static org.opensearch.sql.legacy.TestUtils.getAccountIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getBankIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getBankWithNullValuesIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getDataTypeNonnumericIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getDataTypeNumericIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getDateIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getDateTimeIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getDeepNestedIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getDogIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getDogs2IndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getDogs3IndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getEmployeeNestedTypeIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getGameOfThronesIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getGeopointIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getJoinTypeIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getLocationIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getMappingFile;
-import static org.opensearch.sql.legacy.TestUtils.getNestedSimpleIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getNestedTypeIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getOdbcIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getOrderIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getPeople2IndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getPhraseIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
-import static org.opensearch.sql.legacy.TestUtils.getStringIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getUnexpandedObjectIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.getWeblogsIndexMapping;
-import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
-import static org.opensearch.sql.legacy.TestUtils.loadDataByRestClient;
-import static org.opensearch.sql.legacy.plugin.RestSqlAction.CURSOR_CLOSE_ENDPOINT;
-import static org.opensearch.sql.legacy.plugin.RestSqlAction.EXPLAIN_API_ENDPOINT;
-import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
+import static com.google.common.base.Strings.*;
+import static org.opensearch.sql.legacy.TestUtils.*;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.*;
 
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -50,25 +18,28 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Map;
+
 import javax.management.MBeanServerInvocationHandler;
 import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
-import lombok.SneakyThrows;
+
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
-import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.utils.SerializeUtils;
+
+import com.google.common.base.Strings;
+
+import lombok.SneakyThrows;
 
 /** OpenSearch Rest integration test base for SQL testing */
 public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
@@ -462,6 +433,9 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return String.format("{ \"fetch_size\": \"%s\", \"query\": \"%s\" }", fetch_size, query);
   }
 
+    protected String makeRequest(String query, int fetch_size, String filterQuery) {
+    return String.format("{ \"fetch_size\": \"%s\", \"query\": \"%s\", \"filter\" :  %s }", fetch_size, query, filterQuery);
+  }
   protected String makeFetchLessRequest(String query) {
     return String.format("{\n" + "  \"query\": \"%s\"\n" + "}", query);
   }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -462,6 +462,10 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return String.format("{ \"fetch_size\": \"%s\", \"query\": \"%s\" }", fetch_size, query);
   }
 
+  protected String makeRequest(String query, int fetch_size, String filterQuery) {
+    return String.format("{ \"fetch_size\": \"%s\", \"query\": \"%s\", \"filter\" :  %s }", fetch_size, query, filterQuery);
+  }
+
   protected String makeFetchLessRequest(String query) {
     return String.format("{\n" + "  \"query\": \"%s\"\n" + "}", query);
   }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -463,7 +463,9 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
   }
 
   protected String makeRequest(String query, int fetch_size, String filterQuery) {
-    return String.format("{ \"fetch_size\": \"%s\", \"query\": \"%s\", \"filter\" :  %s }", fetch_size, query, filterQuery);
+    return String.format(
+        "{ \"fetch_size\": \"%s\", \"query\": \"%s\", \"filter\" :  %s }",
+        fetch_size, query, filterQuery);
   }
 
   protected String makeFetchLessRequest(String query) {

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -5,10 +5,42 @@
 
 package org.opensearch.sql.legacy;
 
-import static com.google.common.base.Strings.*;
-import static org.opensearch.sql.legacy.TestUtils.*;
-import static org.opensearch.sql.legacy.plugin.RestSqlAction.*;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.opensearch.sql.legacy.TestUtils.createIndexByRestClient;
+import static org.opensearch.sql.legacy.TestUtils.getAccountIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getBankIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getBankWithNullValuesIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDataTypeNonnumericIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDataTypeNumericIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDateIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDateTimeIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDeepNestedIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDogIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDogs2IndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getDogs3IndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getEmployeeNestedTypeIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getGameOfThronesIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getGeopointIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getJoinTypeIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getLocationIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getMappingFile;
+import static org.opensearch.sql.legacy.TestUtils.getNestedSimpleIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getNestedTypeIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getOdbcIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getOrderIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getPeople2IndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getPhraseIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
+import static org.opensearch.sql.legacy.TestUtils.getStringIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getUnexpandedObjectIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getWeblogsIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
+import static org.opensearch.sql.legacy.TestUtils.loadDataByRestClient;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.CURSOR_CLOSE_ENDPOINT;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.EXPLAIN_API_ENDPOINT;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -18,28 +50,25 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Map;
-
 import javax.management.MBeanServerInvocationHandler;
 import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
-
+import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasource.model.DataSourceMetadata;
 import org.opensearch.sql.utils.SerializeUtils;
-
-import com.google.common.base.Strings;
-
-import lombok.SneakyThrows;
 
 /** OpenSearch Rest integration test base for SQL testing */
 public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
@@ -433,9 +462,6 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
     return String.format("{ \"fetch_size\": \"%s\", \"query\": \"%s\" }", fetch_size, query);
   }
 
-    protected String makeRequest(String query, int fetch_size, String filterQuery) {
-    return String.format("{ \"fetch_size\": \"%s\", \"query\": \"%s\", \"filter\" :  %s }", fetch_size, query, filterQuery);
-  }
   protected String makeFetchLessRequest(String query) {
     return String.format("{\n" + "  \"query\": \"%s\"\n" + "}", query);
   }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -248,7 +248,7 @@ public class PaginationIT extends SQLIntegTestCase {
 
     //Query using the alias with filter
     JSONObject aliasFilteredResponse = new JSONObject(executeFetchQuery(aliasSelectQuery, 4, "jdbc", filterQuery));
-    assertEquals(initialResponse.getInt("size"), 4);
+    assertEquals(aliasFilteredResponse.getInt("size"), 4);
   }
 
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.sql;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ONLINE;
 
@@ -17,6 +18,7 @@ import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.common.setting.Settings;
@@ -214,5 +216,51 @@ public class PaginationIT extends SQLIntegTestCase {
     assertFalse(response.has("cursor"));
     assertEquals(1, response.getInt("total"));
     assertEquals(1, response.getJSONArray("datarows").getJSONArray(0).getInt(0));
+  }
+  @Test
+  public void testAlias() throws Exception {
+    String indexName = Index.ONLINE.getName();
+    String aliasName = "alias_ONLINE";
+    String filterQuery = "{\n" +
+            "  \"term\": {\n" +
+            "    \"107\": 72 \n" +
+            "  }\n" +
+            "}";
+
+    //Execute the SQL query with filter
+    String selectQuery = "SELECT * FROM " + TEST_INDEX_ONLINE;
+    JSONObject initialResponse = new JSONObject(executeFetchQuery(selectQuery, 10, "jdbc", filterQuery));
+    assertEquals(initialResponse.getInt("size"), 10);
+
+    //Create an alias
+    String createAliasQuery = String.format("{ \"actions\": [ { \"add\": { \"index\": \"%s\", \"alias\": \"%s\" } } ] }", indexName, aliasName);
+    Request createAliasRequest = new Request("POST", "/_aliases");
+    createAliasRequest.setJsonEntity(createAliasQuery);
+    JSONObject aliasResponse = new JSONObject(executeRequest(createAliasRequest));
+
+    // Assert that alias creation was acknowledged
+    assertTrue(aliasResponse.getBoolean("acknowledged"));
+
+    //Query using the alias
+    String aliasSelectQuery = String.format("SELECT * FROM %s", aliasName);
+    JSONObject aliasQueryResponse = new JSONObject(executeFetchQuery(aliasSelectQuery, 4, "jdbc"));
+    assertEquals(4, aliasQueryResponse.getInt("size"));
+
+    //Query using the alias with filter
+    JSONObject aliasFilteredResponse = new JSONObject(executeFetchQuery(aliasSelectQuery, 4, "jdbc", filterQuery));
+    assertEquals(initialResponse.getInt("size"), 4);
+  }
+
+
+  private String executeFetchQuery(String query, int fetchSize, String requestType, String  filter) throws IOException{
+    String endpoint = "/_plugins/_sql?format=" + requestType;
+    String requestBody = makeRequest(query, fetchSize, filter);
+
+    Request sqlRequest = new Request("POST", endpoint);
+    sqlRequest.setJsonEntity(requestBody);
+
+    Response response = client().performRequest(sqlRequest);
+    String responseString = getResponseBody(response, true);
+    return responseString;
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -7,21 +7,23 @@ package org.opensearch.sql.sql;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ONLINE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.opensearch.sql.legacy.TestUtils.*;
+import static org.opensearch.sql.legacy.TestsConstants.*;
 
 import java.io.IOException;
-import lombok.SneakyThrows;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
-import org.opensearch.client.ResponseException;
+import org.opensearch.jdbc.protocol.exceptions.ResponseException;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.util.TestUtils;
+
+import lombok.SneakyThrows;
 
 public class PaginationIT extends SQLIntegTestCase {
   @Override
@@ -214,5 +216,53 @@ public class PaginationIT extends SQLIntegTestCase {
     assertFalse(response.has("cursor"));
     assertEquals(1, response.getInt("total"));
     assertEquals(1, response.getJSONArray("datarows").getJSONArray(0).getInt(0));
+  }
+
+    @Test
+  public void testAlias() throws Exception {
+    ///"107":172
+    String indexName = Index.ONLINE.getName();
+    String aliasName = "alias_ONLINE";
+    String filterQuery = "{\n" +
+            "  \"term\": {\n" +
+            "    \"107\": 72 \n" +
+            "  }\n" +
+            "}";
+
+      //Execute the SQL query with filter
+      String selectQuery = "SELECT * FROM " + TEST_INDEX_ONLINE;
+      JSONObject initialResponse = new JSONObject(executeFetchQuery(selectQuery, 10, "jdbc", filterQuery));
+      assertEquals(initialResponse.getInt("size"), 10);
+
+      //Create an alias
+      String createAliasQuery = String.format("{ \"actions\": [ { \"add\": { \"index\": \"%s\", \"alias\": \"%s\" } } ] }", indexName, aliasName);
+      Request createAliasRequest = new Request("POST", "/_aliases");
+      createAliasRequest.setJsonEntity(createAliasQuery);
+      JSONObject aliasResponse = new JSONObject(executeRequest(createAliasRequest));
+
+      // Assert that alias creation was acknowledged
+      assertTrue(aliasResponse.getBoolean("acknowledged"));
+
+      //Query using the alias
+      String aliasSelectQuery = String.format("SELECT * FROM %s", aliasName);
+      JSONObject aliasQueryResponse = new JSONObject(executeFetchQuery(aliasSelectQuery, 4, "jdbc"));
+      assertEquals(4, aliasQueryResponse.getInt("size"));
+
+      //Query using the alias with filter
+      JSONObject aliasFilteredResponse = new JSONObject(executeFetchQuery(aliasSelectQuery, 4, "jdbc", filterQuery));
+      assertEquals(initialResponse.getInt("size"), 4);
+  }
+
+
+  private String executeFetchQuery(String query, int fetchSize, String requestType, String  filter) throws IOException{
+    String endpoint = "/_plugins/_sql?format=" + requestType;
+    String requestBody = makeRequest(query, fetchSize, filter);
+
+    Request sqlRequest = new Request("POST", endpoint);
+    sqlRequest.setJsonEntity(requestBody);
+
+    Response response = client().performRequest(sqlRequest);
+    String responseString = getResponseBody(response, true);
+    return responseString;
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -18,8 +18,8 @@ import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.client.Request;
-import org.opensearch.client.Response;
 import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
@@ -217,23 +217,24 @@ public class PaginationIT extends SQLIntegTestCase {
     assertEquals(1, response.getInt("total"));
     assertEquals(1, response.getJSONArray("datarows").getJSONArray(0).getInt(0));
   }
+
   @Test
   public void testAlias() throws Exception {
     String indexName = Index.ONLINE.getName();
     String aliasName = "alias_ONLINE";
-    String filterQuery = "{\n" +
-            "  \"term\": {\n" +
-            "    \"107\": 72 \n" +
-            "  }\n" +
-            "}";
+    String filterQuery = "{\n" + "  \"term\": {\n" + "    \"107\": 72 \n" + "  }\n" + "}";
 
-    //Execute the SQL query with filter
+    // Execute the SQL query with filter
     String selectQuery = "SELECT * FROM " + TEST_INDEX_ONLINE;
-    JSONObject initialResponse = new JSONObject(executeFetchQuery(selectQuery, 10, "jdbc", filterQuery));
+    JSONObject initialResponse =
+        new JSONObject(executeFetchQuery(selectQuery, 10, "jdbc", filterQuery));
     assertEquals(initialResponse.getInt("size"), 10);
 
-    //Create an alias
-    String createAliasQuery = String.format("{ \"actions\": [ { \"add\": { \"index\": \"%s\", \"alias\": \"%s\" } } ] }", indexName, aliasName);
+    // Create an alias
+    String createAliasQuery =
+        String.format(
+            "{ \"actions\": [ { \"add\": { \"index\": \"%s\", \"alias\": \"%s\" } } ] }",
+            indexName, aliasName);
     Request createAliasRequest = new Request("POST", "/_aliases");
     createAliasRequest.setJsonEntity(createAliasQuery);
     JSONObject aliasResponse = new JSONObject(executeRequest(createAliasRequest));
@@ -241,18 +242,19 @@ public class PaginationIT extends SQLIntegTestCase {
     // Assert that alias creation was acknowledged
     assertTrue(aliasResponse.getBoolean("acknowledged"));
 
-    //Query using the alias
+    // Query using the alias
     String aliasSelectQuery = String.format("SELECT * FROM %s", aliasName);
     JSONObject aliasQueryResponse = new JSONObject(executeFetchQuery(aliasSelectQuery, 4, "jdbc"));
     assertEquals(4, aliasQueryResponse.getInt("size"));
 
-    //Query using the alias with filter
-    JSONObject aliasFilteredResponse = new JSONObject(executeFetchQuery(aliasSelectQuery, 4, "jdbc", filterQuery));
+    // Query using the alias with filter
+    JSONObject aliasFilteredResponse =
+        new JSONObject(executeFetchQuery(aliasSelectQuery, 4, "jdbc", filterQuery));
     assertEquals(aliasFilteredResponse.getInt("size"), 4);
   }
 
-
-  private String executeFetchQuery(String query, int fetchSize, String requestType, String  filter) throws IOException{
+  private String executeFetchQuery(String query, int fetchSize, String requestType, String filter)
+      throws IOException {
     String endpoint = "/_plugins/_sql?format=" + requestType;
     String requestBody = makeRequest(query, fetchSize, filter);
 

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/SelectResultSet.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/SelectResultSet.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
 import org.opensearch.action.search.ClearScrollResponse;
@@ -164,7 +166,11 @@ public class SelectResultSet extends ResultSet {
   private void loadFromEsState(Query query) {
     String indexName = fetchIndexName(query);
     String[] fieldNames = fetchFieldsAsArray(query);
-
+    GetAliasesResponse getAliasesResponse =
+            client.admin().indices().getAliases(new GetAliasesRequest(indexName)).actionGet();
+    if (getAliasesResponse != null && !getAliasesResponse.getAliases().isEmpty()) {
+      indexName = getAliasesResponse.getAliases().keySet().iterator().next();
+    }
     // Reset boolean in the case of JOIN query where multiple calls to loadFromEsState() are made
     selectAll = isSimpleQuerySelectAll(query) || isJoinQuerySelectAll(query, fieldNames);
 
@@ -181,6 +187,7 @@ public class SelectResultSet extends ResultSet {
       throw new IllegalArgumentException(
           String.format("Index type %s does not exist", query.getFrom()));
     }
+    LOG.info("Response Mapping: {}", response.mappings());
     Map<String, FieldMappingMetadata> typeMappings = mappings.get(indexName);
 
     this.indexName = this.indexName == null ? indexName : (this.indexName + "|" + indexName);

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/SelectResultSet.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/SelectResultSet.java
@@ -167,7 +167,7 @@ public class SelectResultSet extends ResultSet {
     String indexName = fetchIndexName(query);
     String[] fieldNames = fetchFieldsAsArray(query);
     GetAliasesResponse getAliasesResponse =
-            client.admin().indices().getAliases(new GetAliasesRequest(indexName)).actionGet();
+        client.admin().indices().getAliases(new GetAliasesRequest(indexName)).actionGet();
     if (getAliasesResponse != null && !getAliasesResponse.getAliases().isEmpty()) {
       indexName = getAliasesResponse.getAliases().keySet().iterator().next();
     }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/SelectResultSet.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/SelectResultSet.java
@@ -187,7 +187,6 @@ public class SelectResultSet extends ResultSet {
       throw new IllegalArgumentException(
           String.format("Index type %s does not exist", query.getFrom()));
     }
-    LOG.info("Response Mapping: {}", response.mappings());
     Map<String, FieldMappingMetadata> typeMappings = mappings.get(indexName);
 
     this.indexName = this.indexName == null ? indexName : (this.indexName + "|" + indexName);


### PR DESCRIPTION
### Description
Alias query in legacy SQL  which had filters to it didn't work . This diff addresses that issue. This diff derives index name from alias, for  legacy sql queries having filters to it. 
 
Before the change
```
curl -X POST "localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' -d '{
  "query": "SELECT * FROM my-alias",
  "fetch_size": 1,
   "filter" : {
    "term" : {
      "field2" : "Sample keyword2"
    }
  }
}'
{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "Index type [my-alias] does not exist",
    "type": "IllegalArgumentException"
  },
  "status": 500
}
```
After the change: 
```
curl -X POST "localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' -d '{
  "query": "SELECT * FROM my-alias",
  "fetch_size": 1,
   "filter" : {
    "term" : {
      "another_field" : "hello"
    }
  }
}'
{
  "schema": [
    {
      "name": "new_field",
      "type": "text"
    },
    {
      "name": "another_field",
      "type": "keyword"
    }
  ],
  "total": 1,
  "datarows": [[
    "Some text",
    "hello"
  ]],
  "size": 1,
  "status": 200
```

### Related Issues
Resolves #2912 
#1398 #1412 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
