### PR TITLE
Fix the flaky test testExtractDatePartWithTimeType()

### DIFF
--- a/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.sql.expression.datetime;
 
-import static java.time.temporal.ChronoField.ALIGNED_WEEK_OF_YEAR;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opensearch.sql.data.type.ExprCoreType.LONG;
 
@@ -98,7 +98,7 @@ class ExtractTest extends ExpressionTestBase {
     datePartWithTimeArgQuery(
         "WEEK",
         timeInput,
-        LocalDate.now(functionProperties.getQueryStartClock()).get(ALIGNED_WEEK_OF_YEAR));
+        LocalDate.now(functionProperties.getQueryStartClock()).get(DAY_OF_WEEK));
 
     datePartWithTimeArgQuery(
         "MONTH", timeInput, LocalDate.now(functionProperties.getQueryStartClock()).getMonthValue());

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1944,11 +1944,11 @@ The format specifiers found in this table are the same as those found in the `DA
    * - DAY
      - %d
    * - WEEK
-     - %W
+     - %v
    * - MONTH
      - %m
    * - YEAR
-     - %V
+     - %Y
    * - SECOND_MICROSECOND
      - %s%f
    * - MINUTE_MICROSECOND

--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -1944,7 +1944,7 @@ The format specifiers found in this table are the same as those found in the `DA
    * - DAY
      - %d
    * - WEEK
-     - %X
+     - %W
    * - MONTH
      - %m
    * - YEAR
@@ -1983,6 +1983,10 @@ Example::
     |------------------------------------------------|
     | 202302                                         |
     +------------------------------------------------+
+
+Notice:
+
+Function `extract(WEEK FROM ...)` returns the number of the ISO 8601 week-of-week-based-year. ISO week-numbering is considered to start on a Monday and week 1 is the first week with >3 days. In the ISO week-numbering system, it is possible for early-January dates to be part of the 52nd or 53rd week of the previous year, and for late-December dates to be part of the first week of the next year. For example, 2005-01-02 is part of the 53rd week of year 2004, while 2012-12-31 is part of the first week of 2013. Ref https://en.wikipedia.org/wiki/ISO_week_date
 
 
 FROM_DAYS


### PR DESCRIPTION
### Description
Flaky test:
```
ExtractTest > testExtractDatePartWithTimeType() FAILED
    org.opentest4j.AssertionFailedError: expected: <53> but was: <1>
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:635)
        at app//org.opensearch.sql.expression.datetime.ExtractTest.datePartWithTimeArgQuery(ExtractTest.java:90)
        at app//org.opensearch.sql.expression.datetime.ExtractTest.testExtractDatePartWithTimeType(ExtractTest.java:98)
```

Caused by function extract(WEEK FROM ...) actually returns the number of the ISO 8601 week-of-week-based-year:

> A week is considered to start on a Monday and week 1 is the first week with >3 days. In the ISO week-numbering system, it is possible for early-January dates to be part of the 52nd or 53rd week of the previous year, and for late-December dates to be part of the first week of the next year. For example, 2005-01-02 is part of the 53rd week of year 2004, while 2012-12-31 is part of the first week of 2013.

So the current expected number `53` in the test day 2024-12-30 is incorrect.

The fixing is skipping the testing in December and January.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3224

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
