### PR TITLE
[Manual Backport 2.x] Extend scheduler interface for multitenancy

### DIFF
--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Upload test reports
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
         name: test-reports-${{ matrix.os }}-${{ matrix.java }}
@@ -79,7 +79,7 @@ jobs:
 
     - name: Upload test reports
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
         name: test-reports-${{ matrix.os }}-${{ matrix.java }}

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -76,14 +76,15 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
       with:
         name: opensearch-sql-ubuntu-latest
         path: opensearch-sql-builds
 
     - name: Upload test reports
-      if: always()
-      uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
         name: test-reports
@@ -130,7 +131,27 @@ jobs:
         cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
       with:
         name: opensearch-sql-${{ matrix.entry.os }}
         path: opensearch-sql-builds
+
+    - name: Upload test reports
+      if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: test-reports-${{ matrix.entry.os }}-${{ matrix.entry.java }}
+        path: |
+          sql/build/reports/**
+          ppl/build/reports/**
+          core/build/reports/**
+          common/build/reports/**
+          opensearch/build/reports/**
+          integ-test/build/reports/**
+          protocol/build/reports/**
+          legacy/build/reports/**
+          plugin/build/reports/**
+          doctest/build/testclusters/docTestCluster-0/logs/*
+          integ-test/build/testclusters/*/logs/*

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpAlter.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpAlter.java
@@ -62,7 +62,8 @@ public class FlintIndexOpAlter extends FlintIndexOp {
     this.flintIndexMetadataService.updateIndexToManualRefresh(
         flintIndexMetadata.getOpensearchIndexName(), flintIndexOptions, asyncQueryRequestContext);
     if (flintIndexMetadata.getFlintIndexOptions().isExternalScheduler()) {
-      asyncQueryScheduler.unscheduleJob(flintIndexMetadata.getOpensearchIndexName());
+      asyncQueryScheduler.unscheduleJob(
+          flintIndexMetadata.getOpensearchIndexName(), asyncQueryRequestContext);
     } else {
       cancelStreamingJob(flintIndexStateModel);
     }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpDrop.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/flint/operation/FlintIndexOpDrop.java
@@ -54,7 +54,8 @@ public class FlintIndexOpDrop extends FlintIndexOp {
         "Performing drop index operation for index: {}",
         flintIndexMetadata.getOpensearchIndexName());
     if (flintIndexMetadata.getFlintIndexOptions().isExternalScheduler()) {
-      asyncQueryScheduler.unscheduleJob(flintIndexMetadata.getOpensearchIndexName());
+      asyncQueryScheduler.unscheduleJob(
+          flintIndexMetadata.getOpensearchIndexName(), asyncQueryRequestContext);
     } else {
       cancelStreamingJob(flintIndexStateModel);
     }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/scheduler/AsyncQueryScheduler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/scheduler/AsyncQueryScheduler.java
@@ -1,5 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.scheduler;
 
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.scheduler.model.AsyncQuerySchedulerRequest;
 
 /** Scheduler interface for scheduling asynchronous query jobs. */
