### PR TITLE
Add stalled PRs workflow

### DIFF
--- a/.github/workflows/stalled.yml
+++ b/.github/workflows/stalled.yml
@@ -1,0 +1,28 @@
+name: Label Stalled PRs
+on:
+  schedule:
+    - cron: '15 15 * * *' # Run every day at 15:15 UTC / 7:15 PST / 8:15 PDT
+permissions:
+  pull-requests: write
+jobs:
+  stale:
+    if: github.repository == 'opensearch-project/OpenSearch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+      - name: Stale PRs
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ steps.github_app_token.outputs.token }}
+          stale-pr-label: 'stalled'
+          stale-pr-message: 'This PR is stalled because it has been open for 30 days with no activity.'
+          days-before-pr-stale: 30
+          days-before-issue-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-close: -1

--- a/.github/workflows/stalled.yml
+++ b/.github/workflows/stalled.yml
@@ -6,7 +6,7 @@ permissions:
   pull-requests: write
 jobs:
   stale:
-    if: github.repository == 'opensearch-project/OpenSearch'
+    if: github.repository == 'opensearch-project/sql'
     runs-on: ubuntu-latest
     steps:
       - name: GitHub App token


### PR DESCRIPTION
### Description
Copies the stalled PR workflow from OS core: https://github.com/opensearch-project/OpenSearch/blob/main/.github/workflows/stalled.yml

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
