### PR TITLE
Revert "Build subprojects in parallel"

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Build with Gradle
       run: |
         chown -R 1000:1000 `pwd`
-        su `id -un 1000` -c "./gradlew --continue --parallel build"
+        su `id -un 1000` -c "./gradlew --continue build"
 
     - name: Create Artifact Path
       run: |
@@ -114,7 +114,7 @@ jobs:
         java-version: ${{ matrix.entry.java }}
 
     - name: Build with Gradle
-      run: ./gradlew --continue --parallel build ${{ matrix.entry.os_build_args }}
+      run: ./gradlew --continue build ${{ matrix.entry.os_build_args }}
 
     - name: Create Artifact Path
       run: |


### PR DESCRIPTION
Reverts opensearch-project/sql#3223 because the async-query module compiling could fail sometimes.

```
> Task :async-query:compileJava FAILED
> Task :async-query-core:compileTestJava FAILED
```