### PR TITLE
Fix broken linkchecker pipeline job

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,30 +4,30 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer        | GitHub ID                                           | Affiliation |
+| Maintainer        | GitHub ID                                     | Affiliation |
 | ----------------- | -------------------------------------------------   | ----------- |
-| Eric Wei          | [mengweieric](https://github.com/mengweieric)       | Amazon      |
-| Joshua Li         | [joshuali925](https://github.com/joshuali925)       | Amazon      |
-| Shenoy Pratik     | [ps48](https://github.com/ps48)                     | Amazon      |
-| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)           | Amazon      |
-| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)             | Amazon      |
-| Derek Ho          | [derek-ho](https://github.com/derek-ho)             | Amazon      |
-| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)               | Amazon      |
-| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons)   | Amazon      |
-| Simeon Widdis     | [swiddis](https://github.com/swiddis)               | Amazon      |
-| Chen Dai          | [dai-chen](https://github.com/dai-chen)             | Amazon      |
-| Vamsi Manohar     | [vamsi-amazon](https://github.com/vamsi-amazon)     | Amazon      |
-| Peng Huo          | [penghuo](https://github.com/penghuo)               | Amazon      |
-| Sean Kao          | [seankao-az](https://github.com/seankao-az)         | Amazon      |
-| Anirudha Jadhav   | [anirudha](https://github.com/anirudha)             | Amazon      |
-| Tomoyuki Morita   | [ykmr1224](https://github.com/ykmr1224)             | Amazon      |
-| Lantao Jin        | [LantaoJin](https://github.com/LantaoJin)           | Amazon      |
-| Louis Chu         | [noCharger](https://github.com/noCharger)           | Amazon      |
-| Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)           | Improving   |
+| Eric Wei          | [mengweieric](https://github.com/mengweieric) | Amazon      |
+| Joshua Li         | [joshuali925](https://github.com/joshuali925) | Amazon      |
+| Shenoy Pratik     | [ps48](https://github.com/ps48)               | Amazon      |
+| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)     | Amazon      |
+| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)       | Amazon      |
+| Derek Ho          | [derek-ho](https://github.com/derek-ho)       | Amazon      |
+| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)         | Amazon      |
+| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons) | Amazon      |
+| Simeon Widdis     | [swiddis](https://github.com/swiddis)         | Amazon      |
+| Chen Dai          | [dai-chen](https://github.com/dai-chen)       | Amazon      |
+| Vamsi Manohar     | [vmmusings](https://github.com/vmmusings)     | Amazon      |
+| Peng Huo          | [penghuo](https://github.com/penghuo)         | Amazon      |
+| Sean Kao          | [seankao-az](https://github.com/seankao-az)   | Amazon      |
+| Anirudha Jadhav   | [anirudha](https://github.com/anirudha)       | Amazon      |
+| Tomoyuki Morita   | [ykmr1224](https://github.com/ykmr1224)       | Amazon      |
+| Lantao Jin        | [LantaoJin](https://github.com/LantaoJin)     | Amazon      |
+| Louis Chu         | [noCharger](https://github.com/noCharger)     | Amazon      |
+| Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)     | Improving   |
 | Yury Fridlyand    | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Improving   |
-| Andrew Carbonetto | [acarbonetto](https://github.com/acarbonetto)       | Improving   |
-| Forest Vey        | [forestmvey](https://github.com/forestmvey)         | Improving   |
-| Guian Gumpac      | [GumpacG](https://github.com/GumpacG)               | Improving   |
+| Andrew Carbonetto | [acarbonetto](https://github.com/acarbonetto) | Improving   |
+| Forest Vey        | [forestmvey](https://github.com/forestmvey)   | Improving   |
+| Guian Gumpac      | [GumpacG](https://github.com/GumpacG)         | Improving   |
 
 ## Emeritus Maintainers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,30 +4,30 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer        | GitHub ID                                     | Affiliation |
-| ----------------- | -------------------------------------------------   | ----------- |
-| Eric Wei          | [mengweieric](https://github.com/mengweieric) | Amazon      |
-| Joshua Li         | [joshuali925](https://github.com/joshuali925) | Amazon      |
-| Shenoy Pratik     | [ps48](https://github.com/ps48)               | Amazon      |
-| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)     | Amazon      |
-| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)       | Amazon      |
-| Derek Ho          | [derek-ho](https://github.com/derek-ho)       | Amazon      |
-| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)         | Amazon      |
-| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons) | Amazon      |
-| Simeon Widdis     | [swiddis](https://github.com/swiddis)         | Amazon      |
-| Chen Dai          | [dai-chen](https://github.com/dai-chen)       | Amazon      |
-| Vamsi Manohar     | [vmmusings](https://github.com/vmmusings)     | Amazon      |
-| Peng Huo          | [penghuo](https://github.com/penghuo)         | Amazon      |
-| Sean Kao          | [seankao-az](https://github.com/seankao-az)   | Amazon      |
-| Anirudha Jadhav   | [anirudha](https://github.com/anirudha)       | Amazon      |
-| Tomoyuki Morita   | [ykmr1224](https://github.com/ykmr1224)       | Amazon      |
-| Lantao Jin        | [LantaoJin](https://github.com/LantaoJin)     | Amazon      |
-| Louis Chu         | [noCharger](https://github.com/noCharger)     | Amazon      |
-| Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)     | Improving   |
+| Maintainer        | GitHub ID                                           | Affiliation |
+| ----------------- |-----------------------------------------------------| ----------- |
+| Eric Wei          | [mengweieric](https://github.com/mengweieric)       | Amazon      |
+| Joshua Li         | [joshuali925](https://github.com/joshuali925)       | Amazon      |
+| Shenoy Pratik     | [ps48](https://github.com/ps48)                     | Amazon      |
+| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)           | Amazon      |
+| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)             | Amazon      |
+| Derek Ho          | [derek-ho](https://github.com/derek-ho)             | Amazon      |
+| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)               | Amazon      |
+| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons)   | Amazon      |
+| Simeon Widdis     | [swiddis](https://github.com/swiddis)               | Amazon      |
+| Chen Dai          | [dai-chen](https://github.com/dai-chen)             | Amazon      |
+| Vamsi Manohar     | [vmmusings](https://github.com/vmmusings)           | Amazon      |
+| Peng Huo          | [penghuo](https://github.com/penghuo)               | Amazon      |
+| Sean Kao          | [seankao-az](https://github.com/seankao-az)         | Amazon      |
+| Anirudha Jadhav   | [anirudha](https://github.com/anirudha)             | Amazon      |
+| Tomoyuki Morita   | [ykmr1224](https://github.com/ykmr1224)             | Amazon      |
+| Lantao Jin        | [LantaoJin](https://github.com/LantaoJin)           | Amazon      |
+| Louis Chu         | [noCharger](https://github.com/noCharger)           | Amazon      |
+| Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)           | Improving   |
 | Yury Fridlyand    | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Improving   |
-| Andrew Carbonetto | [acarbonetto](https://github.com/acarbonetto) | Improving   |
-| Forest Vey        | [forestmvey](https://github.com/forestmvey)   | Improving   |
-| Guian Gumpac      | [GumpacG](https://github.com/GumpacG)         | Improving   |
+| Andrew Carbonetto | [acarbonetto](https://github.com/acarbonetto)       | Improving   |
+| Forest Vey        | [forestmvey](https://github.com/forestmvey)         | Improving   |
+| Guian Gumpac      | [GumpacG](https://github.com/GumpacG)               | Improving   |
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
Signed-off-by: currantw <taylor.curran@improving.com>

### Description

Fixes broken linkchecker pipeline job due to broken link in `MAINTAINERS.md`.

### Related Issues

None

### Check List
- [ ] ~New functionality includes testing.~
- [ ] ~New functionality has been documented.~
- [ ] ~New functionality has javadoc added.~
- [ ] ~New functionality has a user manual doc added.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).