### PR TITLE
Doc: Proposed RFC Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_of_comments.md
+++ b/.github/ISSUE_TEMPLATE/request_of_comments.md
@@ -17,8 +17,7 @@ Explains the existing setup or context and its shortcomings.
 * What are the primary objectives of this solution should fulfill in the long run?
 * How will this solution ensure sustainability or scalability over time?
 * Consider whether the solution addresses the root problem and aligns with the overall goals.
-
--[ ] Does the solution solve the problem?
+* How confident are we that this solution solves the problem?
 
 **Proposal**
 Summarizes the suggested solution or improvement.
@@ -28,9 +27,6 @@ Details the steps or strategy to implement the proposal.
 
 **Alternative**
 Alternative that can serve as workarounds to partially or temporarily solve the problem.
-
-**Do you have any additional context?**
-Add any other context about the problem.
 
 **Implementation Discussion**
 Outlines point the discussion regarding the proposed implementation.

--- a/.github/ISSUE_TEMPLATE/request_of_comments.md
+++ b/.github/ISSUE_TEMPLATE/request_of_comments.md
@@ -12,17 +12,25 @@ Describes the issue or challenge that needs to be addressed.
 **Current State**
 Explains the existing setup or context and its shortcomings.
 
+**Long-Term Goals**
+* Describe the ideal outcome or future state you aim to achieve.
+* What are the primary objectives of this solution should fulfill in the long run?
+* How will this solution ensure sustainability or scalability over time?
+* Consider whether the solution addresses the root problem and aligns with the overall goals.
+
+-[ ] Does the solution solve the problem?
+
 **Proposal**
 Summarizes the suggested solution or improvement.
 
 **Approach**
 Details the steps or strategy to implement the proposal.
 
-**API Design**
-Outlines the interface specifications for any involved APIs.
-
-**Known Limitation**
-Lists constraints or challenges anticipated in the solution.
+**Alternative**
+Alternative that can serve as workarounds to partially or temporarily solve the problem.
 
 **Do you have any additional context?**
 Add any other context about the problem.
+
+**Implementation Discussion**
+Outlines point the discussion regarding the proposed implementation.

--- a/.github/ISSUE_TEMPLATE/request_of_comments.md
+++ b/.github/ISSUE_TEMPLATE/request_of_comments.md
@@ -1,0 +1,28 @@
+---
+name: 📄 Request of comments 
+about: Create a request of comments to initiate an discussion on feature implementation / design. 
+title: '[RFC]'
+labels: 'rfc, untriaged'
+assignees: ''
+---
+
+**Problem Statement**
+Describes the issue or challenge that needs to be addressed.
+
+**Current State**
+Explains the existing setup or context and its shortcomings.
+
+**Proposal**
+Summarizes the suggested solution or improvement.
+
+**Approach**
+Details the steps or strategy to implement the proposal.
+
+**API Design**
+Outlines the interface specifications for any involved APIs.
+
+**Known Limitation**
+Lists constraints or challenges anticipated in the solution.
+
+**Do you have any additional context?**
+Add any other context about the problem.


### PR DESCRIPTION
### Description
Aim to provide a handy Github issue template for RFC, in order to standardize the existing feature intake process, to encourage contributors to submit a RFC when doing any major feature to get the consent / alignment from the community, in order to lower the risk / complexity of the implementation. 

Existing Github template:
<img width="828" alt="image" src="https://github.com/user-attachments/assets/fa2c30bd-fdf1-42bf-b472-d2481e295403">


### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
