### PR TITLE
Improve error handling for malformed query cursors

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
@@ -442,11 +442,11 @@ public class CursorIT extends SQLIntegTestCase {
 
   @Test
   public void testMalformedCursorGracefullyHandled() throws IOException {
-    ResponseException result = assertThrows(
+    ResponseException result =
+        assertThrows(
             "Expected query with malformed cursor to raise error, but didn't",
             ResponseException.class,
-            () -> executeCursorQuery("d:a11b4db33f")
-    );
+            () -> executeCursorQuery("d:a11b4db33f"));
     assertTrue(result.getMessage().contains("Malformed cursor"));
     assertEquals(result.getResponse().getStatusLine().getStatusCode(), 400);
   }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
@@ -440,6 +440,17 @@ public class CursorIT extends SQLIntegTestCase {
     assertThat(rows.length, equalTo(1000));
   }
 
+  @Test
+  public void testMalformedCursorGracefullyHandled() throws IOException {
+    ResponseException result = assertThrows(
+            "Expected query with malformed cursor to raise error, but didn't",
+            ResponseException.class,
+            () -> executeCursorQuery("d:a11b4db33f")
+    );
+    assertTrue(result.getMessage().contains("Malformed cursor"));
+    assertEquals(result.getResponse().getStatusLine().getStatusCode(), 400);
+  }
+
   public void verifyWithAndWithoutPaginationResponse(
       String sqlQuery, String cursorQuery, int fetch_size, boolean shouldFallBackToV1)
       throws IOException {

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -255,12 +255,13 @@ public class PaginationIT extends SQLIntegTestCase {
 
   @Test
   public void testMalformedCursorGracefullyHandled() throws IOException {
-    ResponseException ex = assertThrows(
+    ResponseException result = assertThrows(
             "Expected query with malformed cursor to raise error, but didn't",
             ResponseException.class,
             () -> executeCursorQuery("d:a11b4db33f")
     );
-    assertEquals(ex.getResponse().getStatusLine().getStatusCode(), 400);
+    assertTrue(result.getMessage().contains("Malformed cursor"));
+    assertEquals(result.getResponse().getStatusLine().getStatusCode(), 400);
   }
 
   private String executeFetchQuery(String query, int fetchSize, String requestType, String filter)

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -253,17 +253,6 @@ public class PaginationIT extends SQLIntegTestCase {
     assertEquals(aliasFilteredResponse.getInt("size"), 4);
   }
 
-  @Test
-  public void testMalformedCursorGracefullyHandled() throws IOException {
-    ResponseException result = assertThrows(
-            "Expected query with malformed cursor to raise error, but didn't",
-            ResponseException.class,
-            () -> executeCursorQuery("d:a11b4db33f")
-    );
-    assertTrue(result.getMessage().contains("Malformed cursor"));
-    assertEquals(result.getResponse().getStatusLine().getStatusCode(), 400);
-  }
-
   private String executeFetchQuery(String query, int fetchSize, String requestType, String filter)
       throws IOException {
     String endpoint = "/_plugins/_sql?format=" + requestType;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/PaginationIT.java
@@ -253,6 +253,16 @@ public class PaginationIT extends SQLIntegTestCase {
     assertEquals(aliasFilteredResponse.getInt("size"), 4);
   }
 
+  @Test
+  public void testMalformedCursorGracefullyHandled() throws IOException {
+    ResponseException ex = assertThrows(
+            "Expected query with malformed cursor to raise error, but didn't",
+            ResponseException.class,
+            () -> executeCursorQuery("d:a11b4db33f")
+    );
+    assertEquals(ex.getResponse().getStatusLine().getStatusCode(), 400);
+  }
+
   private String executeFetchQuery(String query, int fetchSize, String requestType, String filter)
       throws IOException {
     String endpoint = "/_plugins/_sql?format=" + requestType;

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/cursor/CursorResultExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/cursor/CursorResultExecutor.java
@@ -60,14 +60,15 @@ public class CursorResultExecutor implements CursorRestExecutor {
     } catch (IllegalArgumentException | JSONException e) {
       Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_CUS).increment();
       LOG.error("Error parsing the cursor", e);
-      channel.sendResponse(new BytesRestResponse(
+      channel.sendResponse(
+          new BytesRestResponse(
               RestStatus.BAD_REQUEST,
               "application/json; charset=UTF-8",
               ErrorMessageFactory.createErrorMessage(
-                      new IllegalArgumentException("Malformed cursor: unable to extract cursor information"),
-                      RestStatus.BAD_REQUEST.getStatus()
-              ).toString()
-      ));
+                      new IllegalArgumentException(
+                          "Malformed cursor: unable to extract cursor information"),
+                      RestStatus.BAD_REQUEST.getStatus())
+                  .toString()));
     } catch (OpenSearchException e) {
       int status = (e.status().getStatus());
       if (status > 399 && status < 500) {

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/cursor/CursorResultExecutor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/cursor/CursorResultExecutor.java
@@ -20,6 +20,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.search.SearchHit;
@@ -36,6 +37,7 @@ import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.legacy.pit.PointInTimeHandler;
 import org.opensearch.sql.legacy.pit.PointInTimeHandlerImpl;
 import org.opensearch.sql.legacy.rewriter.matchtoterm.VerificationException;
+import org.opensearch.sql.opensearch.response.error.ErrorMessageFactory;
 
 public class CursorResultExecutor implements CursorRestExecutor {
 
@@ -58,7 +60,14 @@ public class CursorResultExecutor implements CursorRestExecutor {
     } catch (IllegalArgumentException | JSONException e) {
       Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_CUS).increment();
       LOG.error("Error parsing the cursor", e);
-      channel.sendResponse(new BytesRestResponse(channel, e));
+      channel.sendResponse(new BytesRestResponse(
+              RestStatus.BAD_REQUEST,
+              "application/json; charset=UTF-8",
+              ErrorMessageFactory.createErrorMessage(
+                      new IllegalArgumentException("Malformed cursor: unable to extract cursor information"),
+                      RestStatus.BAD_REQUEST.getStatus()
+              ).toString()
+      ));
     } catch (OpenSearchException e) {
       int status = (e.status().getStatus());
       if (status > 399 && status < 500) {


### PR DESCRIPTION
### Description
Malformed cursors currently return a 500 status with exception messages -- this PR updates it to a tidier message with a 400 status.

### Related Issues
N/A

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
