### PR TITLE
Close stale PRs after 60 days of inactivity

### DIFF
--- a/.github/workflows/stalled.yml
+++ b/.github/workflows/stalled.yml
@@ -24,5 +24,5 @@ jobs:
           stale-pr-message: 'This PR is stalled because it has been open for 30 days with no activity.'
           days-before-pr-stale: 30
           days-before-issue-stale: -1
-          days-before-pr-close: -1
+          days-before-pr-close: 60
           days-before-issue-close: -1

--- a/.github/workflows/stalled.yml
+++ b/.github/workflows/stalled.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           repo-token: ${{ steps.github_app_token.outputs.token }}
           stale-pr-label: 'stalled'
-          stale-pr-message: 'This PR is stalled because it has been open for 30 days with no activity.'
+          stale-pr-message: 'This PR is stalled because it has been open for 30 days with no activity. It will be automatically closed after 60 days of inactivity.'
           days-before-pr-stale: 30
           days-before-issue-stale: -1
           days-before-pr-close: 60


### PR DESCRIPTION
### Description
Updates the stalled PRs action to close PRs that have been inactive for 60 days (marked "stalled" for 30 days). In general the stale PRs tend to not get addressed anyways, [we currently have 14 PRs with no activity for 200 days](https://github.com/user-attachments/assets/614f4897-5012-4960-9ca5-e3746a76e9f0). This is a logical followup to #3221, I want to make it a separate PR for dedicated discussion.

Note that closing PRs isn't a destructive action, authors can easily reopen them if they get falsely closed. It just keeps our pending list more tidy, and also encourages authors to push again for feedback if they believe their changes are relevant and aren't getting attention.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
