### PR TITLE
Fix a regression issue of parsing datetime string with custom time format in Span

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
@@ -46,13 +46,13 @@ public abstract class Rounding<T> {
     if (DOUBLE.isCompatible(type)) {
       return new DoubleRounding(interval);
     }
-    if (type.equals(TIMESTAMP)) {
+    if (type.equals(TIMESTAMP) || type.typeName().equalsIgnoreCase(TIMESTAMP.typeName())) {
       return new TimestampRounding(interval, span.getUnit().getName());
     }
-    if (type.equals(DATE)) {
+    if (type.equals(DATE) || type.typeName().equalsIgnoreCase(DATE.typeName())) {
       return new DateRounding(interval, span.getUnit().getName());
     }
-    if (type.equals(TIME)) {
+    if (type.equals(TIME) || type.typeName().equalsIgnoreCase(TIME.typeName())) {
       return new TimeRounding(interval, span.getUnit().getName());
     }
     return new UnknownRounding();

--- a/core/src/test/java/org/opensearch/sql/planner/physical/collector/RoundingTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/collector/RoundingTest.java
@@ -5,14 +5,18 @@
 
 package org.opensearch.sql.planner.physical.collector;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.sql.data.type.ExprCoreType.DATE;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.data.type.ExprCoreType.TIME;
+import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.span.SpanExpression;
@@ -24,6 +28,35 @@ public class RoundingTest {
     Rounding rounding = Rounding.createRounding(span);
     assertThrows(
         ExpressionEvaluationException.class, () -> rounding.round(new ExprTimeValue("23:30:00")));
+  }
+
+  @Test
+  void datetime_rounding_span() {
+    SpanExpression dateSpan = DSL.span(DSL.ref("date", DATE), DSL.literal(1), "d");
+    Rounding rounding = Rounding.createRounding(dateSpan);
+    assertInstanceOf(Rounding.DateRounding.class, rounding);
+    SpanExpression timeSpan = DSL.span(DSL.ref("time", TIME), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(timeSpan);
+    assertInstanceOf(Rounding.TimeRounding.class, rounding);
+    SpanExpression timestampSpan = DSL.span(DSL.ref("timestamp", TIMESTAMP), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(timestampSpan);
+    assertInstanceOf(Rounding.TimestampRounding.class, rounding);
+  }
+
+  @Test
+  void datetime_rounding_non_core_type_span() {
+    SpanExpression dateSpan =
+        DSL.span(DSL.ref("date", new MockDateExprType()), DSL.literal(1), "d");
+    Rounding rounding = Rounding.createRounding(dateSpan);
+    assertInstanceOf(Rounding.DateRounding.class, rounding);
+    SpanExpression timeSpan =
+        DSL.span(DSL.ref("time", new MockTimeExprType()), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(timeSpan);
+    assertInstanceOf(Rounding.TimeRounding.class, rounding);
+    SpanExpression timestampSpan =
+        DSL.span(DSL.ref("timestamp", new MockTimestampExprType()), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(timestampSpan);
+    assertInstanceOf(Rounding.TimestampRounding.class, rounding);
   }
 
   @Test
@@ -40,5 +73,26 @@ public class RoundingTest {
         IllegalArgumentException.class,
         () -> Rounding.DateTimeUnit.resolve(illegalUnit),
         "Unable to resolve unit " + illegalUnit);
+  }
+
+  static class MockDateExprType implements ExprType {
+    @Override
+    public String typeName() {
+      return "DATE";
+    }
+  }
+
+  static class MockTimeExprType implements ExprType {
+    @Override
+    public String typeName() {
+      return "TIME";
+    }
+  }
+
+  static class MockTimestampExprType implements ExprType {
+    @Override
+    public String typeName() {
+      return "TIMESTAMP";
+    }
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeImplementationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeImplementationIT.java
@@ -6,8 +6,10 @@
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_FORMATS;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 import static org.opensearch.sql.util.MatcherUtils.verifySome;
 
@@ -20,6 +22,7 @@ public class DateTimeImplementationIT extends PPLIntegTestCase {
   @Override
   public void init() throws IOException {
     loadIndex(Index.DATE);
+    loadIndex(Index.DATE_FORMATS);
   }
 
   @Test
@@ -175,5 +178,16 @@ public class DateTimeImplementationIT extends PPLIntegTestCase {
                 TEST_INDEX_DATE));
     verifySchema(result, schema("f", null, "timestamp"));
     verifySome(result.getJSONArray("datarows"), rows(new Object[] {null}));
+  }
+
+  @Test
+  public void testSpanDatetimeWithCustomFormat() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | eval a = 1 | stats count() as cnt by span(yyyy-MM-dd, 1d) as span",
+                TEST_INDEX_DATE_FORMATS));
+    verifySchema(result, schema("cnt", null, "integer"), schema("span", null, "date"));
+    verifyDataRows(result, rows(2, "1984-04-12"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeImplementationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeImplementationIT.java
@@ -190,4 +190,27 @@ public class DateTimeImplementationIT extends PPLIntegTestCase {
     verifySchema(result, schema("cnt", null, "integer"), schema("span", null, "date"));
     verifyDataRows(result, rows(2, "1984-04-12"));
   }
+
+  @Test
+  public void testSpanDatetimeWithEpochMillisFormat() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | eval a = 1 | stats count() as cnt by span(epoch_millis, 1d) as span",
+                TEST_INDEX_DATE_FORMATS));
+    verifySchema(result, schema("cnt", null, "integer"), schema("span", null, "timestamp"));
+    verifyDataRows(result, rows(2, "1984-04-12 00:00:00"));
+  }
+
+  @Test
+  public void testSpanDatetimeWithDisjunctiveDifferentFormats() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | eval a = 1 | stats count() as cnt by span(yyyy-MM-dd_OR_epoch_millis,"
+                    + " 1d) as span",
+                TEST_INDEX_DATE_FORMATS));
+    verifySchema(result, schema("cnt", null, "integer"), schema("span", null, "timestamp"));
+    verifyDataRows(result, rows(2, "1984-04-12 00:00:00"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFormatsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFormatsIT.java
@@ -63,7 +63,7 @@ public class DateTimeFormatsIT extends SQLIntegTestCase {
     String query =
         String.format(
             "SELECT custom_time, custom_timestamp, custom_date_or_date,"
-                + "custom_date_or_custom_time, custom_time_parser_check FROM %s",
+                + "custom_date_or_custom_time, custom_time_parser_check, yyyy-MM-dd FROM %s",
             TEST_INDEX_DATE_FORMATS);
     JSONObject result = executeQuery(query);
     verifySchema(
@@ -72,17 +72,24 @@ public class DateTimeFormatsIT extends SQLIntegTestCase {
         schema("custom_timestamp", null, "timestamp"),
         schema("custom_date_or_date", null, "date"),
         schema("custom_date_or_custom_time", null, "timestamp"),
-        schema("custom_time_parser_check", null, "time"));
+        schema("custom_time_parser_check", null, "time"),
+        schema("yyyy-MM-dd", null, "date"));
     verifyDataRows(
         result,
         rows(
-            "09:07:42", "1984-04-12 09:07:42", "1984-04-12", "1961-04-12 00:00:00", "23:44:36.321"),
+            "09:07:42",
+            "1984-04-12 09:07:42",
+            "1984-04-12",
+            "1961-04-12 00:00:00",
+            "23:44:36.321",
+            "1984-04-12"),
         rows(
             "21:07:42",
             "1984-04-12 22:07:42",
             "1984-04-12",
             "1970-01-01 09:07:00",
-            "09:01:16.542"));
+            "09:01:16.542",
+            "1984-04-12"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFormatsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFormatsIT.java
@@ -63,7 +63,7 @@ public class DateTimeFormatsIT extends SQLIntegTestCase {
     String query =
         String.format(
             "SELECT custom_time, custom_timestamp, custom_date_or_date,"
-                + "custom_date_or_custom_time, custom_time_parser_check, yyyy-MM-dd FROM %s",
+                + "custom_date_or_custom_time, custom_time_parser_check FROM %s",
             TEST_INDEX_DATE_FORMATS);
     JSONObject result = executeQuery(query);
     verifySchema(
@@ -72,24 +72,17 @@ public class DateTimeFormatsIT extends SQLIntegTestCase {
         schema("custom_timestamp", null, "timestamp"),
         schema("custom_date_or_date", null, "date"),
         schema("custom_date_or_custom_time", null, "timestamp"),
-        schema("custom_time_parser_check", null, "time"),
-        schema("yyyy-MM-dd", null, "date"));
+        schema("custom_time_parser_check", null, "time"));
     verifyDataRows(
         result,
         rows(
-            "09:07:42",
-            "1984-04-12 09:07:42",
-            "1984-04-12",
-            "1961-04-12 00:00:00",
-            "23:44:36.321",
-            "1984-04-12"),
+            "09:07:42", "1984-04-12 09:07:42", "1984-04-12", "1961-04-12 00:00:00", "23:44:36.321"),
         rows(
             "21:07:42",
             "1984-04-12 22:07:42",
             "1984-04-12",
             "1970-01-01 09:07:00",
-            "09:01:16.542",
-            "1984-04-12"));
+            "09:01:16.542"));
   }
 
   @Test

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -58,7 +58,6 @@ import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
-import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchBinaryType;
@@ -228,14 +227,6 @@ public class OpenSearchExprValueFactory {
    * @return Parsed value
    */
   private static ExprValue parseDateTimeString(String value, OpenSearchDateType dataType) {
-    try {
-      String customFormat = dataType.getAllCustomFormatters().toString();
-      OpenSearchDateType dateType = OpenSearchDateType.of(customFormat);
-      LocalDate parsedDate = dateType.getParsedDateTime(value).toLocalDate();
-      return ExprValueUtils.dateValue(parsedDate);
-    } catch (Exception ignored) {
-      // nothing to do, try another old parser
-    }
     List<DateFormatter> formatters = dataType.getAllNamedFormatters();
     formatters.addAll(dataType.getAllCustomFormatters());
     ExprCoreType returnFormat = dataType.getExprCoreType();


### PR DESCRIPTION
### Description
This seems a regression issue from https://github.com/opensearch-project/sql/pull/2762. Query of StatsBy with Span on a custom formatted date type will fail.

Here is the reproduce:
```
PUT /ltjin-test1
{
    "mappings":{
        "properties": {
            "Time1": {
                "type": "date",
                "format": "yyyy-MM-dd"
            },
            "Time2": {
                "type": "date",
                "format": "epoch_millis"
            }
        }
    }
}

POST _bulk
{ "index" : { "_index" : "ltjin-test1", "_id" : "1" } }
{ "Time1": "2005-12-05", "Time2": 1133654400000 }

POST /_plugins/_ppl/
{
    "query": """
    source=ltjin-test1 | eval a = 1 | stats Count(a) as a by span(Time1, 1d)
    """
}

POST /_plugins/_ppl/
{
    "query": """
    source=ltjin-test1 | eval a = 1 | stats Count(a) as a by span(Time2, 1d)
    """
}
```
Throws NPE.

### Related Issues
Resolves #3078 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
