### PR TITLE
Bug Fixes for minor issues with SQL PIT refactor

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/PrettyFormatRestExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/PrettyFormatRestExecutor.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.legacy.executor.format;
 import static org.opensearch.sql.common.setting.Settings.Key.SQL_PAGINATION_API_SEARCH_AFTER;
 
 import java.util.Map;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
@@ -132,13 +133,11 @@ public class PrettyFormatRestExecutor implements RestExecutor {
     return protocol;
   }
 
-  private boolean isDefaultCursor(SearchResponse searchResponse, DefaultQueryAction queryAction) {
+  protected boolean isDefaultCursor(SearchResponse searchResponse, DefaultQueryAction queryAction) {
     if (LocalClusterState.state().getSettingValue(SQL_PAGINATION_API_SEARCH_AFTER)) {
-      if (searchResponse.getHits().getTotalHits().value < queryAction.getSqlRequest().fetchSize()) {
-        return false;
-      } else {
-        return true;
-      }
+      return queryAction.getSqlRequest().fetchSize() != 0
+          && Objects.requireNonNull(searchResponse.getHits().getTotalHits()).value
+              >= queryAction.getSqlRequest().fetchSize();
     } else {
       return !Strings.isNullOrEmpty(searchResponse.getScrollId());
     }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/join/ElasticJoinExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/join/ElasticJoinExecutor.java
@@ -99,6 +99,7 @@ public abstract class ElasticJoinExecutor extends ElasticHitsExecutor {
       this.metaResults.setTookImMilli(joinTimeInMilli);
     } catch (Exception e) {
       LOG.error("Failed during join query run.", e);
+      throw new IllegalStateException("Error occurred during join query run", e);
     } finally {
       if (LocalClusterState.state().getSettingValue(SQL_PAGINATION_API_SEARCH_AFTER)) {
         try {

--- a/legacy/src/test/java/org/opensearch/sql/legacy/executor/format/PrettyFormatRestExecutorTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/executor/format/PrettyFormatRestExecutorTest.java
@@ -1,0 +1,89 @@
+package org.opensearch.sql.legacy.executor.format;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.common.setting.Settings.Key.SQL_PAGINATION_API_SEARCH_AFTER;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.sql.legacy.esdomain.LocalClusterState;
+import org.opensearch.sql.legacy.query.DefaultQueryAction;
+import org.opensearch.sql.legacy.request.SqlRequest;
+import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PrettyFormatRestExecutorTest {
+
+  @Mock private SearchResponse searchResponse;
+  @Mock private SearchHits searchHits;
+  @Mock private SearchHit searchHit;
+  @Mock private DefaultQueryAction queryAction;
+  @Mock private SqlRequest sqlRequest;
+  private PrettyFormatRestExecutor executor;
+
+  @Before
+  public void setUp() {
+    OpenSearchSettings settings = mock(OpenSearchSettings.class);
+    LocalClusterState.state().setPluginSettings(settings);
+    when(LocalClusterState.state().getSettingValue(SQL_PAGINATION_API_SEARCH_AFTER))
+        .thenReturn(true);
+    when(queryAction.getSqlRequest()).thenReturn(sqlRequest);
+    executor = new PrettyFormatRestExecutor("jdbc");
+  }
+
+  @Test
+  public void testIsDefaultCursor_fetchSizeZero() {
+    when(sqlRequest.fetchSize()).thenReturn(0);
+
+    assertFalse(executor.isDefaultCursor(searchResponse, queryAction));
+  }
+
+  @Test
+  public void testIsDefaultCursor_totalHitsLessThanFetchSize() {
+    when(sqlRequest.fetchSize()).thenReturn(10);
+    when(searchResponse.getHits())
+        .thenReturn(
+            new SearchHits(
+                new SearchHit[] {searchHit}, new TotalHits(5, TotalHits.Relation.EQUAL_TO), 1.0F));
+
+    assertFalse(executor.isDefaultCursor(searchResponse, queryAction));
+  }
+
+  @Test
+  public void testIsDefaultCursor_totalHitsGreaterThanOrEqualToFetchSize() {
+    when(sqlRequest.fetchSize()).thenReturn(5);
+    when(searchResponse.getHits())
+        .thenReturn(
+            new SearchHits(
+                new SearchHit[] {searchHit}, new TotalHits(5, TotalHits.Relation.EQUAL_TO), 1.0F));
+
+    assertTrue(executor.isDefaultCursor(searchResponse, queryAction));
+  }
+
+  @Test
+  public void testIsDefaultCursor_PaginationApiDisabled() {
+    when(LocalClusterState.state().getSettingValue(SQL_PAGINATION_API_SEARCH_AFTER))
+        .thenReturn(false);
+    when(searchResponse.getScrollId()).thenReturn("someScrollId");
+
+    assertTrue(executor.isDefaultCursor(searchResponse, queryAction));
+  }
+
+  @Test
+  public void testIsDefaultCursor_PaginationApiDisabled_NoScrollId() {
+    when(LocalClusterState.state().getSettingValue(SQL_PAGINATION_API_SEARCH_AFTER))
+        .thenReturn(false);
+    when(searchResponse.getScrollId()).thenReturn(null);
+
+    assertFalse(executor.isDefaultCursor(searchResponse, queryAction));
+  }
+}


### PR DESCRIPTION
### Description
Issue found during E2E testing:

1. If join queries fail to pull results due to internal errors in the service. The API fails with a Null Pointer Exception
Reproducible if you force the OpenSearch client to throw an exception while executing a join.
```
Before:

curl -X POST "http://localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' -d'
> {
>   "query": "SELECT t1.field_1, t2.field_3 FROM testpit t1 INNER JOIN testjoin t2 ON t1.field_2 = t2.field_4"
> }
> '
{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "Cannot invoke \"java.util.List.size()\" because \"this.results\" is null",
    "type": "NullPointerException"
  },
  "status": 500
}


After fix:

curl -X POST "http://localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' -d'
{
  "query": "SELECT t1.field_1, t2.field_3 FROM testpit t1 INNER JOIN testjoin t2 ON t1.field_2 = t2.field_4"
}
'
{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "Error occurred during join query run",
    "type": "IllegalStateException"
  },
  "status": 500
}

```
2. Sometimes, a cursor seems to be returned even when one is not needed eg: select a.* from my-index a  returns a cursor but select * from my-index a does not. 


**After fix:** 
```
curl -X POST "http://localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' -d'
{
  "query": "SELECT a.* FROM testpit a"
}
'


Response: 
{
  "schema": [
    {
      "name": "field_1",
      "type": "text"
    },
    {
      "name": "field_2",
      "type": "integer"
    }
  ],
  "total": 10,
  "datarows": [
    [
      "Sample data 1",
      1
    ],
    [
      "Sample data 2",
      2
    ],
    [
      "Sample data 3",
      3
    ],
    [
      "Sample data 4",
      4
    ],
    [
      "Sample data 5",
      5
    ],
    [
      "Sample data 6",
      6
    ],
    [
      "Sample data 7",
      7
    ],
    [
      "Sample data 8",
      8
    ],
    [
      "Sample data 9",
      9
    ],
    [
      "Sample data 10",
      10
    ]
  ],
  "size": 10,
  "status": 200
}

```
```

curl -X POST "http://localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' -d'
{
  "query": "SELECT a.* FROM testpit a"
}
'

Response: 
{
  "schema": [
    {
      "name": "field_1",
      "type": "text"
    },
    {
      "name": "field_2",
      "type": "integer"
    }
  ],
  "total": 10,
  "datarows": [
    [
      "Sample data 1",
      1
    ],
    [
      "Sample data 2",
      2
    ],
    [
      "Sample data 3",
      3
    ],
    [
      "Sample data 4",
      4
    ],
    [
      "Sample data 5",
      5
    ],
    [
      "Sample data 6",
      6
    ],
    [
      "Sample data 7",
      7
    ],
    [
      "Sample data 8",
      8
    ],
    [
      "Sample data 9",
      9
    ],
    [
      "Sample data 10",
      10
    ]
  ],
  "size": 10,
  "status": 200
}


```
3. The api seems to have an unsupported "size" parameter where it generates a cursor. The cursor is unusable, attempting to use it causes an exception.
Reproducible by specifying a "size" parameter in the request body in place of "fetch_size".
```
After fix, response doesn't contain incorrect default cursor in the response. It just ignores the unsupported fields in the query which is existing behavior. 
```

```
curl -X POST "http://localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' -d'
{
  "query": "SELECT field_1 FROM testpit WHERE field_2 > 0",
  "size": 5
}
'
{
  "schema": [{
    "name": "field_1",
    "type": "text"
  }],
  "total": 10,
  "datarows": [
    ["Sample data 1"],
    ["Sample data 2"],
    ["Sample data 3"],
    ["Sample data 4"],
    ["Sample data 5"],
    ["Sample data 6"],
    ["Sample data 7"],
    ["Sample data 8"],
    ["Sample data 9"],
    ["Sample data 10"]
  ],
  "size": 10,
  "status": 200
}
```
4. From the testing, it appears the v2 engine always appears to always create a PIT context even when one is not needed (could explain 3)

```
This was addressed as part of refactorign PR only in the revised iterations. Here is the code ref for v2 PIT changes where PIT is created only when Scroll was used before. 
https://github.com/opensearch-project/sql/blob/main/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java#L124
```
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
