### PR TITLE
Backport #3187 to 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "1.3.20-SNAPSHOT")
-        spring_version = "5.3.27"
+        spring_version = "5.3.39"
     }
 
     repositories {


### PR DESCRIPTION
### Description
Backport #3187 to 1.3

I realize in hindsight that I probably should have gone to 1.3 directly instead of trying to go through 1.x, this branch is much more up-to-date.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
