### PR TITLE
Throw IllegalArgumentException when cancelJob failed with ValidationException

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
@@ -116,11 +116,16 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
                   } catch (Throwable t) {
                     if (allowExceptionPropagation) {
                       throw t;
-                    } else {
-                      logger.error("Error while making cancel job request to emr:", t);
-                      metricsService.incrementNumericalMetric(EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT);
-                      throw new RuntimeException(GENERIC_INTERNAL_SERVER_ERROR_MESSAGE);
                     }
+
+                    logger.error("Error while making cancel job request to emr:", t);
+                    metricsService.incrementNumericalMetric(EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT);
+                    if (t instanceof ValidationException) {
+                      throw new IllegalArgumentException(
+                          "The input fails to satisfy the constraints specified by AWS EMR"
+                              + " Serverless.");
+                    }
+                    throw new RuntimeException(GENERIC_INTERNAL_SERVER_ERROR_MESSAGE);
                   }
                 });
     logger.info(String.format("Job : %s cancelled", cancelJobRunResult.getJobRunId()));

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/client/EmrServerlessClientImpl.java
@@ -118,7 +118,7 @@ public class EmrServerlessClientImpl implements EMRServerlessClient {
                       throw t;
                     }
 
-                    logger.error("Error while making cancel job request to emr:", t);
+                    logger.error("Error while making cancel job request to emr: jobId=" + jobId, t);
                     metricsService.incrementNumericalMetric(EMR_CANCEL_JOB_REQUEST_FAILURE_COUNT);
                     if (t instanceof ValidationException) {
                       throw new IllegalArgumentException(

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/client/EmrServerlessClientImplTest.java
@@ -172,10 +172,12 @@ public class EmrServerlessClientImplTest {
 
     RuntimeException runtimeException =
         Assertions.assertThrows(
-            RuntimeException.class,
+            IllegalArgumentException.class,
             () -> emrServerlessClient.cancelJobRun(EMRS_APPLICATION_ID, EMR_JOB_ID, false));
 
-    Assertions.assertEquals("Internal Server Error.", runtimeException.getMessage());
+    Assertions.assertEquals(
+        "The input fails to satisfy the constraints specified by AWS EMR Serverless.",
+        runtimeException.getMessage());
   }
 
   @Test


### PR DESCRIPTION
### Description
- Throw IllegalArgumentException when cancelJob failed with ValidationException
  - It is caused when the Job is not cancellable state such as FAILED or COMPLETED 
- This is to distinguish the error for 4xx and 5xx

### Related Issues
n/a

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
