### PR TITLE
Fix FilterOperator to cache next element and avoid repeated consumption on hasNext() calls

### DIFF
--- a/core/src/test/java/org/opensearch/sql/planner/physical/FilterOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/FilterOperatorTest.java
@@ -8,14 +8,24 @@ package org.opensearch.sql.planner.physical;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_FALSE;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_MISSING;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_NULL;
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
 import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.planner.physical.PhysicalPlanDSL.filter;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -26,11 +36,21 @@ import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class FilterOperatorTest extends PhysicalPlanTestBase {
   @Mock private PhysicalPlan inputPlan;
+
+  @Mock private Expression condition;
+
+  private FilterOperator filterOperator;
+
+  @BeforeEach
+  public void setup() {
+    filterOperator = filter(inputPlan, condition);
+  }
 
   @Test
   public void filter_test() {
@@ -81,5 +101,69 @@ class FilterOperatorTest extends PhysicalPlanTestBase {
         new FilterOperator(inputPlan, DSL.equal(DSL.ref("response", INTEGER), DSL.literal(404)));
     List<ExprValue> result = execute(plan);
     assertEquals(0, result.size());
+  }
+
+  @Test
+  public void testHasNextWhenInputHasNoElements() {
+    when(inputPlan.hasNext()).thenReturn(false);
+
+    assertFalse(
+        filterOperator.hasNext(), "hasNext() should return false when input has no elements");
+  }
+
+  @Test
+  public void testHasNextWithMatchingCondition() {
+    ExprValue inputValue = mock(ExprValue.class);
+    when(inputPlan.hasNext()).thenReturn(true).thenReturn(false);
+    when(inputPlan.next()).thenReturn(inputValue);
+    when(condition.valueOf(any())).thenReturn(LITERAL_TRUE);
+
+    assertTrue(filterOperator.hasNext(), "hasNext() should return true when condition matches");
+    assertEquals(
+        inputValue, filterOperator.next(), "next() should return the matching input value");
+  }
+
+  @Test
+  public void testHasNextWithNonMatchingCondition() {
+    ExprValue inputValue = mock(ExprValue.class);
+    when(inputPlan.hasNext()).thenReturn(true, false);
+    when(inputPlan.next()).thenReturn(inputValue);
+    when(condition.valueOf(any())).thenReturn(LITERAL_FALSE);
+
+    assertFalse(
+        filterOperator.hasNext(), "hasNext() should return false if no values match the condition");
+  }
+
+  @Test
+  public void testMultipleCallsToHasNextDoNotConsumeInput() {
+    ExprValue inputValue = mock(ExprValue.class);
+    when(inputPlan.hasNext()).thenReturn(true);
+    when(inputPlan.next()).thenReturn(inputValue);
+    when(condition.valueOf(any())).thenReturn(LITERAL_TRUE);
+
+    assertTrue(
+        filterOperator.hasNext(),
+        "First hasNext() call should return true if there is a matching value");
+    verify(inputPlan, times(1)).next();
+    assertTrue(
+        filterOperator.hasNext(),
+        "Subsequent hasNext() calls should still return true without advancing the input");
+    verify(inputPlan, times(1)).next();
+    assertEquals(
+        inputValue, filterOperator.next(), "next() should return the matching input value");
+    verify(inputPlan, times(1)).next();
+  }
+
+  @Test
+  public void testNextWithoutCallingHasNext() {
+    ExprValue inputValue = mock(ExprValue.class);
+    when(inputPlan.hasNext()).thenReturn(true, false);
+    when(inputPlan.next()).thenReturn(inputValue);
+    when(condition.valueOf(any())).thenReturn(LITERAL_TRUE);
+
+    assertEquals(
+        inputValue,
+        filterOperator.next(),
+        "next() should return the matching input value even if hasNext() was not called");
   }
 }

--- a/integ-test/src/test/resources/correctness/bugfixes/3121.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/3121.txt
@@ -1,0 +1,1 @@
+SELECT Origin, Dest FROM (SELECT * FROM opensearch_dashboards_sample_data_flights WHERE AvgTicketPrice > 100 GROUP BY Origin, Dest, AvgTicketPrice) AS flights WHERE AvgTicketPrice < 1000 ORDER BY AvgTicketPrice LIMIT 30


### PR DESCRIPTION
### Description
This PR addresses a bug in FilterOperator where repeated calls to hasNext() would incorrectly consume input elements. The change includes
* Updated FilterOperator to cache the next matching element, ensuring that repeated hasNext() calls return true without advancing the input.
* Unit Tests: Added a test case to confirm that inputPlan.next() is called only once across multiple hasNext() calls, preventing unintended input consumption.
* IT, `SELECT Origin, Dest FROM (SELECT * FROM opensearch_dashboards_sample_data_flights WHERE AvgTicketPrice > 100 GROUP BY Origin, Dest, AvgTicketPrice) AS flights WHERE AvgTicketPrice < 1000 ORDER BY AvgTicketPrice LIMIT 30`

### Related Issues
https://github.com/opensearch-project/sql/issues/3121

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
