### PR TITLE
Added documentation for the plugins.query.field_type_tolerance setting (#1300)

### DIFF
--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -824,3 +824,55 @@ To Re-enable Data Sources:::
       }
     }
 
+plugins.query.field_type_tolerance
+==================================
+
+Description
+-----------
+
+This setting controls whether preserve arrays. If this setting is set to false, then an array is reduced
+to the first non array value of any level of nesting.
+
+If you have an index with the following value for a field::
+
+    [
+      [
+        {"name": "one", "value": 1},
+        {"name": "two", "value": 2},
+        3
+      ]
+    ]
+
+With plugins.query.field_type_tolerance set to true, the array is returned in full::
+
+    [
+      [
+        {"name": "one", "value": 1},
+        {"name": "two", "value": 2},
+        3
+      ]
+    ]
+
+With plugins.query.field_type_tolerance set to false, the array is reduced::
+
+    {"name": "one", "value": 1}
+
+1. The default value is true (preserve arrays)
+2. This setting is node scope
+3. This setting can be updated dynamically
+
+Update Settings Request::
+
+    sh$ curl -sS -H 'Content-Type: application/json' -X PUT 'localhost:9200/_cluster/settings?pretty' \
+    ... -d '{"transient":{"plugins.query.field_type_tolerance":"false"}}'
+    {
+      "acknowledged": true,
+      "persistent": {},
+      "transient": {
+        "plugins": {
+          "query": {
+            "field_type_tolerance": "false"
+          }
+        }
+      }
+    }

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -833,46 +833,42 @@ Description
 This setting controls whether preserve arrays. If this setting is set to false, then an array is reduced
 to the first non array value of any level of nesting.
 
-If you have an index with the following value for a field::
-
-    [
-      [
-        {"name": "one", "value": 1},
-        {"name": "two", "value": 2},
-        3
-      ]
-    ]
-
-With plugins.query.field_type_tolerance set to true, the array is returned in full::
-
-    [
-      [
-        {"name": "one", "value": 1},
-        {"name": "two", "value": 2},
-        3
-      ]
-    ]
-
-With plugins.query.field_type_tolerance set to false, the array is reduced::
-
-    {"name": "one", "value": 1}
-
 1. The default value is true (preserve arrays)
 2. This setting is node scope
 3. This setting can be updated dynamically
 
-Update Settings Request::
+Querying a field containing array values will return the full array values::
 
-    sh$ curl -sS -H 'Content-Type: application/json' -X PUT 'localhost:9200/_cluster/settings?pretty' \
-    ... -d '{"transient":{"plugins.query.field_type_tolerance":"false"}}'
-    {
-      "acknowledged": true,
-      "persistent": {},
-      "transient": {
-        "plugins": {
-          "query": {
-            "field_type_tolerance": "false"
-          }
-        }
-      }
-    }
+    os> SELECT accounts FROM people;
+    fetched rows / total rows = 1/1
+    +-----------------------+
+    | accounts              |
+    +-----------------------+
+    | [{'id': 1},{'id': 2}] |
+    +-----------------------+
+
+Disable field type tolerance::
+
+    >> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings -d '{
+	    "transient" : {
+	      "plugins.query.field_type_tolerance" : false
+	    }
+	  }'
+
+When field type tolerance is disabled, arrays are collapsed to the first non array value::
+
+    os> SELECT accounts FROM people;
+    fetched rows / total rows = 1/1
+    +-----------+
+    | accounts  |
+    +-----------+
+    | {'id': 1} |
+    +-----------+
+
+Reenable field type tolerance::
+
+    >> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings -d '{
+	    "transient" : {
+	      "plugins.query.field_type_tolerance" : true
+	    }
+	  }'

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -872,3 +872,10 @@ Reenable field type tolerance::
 	      "plugins.query.field_type_tolerance" : true
 	    }
 	  }'
+
+Limitations:
+------------
+* Fields with array values should only be used in the projection list
+* Array values are not supported by SQL or PPL functions
+* Array values in expressions will cause the query to fail or produce incorrect results
+* PPL commands do not support examining or altering array values

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -875,7 +875,10 @@ Reenable field type tolerance::
 
 Limitations:
 ------------
-* Fields with array values should only be used in the projection list
-* Array values are not supported by SQL or PPL functions
-* Array values in expressions will cause the query to fail or produce incorrect results
-* PPL commands do not support examining or altering array values
+OpenSearch does not natively support the ARRAY data type but does allow multi-value fields implicitly. The
+SQL/PPL plugin adheres strictly to the data type semantics defined in index mappings. When parsing OpenSearch
+responses, it expects data to match the declared type and does not account for data in array format. If the
+plugins.query.field_type_tolerance setting is enabled, the SQL/PPL plugin will handle array datasets by returning
+scalar data types, allowing basic queries (e.g., SELECT * FROM tbl WHERE condition). However, using multi-value
+fields in expressions or functions will result in exceptions. If this setting is disabled or absent, only the
+first element of an array is returned, preserving the default behavior.

--- a/docs/user/limitations/limitations.rst
+++ b/docs/user/limitations/limitations.rst
@@ -105,8 +105,16 @@ The query with `aggregation` and `join` does not support pagination for now.
 Limitations on Using Multi-valued Fields
 ========================================
 
-Using a multi-valued field as an argument of a SQL or PPL function/operator will cause the query to fail. For
-example, the following query fails::
+OpenSearch does not natively support the ARRAY data type but does allow multi-value fields implicitly. The
+SQL/PPL plugin adheres strictly to the data type semantics defined in index mappings. When parsing OpenSearch
+responses, it expects data to match the declared type and does not account for data in array format. If the
+plugins.query.field_type_tolerance setting is enabled, the SQL/PPL plugin will handle array datasets by returning
+scalar data types, allowing basic queries (e.g., SELECT * FROM tbl WHERE condition). However, using multi-value
+fields in expressions or functions will result in exceptions. If this setting is disabled or absent, only the
+first element of an array is returned, preserving the default behavior.
+
+For example, the following query tries to calculate the absolute value of a field that contains arrays of
+longs::
 
     POST _plugins/_sql/
     {

--- a/docs/user/limitations/limitations.rst
+++ b/docs/user/limitations/limitations.rst
@@ -101,3 +101,24 @@ The response in JDBC format with cursor id::
     }
 
 The query with `aggregation` and `join` does not support pagination for now.
+
+Limitations on Using Multi-valued Fields
+========================================
+
+Using a multi-valued field as an argument of a SQL or PPL function/operator will cause the query to fail. For
+example, the following query fails::
+
+    POST _plugins/_sql/
+    {
+      "query": "SELECT id, ABS(long_array) FROM multi_value_long"
+    }
+The response in JSON format is::
+
+    {
+      "error": {
+        "reason": "Invalid SQL query",
+        "details": "invalid to get longValue from value of type ARRAY",
+        "type": "ExpressionEvaluationException"
+      },
+      "status": 400
+    }

--- a/doctest/test_data/multi_value_long.json
+++ b/doctest/test_data/multi_value_long.json
@@ -1,0 +1,5 @@
+{"id": 1, "long_array": [1, 2]}
+{"id": 2, "long_array": [3, 4]}
+{"id": 3, "long_array": [1, 5]}
+{"id": 4, "long_array": [1, 2]}
+{"id": 5, "long_array": [2, 3]}


### PR DESCRIPTION
### Description
Add documentation for the `plugins.query.field_type_tolerance` setting.

### Related Issues
Resolves #1300

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
