### PR TITLE
[Followup] Fix the doctest failure

### DIFF
--- a/docs/user/ppl/general/identifiers.rst
+++ b/docs/user/ppl/general/identifiers.rst
@@ -177,12 +177,12 @@ Query metadata fields::
 
     os> source=accounts | fields firstname, lastname, _index, _sort;
     fetched rows / total rows = 4/4
-    +-------------+------------+----------+---------+
-    | firstname   | lastname   | _index   | _sort   |
-    |-------------+------------+----------+---------|
-    | Amber       | Duke       | accounts | -2      |
-    | Hattie      | Bond       | accounts | -2      |
-    | Nanette     | Bates      | accounts | -2      |
-    | Dale        | Adams      | accounts | -2      |
-    +-------------+------------+----------+---------+
+    +-----------+----------+----------+-------+
+    | firstname | lastname | _index   | _sort |
+    |-----------+----------+----------+-------|
+    | Amber     | Duke     | accounts | -2    |
+    | Hattie    | Bond     | accounts | -2    |
+    | Nanette   | Bates    | accounts | -2    |
+    | Dale      | Adams    | accounts | -2    |
+    +-----------+----------+----------+-------+
 


### PR DESCRIPTION
### Description
Followup of https://github.com/opensearch-project/sql/pull/2789. Fix the doctest failure which was success in the previous doctest some time ago.

(No need to backport to 2.x)

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/2788

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
