### PR TITLE
[Backport 2.x] Fix a regression issue of parsing datetime string with custom time format in Span (#3079)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
@@ -49,7 +49,7 @@ public abstract class Rounding<T> {
     if (DOUBLE.isCompatible(type)) {
       return new DoubleRounding(interval);
     }
-    if (type.equals(DATETIME) || type.typeName().equalsIgnoreCase(DATETIME.typeName()))) {
+    if (type.equals(DATETIME) || type.typeName().equalsIgnoreCase(DATETIME.typeName())) {
       return new DatetimeRounding(interval, span.getUnit().getName());
     }
     if (type.equals(TIMESTAMP) || type.typeName().equalsIgnoreCase(TIMESTAMP.typeName())) {

--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/Rounding.java
@@ -49,16 +49,16 @@ public abstract class Rounding<T> {
     if (DOUBLE.isCompatible(type)) {
       return new DoubleRounding(interval);
     }
-    if (type.equals(DATETIME)) {
+    if (type.equals(DATETIME) || type.typeName().equalsIgnoreCase(DATETIME.typeName()))) {
       return new DatetimeRounding(interval, span.getUnit().getName());
     }
-    if (type.equals(TIMESTAMP)) {
+    if (type.equals(TIMESTAMP) || type.typeName().equalsIgnoreCase(TIMESTAMP.typeName())) {
       return new TimestampRounding(interval, span.getUnit().getName());
     }
-    if (type.equals(DATE)) {
+    if (type.equals(DATE) || type.typeName().equalsIgnoreCase(DATE.typeName())) {
       return new DateRounding(interval, span.getUnit().getName());
     }
-    if (type.equals(TIME)) {
+    if (type.equals(TIME) || type.typeName().equalsIgnoreCase(TIME.typeName())) {
       return new TimeRounding(interval, span.getUnit().getName());
     }
     return new UnknownRounding();

--- a/core/src/test/java/org/opensearch/sql/planner/physical/collector/RoundingTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/collector/RoundingTest.java
@@ -5,14 +5,18 @@
 
 package org.opensearch.sql.planner.physical.collector;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opensearch.sql.data.type.ExprCoreType.DATE;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.data.type.ExprCoreType.TIME;
+import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.span.SpanExpression;
@@ -24,6 +28,35 @@ public class RoundingTest {
     Rounding rounding = Rounding.createRounding(span);
     assertThrows(
         ExpressionEvaluationException.class, () -> rounding.round(new ExprTimeValue("23:30:00")));
+  }
+
+  @Test
+  void datetime_rounding_span() {
+    SpanExpression dateSpan = DSL.span(DSL.ref("date", DATE), DSL.literal(1), "d");
+    Rounding rounding = Rounding.createRounding(dateSpan);
+    assertInstanceOf(Rounding.DateRounding.class, rounding);
+    SpanExpression timeSpan = DSL.span(DSL.ref("time", TIME), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(timeSpan);
+    assertInstanceOf(Rounding.TimeRounding.class, rounding);
+    SpanExpression timestampSpan = DSL.span(DSL.ref("timestamp", TIMESTAMP), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(timestampSpan);
+    assertInstanceOf(Rounding.TimestampRounding.class, rounding);
+  }
+
+  @Test
+  void datetime_rounding_non_core_type_span() {
+    SpanExpression dateSpan =
+        DSL.span(DSL.ref("date", new MockDateExprType()), DSL.literal(1), "d");
+    Rounding rounding = Rounding.createRounding(dateSpan);
+    assertInstanceOf(Rounding.DateRounding.class, rounding);
+    SpanExpression timeSpan =
+        DSL.span(DSL.ref("time", new MockTimeExprType()), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(timeSpan);
+    assertInstanceOf(Rounding.TimeRounding.class, rounding);
+    SpanExpression timestampSpan =
+        DSL.span(DSL.ref("timestamp", new MockTimestampExprType()), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(timestampSpan);
+    assertInstanceOf(Rounding.TimestampRounding.class, rounding);
   }
 
   @Test
@@ -40,5 +73,26 @@ public class RoundingTest {
         IllegalArgumentException.class,
         () -> Rounding.DateTimeUnit.resolve(illegalUnit),
         "Unable to resolve unit " + illegalUnit);
+  }
+
+  static class MockDateExprType implements ExprType {
+    @Override
+    public String typeName() {
+      return "DATE";
+    }
+  }
+
+  static class MockTimeExprType implements ExprType {
+    @Override
+    public String typeName() {
+      return "TIME";
+    }
+  }
+
+  static class MockTimestampExprType implements ExprType {
+    @Override
+    public String typeName() {
+      return "TIMESTAMP";
+    }
   }
 }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/collector/RoundingTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/collector/RoundingTest.java
@@ -57,6 +57,10 @@ public class RoundingTest {
         DSL.span(DSL.ref("timestamp", new MockTimestampExprType()), DSL.literal(1), "h");
     rounding = Rounding.createRounding(timestampSpan);
     assertInstanceOf(Rounding.TimestampRounding.class, rounding);
+    SpanExpression datetimeSpan =
+        DSL.span(DSL.ref("datetime", new MockDateTimeExprType()), DSL.literal(1), "h");
+    rounding = Rounding.createRounding(datetimeSpan);
+    assertInstanceOf(Rounding.DatetimeRounding.class, rounding);
   }
 
   @Test
@@ -93,6 +97,13 @@ public class RoundingTest {
     @Override
     public String typeName() {
       return "TIMESTAMP";
+    }
+  }
+
+  static class MockDateTimeExprType implements ExprType {
+    @Override
+    public String typeName() {
+      return "DATETIME";
     }
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeImplementationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeImplementationIT.java
@@ -6,8 +6,10 @@
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_FORMATS;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 import static org.opensearch.sql.util.MatcherUtils.verifySome;
 
@@ -20,6 +22,7 @@ public class DateTimeImplementationIT extends PPLIntegTestCase {
   @Override
   public void init() throws IOException {
     loadIndex(Index.DATE);
+    loadIndex(Index.DATE_FORMATS);
   }
 
   @Test
@@ -175,5 +178,39 @@ public class DateTimeImplementationIT extends PPLIntegTestCase {
                 TEST_INDEX_DATE));
     verifySchema(result, schema("f", null, "datetime"));
     verifySome(result.getJSONArray("datarows"), rows(new Object[] {null}));
+  }
+
+  @Test
+  public void testSpanDatetimeWithCustomFormat() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | eval a = 1 | stats count() as cnt by span(yyyy-MM-dd, 1d) as span",
+                TEST_INDEX_DATE_FORMATS));
+    verifySchema(result, schema("cnt", null, "integer"), schema("span", null, "date"));
+    verifyDataRows(result, rows(2, "1984-04-12"));
+  }
+
+  @Test
+  public void testSpanDatetimeWithEpochMillisFormat() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | eval a = 1 | stats count() as cnt by span(epoch_millis, 1d) as span",
+                TEST_INDEX_DATE_FORMATS));
+    verifySchema(result, schema("cnt", null, "integer"), schema("span", null, "timestamp"));
+    verifyDataRows(result, rows(2, "1984-04-12 00:00:00"));
+  }
+
+  @Test
+  public void testSpanDatetimeWithDisjunctiveDifferentFormats() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | eval a = 1 | stats count() as cnt by span(yyyy-MM-dd_OR_epoch_millis,"
+                    + " 1d) as span",
+                TEST_INDEX_DATE_FORMATS));
+    verifySchema(result, schema("cnt", null, "integer"), schema("span", null, "timestamp"));
+    verifyDataRows(result, rows(2, "1984-04-12 00:00:00"));
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -295,7 +295,7 @@ public class OpenSearchExprValueFactory {
         }
       } else {
         // custom format
-        return parseDateTimeString(value.stringValue(), dt);
+        return parseDateTimeString(value.objectValue().toString(), dt);
       }
     }
     if (value.isString()) {


### PR DESCRIPTION
(cherry picked from commit 4ff1fe3cb48a17ff17b0cf134131283fc0282205)