### PR TITLE
Call LeaseManager for BatchQuery

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -77,7 +77,8 @@ public class BatchQueryHandler extends AsyncQueryHandler {
   }
 
   /**
-   * This method allows RefreshQueryHandler to override the job type when calling leaseManager.borrow.
+   * This method allows RefreshQueryHandler to override the job type when calling
+   * leaseManager.borrow.
    */
   protected void borrow(String datasource) {
     leaseManager.borrow(new LeaseRequest(JobType.BATCH, datasource));

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/BatchQueryHandler.java
@@ -25,6 +25,7 @@ import org.opensearch.sql.spark.dispatcher.model.DispatchQueryRequest;
 import org.opensearch.sql.spark.dispatcher.model.DispatchQueryResponse;
 import org.opensearch.sql.spark.dispatcher.model.JobType;
 import org.opensearch.sql.spark.leasemanager.LeaseManager;
+import org.opensearch.sql.spark.leasemanager.model.LeaseRequest;
 import org.opensearch.sql.spark.metrics.MetricsService;
 import org.opensearch.sql.spark.parameter.SparkSubmitParametersBuilderProvider;
 import org.opensearch.sql.spark.response.JobExecutionResponseReader;
@@ -75,12 +76,21 @@ public class BatchQueryHandler extends AsyncQueryHandler {
     return asyncQueryJobMetadata.getQueryId();
   }
 
+  /**
+   * This method allows RefreshQueryHandler to override the job type when calling leaseManager.borrow.
+   */
+  protected void borrow(String datasource) {
+    leaseManager.borrow(new LeaseRequest(JobType.BATCH, datasource));
+  }
+
   @Override
   public DispatchQueryResponse submit(
       DispatchQueryRequest dispatchQueryRequest, DispatchQueryContext context) {
     String clusterName = dispatchQueryRequest.getClusterName();
     Map<String, String> tags = context.getTags();
     DataSourceMetadata dataSourceMetadata = context.getDataSourceMetadata();
+
+    this.borrow(dispatchQueryRequest.getDatasource());
 
     tags.put(JOB_TYPE_TAG_KEY, JobType.BATCH.getText());
     StartJobRequest startJobRequest =

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/RefreshQueryHandler.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/RefreshQueryHandler.java
@@ -72,9 +72,13 @@ public class RefreshQueryHandler extends BatchQueryHandler {
   }
 
   @Override
+  protected void borrow(String datasource) {
+    leaseManager.borrow(new LeaseRequest(JobType.REFRESH, datasource));
+  }
+
+  @Override
   public DispatchQueryResponse submit(
       DispatchQueryRequest dispatchQueryRequest, DispatchQueryContext context) {
-    leaseManager.borrow(new LeaseRequest(JobType.REFRESH, dispatchQueryRequest.getDatasource()));
 
     DispatchQueryResponse resp = super.submit(dispatchQueryRequest, context);
     DataSourceMetadata dataSourceMetadata = context.getDataSourceMetadata();

--- a/async-query/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/execution/statestore/StateStore.java
@@ -237,7 +237,8 @@ public class StateStore {
     }
   }
 
-  private long count(String indexName, QueryBuilder query) {
+  @VisibleForTesting
+  public long count(String indexName, QueryBuilder query) {
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     searchSourceBuilder.query(query);
     searchSourceBuilder.size(0);

--- a/async-query/src/main/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManager.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManager.java
@@ -92,7 +92,7 @@ public class DefaultLeaseManager implements LeaseManager {
 
     @Override
     public boolean test(LeaseRequest leaseRequest) {
-      if (leaseRequest.getJobType() == JobType.INTERACTIVE) {
+      if (leaseRequest.getJobType() != JobType.REFRESH && leaseRequest.getJobType() != JobType.STREAMING) {
         return true;
       }
       return activeRefreshJobCount(stateStore, ALL_DATASOURCE).get() < refreshJobLimit();

--- a/async-query/src/main/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManager.java
+++ b/async-query/src/main/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManager.java
@@ -92,7 +92,8 @@ public class DefaultLeaseManager implements LeaseManager {
 
     @Override
     public boolean test(LeaseRequest leaseRequest) {
-      if (leaseRequest.getJobType() != JobType.REFRESH && leaseRequest.getJobType() != JobType.STREAMING) {
+      if (leaseRequest.getJobType() != JobType.REFRESH
+          && leaseRequest.getJobType() != JobType.STREAMING) {
         return true;
       }
       return activeRefreshJobCount(stateStore, ALL_DATASOURCE).get() < refreshJobLimit();

--- a/async-query/src/test/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManagerTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManagerTest.java
@@ -33,9 +33,12 @@ class DefaultLeaseManagerTest {
   }
 
   @Test
-  public void concurrentRefreshRuleOnlyNotAppliedToInteractiveQuery() {
+  public void concurrentRefreshRuleNotAppliedToInteractiveAndBatchQuery() {
     assertTrue(
         new DefaultLeaseManager.ConcurrentRefreshJobRule(settings, stateStore)
             .test(new LeaseRequest(JobType.INTERACTIVE, "mys3")));
+    assertTrue(
+        new DefaultLeaseManager.ConcurrentRefreshJobRule(settings, stateStore)
+            .test(new LeaseRequest(JobType.BATCH, "mys3")));
   }
 }

--- a/async-query/src/test/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManagerTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/leasemanager/DefaultLeaseManagerTest.java
@@ -31,12 +31,15 @@ class DefaultLeaseManagerTest {
     DefaultLeaseManager defaultLeaseManager = new DefaultLeaseManager(settings, stateStore);
 
     defaultLeaseManager.borrow(getLeaseRequest(JobType.BATCH));
-    assertThrows(ConcurrencyLimitExceededException.class, () ->
-    defaultLeaseManager.borrow(getLeaseRequest(JobType.INTERACTIVE)));
-    assertThrows(ConcurrencyLimitExceededException.class, () ->
-    defaultLeaseManager.borrow(getLeaseRequest(JobType.STREAMING)));
-    assertThrows(ConcurrencyLimitExceededException.class, () ->
-    defaultLeaseManager.borrow(getLeaseRequest(JobType.REFRESH)));
+    assertThrows(
+        ConcurrencyLimitExceededException.class,
+        () -> defaultLeaseManager.borrow(getLeaseRequest(JobType.INTERACTIVE)));
+    assertThrows(
+        ConcurrencyLimitExceededException.class,
+        () -> defaultLeaseManager.borrow(getLeaseRequest(JobType.STREAMING)));
+    assertThrows(
+        ConcurrencyLimitExceededException.class,
+        () -> defaultLeaseManager.borrow(getLeaseRequest(JobType.REFRESH)));
   }
 
   @Test


### PR DESCRIPTION
### Description
- Call LeaseManager for BatchQuery
  - Currently, LeaseManager.borrow is not called for BatchQuery

### Related Issues
n/a

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
