### PR TITLE
Refactor test workflow to separate bwc tests

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -40,58 +40,58 @@ jobs:
       options: --user root
 
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
 
-      - name: Build with Gradle
-        run: |
-          chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "./gradlew --continue build"
+    - name: Build with Gradle
+      run: |
+        chown -R 1000:1000 `pwd`
+        su `id -un 1000` -c "./gradlew --continue build"
 
-      - name: Create Artifact Path
-        run: |
-          mkdir -p opensearch-sql-builds
-          cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
+    - name: Create Artifact Path
+      run: |
+        mkdir -p opensearch-sql-builds
+        cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
 
-      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
-      - name: Upload SQL Coverage Report
-        if: ${{ always() }}
-        uses: codecov/codecov-action@v3
-        continue-on-error: true
-        with:
-          flags: sql-engine
-          token: ${{ secrets.CODECOV_TOKEN }}
+    # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+    - name: Upload SQL Coverage Report
+      if: ${{ always() }}
+      uses: codecov/codecov-action@v3
+      continue-on-error: true
+      with:
+        flags: sql-engine
+        token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: opensearch-sql-ubuntu-latest-${{ matrix.java }}
-          path: opensearch-sql-builds
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: opensearch-sql-ubuntu-latest-${{ matrix.java }}
+        path: opensearch-sql-builds
 
