### PR TITLE
PPL: Add `json_object` command

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -683,6 +683,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.NOT_LIKE, expressions);
   }
 
+  public static FunctionExpression jsonValid(Expression... expressions){
+    return compile(FunctionProperties.None, BuiltinFunctionName.JSON_VALID, expressions);
+  }
+
   public static Aggregator avg(Expression... expressions) {
     return aggregate(BuiltinFunctionName.AVG, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -683,7 +683,7 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.NOT_LIKE, expressions);
   }
 
-  public static FunctionExpression jsonValid(Expression... expressions){
+  public static FunctionExpression jsonValid(Expression... expressions) {
     return compile(FunctionProperties.None, BuiltinFunctionName.JSON_VALID, expressions);
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -687,6 +687,10 @@ public class DSL {
     return compile(FunctionProperties.None, BuiltinFunctionName.JSON_VALID, expressions);
   }
 
+  public static FunctionExpression jsonObject(Expression... expressions) {
+    return compile(FunctionProperties.None, BuiltinFunctionName.JSON_OBJECT, expressions);
+  }
+
   public static Aggregator avg(Expression... expressions) {
     return aggregate(BuiltinFunctionName.AVG, expressions);
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -204,6 +204,9 @@ public enum BuiltinFunctionName {
   TRIM(FunctionName.of("trim")),
   UPPER(FunctionName.of("upper")),
 
+  /** Json Functions. */
+  JSON_VALID(FunctionName.of("json_valid")),
+
   /** NULL Test. */
   IS_NULL(FunctionName.of("is null")),
   IS_NOT_NULL(FunctionName.of("is not null")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -206,6 +206,7 @@ public enum BuiltinFunctionName {
 
   /** Json Functions. */
   JSON_VALID(FunctionName.of("json_valid")),
+  JSON_OBJECT(FunctionName.of("json_object")),
 
   /** NULL Test. */
   IS_NULL(FunctionName.of("is null")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionRepository.java
@@ -28,6 +28,7 @@ import org.opensearch.sql.expression.aggregation.AggregatorFunctions;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
 import org.opensearch.sql.expression.datetime.IntervalClause;
 import org.opensearch.sql.expression.ip.IPFunctions;
+import org.opensearch.sql.expression.json.JsonFunctions;
 import org.opensearch.sql.expression.operator.arthmetic.ArithmeticFunctions;
 import org.opensearch.sql.expression.operator.arthmetic.MathematicalFunctions;
 import org.opensearch.sql.expression.operator.convert.TypeCastOperators;
@@ -83,6 +84,7 @@ public class BuiltinFunctionRepository {
       SystemFunctions.register(instance);
       OpenSearchFunctions.register(instance);
       IPFunctions.register(instance);
+      JsonFunctions.register(instance);
     }
     return instance;
   }

--- a/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
@@ -5,12 +5,7 @@
 
 package org.opensearch.sql.expression.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.experimental.UtilityClass;
-import org.opensearch.sql.data.model.ExprValue;
-import org.opensearch.sql.data.model.ExprValueUtils;
-import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.expression.function.DefaultFunctionResolver;

--- a/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.expression.json;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.experimental.UtilityClass;
 import org.opensearch.sql.data.model.ExprValue;
@@ -43,7 +44,7 @@ public class JsonFunctions {
         try {
             objectMapper.readTree(jsonExprValue.stringValue());
             return ExprValueUtils.LITERAL_TRUE;
-        } catch (Exception e) {
+        } catch (JsonProcessingException e) {
             return ExprValueUtils.LITERAL_FALSE;
         }
     }

--- a/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
@@ -5,27 +5,27 @@
 
 package org.opensearch.sql.expression.json;
 
-import lombok.experimental.UtilityClass;
-import org.opensearch.sql.expression.function.BuiltinFunctionName;
-import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
-import org.opensearch.sql.expression.function.DefaultFunctionResolver;
-import org.opensearch.sql.utils.JsonUtils;
-
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.expression.function.FunctionDSL.define;
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;
 import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandling;
 
+import lombok.experimental.UtilityClass;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.DefaultFunctionResolver;
+import org.opensearch.sql.utils.JsonUtils;
+
 @UtilityClass
 public class JsonFunctions {
-    public void register(BuiltinFunctionRepository repository) {
-        repository.register(jsonValid());
-    }
+  public void register(BuiltinFunctionRepository repository) {
+    repository.register(jsonValid());
+  }
 
-    private DefaultFunctionResolver jsonValid() {
-        return define(
-                BuiltinFunctionName.JSON_VALID.getName(),
-                impl(nullMissingHandling(JsonUtils::isValidJson), BOOLEAN, STRING));
-    }
+  private DefaultFunctionResolver jsonValid() {
+    return define(
+        BuiltinFunctionName.JSON_VALID.getName(),
+        impl(nullMissingHandling(JsonUtils::isValidJson), BOOLEAN, STRING));
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
@@ -23,7 +23,6 @@ import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHand
 @UtilityClass
 public class JsonFunctions {
     public void register(BuiltinFunctionRepository repository) {
-
         repository.register(jsonValid());
     }
 

--- a/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
@@ -1,0 +1,46 @@
+package org.opensearch.sql.expression.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.experimental.UtilityClass;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.DefaultFunctionResolver;
+
+import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.expression.function.FunctionDSL.define;
+import static org.opensearch.sql.expression.function.FunctionDSL.impl;
+import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandling;
+
+@UtilityClass
+public class JsonFunctions {
+    public void register(BuiltinFunctionRepository repository) {
+
+        repository.register(jsonValid());
+    }
+
+    private DefaultFunctionResolver jsonValid() {
+        return define(
+                BuiltinFunctionName.JSON_VALID.getName(),
+                impl(nullMissingHandling(JsonFunctions::isValidJson), BOOLEAN, STRING));
+    }
+
+    /**
+     * Checks if given JSON string can be parsed as valid JSON.
+     *
+     * @param jsonExprValue JSON string (e.g. "198.51.100.14" or "2001:0db8::ff00:42:8329").
+     * @return true if the string can be parsed as valid JSON, else false.
+     */
+    private ExprValue isValidJson(ExprValue jsonExprValue) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            objectMapper.readTree(jsonExprValue.stringValue());
+            return ExprValueUtils.LITERAL_TRUE;
+        } catch (Exception e) {
+            return ExprValueUtils.LITERAL_FALSE;
+        }
+    }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
@@ -14,6 +14,7 @@ import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.expression.function.DefaultFunctionResolver;
+import org.opensearch.sql.utils.JsonUtils;
 
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
@@ -30,22 +31,6 @@ public class JsonFunctions {
     private DefaultFunctionResolver jsonValid() {
         return define(
                 BuiltinFunctionName.JSON_VALID.getName(),
-                impl(nullMissingHandling(JsonFunctions::isValidJson), BOOLEAN, STRING));
-    }
-
-    /**
-     * Checks if given JSON string can be parsed as valid JSON.
-     *
-     * @param jsonExprValue JSON string (e.g. "198.51.100.14" or "2001:0db8::ff00:42:8329").
-     * @return true if the string can be parsed as valid JSON, else false.
-     */
-    private ExprValue isValidJson(ExprValue jsonExprValue) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            objectMapper.readTree(jsonExprValue.stringValue());
-            return ExprValueUtils.LITERAL_TRUE;
-        } catch (JsonProcessingException e) {
-            return ExprValueUtils.LITERAL_FALSE;
-        }
+                impl(nullMissingHandling(JsonUtils::isValidJson), BOOLEAN, STRING));
     }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.expression.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/json/JsonFunctions.java
@@ -7,25 +7,100 @@ package org.opensearch.sql.expression.json;
 
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
 import static org.opensearch.sql.expression.function.FunctionDSL.define;
 import static org.opensearch.sql.expression.function.FunctionDSL.impl;
 import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHandling;
 
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
 import org.opensearch.sql.expression.function.DefaultFunctionResolver;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.expression.function.FunctionSignature;
 import org.opensearch.sql.utils.JsonUtils;
 
 @UtilityClass
 public class JsonFunctions {
   public void register(BuiltinFunctionRepository repository) {
     repository.register(jsonValid());
+    repository.register(jsonObject());
   }
 
   private DefaultFunctionResolver jsonValid() {
     return define(
         BuiltinFunctionName.JSON_VALID.getName(),
         impl(nullMissingHandling(JsonUtils::isValidJson), BOOLEAN, STRING));
+  }
+
+  /** Creates a JSON Object/tuple expr from a given list of kv pairs. */
+  private static FunctionResolver jsonObject() {
+    return new FunctionResolver() {
+      @Override
+      public FunctionName getFunctionName() {
+        return BuiltinFunctionName.JSON_OBJECT.getName();
+      }
+
+      @Override
+      public Pair<FunctionSignature, FunctionBuilder> resolve(
+          FunctionSignature unresolvedSignature) {
+        List<ExprType> paramList = unresolvedSignature.getParamTypeList();
+        // check that we got an even number of arguments
+        if (paramList.size() % 2 != 0) {
+          throw new SemanticCheckException(
+              String.format(
+                  "Expected an even number of arguments but instead got #%d arguments",
+                  paramList.size()));
+        }
+
+        // check that each "key" argument (of key-value pair) is a string
+        for (int i = 0; i < paramList.size(); i = i + 2) {
+          ExprType paramType = paramList.get(i);
+          if (!ExprCoreType.STRING.equals(paramType)) {
+            throw new SemanticCheckException(
+                String.format(
+                    "Expected type %s instead of %s for parameter #%d",
+                    ExprCoreType.STRING, paramType.typeName(), i + 1));
+          }
+        }
+
+        // return the unresolved signature and function builder
+        return Pair.of(
+            unresolvedSignature,
+            (functionProperties, arguments) ->
+                new FunctionExpression(getFunctionName(), arguments) {
+                  @Override
+                  public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+                    LinkedHashMap<String, ExprValue> tupleValues = new LinkedHashMap<>();
+                    Iterator<Expression> iter = getArguments().iterator();
+                    while (iter.hasNext()) {
+                      tupleValues.put(
+                          iter.next().valueOf(valueEnv).stringValue(),
+                          iter.next().valueOf(valueEnv));
+                    }
+                    return ExprTupleValue.fromExprValueMap(tupleValues);
+                  }
+
+                  @Override
+                  public ExprType type() {
+                    return STRUCT;
+                  }
+                });
+      }
+    };
   }
 }

--- a/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
@@ -1,0 +1,26 @@
+package org.opensearch.sql.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.experimental.UtilityClass;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+
+@UtilityClass
+public class JsonUtils {
+    /**
+     * Checks if given JSON string can be parsed as valid JSON.
+     *
+     * @param jsonExprValue JSON string (e.g. "198.51.100.14" or "2001:0db8::ff00:42:8329").
+     * @return true if the string can be parsed as valid JSON, else false.
+     */
+    public static ExprValue isValidJson(ExprValue jsonExprValue) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            objectMapper.readTree(jsonExprValue.stringValue());
+            return ExprValueUtils.LITERAL_TRUE;
+        } catch (JsonProcessingException e) {
+            return ExprValueUtils.LITERAL_FALSE;
+        }
+    }
+}

--- a/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
@@ -8,19 +8,19 @@ import org.opensearch.sql.data.model.ExprValueUtils;
 
 @UtilityClass
 public class JsonUtils {
-    /**
-     * Checks if given JSON string can be parsed as valid JSON.
-     *
-     * @param jsonExprValue JSON string (e.g. "198.51.100.14" or "2001:0db8::ff00:42:8329").
-     * @return true if the string can be parsed as valid JSON, else false.
-     */
-    public static ExprValue isValidJson(ExprValue jsonExprValue) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            objectMapper.readTree(jsonExprValue.stringValue());
-            return ExprValueUtils.LITERAL_TRUE;
-        } catch (JsonProcessingException e) {
-            return ExprValueUtils.LITERAL_FALSE;
-        }
+  /**
+   * Checks if given JSON string can be parsed as valid JSON.
+   *
+   * @param jsonExprValue JSON string (e.g. "198.51.100.14" or "2001:0db8::ff00:42:8329").
+   * @return true if the string can be parsed as valid JSON, else false.
+   */
+  public static ExprValue isValidJson(ExprValue jsonExprValue) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      objectMapper.readTree(jsonExprValue.stringValue());
+      return ExprValueUtils.LITERAL_TRUE;
+    } catch (JsonProcessingException e) {
+      return ExprValueUtils.LITERAL_FALSE;
     }
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
@@ -11,7 +11,7 @@ public class JsonUtils {
   /**
    * Checks if given JSON string can be parsed as valid JSON.
    *
-   * @param jsonExprValue JSON string (e.g. "198.51.100.14" or "2001:0db8::ff00:42:8329").
+   * @param jsonExprValue JSON string (e.g. "{\"hello\": \"world\"}").
    * @return true if the string can be parsed as valid JSON, else false.
    */
   public static ExprValue isValidJson(ExprValue jsonExprValue) {

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -27,7 +27,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -1230,7 +1230,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   }
 
   @Test
-  @Disabled("Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
+  @Disabled(
+      "Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testWeekOfYearWithTimeType() {
     assertAll(
         () ->

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -1229,9 +1229,9 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         expectedInteger);
   }
 
+  // subtracting 1 as a temporary fix for year 2024.
+  // Issue: https://github.com/opensearch-project/sql/issues/2477
   @Test
-  @Disabled(
-      "Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testWeekOfYearWithTimeType() {
     assertAll(
         () ->

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -27,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -1228,9 +1229,8 @@ class DateTimeFunctionTest extends ExpressionTestBase {
         expectedInteger);
   }
 
-  // subtracting 1 as a temporary fix for year 2024.
-  // Issue: https://github.com/opensearch-project/sql/issues/2477
   @Test
+  @Disabled("Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testWeekOfYearWithTimeType() {
     assertAll(
         () ->

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
@@ -92,8 +92,6 @@ class ExtractTest extends ExpressionTestBase {
   }
 
   @Test
-  @Disabled(
-      "Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testExtractDatePartWithTimeType() {
     datePartWithTimeArgQuery(
         "DAY", timeInput, LocalDate.now(functionProperties.getQueryStartClock()).getDayOfMonth());

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
@@ -11,7 +11,6 @@ import static org.opensearch.sql.data.type.ExprCoreType.LONG;
 
 import java.time.LocalDate;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -93,7 +92,8 @@ class ExtractTest extends ExpressionTestBase {
   }
 
   @Test
-  @Disabled("Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
+  @Disabled(
+      "Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testExtractDatePartWithTimeType() {
     datePartWithTimeArgQuery(
         "DAY", timeInput, LocalDate.now(functionProperties.getQueryStartClock()).getDayOfMonth());

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
@@ -11,6 +11,8 @@ import static org.opensearch.sql.data.type.ExprCoreType.LONG;
 
 import java.time.LocalDate;
 import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -91,6 +93,7 @@ class ExtractTest extends ExpressionTestBase {
   }
 
   @Test
+  @Disabled("Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testExtractDatePartWithTimeType() {
     datePartWithTimeArgQuery(
         "DAY", timeInput, LocalDate.now(functionProperties.getQueryStartClock()).getDayOfMonth());

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/YearweekTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/YearweekTest.java
@@ -98,9 +98,9 @@ class YearweekTest extends ExpressionTestBase {
     assertEquals(eval(expression), eval(expressionWithoutMode));
   }
 
+  // subtracting 1 as a temporary fix for year 2024.
+  // Issue: https://github.com/opensearch-project/sql/issues/2477
   @Test
-  @Disabled(
-      "Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testYearweekWithTimeType() {
     int week = LocalDate.now(functionProperties.getQueryStartClock()).get(ALIGNED_WEEK_OF_YEAR) - 1;
     int year = LocalDate.now(functionProperties.getQueryStartClock()).getYear();

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/YearweekTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/YearweekTest.java
@@ -14,7 +14,6 @@ import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 
 import java.time.LocalDate;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -100,7 +99,8 @@ class YearweekTest extends ExpressionTestBase {
   }
 
   @Test
-  @Disabled("Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
+  @Disabled(
+      "Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testYearweekWithTimeType() {
     int week = LocalDate.now(functionProperties.getQueryStartClock()).get(ALIGNED_WEEK_OF_YEAR) - 1;
     int year = LocalDate.now(functionProperties.getQueryStartClock()).getYear();

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/YearweekTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/YearweekTest.java
@@ -14,6 +14,8 @@ import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 
 import java.time.LocalDate;
 import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -97,9 +99,8 @@ class YearweekTest extends ExpressionTestBase {
     assertEquals(eval(expression), eval(expressionWithoutMode));
   }
 
-  // subtracting 1 as a temporary fix for year 2024.
-  // Issue: https://github.com/opensearch-project/sql/issues/2477
   @Test
+  @Disabled("Test is disabled because of issue https://github.com/opensearch-project/sql/issues/2477")
   public void testYearweekWithTimeType() {
     int week = LocalDate.now(functionProperties.getQueryStartClock()).get(ALIGNED_WEEK_OF_YEAR) - 1;
     int year = LocalDate.now(functionProperties.getQueryStartClock()).getYear();

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -6,10 +6,8 @@
 package org.opensearch.sql.expression.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_FALSE;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
-import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,29 +19,31 @@ import org.opensearch.sql.expression.FunctionExpression;
 
 @ExtendWith(MockitoExtension.class)
 public class JsonFunctionsTest {
-    private static final ExprValue JsonObject = ExprValueUtils.stringValue("{\"a\":\"1\",\"b\":\"2\"}");
-    private static final ExprValue JsonArray = ExprValueUtils.stringValue("[1, 2, 3, 4]");
-    private static final ExprValue JsonScalarString = ExprValueUtils.stringValue("\"abc\"");
-    private static final ExprValue JsonEmptyString = ExprValueUtils.stringValue("");
-    private static final ExprValue JsonInvalidObject = ExprValueUtils.stringValue("{\"invalid\":\"json\", \"string\"}");
-    private static final ExprValue JsonInvalidScalar = ExprValueUtils.stringValue("abc");
+  private static final ExprValue JsonObject =
+      ExprValueUtils.stringValue("{\"a\":\"1\",\"b\":\"2\"}");
+  private static final ExprValue JsonArray = ExprValueUtils.stringValue("[1, 2, 3, 4]");
+  private static final ExprValue JsonScalarString = ExprValueUtils.stringValue("\"abc\"");
+  private static final ExprValue JsonEmptyString = ExprValueUtils.stringValue("");
+  private static final ExprValue JsonInvalidObject =
+      ExprValueUtils.stringValue("{\"invalid\":\"json\", \"string\"}");
+  private static final ExprValue JsonInvalidScalar = ExprValueUtils.stringValue("abc");
 
-    @Test
-    public void json_valid_returns_false() {
-        assertEquals(LITERAL_FALSE, execute(JsonInvalidObject));
-        assertEquals(LITERAL_FALSE, execute(JsonInvalidScalar));
-    }
+  @Test
+  public void json_valid_returns_false() {
+    assertEquals(LITERAL_FALSE, execute(JsonInvalidObject));
+    assertEquals(LITERAL_FALSE, execute(JsonInvalidScalar));
+  }
 
-    @Test
-    public void json_valid_returns_true() {
-        assertEquals(LITERAL_TRUE, execute(JsonObject));
-        assertEquals(LITERAL_TRUE, execute(JsonArray));
-        assertEquals(LITERAL_TRUE, execute(JsonScalarString));
-        assertEquals(LITERAL_TRUE, execute(JsonEmptyString));
-    }
+  @Test
+  public void json_valid_returns_true() {
+    assertEquals(LITERAL_TRUE, execute(JsonObject));
+    assertEquals(LITERAL_TRUE, execute(JsonArray));
+    assertEquals(LITERAL_TRUE, execute(JsonScalarString));
+    assertEquals(LITERAL_TRUE, execute(JsonEmptyString));
+  }
 
-    private ExprValue execute(ExprValue jsonString) {
-        FunctionExpression exp = DSL.jsonValid(DSL.literal(jsonString));
-        return exp.valueOf();
-    }
+  private ExprValue execute(ExprValue jsonString) {
+    FunctionExpression exp = DSL.jsonValid(DSL.literal(jsonString));
+    return exp.valueOf();
+  }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_FALSE;
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+public class JsonFunctionsTest {
+
+    private static final ExprValue JsonObject = ExprValueUtils.stringValue("{\"a\":\"1\",\"b\":\"2\"}");
+    private static final ExprValue JsonArray = ExprValueUtils.stringValue("[1, 2, 3, 4]");
+    private static final ExprValue JsonScalarString = ExprValueUtils.stringValue("\"abc\"");
+    private static final ExprValue JsonEmptyString = ExprValueUtils.stringValue("");
+    private static final ExprValue JsonInvalidObject = ExprValueUtils.stringValue("{\"invalid\":\"json\", \"string\"}");
+    private static final ExprValue JsonInvalidScalar = ExprValueUtils.stringValue("abc");
+
+    @Mock private Environment<Expression, ExprValue> env;
+
+    @Test
+    public void json_valid_invalid_json_string() {
+        assertEquals(LITERAL_FALSE, execute(JsonInvalidObject));
+        assertEquals(LITERAL_FALSE, execute(JsonInvalidScalar));
+    }
+
+    @Test
+    public void json_valid_valid_json_string() {
+        assertEquals(LITERAL_TRUE, JsonObject);
+        assertEquals(LITERAL_TRUE, JsonArray);
+        assertEquals(LITERAL_TRUE, JsonScalarString);
+        assertEquals(LITERAL_TRUE, JsonEmptyString);
+    }
+
+    private ExprValue execute(ExprValue jsonString) {
+        final String fieldName = "json_string";
+        FunctionExpression exp = DSL.jsonValid(DSL.literal(jsonString));
+
+        when(DSL.ref(fieldName, STRING).valueOf(env)).thenReturn(jsonString);
+
+        return exp.valueOf(env);
+    }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -29,13 +29,13 @@ public class JsonFunctionsTest {
     private static final ExprValue JsonInvalidScalar = ExprValueUtils.stringValue("abc");
 
     @Test
-    public void json_valid_invalid_json_string() {
+    public void json_valid_returns_false() {
         assertEquals(LITERAL_FALSE, execute(JsonInvalidObject));
         assertEquals(LITERAL_FALSE, execute(JsonInvalidScalar));
     }
 
     @Test
-    public void json_valid_valid_json_string() {
+    public void json_valid_returns_true() {
         assertEquals(LITERAL_TRUE, execute(JsonObject));
         assertEquals(LITERAL_TRUE, execute(JsonArray));
         assertEquals(LITERAL_TRUE, execute(JsonScalarString));

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -13,26 +13,20 @@ import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.expression.DSL;
-import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.FunctionExpression;
-import org.opensearch.sql.expression.env.Environment;
 
 @ExtendWith(MockitoExtension.class)
 public class JsonFunctionsTest {
-
     private static final ExprValue JsonObject = ExprValueUtils.stringValue("{\"a\":\"1\",\"b\":\"2\"}");
     private static final ExprValue JsonArray = ExprValueUtils.stringValue("[1, 2, 3, 4]");
     private static final ExprValue JsonScalarString = ExprValueUtils.stringValue("\"abc\"");
     private static final ExprValue JsonEmptyString = ExprValueUtils.stringValue("");
     private static final ExprValue JsonInvalidObject = ExprValueUtils.stringValue("{\"invalid\":\"json\", \"string\"}");
     private static final ExprValue JsonInvalidScalar = ExprValueUtils.stringValue("abc");
-
-    @Mock private Environment<Expression, ExprValue> env;
 
     @Test
     public void json_valid_invalid_json_string() {
@@ -42,18 +36,14 @@ public class JsonFunctionsTest {
 
     @Test
     public void json_valid_valid_json_string() {
-        assertEquals(LITERAL_TRUE, JsonObject);
-        assertEquals(LITERAL_TRUE, JsonArray);
-        assertEquals(LITERAL_TRUE, JsonScalarString);
-        assertEquals(LITERAL_TRUE, JsonEmptyString);
+        assertEquals(LITERAL_TRUE, execute(JsonObject));
+        assertEquals(LITERAL_TRUE, execute(JsonArray));
+        assertEquals(LITERAL_TRUE, execute(JsonScalarString));
+        assertEquals(LITERAL_TRUE, execute(JsonEmptyString));
     }
 
     private ExprValue execute(ExprValue jsonString) {
-        final String fieldName = "json_string";
         FunctionExpression exp = DSL.jsonValid(DSL.literal(jsonString));
-
-        when(DSL.ref(fieldName, STRING).valueOf(env)).thenReturn(jsonString);
-
-        return exp.valueOf(env);
+        return exp.valueOf();
     }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -6,16 +6,31 @@
 package org.opensearch.sql.expression.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_FALSE;
+import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_NULL;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.data.model.ExprBooleanValue;
+import org.opensearch.sql.data.model.ExprCollectionValue;
+import org.opensearch.sql.data.model.ExprDoubleValue;
+import org.opensearch.sql.data.model.ExprLongValue;
+import org.opensearch.sql.data.model.ExprNullValue;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
 
 @ExtendWith(MockitoExtension.class)
 public class JsonFunctionsTest {
@@ -45,5 +60,75 @@ public class JsonFunctionsTest {
   private ExprValue execute(ExprValue jsonString) {
     FunctionExpression exp = DSL.jsonValid(DSL.literal(jsonString));
     return exp.valueOf();
+  }
+
+  @Test
+  public void json_object_returns_tuple() {
+    FunctionExpression exp;
+
+    // Setup
+    LinkedHashMap<String, ExprValue> objectMap = new LinkedHashMap<>();
+    objectMap.put("foo", new ExprStringValue("foo"));
+    objectMap.put("fuzz", ExprBooleanValue.of(true));
+    objectMap.put("bar", new ExprLongValue(1234));
+    objectMap.put("bar2", new ExprDoubleValue(12.34));
+    objectMap.put("baz", ExprNullValue.of());
+    objectMap.put(
+        "obj", ExprTupleValue.fromExprValueMap(Map.of("internal", new ExprStringValue("value"))));
+    // TODO: requires json_array()
+    //    objectMap.put(
+    //        "arr",
+    //        new ExprCollectionValue(
+    //            List.of(new ExprStringValue("string"), ExprBooleanValue.of(true), ExprNullValue.of())));
+    ExprValue expectedTupleExpr = ExprTupleValue.fromExprValueMap(objectMap);
+
+    // exercise
+    exp = DSL.jsonObject(
+        DSL.literal("foo"), DSL.literal("foo"),
+        DSL.literal("fuzz"), DSL.literal(true),
+        DSL.literal("bar"), DSL.literal(1234),
+        DSL.literal("bar2"), DSL.literal(12.34),
+        DSL.literal("baz"), new LiteralExpression(ExprValueUtils.nullValue()),
+        DSL.literal("obj"), DSL.jsonObject(
+            DSL.literal("internal"), DSL.literal("value")
+        )
+    );
+
+    // Verify
+    var value = exp.valueOf();
+    assertTrue(value instanceof ExprTupleValue);
+    assertEquals(expectedTupleExpr, value);
+  }
+
+  @Test
+  public void json_object_returns_empty_tuple() {
+    FunctionExpression exp;
+
+    // Setup
+    LinkedHashMap<String, ExprValue> objectMap = new LinkedHashMap<>();
+    ExprValue expectedTupleExpr = ExprTupleValue.fromExprValueMap(objectMap);
+
+    // exercise
+    exp = DSL.jsonObject();
+
+    // Verify
+    var value = exp.valueOf();
+    assertTrue(value instanceof ExprTupleValue);
+    assertEquals(expectedTupleExpr, value);
+  }
+
+  @Test
+  public void json_object_throws_SemanticCheckException() {
+    // wrong number of arguments
+    assertThrows(
+        SemanticCheckException.class, () -> DSL.jsonObject(DSL.literal("only one")).valueOf());
+    assertThrows(
+        SemanticCheckException.class, () -> DSL.jsonObject(DSL.literal("one"), DSL.literal("two"), DSL.literal("three")).valueOf());
+
+    // key argument is not a string
+    assertThrows(
+        SemanticCheckException.class, () -> DSL.jsonObject(DSL.literal(1234), DSL.literal("two")).valueOf());
+    assertThrows(
+        SemanticCheckException.class, () -> DSL.jsonObject(DSL.literal("one"), DSL.literal(true), DSL.literal(true), DSL.literal("four")).valueOf());
   }
 }

--- a/docs/category.json
+++ b/docs/category.json
@@ -34,6 +34,7 @@
     "user/ppl/functions/datetime.rst",
     "user/ppl/functions/expressions.rst",
     "user/ppl/functions/ip.rst",
+    "user/ppl/functions/json.rst",
     "user/ppl/functions/math.rst",
     "user/ppl/functions/relevance.rst",
     "user/ppl/functions/string.rst"

--- a/docs/user/dql/metadata.rst
+++ b/docs/user/dql/metadata.rst
@@ -35,7 +35,7 @@ Example 1: Show All Indices Information
 SQL query::
 
     os> SHOW TABLES LIKE '%'
-    fetched rows / total rows = 10/10
+    fetched rows / total rows = 11/11
     +----------------+-------------+-----------------+------------+---------+----------+------------+-----------+---------------------------+----------------+
     | TABLE_CAT      | TABLE_SCHEM | TABLE_NAME      | TABLE_TYPE | REMARKS | TYPE_CAT | TYPE_SCHEM | TYPE_NAME | SELF_REFERENCING_COL_NAME | REF_GENERATION |
     |----------------+-------------+-----------------+------------+---------+----------+------------+-----------+---------------------------+----------------|
@@ -44,6 +44,7 @@ SQL query::
     | docTestCluster | null        | accounts        | BASE TABLE | null    | null     | null       | null      | null                      | null           |
     | docTestCluster | null        | apache          | BASE TABLE | null    | null     | null       | null      | null                      | null           |
     | docTestCluster | null        | books           | BASE TABLE | null    | null     | null       | null      | null                      | null           |
+    | docTestCluster | null        | json_test       | BASE TABLE | null    | null     | null       | null      | null                      | null           |
     | docTestCluster | null        | nested          | BASE TABLE | null    | null     | null       | null      | null                      | null           |
     | docTestCluster | null        | nyc_taxi        | BASE TABLE | null    | null     | null       | null      | null                      | null           |
     | docTestCluster | null        | people          | BASE TABLE | null    | null     | null       | null      | null                      | null           |

--- a/docs/user/ppl/functions/json.rst
+++ b/docs/user/ppl/functions/json.rst
@@ -22,13 +22,14 @@ Return type: BOOLEAN
 
 Example::
 
-    > source=json_test | where json_valid(json_string) | fields test_name, json_string
+    > source=json_test | eval is_valid = json_valid(json_string) | fields test_name, json_string, is_valid
     fetched rows / total rows = 4/4
-    +--------------------+--------------------+
-    | test_name          | json_string        |
-    |--------------------|--------------------|
-    | json object        | {"a":"1","b":"2"}  |
-    | json array         | [1, 2, 3, 4]       |
-    | json scalar string | [1, 2, 3, 4]       |
-    | json empty string  | [1, 2, 3, 4]       |
-    +--------------------+--------------------+
+    +---------------------+------------------------------+----------+
+    | test_name           | json_string                  | is_valid |
+    |---------------------|------------------------------|----------|
+    | json object         | {"a":"1","b":"2"}            | True     |
+    | json array          | [1, 2, 3, 4]                 | True     |
+    | json scalar string  | "abc"                        | True     |
+    | json empty string   |                              | True     |
+    | json invalid object | {"invalid":"json", "string"} | True     |
+    +---------------------+------------------------------+----------+

--- a/docs/user/ppl/functions/json.rst
+++ b/docs/user/ppl/functions/json.rst
@@ -1,0 +1,34 @@
+====================
+IP Address Functions
+====================
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 1
+
+JSON_VALID
+----------
+
+Description
+>>>>>>>>>>>
+
+Usage: `json_valid(json_string)` checks if `json_string` is a valid STRING string.
+
+Argument type: STRING
+
+Return type: BOOLEAN
+
+Example::
+
+    > source=json_test | where json_valid(json_string) | fields test_name, json_string
+    fetched rows / total rows = 4/4
+    +--------------------+--------------------+
+    | test_name          | json_string        |
+    |--------------------|--------------------|
+    | json object        | {"a":"1","b":"2"}  |
+    | json array         | [1, 2, 3, 4]       |
+    | json scalar string | [1, 2, 3, 4]       |
+    | json empty string  | [1, 2, 3, 4]       |
+    +--------------------+--------------------+

--- a/docs/user/ppl/functions/json.rst
+++ b/docs/user/ppl/functions/json.rst
@@ -33,3 +33,43 @@ Example::
     | json empty string   |                              | True     |
     | json invalid object | {"invalid":"json", "string"} | True     |
     +---------------------+------------------------------+----------+
+
+JSON_OBJECT
+-----------
+
+Description
+>>>>>>>>>>>
+
+Usage: `json_object(<key>, <value>[, <key>, <value>]...)` returns a JSON object from key-value pairs.
+
+Argument type:
+- A \<key\> must be STRING.
+- A \<value\> can be a scalar, another json object, or json array type.  Note: scalar fields will be treated as single-value.  Use `json_array` to construct an array value from a multi-value.
+
+Return type: STRUCT
+
+Example:
+
+    os> source=people | eval result = json_object('key', 123.45) | fields result
+    fetched rows / total rows = 1/1
+    +------------------+
+    | result           |
+    +------------------+
+    | {"key":123.45}   |
+    +------------------+
+
+    os> source=people | eval result = json_object('outer', json_object('inner', 123.45)) | fields result
+    fetched rows / total rows = 1/1
+    +------------------------------+
+    | result                       |
+    +------------------------------+
+    | {"outer":{"inner":123.45}}   |
+    +------------------------------+
+
+    os> source=people | eval result = json_object('array_doc', json_array(123.45, "string", true, null)) | fields result
+    fetched rows / total rows = 1/1
+    +------------------------------+
+    | result                       |
+    +------------------------------+
+    | {"array_doc":[123.45, "string", true, null]}   |
+    +------------------------------+

--- a/doctest/test_data/json_test.json
+++ b/doctest/test_data/json_test.json
@@ -1,0 +1,5 @@
+{"test_name":"json object", "json_string":"{\"a\":\"1\",\"b\":\"2\"}"}
+{"test_name":"json array", "json_string":"[1, 2, 3, 4]"}
+{"test_name":"json scalar string", "json_string":"\"abc\""}
+{"test_name":"json empty string","json_string":""}
+{"test_name":"json invalid object", "json_string":"{\"invalid\":\"json\", \"string\"}"}

--- a/doctest/test_docs.py
+++ b/doctest/test_docs.py
@@ -30,6 +30,7 @@ WILDCARD = "wildcard"
 NESTED = "nested"
 DATASOURCES = ".ql-datasources"
 WEBLOGS = "weblogs"
+JSON_TEST = "json_test"
 
 class DocTestConnection(OpenSearchConnection):
 
@@ -123,6 +124,7 @@ def set_up_test_indices(test):
     load_file("nested_objects.json", index_name=NESTED)
     load_file("datasources.json", index_name=DATASOURCES)
     load_file("weblogs.json", index_name=WEBLOGS)
+    load_file("json_test.json", index_name=JSON_TEST)
 
 
 def load_file(filename, index_name):
@@ -151,7 +153,7 @@ def set_up(test):
 
 def tear_down(test):
     # drop leftover tables after each test
-    test_data_client.indices.delete(index=[ACCOUNTS, EMPLOYEES, PEOPLE, ACCOUNT2, NYC_TAXI, BOOKS, APACHE, WILDCARD, NESTED, WEBLOGS], ignore_unavailable=True)
+    test_data_client.indices.delete(index=[ACCOUNTS, EMPLOYEES, PEOPLE, ACCOUNT2, NYC_TAXI, BOOKS, APACHE, WILDCARD, NESTED, WEBLOGS, JSON_TEST], ignore_unavailable=True)
 
 
 docsuite = partial(doctest.DocFileSuite,

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -22,6 +22,7 @@ import static org.opensearch.sql.legacy.TestUtils.getEmployeeNestedTypeIndexMapp
 import static org.opensearch.sql.legacy.TestUtils.getGameOfThronesIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getGeopointIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getJoinTypeIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getJsonTestIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getLocationIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getMappingFile;
 import static org.opensearch.sql.legacy.TestUtils.getNestedSimpleIndexMapping;
@@ -745,7 +746,12 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         TestsConstants.TEST_INDEX_GEOPOINT,
         "dates",
         getGeopointIndexMapping(),
-        "src/test/resources/geopoints.json");
+        "src/test/resources/geopoints.json"),
+    JSON_TEST(
+        TestsConstants.TEST_INDEX_JSON_TEST,
+        "json",
+        getJsonTestIndexMapping(),
+        "src/test/resources/json_test.json");
 
     private final String name;
     private final String type;

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
@@ -250,6 +250,11 @@ public class TestUtils {
     return getMappingFile(mappingFile);
   }
 
+  public static String getJsonTestIndexMapping() {
+    String mappingFile = "json_test_index_mapping.json";
+    return getMappingFile(mappingFile);
+  }
+
   public static void loadBulk(Client client, String jsonPath, String defaultIndex)
       throws Exception {
     System.out.println(String.format("Loading file %s into opensearch cluster", jsonPath));

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -58,6 +58,7 @@ public class TestsConstants {
   public static final String TEST_INDEX_MULTI_NESTED_TYPE = TEST_INDEX + "_multi_nested";
   public static final String TEST_INDEX_NESTED_WITH_NULLS = TEST_INDEX + "_nested_with_nulls";
   public static final String TEST_INDEX_GEOPOINT = TEST_INDEX + "_geopoint";
+  public static final String TEST_INDEX_JSON_TEST = TEST_INDEX + "_json_test";
   public static final String DATASOURCES = ".ql-datasources";
 
   public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/JsonFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/JsonFunctionIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import org.json.JSONObject;
+
+import javax.json.Json;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_JSON_TEST;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+public class JsonFunctionIT extends PPLIntegTestCase {
+    @Override
+    public void init() throws IOException {
+        loadIndex(Index.JSON_TEST);
+    }
+
+    @Test
+    public void test_json_valid() throws IOException {
+        JSONObject result;
+
+        result =
+            executeQuery(
+                String.format(
+                    "source=%s | where json_valid(json_string) | fields test_name",
+                    TEST_INDEX_JSON_TEST
+                )
+            );
+        verifySchema(result, schema("test_name", null,  "string"));
+        verifyDataRows(
+                result,
+                rows("json object"),
+                rows("json array"),
+                rows("json scalar string"),
+                rows("json empty string")
+        );
+    }
+
+    @Test
+    public void test_not_json_valid() throws IOException {
+        JSONObject result;
+
+        result =
+                executeQuery(
+                        String.format(
+                                "source=%s | where not json_valid(json_string) | fields test_name",
+                                TEST_INDEX_JSON_TEST
+                        )
+                );
+        verifySchema(result, schema("test_name", null,  "string"));
+        verifyDataRows(
+                result,
+                rows("json invalid object")
+        );
+    }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/JsonFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/JsonFunctionIT.java
@@ -5,61 +5,50 @@
 
 package org.opensearch.sql.ppl;
 
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import org.json.JSONObject;
-
-import javax.json.Json;
-
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_JSON_TEST;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
 public class JsonFunctionIT extends PPLIntegTestCase {
-    @Override
-    public void init() throws IOException {
-        loadIndex(Index.JSON_TEST);
-    }
+  @Override
+  public void init() throws IOException {
+    loadIndex(Index.JSON_TEST);
+  }
 
-    @Test
-    public void test_json_valid() throws IOException {
-        JSONObject result;
+  @Test
+  public void test_json_valid() throws IOException {
+    JSONObject result;
 
-        result =
-            executeQuery(
-                String.format(
-                    "source=%s | where json_valid(json_string) | fields test_name",
-                    TEST_INDEX_JSON_TEST
-                )
-            );
-        verifySchema(result, schema("test_name", null,  "string"));
-        verifyDataRows(
-                result,
-                rows("json object"),
-                rows("json array"),
-                rows("json scalar string"),
-                rows("json empty string")
-        );
-    }
+    result =
+        executeQuery(
+            String.format(
+                "source=%s | where json_valid(json_string) | fields test_name",
+                TEST_INDEX_JSON_TEST));
+    verifySchema(result, schema("test_name", null, "string"));
+    verifyDataRows(
+        result,
+        rows("json object"),
+        rows("json array"),
+        rows("json scalar string"),
+        rows("json empty string"));
+  }
 
-    @Test
-    public void test_not_json_valid() throws IOException {
-        JSONObject result;
+  @Test
+  public void test_not_json_valid() throws IOException {
+    JSONObject result;
 
-        result =
-                executeQuery(
-                        String.format(
-                                "source=%s | where not json_valid(json_string) | fields test_name",
-                                TEST_INDEX_JSON_TEST
-                        )
-                );
-        verifySchema(result, schema("test_name", null,  "string"));
-        verifyDataRows(
-                result,
-                rows("json invalid object")
-        );
-    }
+    result =
+        executeQuery(
+            String.format(
+                "source=%s | where not json_valid(json_string) | fields test_name",
+                TEST_INDEX_JSON_TEST));
+    verifySchema(result, schema("test_name", null, "string"));
+    verifyDataRows(result, rows("json invalid object"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/JsonFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/JsonFunctionIT.java
@@ -12,6 +12,8 @@ import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -50,5 +52,25 @@ public class JsonFunctionIT extends PPLIntegTestCase {
                 TEST_INDEX_JSON_TEST));
     verifySchema(result, schema("test_name", null, "string"));
     verifyDataRows(result, rows("json invalid object"));
+  }
+
+  @Test
+  public void test_json_object() throws IOException {
+    JSONObject result;
+
+    result =
+        executeQuery(
+            String.format(
+                "source=%s | eval obj=json_object(\"key\", json(json_string)) | fields test_name, obj"
+                    + " test_name, casted",
+                TEST_INDEX_JSON_TEST));
+    verifySchema(result, schema("test_name", null, "string"), schema("casted", null, "undefined"));
+    verifyDataRows(
+        result,
+        rows("json object", Map.of("key", Map.of("a", "1", "b", "2"))),
+        rows("json array", Map.of("key", List.of(1, 2, 3, 4))),
+        rows("json scalar string", Map.of("key", "abc")),
+        rows("json empty string", Map.of("key", null))
+    );
   }
 }

--- a/integ-test/src/test/resources/indexDefinitions/json_test_index_mappping.json
+++ b/integ-test/src/test/resources/indexDefinitions/json_test_index_mappping.json
@@ -1,0 +1,12 @@
+{
+  "mappings": {
+    "properties": {
+      "test_name": {
+        "type": "text"
+      },
+      "json_string": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/integ-test/src/test/resources/indexDefinitions/json_test_index_mappping.json
+++ b/integ-test/src/test/resources/indexDefinitions/json_test_index_mappping.json
@@ -2,7 +2,7 @@
   "mappings": {
     "properties": {
       "test_name": {
-        "type": "text"
+        "type": "keyword"
       },
       "json_string": {
         "type": "text"

--- a/integ-test/src/test/resources/json_test.json
+++ b/integ-test/src/test/resources/json_test.json
@@ -1,0 +1,10 @@
+{"index":{"_id":"1"}}
+{"test_name":"json object", "json_string":"{\"a\":\"1\",\"b\":\"2\"}"}
+{"index":{"_id":"2"}}
+{"test_name":"json array", "json_string":"[1, 2, 3, 4]"}
+{"index":{"_id":"3"}}
+{"test_name":"json scalar string", "json_string":"\"abc\""}
+{"index":{"_id":"4"}}
+{"test_name":"json empty string","json_string":""}
+{"index":{"_id":"5"}}
+{"test_name":"json invalid object", "json_string":"{\"invalid\":\"json\", \"string\"}"}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -332,6 +332,9 @@ ISNULL:                             'ISNULL';
 ISNOTNULL:                          'ISNOTNULL';
 CIDRMATCH:                          'CIDRMATCH';
 
+// JSON FUNCTIONS
+JSON_VALID:                         'JSON_VALID';
+
 // FLOWCONTROL FUNCTIONS
 IFNULL:                             'IFNULL';
 NULLIF:                             'NULLIF';

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -334,6 +334,7 @@ CIDRMATCH:                          'CIDRMATCH';
 
 // JSON FUNCTIONS
 JSON_VALID:                         'JSON_VALID';
+JSON_OBJECT:                        'JSON_OBJECT';
 
 // FLOWCONTROL FUNCTIONS
 IFNULL:                             'IFNULL';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -662,6 +662,7 @@ conditionFunctionName
    | ISNULL
    | ISNOTNULL
    | CIDRMATCH
+   | JSON_VALID
    ;
 
 // flow control function return non-boolean value

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -310,6 +310,7 @@ valueExpression
    | extractFunction                                                                            # extractFunctionCall
    | getFormatFunction                                                                          # getFormatFunctionCall
    | timestampFunction                                                                          # timestampFunctionCall
+   | jsonObjectFunction                                                                         # jsonObjectFunctionCall
    | LT_PRTHS valueExpression RT_PRTHS                                                          # parentheticValueExpr
    ;
 
@@ -322,6 +323,10 @@ primaryExpression
 
 positionFunction
    : positionFunctionName LT_PRTHS functionArg IN functionArg RT_PRTHS
+   ;
+
+jsonObjectFunction
+   : jsonObjectFunctionName LT_PRTHS functionArg COMMA functionArg (COMMA functionArg COMMA functionArg)* RT_PRTHS
    ;
 
 booleanExpression
@@ -419,6 +424,7 @@ evalFunctionName
    | flowControlFunctionName
    | systemFunctionName
    | positionFunctionName
+   | jsonObjectFunctionName
    ;
 
 functionArgs
@@ -699,6 +705,10 @@ textFunctionName
 positionFunctionName
    : POSITION
    ;
+
+jsonObjectFunctionName
+  : JSON_OBJECT
+  ;
 
 // operators
  comparisonOperator


### PR DESCRIPTION
This PR depends on the `json_valid` command: #3207 

### Description

For OpenSearch-PPL, adds the json_object() functions that takes a even number of varargs (key/value pairs). Returns an expression type that is valid json object (STRUCT).

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3208

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
