### PR TITLE
Add FILLNULL command in PPL (#3032)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -559,7 +559,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
     return new LogicalAD(child, options);
   }
 
-  /** Build {@link LogicalAD} for fillnull command. */
+  /** Build {@link LogicalEval} for fillnull command. */
   @Override
   public LogicalPlan visitFillNull(final FillNull node, final AnalysisContext context) {
     LogicalPlan child = node.getChild().get(0).accept(this, context);

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -45,6 +45,7 @@ import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.Dedupe;
 import org.opensearch.sql.ast.tree.Eval;
 import org.opensearch.sql.ast.tree.FetchCursor;
+import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Kmeans;
@@ -311,5 +312,9 @@ public abstract class AbstractNodeVisitor<T, C> {
 
   public T visitCloseCursor(CloseCursor closeCursor, C context) {
     return visitChildren(closeCursor, context);
+  }
+
+  public T visitFillNull(FillNull fillNull, C context) {
+    return visitChildren(fillNull, context);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -5,10 +5,12 @@
 
 package org.opensearch.sql.ast.dsl;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Alias;
@@ -46,6 +48,7 @@ import org.opensearch.sql.ast.expression.Xor;
 import org.opensearch.sql.ast.tree.Aggregation;
 import org.opensearch.sql.ast.tree.Dedupe;
 import org.opensearch.sql.ast.tree.Eval;
+import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Limit;
@@ -470,5 +473,23 @@ public class AstDSL {
       Literal pattern,
       java.util.Map<String, Literal> arguments) {
     return new Parse(parseMethod, sourceField, pattern, arguments, input);
+  }
+
+  public static FillNull fillNull(UnresolvedExpression replaceNullWithMe, Field... fields) {
+    return new FillNull(
+        FillNull.ContainNullableFieldFill.ofSameValue(
+            replaceNullWithMe, ImmutableList.copyOf(fields)));
+  }
+
+  public static FillNull fillNull(
+      List<ImmutablePair<Field, UnresolvedExpression>> fieldAndReplacements) {
+    ImmutableList.Builder<FillNull.NullableFieldFill> replacementsBuilder = ImmutableList.builder();
+    for (ImmutablePair<Field, UnresolvedExpression> fieldAndReplacement : fieldAndReplacements) {
+      replacementsBuilder.add(
+          new FillNull.NullableFieldFill(
+              fieldAndReplacement.getLeft(), fieldAndReplacement.getRight()));
+    }
+    return new FillNull(
+        FillNull.ContainNullableFieldFill.ofVariousValue(replacementsBuilder.build()));
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/tree/FillNull.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/FillNull.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import java.util.List;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class FillNull extends UnresolvedPlan {
+
+  @Getter
+  @RequiredArgsConstructor
+  public static class NullableFieldFill {
+    @NonNull private final Field nullableFieldReference;
+    @NonNull private final UnresolvedExpression replaceNullWithMe;
+  }
+
+  public interface ContainNullableFieldFill {
+    List<NullableFieldFill> getNullFieldFill();
+
+    static ContainNullableFieldFill ofVariousValue(List<NullableFieldFill> replacements) {
+      return new VariousValueNullFill(replacements);
+    }
+
+    static ContainNullableFieldFill ofSameValue(
+        UnresolvedExpression replaceNullWithMe, List<Field> nullableFieldReferences) {
+      return new SameValueNullFill(replaceNullWithMe, nullableFieldReferences);
+    }
+  }
+
+  private static class SameValueNullFill implements ContainNullableFieldFill {
+    @Getter(onMethod_ = @Override)
+    private final List<NullableFieldFill> nullFieldFill;
+
+    public SameValueNullFill(
+        UnresolvedExpression replaceNullWithMe, List<Field> nullableFieldReferences) {
+      Objects.requireNonNull(replaceNullWithMe, "Null replacement is required");
+      this.nullFieldFill =
+          Objects.requireNonNull(nullableFieldReferences, "Nullable field reference is required")
+              .stream()
+              .map(nullableReference -> new NullableFieldFill(nullableReference, replaceNullWithMe))
+              .toList();
+    }
+  }
+
+  @RequiredArgsConstructor
+  private static class VariousValueNullFill implements ContainNullableFieldFill {
+    @NonNull
+    @Getter(onMethod_ = @Override)
+    private final List<NullableFieldFill> nullFieldFill;
+  }
+
+  private UnresolvedPlan child;
+
+  @NonNull private final ContainNullableFieldFill containNullableFieldFill;
+
+  public List<NullableFieldFill> getNullableFieldFills() {
+    return containNullableFieldFill.getNullFieldFill();
+  }
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    this.child = child;
+    return this;
+  }
+
+  @Override
+  public List<? extends Node> getChild() {
+    return child == null ? List.of() : List.of(child);
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitFillNull(this, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/ast/tree/FillNull.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/FillNull.java
@@ -16,6 +16,7 @@ import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
+/** AST node represent FillNull operation. */
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class FillNull extends UnresolvedPlan {

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -73,6 +73,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.HighlightFunction;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.ParseMethod;
@@ -81,6 +82,7 @@ import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.AD;
 import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.FetchCursor;
+import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.ML;
 import org.opensearch.sql.ast.tree.Paginate;
@@ -1435,6 +1437,48 @@ class AnalyzerTest extends AnalyzerTestBase {
     assertAnalyzeEqual(
         new LogicalMLCommons(LogicalPlanDSL.relation("schema", table), "kmeans", argumentMap),
         new Kmeans(AstDSL.relation("schema"), argumentMap));
+  }
+
+  @Test
+  public void fillnull_same_value() {
+    assertAnalyzeEqual(
+        LogicalPlanDSL.eval(
+            LogicalPlanDSL.relation("schema", table),
+            ImmutablePair.of(
+                DSL.ref("integer_value", INTEGER),
+                DSL.ifnull(DSL.ref("integer_value", INTEGER), DSL.literal(0))),
+            ImmutablePair.of(
+                DSL.ref("int_null_value", INTEGER),
+                DSL.ifnull(DSL.ref("int_null_value", INTEGER), DSL.literal(0)))),
+        new FillNull(
+            AstDSL.relation("schema"),
+            FillNull.ContainNullableFieldFill.ofSameValue(
+                AstDSL.intLiteral(0),
+                ImmutableList.<Field>builder()
+                    .add(AstDSL.field("integer_value"))
+                    .add(AstDSL.field("int_null_value"))
+                    .build())));
+  }
+
+  @Test
+  public void fillnull_various_values() {
+    assertAnalyzeEqual(
+        LogicalPlanDSL.eval(
+            LogicalPlanDSL.relation("schema", table),
+            ImmutablePair.of(
+                DSL.ref("integer_value", INTEGER),
+                DSL.ifnull(DSL.ref("integer_value", INTEGER), DSL.literal(0))),
+            ImmutablePair.of(
+                DSL.ref("int_null_value", INTEGER),
+                DSL.ifnull(DSL.ref("int_null_value", INTEGER), DSL.literal(1)))),
+        new FillNull(
+            AstDSL.relation("schema"),
+            FillNull.ContainNullableFieldFill.ofVariousValue(
+                ImmutableList.of(
+                    new FillNull.NullableFieldFill(
+                        AstDSL.field("integer_value"), AstDSL.intLiteral(0)),
+                    new FillNull.NullableFieldFill(
+                        AstDSL.field("int_null_value"), AstDSL.intLiteral(1))))));
   }
 
   @Test

--- a/docs/category.json
+++ b/docs/category.json
@@ -14,6 +14,7 @@
     "user/ppl/cmd/information_schema.rst",
     "user/ppl/cmd/eval.rst",
     "user/ppl/cmd/fields.rst",
+    "user/ppl/cmd/fillnull.rst",
     "user/ppl/cmd/grok.rst",
     "user/ppl/cmd/head.rst",
     "user/ppl/cmd/parse.rst",

--- a/docs/user/ppl/cmd/fillnull.rst
+++ b/docs/user/ppl/cmd/fillnull.rst
@@ -51,16 +51,16 @@ The example show to replace null values for email with "<not found>" and null va
 
 PPL query::
 
-    os> source=accounts | fields email, host | fillnull using email = '<not found>', host = '<no host>' ;
+    os> source=accounts | fields email, employer | fillnull using email = '<not found>', employer = '<no employer>' ;
     fetched rows / total rows = 4/4
-    +-----------------------+------------+
-    | email                 | host       |
-    |-----------------------+------------|
-    | amberduke@pyrami.com  | pyrami.com |
-    | hattiebond@netagy.com | netagy.com |
-    | <not found>           |            |
-    | daleadams@boink.com   | boink.com  |
-    +-----------------------+------------+
+    +-----------------------+---------------+
+    | email                 | employer      |
+    |-----------------------+---------------|
+    | amberduke@pyrami.com  | Pyrami        |
+    | hattiebond@netagy.com | Netagy        |
+    | <not found>           | Quility       |
+    | daleadams@boink.com   | <no employer> |
+    +-----------------------+---------------+
 
 Limitation
 ==========

--- a/docs/user/ppl/cmd/fillnull.rst
+++ b/docs/user/ppl/cmd/fillnull.rst
@@ -33,16 +33,16 @@ The example show to replace null values for email and host with "<not found>".
 
 PPL query::
 
-    os> source=accounts | fields email, host | fillnull with '<not found>' email, host ;
+    os> source=accounts | fields email, employer | fillnull with '<not found>' in email ;
     fetched rows / total rows = 4/4
-    +-----------------------+------------+
-    | email                 | host       |
-    |-----------------------+------------|
-    | amberduke@pyrami.com  | pyrami.com |
-    | hattiebond@netagy.com | netagy.com |
-    | <not found>           |            |
-    | daleadams@boink.com   | boink.com  |
-    +-----------------------+------------+
+    +-----------------------+----------+
+    | email                 | employer |
+    |-----------------------+----------|
+    | amberduke@pyrami.com  | Pyrami   |
+    | hattiebond@netagy.com | Netagy   |
+    | <not found>           | Quility  |
+    | daleadams@boink.com   | null     |
+    +-----------------------+----------+
 
 Example 2: Replace null values for multiple fields with different values
 ========================================================================

--- a/docs/user/ppl/cmd/fillnull.rst
+++ b/docs/user/ppl/cmd/fillnull.rst
@@ -11,25 +11,20 @@ fillnull
 
 Description
 ============
-| The ``fillnull`` command replaces null values for one or more fields.
+Using ``fillnull`` command to fill null with provided value in one or more fields in the search result.
 
 
 Syntax
 ============
-fillnull "with" <expression> <field> ["," <field> ]...
+`fillnull [with <null-replacement> in <nullable-field>["," <nullable-field>]] | [using <source-field> = <null-replacement> [","<source-field> = <null-replacement>]]`
 
-* field: mandatory. Name of an existing field that was piped into ``fillnull``. Null values for all specified fields are replaced with the value of expression.
-* expression: mandatory. Any expression support by the system. The expression value type must match the type of field.
+* null-replacement: mandatory. The value used to replace `null`s.
+* nullable-field: mandatory. Field reference. The `null` values in the field referred to by the property will be replaced with the values from the null-replacement.
 
-fillnull "using" <field> "=" <expression> ["," <field> "=" <expression> ]...
-
-* field: mandatory. Name of an existing field that was piped into ``fillnull``.
-* expression: mandatory. Any expression support by the system. The expression value type must match the type of field.
-
-Example 1: Replace null values with the same value for multiple fields
+Example 1: fillnull one field
 ======================================================================
 
-The example show to replace null values for email and host with "<not found>".
+The example show fillnull one field.
 
 PPL query::
 
@@ -44,10 +39,10 @@ PPL query::
     | daleadams@boink.com   | null     |
     +-----------------------+----------+
 
-Example 2: Replace null values for multiple fields with different values
+Example 2: fillnull applied to multiple fields
 ========================================================================
 
-The example show to replace null values for email with "<not found>" and null values for host with "<no host>".
+The example show fillnull applied to multiple fields.
 
 PPL query::
 

--- a/docs/user/ppl/cmd/fillnull.rst
+++ b/docs/user/ppl/cmd/fillnull.rst
@@ -1,0 +1,67 @@
+=============
+fillnull
+=============
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Description
+============
+| The ``fillnull`` command replaces null values for one or more fields.
+
+
+Syntax
+============
+fillnull "with" <expression> <field> ["," <field> ]...
+
+* field: mandatory. Name of an existing field that was piped into ``fillnull``. Null values for all specified fields are replaced with the value of expression.
+* expression: mandatory. Any expression support by the system. The expression value type must match the type of field.
+
+fillnull "using" <field> "=" <expression> ["," <field> "=" <expression> ]...
+
+* field: mandatory. Name of an existing field that was piped into ``fillnull``.
+* expression: mandatory. Any expression support by the system. The expression value type must match the type of field.
+
+Example 1: Replace null values with the same value for multiple fields
+======================================================================
+
+The example show to replace null values for email and host with "<not found>".
+
+PPL query::
+
+    os> source=accounts | fields email, host | fillnull with '<not found>' email, host ;
+    fetched rows / total rows = 4/4
+    +-----------------------+------------+
+    | email                 | host       |
+    |-----------------------+------------|
+    | amberduke@pyrami.com  | pyrami.com |
+    | hattiebond@netagy.com | netagy.com |
+    | <not found>           |            |
+    | daleadams@boink.com   | boink.com  |
+    +-----------------------+------------+
+
+Example 2: Replace null values for multiple fields with different values
+========================================================================
+
+The example show to replace null values for email with "<not found>" and null values for host with "<no host>".
+
+PPL query::
+
+    os> source=accounts | fields email, host | fillnull using email = '<not found>', host = '<no host>' ;
+    fetched rows / total rows = 4/4
+    +-----------------------+------------+
+    | email                 | host       |
+    |-----------------------+------------|
+    | amberduke@pyrami.com  | pyrami.com |
+    | hattiebond@netagy.com | netagy.com |
+    | <not found>           |            |
+    | daleadams@boink.com   | boink.com  |
+    +-----------------------+------------+
+
+Limitation
+==========
+The ``fillnull`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
@@ -89,6 +89,18 @@ public class ExplainIT extends PPLIntegTestCase {
                 + "| fields ageMinus"));
   }
 
+  @Test
+  public void testFillNullPushDownExplain() throws Exception {
+    String expected = loadFromFile("expectedOutput/ppl/explain_fillnull_push.json");
+
+    assertJsonEquals(
+        expected,
+        explainQueryToString(
+            "source=opensearch-sql_test_index_account"
+                + "| fields age, balance "
+                + "| fillnull with -1 in age,balance"));
+  }
+
   String loadFromFile(String filename) throws Exception {
     URI uri = Resources.getResource(filename).toURI();
     return new String(Files.readAllBytes(Paths.get(uri)));

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
@@ -97,8 +97,7 @@ public class ExplainIT extends PPLIntegTestCase {
         expected,
         explainQueryToString(
             "source=opensearch-sql_test_index_account"
-                + "| fields age, balance "
-                + "| fillnull with -1 in age,balance"));
+                + " | fillnull with -1 in age,balance | fields age, balance"));
   }
 
   String loadFromFile(String filename) throws Exception {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/FillNullCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/FillNullCommandIT.java
@@ -127,4 +127,88 @@ public class FillNullCommandIT extends PPLIntegTestCase {
         rows(-1, 10.98),
         rows(-1, 7.87));
   }
+
+  @Test
+  public void testFillNullWithOtherField() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | fillnull using num0 = num1 | fields str2, num0", TEST_INDEX_CALCS));
+    verifyDataRows(
+        result,
+        rows("one", 12.3),
+        rows("two", -12.3),
+        rows("three", 15.7),
+        rows(null, -15.7),
+        rows("five", 3.5),
+        rows("six", -3.5),
+        rows(null, 0),
+        rows("eight", 11.38),
+        rows("nine", 10),
+        rows("ten", 12.4),
+        rows("eleven", 10.32),
+        rows("twelve", 2.47),
+        rows(null, 12.05),
+        rows("fourteen", 10.37),
+        rows("fifteen", 7.1),
+        rows("sixteen", 16.81),
+        rows(null, 7.12));
+  }
+
+  @Test
+  public void testFillNullWithFunctionOnOtherField() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | fillnull with ceil(num1) in num0 | fields str2, num0",
+                TEST_INDEX_CALCS));
+    verifyDataRows(
+        result,
+        rows("one", 12.3),
+        rows("two", -12.3),
+        rows("three", 15.7),
+        rows(null, -15.7),
+        rows("five", 3.5),
+        rows("six", -3.5),
+        rows(null, 0),
+        rows("eight", 12),
+        rows("nine", 10),
+        rows("ten", 13),
+        rows("eleven", 11),
+        rows("twelve", 3),
+        rows(null, 13),
+        rows("fourteen", 11),
+        rows("fifteen", 8),
+        rows("sixteen", 17),
+        rows(null, 8));
+  }
+
+  @Test
+  public void testFillNullWithFunctionMultipleCommands() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | fillnull with num1 in num0 | fields str2, num0 | fillnull with"
+                    + " 'unknown' in str2",
+                TEST_INDEX_CALCS));
+    verifyDataRows(
+        result,
+        rows("one", 12.3),
+        rows("two", -12.3),
+        rows("three", 15.7),
+        rows("unknown", -15.7),
+        rows("five", 3.5),
+        rows("six", -3.5),
+        rows("unknown", 0),
+        rows("eight", 11.38),
+        rows("nine", 10),
+        rows("ten", 12.4),
+        rows("eleven", 10.32),
+        rows("twelve", 2.47),
+        rows("unknown", 12.05),
+        rows("fourteen", 10.37),
+        rows("fifteen", 7.1),
+        rows("sixteen", 16.81),
+        rows("unknown", 7.12));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/FillNullCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/FillNullCommandIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CALCS;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+public class FillNullCommandIT extends PPLIntegTestCase {
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.CALCS);
+  }
+
+  @Test
+  public void testFillNullSameValueOneField() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | fields str2, num0 | fillnull with -1 in num0", TEST_INDEX_CALCS));
+    verifyDataRows(
+        result,
+        rows("one", 12.3),
+        rows("two", -12.3),
+        rows("three", 15.7),
+        rows(null, -15.7),
+        rows("five", 3.5),
+        rows("six", -3.5),
+        rows(null, 0),
+        rows("eight", -1),
+        rows("nine", 10),
+        rows("ten", -1),
+        rows("eleven", -1),
+        rows("twelve", -1),
+        rows(null, -1),
+        rows("fourteen", -1),
+        rows("fifteen", -1),
+        rows("sixteen", -1),
+        rows(null, -1));
+  }
+
+  @Test
+  public void testFillNullSameValueTwoFields() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | fields num0, num2 | fillnull with -1 in num0,num2", TEST_INDEX_CALCS));
+    verifyDataRows(
+        result,
+        rows(12.3, 17.86),
+        rows(-12.3, 16.73),
+        rows(15.7, -1),
+        rows(-15.7, 8.51),
+        rows(3.5, 6.46),
+        rows(-3.5, 8.98),
+        rows(0, 11.69),
+        rows(-1, 17.25),
+        rows(10, -1),
+        rows(-1, 11.5),
+        rows(-1, 6.8),
+        rows(-1, 3.79),
+        rows(-1, -1),
+        rows(-1, 13.04),
+        rows(-1, -1),
+        rows(-1, 10.98),
+        rows(-1, 7.87));
+  }
+
+  @Test
+  public void testFillNullVariousValuesOneField() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | fields str2, num0 | fillnull using num0 = -1", TEST_INDEX_CALCS));
+    verifyDataRows(
+        result,
+        rows("one", 12.3),
+        rows("two", -12.3),
+        rows("three", 15.7),
+        rows(null, -15.7),
+        rows("five", 3.5),
+        rows("six", -3.5),
+        rows(null, 0),
+        rows("eight", -1),
+        rows("nine", 10),
+        rows("ten", -1),
+        rows("eleven", -1),
+        rows("twelve", -1),
+        rows(null, -1),
+        rows("fourteen", -1),
+        rows("fifteen", -1),
+        rows("sixteen", -1),
+        rows(null, -1));
+  }
+
+  @Test
+  public void testFillNullVariousValuesTwoFields() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | fields num0, num2 | fillnull using num0 = -1, num2 = -2",
+                TEST_INDEX_CALCS));
+    verifyDataRows(
+        result,
+        rows(12.3, 17.86),
+        rows(-12.3, 16.73),
+        rows(15.7, -2),
+        rows(-15.7, 8.51),
+        rows(3.5, 6.46),
+        rows(-3.5, 8.98),
+        rows(0, 11.69),
+        rows(-1, 17.25),
+        rows(10, -2),
+        rows(-1, 11.5),
+        rows(-1, 6.8),
+        rows(-1, 3.79),
+        rows(-1, -2),
+        rows(-1, 13.04),
+        rows(-1, -2),
+        rows(-1, 10.98),
+        rows(-1, 7.87));
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_fillnull_push.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_fillnull_push.json
@@ -1,0 +1,36 @@
+{
+  "root": {
+    "name": "ProjectOperator",
+    "description": {
+      "fields": "[age, balance]"
+    },
+    "children": [
+      {
+        "name":"EvalOperator",
+        "description": {
+          "expressions": {
+            "balance": "ifnull(balance, -1)",
+            "age":"ifnull(age, -1)"
+          }
+        },
+        "children": [
+          {
+            "name": "ProjectOperator",
+            "description": {
+              "fields": "[age, balance]"
+            },
+            "children": [
+              {
+                "name": "OpenSearchIndexScan",
+                "description": {
+                  "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"balance\",\"age\"],\"excludes\":[]}}, needClean=true, searchDone=false, pitId=null, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
+                },
+                "children": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_fillnull_push.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_fillnull_push.json
@@ -6,11 +6,11 @@
     },
     "children": [
       {
-        "name":"EvalOperator",
+        "name": "EvalOperator",
         "description": {
           "expressions": {
             "balance": "ifnull(balance, -1)",
-            "age":"ifnull(age, -1)"
+            "age": "ifnull(age, -1)"
           }
         },
         "children": [
@@ -23,7 +23,7 @@
               {
                 "name": "OpenSearchIndexScan",
                 "description": {
-                  "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"balance\",\"age\"],\"excludes\":[]}}, needClean=true, searchDone=false, pitId=null, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
+                  "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\",\"balance\"],\"excludes\":[]}}, needClean=true, searchDone=false, pitId=null, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
                 },
                 "children": []
               }

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_fillnull_push.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_fillnull_push.json
@@ -15,19 +15,11 @@
         },
         "children": [
           {
-            "name": "ProjectOperator",
+            "name": "OpenSearchIndexScan",
             "description": {
-              "fields": "[age, balance]"
+              "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\"}, needClean=true, searchDone=false, pitId=null, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
             },
-            "children": [
-              {
-                "name": "OpenSearchIndexScan",
-                "description": {
-                  "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\",\"balance\"],\"excludes\":[]}}, needClean=true, searchDone=false, pitId=null, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-                },
-                "children": []
-              }
-            ]
+            "children": []
           }
         ]
       }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -35,6 +35,7 @@ NEW_FIELD:                          'NEW_FIELD';
 KMEANS:                             'KMEANS';
 AD:                                 'AD';
 ML:                                 'ML';
+FILLNULL:                           'FILLNULL';
 
 // COMMAND ASSIST KEYWORDS
 AS:                                 'AS';
@@ -44,6 +45,8 @@ INDEX:                              'INDEX';
 D:                                  'D';
 DESC:                               'DESC';
 DATASOURCES:                        'DATASOURCES';
+USING:                              'USING';
+WITH:                               'WITH';
 
 // CLAUSE KEYWORDS
 SORTBY:                             'SORTBY';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -134,19 +134,15 @@ fillnullCommand
    ;
 
 fillNullWithTheSameValue
-   : WITH nullReplacement IN nullableField (COMMA nullableField)*
+   : WITH nullReplacement = valueExpression IN nullableFieldList = fieldList
    ;
 
 fillNullWithFieldVariousValues
-   : USING nullableField EQUAL nullReplacement (COMMA nullableField EQUAL nullReplacement)*
+   : USING nullReplacementExpression (COMMA nullReplacementExpression)*
    ;
 
-nullableField
-   : fieldExpression
-   ;
-
-nullReplacement
-   : valueExpression
+nullReplacementExpression
+   : nullableField = fieldExpression EQUAL nullReplacement = valueExpression
    ;
 
 kmeansCommand

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -865,6 +865,7 @@ keywordsCanBeId
    | DEDUP
    | SORT
    | EVAL
+   | FILLNULL
    | HEAD
    | TOP
    | RARE

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -146,7 +146,7 @@ nullableField
    ;
 
 nullReplacement
-   : expression
+   : valueExpression
    ;
 
 kmeansCommand

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -49,6 +49,7 @@ commands
    | kmeansCommand
    | adCommand
    | mlCommand
+   | fillnullCommand
    ;
 
 searchCommand
@@ -125,6 +126,27 @@ patternsParameter
 patternsMethod
    : PUNCT
    | REGEX
+   ;
+
+fillnullCommand
+   : FILLNULL (fillNullWithTheSameValue
+   | fillNullWithFieldVariousValues)
+   ;
+
+fillNullWithTheSameValue
+   : WITH nullReplacement IN nullableField (COMMA nullableField)*
+   ;
+
+fillNullWithFieldVariousValues
+   : USING nullableField EQUAL nullReplacement (COMMA nullableField EQUAL nullReplacement)*
+   ;
+
+nullableField
+   : fieldExpression
+   ;
+
+nullReplacement
+   : expression
    ;
 
 kmeansCommand

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -399,8 +399,10 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
       OpenSearchPPLParser.FillNullWithTheSameValueContext ctx) {
     return new FillNull(
         FillNull.ContainNullableFieldFill.ofSameValue(
-            internalVisitExpression(ctx.nullReplacement()),
-            ctx.nullableField().stream().map(f -> (Field) internalVisitExpression(f)).toList()));
+            internalVisitExpression(ctx.nullReplacement),
+            ctx.nullableFieldList.fieldExpression().stream()
+                .map(f -> (Field) internalVisitExpression(f))
+                .toList()));
   }
 
   /** fillnull command. */
@@ -408,11 +410,11 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   public UnresolvedPlan visitFillNullWithFieldVariousValues(
       OpenSearchPPLParser.FillNullWithFieldVariousValuesContext ctx) {
     ImmutableList.Builder<FillNull.NullableFieldFill> replacementsBuilder = ImmutableList.builder();
-    for (int i = 0; i < ctx.nullableField().size(); i++) {
+    for (int i = 0; i < ctx.nullReplacementExpression().size(); i++) {
       replacementsBuilder.add(
           new FillNull.NullableFieldFill(
-              (Field) internalVisitExpression(ctx.nullableField(i)),
-              internalVisitExpression(ctx.nullReplacement(i))));
+              (Field) internalVisitExpression(ctx.nullReplacementExpression(i).nullableField),
+              internalVisitExpression(ctx.nullReplacementExpression(i).nullReplacement)));
     }
 
     return new FillNull(

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -247,7 +247,7 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
           firstReplacement,
           node.getNullableFieldFills().stream()
               .map(n -> visitExpression(n.getNullableFieldReference()))
-              .collect(Collectors.joining(",")));
+              .collect(Collectors.joining(", ")));
     } else {
       return StringUtils.format(
           "%s | fillnull using %s",

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -421,7 +421,7 @@ public class PPLSyntaxParserTest {
   @Test
   public void testCanParseFillNullSameValue() {
     assertNotNull(new PPLSyntaxParser().parse("SOURCE=test | fillnull with 0 in a"));
-    assertNotNull(new PPLSyntaxParser().parse("SOURCE=test | fillnull with 0 in a,b"));
+    assertNotNull(new PPLSyntaxParser().parse("SOURCE=test | fillnull with 0 in a, b"));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -417,4 +417,16 @@ public class PPLSyntaxParserTest {
         new PPLSyntaxParser()
             .parse("SOURCE=test | eval k = TIMESTAMPDIFF(WEEK,'2003-01-02','2003-01-02')"));
   }
+
+  @Test
+  public void testCanParseFillNullSameValue() {
+    assertNotNull(new PPLSyntaxParser().parse("SOURCE=test | fillnull with 0 in a"));
+    assertNotNull(new PPLSyntaxParser().parse("SOURCE=test | fillnull with 0 in a,b"));
+  }
+
+  @Test
+  public void testCanParseFillNullVariousValues() {
+    assertNotNull(new PPLSyntaxParser().parse("SOURCE=test | fillnull using a = 0"));
+    assertNotNull(new PPLSyntaxParser().parse("SOURCE=test | fillnull using a = 0, b = 1"));
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -42,6 +42,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.unresolvedArg;
 import static org.opensearch.sql.utils.SystemIndexUtils.DATASOURCES_TABLE_NAME;
 import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import org.junit.Ignore;
@@ -50,10 +51,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.ParseMethod;
 import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.AD;
+import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.ML;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
@@ -658,6 +661,35 @@ public class AstBuilderTest {
                 .put("iteration", new Literal(2, DataType.INTEGER))
                 .put("dist_type", new Literal("l1", DataType.STRING))
                 .build()));
+  }
+
+  @Test
+  public void testFillNullCommandSameValue() {
+    assertEqual(
+        "source=t | fillnull with 0 in a,b,c",
+        new FillNull(
+            relation("t"),
+            FillNull.ContainNullableFieldFill.ofSameValue(
+                intLiteral(0),
+                ImmutableList.<Field>builder()
+                    .add(field("a"))
+                    .add(field("b"))
+                    .add(field("c"))
+                    .build())));
+  }
+
+  @Test
+  public void testFillNullCommandVariousValues() {
+    assertEqual(
+        "source=t | fillnull using a = 1, b = 2, c = 3",
+        new FillNull(
+            relation("t"),
+            FillNull.ContainNullableFieldFill.ofVariousValue(
+                ImmutableList.<FillNull.NullableFieldFill>builder()
+                    .add(new FillNull.NullableFieldFill(field("a"), intLiteral(1)))
+                    .add(new FillNull.NullableFieldFill(field("b"), intLiteral(2)))
+                    .add(new FillNull.NullableFieldFill(field("c"), intLiteral(3)))
+                    .build())));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -666,7 +666,7 @@ public class AstBuilderTest {
   @Test
   public void testFillNullCommandSameValue() {
     assertEqual(
-        "source=t | fillnull with 0 in a,b,c",
+        "source=t | fillnull with 0 in a, b, c",
         new FillNull(
             relation("t"),
             FillNull.ContainNullableFieldFill.ofSameValue(

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -106,6 +106,19 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testFillNullSameValue() {
+    assertEquals(
+        "source=t | fillnull with 0 in f1,f2", anonymize("source=t | fillnull with 0 in f1,f2"));
+  }
+
+  @Test
+  public void testFillNullVariousValues() {
+    assertEquals(
+        "source=t | fillnull using f1 = 0, f2 = -1",
+        anonymize("source=t | fillnull using f1 = 0, f2 = -1"));
+  }
+
+  @Test
   public void testRareCommandWithGroupBy() {
     assertEquals("source=t | rare 10 a by b", anonymize("source=t | rare a by b"));
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -108,7 +108,7 @@ public class PPLQueryDataAnonymizerTest {
   @Test
   public void testFillNullSameValue() {
     assertEquals(
-        "source=t | fillnull with 0 in f1,f2", anonymize("source=t | fillnull with 0 in f1,f2"));
+        "source=t | fillnull with 0 in f1, f2", anonymize("source=t | fillnull with 0 in f1, f2"));
   }
 
   @Test


### PR DESCRIPTION
### Description
Adds the FILLNULL command for PPL. FILLNULL will replace NULL values in specified fields.

### Related Issues
Resolves #3032
Based on this PR for Spark: https://github.com/opensearch-project/opensearch-spark/pull/723

### Check List
- [Y] New functionality includes testing.
- [Y] New functionality has been documented.
- [Y] New functionality has javadoc added.
- [Y] New functionality has a user manual doc added.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [Y] Commits are signed per the DCO using `--signoff`.
- [Y] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

An example query using fillnull.
```
    os> source=accounts | fields email, employer | fillnull with '<not found>' in email ;
    fetched rows / total rows = 4/4
    +-----------------------+----------+
    | email                 | employer |
    |-----------------------+----------|
    | amberduke@pyrami.com  | Pyrami   |
    | hattiebond@netagy.com | Netagy   |
    | <not found>           | Quility  |
    | daleadams@boink.com   | null     |
    +-----------------------+----------+
```