### PR TITLE
Fix: Date field format parsing for legacy query engine 

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/CursorIT.java
@@ -280,7 +280,9 @@ public class CursorIT extends SQLIntegTestCase {
         Arrays.asList(
             "2015-01-01 00:00:00.000",
             "2015-01-01 12:10:30.000",
-            "1585882955", // by existing design, this is not formatted in MySQL standard format
+            // Conversion will be applied when dateTime is stored on unix timestamp,
+            // https://github.com/opensearch-project/sql/pull/3160
+            "2020-04-03 03:02:35.000",
             "2020-04-08 06:10:30.000");
 
     assertThat(actualDateList, equalTo(expectedDateList));

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/DateFieldFormatter.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/DateFieldFormatter.java
@@ -152,25 +152,26 @@ public class DateFieldFormatter {
         switch (columnFormat) {
           case "date_optional_time":
           case "strict_date_optional_time":
-            // It's possible to have date stored in second / millisecond form without explicit format hint.
+            // It's possible to have date stored in second / millisecond form without explicit
+            // format hint.
             // Parse it on a best-effort basis.
-            if (StringUtils.isNumeric(columnOriginalDate) ) {
+            if (StringUtils.isNumeric(columnOriginalDate)) {
               long timestamp = Long.parseLong(columnOriginalDate);
               if (timestamp > Integer.MAX_VALUE) {
                 parsedDate = new Date(timestamp);
               } else {
-                parsedDate = new Date(timestamp*1000);
+                parsedDate = new Date(timestamp * 1000);
               }
             } else {
               parsedDate =
-                      DateUtils.parseDate(
-                              columnOriginalDate,
-                              FORMAT_DOT_OPENSEARCH_DASHBOARDS_SAMPLE_DATA_LOGS_EXCEPTION,
-                              FORMAT_DOT_OPENSEARCH_DASHBOARDS_SAMPLE_DATA_FLIGHTS_EXCEPTION,
-                              FORMAT_DOT_OPENSEARCH_DASHBOARDS_SAMPLE_DATA_FLIGHTS_EXCEPTION_NO_TIME,
-                              FORMAT_DOT_OPENSEARCH_DASHBOARDS_SAMPLE_DATA_ECOMMERCE_EXCEPTION,
-                              FORMAT_DOT_DATE_AND_TIME,
-                              FORMAT_DOT_DATE);
+                  DateUtils.parseDate(
+                      columnOriginalDate,
+                      FORMAT_DOT_OPENSEARCH_DASHBOARDS_SAMPLE_DATA_LOGS_EXCEPTION,
+                      FORMAT_DOT_OPENSEARCH_DASHBOARDS_SAMPLE_DATA_FLIGHTS_EXCEPTION,
+                      FORMAT_DOT_OPENSEARCH_DASHBOARDS_SAMPLE_DATA_FLIGHTS_EXCEPTION_NO_TIME,
+                      FORMAT_DOT_OPENSEARCH_DASHBOARDS_SAMPLE_DATA_ECOMMERCE_EXCEPTION,
+                      FORMAT_DOT_DATE_AND_TIME,
+                      FORMAT_DOT_DATE);
             }
             break;
           case "epoch_millis":

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/DateFieldFormatter.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/DateFieldFormatter.java
@@ -84,7 +84,6 @@ public class DateFieldFormatter {
       Date date = parseDateString(formats, columnOriginalDate.toString());
       if (date != null) {
         rowSource.put(columnName, DateFormat.getFormattedDate(date, FORMAT_JDBC));
-//        break;
       } else {
         LOG.warn("Could not parse date value; returning original value");
       }

--- a/legacy/src/test/java/org/opensearch/sql/legacy/executor/format/DateFieldFormatterTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/executor/format/DateFieldFormatterTest.java
@@ -575,7 +575,7 @@ public class DateFieldFormatterTest {
     String dateFormat = "date_optional_time";
     String originalDateValue = "1581724085";
     // Invalid format for date value; should return original value
-    String expectedDateValue = "1581724085";
+    String expectedDateValue = "2020-02-14 23:48:05.000";
 
     verifyFormatting(columnName, dateFormat, originalDateValue, expectedDateValue);
   }

--- a/legacy/src/test/java/org/opensearch/sql/legacy/executor/format/DateFieldFormatterTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/executor/format/DateFieldFormatterTest.java
@@ -609,6 +609,24 @@ public class DateFieldFormatterTest {
     verifyFormatting(columnName, dateFormat, originalDateValue, expectedDateValue);
   }
 
+  @Test
+  public void testDateInTimestampFormInSecondWithoutHint() {
+    String columnName = "date_field";
+    String dateFormat = "date_optional_time";
+    String originalDateValue = "1732057981";
+    String expectedDateValue = "2024-11-19 23:13:01.000";
+    verifyFormatting(columnName, dateFormat, originalDateValue, expectedDateValue);
+  }
+
+  @Test
+  public void testDateInTimestampFormInMilliSecondWithoutHint() {
+    String columnName = "date_field";
+    String dateFormat = "date_optional_time";
+    String originalDateValue = "1732057981000";
+    String expectedDateValue = "2024-11-19 23:13:01.000";
+    verifyFormatting(columnName, dateFormat, originalDateValue, expectedDateValue);
+  }
+
   private void verifyFormatting(
       String columnName,
       String dateFormatProperty,


### PR DESCRIPTION
### Description

This is a MR, which aim to fix the issue described over https://github.com/opensearch-project/sql/issues/1545 to align the representation of `date` field between the legacy engine and the v2 engine. 

Code changes highlight:
 - Remove the `break` identifier from `DateFieldFormatter`, the current behaviour will only parse the first `date` field from the resultSet, which is not a valid assumption, because OpenSearch as platform allow multiple `date` fields co-exist on an index, also this is not an uncommon use-case for enterprise. Hence all `date` fields present on any given index should be formatted regardless of the order.
 - To detect and attempt parse any unix timestamp (second || milisecond) on best-effort basis, OpenSearch as platform allow unix timestamp value to be inserted despite `epoch_millis` being explicitly specified on field format, in this particular case there is no clear hint from the query indicate this is numeric timestamp from OpenSearch. 


Although issue is being reported https://github.com/opensearch-project/sql/issues/1545 under nested-query, however this bug has wider impact outside of nested-query, and the conditions to trigger are:
- Query that **unsupported** by the v2 engine and being forwarded to legacy engine
- Multiple `date` fields are being specified on the Index schema WITHOUT any explicit `format` configuration. 

When this happen, the current behaviour will only parse the first `date` field from the resultset.


### Reference doc:
 - OpenSearch Product doc mentioning that integer value will also be accepted. 
https://opensearch.org/docs/latest/field-types/supported-field-types/date/

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/1545

### Testing plan
```
# Create table
PUT http://localhost:9200/datetype_test?pretty

{
  "mappings": {
    "properties": {
      "dateAsDate": {"type": "date"},
      "longAsDate": {"type": "date"},      
      "id": { "type": "long" },
      "projects": {
        "type": "nested", 
        "properties": {
          "name": { "type": "text", "fields": {"keyword": {"type": "keyword"   }
            }
          }}}}}}

# Insert data
POST http://localhost:9200/datetype_test/_bulk?refresh

{"index":{"_id":"1"}}
{"id":3,"dateAsDate":"2023-01-01T00:00:00", "longAsDate": 1672531200000, "projects":[{"name":"SQL Spectrum querying"},{"name":"SQL security"},{"name":"OpenSearch security"}]}
{"index":{"_id":"2"}}
{"id":4,"dateAsDate":"2024-01-01T00:00:00", "longAsDate": 1704067200000, "projects":[]}
{"index":{"_id":"3"}}
{"id":6,"dateAsDate":"2025-01-01T00:00:00","longAsDate": 1735689600000, "projects":[{"name":"SQL security"},{"name":"Hello security"}]}

#Qeury, both fields should be in simple date format.
POST http://localhost:9200/_plugins/_sql

{
  "query" : "SELECT t.id, t.dateAsDate, t.longAsDate FROM datetype_test AS t, t.projects AS p"
}


```


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).




