### PR TITLE
Build subprojects in parallel

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Build with Gradle
       run: |
         chown -R 1000:1000 `pwd`
-        su `id -un 1000` -c "./gradlew --continue build"
+        su `id -un 1000` -c "./gradlew --continue --parallel build"
 
     - name: Create Artifact Path
       run: |
@@ -113,7 +113,7 @@ jobs:
         java-version: ${{ matrix.entry.java }}
 
     - name: Build with Gradle
-      run: ./gradlew --continue build ${{ matrix.entry.os_build_args }}
+      run: ./gradlew --continue --parallel build ${{ matrix.entry.os_build_args }}
 
     - name: Create Artifact Path
       run: |


### PR DESCRIPTION
### Description
Not all subprojects need to be executed sequentially. We can build subprojects in parallel to speed up the CI workflow.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3226

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
