### PR TITLE
Support for OpenSearch alias type 

### DIFF
--- a/core/src/main/java/org/opensearch/sql/data/type/ExprType.java
+++ b/core/src/main/java/org/opensearch/sql/data/type/ExprType.java
@@ -9,6 +9,7 @@ import static org.opensearch.sql.data.type.ExprCoreType.UNKNOWN;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.Expression;
 
@@ -53,5 +54,18 @@ public interface ExprType {
   /** Get the legacy type name for old engine. */
   default String legacyTypeName() {
     return typeName();
+  }
+
+  /** Get the original path. Types like alias type will set the actual path in field property. */
+  default Optional<String> getOriginalPath() {
+    return Optional.empty();
+  }
+
+  /**
+   * Get the original path. Types like alias type should be derived from the type of the original
+   * field.
+   */
+  default ExprType getOriginalExprType() {
+    return this;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/ReferenceExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/ReferenceExpression.java
@@ -23,6 +23,8 @@ import org.opensearch.sql.expression.env.Environment;
 public class ReferenceExpression implements Expression {
   @Getter private final String attr;
 
+  @Getter private final String rawPath;
+
   @Getter private final List<String> paths;
 
   private final ExprType type;
@@ -36,8 +38,11 @@ public class ReferenceExpression implements Expression {
   public ReferenceExpression(String ref, ExprType type) {
     this.attr = ref;
     // Todo. the define of paths need to be redefined after adding multiple index/variable support.
-    this.paths = Arrays.asList(ref.split("\\."));
-    this.type = type;
+    // For AliasType, the actual path is set in the property of `path` and the type is derived
+    // from the type of field on that path; Otherwise, use ref itself as the path
+    this.rawPath = type.getOriginalPath().orElse(ref);
+    this.paths = Arrays.asList(rawPath.split("\\."));
+    this.type = type.getOriginalExprType();
   }
 
   @Override

--- a/core/src/test/java/org/opensearch/sql/data/type/ExprTypeTest.java
+++ b/core/src/test/java/org/opensearch/sql/data/type/ExprTypeTest.java
@@ -24,6 +24,7 @@ import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 import static org.opensearch.sql.data.type.ExprCoreType.UNDEFINED;
 import static org.opensearch.sql.data.type.ExprCoreType.UNKNOWN;
 
+import java.util.Optional;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
@@ -84,5 +85,17 @@ class ExprTypeTest {
   void defaultLegacyTypeName() {
     final ExprType exprType = () -> "dummy";
     assertEquals("dummy", exprType.legacyTypeName());
+  }
+
+  @Test
+  void getOriginalPath() {
+    final ExprType exprType = () -> "dummy";
+    assertEquals(Optional.empty(), exprType.getOriginalPath());
+  }
+
+  @Test
+  void getOriginalExprType() {
+    final ExprType exprType = () -> "dummy";
+    assertEquals(exprType, exprType.getOriginalExprType());
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.legacy;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.opensearch.sql.legacy.TestUtils.createIndexByRestClient;
 import static org.opensearch.sql.legacy.TestUtils.getAccountIndexMapping;
+import static org.opensearch.sql.legacy.TestUtils.getAliasIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getBankIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getBankWithNullValuesIndexMapping;
 import static org.opensearch.sql.legacy.TestUtils.getDataTypeNonnumericIndexMapping;
@@ -745,7 +746,12 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         TestsConstants.TEST_INDEX_GEOPOINT,
         "dates",
         getGeopointIndexMapping(),
-        "src/test/resources/geopoints.json");
+        "src/test/resources/geopoints.json"),
+    DATA_TYPE_ALIAS(
+        TestsConstants.TEST_INDEX_ALIAS,
+        "alias",
+        getAliasIndexMapping(),
+        "src/test/resources/alias.json");
 
     private final String name;
     private final String type;

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
@@ -250,6 +250,11 @@ public class TestUtils {
     return getMappingFile(mappingFile);
   }
 
+  public static String getAliasIndexMapping() {
+    String mappingFile = "alias_index_mapping.json";
+    return getMappingFile(mappingFile);
+  }
+
   public static void loadBulk(Client client, String jsonPath, String defaultIndex)
       throws Exception {
     System.out.println(String.format("Loading file %s into opensearch cluster", jsonPath));

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -58,6 +58,7 @@ public class TestsConstants {
   public static final String TEST_INDEX_MULTI_NESTED_TYPE = TEST_INDEX + "_multi_nested";
   public static final String TEST_INDEX_NESTED_WITH_NULLS = TEST_INDEX + "_nested_with_nulls";
   public static final String TEST_INDEX_GEOPOINT = TEST_INDEX + "_geopoint";
+  public static final String TEST_INDEX_ALIAS = TEST_INDEX + "_alias";
   public static final String DATASOURCES = ".ql-datasources";
 
   public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
@@ -5,8 +5,10 @@
 
 package org.opensearch.sql.ppl;
 
+import static org.opensearch.sql.legacy.SQLIntegTestCase.Index.DATA_TYPE_ALIAS;
 import static org.opensearch.sql.legacy.SQLIntegTestCase.Index.DATA_TYPE_NONNUMERIC;
 import static org.opensearch.sql.legacy.SQLIntegTestCase.Index.DATA_TYPE_NUMERIC;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ALIAS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATATYPE_NONNUMERIC;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATATYPE_NUMERIC;
 import static org.opensearch.sql.util.MatcherUtils.schema;
@@ -22,6 +24,7 @@ public class DataTypeIT extends PPLIntegTestCase {
   public void init() throws IOException {
     loadIndex(DATA_TYPE_NUMERIC);
     loadIndex(DATA_TYPE_NONNUMERIC);
+    loadIndex(DATA_TYPE_ALIAS);
   }
 
   @Test
@@ -74,5 +77,15 @@ public class DataTypeIT extends PPLIntegTestCase {
         schema("int2", "integer"),
         schema("long1", "long"),
         schema("long2", "long"));
+  }
+
+  @Test
+  public void test_alias_data_type() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where alias_col > 1 " + "| fields original_col, alias_col ",
+                TEST_INDEX_ALIAS));
+    verifySchema(result, schema("original_col", "integer"), schema("alias_col", "integer"));
   }
 }

--- a/integ-test/src/test/resources/alias.json
+++ b/integ-test/src/test/resources/alias.json
@@ -1,0 +1,6 @@
+{"index":{"_id":"1"}}
+{"original_col" : 1}
+{"index":{"_id":"2"}}
+{"original_col" : 2}
+{"index":{"_id":"3"}}
+{"original_col" : 3}

--- a/integ-test/src/test/resources/indexDefinitions/alias_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/alias_index_mapping.json
@@ -1,0 +1,13 @@
+{
+  "mappings": {
+    "properties": {
+      "original_col": {
+        "type": "integer"
+      },
+      "alias_col": {
+        "type": "alias",
+        "path": "original_col"
+      }
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchAliasType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchAliasType.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.data.type;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.opensearch.sql.data.type.ExprType;
+
+/**
+ * The type of alias. See <a
+ * href="https://opensearch.org/docs/latest/opensearch/supported-field-types/alias/">doc</a>
+ */
+public class OpenSearchAliasType extends OpenSearchDataType {
+
+  public static final String typeName = "alias";
+  public static final String pathPropertyName = "path";
+  public static final Set<MappingType> objectFieldTypes =
+      Set.of(MappingType.Object, MappingType.Nested);
+  private final String path;
+  private final OpenSearchDataType originalType;
+
+  public OpenSearchAliasType(String path, OpenSearchDataType type) {
+    super(type.getExprCoreType());
+    if (type instanceof OpenSearchAliasType) {
+      throw new IllegalStateException(
+          String.format("Alias field cannot refer to the path [%s] of alias type", path));
+    } else if (objectFieldTypes.contains(type.getMappingType())) {
+      throw new IllegalStateException(
+          String.format("Alias field cannot refer to the path [%s] of object type", path));
+    }
+    this.path = path;
+    this.originalType = type;
+  }
+
+  @Override
+  public Optional<String> getOriginalPath() {
+    return Optional.of(this.path);
+  }
+
+  @Override
+  public ExprType getOriginalExprType() {
+    return originalType.getExprType();
+  }
+
+  @Override
+  public ExprType getExprType() {
+    return this;
+  }
+
+  @Override
+  public OpenSearchDataType cloneEmpty() {
+    return new OpenSearchAliasType(this.path, originalType.cloneEmpty());
+  }
+
+  @Override
+  public boolean isCompatible(ExprType other) {
+    return originalType.isCompatible(other);
+  }
+
+  @Override
+  public List<ExprType> getParent() {
+    return originalType.getParent();
+  }
+
+  @Override
+  public String typeName() {
+    return originalType.typeName();
+  }
+
+  @Override
+  public String legacyTypeName() {
+    return originalType.legacyTypeName();
+  }
+
+  @Override
+  public boolean shouldCast(ExprType other) {
+    return originalType.shouldCast(other);
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
@@ -281,7 +281,7 @@ public class OpenSearchRequestBuilder {
   /** Push down project list to DSL requests. */
   public void pushDownProjects(Set<ReferenceExpression> projects) {
     sourceBuilder.fetchSource(
-        projects.stream().map(ReferenceExpression::getAttr).distinct().toArray(String[]::new),
+        projects.stream().map(ReferenceExpression::getRawPath).distinct().toArray(String[]::new),
         new String[0]);
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -70,6 +70,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.sql.data.model.ExprIntegerValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.opensearch.data.type.OpenSearchAliasType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
@@ -159,9 +160,9 @@ class OpenSearchNodeClientTest {
     var parsedTypes = OpenSearchDataType.traverseAndFlatten(mapping);
     assertAll(
         () -> assertEquals(1, indexMappings.size()),
-        // 10 types extended to 17 after flattening
-        () -> assertEquals(10, mapping.size()),
-        () -> assertEquals(17, parsedTypes.size()),
+        // 11 types extended to 18 after flattening
+        () -> assertEquals(11, mapping.size()),
+        () -> assertEquals(18, parsedTypes.size()),
         () -> assertEquals("TEXT", mapping.get("address").legacyTypeName()),
         () -> assertEquals(OpenSearchTextType.of(MappingType.Text), parsedTypes.get("address")),
         () -> assertEquals("INTEGER", mapping.get("age").legacyTypeName()),
@@ -186,6 +187,11 @@ class OpenSearchNodeClientTest {
         () -> assertEquals(OpenSearchTextType.of(MappingType.Text), parsedTypes.get("employer")),
         // `employer` is a `text` with `fields`
         () -> assertTrue(((OpenSearchTextType) parsedTypes.get("employer")).getFields().size() > 0),
+        () -> assertEquals("TEXT", mapping.get("employer_alias").legacyTypeName()),
+        () ->
+            assertEquals(
+                new OpenSearchAliasType("employer", OpenSearchTextType.of(MappingType.Text)),
+                parsedTypes.get("employer_alias")),
         () -> assertEquals("NESTED", mapping.get("projects").legacyTypeName()),
         () -> assertEquals(OpenSearchTextType.of(MappingType.Nested), parsedTypes.get("projects")),
         () ->

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
@@ -68,6 +68,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.sql.data.model.ExprIntegerValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.opensearch.data.type.OpenSearchAliasType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
@@ -162,9 +163,9 @@ class OpenSearchRestClientTest {
     var parsedTypes = OpenSearchDataType.traverseAndFlatten(mapping);
     assertAll(
         () -> assertEquals(1, indexMappings.size()),
-        // 10 types extended to 17 after flattening
-        () -> assertEquals(10, mapping.size()),
-        () -> assertEquals(17, parsedTypes.size()),
+        // 11 types extended to 18 after flattening
+        () -> assertEquals(11, mapping.size()),
+        () -> assertEquals(18, parsedTypes.size()),
         () -> assertEquals("TEXT", mapping.get("address").legacyTypeName()),
         () -> assertEquals(OpenSearchTextType.of(MappingType.Text), parsedTypes.get("address")),
         () -> assertEquals("INTEGER", mapping.get("age").legacyTypeName()),
@@ -189,6 +190,11 @@ class OpenSearchRestClientTest {
         () -> assertEquals(OpenSearchTextType.of(MappingType.Text), parsedTypes.get("employer")),
         // `employer` is a `text` with `fields`
         () -> assertTrue(((OpenSearchTextType) parsedTypes.get("employer")).getFields().size() > 0),
+        () -> assertEquals("TEXT", mapping.get("employer_alias").legacyTypeName()),
+        () ->
+            assertEquals(
+                new OpenSearchAliasType("employer", OpenSearchTextType.of(MappingType.Text)),
+                parsedTypes.get("employer_alias")),
         () -> assertEquals("NESTED", mapping.get("projects").legacyTypeName()),
         () -> assertEquals(OpenSearchTextType.of(MappingType.Nested), parsedTypes.get("projects")),
         () ->

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
@@ -52,7 +52,9 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.data.type.OpenSearchAliasType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
+import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.response.agg.CompositeAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.OpenSearchAggregationResponseParser;
@@ -625,6 +627,35 @@ class OpenSearchRequestBuilderTest {
             .size(DEFAULT_LIMIT)
             .timeout(DEFAULT_QUERY_TIMEOUT),
         requestBuilder);
+  }
+
+  @Test
+  void test_push_down_project_with_alias_type() {
+    Set<ReferenceExpression> references =
+        Set.of(
+            DSL.ref("intA", OpenSearchTextType.of()),
+            DSL.ref("intB", new OpenSearchAliasType("intA", OpenSearchTextType.of())));
+    requestBuilder.pushDownProjects(references);
+
+    assertSearchSourceBuilder(
+        new SearchSourceBuilder()
+            .from(DEFAULT_OFFSET)
+            .size(DEFAULT_LIMIT)
+            .timeout(DEFAULT_QUERY_TIMEOUT)
+            .fetchSource(new String[] {"intA"}, new String[0]),
+        requestBuilder);
+
+    assertEquals(
+        new OpenSearchQueryRequest(
+            new OpenSearchRequest.IndexName("test"),
+            new SearchSourceBuilder()
+                .from(DEFAULT_OFFSET)
+                .size(DEFAULT_LIMIT)
+                .timeout(DEFAULT_QUERY_TIMEOUT)
+                .fetchSource("intA", null),
+            exprValueFactory,
+            List.of("intA")),
+        requestBuilder.build(indexName, MAX_RESULT_WINDOW, DEFAULT_QUERY_TIMEOUT, client));
   }
 
   @Test

--- a/opensearch/src/test/resources/mappings/accounts.json
+++ b/opensearch/src/test/resources/mappings/accounts.json
@@ -36,6 +36,10 @@
               }
             }
           },
+          "employer_alias": {
+            "type": "alias",
+            "path": "employer"
+          },
           "projects": {
             "type": "nested",
             "properties": {


### PR DESCRIPTION
### Description
Add Support for OpenSearch alias type, so PPL can query fields of alias type correctly. 

Implementation:
- Add a new ExprType named `OpenSearchAliasType`
- Add special parsing logic for alias type in `OpenSearchDataType::parseMapping`
- Use original path and type when constructing `ReferenceExpression`. For now, only alias type will have different original path and type.
- When constructing `_source` in `OpenSearchRequestBuilder::pushDownProjects`, use path instead of attr since they are different for alias type. The former one is more accurate since OpenSearch don't accept fields of alias type in `_source`.

e.g. After this PR:

```
# Create Index with alias type
PUT /try
{
    "mappings":{
        "properties": {
            "time1": {
                "type": "date"
            },
            "time2": {
                "type": "alias",
                "path": "time1"
            }
        }
    }
}

# Add doc
POST try/_doc
{
  "time1": 1736911491131
}
```

```
# Query with field of alias type
POST /_plugins/_ppl/
{
   "query": "source=try |where `time2` > '2025-01-01' |  fields `time2`"
}

# Get result
{
  "schema": [
    {
      "name": "time2",
      "type": "timestamp"
    }
  ],
  "datarows": [
    [
      "2025-01-15 03:24:51.131"
    ]
  ],
  "total": 1,
  "size": 1
}
```




### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3069

### Options for this feature

#### Option1(The PR for now):
Add compounded datatype named OpenSearchAliasType in TypeEnvironment, and resolve ident of alias field inner ReferenceExpression. OpenSearchAliasType will record both path and original basic datatype inner it.

#### Option2:
Add a new hashmap in IndexMapping to record the alias field mapping to its referred path, it may has structure like:
Map<String, String> aliasMapping
and also add a new hashmap in SymbleTable to record the alias field, it may has structure like:
Map<Namespace, NavigableMap<String, String>> aliasByNamespace
When resolving ident, we need to lookup aliasByNamespace first to identify if this field is an alias, then lookup the original tableByNamespace to reslve type. It makes more sense to not maintaining a wired data type of alias, but will have drawback of making this analyzing process more complex than option1

#### Option3:
Parsing the data type of alias fields to be the data type of its referred field directly.
But in OpenSearchIndexScan, it should be aware of the mapping of opensearch index, and then populating ExprValue with alias fields filled with the value of their referred fields. It aims to resolve the alias fields from the source data.
That’s said, since we’ve resolved the alias fields from the soruce, they are no longer alias fields in the following processing. Assuming we have update on its referred fields after scanning, the alias field won’t be udpated as its path has no relation with the value on updated path. The functionality may not align with the original purpose of opensearch alias type in some cases.

-----
#### Option for moving to Calcite in future
In Calcite, there is a special data type named SingleColumnAliasRelDataType, which may satisfy our requirements. This RelDataType maintains single column but can resolve 2 kinds of idents with name in original or alias. But I’m afraid it cannot handle the corner cases that more than one alias field refer to the same path, which is rare but actually allowed in OpenSearch. Unless we can extend that RelDataType to remove the limitation and handle multiple fields in alias.



### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
