### PR TITLE
Fix coverage issue for #3063

### DIFF
--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/FlatResponseBase.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/FlatResponseBase.java
@@ -84,7 +84,7 @@ public class FlatResponseBase {
 
   protected String quoteIfRequired(String separator, String cell) {
     final String quote = "\"";
-    if (cell != null && (cell.contains(separator) || cell.contains(quote))) {
+    if (cell.contains(separator) || cell.contains(quote)) {
       return quote + cell.replaceAll(quote, quote + quote) + quote;
     } else {
       return cell;


### PR DESCRIPTION
### Description
- Fix coverage issue for #3063
- `cell` parameter in `quoteIfRequired` won't be `null` since:
  - getOriginalData method convert `null` value to `""`
  - getOriginalHeaders method does not accept `null` column value when adding to ImmutableList

### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
