### PR TITLE
Add validation method for Flint extension queries and wire it into the dispatcher

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcher.java
@@ -51,6 +51,7 @@ public class SparkQueryDispatcher {
       String query = dispatchQueryRequest.getQuery();
 
       if (SQLQueryUtils.isFlintExtensionQuery(query)) {
+        sqlQueryValidator.validateFlintExtensionQuery(query, dataSourceMetadata.getConnector());
         return handleFlintExtensionQuery(
             dispatchQueryRequest, asyncQueryRequestContext, dataSourceMetadata);
       }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidator.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidator.java
@@ -36,4 +36,7 @@ public class SQLQueryValidator {
       throw e;
     }
   }
+
+  public void validateFlintExtensionQuery(String sqlQuery, DataSourceType dataSourceType) {
+  }
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidator.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidator.java
@@ -37,6 +37,5 @@ public class SQLQueryValidator {
     }
   }
 
-  public void validateFlintExtensionQuery(String sqlQuery, DataSourceType dataSourceType) {
-  }
+  public void validateFlintExtensionQuery(String sqlQuery, DataSourceType dataSourceType) {}
 }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidator.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidator.java
@@ -37,5 +37,11 @@ public class SQLQueryValidator {
     }
   }
 
+  /**
+   * Validates a query from the Flint extension grammar. The method is currently a no-op.
+   *
+   * @param sqlQuery The Flint extension query to be validated
+   * @param dataSourceType The type of the datasource the query is being run on
+   */
   public void validateFlintExtensionQuery(String sqlQuery, DataSourceType dataSourceType) {}
 }

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/dispatcher/SparkQueryDispatcherTest.java
@@ -641,6 +641,11 @@ public class SparkQueryDispatcherTest {
 
   @Test
   void testDispatchRecoverIndexQuery() {
+    DataSourceMetadata dataSourceMetadata = constructMyGlueDataSourceMetadata();
+    when(dataSourceService.verifyDataSourceAccessAndGetRawMetadata(
+            MY_GLUE, asyncQueryRequestContext))
+        .thenReturn(dataSourceMetadata);
+
     String query = "RECOVER INDEX JOB `flint_spark_catalog_default_test_skipping_index`";
     Assertions.assertThrows(
         IllegalArgumentException.class,

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/validator/SQLQueryValidatorTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/validator/SQLQueryValidatorTest.java
@@ -5,11 +5,14 @@
 
 package org.opensearch.sql.spark.validator;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -559,6 +562,12 @@ class SQLQueryValidatorTest {
     v.ng(TestElement.SCALAR_USER_DEFINED_FUNCTIONS);
     v.ng(TestElement.USER_DEFINED_AGGREGATE_FUNCTIONS);
     v.ng(TestElement.INTEGRATION_WITH_HIVE_UDFS_UDAFS_UDTFS);
+  }
+
+  @Test
+  void testValidateFlintExtensionQuery() {
+    assertDoesNotThrow(() -> 
+            sqlQueryValidator.validateFlintExtensionQuery(UUID.randomUUID().toString(), DataSourceType.SECURITY_LAKE));
   }
 
   @AllArgsConstructor

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/validator/SQLQueryValidatorTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/validator/SQLQueryValidatorTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -566,8 +565,10 @@ class SQLQueryValidatorTest {
 
   @Test
   void testValidateFlintExtensionQuery() {
-    assertDoesNotThrow(() -> 
-            sqlQueryValidator.validateFlintExtensionQuery(UUID.randomUUID().toString(), DataSourceType.SECURITY_LAKE));
+    assertDoesNotThrow(
+        () ->
+            sqlQueryValidator.validateFlintExtensionQuery(
+                UUID.randomUUID().toString(), DataSourceType.SECURITY_LAKE));
   }
 
   @AllArgsConstructor


### PR DESCRIPTION
### Description
Adds a new method to validate a Flint extension query in the SQLQueryValidator. The method is a no-op currently. Wire this call into the dispatcher.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
