### PR TITLE
Updating JobExecutionResponseReader interface to add RequestContext

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -47,8 +47,8 @@ public class BatchQueryHandler extends AsyncQueryHandler {
       AsyncQueryRequestContext asyncQueryRequestContext) {
     // either empty json when the result is not available or data with status
     // Fetch from Result Index
-    return jobExecutionResponseReader.getResultWithJobId(
-        asyncQueryJobMetadata.getJobId(), asyncQueryJobMetadata.getResultIndex());
+    return jobExecutionResponseReader.getResultFromResultIndex(
+        asyncQueryJobMetadata, asyncQueryRequestContext);
   }
 
   @Override

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/IndexDMLHandler.java
@@ -169,7 +169,7 @@ public class IndexDMLHandler extends AsyncQueryHandler {
       AsyncQueryRequestContext asyncQueryRequestContext) {
     String queryId = asyncQueryJobMetadata.getQueryId();
     return jobExecutionResponseReader.getResultWithQueryId(
-        queryId, asyncQueryJobMetadata.getResultIndex());
+        queryId, asyncQueryJobMetadata.getResultIndex(), asyncQueryRequestContext);
   }
 
   @Override

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/InteractiveQueryHandler.java
@@ -56,7 +56,7 @@ public class InteractiveQueryHandler extends AsyncQueryHandler {
       AsyncQueryRequestContext asyncQueryRequestContext) {
     String queryId = asyncQueryJobMetadata.getQueryId();
     return jobExecutionResponseReader.getResultWithQueryId(
-        queryId, asyncQueryJobMetadata.getResultIndex());
+        queryId, asyncQueryJobMetadata.getResultIndex(), asyncQueryRequestContext);
   }
 
   @Override

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/response/JobExecutionResponseReader.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/response/JobExecutionResponseReader.java
@@ -6,17 +6,21 @@
 package org.opensearch.sql.spark.response;
 
 import org.json.JSONObject;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 
 /** Interface for reading job execution result */
 public interface JobExecutionResponseReader {
   /**
    * Retrieves the job execution result based on the job ID.
    *
-   * @param jobId The job ID.
-   * @param resultLocation The location identifier where the result is stored (optional).
+   * @param asyncQueryJobMetadata metadata will have jobId and resultLocation and other required
+   *     params.
    * @return A JSONObject containing the result data.
    */
-  JSONObject getResultWithJobId(String jobId, String resultLocation);
+  JSONObject getResultFromResultIndex(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext);
 
   /**
    * Retrieves the job execution result based on the query ID.
@@ -25,5 +29,6 @@ public interface JobExecutionResponseReader {
    * @param resultLocation The location identifier where the result is stored (optional).
    * @return A JSONObject containing the result data.
    */
-  JSONObject getResultWithQueryId(String queryId, String resultLocation);
+  JSONObject getResultWithQueryId(
+      String queryId, String resultLocation, AsyncQueryRequestContext asyncQueryRequestContext);
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/response/JobExecutionResponseReader.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/response/JobExecutionResponseReader.java
@@ -16,6 +16,7 @@ public interface JobExecutionResponseReader {
    *
    * @param asyncQueryJobMetadata metadata will have jobId and resultLocation and other required
    *     params.
+   * @param asyncQueryRequestContext request context passed to AsyncQueryExecutorService
    * @return A JSONObject containing the result data.
    */
   JSONObject getResultFromResultIndex(

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryCoreIntegTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryCoreIntegTest.java
@@ -452,7 +452,8 @@ public class AsyncQueryCoreIntegTest {
             .sessionId(SESSION_ID)
             .resultIndex(RESULT_INDEX));
     JSONObject result = getValidExecutionResponse();
-    when(jobExecutionResponseReader.getResultWithQueryId(QUERY_ID, RESULT_INDEX))
+    when(jobExecutionResponseReader.getResultWithQueryId(
+            QUERY_ID, RESULT_INDEX, asyncQueryRequestContext))
         .thenReturn(result);
 
     AsyncQueryExecutionResponse response =
@@ -471,7 +472,8 @@ public class AsyncQueryCoreIntegTest {
             .jobId(DROP_INDEX_JOB_ID)
             .resultIndex(RESULT_INDEX));
     JSONObject result = getValidExecutionResponse();
-    when(jobExecutionResponseReader.getResultWithQueryId(QUERY_ID, RESULT_INDEX))
+    when(jobExecutionResponseReader.getResultWithQueryId(
+            QUERY_ID, RESULT_INDEX, asyncQueryRequestContext))
         .thenReturn(result);
 
     AsyncQueryExecutionResponse response =
@@ -491,7 +493,18 @@ public class AsyncQueryCoreIntegTest {
             .jobType(JobType.BATCH)
             .resultIndex(RESULT_INDEX));
     JSONObject result = getValidExecutionResponse();
-    when(jobExecutionResponseReader.getResultWithJobId(JOB_ID, RESULT_INDEX)).thenReturn(result);
+    when(jobExecutionResponseReader.getResultFromResultIndex(
+            AsyncQueryJobMetadata.builder()
+                .applicationId(APPLICATION_ID)
+                .queryId(QUERY_ID)
+                .jobId(JOB_ID)
+                .datasourceName(DATASOURCE_NAME)
+                .resultIndex(RESULT_INDEX)
+                .jobType(JobType.BATCH)
+                .metadata(ImmutableMap.of())
+                .build(),
+            asyncQueryRequestContext))
+        .thenReturn(result);
 
     AsyncQueryExecutionResponse response =
         asyncQueryExecutorService.getAsyncQueryResults(QUERY_ID, asyncQueryRequestContext);

--- a/async-query/src/main/java/org/opensearch/sql/spark/response/OpenSearchJobExecutionResponseReader.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/response/OpenSearchJobExecutionResponseReader.java
@@ -21,6 +21,8 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 
 /** JobExecutionResponseReader implementation for reading response from OpenSearch index. */
 public class OpenSearchJobExecutionResponseReader implements JobExecutionResponseReader {
@@ -32,12 +34,12 @@ public class OpenSearchJobExecutionResponseReader implements JobExecutionRespons
   }
 
   @Override
-  public JSONObject getResultWithJobId(String jobId, String resultLocation) {
-    return searchInSparkIndex(QueryBuilders.termQuery(JOB_ID_FIELD, jobId), resultLocation);
+  public JSONObject getResultFromResultIndex(AsyncQueryJobMetadata asyncQueryJobMetadata, AsyncQueryRequestContext asyncQueryRequestContext) {
+    return searchInSparkIndex(QueryBuilders.termQuery(JOB_ID_FIELD, asyncQueryJobMetadata.getJobId()), asyncQueryJobMetadata.getResultIndex());
   }
 
   @Override
-  public JSONObject getResultWithQueryId(String queryId, String resultLocation) {
+  public JSONObject getResultWithQueryId(String queryId, String resultLocation, AsyncQueryRequestContext asyncQueryRequestContext) {
     return searchInSparkIndex(QueryBuilders.termQuery("queryId", queryId), resultLocation);
   }
 

--- a/async-query/src/main/java/org/opensearch/sql/spark/response/OpenSearchJobExecutionResponseReader.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/response/OpenSearchJobExecutionResponseReader.java
@@ -34,12 +34,17 @@ public class OpenSearchJobExecutionResponseReader implements JobExecutionRespons
   }
 
   @Override
-  public JSONObject getResultFromResultIndex(AsyncQueryJobMetadata asyncQueryJobMetadata, AsyncQueryRequestContext asyncQueryRequestContext) {
-    return searchInSparkIndex(QueryBuilders.termQuery(JOB_ID_FIELD, asyncQueryJobMetadata.getJobId()), asyncQueryJobMetadata.getResultIndex());
+  public JSONObject getResultFromResultIndex(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
+    return searchInSparkIndex(
+        QueryBuilders.termQuery(JOB_ID_FIELD, asyncQueryJobMetadata.getJobId()),
+        asyncQueryJobMetadata.getResultIndex());
   }
 
   @Override
-  public JSONObject getResultWithQueryId(String queryId, String resultLocation, AsyncQueryRequestContext asyncQueryRequestContext) {
+  public JSONObject getResultWithQueryId(
+      String queryId, String resultLocation, AsyncQueryRequestContext asyncQueryRequestContext) {
     return searchInSparkIndex(QueryBuilders.termQuery("queryId", queryId), resultLocation);
   }
 

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
@@ -429,13 +429,22 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
                */
               new JobExecutionResponseReader() {
                 @Override
-                public JSONObject getResultFromResultIndex(AsyncQueryJobMetadata asyncQueryJobMetadata, AsyncQueryRequestContext asyncQueryRequestContext) {
-                    return interaction.interact(new InteractionStep(emrClient, asyncQueryJobMetadata.getJobId(), asyncQueryJobMetadata.getResultIndex()));
+                public JSONObject getResultFromResultIndex(
+                    AsyncQueryJobMetadata asyncQueryJobMetadata,
+                    AsyncQueryRequestContext asyncQueryRequestContext) {
+                  return interaction.interact(
+                      new InteractionStep(
+                          emrClient,
+                          asyncQueryJobMetadata.getJobId(),
+                          asyncQueryJobMetadata.getResultIndex()));
                 }
 
                 @Override
-                public JSONObject getResultWithQueryId(String queryId, String resultIndex, AsyncQueryRequestContext asyncQueryRequestContext) {
-                    return interaction.interact(new InteractionStep(emrClient, queryId, resultIndex));
+                public JSONObject getResultWithQueryId(
+                    String queryId,
+                    String resultIndex,
+                    AsyncQueryRequestContext asyncQueryRequestContext) {
+                  return interaction.interact(new InteractionStep(emrClient, queryId, resultIndex));
                 }
               });
       this.createQueryResponse =
@@ -502,7 +511,7 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
     /** Simulate PPL plugin search query_execution_result */
     JSONObject pluginSearchQueryResult() {
       return new OpenSearchJobExecutionResponseReader(client)
-              .getResultWithQueryId(queryId, resultIndex, null);
+          .getResultWithQueryId(queryId, resultIndex, null);
     }
 
     /** Simulate EMR-S bulk writes query_execution_result with refresh = wait_for */

--- a/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryGetResultSpecTest.java
@@ -24,6 +24,7 @@ import org.opensearch.sql.executor.pagination.Cursor;
 import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
 import org.opensearch.sql.protocol.response.format.ResponseFormatter;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
 import org.opensearch.sql.spark.asyncquery.model.MockFlintSparkJob;
 import org.opensearch.sql.spark.asyncquery.model.NullAsyncQueryRequestContext;
@@ -428,13 +429,13 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
                */
               new JobExecutionResponseReader() {
                 @Override
-                public JSONObject getResultWithJobId(String jobId, String resultIndex) {
-                  return interaction.interact(new InteractionStep(emrClient, jobId, resultIndex));
+                public JSONObject getResultFromResultIndex(AsyncQueryJobMetadata asyncQueryJobMetadata, AsyncQueryRequestContext asyncQueryRequestContext) {
+                    return interaction.interact(new InteractionStep(emrClient, asyncQueryJobMetadata.getJobId(), asyncQueryJobMetadata.getResultIndex()));
                 }
 
                 @Override
-                public JSONObject getResultWithQueryId(String queryId, String resultIndex) {
-                  return interaction.interact(new InteractionStep(emrClient, queryId, resultIndex));
+                public JSONObject getResultWithQueryId(String queryId, String resultIndex, AsyncQueryRequestContext asyncQueryRequestContext) {
+                    return interaction.interact(new InteractionStep(emrClient, queryId, resultIndex));
                 }
               });
       this.createQueryResponse =
@@ -501,7 +502,7 @@ public class AsyncQueryGetResultSpecTest extends AsyncQueryExecutorServiceSpec {
     /** Simulate PPL plugin search query_execution_result */
     JSONObject pluginSearchQueryResult() {
       return new OpenSearchJobExecutionResponseReader(client)
-          .getResultWithQueryId(queryId, resultIndex);
+              .getResultWithQueryId(queryId, resultIndex, null);
     }
 
     /** Simulate EMR-S bulk writes query_execution_result with refresh = wait_for */

--- a/async-query/src/test/java/org/opensearch/sql/spark/response/OpenSearchJobExecutionResponseReaderTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/response/OpenSearchJobExecutionResponseReaderTest.java
@@ -29,6 +29,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 
 @ExtendWith(MockitoExtension.class)
 public class OpenSearchJobExecutionResponseReaderTest {
@@ -50,7 +51,7 @@ public class OpenSearchJobExecutionResponseReaderTest {
                 new SearchHit[] {searchHit}, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0F));
     Mockito.when(searchHit.getSourceAsMap()).thenReturn(Map.of("stepId", EMR_JOB_ID));
 
-    assertFalse(jobExecutionResponseReader.getResultWithJobId(EMR_JOB_ID, null).isEmpty());
+    assertFalse(jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null).isEmpty());
   }
 
   @Test
@@ -64,7 +65,7 @@ public class OpenSearchJobExecutionResponseReaderTest {
                 new SearchHit[] {searchHit}, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0F));
     Mockito.when(searchHit.getSourceAsMap()).thenReturn(Map.of("stepId", EMR_JOB_ID));
 
-    assertFalse(jobExecutionResponseReader.getResultWithJobId(EMR_JOB_ID, "foo").isEmpty());
+    assertFalse(jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).resultIndex("foo").build(), null).isEmpty());
   }
 
   @Test
@@ -76,7 +77,7 @@ public class OpenSearchJobExecutionResponseReaderTest {
     RuntimeException exception =
         assertThrows(
             RuntimeException.class,
-            () -> jobExecutionResponseReader.getResultWithJobId(EMR_JOB_ID, null));
+                () -> jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null));
 
     Assertions.assertEquals(
         "Fetching result from "
@@ -92,13 +93,13 @@ public class OpenSearchJobExecutionResponseReaderTest {
 
     assertThrows(
         RuntimeException.class,
-        () -> jobExecutionResponseReader.getResultWithJobId(EMR_JOB_ID, null));
+            () -> jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null));
   }
 
   @Test
   public void testIndexNotFoundException() {
     when(client.search(any())).thenThrow(IndexNotFoundException.class);
 
-    assertTrue(jobExecutionResponseReader.getResultWithJobId(EMR_JOB_ID, "foo").isEmpty());
+    assertTrue(jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).resultIndex("foo").build(), null).isEmpty());
   }
 }

