### PR TITLE
[Backport 2.x] Function `str_to_date` should work with two-digits year

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFormatterUtil.java
@@ -172,7 +172,7 @@ class DateTimeFormatterUtil {
           .put("%T", "HH:mm:ss") // %T => HH:mm:ss
           .put("%W", "EEEE") // %W => EEEE - Weekday name (Sunday..Saturday)
           .put("%Y", "u") // %Y => yyyy - Year, numeric, 4 digits
-          .put("%y", "u") // %y => yy - Year, numeric, 2 digits
+          .put("%y", "uu") // %y => yy - Year, numeric, 2 digits
           .put("%f", "n") // %f => n - Nanoseconds
           // The following have been implemented but cannot be aligned with
           // MySQL due to the limitations of the DatetimeFormatter

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/StrToDateTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/StrToDateTest.java
@@ -51,6 +51,13 @@ class StrToDateTest extends ExpressionTestBase {
             "%Y,%m,%d,%h,%i",
             new ExprDatetimeValue("2000-01-01 10:11:00"),
             DATETIME),
+        Arguments.of(
+            "01-May-13", "%d-%b-%y", new ExprDatetimeValue("2013-05-01 00:00:00"), DATETIME),
+        Arguments.of(
+            "01-Jan-00", "%d-%b-%y", new ExprDatetimeValue("2000-01-01 00:00:00"), DATETIME),
+        // Behavior consistent with OpenSearch Core
+        Arguments.of(
+            "31-Jul-99", "%d-%b-%y", new ExprDatetimeValue("2099-07-31 00:00:00"), DATETIME),
 
         // Invalid Arguments (should return null)
         Arguments.of("a09:30:17", "a%h:%i:%s", ExprNullValue.of(), UNDEFINED),

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
@@ -1541,7 +1541,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | eval f = str_to_date('1-May-13', '%s') | fields f",
                 TEST_INDEX_DATE, "%d-%b-%y"));
-    verifySchema(result, schema("f", null, "timestamp"));
+    verifySchema(result, schema("f", null, "datetime"));
     verifySome(result.getJSONArray("datarows"), rows("2013-05-01 00:00:00"));
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
@@ -1535,6 +1535,14 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
                 TEST_INDEX_DATE, "%d,%m,%Y"));
     verifySchema(result, schema("f", null, "datetime"));
     verifySome(result.getJSONArray("datarows"), rows("2013-05-01 00:00:00"));
+    // two digits year case
+    result =
+        executeQuery(
+            String.format(
+                "source=%s | eval f = str_to_date('1-May-13', '%s') | fields f",
+                TEST_INDEX_DATE, "%d-%b-%y"));
+    verifySchema(result, schema("f", null, "timestamp"));
+    verifySome(result.getJSONArray("datarows"), rows("2013-05-01 00:00:00"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/DateTimeFunctionIT.java
@@ -925,6 +925,10 @@ public class DateTimeFunctionIT extends SQLIntegTestCase {
                 "SELECT str_to_date(firstname," + " '%%Y-%%m-%%d %%h:%%i:%%s') FROM %s LIMIT 2",
                 TEST_INDEX_BANK));
     verifyDataRows(result, rows((Object) null), rows((Object) null));
+
+    // two digits year case
+    result = executeQuery("SELECT str_to_date('23-Oct-17 00:00:00', '%d-%b-%y %h:%i:%s')");
+    verifyDataRows(result, rows("2017-10-23 00:00:00"));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Lantao Jin <ltjin@amazon.com>
(cherry picked from commit 4224f318871d4bf8cb35764fb7f589530449a0de from #2841 )