-      - name: Upload test reports
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: test-reports-ubuntu-latest-${{ matrix.java }}
-          path: |
-            sql/build/reports/**
-            ppl/build/reports/**
-            core/build/reports/**
-            common/build/reports/**
-            opensearch/build/reports/**
-            integ-test/build/reports/**
-            protocol/build/reports/**
-            legacy/build/reports/**
-            plugin/build/reports/**
-            doctest/build/testclusters/docTestCluster-0/logs/*
-            integ-test/build/testclusters/*/logs/*
+    - name: Upload test reports
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: test-reports-ubuntu-latest-${{ matrix.java }}
+        path: |
+          sql/build/reports/**
+          ppl/build/reports/**
+          core/build/reports/**
+          common/build/reports/**
+          opensearch/build/reports/**
+          integ-test/build/reports/**
+          protocol/build/reports/**
+          legacy/build/reports/**
+          plugin/build/reports/**
+          doctest/build/testclusters/docTestCluster-0/logs/*
+          integ-test/build/testclusters/*/logs/*
 
   build-windows-macos:
     strategy:
@@ -104,56 +104,56 @@ jobs:
     runs-on: ${{ matrix.entry.os }}
 
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.entry.java }}
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.entry.java }}
 
-      - name: Build with Gradle
-        run: ./gradlew --continue build ${{ matrix.entry.os_build_args }}
+    - name: Build with Gradle
+      run: ./gradlew --continue build ${{ matrix.entry.os_build_args }}
 
-      - name: Create Artifact Path
-        run: |
-          mkdir -p opensearch-sql-builds
-          cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
+    - name: Create Artifact Path
+      run: |
+        mkdir -p opensearch-sql-builds
+        cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
 
-      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
-      - name: Upload SQL Coverage Report
-        if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@v3
-        continue-on-error: true
-        with:
-          flags: sql-engine
-          token: ${{ secrets.CODECOV_TOKEN }}
+    # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+    - name: Upload SQL Coverage Report
+      if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
+      uses: codecov/codecov-action@v3
+      continue-on-error: true
+      with:
+        flags: sql-engine
+        token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: opensearch-sql-${{ matrix.entry.os }}-${{ matrix.entry.java }}
-          path: opensearch-sql-builds
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: opensearch-sql-${{ matrix.entry.os }}-${{ matrix.entry.java }}
+        path: opensearch-sql-builds
 
-      - name: Upload test reports
-        if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: test-reports-${{ matrix.entry.os }}-${{ matrix.entry.java }}
-          path: |
-            sql/build/reports/**
-            ppl/build/reports/**
-            core/build/reports/**
-            common/build/reports/**
-            opensearch/build/reports/**
-            integ-test/build/reports/**
-            protocol/build/reports/**
-            legacy/build/reports/**
-            plugin/build/reports/**
-            doctest/build/testclusters/docTestCluster-0/logs/*
-            integ-test/build/testclusters/*/logs/*
+    - name: Upload test reports
+      if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: test-reports-${{ matrix.entry.os }}-${{ matrix.entry.java }}
+        path: |
+          sql/build/reports/**
+          ppl/build/reports/**
+          core/build/reports/**
+          common/build/reports/**
+          opensearch/build/reports/**
+          integ-test/build/reports/**
+          protocol/build/reports/**
+          legacy/build/reports/**
+          plugin/build/reports/**
+          doctest/build/testclusters/docTestCluster-0/logs/*
+          integ-test/build/testclusters/*/logs/*
 
   bwc-tests:
     needs: Get-CI-Image-Tag
@@ -168,34 +168,34 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
 
-      - name: Run backward compatibility tests
-        run: |
-          chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "./scripts/bwctest.sh"
+    - name: Run backward compatibility tests
+      run: |
+        chown -R 1000:1000 `pwd`
+        su `id -un 1000` -c "./scripts/bwctest.sh"
 
-      - name: Upload test reports
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: test-reports-ubuntu-latest-${{ matrix.java }}-bwc
-          path: |
-            sql/build/reports/**
-            ppl/build/reports/**
-            core/build/reports/**
-            common/build/reports/**
-            opensearch/build/reports/**
-            integ-test/build/reports/**
-            protocol/build/reports/**
-            legacy/build/reports/**
-            plugin/build/reports/**
-            doctest/build/testclusters/docTestCluster-0/logs/*
-            integ-test/build/testclusters/*/logs/*
+    - name: Upload test reports
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: test-reports-ubuntu-latest-${{ matrix.java }}-bwc
+        path: |
+          sql/build/reports/**
+          ppl/build/reports/**
+          core/build/reports/**
+          common/build/reports/**
+          opensearch/build/reports/**
+          integ-test/build/reports/**
+          protocol/build/reports/**
+          legacy/build/reports/**
+          plugin/build/reports/**
+          doctest/build/testclusters/docTestCluster-0/logs/*
+          integ-test/build/testclusters/*/logs/*

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -22,7 +22,78 @@ jobs:
     with:
       product: opensearch
 
-  build:
+  build-linux:
+    needs: Get-CI-Image-Tag
+    strategy:
+      # Run all jobs
+      fail-fast: false
+      matrix:
+        java: [21]
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    runs-on: ubuntu-latest
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
+      options: --user root
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Build with Gradle
+        run: |
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "./gradlew --continue build"
+
+      - name: Create Artifact Path
+        run: |
+          mkdir -p opensearch-sql-builds
+          cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
+
+      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+      - name: Upload SQL Coverage Report
+        if: ${{ always() }}
+        uses: codecov/codecov-action@v3
+        continue-on-error: true
+        with:
+          flags: sql-engine
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: opensearch-sql-ubuntu-latest-${{ matrix.java }}
+          path: opensearch-sql-builds
+
+      - name: Upload test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: test-reports-ubuntu-latest-${{ matrix.java }}
+          path: |
+            sql/build/reports/**
+            ppl/build/reports/**
+            core/build/reports/**
+            common/build/reports/**
+            opensearch/build/reports/**
+            integ-test/build/reports/**
+            protocol/build/reports/**
+            legacy/build/reports/**
+            plugin/build/reports/**
+            doctest/build/testclusters/docTestCluster-0/logs/*
+            integ-test/build/testclusters/*/logs/*
+
+  build-windows-macos:
     strategy:
       # Run all jobs
       fail-fast: false
@@ -30,67 +101,59 @@ jobs:
         entry:
           - { os: windows-latest, java: 21, os_build_args: -x doctest -PbuildPlatform=windows }
           - { os: macos-13, java: 21 }
-          - { os: ubuntu-latest, java: 21 }
     runs-on: ${{ matrix.entry.os }}
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.entry.java }}
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.entry.java }}
 
-    - name: Build with Gradle
-      run: ./gradlew --continue build ${{ matrix.entry.os_build_args }}
+      - name: Build with Gradle
+        run: ./gradlew --continue build ${{ matrix.entry.os_build_args }}
 
-    - name: Create Artifact Path
-      run: |
-        mkdir -p opensearch-sql-builds
-        cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
-
-    - name: Create Artifact Path
-      run: |
-        mkdir -p opensearch-sql-builds
-        cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
+      - name: Create Artifact Path
+        run: |
+          mkdir -p opensearch-sql-builds
+          cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
 
       # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
-    - name: Upload SQL Coverage Report
-      if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
-      uses: codecov/codecov-action@v3
-      continue-on-error: true
-      with:
-        flags: sql-engine
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload SQL Coverage Report
+        if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
+        uses: codecov/codecov-action@v3
+        continue-on-error: true
+        with:
+          flags: sql-engine
+          token: ${{ secrets.CODECOV_TOKEN }}
 
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
-      continue-on-error: true
-      with:
-        name: opensearch-sql-ubuntu-latest-${{ matrix.java }}
-        path: opensearch-sql-builds
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: opensearch-sql-${{ matrix.entry.os }}-${{ matrix.entry.java }}
+          path: opensearch-sql-builds
 
-    - name: Upload test reports
-      if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
-      uses: actions/upload-artifact@v4
-      continue-on-error: true
-      with:
-        name: test-reports-ubuntu-latest-${{ matrix.java }}
-        path: |
-          sql/build/reports/**
-          ppl/build/reports/**
-          core/build/reports/**
-          common/build/reports/**
-          opensearch/build/reports/**
-          integ-test/build/reports/**
-          protocol/build/reports/**
-          legacy/build/reports/**
-          plugin/build/reports/**
-          doctest/build/testclusters/docTestCluster-0/logs/*
-          integ-test/build/testclusters/*/logs/*
+      - name: Upload test reports
+        if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: test-reports-${{ matrix.entry.os }}-${{ matrix.entry.java }}
+          path: |
+            sql/build/reports/**
+            ppl/build/reports/**
+            core/build/reports/**
+            common/build/reports/**
+            opensearch/build/reports/**
+            integ-test/build/reports/**
+            protocol/build/reports/**
+            legacy/build/reports/**
+            plugin/build/reports/**
+            doctest/build/testclusters/docTestCluster-0/logs/*
+            integ-test/build/testclusters/*/logs/*
 
   bwc-tests:
     needs: Get-CI-Image-Tag
@@ -101,6 +164,8 @@ jobs:
     container:
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       options: --user root
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -93,10 +93,14 @@ jobs:
           integ-test/build/testclusters/*/logs/*
 
   bwc-tests:
+    needs: Get-CI-Image-Tag
     runs-on: ubuntu-latest
     strategy:
       matrix:
         java: [21]
+    container:
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      options: --user root
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -22,83 +22,7 @@ jobs:
     with:
       product: opensearch
 
-  build-linux:
-    needs: Get-CI-Image-Tag
-    strategy:
-      # Run all jobs
-      fail-fast: false
-      matrix:
-        java: [21]
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-    runs-on: ubuntu-latest
-    container:
-      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
-      # this image tag is subject to change as more dependencies and updates will arrive over time
-      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java }}
-
-    - name: Build with Gradle
-      run: |
-        chown -R 1000:1000 `pwd`
-        su `id -un 1000` -c "./gradlew --continue build"
-
-    - name: Run backward compatibility tests
-      run: |
-        chown -R 1000:1000 `pwd`
-        su `id -un 1000` -c "./scripts/bwctest.sh"
-
-    - name: Create Artifact Path
-      run: |
-        mkdir -p opensearch-sql-builds
-        cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
-
-    # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
-    - name: Upload SQL Coverage Report
-      if: ${{ always() }}
-      uses: codecov/codecov-action@v3
-      continue-on-error: true
-      with:
-        flags: sql-engine
-        token: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
-      continue-on-error: true
-      with:
-        name: opensearch-sql-ubuntu-latest-${{ matrix.java }}
-        path: opensearch-sql-builds
-
-    - name: Upload test reports
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      continue-on-error: true
-      with:
-        name: test-reports-ubuntu-latest-${{ matrix.java }}
-        path: |
-          sql/build/reports/**
-          ppl/build/reports/**
-          core/build/reports/**
-          common/build/reports/**
-          opensearch/build/reports/**
-          integ-test/build/reports/**
-          protocol/build/reports/**
-          legacy/build/reports/**
-          plugin/build/reports/**
-          doctest/build/testclusters/docTestCluster-0/logs/*
-          integ-test/build/testclusters/*/logs/*
-
-  build-windows-macos:
+  build:
     strategy:
       # Run all jobs
       fail-fast: false
@@ -106,7 +30,10 @@ jobs:
         entry:
           - { os: windows-latest, java: 21, os_build_args: -x doctest -PbuildPlatform=windows }
           - { os: macos-13, java: 21 }
+          - { os: ubuntu-latest, java: 21 }
     runs-on: ${{ matrix.entry.os }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - uses: actions/checkout@v3
@@ -125,7 +52,12 @@ jobs:
         mkdir -p opensearch-sql-builds
         cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
 
-    # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
+    - name: Create Artifact Path
+      run: |
+        mkdir -p opensearch-sql-builds
+        cp -r ./plugin/build/distributions/*.zip opensearch-sql-builds/
+
+      # This step uses the codecov-action Github action: https://github.com/codecov/codecov-action
     - name: Upload SQL Coverage Report
       if: ${{ always() && matrix.entry.os == 'ubuntu-latest' }}
       uses: codecov/codecov-action@v3
@@ -138,7 +70,7 @@ jobs:
       uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
-        name: opensearch-sql-${{ matrix.entry.os }}-${{ matrix.entry.java }}
+        name: opensearch-sql-ubuntu-latest-${{ matrix.java }}
         path: opensearch-sql-builds
 
     - name: Upload test reports
@@ -146,7 +78,7 @@ jobs:
       uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
-        name: test-reports-${{ matrix.entry.os }}-${{ matrix.entry.java }}
+        name: test-reports-ubuntu-latest-${{ matrix.java }}
         path: |
           sql/build/reports/**
           ppl/build/reports/**
@@ -159,3 +91,42 @@ jobs:
           plugin/build/reports/**
           doctest/build/testclusters/docTestCluster-0/logs/*
           integ-test/build/testclusters/*/logs/*
+
+  bwc-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [21]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Run backward compatibility tests
+        run: |
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "./scripts/bwctest.sh"
+
+      - name: Upload test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: test-reports-ubuntu-latest-${{ matrix.java }}-bwc
+          path: |
+            sql/build/reports/**
+            ppl/build/reports/**
+            core/build/reports/**
+            common/build/reports/**
+            opensearch/build/reports/**
+            integ-test/build/reports/**
+            protocol/build/reports/**
+            legacy/build/reports/**
+            plugin/build/reports/**
+            doctest/build/testclusters/docTestCluster-0/logs/*
+            integ-test/build/testclusters/*/logs/*

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
@@ -393,7 +393,7 @@ public class CursorIT extends SQLIntegTestCase {
 
     JSONObject resp = new JSONObject(TestUtils.getResponseBody(response));
     assertThat(resp.getInt("status"), equalTo(400));
-    assertThat(resp.query("/error/type"), equalTo("illegal_argument_exception"));
+    assertThat(resp.query("/error/type"), equalTo("IllegalArgumentException"));
   }
 
   /**


### PR DESCRIPTION
### Description
Makes linux test failures more visible by splitting out the failing BWC tests to their own action. I'm not sure how to fix the BWC tests, I've been told they start failing semi-regularly due to external factors so it seems like it's a wise decision to keep it separate from more reliable tests.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