--- a/async-query/src/test/java/org/opensearch/sql/spark/response/OpenSearchJobExecutionResponseReaderTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/response/OpenSearchJobExecutionResponseReaderTest.java
@@ -51,7 +51,11 @@ public class OpenSearchJobExecutionResponseReaderTest {
                 new SearchHit[] {searchHit}, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0F));
     Mockito.when(searchHit.getSourceAsMap()).thenReturn(Map.of("stepId", EMR_JOB_ID));
 
-    assertFalse(jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null).isEmpty());
+    assertFalse(
+        jobExecutionResponseReader
+            .getResultFromResultIndex(
+                AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null)
+            .isEmpty());
   }
 
   @Test
@@ -65,7 +69,11 @@ public class OpenSearchJobExecutionResponseReaderTest {
                 new SearchHit[] {searchHit}, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0F));
     Mockito.when(searchHit.getSourceAsMap()).thenReturn(Map.of("stepId", EMR_JOB_ID));
 
-    assertFalse(jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).resultIndex("foo").build(), null).isEmpty());
+    assertFalse(
+        jobExecutionResponseReader
+            .getResultFromResultIndex(
+                AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).resultIndex("foo").build(), null)
+            .isEmpty());
   }
 
   @Test
@@ -77,7 +85,9 @@ public class OpenSearchJobExecutionResponseReaderTest {
     RuntimeException exception =
         assertThrows(
             RuntimeException.class,
-                () -> jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null));
+            () ->
+                jobExecutionResponseReader.getResultFromResultIndex(
+                    AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null));
 
     Assertions.assertEquals(
         "Fetching result from "
@@ -93,13 +103,18 @@ public class OpenSearchJobExecutionResponseReaderTest {
 
     assertThrows(
         RuntimeException.class,
-            () -> jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null));
+        () ->
+            jobExecutionResponseReader.getResultFromResultIndex(
+                AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).build(), null));
   }
 
   @Test
   public void testIndexNotFoundException() {
     when(client.search(any())).thenThrow(IndexNotFoundException.class);
-
-    assertTrue(jobExecutionResponseReader.getResultFromResultIndex(AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).resultIndex("foo").build(), null).isEmpty());
+    assertTrue(
+        jobExecutionResponseReader
+            .getResultFromResultIndex(
+                AsyncQueryJobMetadata.builder().jobId(EMR_JOB_ID).resultIndex("foo").build(), null)
+            .isEmpty());
   }
 }


### PR DESCRIPTION
### Description
1. updating the signature of JobExecutionResponseReader interface
2. updating signature from `JSONObject getResultWithJobId(String jobId, String resultLocation)` to `getResultFromResultIndex(
      AsyncQueryJobMetadata asyncQueryJobMetadata,
      AsyncQueryRequestContext asyncQueryRequestContext)`
3. adding in AsyncQueryRequestContext in getResultWithQueryId method

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
na

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
