### PR TITLE
Call updateState when query is cancelled

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImpl.java
@@ -19,6 +19,7 @@ import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundExceptio
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.QueryState;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
 import org.opensearch.sql.spark.dispatcher.SparkQueryDispatcher;
@@ -116,7 +117,11 @@ public class AsyncQueryExecutorServiceImpl implements AsyncQueryExecutorService 
     Optional<AsyncQueryJobMetadata> asyncQueryJobMetadata =
         asyncQueryJobMetadataStorageService.getJobMetadata(queryId);
     if (asyncQueryJobMetadata.isPresent()) {
-      return sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata.get(), asyncQueryRequestContext);
+      String result =
+          sparkQueryDispatcher.cancelJob(asyncQueryJobMetadata.get(), asyncQueryRequestContext);
+      asyncQueryJobMetadataStorageService.updateState(
+          asyncQueryJobMetadata.get(), QueryState.CANCELLED, asyncQueryRequestContext);
+      return result;
     }
     throw new AsyncQueryNotFoundException(String.format("QueryId: %s not found", queryId));
   }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryJobMetadataStorageService.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/asyncquery/AsyncQueryJobMetadataStorageService.java
@@ -10,11 +10,17 @@ package org.opensearch.sql.spark.asyncquery;
 import java.util.Optional;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.QueryState;
 
 public interface AsyncQueryJobMetadataStorageService {
 
   void storeJobMetadata(
       AsyncQueryJobMetadata asyncQueryJobMetadata,
+      AsyncQueryRequestContext asyncQueryRequestContext);
+
+  void updateState(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      QueryState newState,
       AsyncQueryRequestContext asyncQueryRequestContext);
 
   Optional<AsyncQueryJobMetadata> getJobMetadata(String jobId);

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.spark.asyncquery;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -27,12 +28,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryExecutionResponse;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.QueryState;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfig;
 import org.opensearch.sql.spark.config.SparkExecutionEngineConfigSupplier;
 import org.opensearch.sql.spark.config.SparkSubmitParameterModifier;
@@ -57,6 +61,8 @@ public class AsyncQueryExecutorServiceImplTest {
   @Mock private SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier;
   @Mock private SparkSubmitParameterModifier sparkSubmitParameterModifier;
   @Mock private AsyncQueryRequestContext asyncQueryRequestContext;
+
+  @Captor private ArgumentCaptor<AsyncQueryJobMetadata> asyncQueryJobMetadataCaptor;
 
   @BeforeEach
   void setUp() {
@@ -109,7 +115,7 @@ public class AsyncQueryExecutorServiceImplTest {
         .getSparkExecutionEngineConfig(asyncQueryRequestContext);
     verify(sparkQueryDispatcher, times(1))
         .dispatch(expectedDispatchQueryRequest, asyncQueryRequestContext);
-    Assertions.assertEquals(QUERY_ID, createAsyncQueryResponse.getQueryId());
+    assertEquals(QUERY_ID, createAsyncQueryResponse.getQueryId());
   }
 
   @Test
@@ -153,8 +159,7 @@ public class AsyncQueryExecutorServiceImplTest {
             AsyncQueryNotFoundException.class,
             () -> jobExecutorService.getAsyncQueryResults(EMR_JOB_ID, asyncQueryRequestContext));
 
-    Assertions.assertEquals(
-        "QueryId: " + EMR_JOB_ID + " not found", asyncQueryNotFoundException.getMessage());
+    assertEquals("QueryId: " + EMR_JOB_ID + " not found", asyncQueryNotFoundException.getMessage());
     verifyNoInteractions(sparkQueryDispatcher);
     verifyNoInteractions(sparkExecutionEngineConfigSupplier);
   }
@@ -174,7 +179,7 @@ public class AsyncQueryExecutorServiceImplTest {
 
     Assertions.assertNull(asyncQueryExecutionResponse.getResults());
     Assertions.assertNull(asyncQueryExecutionResponse.getSchema());
-    Assertions.assertEquals("PENDING", asyncQueryExecutionResponse.getStatus());
+    assertEquals("PENDING", asyncQueryExecutionResponse.getStatus());
     verifyNoInteractions(sparkExecutionEngineConfigSupplier);
   }
 
@@ -191,11 +196,10 @@ public class AsyncQueryExecutorServiceImplTest {
     AsyncQueryExecutionResponse asyncQueryExecutionResponse =
         jobExecutorService.getAsyncQueryResults(EMR_JOB_ID, asyncQueryRequestContext);
 
-    Assertions.assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
-    Assertions.assertEquals(1, asyncQueryExecutionResponse.getSchema().getColumns().size());
-    Assertions.assertEquals(
-        "1", asyncQueryExecutionResponse.getSchema().getColumns().get(0).getName());
-    Assertions.assertEquals(
+    assertEquals("SUCCESS", asyncQueryExecutionResponse.getStatus());
+    assertEquals(1, asyncQueryExecutionResponse.getSchema().getColumns().size());
+    assertEquals("1", asyncQueryExecutionResponse.getSchema().getColumns().get(0).getName());
+    assertEquals(
         1,
         ((HashMap<String, String>) asyncQueryExecutionResponse.getResults().get(0).value())
             .get("1"));
@@ -212,8 +216,7 @@ public class AsyncQueryExecutorServiceImplTest {
             AsyncQueryNotFoundException.class,
             () -> jobExecutorService.cancelQuery(EMR_JOB_ID, asyncQueryRequestContext));
 
-    Assertions.assertEquals(
-        "QueryId: " + EMR_JOB_ID + " not found", asyncQueryNotFoundException.getMessage());
+    assertEquals("QueryId: " + EMR_JOB_ID + " not found", asyncQueryNotFoundException.getMessage());
     verifyNoInteractions(sparkQueryDispatcher);
     verifyNoInteractions(sparkExecutionEngineConfigSupplier);
   }
@@ -227,7 +230,9 @@ public class AsyncQueryExecutorServiceImplTest {
 
     String jobId = jobExecutorService.cancelQuery(EMR_JOB_ID, asyncQueryRequestContext);
 
-    Assertions.assertEquals(EMR_JOB_ID, jobId);
+    assertEquals(EMR_JOB_ID, jobId);
+    verify(asyncQueryJobMetadataStorageService)
+        .updateState(any(), eq(QueryState.CANCELLED), eq(asyncQueryRequestContext));
     verifyNoInteractions(sparkExecutionEngineConfigSupplier);
   }
 

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/asyncquery/AsyncQueryExecutorServiceImplTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundException;
@@ -61,8 +59,6 @@ public class AsyncQueryExecutorServiceImplTest {
   @Mock private SparkExecutionEngineConfigSupplier sparkExecutionEngineConfigSupplier;
   @Mock private SparkSubmitParameterModifier sparkSubmitParameterModifier;
   @Mock private AsyncQueryRequestContext asyncQueryRequestContext;
-
-  @Captor private ArgumentCaptor<AsyncQueryJobMetadata> asyncQueryJobMetadataCaptor;
 
   @BeforeEach
   void setUp() {

--- a/async-query/src/main/java/org/opensearch/sql/spark/asyncquery/OpenSearchAsyncQueryJobMetadataStorageService.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/asyncquery/OpenSearchAsyncQueryJobMetadataStorageService.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.spark.asyncquery.exceptions.AsyncQueryNotFoundException;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryJobMetadata;
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;
+import org.opensearch.sql.spark.asyncquery.model.QueryState;
 import org.opensearch.sql.spark.execution.statestore.OpenSearchStateStoreUtil;
 import org.opensearch.sql.spark.execution.statestore.StateStore;
 import org.opensearch.sql.spark.execution.xcontent.AsyncQueryJobMetadataXContentSerializer;
@@ -37,6 +38,14 @@ public class OpenSearchAsyncQueryJobMetadataStorageService
         asyncQueryJobMetadata,
         AsyncQueryJobMetadata::copy,
         OpenSearchStateStoreUtil.getIndexName(asyncQueryJobMetadata.getDatasourceName()));
+  }
+
+  @Override
+  public void updateState(
+      AsyncQueryJobMetadata asyncQueryJobMetadata,
+      QueryState newState,
+      AsyncQueryRequestContext asyncQueryRequestContext) {
+    // NoOp since AsyncQueryJobMetadata record does not store state now
   }
 
   private String mapIdToDocumentId(String id) {


### PR DESCRIPTION
### Description
- Call updateState when query is cancelled
  - This change is for async-query-core library consumer to update cancel status
  - This does not affect the async-query behavior since AsyncQueryJobMetadata record does not store status yet. (#3140 is an issue for unifying the model to single one, and we need to handle the update status within the fix)

### Related Issues
#3140 (This PR does not solve this issue)

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