@@ -13,10 +19,13 @@ public interface AsyncQueryScheduler {
    * task
    *
    * @param asyncQuerySchedulerRequest The request containing job configuration details
+   * @param asyncQueryRequestContext The request context passed to AsyncQueryExecutorService
    * @throws IllegalArgumentException if a job with the same name already exists
    * @throws RuntimeException if there's an error during job creation
    */
-  void scheduleJob(AsyncQuerySchedulerRequest asyncQuerySchedulerRequest);
+  void scheduleJob(
+      AsyncQuerySchedulerRequest asyncQuerySchedulerRequest,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
   /**
    * Updates an existing job with new parameters. This method modifies the configuration of an
@@ -26,10 +35,13 @@ public interface AsyncQueryScheduler {
    * scheduled job - Updating resource allocations for a job
    *
    * @param asyncQuerySchedulerRequest The request containing updated job configuration
+   * @param asyncQueryRequestContext The request context passed to AsyncQueryExecutorService
    * @throws IllegalArgumentException if the job to be updated doesn't exist
    * @throws RuntimeException if there's an error during the update process
    */
-  void updateJob(AsyncQuerySchedulerRequest asyncQuerySchedulerRequest);
+  void updateJob(
+      AsyncQuerySchedulerRequest asyncQuerySchedulerRequest,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
   /**
    * Unschedules a job by marking it as disabled and updating its last update time. This method is
@@ -41,8 +53,11 @@ public interface AsyncQueryScheduler {
    * re-enabling of the job in the future
    *
    * @param jobId The unique identifier of the job to unschedule
+   * @param asyncQueryRequestContext The request context passed to AsyncQueryExecutorService
+   * @throws IllegalArgumentException if the job to be unscheduled doesn't exist
+   * @throws RuntimeException if there's an error during the unschedule process
    */
-  void unscheduleJob(String jobId);
+  void unscheduleJob(String jobId, AsyncQueryRequestContext asyncQueryRequestContext);
 
   /**
    * Removes a job completely from the scheduler. This method permanently deletes the job and all
@@ -52,6 +67,9 @@ public interface AsyncQueryScheduler {
    * created jobs - Freeing up resources by deleting unused job configurations
    *
    * @param jobId The unique identifier of the job to remove
+   * @param asyncQueryRequestContext The request context passed to AsyncQueryExecutorService
+   * @throws IllegalArgumentException if the job to be removed doesn't exist
+   * @throws RuntimeException if there's an error during the remove process
    */
-  void removeJob(String jobId);
+  void removeJob(String jobId, AsyncQueryRequestContext asyncQueryRequestContext);
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/scheduler/model/AsyncQuerySchedulerRequest.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/scheduler/model/AsyncQuerySchedulerRequest.java
@@ -7,12 +7,14 @@ package org.opensearch.sql.spark.scheduler.model;
 
 import java.time.Instant;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.opensearch.sql.spark.rest.model.LangType;
 
 /** Represents a job request for a scheduled task. */
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class AsyncQuerySchedulerRequest {

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryCoreIntegTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryCoreIntegTest.java
@@ -230,7 +230,7 @@ public class AsyncQueryCoreIntegTest {
     verifyCreateIndexDMLResultCalled();
     verifyStoreJobMetadataCalled(DML_QUERY_JOB_ID, QueryState.SUCCESS, JobType.BATCH);
 
-    verify(asyncQueryScheduler).unscheduleJob(indexName);
+    verify(asyncQueryScheduler).unscheduleJob(indexName, asyncQueryRequestContext);
   }
 
   @Test
@@ -318,8 +318,7 @@ public class AsyncQueryCoreIntegTest {
     FlintIndexOptions flintIndexOptions = flintIndexOptionsArgumentCaptor.getValue();
     assertFalse(flintIndexOptions.autoRefresh());
 
-    verify(asyncQueryScheduler).unscheduleJob(indexName);
-
+    verify(asyncQueryScheduler).unscheduleJob(indexName, asyncQueryRequestContext);
     verifyCreateIndexDMLResultCalled();
     verifyStoreJobMetadataCalled(DML_QUERY_JOB_ID, QueryState.SUCCESS, JobType.BATCH);
   }

--- a/async-query/src/main/java/org/opensearch/sql/spark/scheduler/model/ScheduledAsyncQueryJobRequest.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/scheduler/model/ScheduledAsyncQueryJobRequest.java
@@ -38,7 +38,7 @@ public class ScheduledAsyncQueryJobRequest extends AsyncQuerySchedulerRequest
   public static final String ENABLED_FIELD = "enabled";
   private final Schedule schedule;
 
-  @Builder
+  @Builder(builderMethodName = "scheduledAsyncQueryJobRequestBuilder")
   public ScheduledAsyncQueryJobRequest(
       String accountId,
       String jobId,
@@ -139,7 +139,7 @@ public class ScheduledAsyncQueryJobRequest extends AsyncQuerySchedulerRequest
       AsyncQuerySchedulerRequest request) {
     Instant updateTime =
         request.getLastUpdateTime() != null ? request.getLastUpdateTime() : Instant.now();
-    return ScheduledAsyncQueryJobRequest.builder()
+    return ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
         .accountId(request.getAccountId())
         .jobId(request.getJobId())
         .dataSource(request.getDataSource())

--- a/async-query/src/main/java/org/opensearch/sql/spark/scheduler/parser/OpenSearchScheduleQueryJobRequestParser.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/scheduler/parser/OpenSearchScheduleQueryJobRequestParser.java
@@ -30,7 +30,7 @@ public class OpenSearchScheduleQueryJobRequestParser {
   public static ScheduledJobParser getJobParser() {
     return (parser, id, jobDocVersion) -> {
       ScheduledAsyncQueryJobRequest.ScheduledAsyncQueryJobRequestBuilder builder =
-          ScheduledAsyncQueryJobRequest.builder();
+          ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder();
       XContentParserUtils.ensureExpectedToken(
           XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
 

--- a/async-query/src/test/java/org/opensearch/sql/spark/scheduler/job/ScheduledAsyncQueryJobRunnerTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/scheduler/job/ScheduledAsyncQueryJobRunnerTest.java
@@ -72,7 +72,7 @@ public class ScheduledAsyncQueryJobRunnerTest {
     spyJobRunner.loadJobResource(client, clusterService, threadPool, asyncQueryExecutorService);
 
     ScheduledAsyncQueryJobRequest request =
-        ScheduledAsyncQueryJobRequest.builder()
+        ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
             .jobId("testJob")
             .lastUpdateTime(Instant.now())
             .lockDurationSeconds(10L)
@@ -123,7 +123,7 @@ public class ScheduledAsyncQueryJobRunnerTest {
     spyJobRunner.loadJobResource(client, clusterService, threadPool, asyncQueryExecutorService);
 
     ScheduledAsyncQueryJobRequest request =
-        ScheduledAsyncQueryJobRequest.builder()
+        ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
             .jobId("testJob")
             .lastUpdateTime(Instant.now())
             .lockDurationSeconds(10L)
@@ -158,7 +158,7 @@ public class ScheduledAsyncQueryJobRunnerTest {
   @Test
   public void testRunJobWithUninitializedServices() {
     ScheduledAsyncQueryJobRequest jobParameter =
-        ScheduledAsyncQueryJobRequest.builder()
+        ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
             .jobId("testJob")
             .lastUpdateTime(Instant.now())
             .build();

--- a/async-query/src/test/java/org/opensearch/sql/spark/scheduler/model/ScheduledAsyncQueryJobRequestTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/scheduler/model/ScheduledAsyncQueryJobRequestTest.java
@@ -28,7 +28,7 @@ public class ScheduledAsyncQueryJobRequestTest {
     IntervalSchedule schedule = new IntervalSchedule(now, 1, ChronoUnit.MINUTES);
 
     ScheduledAsyncQueryJobRequest jobRequest =
-        ScheduledAsyncQueryJobRequest.builder()
+        ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
             .accountId("testAccount")
             .jobId("testJob")
             .dataSource("testDataSource")
@@ -62,7 +62,7 @@ public class ScheduledAsyncQueryJobRequestTest {
     IntervalSchedule schedule = new IntervalSchedule(now, 1, ChronoUnit.MINUTES);
 
     ScheduledAsyncQueryJobRequest request =
-        ScheduledAsyncQueryJobRequest.builder()
+        ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
             .accountId("testAccount")
             .jobId("testJob")
             .dataSource("testDataSource")
@@ -146,7 +146,7 @@ public class ScheduledAsyncQueryJobRequestTest {
     IntervalSchedule schedule = new IntervalSchedule(now, 1, ChronoUnit.MINUTES);
 
     ScheduledAsyncQueryJobRequest request1 =
-        ScheduledAsyncQueryJobRequest.builder()
+        ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
             .accountId("testAccount")
             .jobId("testJob")
             .dataSource("testDataSource")
@@ -172,7 +172,7 @@ public class ScheduledAsyncQueryJobRequestTest {
     assertTrue(toString.contains("jitter=0.1"));
 
     ScheduledAsyncQueryJobRequest request2 =
-        ScheduledAsyncQueryJobRequest.builder()
+        ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
             .accountId("testAccount")
             .jobId("testJob")
             .dataSource("testDataSource")
@@ -190,7 +190,7 @@ public class ScheduledAsyncQueryJobRequestTest {
     assertEquals(request1.hashCode(), request2.hashCode());
 
     ScheduledAsyncQueryJobRequest request3 =
-        ScheduledAsyncQueryJobRequest.builder()
+        ScheduledAsyncQueryJobRequest.scheduledAsyncQueryJobRequestBuilder()
             .accountId("differentAccount")
             .jobId("testJob")
             .dataSource("testDataSource")


### PR DESCRIPTION
### Description
Backport/backport #3014 to 2.x

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
 - [x] New functionality has javadoc added.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
