### PR TITLE
Framework of Calcite Engine: Parser, Catalog Binding and Plan Converter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,19 @@ allprojects {
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib:1.9.10"
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10"
         resolutionStrategy.force "net.bytebuddy:byte-buddy:1.14.9"
+        resolutionStrategy.force "org.apache.httpcomponents.client5:httpclient5:5.3.1"
+        resolutionStrategy.force 'org.apache.httpcomponents.core5:httpcore5:5.2.5'
+        resolutionStrategy.force 'org.apache.httpcomponents.core5:httpcore5-h2:5.2.5'
+        resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-annotations:2.17.2'
+        resolutionStrategy.force 'com.fasterxml.jackson:jackson-bom:2.17.2'
+        resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.25.5'
+        resolutionStrategy.force 'org.locationtech.jts:jts-core:1.19.0'
+        resolutionStrategy.force 'com.google.errorprone:error_prone_annotations:2.28.0'
+        resolutionStrategy.force 'org.checkerframework:checker-qual:3.43.0'
+        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.13.0'
+        resolutionStrategy.force 'org.apache.commons:commons-text:1.11.0'
+        resolutionStrategy.force 'commons-io:commons-io:2.15.0'
+        resolutionStrategy.force 'org.yaml:snakeyaml:2.2'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,8 +56,13 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
     api group: 'com.tdunning', name: 't-digest', version: '3.3'
+    api 'org.apache.calcite:calcite-core:1.38.0'
+    api 'org.apache.calcite:calcite-linq4j:1.38.0'
     api project(':common')
     implementation "com.github.seancfoley:ipaddress:5.4.2"
+
+    annotationProcessor('org.immutables:value:2.8.8')
+    compileOnly('org.immutables:value-annotations:2.8.8')
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
@@ -113,22 +118,23 @@ jacocoTestCoverageVerification {
                     'org.opensearch.sql.utils.Constants',
                     'org.opensearch.sql.datasource.model.DataSource',
                     'org.opensearch.sql.datasource.model.DataSourceStatus',
-                    'org.opensearch.sql.datasource.model.DataSourceType'
+                    'org.opensearch.sql.datasource.model.DataSourceType',
+                    'org.opensearch.sql.executor.ExecutionEngine'
             ]
             limit {
                 counter = 'LINE'
-                minimum = 1.0
+                minimum = 0.5 // calcite dev only
             }
             limit {
                 counter = 'BRANCH'
-                minimum = 1.0
+                minimum = 0.5 // calcite dev only
             }
         }
     }
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it,
-                    exclude: ['**/ast/**'])
+                    exclude: ['**/ast/**', '**/calcite/**']) // calcite dev only
         }))
     }
 }

--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -65,6 +65,7 @@ import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
+import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
@@ -144,6 +145,27 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   }
 
   @Override
+  public LogicalPlan visitSubqueryAlias(SubqueryAlias node, AnalysisContext context) {
+    LogicalPlan child = analyze(node.getChild().get(0), context);
+    if (child instanceof LogicalRelation) {
+      // Put index name or its alias in index namespace on type environment so qualifier
+      // can be removed when analyzing qualified name. The value (expr type) here doesn't matter.
+      TypeEnvironment curEnv = context.peek();
+      curEnv.define(
+          new Symbol(
+              Namespace.INDEX_NAME,
+              (node.getAlias() == null)
+                  ? ((LogicalRelation) child).getRelationName()
+                  : node.getAlias()),
+          STRUCT);
+      return child;
+    } else {
+      // TODO
+      throw new UnsupportedOperationException("SubqueryAlias is only supported in table alias");
+    }
+  }
+
+  @Override
   public LogicalPlan visitRelation(Relation node, AnalysisContext context) {
     QualifiedName qualifiedName = node.getTableQualifiedName();
     DataSourceSchemaIdentifierNameResolver dataSourceSchemaIdentifierNameResolver =
@@ -169,12 +191,6 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
     table
         .getReservedFieldTypes()
         .forEach((k, v) -> curEnv.define(new Symbol(Namespace.HIDDEN_FIELD_NAME, k), v));
-
-    // Put index name or its alias in index namespace on type environment so qualifier
-    // can be removed when analyzing qualified name. The value (expr type) here doesn't matter.
-    curEnv.define(
-        new Symbol(Namespace.INDEX_NAME, (node.getAlias() == null) ? tableName : node.getAlias()),
-        STRUCT);
 
     return new LogicalRelation(tableName, table);
   }
@@ -306,7 +322,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
     for (UnresolvedExpression expr : node.getAggExprList()) {
       NamedExpression aggExpr = namedExpressionAnalyzer.analyze(expr, context);
       aggregatorBuilder.add(
-          new NamedAggregator(aggExpr.getNameOrAlias(), (Aggregator) aggExpr.getDelegated()));
+          new NamedAggregator(aggExpr.getName(), (Aggregator) aggExpr.getDelegated()));
     }
 
     ImmutableList.Builder<NamedExpression> groupbyBuilder = new ImmutableList.Builder<>();
@@ -331,8 +347,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
             newEnv.define(
                 new Symbol(Namespace.FIELD_NAME, aggregator.getName()), aggregator.type()));
     groupBys.forEach(
-        group ->
-            newEnv.define(new Symbol(Namespace.FIELD_NAME, group.getNameOrAlias()), group.type()));
+        group -> newEnv.define(new Symbol(Namespace.FIELD_NAME, group.getName()), group.type()));
     return new LogicalAggregation(child, aggregators, groupBys);
   }
 
@@ -425,8 +440,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
     context.push();
     TypeEnvironment newEnv = context.peek();
     namedExpressions.forEach(
-        expr ->
-            newEnv.define(new Symbol(Namespace.FIELD_NAME, expr.getNameOrAlias()), expr.type()));
+        expr -> newEnv.define(new Symbol(Namespace.FIELD_NAME, expr.getName()), expr.type()));
     List<NamedExpression> namedParseExpressions = context.getNamedParseExpressions();
     return new LogicalProject(child, namedExpressions, namedParseExpressions);
   }

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -416,7 +416,7 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
   private Expression visitIdentifier(String ident, AnalysisContext context) {
     // ParseExpression will always override ReferenceExpression when ident conflicts
     for (NamedExpression expr : context.getNamedParseExpressions()) {
-      if (expr.getNameOrAlias().equals(ident) && expr.getDelegated() instanceof ParseExpression) {
+      if (expr.getName().equals(ident) && expr.getDelegated() instanceof ParseExpression) {
         return expr.getDelegated();
       }
     }

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionReferenceOptimizer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionReferenceOptimizer.java
@@ -144,7 +144,7 @@ public class ExpressionReferenceOptimizer
               groupBy ->
                   expressionMap.put(
                       groupBy.getDelegated(),
-                      new ReferenceExpression(groupBy.getNameOrAlias(), groupBy.type())));
+                      new ReferenceExpression(groupBy.getName(), groupBy.type())));
       return null;
     }
 

--- a/core/src/main/java/org/opensearch/sql/analysis/NamedExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/NamedExpressionAnalyzer.java
@@ -8,7 +8,6 @@ package org.opensearch.sql.analysis;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Alias;
-import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.NamedExpression;
@@ -28,18 +27,6 @@ public class NamedExpressionAnalyzer extends AbstractNodeVisitor<NamedExpression
 
   @Override
   public NamedExpression visitAlias(Alias node, AnalysisContext context) {
-    return DSL.named(
-        unqualifiedNameIfFieldOnly(node, context),
-        node.getDelegated().accept(expressionAnalyzer, context),
-        node.getAlias());
-  }
-
-  private String unqualifiedNameIfFieldOnly(Alias node, AnalysisContext context) {
-    UnresolvedExpression selectItem = node.getDelegated();
-    if (selectItem instanceof QualifiedName) {
-      QualifierAnalyzer qualifierAnalyzer = new QualifierAnalyzer(context);
-      return qualifierAnalyzer.unqualified((QualifiedName) selectItem);
-    }
-    return node.getName();
+    return DSL.named(node.getName(), node.getDelegated().accept(expressionAnalyzer, context));
   }
 }

--- a/core/src/main/java/org/opensearch/sql/analysis/SelectExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/SelectExpressionAnalyzer.java
@@ -65,8 +65,7 @@ public class SelectExpressionAnalyzer
     }
 
     Expression expr = referenceIfSymbolDefined(node, context);
-    return Collections.singletonList(
-        DSL.named(unqualifiedNameIfFieldOnly(node, context), expr, node.getAlias()));
+    return Collections.singletonList(DSL.named(node.getName(), expr));
   }
 
   /**
@@ -77,7 +76,7 @@ public class SelectExpressionAnalyzer
    *       aggExpr)) Agg(Alias("AVG(age)", aggExpr))
    *   <li>SELECT length(name), AVG(age) FROM s BY length(name) Project(Alias("name", expr),
    *       Alias("AVG(age)", aggExpr)) Agg(Alias("AVG(age)", aggExpr))
-   *   <li>SELECT length(name) as l, AVG(age) FROM s BY l Project(Alias("name", expr, l),
+   *   <li>SELECT length(name) as l, AVG(age) FROM s BY l Project(Alias("l", expr),
    *       Alias("AVG(age)", aggExpr)) Agg(Alias("AVG(age)", aggExpr), Alias("length(name)",
    *       groupExpr))
    * </ol>
@@ -89,7 +88,9 @@ public class SelectExpressionAnalyzer
     // (OVER clause) and thus depends on name in alias to be replaced correctly
     return optimizer.optimize(
         DSL.named(
-            expr.getName(), delegatedExpr.accept(expressionAnalyzer, context), expr.getAlias()),
+            delegatedExpr.toString(),
+            delegatedExpr.accept(expressionAnalyzer, context),
+            expr.getName()),
         context);
   }
 
@@ -127,22 +128,5 @@ public class SelectExpressionAnalyzer
               return DSL.named("nested(" + entry.getKey() + ")", nestedFunc);
             })
         .collect(Collectors.toList());
-  }
-
-  /**
-   * Get unqualified name if select item is just a field. For example, suppose an index named
-   * "accounts", return "age" for "SELECT accounts.age". But do nothing for expression in "SELECT
-   * ABS(accounts.age)". Note that an assumption is made implicitly that original name field in
-   * Alias must be the same as the values in QualifiedName. This is true because AST builder does
-   * this. Otherwise, what unqualified() returns will override Alias's name as NamedExpression's
-   * name even though the QualifiedName doesn't have qualifier.
-   */
-  private String unqualifiedNameIfFieldOnly(Alias node, AnalysisContext context) {
-    UnresolvedExpression selectItem = node.getDelegated();
-    if (selectItem instanceof QualifiedName) {
-      QualifierAnalyzer qualifierAnalyzer = new QualifierAnalyzer(context);
-      return qualifierAnalyzer.unqualified((QualifiedName) selectItem);
-    }
-    return node.getName();
   }
 }

--- a/core/src/main/java/org/opensearch/sql/analysis/WindowExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/WindowExpressionAnalyzer.java
@@ -65,8 +65,7 @@ public class WindowExpressionAnalyzer extends AbstractNodeVisitor<LogicalPlan, A
     List<Pair<SortOption, Expression>> sortList = analyzeSortList(unresolved, context);
 
     WindowDefinition windowDefinition = new WindowDefinition(partitionByList, sortList);
-    NamedExpression namedWindowFunction =
-        new NamedExpression(node.getName(), windowFunction, node.getAlias());
+    NamedExpression namedWindowFunction = new NamedExpression(node.getName(), windowFunction);
     List<Pair<SortOption, Expression>> allSortItems = windowDefinition.getAllSortItems();
 
     if (allSortItems.isEmpty()) {

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -48,8 +48,10 @@ import org.opensearch.sql.ast.tree.FetchCursor;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
+import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.Limit;
+import org.opensearch.sql.ast.tree.Lookup;
 import org.opensearch.sql.ast.tree.ML;
 import org.opensearch.sql.ast.tree.Paginate;
 import org.opensearch.sql.ast.tree.Parse;
@@ -59,6 +61,7 @@ import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
+import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.ast.tree.Values;
@@ -325,5 +328,17 @@ public abstract class AbstractNodeVisitor<T, C> {
 
   public T visitFillNull(FillNull fillNull, C context) {
     return visitChildren(fillNull, context);
+  }
+
+  public T visitJoin(Join node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitLookup(Lookup node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitSubqueryAlias(SubqueryAlias node, C context) {
+    return visitChildren(node, context);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -48,6 +48,7 @@ import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.expression.Xor;
 import org.opensearch.sql.ast.tree.Aggregation;
 import org.opensearch.sql.ast.tree.Dedupe;
+import org.opensearch.sql.ast.tree.DescribeRelation;
 import org.opensearch.sql.ast.tree.Eval;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
@@ -62,6 +63,7 @@ import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
+import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
@@ -89,7 +91,15 @@ public class AstDSL {
   }
 
   public UnresolvedPlan relation(String tableName, String alias) {
-    return new Relation(qualifiedName(tableName), alias);
+    return new SubqueryAlias(alias, new Relation(qualifiedName(tableName)));
+  }
+
+  public UnresolvedPlan describe(String tableName) {
+    return new DescribeRelation(qualifiedName(tableName));
+  }
+
+  public UnresolvedPlan subqueryAlias(UnresolvedPlan child, String alias) {
+    return new SubqueryAlias(child, alias);
   }
 
   public UnresolvedPlan tableFunction(List<String> functionName, UnresolvedExpression... args) {
@@ -385,8 +395,13 @@ public class AstDSL {
     return new Alias(name, expr);
   }
 
+  @Deprecated
   public Alias alias(String name, UnresolvedExpression expr, String alias) {
-    return new Alias(name, expr, alias);
+    if (alias == null) {
+      return new Alias(name, expr);
+    } else {
+      return new Alias(alias, expr);
+    }
   }
 
   public NestedAllTupleFields nestedAllTupleFields(String path) {

--- a/core/src/main/java/org/opensearch/sql/ast/expression/Alias.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/Alias.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.ast.expression;
 
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,26 +12,22 @@ import lombok.ToString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 
 /**
- * Alias abstraction that associate an unnamed expression with a name and an optional alias. The
- * name and alias information preserved is useful for semantic analysis and response formatting
- * eventually. This can avoid restoring the info in toString() method which is inaccurate because
- * original info is already lost.
+ * Alias abstraction that associate an unnamed expression with a name. The name information
+ * preserved is useful for semantic analysis and response formatting eventually. This can avoid
+ * restoring the info in toString() method which is inaccurate because original info is already
+ * lost.
  */
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 @Getter
 @RequiredArgsConstructor
 @ToString
 public class Alias extends UnresolvedExpression {
 
-  /** Original field name. */
+  /** The name to be associated with the result of computing delegated expression. */
   private final String name;
 
   /** Expression aliased. */
   private final UnresolvedExpression delegated;
-
-  /** Optional field alias. */
-  private String alias;
 
   @Override
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {

--- a/core/src/main/java/org/opensearch/sql/ast/tree/DescribeRelation.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/DescribeRelation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import java.util.Collections;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+/** Extend Relation to describe the table itself */
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class DescribeRelation extends Relation {
+  public DescribeRelation(UnresolvedExpression tableName) {
+    super(Collections.singletonList(tableName));
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/ast/tree/FillNull.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/FillNull.java
@@ -42,8 +42,7 @@ public class FillNull extends UnresolvedPlan {
   }
 
   private static class SameValueNullFill implements ContainNullableFieldFill {
-    @Getter(onMethod_ = @Override)
-    private final List<NullableFieldFill> nullFieldFill;
+    @Getter private final List<NullableFieldFill> nullFieldFill;
 
     public SameValueNullFill(
         UnresolvedExpression replaceNullWithMe, List<Field> nullableFieldReferences) {
@@ -58,9 +57,7 @@ public class FillNull extends UnresolvedPlan {
 
   @RequiredArgsConstructor
   private static class VariousValueNullFill implements ContainNullableFieldFill {
-    @NonNull
-    @Getter(onMethod_ = @Override)
-    private final List<NullableFieldFill> nullFieldFill;
+    @NonNull @Getter private final List<NullableFieldFill> nullFieldFill;
   }
 
   private UnresolvedPlan child;

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Join.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Join.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+@ToString
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class Join extends UnresolvedPlan {
+  private UnresolvedPlan left;
+  private final UnresolvedPlan right;
+  private final Optional<String> leftAlias;
+  private final Optional<String> rightAlias;
+  private final JoinType joinType;
+  private final Optional<UnresolvedExpression> joinCondition;
+  private final JoinHint joinHint;
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    this.left = leftAlias.isEmpty() ? child : new SubqueryAlias(leftAlias.get(), child);
+    return this;
+  }
+
+  @Override
+  public List<UnresolvedPlan> getChild() {
+    return ImmutableList.of(left);
+  }
+
+  public List<UnresolvedPlan> getChildren() {
+    return ImmutableList.of(left, right);
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitJoin(this, context);
+  }
+
+  public enum JoinType {
+    INNER,
+    LEFT,
+    RIGHT,
+    SEMI,
+    ANTI,
+    CROSS,
+    FULL
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public static class JoinHint {
+    private final Map<String, String> hints;
+
+    public JoinHint() {
+      this.hints = ImmutableMap.of();
+    }
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Lookup.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Lookup.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.QualifiedName;
+
+/** AST node represent Lookup operation. */
+@ToString
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class Lookup extends UnresolvedPlan {
+  private UnresolvedPlan child;
+  private final UnresolvedPlan lookupRelation;
+  private final Map<Alias, Field> lookupMappingMap;
+  private final OutputStrategy outputStrategy;
+
+  /**
+   * Output candidate field map. Format: Key -> Alias(outputFieldName, inputField), Value ->
+   * Field(outputField). For example: 1. When output candidate is "name AS cName", the key will be
+   * Alias("cName", Field(name)), the value will be Field(cName) 2. When output candidate is "dept",
+   * the key is Alias("dept", Field(dept)), value is Field(dept)
+   */
+  private final Map<Alias, Field> outputCandidateMap;
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    this.child = new SubqueryAlias(child, "_s"); // add a auto generated alias name
+    return this;
+  }
+
+  @Override
+  public List<? extends Node> getChild() {
+    return ImmutableList.of(child);
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> visitor, C context) {
+    return visitor.visitLookup(this, context);
+  }
+
+  public enum OutputStrategy {
+    APPEND,
+    REPLACE
+  }
+
+  public String getLookupSubqueryAliasName() {
+    return ((SubqueryAlias) lookupRelation).getAlias();
+  }
+
+  public String getSourceSubqueryAliasName() {
+    return ((SubqueryAlias) child).getAlias();
+  }
+
+  /**
+   * Lookup mapping field map. For example: 1. When mapping is "name AS cName", the original key
+   * will be Alias(cName, Field(name)), the original value will be Field(cName). Returns a map which
+   * left join key is Field(name), right join key is Field(cName) 2. When mapping is "dept", the
+   * original key is Alias(dept, Field(dept)), the original value is Field(dept). Returns a map
+   * which left join key is Field(dept), the right join key is Field(dept) too.
+   */
+  public Map<Field, Field> getLookupMappingMap() {
+    return lookupMappingMap.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                entry -> (Field) (entry.getKey()).getDelegated(),
+                Map.Entry::getValue,
+                (k, y) -> y,
+                LinkedHashMap::new));
+  }
+
+  /** Return a new input field list with source side SubqueryAlias */
+  public List<Field> getFieldListWithSourceSubqueryAlias() {
+    return getOutputCandidateMap().values().stream()
+        .map(
+            f ->
+                new Field(
+                    QualifiedName.of(getSourceSubqueryAliasName(), f.getField().toString()),
+                    f.getFieldArgs()))
+        .collect(Collectors.toList());
+  }
+
+  /** Return the input field list instead of Alias list */
+  public List<Field> getInputFieldList() {
+    return getOutputCandidateMap().keySet().stream()
+        .map(alias -> (Field) alias.getDelegated())
+        .collect(Collectors.toList());
+  }
+
+  public boolean allFieldsShouldAppliedToOutputList() {
+    return getOutputCandidateMap().isEmpty();
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/ast/tree/SubqueryAlias.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/SubqueryAlias.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class SubqueryAlias extends UnresolvedPlan {
+  @Getter private final String alias;
+  private UnresolvedPlan child;
+
+  /** Create an alias (SubqueryAlias) for a sub-query with a default alias name */
+  public SubqueryAlias(UnresolvedPlan child, String suffix) {
+    this.alias = "__auto_generated_subquery_name" + suffix;
+    this.child = child;
+  }
+
+  public SubqueryAlias(String alias, UnresolvedPlan child) {
+    this.alias = alias;
+    this.child = child;
+  }
+
+  public List<UnresolvedPlan> getChild() {
+    return ImmutableList.of(child);
+  }
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    this.child = child;
+    return this;
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitSubqueryAlias(this, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteAggCallVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteAggCallVisitor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder.AggCall;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.AggregateFunction;
+import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.calcite.utils.AggregateUtils;
+
+public class CalciteAggCallVisitor extends AbstractNodeVisitor<AggCall, CalcitePlanContext> {
+  private final CalciteRexNodeVisitor rexNodeVisitor;
+
+  public CalciteAggCallVisitor(CalciteRexNodeVisitor rexNodeVisitor) {
+    this.rexNodeVisitor = rexNodeVisitor;
+  }
+
+  public AggCall analyze(UnresolvedExpression unresolved, CalcitePlanContext context) {
+    return unresolved.accept(this, context);
+  }
+
+  @Override
+  public AggCall visitAlias(Alias node, CalcitePlanContext context) {
+    AggCall aggCall = analyze(node.getDelegated(), context);
+    return aggCall.as(node.getName());
+  }
+
+  @Override
+  public AggCall visitAggregateFunction(AggregateFunction node, CalcitePlanContext context) {
+    RexNode field = rexNodeVisitor.analyze(node.getField(), context);
+    return AggregateUtils.translate(node, field, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite;
+
+import java.util.function.BiFunction;
+import lombok.Getter;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.RelBuilder;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+public class CalcitePlanContext {
+
+  public FrameworkConfig config;
+  public final RelBuilder relBuilder;
+  public final ExtendedRexBuilder rexBuilder;
+
+  @Getter private boolean isResolvingJoinCondition = false;
+
+  public CalcitePlanContext(FrameworkConfig config) {
+    this.config = config;
+    this.relBuilder = RelBuilder.create(config);
+    this.rexBuilder = new ExtendedRexBuilder(relBuilder.getRexBuilder());
+  }
+
+  public RexNode resolveJoinCondition(
+      UnresolvedExpression expr,
+      BiFunction<UnresolvedExpression, CalcitePlanContext, RexNode> transformFunction) {
+    isResolvingJoinCondition = true;
+    RexNode result = transformFunction.apply(expr, this);
+    isResolvingJoinCondition = false;
+    return result;
+  }
+
+  public static CalcitePlanContext create(FrameworkConfig config) {
+    return new CalcitePlanContext(config);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite;
+
+import static org.apache.calcite.sql.SqlKind.AS;
+import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_FIRST;
+import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_LAST;
+import static org.opensearch.sql.ast.tree.Sort.SortOption.DEFAULT_DESC;
+import static org.opensearch.sql.ast.tree.Sort.SortOrder.ASC;
+import static org.opensearch.sql.ast.tree.Sort.SortOrder.DESC;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.ViewExpanders;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilder.AggCall;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.AllFields;
+import org.opensearch.sql.ast.expression.Argument;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.ast.tree.Aggregation;
+import org.opensearch.sql.ast.tree.Eval;
+import org.opensearch.sql.ast.tree.Filter;
+import org.opensearch.sql.ast.tree.Head;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.ast.tree.Lookup;
+import org.opensearch.sql.ast.tree.Project;
+import org.opensearch.sql.ast.tree.Relation;
+import org.opensearch.sql.ast.tree.Sort;
+import org.opensearch.sql.ast.tree.SubqueryAlias;
+import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.calcite.utils.JoinAndLookupUtils;
+
+public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalcitePlanContext> {
+
+  private final CalciteRexNodeVisitor rexVisitor;
+  private final CalciteAggCallVisitor aggVisitor;
+
+  public CalciteRelNodeVisitor() {
+    this.rexVisitor = new CalciteRexNodeVisitor();
+    this.aggVisitor = new CalciteAggCallVisitor(rexVisitor);
+  }
+
+  public RelNode analyze(UnresolvedPlan unresolved, CalcitePlanContext context) {
+    return unresolved.accept(this, context);
+  }
+
+  @Override
+  public RelNode visitRelation(Relation node, CalcitePlanContext context) {
+    for (QualifiedName qualifiedName : node.getQualifiedNames()) {
+      SchemaPlus schema = context.config.getDefaultSchema();
+      if (schema != null && schema.getName().equals(OpenSearchSchema.OPEN_SEARCH_SCHEMA_NAME)) {
+        schema.unwrap(OpenSearchSchema.class).registerTable(qualifiedName);
+      }
+      context.relBuilder.scan(qualifiedName.getParts());
+    }
+    if (node.getQualifiedNames().size() > 1) {
+      context.relBuilder.union(true, node.getQualifiedNames().size());
+    }
+    return context.relBuilder.peek();
+  }
+
+  // This is a tool method to add an existed RelOptTable to builder stack, not used for now
+  private RelBuilder scan(RelOptTable tableSchema, CalcitePlanContext context) {
+    final RelNode scan =
+        context
+            .relBuilder
+            .getScanFactory()
+            .createScan(ViewExpanders.simpleContext(context.relBuilder.getCluster()), tableSchema);
+    context.relBuilder.push(scan);
+    return context.relBuilder;
+  }
+
+  @Override
+  public RelNode visitFilter(Filter node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    RexNode condition = rexVisitor.analyze(node.getCondition(), context);
+    context.relBuilder.filter(condition);
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitProject(Project node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    List<RexNode> projectList =
+        node.getProjectList().stream()
+            .filter(expr -> !(expr instanceof AllFields))
+            .map(expr -> rexVisitor.analyze(expr, context))
+            .collect(Collectors.toList());
+    if (projectList.isEmpty()) {
+      return context.relBuilder.peek();
+    }
+    if (node.isExcluded()) {
+      context.relBuilder.projectExcept(projectList);
+    } else {
+      context.relBuilder.project(projectList);
+    }
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitSort(Sort node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    List<RexNode> sortList =
+        node.getSortList().stream()
+            .map(
+                expr -> {
+                  RexNode sortField = rexVisitor.analyze(expr, context);
+                  Sort.SortOption sortOption = analyzeSortOption(expr.getFieldArgs());
+                  if (sortOption == DEFAULT_DESC) {
+                    return context.relBuilder.desc(sortField);
+                  } else {
+                    return sortField;
+                  }
+                })
+            .collect(Collectors.toList());
+    context.relBuilder.sort(sortList);
+    return context.relBuilder.peek();
+  }
+
+  private Sort.SortOption analyzeSortOption(List<Argument> fieldArgs) {
+    Boolean asc = (Boolean) fieldArgs.get(0).getValue().getValue();
+    Optional<Argument> nullFirst =
+        fieldArgs.stream().filter(option -> "nullFirst".equals(option.getArgName())).findFirst();
+
+    if (nullFirst.isPresent()) {
+      Boolean isNullFirst = (Boolean) nullFirst.get().getValue().getValue();
+      return new Sort.SortOption((asc ? ASC : DESC), (isNullFirst ? NULL_FIRST : NULL_LAST));
+    }
+    return asc ? Sort.SortOption.DEFAULT_ASC : DEFAULT_DESC;
+  }
+
+  @Override
+  public RelNode visitHead(Head node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    context.relBuilder.limit(node.getFrom(), node.getSize());
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitEval(Eval node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    List<String> originalFieldNames = context.relBuilder.peek().getRowType().getFieldNames();
+    List<RexNode> evalList =
+        node.getExpressionList().stream()
+            .map(
+                expr -> {
+                  RexNode eval = rexVisitor.analyze(expr, context);
+                  context.relBuilder.projectPlus(eval);
+                  return eval;
+                })
+            .collect(Collectors.toList());
+    // Overriding the existing field if the alias has the same name with original field name. For
+    // example, eval field = 1
+    List<String> overriding =
+        evalList.stream()
+            .filter(expr -> expr.getKind() == AS)
+            .map(
+                expr ->
+                    ((RexLiteral) ((RexCall) expr).getOperands().get(1)).getValueAs(String.class))
+            .collect(Collectors.toList());
+    overriding.retainAll(originalFieldNames);
+    if (!overriding.isEmpty()) {
+      List<RexNode> toDrop = context.relBuilder.fields(overriding);
+      context.relBuilder.projectExcept(toDrop);
+    }
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitAggregation(Aggregation node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    List<AggCall> aggList =
+        node.getAggExprList().stream()
+            .map(expr -> aggVisitor.analyze(expr, context))
+            .collect(Collectors.toList());
+    List<RexNode> groupByList =
+        node.getGroupExprList().stream()
+            .map(expr -> rexVisitor.analyze(expr, context))
+            .collect(Collectors.toList());
+
+    UnresolvedExpression span = node.getSpan();
+    if (!Objects.isNull(span)) {
+      RexNode spanRex = rexVisitor.analyze(span, context);
+      groupByList.add(spanRex);
+      // add span's group alias field (most recent added expression)
+    }
+    //        List<RexNode> aggList = node.getAggExprList().stream()
+    //            .map(expr -> rexVisitor.analyze(expr, context))
+    //            .collect(Collectors.toList());
+    //        relBuilder.aggregate(relBuilder.groupKey(groupByList),
+    //            aggList.stream().map(rex -> (MyAggregateCall) rex)
+    //                .map(MyAggregateCall::getCall).collect(Collectors.toList()));
+    context.relBuilder.aggregate(context.relBuilder.groupKey(groupByList), aggList);
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitJoin(Join node, CalcitePlanContext context) {
+    List<UnresolvedPlan> children = node.getChildren();
+    children.forEach(c -> analyze(c, context));
+    RexNode joinCondition =
+        node.getJoinCondition()
+            .map(c -> rexVisitor.analyzeJoinCondition(c, context))
+            .orElse(context.relBuilder.literal(true));
+    context.relBuilder.join(
+        JoinAndLookupUtils.translateJoinType(node.getJoinType()), joinCondition);
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitSubqueryAlias(SubqueryAlias node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    context.relBuilder.as(node.getAlias());
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitLookup(Lookup node, CalcitePlanContext context) {
+    // 1. resolve source side
+    visitChildren(node, context);
+    // get sourceOutputFields from top of stack which is used to build final output
+    List<RexNode> sourceOutputFields = context.relBuilder.fields();
+
+    // 2. resolve lookup table
+    analyze(node.getLookupRelation(), context);
+    // If the output fields are specified, build a project list for lookup table.
+    // The mapping fields of lookup table should be added in this project list, otherwise join will
+    // fail.
+    // So the mapping fields of lookup table should be dropped after join.
+    List<RexNode> projectList =
+        JoinAndLookupUtils.buildLookupRelationProjectList(node, rexVisitor, context);
+    if (!projectList.isEmpty()) {
+      context.relBuilder.project(projectList);
+    }
+
+    // 3. resolve join condition
+    RexNode joinCondition =
+        JoinAndLookupUtils.buildLookupMappingCondition(node)
+            .map(c -> rexVisitor.analyzeJoinCondition(c, context))
+            .orElse(context.relBuilder.literal(true));
+
+    // 4. If no output field is specified, all fields from lookup table are applied to the output.
+    if (node.allFieldsShouldAppliedToOutputList()) {
+      context.relBuilder.join(JoinRelType.LEFT, joinCondition);
+      return context.relBuilder.peek();
+    }
+
+    // 5. push join to stack
+    context.relBuilder.join(JoinRelType.LEFT, joinCondition);
+
+    // 6. Drop the mapping fields of lookup table in result:
+    // For example, in command "LOOKUP lookTbl Field1 AS Field2, Field3",
+    // the Field1 and Field3 are projection fields and join keys which will be dropped in result.
+    List<Field> mappingFieldsOfLookup =
+        node.getLookupMappingMap().entrySet().stream()
+            .map(
+                kv ->
+                    kv.getKey().getField() == kv.getValue().getField()
+                        ? JoinAndLookupUtils.buildFieldWithLookupSubqueryAlias(node, kv.getKey())
+                        : kv.getKey())
+            .collect(Collectors.toList());
+    List<RexNode> dropListOfLookupMappingFields =
+        JoinAndLookupUtils.buildProjectListFromFields(mappingFieldsOfLookup, rexVisitor, context);
+    // Drop the $sourceOutputField if existing
+    List<RexNode> dropListOfSourceFields =
+        node.getFieldListWithSourceSubqueryAlias().stream()
+            .map(
+                field -> {
+                  try {
+                    return rexVisitor.analyze(field, context);
+                  } catch (RuntimeException e) {
+                    // If the field is not found in the source, skip it
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    List<RexNode> toDrop = new ArrayList<>(dropListOfLookupMappingFields);
+    toDrop.addAll(dropListOfSourceFields);
+
+    // 7. build final outputs
+    List<RexNode> outputFields = new ArrayList<>(sourceOutputFields);
+    // Add new columns based on different strategies:
+    // Append:  coalesce($outputField, $"inputField").as(outputFieldName)
+    // Replace: $outputField.as(outputFieldName)
+    outputFields.addAll(JoinAndLookupUtils.buildOutputProjectList(node, rexVisitor, context));
+    outputFields.removeAll(toDrop);
+
+    context.relBuilder.project(outputFields);
+
+    return context.relBuilder.peek();
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite;
+
+import static org.opensearch.sql.ast.expression.SpanUnit.NONE;
+import static org.opensearch.sql.ast.expression.SpanUnit.UNKNOWN;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.And;
+import org.opensearch.sql.ast.expression.Compare;
+import org.opensearch.sql.ast.expression.EqualTo;
+import org.opensearch.sql.ast.expression.Function;
+import org.opensearch.sql.ast.expression.Let;
+import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.expression.Not;
+import org.opensearch.sql.ast.expression.Or;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.Span;
+import org.opensearch.sql.ast.expression.SpanUnit;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.ast.expression.Xor;
+import org.opensearch.sql.calcite.utils.BuiltinFunctionUtils;
+import org.opensearch.sql.calcite.utils.DataTypeTransformer;
+
+public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalcitePlanContext> {
+
+  public RexNode analyze(UnresolvedExpression unresolved, CalcitePlanContext context) {
+    return unresolved.accept(this, context);
+  }
+
+  public RexNode analyzeJoinCondition(UnresolvedExpression unresolved, CalcitePlanContext context) {
+    return context.resolveJoinCondition(unresolved, this::analyze);
+  }
+
+  @Override
+  public RexNode visitLiteral(Literal node, CalcitePlanContext context) {
+    RexBuilder rexBuilder = context.rexBuilder;
+    RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+    final Object value = node.getValue();
+    if (value == null) {
+      final RelDataType type = typeFactory.createSqlType(SqlTypeName.NULL);
+      return rexBuilder.makeNullLiteral(type);
+    }
+    switch (node.getType()) {
+      case NULL:
+        return rexBuilder.makeNullLiteral(typeFactory.createSqlType(SqlTypeName.NULL));
+      case STRING:
+        return rexBuilder.makeLiteral(value.toString());
+      case INTEGER:
+        return rexBuilder.makeExactLiteral(new BigDecimal((Integer) value));
+      case LONG:
+        return rexBuilder.makeBigintLiteral(new BigDecimal((Long) value));
+      case SHORT:
+        return rexBuilder.makeExactLiteral(
+            new BigDecimal((Short) value), typeFactory.createSqlType(SqlTypeName.SMALLINT));
+      case FLOAT:
+        return rexBuilder.makeApproxLiteral(
+            new BigDecimal(Float.toString((Float) value)),
+            typeFactory.createSqlType(SqlTypeName.FLOAT));
+      case DOUBLE:
+        return rexBuilder.makeApproxLiteral(
+            new BigDecimal(Double.toString((Double) value)),
+            typeFactory.createSqlType(SqlTypeName.DOUBLE));
+      case BOOLEAN:
+        return rexBuilder.makeLiteral((Boolean) value);
+      case DATE:
+        return rexBuilder.makeDateLiteral(new DateString(value.toString()));
+      case TIME:
+        return rexBuilder.makeTimeLiteral(
+            new TimeString(value.toString()), RelDataType.PRECISION_NOT_SPECIFIED);
+      case TIMESTAMP:
+        return rexBuilder.makeTimestampLiteral(
+            new TimestampString(value.toString()), RelDataType.PRECISION_NOT_SPECIFIED);
+      case INTERVAL:
+        //                return rexBuilder.makeIntervalLiteral(BigDecimal.valueOf((long)
+        // node.getValue()));
+      default:
+        throw new UnsupportedOperationException("Unsupported literal type: " + node.getType());
+    }
+  }
+
+  @Override
+  public RexNode visitAnd(And node, CalcitePlanContext context) {
+    final RelDataType booleanType =
+        context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN);
+    final RexNode left = analyze(node.getLeft(), context);
+    final RexNode right = analyze(node.getRight(), context);
+    return context.rexBuilder.makeCall(booleanType, SqlStdOperatorTable.AND, List.of(left, right));
+  }
+
+  @Override
+  public RexNode visitOr(Or node, CalcitePlanContext context) {
+    final RexNode left = analyze(node.getLeft(), context);
+    final RexNode right = analyze(node.getRight(), context);
+    return context.relBuilder.or(left, right);
+  }
+
+  @Override
+  public RexNode visitXor(Xor node, CalcitePlanContext context) {
+    final RelDataType booleanType =
+        context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN);
+    final RexNode left = analyze(node.getLeft(), context);
+    final RexNode right = analyze(node.getRight(), context);
+    return context.rexBuilder.makeCall(
+        booleanType, SqlStdOperatorTable.BIT_XOR, List.of(left, right));
+  }
+
+  @Override
+  public RexNode visitNot(Not node, CalcitePlanContext context) {
+    final RexNode expr = analyze(node.getExpression(), context);
+    return context.relBuilder.not(expr);
+  }
+
+  @Override
+  public RexNode visitCompare(Compare node, CalcitePlanContext context) {
+    final RelDataType booleanType =
+        context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN);
+    final RexNode left = analyze(node.getLeft(), context);
+    final RexNode right = analyze(node.getRight(), context);
+    return context.rexBuilder.makeCall(
+        booleanType, BuiltinFunctionUtils.translate(node.getOperator()), List.of(left, right));
+  }
+
+  @Override
+  public RexNode visitEqualTo(EqualTo node, CalcitePlanContext context) {
+    final RexNode left = analyze(node.getLeft(), context);
+    final RexNode right = analyze(node.getRight(), context);
+    return context.rexBuilder.equals(left, right);
+  }
+
+  @Override
+  public RexNode visitQualifiedName(QualifiedName node, CalcitePlanContext context) {
+    if (context.isResolvingJoinCondition()) {
+      List<String> parts = node.getParts();
+      if (parts.size() == 1) { // Handle the case of `id = cid`
+        try {
+          return context.relBuilder.field(2, 0, parts.get(0));
+        } catch (IllegalArgumentException i) {
+          return context.relBuilder.field(2, 1, parts.get(0));
+        }
+      } else if (parts.size()
+          == 2) { // Handle the case of `t1.id = t2.id` or `alias1.id = alias2.id`
+        return context.relBuilder.field(2, parts.get(0), parts.get(1));
+      } else if (parts.size() == 3) {
+        throw new UnsupportedOperationException("Unsupported qualified name: " + node);
+      }
+    }
+    String qualifiedName = node.toString();
+    List<String> currentFields = context.relBuilder.peek().getRowType().getFieldNames();
+    if (currentFields.contains(qualifiedName)) {
+      return context.relBuilder.field(qualifiedName);
+    } else if (node.getParts().size() == 2) {
+      List<String> parts = node.getParts();
+      return context.relBuilder.field(1, parts.get(0), parts.get(1));
+    } else if (currentFields.stream().noneMatch(f -> f.startsWith(qualifiedName))) {
+      return context.relBuilder.field(qualifiedName);
+    }
+    // Handle the overriding fields, for example, `eval SAL = SAL + 1` will delete the original SAL
+    // and add a SAL0
+    Map<String, String> fieldMap =
+        currentFields.stream().collect(Collectors.toMap(s -> s.replaceAll("\\d", ""), s -> s));
+    if (fieldMap.containsKey(qualifiedName)) {
+      return context.relBuilder.field(fieldMap.get(qualifiedName));
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public RexNode visitAlias(Alias node, CalcitePlanContext context) {
+    RexNode expr = analyze(node.getDelegated(), context);
+    return context.relBuilder.alias(expr, node.getName());
+  }
+
+  @Override
+  public RexNode visitSpan(Span node, CalcitePlanContext context) {
+    RexNode field = analyze(node.getField(), context);
+    RexNode value = analyze(node.getValue(), context);
+    RelDataTypeFactory typeFactory = context.rexBuilder.getTypeFactory();
+    SpanUnit unit = node.getUnit();
+    if (isTimeBased(unit)) {
+      String datetimeUnitString = DataTypeTransformer.translate(unit);
+      RexNode interval =
+          context.rexBuilder.makeIntervalLiteral(
+              new BigDecimal(value.toString()),
+              new SqlIntervalQualifier(datetimeUnitString, SqlParserPos.ZERO));
+      // TODO not supported yet
+      return interval;
+    } else {
+      // if the unit is not time base - create a math expression to bucket the span partitions
+      return context.rexBuilder.makeCall(
+          typeFactory.createSqlType(SqlTypeName.DOUBLE),
+          SqlStdOperatorTable.MULTIPLY,
+          List.of(
+              context.rexBuilder.makeCall(
+                  typeFactory.createSqlType(SqlTypeName.DOUBLE),
+                  SqlStdOperatorTable.FLOOR,
+                  List.of(
+                      context.rexBuilder.makeCall(
+                          typeFactory.createSqlType(SqlTypeName.DOUBLE),
+                          SqlStdOperatorTable.DIVIDE,
+                          List.of(field, value)))),
+              value));
+    }
+  }
+
+  private boolean isTimeBased(SpanUnit unit) {
+    return !(unit == NONE || unit == UNKNOWN);
+  }
+
+  //    @Override
+  //    public RexNode visitAggregateFunction(AggregateFunction node, Context context) {
+  //        RexNode field = analyze(node.getField(), context);
+  //        AggregateCall aggregateCall = translateAggregateCall(node, field, relBuilder);
+  //        return new MyAggregateCall(aggregateCall);
+  //    }
+
+  @Override
+  public RexNode visitLet(Let node, CalcitePlanContext context) {
+    RexNode expr = analyze(node.getExpression(), context);
+    return context.relBuilder.alias(expr, node.getVar().getField().toString());
+  }
+
+  @Override
+  public RexNode visitFunction(Function node, CalcitePlanContext context) {
+    List<RexNode> arguments =
+        node.getFuncArgs().stream().map(arg -> analyze(arg, context)).collect(Collectors.toList());
+    return context.rexBuilder.makeCall(
+        BuiltinFunctionUtils.translate(node.getFuncName()), arguments);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite;
+
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+public class ExtendedRexBuilder extends RexBuilder {
+
+  public ExtendedRexBuilder(RexBuilder rexBuilder) {
+    super(rexBuilder.getTypeFactory());
+  }
+
+  public RexNode coalesce(RexNode... nodes) {
+    return this.makeCall(SqlStdOperatorTable.COALESCE, nodes);
+  }
+
+  public RexNode equals(RexNode n1, RexNode n2) {
+    return this.makeCall(SqlStdOperatorTable.EQUALS, n1, n2);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/OpenSearchSchema.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/OpenSearchSchema.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.opensearch.sql.DataSourceSchemaName;
+import org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.datasource.DataSourceService;
+
+@Getter
+@AllArgsConstructor
+public class OpenSearchSchema extends AbstractSchema {
+  public static final String OPEN_SEARCH_SCHEMA_NAME = "OpenSearch";
+
+  private final DataSourceService dataSourceService;
+
+  private final Map<String, Table> tableMap = new HashMap<>();
+
+  public void registerTable(QualifiedName qualifiedName) {
+    DataSourceSchemaIdentifierNameResolver nameResolver =
+        new DataSourceSchemaIdentifierNameResolver(dataSourceService, qualifiedName.getParts());
+    org.opensearch.sql.storage.Table table =
+        dataSourceService
+            .getDataSource(nameResolver.getDataSourceName())
+            .getStorageEngine()
+            .getTable(
+                new DataSourceSchemaName(
+                    nameResolver.getDataSourceName(), nameResolver.getSchemaName()),
+                nameResolver.getIdentifierName());
+    tableMap.put(qualifiedName.toString(), (org.apache.calcite.schema.Table) table);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.plan;
+
+import java.util.Map;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+
+public interface OpenSearchConstants {
+
+  String METADATA_FIELD_ID = "_id";
+  String METADATA_FIELD_UID = "_uid";
+  String METADATA_FIELD_INDEX = "_index";
+  String METADATA_FIELD_SCORE = "_score";
+  String METADATA_FIELD_MAXSCORE = "_maxscore";
+  String METADATA_FIELD_SORT = "_sort";
+
+  String METADATA_FIELD_ROUTING = "_routing";
+
+  java.util.Map<String, ExprType> METADATAFIELD_TYPE_MAP =
+      Map.of(
+          METADATA_FIELD_ID, ExprCoreType.STRING,
+          METADATA_FIELD_UID, ExprCoreType.STRING,
+          METADATA_FIELD_INDEX, ExprCoreType.STRING,
+          METADATA_FIELD_SCORE, ExprCoreType.FLOAT,
+          METADATA_FIELD_MAXSCORE, ExprCoreType.FLOAT,
+          METADATA_FIELD_SORT, ExprCoreType.LONG,
+          METADATA_FIELD_ROUTING, ExprCoreType.STRING);
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchQueryable.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchQueryable.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.plan;
+
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTableQueryable;
+
+public class OpenSearchQueryable<T> extends AbstractTableQueryable<T> {
+
+  OpenSearchQueryable(
+      QueryProvider queryProvider, SchemaPlus schema, OpenSearchTable table, String tableName) {
+    super(queryProvider, schema, table, tableName);
+  }
+
+  @Override
+  public Enumerator<T> enumerator() {
+    throw new UnsupportedOperationException("enumerator");
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchRules.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchRules.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.plan;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.calcite.rel.convert.ConverterRule;
+
+public class OpenSearchRules {
+  public static final List<ConverterRule> OPEN_SEARCH_OPT_RULES = ImmutableList.of();
+
+  // prevent instantiation
+  private OpenSearchRules() {}
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchTable.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchTable.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.plan;
+
+import java.lang.reflect.Type;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.QueryableTable;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Schemas;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.opensearch.sql.calcite.utils.OpenSearchRelDataTypes;
+import org.opensearch.sql.data.model.ExprValue;
+
+public abstract class OpenSearchTable extends AbstractTable
+    implements TranslatableTable, QueryableTable, org.opensearch.sql.storage.Table {
+
+  @Override
+  public RelDataType getRowType(RelDataTypeFactory relDataTypeFactory) {
+    return OpenSearchRelDataTypes.convertSchema(this);
+  }
+
+  @Override
+  public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable relOptTable) {
+    final RelOptCluster cluster = context.getCluster();
+    return new OpenSearchTableScan(cluster, relOptTable, this);
+  }
+
+  @Override
+  public <T> Queryable<T> asQueryable(
+      QueryProvider queryProvider, SchemaPlus schema, String tableName) {
+    return new OpenSearchQueryable<>(queryProvider, schema, this, tableName);
+  }
+
+  @Override
+  public Type getElementType() {
+    return getRowType(null).getClass();
+  }
+
+  @Override
+  public Expression getExpression(SchemaPlus schema, String tableName, Class clazz) {
+    return Schemas.tableExpression(schema, getElementType(), tableName, clazz);
+  }
+
+  public abstract Enumerable<ExprValue> search();
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchTableScan.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchTableScan.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.plan;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.calcite.adapter.enumerable.EnumerableConvention;
+import org.apache.calcite.adapter.enumerable.EnumerableRel;
+import org.apache.calcite.adapter.enumerable.EnumerableRelImplementor;
+import org.apache.calcite.adapter.enumerable.PhysType;
+import org.apache.calcite.adapter.enumerable.PhysTypeImpl;
+import org.apache.calcite.linq4j.tree.Blocks;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.rules.CoreRules;
+
+/** Relational expression representing a scan of an OpenSearch type. */
+public class OpenSearchTableScan extends TableScan implements EnumerableRel {
+  private final OpenSearchTable osTable;
+
+  /**
+   * Creates an OpenSearchTableScan.
+   *
+   * @param cluster Cluster
+   * @param table Table
+   * @param osTable OpenSearch table
+   */
+  OpenSearchTableScan(RelOptCluster cluster, RelOptTable table, OpenSearchTable osTable) {
+    super(cluster, cluster.traitSetOf(EnumerableConvention.INSTANCE), ImmutableList.of(), table);
+    this.osTable = requireNonNull(osTable, "OpenSearch table");
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    assert inputs.isEmpty();
+    return new OpenSearchTableScan(getCluster(), table, osTable);
+  }
+
+  @Override
+  public void register(RelOptPlanner planner) {
+    for (RelOptRule rule : OpenSearchRules.OPEN_SEARCH_OPT_RULES) {
+      planner.addRule(rule);
+    }
+
+    // remove this rule otherwise opensearch can't correctly interpret approx_count_distinct()
+    // it is converted to cardinality aggregation in OpenSearch
+    planner.removeRule(CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES);
+  }
+
+  @Override
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+    PhysType physType =
+        PhysTypeImpl.of(implementor.getTypeFactory(), getRowType(), pref.preferArray());
+
+    return implementor.result(
+        physType,
+        Blocks.toBlock(
+            Expressions.call(
+                requireNonNull(table.getExpression(OpenSearchTable.class)), "search")));
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/TimeWindow.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/TimeWindow.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.plan;
+
+import java.util.List;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rex.RexNode;
+
+public class TimeWindow extends SingleRel {
+  private final RexNode timeColumn;
+  private final RexNode windowDuration;
+  private final RexNode slideDuration;
+  private final RexNode startTime;
+
+  public TimeWindow(
+      RelOptCluster cluster,
+      RelTraitSet traits,
+      RelNode input,
+      RexNode timeColumn,
+      RexNode windowDuration,
+      RexNode slideDuration,
+      RexNode startTime) {
+    super(cluster, traits, input);
+    this.timeColumn = timeColumn;
+    this.windowDuration = windowDuration;
+    this.slideDuration = slideDuration;
+    this.startTime = startTime;
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    return new TimeWindow(
+        getCluster(), traitSet, sole(inputs), timeColumn, windowDuration, slideDuration, startTime);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/AggregateUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/AggregateUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.utils;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+import org.opensearch.sql.ast.expression.AggregateFunction;
+import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+
+public interface AggregateUtils {
+
+  static RelBuilder.AggCall translate(
+      AggregateFunction agg, RexNode field, CalcitePlanContext context) {
+    if (BuiltinFunctionName.ofAggregation(agg.getFuncName()).isEmpty())
+      throw new IllegalStateException("Unexpected value: " + agg.getFuncName());
+
+    // Additional aggregation function operators will be added here
+    BuiltinFunctionName functionName = BuiltinFunctionName.ofAggregation(agg.getFuncName()).get();
+    switch (functionName) {
+      case MAX:
+        return context.relBuilder.max(field);
+      case MIN:
+        return context.relBuilder.min(field);
+      case AVG:
+        return context.relBuilder.avg(agg.getDistinct(), null, field);
+      case COUNT:
+        return context.relBuilder.count(
+            agg.getDistinct(), null, field == null ? ImmutableList.of() : ImmutableList.of(field));
+      case SUM:
+        return context.relBuilder.sum(agg.getDistinct(), null, field);
+        //            case MEAN:
+        //                throw new UnsupportedOperationException("MEAN is not supported in PPL");
+        //            case STDDEV:
+        //                return context.relBuilder.aggregateCall(SqlStdOperatorTable.STDDEV,
+        // field);
+      case STDDEV_POP:
+        return context.relBuilder.aggregateCall(SqlStdOperatorTable.STDDEV_POP, field);
+      case STDDEV_SAMP:
+        return context.relBuilder.aggregateCall(SqlStdOperatorTable.STDDEV_SAMP, field);
+        //            case PERCENTILE_APPROX:
+        //                return
+        // context.relBuilder.aggregateCall(SqlStdOperatorTable.PERCENTILE_CONT, field);
+      case PERCENTILE_APPROX:
+        throw new UnsupportedOperationException("PERCENTILE_APPROX is not supported in PPL");
+        //            case APPROX_COUNT_DISTINCT:
+        //                return
+        // context.relBuilder.aggregateCall(SqlStdOperatorTable.APPROX_COUNT_DISTINCT, field);
+    }
+    throw new IllegalStateException("Not Supported value: " + agg.getFuncName());
+  }
+
+  static AggregateCall aggCreate(SqlAggFunction agg, boolean isDistinct, RexNode field) {
+    int index = ((RexInputRef) field).getIndex();
+    return AggregateCall.create(
+        agg,
+        isDistinct,
+        false,
+        false,
+        ImmutableList.of(),
+        ImmutableList.of(index),
+        -1,
+        null,
+        RelCollations.EMPTY,
+        field.getType(),
+        null);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.utils;
+
+import java.util.Locale;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+public interface BuiltinFunctionUtils {
+
+  static SqlOperator translate(String op) {
+    switch (op.toUpperCase(Locale.ROOT)) {
+      case "AND":
+        return SqlStdOperatorTable.AND;
+      case "OR":
+        return SqlStdOperatorTable.OR;
+      case "NOT":
+        return SqlStdOperatorTable.NOT;
+      case "XOR":
+        return SqlStdOperatorTable.BIT_XOR;
+      case "=":
+        return SqlStdOperatorTable.EQUALS;
+      case "<>":
+      case "!=":
+        return SqlStdOperatorTable.NOT_EQUALS;
+      case ">":
+        return SqlStdOperatorTable.GREATER_THAN;
+      case ">=":
+        return SqlStdOperatorTable.GREATER_THAN_OR_EQUAL;
+      case "<":
+        return SqlStdOperatorTable.LESS_THAN;
+      case "<=":
+        return SqlStdOperatorTable.LESS_THAN_OR_EQUAL;
+      case "+":
+        return SqlStdOperatorTable.PLUS;
+      case "-":
+        return SqlStdOperatorTable.MINUS;
+      case "*":
+        return SqlStdOperatorTable.MULTIPLY;
+      case "/":
+        return SqlStdOperatorTable.DIVIDE;
+        // Built-in String Functions
+      case "LOWER":
+        return SqlStdOperatorTable.LOWER;
+      case "LIKE":
+        return SqlStdOperatorTable.LIKE;
+        // Built-in Math Functions
+      case "ABS":
+        return SqlStdOperatorTable.ABS;
+        // Built-in Date Functions
+      case "CURRENT_TIMESTAMP":
+        return SqlStdOperatorTable.CURRENT_TIMESTAMP;
+      case "CURRENT_DATE":
+        return SqlStdOperatorTable.CURRENT_DATE;
+      case "DATE":
+        return SqlLibraryOperators.DATE;
+      case "ADDDATE":
+        return SqlLibraryOperators.DATE_ADD_SPARK;
+      case "DATE_ADD":
+        return SqlLibraryOperators.DATEADD;
+        // TODO Add more, ref RexImpTable
+      default:
+        throw new IllegalArgumentException("Unsupported operator: " + op);
+    }
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/DataTypeTransformer.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/DataTypeTransformer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.utils;
+
+import static org.opensearch.sql.ast.expression.SpanUnit.DAY;
+import static org.opensearch.sql.ast.expression.SpanUnit.HOUR;
+import static org.opensearch.sql.ast.expression.SpanUnit.MILLISECOND;
+import static org.opensearch.sql.ast.expression.SpanUnit.MINUTE;
+import static org.opensearch.sql.ast.expression.SpanUnit.MONTH;
+import static org.opensearch.sql.ast.expression.SpanUnit.NONE;
+import static org.opensearch.sql.ast.expression.SpanUnit.QUARTER;
+import static org.opensearch.sql.ast.expression.SpanUnit.SECOND;
+import static org.opensearch.sql.ast.expression.SpanUnit.WEEK;
+import static org.opensearch.sql.ast.expression.SpanUnit.YEAR;
+
+import org.opensearch.sql.ast.expression.SpanUnit;
+
+public interface DataTypeTransformer {
+
+  static String translate(SpanUnit unit) {
+    switch (unit) {
+      case UNKNOWN:
+      case NONE:
+        return NONE.name();
+      case MILLISECOND:
+      case MS:
+        return MILLISECOND.name();
+      case SECOND:
+      case S:
+        return SECOND.name();
+      case MINUTE:
+      case m:
+        return MINUTE.name();
+      case HOUR:
+      case H:
+        return HOUR.name();
+      case DAY:
+      case D:
+        return DAY.name();
+      case WEEK:
+      case W:
+        return WEEK.name();
+      case MONTH:
+      case M:
+        return MONTH.name();
+      case QUARTER:
+      case Q:
+        return QUARTER.name();
+      case YEAR:
+      case Y:
+        return YEAR.name();
+    }
+    return "";
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/JoinAndLookupUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/JoinAndLookupUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.sql.ast.expression.Alias;
+import org.opensearch.sql.ast.expression.And;
+import org.opensearch.sql.ast.expression.EqualTo;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.ast.tree.Lookup;
+import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.calcite.CalciteRexNodeVisitor;
+
+public interface JoinAndLookupUtils {
+
+  static JoinRelType translateJoinType(Join.JoinType joinType) {
+    switch (joinType) {
+      case LEFT:
+        return JoinRelType.LEFT;
+      case RIGHT:
+        return JoinRelType.RIGHT;
+      case FULL:
+        return JoinRelType.FULL;
+      case SEMI:
+        return JoinRelType.SEMI;
+      case ANTI:
+        return JoinRelType.ANTI;
+      case INNER:
+      default:
+        return JoinRelType.INNER;
+    }
+  }
+
+  static Optional<UnresolvedExpression> buildLookupMappingCondition(Lookup node) {
+    // only equi-join conditions are accepted in lookup command
+    List<UnresolvedExpression> equiConditions = new ArrayList<>();
+    for (Map.Entry<Field, Field> entry : node.getLookupMappingMap().entrySet()) {
+      EqualTo equalTo;
+      if (entry.getKey().getField() == entry.getValue().getField()) {
+        Field lookupWithAlias = buildFieldWithLookupSubqueryAlias(node, entry.getKey());
+        Field sourceWithAlias = buildFieldWithSourceSubqueryAlias(node, entry.getValue());
+        equalTo = new EqualTo(sourceWithAlias, lookupWithAlias);
+      } else {
+        equalTo = new EqualTo(entry.getValue(), entry.getKey());
+      }
+
+      equiConditions.add(equalTo);
+    }
+    return equiConditions.stream().reduce(And::new);
+  }
+
+  static Field buildFieldWithLookupSubqueryAlias(Lookup node, Field field) {
+    return new Field(
+        QualifiedName.of(node.getLookupSubqueryAliasName(), field.getField().toString()));
+  }
+
+  static Field buildFieldWithSourceSubqueryAlias(Lookup node, Field field) {
+    return new Field(
+        QualifiedName.of(node.getSourceSubqueryAliasName(), field.getField().toString()));
+  }
+
+  /** lookup mapping fields + input fields */
+  static List<RexNode> buildLookupRelationProjectList(
+      Lookup node, CalciteRexNodeVisitor rexVisitor, CalcitePlanContext context) {
+    List<Field> lookupMappingFields = new ArrayList<>(node.getLookupMappingMap().keySet());
+    List<Field> inputFields = new ArrayList<>(node.getInputFieldList());
+    if (inputFields.isEmpty()) {
+      // All fields will be applied to the output if no input field is specified.
+      return Collections.emptyList();
+    }
+    lookupMappingFields.addAll(inputFields);
+    return buildProjectListFromFields(lookupMappingFields, rexVisitor, context);
+  }
+
+  static List<RexNode> buildProjectListFromFields(
+      List<Field> fields, CalciteRexNodeVisitor rexVisitor, CalcitePlanContext context) {
+    return fields.stream()
+        .map(expr -> rexVisitor.analyze(expr, context))
+        .collect(Collectors.toList());
+  }
+
+  static List<RexNode> buildOutputProjectList(
+      Lookup node, CalciteRexNodeVisitor rexVisitor, CalcitePlanContext context) {
+    List<RexNode> outputProjectList = new ArrayList<>();
+    for (Map.Entry<Alias, Field> entry : node.getOutputCandidateMap().entrySet()) {
+      Alias inputFieldWithAlias = entry.getKey();
+      Field inputField = (Field) inputFieldWithAlias.getDelegated();
+      Field outputField = entry.getValue();
+      RexNode inputCol = rexVisitor.visitField(inputField, context);
+      RexNode outputCol = rexVisitor.visitField(outputField, context);
+
+      RexNode child;
+      if (node.getOutputStrategy() == Lookup.OutputStrategy.APPEND) {
+        child = context.rexBuilder.coalesce(outputCol, inputCol);
+      } else {
+        child = inputCol;
+      }
+      // The result output project list we build here is used to replace the source output,
+      // for the unmatched rows of left outer join, the outputs are null, so fall back to source
+      // output.
+      RexNode nullSafeOutput = context.rexBuilder.coalesce(child, outputCol);
+      RexNode withAlias = context.relBuilder.alias(nullSafeOutput, inputFieldWithAlias.getName());
+      outputProjectList.add(withAlias);
+    }
+    return outputProjectList;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchRelDataTypes.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchRelDataTypes.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.storage.Table;
+
+public class OpenSearchRelDataTypes extends JavaTypeFactoryImpl {
+  public static final OpenSearchRelDataTypes TYPE_FACTORY =
+      new OpenSearchRelDataTypes(RelDataTypeSystem.DEFAULT);
+
+  private OpenSearchRelDataTypes(RelDataTypeSystem typeSystem) {
+    super(typeSystem);
+  }
+
+  public RelDataType createSqlType(SqlTypeName typeName, boolean nullable) {
+    return createTypeWithNullability(super.createSqlType(typeName), nullable);
+  }
+
+  public RelDataType createStructType(
+      List<RelDataType> typeList, List<String> fieldNameList, boolean nullable) {
+    return createTypeWithNullability(super.createStructType(typeList, fieldNameList), nullable);
+  }
+
+  public RelDataType createMultisetType(RelDataType type, long maxCardinality, boolean nullable) {
+    return createTypeWithNullability(super.createMultisetType(type, maxCardinality), nullable);
+  }
+
+  public RelDataType createMapType(RelDataType keyType, RelDataType valueType, boolean nullable) {
+    return createTypeWithNullability(super.createMapType(keyType, valueType), nullable);
+  }
+
+  public static RelDataType convertSchemaField(ExprType field) {
+    return convertSchemaField(field, true);
+  }
+
+  /** Converts a OpenSearch ExprCoreType field to relational type. */
+  public static RelDataType convertSchemaField(ExprType fieldType, boolean nullable) {
+    if (fieldType instanceof ExprCoreType) {
+      switch ((ExprCoreType) fieldType) {
+        case UNDEFINED:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.NULL, nullable);
+        case BYTE:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.TINYINT, nullable);
+        case SHORT:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.SMALLINT, nullable);
+        case INTEGER:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER, nullable);
+        case LONG:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT, nullable);
+        case FLOAT:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.REAL, nullable);
+        case DOUBLE:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE, nullable);
+        case STRING:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR, nullable);
+        case BOOLEAN:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN, nullable);
+        case DATE:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.DATE, nullable);
+        case TIME:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.TIME, nullable);
+        case TIMESTAMP:
+          return TYPE_FACTORY.createSqlType(SqlTypeName.TIMESTAMP, nullable);
+        case ARRAY:
+          return TYPE_FACTORY.createArrayType(
+              TYPE_FACTORY.createSqlType(SqlTypeName.ANY, nullable), -1);
+        case STRUCT:
+          final RelDataType relKey = TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
+          return TYPE_FACTORY.createMapType(
+              relKey, TYPE_FACTORY.createSqlType(SqlTypeName.BINARY), nullable);
+        case UNKNOWN:
+        default:
+          throw new IllegalArgumentException(
+              "Unsupported conversion for OpenSearch Data type: " + fieldType.typeName());
+      }
+    } else {
+      if (fieldType.legacyTypeName().equalsIgnoreCase("binary")) {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.BINARY, nullable);
+      } else if (fieldType.legacyTypeName().equalsIgnoreCase("geo_point")) {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.GEOMETRY, nullable);
+      } else if (fieldType.legacyTypeName().equalsIgnoreCase("text")) {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR, nullable);
+      } else if (fieldType.legacyTypeName().equalsIgnoreCase("ip")) {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR, nullable);
+      } else {
+        throw new IllegalArgumentException(
+            "Unsupported conversion for OpenSearch Data type: " + fieldType.typeName());
+      }
+    }
+  }
+
+  public static RelDataType convertSchema(Table table) {
+    List<String> fieldNameList = new ArrayList<>();
+    List<RelDataType> typeList = new ArrayList<>();
+    for (Map.Entry<String, ExprType> entry : table.getFieldTypes().entrySet()) {
+      fieldNameList.add(entry.getKey());
+      typeList.add(OpenSearchRelDataTypes.convertSchemaField(entry.getValue()));
+    }
+    return TYPE_FACTORY.createStructType(typeList, fieldNameList, true);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/data/type/ExprCoreType.java
+++ b/core/src/main/java/org/opensearch/sql/data/type/ExprCoreType.java
@@ -77,6 +77,10 @@ public enum ExprCoreType implements ExprType {
 
   ExprCoreType(ExprCoreType... compatibleTypes) {
     for (ExprCoreType subType : compatibleTypes) {
+      // for example: TIMESTAMP(STRING, DATE, TIME) and DATE(STRING) means
+      // STRING's parents is TIMESTAMP and DATE
+      // DATE's parent is TIMESTAMP
+      // TIME's parent is TIMESTAMP
       subType.parents.add(this);
     }
   }

--- a/core/src/main/java/org/opensearch/sql/executor/ExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/ExecutionEngine.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprType;
@@ -41,6 +43,10 @@ public interface ExecutionEngine {
    * @param listener response listener
    */
   void explain(PhysicalPlan plan, ResponseListener<ExplainResponse> listener);
+
+  /** Execute calcite RelNode plan with {@link ExecutionContext} and call back response listener. */
+  default void execute(
+      RelNode plan, CalcitePlanContext context, ResponseListener<QueryResponse> listener) {}
 
   /** Data class that encapsulates ExprValue. */
   @Data

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -8,11 +8,26 @@
 
 package org.opensearch.sql.executor;
 
+import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Programs;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.analysis.AnalysisContext;
 import org.opensearch.sql.analysis.Analyzer;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
+import org.opensearch.sql.calcite.OpenSearchSchema;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.Planner;
 import org.opensearch.sql.planner.logical.LogicalPlan;
@@ -20,13 +35,19 @@ import org.opensearch.sql.planner.physical.PhysicalPlan;
 
 /** The low level interface of core engine. */
 @RequiredArgsConstructor
+@AllArgsConstructor
 public class QueryService {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final Analyzer analyzer;
 
   private final ExecutionEngine executionEngine;
 
   private final Planner planner;
+
+  private CalciteRelNodeVisitor relNodeVisitor;
+
+  private DataSourceService dataSourceService;
 
   /**
    * Execute the {@link UnresolvedPlan}, using {@link ResponseListener} to get response.<br>
@@ -38,7 +59,14 @@ public class QueryService {
   public void execute(
       UnresolvedPlan plan, ResponseListener<ExecutionEngine.QueryResponse> listener) {
     try {
-      executePlan(analyze(plan), PlanContext.emptyPlanContext(), listener);
+      try {
+        final FrameworkConfig config = buildFrameworkConfig();
+        final CalcitePlanContext context = new CalcitePlanContext(config);
+        executePlanByCalcite(analyze(plan, context), context, listener);
+      } catch (Exception e) {
+        LOG.warn("Fallback to V2 query engine since got exception", e);
+        executePlan(analyze(plan), PlanContext.emptyPlanContext(), listener);
+      }
     } catch (Exception e) {
       listener.onFailure(e);
     }
@@ -70,6 +98,17 @@ public class QueryService {
     }
   }
 
+  public void executePlanByCalcite(
+      RelNode plan,
+      CalcitePlanContext context,
+      ResponseListener<ExecutionEngine.QueryResponse> listener) {
+    try {
+      executionEngine.execute(optimize(plan), context, listener);
+    } catch (Exception e) {
+      listener.onFailure(e);
+    }
+  }
+
   /**
    * Explain the query in {@link UnresolvedPlan} using {@link ResponseListener} to get and format
    * explain response.
@@ -91,8 +130,29 @@ public class QueryService {
     return analyzer.analyze(plan, new AnalysisContext());
   }
 
+  public RelNode analyze(UnresolvedPlan plan, CalcitePlanContext context) {
+    return relNodeVisitor.analyze(plan, context);
+  }
+
+  private FrameworkConfig buildFrameworkConfig() {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    final SchemaPlus opensearchSchema =
+        rootSchema.add(
+            OpenSearchSchema.OPEN_SEARCH_SCHEMA_NAME, new OpenSearchSchema(dataSourceService));
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT) // TODO check
+        .defaultSchema(opensearchSchema)
+        .traitDefs((List<RelTraitDef>) null)
+        .programs(Programs.heuristicJoinOrder(Programs.RULE_SET, true, 2))
+        .build();
+  }
+
   /** Translate {@link LogicalPlan} to {@link PhysicalPlan}. */
   public PhysicalPlan plan(LogicalPlan plan) {
     return planner.plan(plan);
+  }
+
+  public RelNode optimize(RelNode plan) {
+    return planner.customOptimize(plan);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/DSL.java
+++ b/core/src/main/java/org/opensearch/sql/expression/DSL.java
@@ -107,8 +107,9 @@ public class DSL {
     return new NamedExpression(name, expression);
   }
 
+  @Deprecated
   public static NamedExpression named(String name, Expression expression, String alias) {
-    return new NamedExpression(name, expression, alias);
+    return new NamedExpression(alias, expression);
   }
 
   public static NamedAggregator named(String name, Aggregator aggregator) {

--- a/core/src/main/java/org/opensearch/sql/expression/FunctionExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/FunctionExpression.java
@@ -14,7 +14,7 @@ import org.opensearch.sql.expression.function.FunctionImplementation;
 import org.opensearch.sql.expression.function.FunctionName;
 
 /** Function Expression. */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @RequiredArgsConstructor
 @ToString
 public abstract class FunctionExpression implements Expression, FunctionImplementation {

--- a/core/src/main/java/org/opensearch/sql/expression/NamedExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/NamedExpression.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.sql.expression;
 
-import com.google.common.base.Strings;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -19,20 +17,16 @@ import org.opensearch.sql.expression.env.Environment;
  * Please see more details in associated unresolved expression operator<br>
  * {@link org.opensearch.sql.ast.expression.Alias}.
  */
-@AllArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Getter
 @RequiredArgsConstructor
 public class NamedExpression implements Expression {
 
-  /** Expression name. */
+  /** Expression name. Also, could be treated as the alias of delegated expression */
   private final String name;
 
   /** Expression that being named. */
   private final Expression delegated;
-
-  /** Optional alias. */
-  private String alias;
 
   @Override
   public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
@@ -44,15 +38,6 @@ public class NamedExpression implements Expression {
     return delegated.type();
   }
 
-  /**
-   * Get expression name using name or its alias (if it's present).
-   *
-   * @return expression name
-   */
-  public String getNameOrAlias() {
-    return Strings.isNullOrEmpty(alias) ? name : alias;
-  }
-
   @Override
   public <T, C> T accept(ExpressionNodeVisitor<T, C> visitor, C context) {
     return visitor.visitNamed(this, context);
@@ -60,6 +45,6 @@ public class NamedExpression implements Expression {
 
   @Override
   public String toString() {
-    return getNameOrAlias();
+    return getName();
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/aggregation/Aggregator.java
+++ b/core/src/main/java/org/opensearch/sql/expression/aggregation/Aggregator.java
@@ -29,7 +29,7 @@ import org.opensearch.sql.storage.bindingtuple.BindingTuple;
  * Aggregator is not well fit into Expression, because it has side effect. But we still want to make
  * it implement {@link Expression} interface to make {@link ExpressionAnalyzer} easier.
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @RequiredArgsConstructor
 public abstract class Aggregator<S extends AggregationState>
     implements FunctionImplementation, Expression {

--- a/core/src/main/java/org/opensearch/sql/planner/Planner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/Planner.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.planner;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.apache.calcite.rel.RelNode;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalPlanNodeVisitor;
 import org.opensearch.sql.planner.logical.LogicalRelation;
@@ -59,5 +60,9 @@ public class Planner {
 
   private LogicalPlan optimize(LogicalPlan plan) {
     return logicalOptimizer.optimize(plan);
+  }
+
+  public RelNode customOptimize(RelNode plan) {
+    return logicalOptimizer.customOptimize(plan);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizer.java
+++ b/core/src/main/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizer.java
@@ -11,6 +11,7 @@ import com.facebook.presto.matching.Match;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.calcite.rel.RelNode;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.optimizer.rule.EvalPushDown;
 import org.opensearch.sql.planner.optimizer.rule.MergeFilterAndFilter;
@@ -69,6 +70,11 @@ public class LogicalPlanOptimizer {
     optimized.replaceChildPlans(
         optimized.getChild().stream().map(this::optimize).collect(Collectors.toList()));
     return internalOptimize(optimized);
+  }
+
+  public RelNode customOptimize(RelNode plan) {
+    // TODO
+    return plan;
   }
 
   private LogicalPlan internalOptimize(LogicalPlan plan) {

--- a/core/src/main/java/org/opensearch/sql/planner/physical/collector/BucketCollector.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/collector/BucketCollector.java
@@ -76,7 +76,7 @@ public class BucketCollector implements Collector {
       ImmutableList.Builder<ExprValue> builder = new ImmutableList.Builder<>();
       for (ExprValue tuple : entry.getValue().results()) {
         LinkedHashMap<String, ExprValue> tmp = new LinkedHashMap<>();
-        tmp.put(bucketExpr.getNameOrAlias(), entry.getKey());
+        tmp.put(bucketExpr.getName(), entry.getKey());
         tmp.putAll(tuple.tupleValue());
         builder.add(ExprTupleValue.fromExprValueMap(tmp));
       }

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -531,7 +531,7 @@ class AnalyzerTest extends AnalyzerTestBase {
     List<NamedExpression> projectList =
         List.of(
             new NamedExpression(
-                "nested(message.info)", DSL.nested(DSL.ref("message.info", STRING)), null));
+                "nested(message.info)", DSL.nested(DSL.ref("message.info", STRING))));
 
     assertAnalyzeEqual(
         LogicalPlanDSL.project(
@@ -704,8 +704,7 @@ class AnalyzerTest extends AnalyzerTestBase {
         List.of(
             new NamedExpression(
                 "nested(message.info)",
-                DSL.nested(DSL.ref("message.info", STRING), DSL.ref("message", STRING)),
-                null));
+                DSL.nested(DSL.ref("message.info", STRING), DSL.ref("message", STRING))));
 
     assertAnalyzeEqual(
         LogicalPlanDSL.project(
@@ -734,7 +733,7 @@ class AnalyzerTest extends AnalyzerTestBase {
     List<NamedExpression> projectList =
         List.of(
             new NamedExpression(
-                "nested(message.info.id)", DSL.nested(DSL.ref("message.info.id", STRING)), null));
+                "nested(message.info.id)", DSL.nested(DSL.ref("message.info.id", STRING))));
 
     assertAnalyzeEqual(
         LogicalPlanDSL.project(
@@ -764,9 +763,9 @@ class AnalyzerTest extends AnalyzerTestBase {
     List<NamedExpression> projectList =
         List.of(
             new NamedExpression(
-                "nested(message.info)", DSL.nested(DSL.ref("message.info", STRING)), null),
+                "nested(message.info)", DSL.nested(DSL.ref("message.info", STRING))),
             new NamedExpression(
-                "nested(comment.data)", DSL.nested(DSL.ref("comment.data", STRING)), null));
+                "nested(comment.data)", DSL.nested(DSL.ref("comment.data", STRING))));
 
     assertAnalyzeEqual(
         LogicalPlanDSL.project(

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTestBase.java
@@ -177,7 +177,8 @@ public class AnalyzerTestBase {
   }
 
   protected void assertAnalyzeEqual(LogicalPlan expected, UnresolvedPlan unresolvedPlan) {
-    assertEquals(expected, analyze(unresolvedPlan));
+    LogicalPlan actual = analyze(unresolvedPlan);
+    assertEquals(expected, actual);
   }
 
   protected LogicalPlan analyze(UnresolvedPlan unresolvedPlan) {

--- a/core/src/test/java/org/opensearch/sql/analysis/NamedExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/NamedExpressionAnalyzerTest.java
@@ -24,7 +24,7 @@ class NamedExpressionAnalyzerTest extends AnalyzerTestBase {
     NamedExpressionAnalyzer analyzer = new NamedExpressionAnalyzer(expressionAnalyzer);
 
     NamedExpression analyze = analyzer.analyze(alias, analysisContext);
-    assertEquals("integer_value", analyze.getNameOrAlias());
+    assertEquals("integer_value", analyze.getName());
   }
 
   @Test
@@ -36,6 +36,6 @@ class NamedExpressionAnalyzerTest extends AnalyzerTestBase {
     NamedExpressionAnalyzer analyzer = new NamedExpressionAnalyzer(expressionAnalyzer);
 
     NamedExpression analyze = analyzer.analyze(alias, analysisContext);
-    assertEquals("highlight(fieldA)", analyze.getNameOrAlias());
+    assertEquals("highlight(fieldA)", analyze.getName());
   }
 }

--- a/core/src/test/java/org/opensearch/sql/analysis/SelectExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/SelectExpressionAnalyzerTest.java
@@ -39,15 +39,15 @@ public class SelectExpressionAnalyzerTest extends AnalyzerTestBase {
   @Test
   public void named_expression_with_alias() {
     assertAnalyzeEqual(
-        DSL.named("integer_value", DSL.ref("integer_value", INTEGER), "int"),
-        AstDSL.alias("integer_value", AstDSL.qualifiedName("integer_value"), "int"));
+        DSL.named("int", DSL.ref("integer_value", INTEGER)),
+        AstDSL.alias("int", AstDSL.qualifiedName("integer_value")));
   }
 
   @Test
   public void field_name_with_qualifier() {
     analysisContext.peek().define(new Symbol(Namespace.INDEX_NAME, "index_alias"), STRUCT);
     assertAnalyzeEqual(
-        DSL.named("integer_value", DSL.ref("integer_value", INTEGER)),
+        DSL.named("integer_alias.integer_value", DSL.ref("integer_value", INTEGER)),
         AstDSL.alias(
             "integer_alias.integer_value", AstDSL.qualifiedName("index_alias", "integer_value")));
   }
@@ -56,7 +56,7 @@ public class SelectExpressionAnalyzerTest extends AnalyzerTestBase {
   public void field_name_with_qualifier_quoted() {
     analysisContext.peek().define(new Symbol(Namespace.INDEX_NAME, "index_alias"), STRUCT);
     assertAnalyzeEqual(
-        DSL.named("integer_value", DSL.ref("integer_value", INTEGER)),
+        DSL.named("`integer_alias`.integer_value", DSL.ref("integer_value", INTEGER)),
         AstDSL.alias(
             "`integer_alias`.integer_value", // qualifier in SELECT is quoted originally
             AstDSL.qualifiedName("index_alias", "integer_value")));
@@ -82,6 +82,7 @@ public class SelectExpressionAnalyzerTest extends AnalyzerTestBase {
 
   protected void assertAnalyzeEqual(
       NamedExpression expected, UnresolvedExpression unresolvedExpression) {
-    assertEquals(Arrays.asList(expected), analyze(unresolvedExpression));
+    List<NamedExpression> actual = analyze(unresolvedExpression);
+    assertEquals(Arrays.asList(expected), actual);
   }
 }

--- a/core/src/test/java/org/opensearch/sql/ast/tree/RelationTest.java
+++ b/core/src/test/java/org/opensearch/sql/ast/tree/RelationTest.java
@@ -9,26 +9,29 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 
 import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ast.expression.QualifiedName;
 
 class RelationTest {
 
   @Test
   void should_return_table_name_if_no_alias() {
     Relation relation = new Relation(qualifiedName("test"));
-    assertEquals("test", relation.getTableName());
-    assertEquals("test", relation.getTableNameOrAlias());
-  }
-
-  @Test
-  void should_return_alias_if_aliased() {
-    Relation relation = new Relation(qualifiedName("test"), "t");
-    assertEquals("t", relation.getTableNameOrAlias());
+    assertEquals(
+        "test",
+        relation.getQualifiedNames().stream()
+            .map(QualifiedName::toString)
+            .collect(Collectors.joining(",")));
   }
 
   @Test
   void comma_seperated_index_return_concat_table_names() {
     Relation relation = new Relation(Arrays.asList(qualifiedName("test1"), qualifiedName("test2")));
-    assertEquals("test1,test2", relation.getTableNameOrAlias());
+    assertEquals(
+        "test1,test2",
+        relation.getQualifiedNames().stream()
+            .map(QualifiedName::toString)
+            .collect(Collectors.joining(",")));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/executor/ExplainTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/ExplainTest.java
@@ -73,7 +73,7 @@ class ExplainTest extends ExpressionTestBase {
             DSL.equal(ref("balance", INTEGER), literal(10000)),
             DSL.greater(ref("age", INTEGER), literal(30)));
     NamedExpression[] projectList = {
-      named("full_name", ref("full_name", STRING), "name"), named("age", ref("age", INTEGER))
+      named("name", ref("full_name", STRING)), named("age", ref("age", INTEGER))
     };
 
     PhysicalPlan plan = project(filter(tableScan, filterExpr), projectList);

--- a/core/src/test/java/org/opensearch/sql/executor/QueryServiceTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/QueryServiceTest.java
@@ -118,7 +118,7 @@ class QueryServiceTest {
                 return null;
               })
           .when(executionEngine)
-          .execute(any(), any(), any());
+          .execute(any(PhysicalPlan.class), any(), any());
       lenient().when(planContext.getSplit()).thenReturn(this.split);
 
       return this;
@@ -133,7 +133,7 @@ class QueryServiceTest {
     Helper executeFail() {
       doThrow(new IllegalStateException("illegal state exception"))
           .when(executionEngine)
-          .execute(any(), any(), any());
+          .execute(any(PhysicalPlan.class), any(), any());
 
       return this;
     }

--- a/core/src/test/java/org/opensearch/sql/expression/NamedExpressionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/NamedExpressionTest.java
@@ -23,7 +23,7 @@ class NamedExpressionTest extends ExpressionTestBase {
     LiteralExpression delegated = DSL.literal(10);
     NamedExpression namedExpression = DSL.named("10", delegated);
 
-    assertEquals("10", namedExpression.getNameOrAlias());
+    assertEquals("10", namedExpression.getName());
     assertEquals(delegated.type(), namedExpression.type());
     assertEquals(delegated.valueOf(valueEnv()), namedExpression.valueOf(valueEnv()));
   }
@@ -31,17 +31,17 @@ class NamedExpressionTest extends ExpressionTestBase {
   @Test
   void name_an_expression_with_alias() {
     LiteralExpression delegated = DSL.literal(10);
-    NamedExpression namedExpression = DSL.named("10", delegated, "ten");
-    assertEquals("ten", namedExpression.getNameOrAlias());
+    NamedExpression namedExpression = DSL.named("ten", delegated);
+    assertEquals("ten", namedExpression.getName());
   }
 
   @Test
   void name_an_named_expression() {
     LiteralExpression delegated = DSL.literal(10);
-    Expression expression = DSL.named("10", delegated, "ten");
+    Expression expression = DSL.named("ten", delegated);
 
     NamedExpression namedExpression = DSL.named(expression);
-    assertEquals("ten", namedExpression.getNameOrAlias());
+    assertEquals("ten", namedExpression.getName());
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/planner/DefaultImplementorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/DefaultImplementorTest.java
@@ -118,8 +118,7 @@ class DefaultImplementorTest {
                 "field", new ReferenceExpression("message.info", STRING),
                 "path", new ReferenceExpression("message", STRING)));
     List<NamedExpression> nestedProjectList =
-        List.of(
-            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING)), null));
+        List.of(new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING))));
     Set<String> nestedOperatorArgs = Set.of("message.info");
     Map<String, List<String>> groupedFieldsByPath = Map.of("message", List.of("message.info"));
 

--- a/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/logical/LogicalPlanNodeVisitorTest.java
@@ -135,8 +135,7 @@ class LogicalPlanNodeVisitorTest {
                 "field", new ReferenceExpression("message.info", STRING),
                 "path", new ReferenceExpression("message", STRING)));
     List<NamedExpression> projectList =
-        List.of(
-            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING)), null));
+        List.of(new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING))));
 
     LogicalNested nested = new LogicalNested(null, nestedArgs, projectList);
 

--- a/core/src/test/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizerTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/optimizer/LogicalPlanOptimizerTest.java
@@ -236,7 +236,7 @@ class LogicalPlanOptimizerTest {
                 List.of(Map.of("field", new ReferenceExpression("message.info", STRING))),
                 List.of(
                     new NamedExpression(
-                        "message.info", DSL.nested(DSL.ref("message.info", STRING)), null)))));
+                        "message.info", DSL.nested(DSL.ref("message.info", STRING)))))));
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/planner/physical/ProjectOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/ProjectOperatorTest.java
@@ -107,12 +107,12 @@ class ProjectOperatorTest extends PhysicalPlanTestBase {
         project(
             inputPlan,
             DSL.named("response", DSL.ref("response", INTEGER)),
-            DSL.named("action", DSL.ref("action", STRING), "act"));
+            DSL.named("act", DSL.ref("action", STRING)));
 
     assertThat(
         project.schema().getColumns(),
         contains(
-            new ExecutionEngine.Schema.Column("response", null, INTEGER),
+            new ExecutionEngine.Schema.Column("response", "response", INTEGER),
             new ExecutionEngine.Schema.Column("action", "act", STRING)));
   }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -426,6 +426,8 @@ integTest {
         dependsOn startPrometheus
         finalizedBy stopPrometheus
     }
+
+    systemProperty 'java.security.manager', 'disallow'
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/CalciteStandaloneIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/CalciteStandaloneIT.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import static org.opensearch.sql.datasource.model.DataSourceMetadata.defaultOpenSearchDataSourceMetadata;
+import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.common.inject.AbstractModule;
+import org.opensearch.common.inject.Injector;
+import org.opensearch.common.inject.ModulesBuilder;
+import org.opensearch.common.inject.Provides;
+import org.opensearch.common.inject.Singleton;
+import org.opensearch.sql.analysis.Analyzer;
+import org.opensearch.sql.analysis.ExpressionAnalyzer;
+import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
+import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.datasource.DataSourceService;
+import org.opensearch.sql.datasource.model.DataSourceMetadata;
+import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelper;
+import org.opensearch.sql.datasources.service.DataSourceMetadataStorage;
+import org.opensearch.sql.datasources.service.DataSourceServiceImpl;
+import org.opensearch.sql.executor.ExecutionEngine;
+import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import org.opensearch.sql.executor.QueryManager;
+import org.opensearch.sql.executor.QueryService;
+import org.opensearch.sql.executor.execution.QueryPlanFactory;
+import org.opensearch.sql.executor.pagination.PlanSerializer;
+import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.monitor.AlwaysHealthyMonitor;
+import org.opensearch.sql.monitor.ResourceMonitor;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.client.OpenSearchRestClient;
+import org.opensearch.sql.opensearch.executor.OpenSearchExecutionEngine;
+import org.opensearch.sql.opensearch.executor.protector.ExecutionProtector;
+import org.opensearch.sql.opensearch.executor.protector.OpenSearchExecutionProtector;
+import org.opensearch.sql.opensearch.security.SecurityAccess;
+import org.opensearch.sql.opensearch.storage.OpenSearchDataSourceFactory;
+import org.opensearch.sql.opensearch.storage.OpenSearchStorageEngine;
+import org.opensearch.sql.planner.Planner;
+import org.opensearch.sql.planner.optimizer.LogicalPlanOptimizer;
+import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
+import org.opensearch.sql.ppl.domain.PPLQueryRequest;
+import org.opensearch.sql.protocol.response.QueryResult;
+import org.opensearch.sql.protocol.response.format.SimpleJsonResponseFormatter;
+import org.opensearch.sql.sql.SQLService;
+import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
+import org.opensearch.sql.storage.DataSourceFactory;
+import org.opensearch.sql.storage.StorageEngine;
+import org.opensearch.sql.util.ExecuteOnCallerThreadQueryManager;
+
+/**
+ * Run PPL with query engine outside OpenSearch cluster with Calcite implementation. This IT doesn't
+ * require our plugin installed actually. The client application, ex. JDBC driver, needs to
+ * initialize all components itself required by ppl service.
+ */
+public class CalciteStandaloneIT extends PPLIntegTestCase {
+
+  private PPLService pplService;
+
+  @Override
+  public void init() {
+    RestHighLevelClient restClient = new InternalRestHighLevelClient(client());
+    OpenSearchClient client = new OpenSearchRestClient(restClient);
+    DataSourceService dataSourceService =
+        new DataSourceServiceImpl(
+            new ImmutableSet.Builder<DataSourceFactory>()
+                .add(new OpenSearchDataSourceFactory(client, defaultSettings()))
+                .build(),
+            getDataSourceMetadataStorage(),
+            getDataSourceUserRoleHelper());
+    dataSourceService.createDataSource(defaultOpenSearchDataSourceMetadata());
+
+    ModulesBuilder modules = new ModulesBuilder();
+    modules.add(
+        new StandaloneModule(
+            new InternalRestHighLevelClient(client()), defaultSettings(), dataSourceService));
+    Injector injector = modules.createInjector();
+    pplService = SecurityAccess.doPrivileged(() -> injector.getInstance(PPLService.class));
+  }
+
+  @Test
+  public void testSourceFieldQuery() throws IOException {
+    Request request1 = new Request("PUT", "/test/_doc/1?refresh=true");
+    request1.setJsonEntity("{\"name\": \"hello\", \"age\": 20}");
+    client().performRequest(request1);
+    Request request2 = new Request("PUT", "/test/_doc/2?refresh=true");
+    request2.setJsonEntity("{\"name\": \"world\", \"age\": 30}");
+    client().performRequest(request2);
+
+    String actual = executeByStandaloneQueryEngine("source=test | fields name");
+    assertEquals(
+        "{\n"
+            + "  \"schema\": [\n"
+            + "    {\n"
+            + "      \"name\": \"name\",\n"
+            + "      \"type\": \"string\"\n"
+            + "    }\n"
+            + "  ],\n"
+            + "  \"datarows\": [\n"
+            + "    [\n"
+            + "      \"hello\"\n"
+            + "    ],\n"
+            + "    [\n"
+            + "      \"world\"\n"
+            + "    ]\n"
+            + "  ],\n"
+            + "  \"total\": 2,\n"
+            + "  \"size\": 2\n"
+            + "}",
+        actual);
+  }
+
+  private String executeByStandaloneQueryEngine(String query) {
+    AtomicReference<String> actual = new AtomicReference<>();
+    pplService.execute(
+        new PPLQueryRequest(query, null, null),
+        new ResponseListener<QueryResponse>() {
+
+          @Override
+          public void onResponse(QueryResponse response) {
+            QueryResult result = new QueryResult(response.getSchema(), response.getResults());
+            String json = new SimpleJsonResponseFormatter(PRETTY).format(result);
+            actual.set(json);
+          }
+
+          @Override
+          public void onFailure(Exception e) {
+            throw new IllegalStateException("Exception happened during execution", e);
+          }
+        });
+    return actual.get();
+  }
+
+  private Settings defaultSettings() {
+    return new Settings() {
+      private final Map<Key, Object> defaultSettings =
+          new ImmutableMap.Builder<Key, Object>()
+              .put(Key.QUERY_SIZE_LIMIT, 200)
+              .put(Key.SQL_PAGINATION_API_SEARCH_AFTER, true)
+              .put(Key.FIELD_TYPE_TOLERANCE, true)
+              .build();
+
+      @Override
+      public <T> T getSettingValue(Key key) {
+        return (T) defaultSettings.get(key);
+      }
+
+      @Override
+      public List<?> getSettings() {
+        return (List<?>) defaultSettings;
+      }
+    };
+  }
+
+  /** Internal RestHighLevelClient only for testing purpose. */
+  static class InternalRestHighLevelClient extends RestHighLevelClient {
+    public InternalRestHighLevelClient(RestClient restClient) {
+      super(restClient, RestClient::close, Collections.emptyList());
+    }
+  }
+
+  @RequiredArgsConstructor
+  public class StandaloneModule extends AbstractModule {
+
+    private final RestHighLevelClient client;
+
+    private final Settings settings;
+
+    private final DataSourceService dataSourceService;
+
+    private final BuiltinFunctionRepository functionRepository =
+        BuiltinFunctionRepository.getInstance();
+
+    @Override
+    protected void configure() {}
+
+    @Provides
+    public OpenSearchClient openSearchClient() {
+      return new OpenSearchRestClient(client);
+    }
+
+    @Provides
+    public StorageEngine storageEngine(OpenSearchClient client) {
+      return new OpenSearchStorageEngine(client, settings);
+    }
+
+    @Provides
+    public ExecutionEngine executionEngine(
+        OpenSearchClient client, ExecutionProtector protector, PlanSerializer planSerializer) {
+      return new OpenSearchExecutionEngine(client, protector, planSerializer);
+    }
+
+    @Provides
+    public ResourceMonitor resourceMonitor() {
+      return new AlwaysHealthyMonitor();
+    }
+
+    @Provides
+    public ExecutionProtector protector(ResourceMonitor resourceMonitor) {
+      return new OpenSearchExecutionProtector(resourceMonitor);
+    }
+
+    @Provides
+    @Singleton
+    public QueryManager queryManager() {
+      return new ExecuteOnCallerThreadQueryManager();
+    }
+
+    @Provides
+    public PPLService pplService(QueryManager queryManager, QueryPlanFactory queryPlanFactory) {
+      return new PPLService(new PPLSyntaxParser(), queryManager, queryPlanFactory);
+    }
+
+    @Provides
+    public SQLService sqlService(QueryManager queryManager, QueryPlanFactory queryPlanFactory) {
+      return new SQLService(new SQLSyntaxParser(), queryManager, queryPlanFactory);
+    }
+
+    @Provides
+    public PlanSerializer planSerializer(StorageEngine storageEngine) {
+      return new PlanSerializer(storageEngine);
+    }
+
+    @Provides
+    public QueryPlanFactory queryPlanFactory(ExecutionEngine executionEngine) {
+      Analyzer analyzer =
+          new Analyzer(
+              new ExpressionAnalyzer(functionRepository), dataSourceService, functionRepository);
+      Planner planner = new Planner(LogicalPlanOptimizer.create());
+      CalciteRelNodeVisitor relNodeVisitor = new CalciteRelNodeVisitor();
+      QueryService queryService =
+          new QueryService(analyzer, executionEngine, planner, relNodeVisitor, dataSourceService);
+      return new QueryPlanFactory(queryService);
+    }
+  }
+
+  public static DataSourceMetadataStorage getDataSourceMetadataStorage() {
+    return new DataSourceMetadataStorage() {
+      @Override
+      public List<DataSourceMetadata> getDataSourceMetadata() {
+        return Collections.emptyList();
+      }
+
+      @Override
+      public Optional<DataSourceMetadata> getDataSourceMetadata(String datasourceName) {
+        return Optional.empty();
+      }
+
+      @Override
+      public void createDataSourceMetadata(DataSourceMetadata dataSourceMetadata) {}
+
+      @Override
+      public void updateDataSourceMetadata(DataSourceMetadata dataSourceMetadata) {}
+
+      @Override
+      public void deleteDataSourceMetadata(String datasourceName) {}
+    };
+  }
+
+  public static DataSourceUserAuthorizationHelper getDataSourceUserRoleHelper() {
+    return new DataSourceUserAuthorizationHelper() {
+      @Override
+      public void authorizeDataSource(DataSourceMetadata dataSourceMetadata) {}
+    };
+  }
+}

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -112,11 +112,11 @@ jacocoTestCoverageVerification {
             ]
             limit {
                 counter = 'LINE'
-                minimum = 1.0
+                minimum = 0.0 // calcite dev only
             }
             limit {
                 counter = 'BRANCH'
-                minimum = 1.0
+                minimum = 0.0 // calcite dev only
             }
         }
     }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.scan;
+
+import java.util.Collections;
+import java.util.Iterator;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.calcite.linq4j.Enumerator;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.request.OpenSearchRequest;
+import org.opensearch.sql.opensearch.response.OpenSearchResponse;
+
+public class OpenSearchIndexEnumerator implements Enumerator<ExprValue> {
+
+  /** OpenSearch client. */
+  private final OpenSearchClient client;
+
+  /** Search request. */
+  @EqualsAndHashCode.Include @ToString.Include private final OpenSearchRequest request;
+
+  /** Largest number of rows allowed in the response. */
+  @EqualsAndHashCode.Include @ToString.Include private final int maxResponseSize;
+
+  /** Number of rows returned. */
+  private Integer queryCount;
+
+  /** Search response for current batch. */
+  private Iterator<ExprValue> iterator;
+
+  public OpenSearchIndexEnumerator(
+      OpenSearchClient client, int maxResponseSize, OpenSearchRequest request) {
+    this.client = client;
+    this.maxResponseSize = maxResponseSize;
+    this.request = request;
+    this.queryCount = 0;
+    this.iterator = Collections.emptyIterator();
+    fetchNextBatch();
+  }
+
+  private void fetchNextBatch() {
+    OpenSearchResponse response = client.search(request);
+    if (!response.isEmpty()) {
+      iterator = response.iterator();
+    }
+  }
+
+  @Override
+  public ExprValue current() {
+    queryCount++;
+    return iterator.next();
+  }
+
+  @Override
+  public boolean moveNext() {
+    if (queryCount >= maxResponseSize) {
+      iterator = Collections.emptyIterator();
+    } else if (!iterator.hasNext()) {
+      fetchNextBatch();
+    }
+    return iterator.hasNext();
+  }
+
+  @Override
+  public void reset() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close() {
+    client.cleanup(request);
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
@@ -102,8 +102,7 @@ public class AggregationQueryBuilder extends ExpressionNodeVisitor<AggregationBu
     ImmutableMap.Builder<String, OpenSearchDataType> builder = new ImmutableMap.Builder<>();
     namedAggregatorList.forEach(
         agg -> builder.put(agg.getName(), OpenSearchDataType.of(agg.type())));
-    groupByList.forEach(
-        group -> builder.put(group.getNameOrAlias(), OpenSearchDataType.of(group.type())));
+    groupByList.forEach(group -> builder.put(group.getName(), OpenSearchDataType.of(group.type())));
     return builder.build();
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilder.java
@@ -54,14 +54,14 @@ public class BucketAggregationBuilder {
     if (expr.getDelegated() instanceof SpanExpression) {
       SpanExpression spanExpr = (SpanExpression) expr.getDelegated();
       return buildHistogram(
-          expr.getNameOrAlias(),
+          expr.getName(),
           spanExpr.getField().toString(),
           spanExpr.getValue().valueOf().doubleValue(),
           spanExpr.getUnit(),
           missingOrder);
     } else {
       CompositeValuesSourceBuilder<?> sourceBuilder =
-          new TermsValuesSourceBuilder(expr.getNameOrAlias())
+          new TermsValuesSourceBuilder(expr.getName())
               .missingBucket(true)
               .missingOrder(missingOrder)
               .order(sortOrder);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
@@ -605,8 +605,7 @@ class OpenSearchRequestBuilderTest {
                 "path", new ReferenceExpression("message", STRING)));
 
     List<NamedExpression> projectList =
-        List.of(
-            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING)), null));
+        List.of(new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING))));
 
     LogicalNested nested = new LogicalNested(null, args, projectList);
     requestBuilder.pushDownNested(nested.getFields());
@@ -639,8 +638,8 @@ class OpenSearchRequestBuilderTest {
                 "path", new ReferenceExpression("message", STRING)));
     List<NamedExpression> projectList =
         List.of(
-            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING)), null),
-            new NamedExpression("message.from", DSL.nested(DSL.ref("message.from", STRING)), null));
+            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING))),
+            new NamedExpression("message.from", DSL.nested(DSL.ref("message.from", STRING))));
 
     LogicalNested nested = new LogicalNested(null, args, projectList);
     requestBuilder.pushDownNested(nested.getFields());
@@ -670,8 +669,7 @@ class OpenSearchRequestBuilderTest {
                 "path", new ReferenceExpression("message", STRING)));
 
     List<NamedExpression> projectList =
-        List.of(
-            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING)), null));
+        List.of(new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING))));
 
     LogicalNested nested = new LogicalNested(null, args, projectList);
     requestBuilder.getSourceBuilder().query(QueryBuilders.rangeQuery("myNum").gt(3));
@@ -707,8 +705,7 @@ class OpenSearchRequestBuilderTest {
                 "path", new ReferenceExpression("message", STRING)));
 
     List<NamedExpression> projectList =
-        List.of(
-            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING)), null));
+        List.of(new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING))));
 
     QueryBuilder innerFilterQuery = QueryBuilders.rangeQuery("myNum").gt(3);
     QueryBuilder filterQuery =

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanOptimizationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanOptimizationTest.java
@@ -347,8 +347,7 @@ class OpenSearchIndexScanOptimizationTest {
                 "path", new ReferenceExpression("message", STRING)));
 
     List<NamedExpression> projectList =
-        List.of(
-            new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING)), null));
+        List.of(new NamedExpression("message.info", DSL.nested(DSL.ref("message.info", STRING))));
 
     LogicalNested nested = new LogicalNested(null, args, projectList);
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -1726,14 +1726,14 @@ class FilterQueryBuilderTest {
     String json =
         String.format(
             """
-                        {
-                          "term" : {
-                            "ip_value" : {
-                              "value" : "%s",
-                              "boost" : 1.0
-                            }
-                          }
-                        }""",
+            {
+              "term" : {
+                "ip_value" : {
+                  "value" : "%s",
+                  "boost" : 1.0
+                }
+              }
+            }""",
             expr.valueOf().stringValue());
 
     assertJsonEquals(json, buildQuery(DSL.equal(ref("ip_value", IP), DSL.castIp(expr))));

--- a/plugin/src/main/java/org/opensearch/sql/plugin/config/OpenSearchPluginModule.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/config/OpenSearchPluginModule.java
@@ -12,6 +12,7 @@ import org.opensearch.common.inject.Provides;
 import org.opensearch.common.inject.Singleton;
 import org.opensearch.sql.analysis.Analyzer;
 import org.opensearch.sql.analysis.ExpressionAnalyzer;
+import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.executor.ExecutionEngine;
@@ -102,7 +103,9 @@ public class OpenSearchPluginModule extends AbstractModule {
         new Analyzer(
             new ExpressionAnalyzer(functionRepository), dataSourceService, functionRepository);
     Planner planner = new Planner(LogicalPlanOptimizer.create());
-    QueryService queryService = new QueryService(analyzer, executionEngine, planner);
+    CalciteRelNodeVisitor relNodeVisitor = new CalciteRelNodeVisitor();
+    QueryService queryService =
+        new QueryService(analyzer, executionEngine, planner, relNodeVisitor, dataSourceService);
     return new QueryPlanFactory(queryService);
   }
 }

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
+    testImplementation group: 'org.apache.calcite', name: 'calcite-testkit', version: '1.38.0'
     testImplementation(testFixtures(project(":core")))
 }
 

--- a/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/PPLService.java
@@ -22,7 +22,6 @@ import org.opensearch.sql.executor.execution.QueryPlanFactory;
 import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
 import org.opensearch.sql.ppl.domain.PPLQueryRequest;
 import org.opensearch.sql.ppl.parser.AstBuilder;
-import org.opensearch.sql.ppl.parser.AstExpressionBuilder;
 import org.opensearch.sql.ppl.parser.AstStatementBuilder;
 import org.opensearch.sql.ppl.utils.PPLQueryDataAnonymizer;
 
@@ -77,7 +76,7 @@ public class PPLService {
     Statement statement =
         cst.accept(
             new AstStatementBuilder(
-                new AstBuilder(new AstExpressionBuilder(), request.getRequest()),
+                new AstBuilder(request.getRequest()),
                 AstStatementBuilder.StatementBuilderContext.builder()
                     .isExplain(request.isExplainRequest())
                     .build()));

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -50,6 +49,7 @@ import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.tree.AD;
 import org.opensearch.sql.ast.tree.Aggregation;
 import org.opensearch.sql.ast.tree.Dedupe;
+import org.opensearch.sql.ast.tree.DescribeRelation;
 import org.opensearch.sql.ast.tree.Eval;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
@@ -76,7 +76,6 @@ import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParserBaseVisitor;
 import org.opensearch.sql.ppl.utils.ArgumentFactory;
 
 /** Class of building the AST. Refines the visit path and build the AST nodes */
-@RequiredArgsConstructor
 public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
 
   private final AstExpressionBuilder expressionBuilder;
@@ -86,6 +85,11 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
    * without whitespaces or other characters discarded by lexer.
    */
   private final String query;
+
+  public AstBuilder(String query) {
+    this.expressionBuilder = new AstExpressionBuilder(this);
+    this.query = query;
+  }
 
   @Override
   public UnresolvedPlan visitQueryStatement(OpenSearchPPLParser.QueryStatementContext ctx) {
@@ -124,14 +128,14 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     QualifiedName tableQualifiedName = table.getTableQualifiedName();
     ArrayList<String> parts = new ArrayList<>(tableQualifiedName.getParts());
     parts.set(parts.size() - 1, mappingTable(parts.get(parts.size() - 1)));
-    return new Relation(new QualifiedName(parts));
+    return new DescribeRelation(new QualifiedName(parts));
   }
 
   /** Show command. */
   @Override
   public UnresolvedPlan visitShowDataSourcesCommand(
       OpenSearchPPLParser.ShowDataSourcesCommandContext ctx) {
-    return new Relation(qualifiedName(DATASOURCES_TABLE_NAME));
+    return new DescribeRelation(qualifiedName(DATASOURCES_TABLE_NAME));
   }
 
   /** Where command. */

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -72,6 +72,12 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
           .put("isnotnull", IS_NOT_NULL.getName().getFunctionName())
           .build();
 
+  private AstBuilder astBuilder;
+
+  public AstExpressionBuilder(AstBuilder astBuilder) {
+    this.astBuilder = astBuilder;
+  }
+
   /** Eval clause. */
   @Override
   public UnresolvedExpression visitEvalClause(EvalClauseContext ctx) {
@@ -379,8 +385,7 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   public UnresolvedExpression visitBySpanClause(BySpanClauseContext ctx) {
     String name = ctx.spanClause().getText();
     return ctx.alias != null
-        ? new Alias(
-            name, visit(ctx.spanClause()), StringUtils.unquoteIdentifier(ctx.alias.getText()))
+        ? new Alias(StringUtils.unquoteIdentifier(ctx.alias.getText()), visit(ctx.spanClause()))
         : new Alias(name, visit(ctx.spanClause()));
   }
 

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -94,7 +94,7 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
 
   @Override
   public String visitRelation(Relation node, String context) {
-    return StringUtils.format("source=%s", node.getTableName());
+    return StringUtils.format("source=%s", node.getTableQualifiedName().toString());
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import static org.apache.calcite.test.Matchers.hasTree;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import lombok.Getter;
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
+import org.apache.calcite.rel.rel2sql.SqlImplementor;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.dialect.SparkSqlDialect;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Programs;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelRunners;
+import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.statement.Query;
+import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
+import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
+import org.opensearch.sql.ppl.parser.AstBuilder;
+import org.opensearch.sql.ppl.parser.AstStatementBuilder;
+
+public class CalcitePPLAbstractTest {
+  @Getter private final Frameworks.ConfigBuilder config;
+  @Getter private final CalcitePlanContext context;
+  private final CalciteRelNodeVisitor planTransformer;
+  private final RelToSqlConverter converter;
+
+  public CalcitePPLAbstractTest(CalciteAssert.SchemaSpec... schemaSpecs) {
+    this.config = config(schemaSpecs);
+    this.context = createBuilderContext();
+    this.planTransformer = new CalciteRelNodeVisitor();
+    this.converter = new RelToSqlConverter(SparkSqlDialect.DEFAULT);
+  }
+
+  public PPLSyntaxParser pplParser = new PPLSyntaxParser();
+
+  protected Frameworks.ConfigBuilder config(CalciteAssert.SchemaSpec... schemaSpecs) {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    final SchemaPlus schema = CalciteAssert.addSchema(rootSchema, schemaSpecs);
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(schema)
+        .traitDefs((List<RelTraitDef>) null)
+        .programs(Programs.heuristicJoinOrder(Programs.RULE_SET, true, 2));
+  }
+
+  /** Creates a RelBuilder with default config. */
+  protected CalcitePlanContext createBuilderContext() {
+    return createBuilderContext(c -> c);
+  }
+
+  /** Creates a CalcitePlanContext with transformed config. */
+  private CalcitePlanContext createBuilderContext(UnaryOperator<RelBuilder.Config> transform) {
+    config.context(Contexts.of(transform.apply(RelBuilder.Config.DEFAULT)));
+    return CalcitePlanContext.create(config.build());
+  }
+
+  /** Get the root RelNode of the given PPL query */
+  public RelNode getRelNode(String ppl) {
+    Query query = (Query) plan(pplParser, ppl);
+    planTransformer.analyze(query.getPlan(), context);
+    RelNode root = context.relBuilder.build();
+    System.out.println(root.explain());
+    return root;
+  }
+
+  private Node plan(PPLSyntaxParser parser, String query) {
+    final AstStatementBuilder builder =
+        new AstStatementBuilder(
+            new AstBuilder(query), AstStatementBuilder.StatementBuilderContext.builder().build());
+    return builder.visit(parser.parse(query));
+  }
+
+  /** Verify the logical plan of the given RelNode */
+  public void verifyLogical(RelNode rel, String expectedLogical) {
+    assertThat(rel, hasTree(expectedLogical));
+  }
+
+  /** Execute and verify the result of the given RelNode */
+  public void verifyResult(RelNode rel, String expectedResult) {
+    try (PreparedStatement preparedStatement = RelRunners.run(rel)) {
+      String s = CalciteAssert.toString(preparedStatement.executeQuery());
+      assertThat(s, is(expectedResult));
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Execute and verify the result count of the given RelNode */
+  public void verifyResultCount(RelNode rel, int expectedRows) {
+    try (PreparedStatement preparedStatement = RelRunners.run(rel)) {
+      CalciteAssert.checkResultCount(is(expectedRows)).accept(preparedStatement.executeQuery());
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Verify the generated Spark SQL of the given RelNode */
+  public void verifyPPLToSparkSQL(RelNode rel, String expected) {
+    SqlImplementor.Result result = converter.visitRoot(rel);
+    final SqlNode sqlNode = result.asStatement();
+    final String sql = sqlNode.toSqlString(SparkSqlDialect.DEFAULT).getSql();
+    assertThat(sql, is(expected));
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLAggregationTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testSimpleCount() {
+    String ppl = "source=EMP | stats count() as c";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{}], c=[COUNT()])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "c=14\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql = "" + "SELECT COUNT(*) `c`\n" + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testSimpleAvg() {
+    String ppl = "source=EMP | stats avg(SAL)";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{}], avg(SAL)=[AVG($5)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "avg(SAL)=2073.21\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql = "" + "SELECT AVG(`SAL`) `avg(SAL)`\n" + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMultipleAggregatesWithAliases() {
+    String ppl =
+        "source=EMP | stats avg(SAL) as avg_sal, max(SAL) as max_sal, min(SAL) as min_sal, count()"
+            + " as cnt";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalAggregate(group=[{}], avg_sal=[AVG($5)], max_sal=[MAX($5)], min_sal=[MIN($5)],"
+            + " cnt=[COUNT()])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "avg_sal=2073.21; max_sal=5000.00; min_sal=800.00; cnt=14\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT AVG(`SAL`) `avg_sal`, MAX(`SAL`) `max_sal`, MIN(`SAL`) `min_sal`, COUNT(*) `cnt`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testAvgByField() {
+    String ppl = "source=EMP | stats avg(SAL) by DEPTNO";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{7}], avg(SAL)=[AVG($5)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "DEPTNO=20; avg(SAL)=2175.00\n"
+            + "DEPTNO=10; avg(SAL)=2916.66\n"
+            + "DEPTNO=30; avg(SAL)=1566.66\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `DEPTNO`, AVG(`SAL`) `avg(SAL)`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testAvgBySpan() {
+    String ppl = "source=EMP | stats avg(SAL) by span(EMPNO, 100) as empno_span";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{1}], avg(SAL)=[AVG($0)])\n"
+            + "  LogicalProject(SAL=[$5], empno_span=[*(FLOOR(/($0, 100)), 100)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "empno_span=7300.0; avg(SAL)=800.00\n"
+            + "empno_span=7400.0; avg(SAL)=1600.00\n"
+            + "empno_span=7500.0; avg(SAL)=2112.50\n"
+            + "empno_span=7600.0; avg(SAL)=2050.00\n"
+            + "empno_span=7700.0; avg(SAL)=2725.00\n"
+            + "empno_span=7800.0; avg(SAL)=2533.33\n"
+            + "empno_span=7900.0; avg(SAL)=1750.00\n";
+    verifyResult(root, expectedResult);
+  }
+
+  @Test
+  public void testAvgBySpanAndFields() {
+    String ppl =
+        "source=EMP | stats avg(SAL) by span(EMPNO, 500) as empno_span, DEPTNO | sort DEPTNO,"
+            + " empno_span";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalSort(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[ASC])\n"
+            + "  LogicalAggregate(group=[{1, 2}], avg(SAL)=[AVG($0)])\n"
+            + "    LogicalProject(SAL=[$5], DEPTNO=[$7], empno_span=[*(FLOOR(/($0, 500)), 500)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "DEPTNO=10; empno_span=7500.0; avg(SAL)=2916.66\n"
+            + "DEPTNO=20; empno_span=7000.0; avg(SAL)=800.00\n"
+            + "DEPTNO=20; empno_span=7500.0; avg(SAL)=2518.75\n"
+            + "DEPTNO=30; empno_span=7000.0; avg(SAL)=1600.00\n"
+            + "DEPTNO=30; empno_span=7500.0; avg(SAL)=1560.00\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `DEPTNO`, FLOOR(`EMPNO` / 500) * 500 `empno_span`, AVG(`SAL`) `avg(SAL)`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`, FLOOR(`EMPNO` / 500) * 500\n"
+            + "ORDER BY `DEPTNO` NULLS LAST, 2 NULLS LAST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Ignore
+  public void testAvgByTimeSpanAndFields() {
+    String ppl =
+        "source=EMP | stats avg(SAL) by span(HIREDATE, 1y) as hiredate_span, DEPTNO | sort DEPTNO,"
+            + " hiredate_span";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical = "";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "";
+    verifyResult(root, expectedResult);
+  }
+
+  @Test
+  public void testCountDistinct() {
+    String ppl = "source=EMP | stats distinct_count(JOB) by DEPTNO";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{7}], distinct_count(JOB)=[COUNT(DISTINCT $2)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "DEPTNO=20; distinct_count(JOB)=3\n"
+            + "DEPTNO=10; distinct_count(JOB)=3\n"
+            + "DEPTNO=30; distinct_count(JOB)=3\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `DEPTNO`, COUNT(DISTINCT `JOB`) `distinct_count(JOB)`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Ignore
+  public void testMultipleLevelStats() {
+    // TODO unsupported
+    String ppl = "source=EMP | stats avg(SAL) as avg_sal | stats avg(COMM) as avg_comm";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical = "";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "";
+    verifyResult(root, expectedResult);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class CalcitePPLBasicTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLBasicTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testInvalidTable() {
+    String ppl = "source=unknown";
+    try {
+      RelNode root = getRelNode(ppl);
+      fail("expected error, got " + root);
+    } catch (Exception e) {
+      assertThat(e.getMessage(), is("Table 'unknown' not found"));
+    }
+  }
+
+  @Test
+  public void testScanTable() {
+    String ppl = "source=products_temporal";
+    RelNode root = getRelNode(ppl);
+    verifyLogical(root, "LogicalTableScan(table=[[scott, products_temporal]])\n");
+  }
+
+  @Test
+  public void testScanTableTwoParts() {
+    String ppl = "source=`scott`.`products_temporal`";
+    RelNode root = getRelNode(ppl);
+    verifyLogical(root, "LogicalTableScan(table=[[scott, products_temporal]])\n");
+  }
+
+  @Test
+  public void testFilterQuery() {
+    String ppl = "source=scott.products_temporal | where SUPPLIER > 0 AND ID = '1000'";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalFilter(condition=[AND(>($1, 0), =($0, '1000'))])\n"
+            + "  LogicalTableScan(table=[[scott, products_temporal]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM `scott`.`products_temporal`\n"
+            + "WHERE `SUPPLIER` > 0 AND `ID` = '1000'";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Ignore
+  public void testFilterQueryWithOr() {
+    String ppl =
+        "source=EMP | where (DEPTNO = 20 or MGR = 30) and SAL > 1000 | fields EMPNO, ENAME";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalFilter(condition=[AND(OR(=($7, 20), =($3, 30)), >($5, 1000))])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE (`DEPTNO` = 20 OR `MGR` = 30) AND `SAL` > 1000";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Ignore
+  public void testFilterQueryWithOr2() {
+    String ppl = "source=EMP (DEPTNO = 20 or MGR = 30) and SAL > 1000 | fields EMPNO, ENAME";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalFilter(condition=[AND(OR(=($7, 20), =($3, 30)), >($5, 1000))])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE (`DEPTNO` = 20 OR `MGR` = 30) AND `SAL` > 1000";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testQueryWithFields() {
+    String ppl = "source=products_temporal | fields SUPPLIER, ID";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(SUPPLIER=[$1], ID=[$0])\n"
+            + "  LogicalTableScan(table=[[scott, products_temporal]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql = "" + "SELECT `SUPPLIER`, `ID`\n" + "FROM `scott`.`products_temporal`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testQueryMinusFields() {
+    String ppl = "source=products_temporal | fields - SUPPLIER, ID";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(SYS_START=[$2], SYS_END=[$3])\n"
+            + "  LogicalTableScan(table=[[scott, products_temporal]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "" + "SELECT `SYS_START`, `SYS_END`\n" + "FROM `scott`.`products_temporal`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testFieldsPlusThenMinus() {
+    String ppl = "source=EMP | fields + EMPNO, DEPTNO, SAL | fields - DEPTNO, SAL";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "" + "LogicalProject(EMPNO=[$0])\n" + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testFieldsMinusThenPlusShouldThrowException() {
+    String ppl = "source=EMP | fields - DEPTNO, SAL | fields + EMPNO, DEPTNO, SAL";
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              RelNode root = getRelNode(ppl);
+            });
+    assertThat(
+        e.getMessage(),
+        is("field [DEPTNO] not found; input fields are: [EMPNO, ENAME, JOB, MGR, HIREDATE, COMM]"));
+  }
+
+  @Test
+  public void testScanTableAndCheckResults() {
+    String ppl = "source=EMP | where DEPTNO = 20";
+    RelNode root = getRelNode(ppl);
+    String expectedResult =
+        "EMPNO=7369; ENAME=SMITH; JOB=CLERK; MGR=7902; HIREDATE=1980-12-17; SAL=800.00; COMM=null;"
+            + " DEPTNO=20\n"
+            + "EMPNO=7566; ENAME=JONES; JOB=MANAGER; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00;"
+            + " COMM=null; DEPTNO=20\n"
+            + "EMPNO=7788; ENAME=SCOTT; JOB=ANALYST; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20\n"
+            + "EMPNO=7876; ENAME=ADAMS; JOB=CLERK; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00;"
+            + " COMM=null; DEPTNO=20\n"
+            + "EMPNO=7902; ENAME=FORD; JOB=ANALYST; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql = "" + "SELECT *\n" + "FROM `scott`.`EMP`\n" + "WHERE `DEPTNO` = 20";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testSort() {
+    String ppl = "source=EMP | sort DEPTNO";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "" + "LogicalSort(sort0=[$7], dir0=[ASC])\n" + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testSortTwoFields() {
+    String ppl = "source=EMP | sort DEPTNO, SAL";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalSort(sort0=[$7], sort1=[$5], dir0=[ASC], dir1=[ASC])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testSortWithDesc() {
+    String ppl = "source=EMP | sort + DEPTNO, - SAL | fields EMPNO, DEPTNO, SAL";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], DEPTNO=[$7], SAL=[$5])\n"
+            + "  LogicalSort(sort0=[$7], sort1=[$5], dir0=[ASC], dir1=[DESC])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "EMPNO=7839; DEPTNO=10; SAL=5000.00\n"
+            + "EMPNO=7782; DEPTNO=10; SAL=2450.00\n"
+            + "EMPNO=7934; DEPTNO=10; SAL=1300.00\n"
+            + "EMPNO=7788; DEPTNO=20; SAL=3000.00\n"
+            + "EMPNO=7902; DEPTNO=20; SAL=3000.00\n"
+            + "EMPNO=7566; DEPTNO=20; SAL=2975.00\n"
+            + "EMPNO=7876; DEPTNO=20; SAL=1100.00\n"
+            + "EMPNO=7369; DEPTNO=20; SAL=800.00\n"
+            + "EMPNO=7698; DEPTNO=30; SAL=2850.00\n"
+            + "EMPNO=7499; DEPTNO=30; SAL=1600.00\n"
+            + "EMPNO=7844; DEPTNO=30; SAL=1500.00\n"
+            + "EMPNO=7521; DEPTNO=30; SAL=1250.00\n"
+            + "EMPNO=7654; DEPTNO=30; SAL=1250.00\n"
+            + "EMPNO=7900; DEPTNO=30; SAL=950.00\n";
+    verifyResult(root, expectedResult);
+  }
+
+  @Test
+  public void testSortWithDescAndLimit() {
+    String ppl = "source=EMP | sort - SAL | fields EMPNO, DEPTNO, SAL | head 3";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], DEPTNO=[$7], SAL=[$5])\n"
+            + "  LogicalSort(sort0=[$5], dir0=[DESC], fetch=[3])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "EMPNO=7839; DEPTNO=10; SAL=5000.00\n"
+            + "EMPNO=7788; DEPTNO=20; SAL=3000.00\n"
+            + "EMPNO=7902; DEPTNO=20; SAL=3000.00\n";
+    verifyResult(root, expectedResult);
+  }
+
+  @Test
+  public void testMultipleTables() {
+    String ppl = "source=EMP, EMP";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalUnion(all=[true])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testMultipleTablesAndFilters() {
+    String ppl = "source=EMP, EMP DEPTNO = 20 | fields EMPNO, DEPTNO, SAL";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], DEPTNO=[$7], SAL=[$5])\n"
+            + "  LogicalFilter(condition=[=($7, 20)])\n"
+            + "    LogicalUnion(all=[true])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "EMPNO=7369; DEPTNO=20; SAL=800.00\n"
+            + "EMPNO=7566; DEPTNO=20; SAL=2975.00\n"
+            + "EMPNO=7788; DEPTNO=20; SAL=3000.00\n"
+            + "EMPNO=7876; DEPTNO=20; SAL=1100.00\n"
+            + "EMPNO=7902; DEPTNO=20; SAL=3000.00\n"
+            + "EMPNO=7369; DEPTNO=20; SAL=800.00\n"
+            + "EMPNO=7566; DEPTNO=20; SAL=2975.00\n"
+            + "EMPNO=7788; DEPTNO=20; SAL=3000.00\n"
+            + "EMPNO=7876; DEPTNO=20; SAL=1100.00\n"
+            + "EMPNO=7902; DEPTNO=20; SAL=3000.00\n";
+
+    verifyResult(root, expectedResult);
+  }
+
+  @Ignore
+  public void testLineComments() {
+    String ppl1 = "source=products_temporal  //this is a comment";
+    verifyLogical(getRelNode(ppl1), "LogicalTableScan(table=[[scott, products_temporal]])\n");
+    String ppl2 = "source=products_temporal  // this is a comment";
+    verifyLogical(getRelNode(ppl2), "LogicalTableScan(table=[[scott, products_temporal]])\n");
+    String ppl3 =
+        ""
+            + "// test is a new line comment\n"
+            + "source=products_temporal  // this is a comment\n"
+            + "| fields SUPPLIER, ID  // this is line comment inner ppl command\n"
+            + "////this is a new line comment";
+    String expectedLogical =
+        ""
+            + "LogicalProject(SUPPLIER=[$1], ID=[$0])\n"
+            + "  LogicalTableScan(table=[[scott, products_temporal]])\n";
+    verifyLogical(getRelNode(ppl3), expectedLogical);
+  }
+
+  @Ignore
+  public void testBlockComments() {
+    String ppl1 = "/* this is a block comment */ source=products_temporal";
+    verifyLogical(getRelNode(ppl1), "LogicalTableScan(table=[[scott, products_temporal]])\n");
+    String ppl2 = "source=products_temporal | /*this is a block comment*/ fields SUPPLIER, ID";
+    String expectedLogical2 =
+        ""
+            + "LogicalProject(SUPPLIER=[$1], ID=[$0])\n"
+            + "  LogicalTableScan(table=[[scott, products_temporal]])\n";
+    verifyLogical(getRelNode(ppl2), expectedLogical2);
+    String ppl3 =
+        ""
+            + "/*\n"
+            + " * This is a\n"
+            + " *   multiple\n"
+            + " * line\n"
+            + " *   block\n"
+            + " *     comment\n"
+            + " */\n"
+            + "search /* block comment */ source=products_temporal /* block comment */ ID = 0\n"
+            + "| /*\n"
+            + "     This is a\n"
+            + "       multiple\n"
+            + "     line\n"
+            + "       block\n"
+            + "         comment */ fields SUPPLIER, ID /* block comment */\n"
+            + "/* block comment */";
+    String expectedLogical3 =
+        ""
+            + "LogicalProject(SUPPLIER=[$1], ID=[$0])\n"
+            + "  LogicalFilter(condition=[=($0, 0)])\n"
+            + "    LogicalTableScan(table=[[scott, products_temporal]])\n";
+    verifyLogical(getRelNode(ppl3), expectedLogical3);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDateTimeFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDateTimeFunctionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import java.time.LocalDate;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLDateTimeFunctionTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLDateTimeFunctionTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testDateAndCurrentTimestamp() {
+    String ppl = "source=EMP | eval added = DATE(CURRENT_TIMESTAMP()) | fields added | head 1";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalSort(fetch=[1])\n"
+            + "  LogicalProject(added=[DATE(CURRENT_TIMESTAMP)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "added=" + LocalDate.now() + "\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "" + "SELECT DATE(CURRENT_TIMESTAMP) `added`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testCurrentDate() {
+    String ppl = "source=EMP | eval added = CURRENT_DATE() | fields added | head 1";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalSort(fetch=[1])\n"
+            + "  LogicalProject(added=[CURRENT_DATE])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "added=" + LocalDate.now() + "\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "" + "SELECT CURRENT_DATE `added`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEvalTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEvalTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLEvalTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLEvalTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testEval1() {
+    String ppl = "source=EMP | eval a = 1";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], a=[1])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`, 1 `a`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testEvalAndFields() {
+    String ppl = "source=EMP | eval a = 1 | fields EMPNO, a";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "" + "LogicalProject(EMPNO=[$0], a=[1])\n" + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "EMPNO=7369; a=1\n"
+            + "EMPNO=7499; a=1\n"
+            + "EMPNO=7521; a=1\n"
+            + "EMPNO=7566; a=1\n"
+            + "EMPNO=7654; a=1\n"
+            + "EMPNO=7698; a=1\n"
+            + "EMPNO=7782; a=1\n"
+            + "EMPNO=7788; a=1\n"
+            + "EMPNO=7839; a=1\n"
+            + "EMPNO=7844; a=1\n"
+            + "EMPNO=7876; a=1\n"
+            + "EMPNO=7900; a=1\n"
+            + "EMPNO=7902; a=1\n"
+            + "EMPNO=7934; a=1\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql = "" + "SELECT `EMPNO`, 1 `a`\n" + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testEval2() {
+    String ppl = "source=EMP | eval a = 1, b = 2";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], a=[1], b=[2])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`, 1 `a`, 2 `b`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testEval3() {
+    String ppl = "source=EMP | eval a = 1 | eval b = 2 | eval c = 3";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], a=[1], b=[2], c=[3])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`, 1 `a`, 2 `b`,"
+            + " 3 `c`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testEvalWithSort() {
+    String ppl = "source=EMP | eval a = EMPNO | sort - a | fields a";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(a=[$8])\n"
+            + "  LogicalSort(sort0=[$8], dir0=[DESC])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], a=[$0])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "a=7934\n"
+            + "a=7902\n"
+            + "a=7900\n"
+            + "a=7876\n"
+            + "a=7844\n"
+            + "a=7839\n"
+            + "a=7788\n"
+            + "a=7782\n"
+            + "a=7698\n"
+            + "a=7654\n"
+            + "a=7566\n"
+            + "a=7521\n"
+            + "a=7499\n"
+            + "a=7369\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "" + "SELECT `EMPNO` `a`\n" + "FROM `scott`.`EMP`\n" + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testEvalUsingExistingFields() {
+    String ppl =
+        "source=EMP | eval EMPNO_PLUS = EMPNO + 1 | sort - EMPNO_PLUS | fields EMPNO, EMPNO_PLUS |"
+            + " head 3";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], EMPNO_PLUS=[$8])\n"
+            + "  LogicalSort(sort0=[$8], dir0=[DESC], fetch=[3])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], EMPNO_PLUS=[+($0, 1)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "EMPNO=7934; EMPNO_PLUS=7935\n"
+            + "EMPNO=7902; EMPNO_PLUS=7903\n"
+            + "EMPNO=7900; EMPNO_PLUS=7901\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `EMPNO_PLUS`\n"
+            + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`,"
+            + " `EMPNO` + 1 `EMPNO_PLUS`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "ORDER BY 9 DESC NULLS FIRST\n"
+            + "LIMIT 3) `t0`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testEvalOverridingExistingFields() {
+    String ppl =
+        "source=EMP | eval SAL = DEPTNO + 10000 | sort - EMPNO | fields EMPNO, SAL | head 3";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], SAL0=[$7])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC], fetch=[3])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " COMM=[$6], DEPTNO=[$7], SAL0=[+($7, 10000)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        "" + "EMPNO=7934; SAL0=10010\n" + "EMPNO=7902; SAL0=10020\n" + "EMPNO=7900; SAL0=10030\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `DEPTNO` + 10000 `SAL0`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST\n"
+            + "LIMIT 3";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testComplexEvalCommands1() {
+    String ppl =
+        "source=EMP | eval col1 = 1 | sort col1 | head 4 | eval col2 = 2 | sort - col2 | sort EMPNO"
+            + " | head 2 | fields EMPNO, ENAME, col2";
+    RelNode root = getRelNode(ppl);
+    String expectedResult =
+        "" + "EMPNO=7369; ENAME=SMITH; col2=2\n" + "EMPNO=7499; ENAME=ALLEN; col2=2\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `col2`\n"
+            + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`,"
+            + " `col1`, `col2`\n"
+            + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`, 1"
+            + " `col1`, 2 `col2`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "ORDER BY '1' NULLS LAST\n"
+            + "LIMIT 4) `t1`\n"
+            + "ORDER BY `col2` DESC NULLS FIRST) `t2`\n"
+            + "ORDER BY `EMPNO` NULLS LAST\n"
+            + "LIMIT 2";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testComplexEvalCommands2() {
+    String ppl =
+        "source=EMP | eval col1 = SAL | sort - col1 | head 3 | eval col2 = SAL | sort + col2 |"
+            + " fields ENAME, SAL | head 2";
+    RelNode root = getRelNode(ppl);
+    String expectedResult = "" + "ENAME=SCOTT; SAL=3000.00\n" + "ENAME=FORD; SAL=3000.00\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `ENAME`, `SAL`\n"
+            + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`,"
+            + " `SAL` `col1`, `SAL` `col2`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "ORDER BY `SAL` DESC NULLS FIRST\n"
+            + "LIMIT 3) `t1`\n"
+            + "ORDER BY `col2` NULLS LAST\n"
+            + "LIMIT 2";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testComplexEvalCommands3() {
+    String ppl =
+        "source=EMP | eval col1 = SAL | sort - col1 | head 3 | fields ENAME, col1 | eval col2 ="
+            + " col1 | sort + col2 | fields ENAME, col2 | eval col3 = col2 | head 2 | fields ENAME,"
+            + " col3";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(ENAME=[$0], col3=[$2])\n"
+            + "  LogicalSort(sort0=[$2], dir0=[ASC], fetch=[2])\n"
+            + "    LogicalProject(ENAME=[$1], col1=[$8], col2=[$8])\n"
+            + "      LogicalSort(sort0=[$8], dir0=[DESC], fetch=[3])\n"
+            + "        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], col1=[$5])\n"
+            + "          LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "" + "ENAME=SCOTT; col3=3000.00\n" + "ENAME=FORD; col3=3000.00\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `ENAME`, `col2` `col3`\n"
+            + "FROM (SELECT `ENAME`, `SAL` `col1`, `SAL` `col2`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "ORDER BY `SAL` DESC NULLS FIRST\n"
+            + "LIMIT 3) `t1`\n"
+            + "ORDER BY `col2` NULLS LAST\n"
+            + "LIMIT 2";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testComplexEvalCommands4() {
+    String ppl =
+        "source=EMP | eval col1 = SAL | sort - col1 | head 3 | fields ENAME, col1 | eval col2 ="
+            + " col1 | sort + col2 | fields ENAME, col2 | eval col3 = col2 | head 2 | fields"
+            + " HIREDATE, col3";
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              RelNode root = getRelNode(ppl);
+            });
+    assertThat(
+        e.getMessage(), is("field [HIREDATE] not found; input fields are: [ENAME, col2, col3]"));
+  }
+
+  @Test
+  public void testEvalWithAggregation() {
+    String ppl = "source=EMP | eval a = SAL, b = DEPTNO | stats avg(a) by b";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{1}], avg(a)=[AVG($0)])\n"
+            + "  LogicalProject(a=[$5], b=[$7])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        "" + "b=20; avg(a)=2175.00\n" + "b=10; avg(a)=2916.66\n" + "b=30; avg(a)=1566.66\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `DEPTNO` `b`, AVG(`SAL`) `avg(a)`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testDependedEval() {
+    String ppl = "source=EMP | eval a = SAL | eval b = a + 10000 | stats avg(b) by DEPTNO";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{0}], avg(b)=[AVG($1)])\n"
+            + "  LogicalProject(DEPTNO=[$7], b=[+($5, 10000)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "DEPTNO=20; avg(b)=12175.00\n"
+            + "DEPTNO=10; avg(b)=12916.66\n"
+            + "DEPTNO=30; avg(b)=11566.66\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `DEPTNO`, AVG(`SAL` + 10000) `avg(b)`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testDependedLateralEval() {
+    String ppl = "source=EMP | eval a = SAL, b = a + 10000 | stats avg(b) by DEPTNO";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{0}], avg(b)=[AVG($1)])\n"
+            + "  LogicalProject(DEPTNO=[$7], b=[+($5, 10000)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "DEPTNO=20; avg(b)=12175.00\n"
+            + "DEPTNO=10; avg(b)=12916.66\n"
+            + "DEPTNO=30; avg(b)=11566.66\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `DEPTNO`, AVG(`SAL` + 10000) `avg(b)`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore
+public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLJoinTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testJoinConditionWithTableNames() {
+    String ppl = "source=EMP | join on EMP.DEPTNO = DEPT.DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testJoinConditionWithAlias() {
+    String ppl = "source=EMP as e | join on e.DEPTNO = d.DEPTNO DEPT as d";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testJoinConditionWithoutTableName() {
+    String ppl = "source=EMP | join on ENAME = DNAME DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[=($1, $9)], joinType=[inner])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 0);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`ENAME` = `DEPT`.`DNAME`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testJoinWithSpecificAliases() {
+    String ppl = "source=EMP | join left = l right = r on l.DEPTNO = r.DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testLeftJoin() {
+    String ppl = "source=EMP as e | left join on e.DEPTNO = d.DEPTNO DEPT as d";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LEFT JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testCrossJoin() {
+    String ppl = "source=EMP as e | cross join DEPT as d";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[true], joinType=[inner])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 56);
+
+    String expectedSparkSql =
+        "" + "SELECT *\n" + "FROM `scott`.`EMP`\n" + "CROSS JOIN `scott`.`DEPT`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testNonEquiJoin() {
+    String ppl = "source=EMP as e | join on e.DEPTNO > d.DEPTNO DEPT as d";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[>($7, $8)], joinType=[inner])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 17);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` > `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLLookupTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLLookupTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore
+public class CalcitePPLLookupTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLLookupTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testReplace() {
+    String ppl = "source=EMP | lookup DEPT DEPTNO replace LOC";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], LOC=[$9])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalProject(DEPTNO=[$0], LOC=[$2])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        "EMPNO=7782; ENAME=CLARK; JOB=MANAGER; MGR=7839; HIREDATE=1981-06-09; SAL=2450.00;"
+            + " COMM=null; DEPTNO=10; LOC=NEW YORK\n"
+            + "EMPNO=7839; ENAME=KING; JOB=PRESIDENT; MGR=null; HIREDATE=1981-11-17; SAL=5000.00;"
+            + " COMM=null; DEPTNO=10; LOC=NEW YORK\n"
+            + "EMPNO=7934; ENAME=MILLER; JOB=CLERK; MGR=7782; HIREDATE=1982-01-23; SAL=1300.00;"
+            + " COMM=null; DEPTNO=10; LOC=NEW YORK\n"
+            + "EMPNO=7369; ENAME=SMITH; JOB=CLERK; MGR=7902; HIREDATE=1980-12-17; SAL=800.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7566; ENAME=JONES; JOB=MANAGER; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7788; ENAME=SCOTT; JOB=ANALYST; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7876; ENAME=ADAMS; JOB=CLERK; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7902; ENAME=FORD; JOB=ANALYST; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7499; ENAME=ALLEN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-20; SAL=1600.00;"
+            + " COMM=300.00; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7521; ENAME=WARD; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-22; SAL=1250.00;"
+            + " COMM=500.00; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7654; ENAME=MARTIN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-28; SAL=1250.00;"
+            + " COMM=1400.00; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7698; ENAME=BLAKE; JOB=MANAGER; MGR=7839; HIREDATE=1981-01-05; SAL=2850.00;"
+            + " COMM=null; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7844; ENAME=TURNER; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-08; SAL=1500.00;"
+            + " COMM=0.00; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7900; ENAME=JAMES; JOB=CLERK; MGR=7698; HIREDATE=1981-12-03; SAL=950.00;"
+            + " COMM=null; DEPTNO=30; LOC=CHICAGO\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `t`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LEFT JOIN (SELECT `DEPTNO`, `LOC`\n"
+            + "FROM `scott`.`DEPT`) `t` ON `EMP`.`DEPTNO` = `t`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testReplaceAs() {
+    String ppl = "source=EMP | lookup DEPT DEPTNO replace LOC as JOB";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6],"
+            + " DEPTNO=[$7], JOB=[COALESCE($9, $2)])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalProject(DEPTNO=[$0], LOC=[$2])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        "EMPNO=7782; ENAME=CLARK; MGR=7839; HIREDATE=1981-06-09; SAL=2450.00; COMM=null; DEPTNO=10;"
+            + " JOB=NEW YORK\n"
+            + "EMPNO=7839; ENAME=KING; MGR=null; HIREDATE=1981-11-17; SAL=5000.00; COMM=null;"
+            + " DEPTNO=10; JOB=NEW YORK\n"
+            + "EMPNO=7934; ENAME=MILLER; MGR=7782; HIREDATE=1982-01-23; SAL=1300.00; COMM=null;"
+            + " DEPTNO=10; JOB=NEW YORK\n"
+            + "EMPNO=7369; ENAME=SMITH; MGR=7902; HIREDATE=1980-12-17; SAL=800.00; COMM=null;"
+            + " DEPTNO=20; JOB=DALLAS\n"
+            + "EMPNO=7566; ENAME=JONES; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00; COMM=null;"
+            + " DEPTNO=20; JOB=DALLAS\n"
+            + "EMPNO=7788; ENAME=SCOTT; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00; COMM=null;"
+            + " DEPTNO=20; JOB=DALLAS\n"
+            + "EMPNO=7876; ENAME=ADAMS; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00; COMM=null;"
+            + " DEPTNO=20; JOB=DALLAS\n"
+            + "EMPNO=7902; ENAME=FORD; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00; COMM=null;"
+            + " DEPTNO=20; JOB=DALLAS\n"
+            + "EMPNO=7499; ENAME=ALLEN; MGR=7698; HIREDATE=1981-02-20; SAL=1600.00; COMM=300.00;"
+            + " DEPTNO=30; JOB=CHICAGO\n"
+            + "EMPNO=7521; ENAME=WARD; MGR=7698; HIREDATE=1981-02-22; SAL=1250.00; COMM=500.00;"
+            + " DEPTNO=30; JOB=CHICAGO\n"
+            + "EMPNO=7654; ENAME=MARTIN; MGR=7698; HIREDATE=1981-09-28; SAL=1250.00; COMM=1400.00;"
+            + " DEPTNO=30; JOB=CHICAGO\n"
+            + "EMPNO=7698; ENAME=BLAKE; MGR=7839; HIREDATE=1981-01-05; SAL=2850.00; COMM=null;"
+            + " DEPTNO=30; JOB=CHICAGO\n"
+            + "EMPNO=7844; ENAME=TURNER; MGR=7698; HIREDATE=1981-09-08; SAL=1500.00; COMM=0.00;"
+            + " DEPTNO=30; JOB=CHICAGO\n"
+            + "EMPNO=7900; ENAME=JAMES; MGR=7698; HIREDATE=1981-12-03; SAL=950.00; COMM=null;"
+            + " DEPTNO=30; JOB=CHICAGO\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`MGR`, `EMP`.`HIREDATE`, `EMP`.`SAL`,"
+            + " `EMP`.`COMM`, `EMP`.`DEPTNO`, COALESCE(`t`.`LOC`, `EMP`.`JOB`) `JOB`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LEFT JOIN (SELECT `DEPTNO`, `LOC`\n"
+            + "FROM `scott`.`DEPT`) `t` ON `EMP`.`DEPTNO` = `t`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Ignore
+  public void testMultipleLookupKeysReplace() {
+    String ppl =
+        "source=EMP | eval newNO = DEPTNO | lookup DEPT DEPTNO as newNO, DEPTNO replace LOC as JOB";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "";
+    verifyResult(root, expectedResult);
+  }
+
+  @Test
+  public void testAppend() {
+    String ppl = "source=EMP | lookup DEPT DEPTNO append LOC";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], LOC=[$9])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalProject(DEPTNO=[$0], LOC=[$2])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        "EMPNO=7782; ENAME=CLARK; JOB=MANAGER; MGR=7839; HIREDATE=1981-06-09; SAL=2450.00;"
+            + " COMM=null; DEPTNO=10; LOC=NEW YORK\n"
+            + "EMPNO=7839; ENAME=KING; JOB=PRESIDENT; MGR=null; HIREDATE=1981-11-17; SAL=5000.00;"
+            + " COMM=null; DEPTNO=10; LOC=NEW YORK\n"
+            + "EMPNO=7934; ENAME=MILLER; JOB=CLERK; MGR=7782; HIREDATE=1982-01-23; SAL=1300.00;"
+            + " COMM=null; DEPTNO=10; LOC=NEW YORK\n"
+            + "EMPNO=7369; ENAME=SMITH; JOB=CLERK; MGR=7902; HIREDATE=1980-12-17; SAL=800.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7566; ENAME=JONES; JOB=MANAGER; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7788; ENAME=SCOTT; JOB=ANALYST; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7876; ENAME=ADAMS; JOB=CLERK; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7902; ENAME=FORD; JOB=ANALYST; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20; LOC=DALLAS\n"
+            + "EMPNO=7499; ENAME=ALLEN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-20; SAL=1600.00;"
+            + " COMM=300.00; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7521; ENAME=WARD; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-22; SAL=1250.00;"
+            + " COMM=500.00; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7654; ENAME=MARTIN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-28; SAL=1250.00;"
+            + " COMM=1400.00; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7698; ENAME=BLAKE; JOB=MANAGER; MGR=7839; HIREDATE=1981-01-05; SAL=2850.00;"
+            + " COMM=null; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7844; ENAME=TURNER; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-08; SAL=1500.00;"
+            + " COMM=0.00; DEPTNO=30; LOC=CHICAGO\n"
+            + "EMPNO=7900; ENAME=JAMES; JOB=CLERK; MGR=7698; HIREDATE=1981-12-03; SAL=950.00;"
+            + " COMM=null; DEPTNO=30; LOC=CHICAGO\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `t`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LEFT JOIN (SELECT `DEPTNO`, `LOC`\n"
+            + "FROM `scott`.`DEPT`) `t` ON `EMP`.`DEPTNO` = `t`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testAppendAs() {
+    String ppl = "source=EMP | lookup DEPT DEPTNO append LOC as JOB";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6],"
+            + " DEPTNO=[$7], JOB=[COALESCE(COALESCE($2, $9), $2)])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalProject(DEPTNO=[$0], LOC=[$2])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        "EMPNO=7782; ENAME=CLARK; MGR=7839; HIREDATE=1981-06-09; SAL=2450.00; COMM=null; DEPTNO=10;"
+            + " JOB=MANAGER\n"
+            + "EMPNO=7839; ENAME=KING; MGR=null; HIREDATE=1981-11-17; SAL=5000.00; COMM=null;"
+            + " DEPTNO=10; JOB=PRESIDENT\n"
+            + "EMPNO=7934; ENAME=MILLER; MGR=7782; HIREDATE=1982-01-23; SAL=1300.00; COMM=null;"
+            + " DEPTNO=10; JOB=CLERK\n"
+            + "EMPNO=7369; ENAME=SMITH; MGR=7902; HIREDATE=1980-12-17; SAL=800.00; COMM=null;"
+            + " DEPTNO=20; JOB=CLERK\n"
+            + "EMPNO=7566; ENAME=JONES; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00; COMM=null;"
+            + " DEPTNO=20; JOB=MANAGER\n"
+            + "EMPNO=7788; ENAME=SCOTT; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00; COMM=null;"
+            + " DEPTNO=20; JOB=ANALYST\n"
+            + "EMPNO=7876; ENAME=ADAMS; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00; COMM=null;"
+            + " DEPTNO=20; JOB=CLERK\n"
+            + "EMPNO=7902; ENAME=FORD; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00; COMM=null;"
+            + " DEPTNO=20; JOB=ANALYST\n"
+            + "EMPNO=7499; ENAME=ALLEN; MGR=7698; HIREDATE=1981-02-20; SAL=1600.00; COMM=300.00;"
+            + " DEPTNO=30; JOB=SALESMAN\n"
+            + "EMPNO=7521; ENAME=WARD; MGR=7698; HIREDATE=1981-02-22; SAL=1250.00; COMM=500.00;"
+            + " DEPTNO=30; JOB=SALESMAN\n"
+            + "EMPNO=7654; ENAME=MARTIN; MGR=7698; HIREDATE=1981-09-28; SAL=1250.00; COMM=1400.00;"
+            + " DEPTNO=30; JOB=SALESMAN\n"
+            + "EMPNO=7698; ENAME=BLAKE; MGR=7839; HIREDATE=1981-01-05; SAL=2850.00; COMM=null;"
+            + " DEPTNO=30; JOB=MANAGER\n"
+            + "EMPNO=7844; ENAME=TURNER; MGR=7698; HIREDATE=1981-09-08; SAL=1500.00; COMM=0.00;"
+            + " DEPTNO=30; JOB=SALESMAN\n"
+            + "EMPNO=7900; ENAME=JAMES; MGR=7698; HIREDATE=1981-12-03; SAL=950.00; COMM=null;"
+            + " DEPTNO=30; JOB=CLERK\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`MGR`, `EMP`.`HIREDATE`, `EMP`.`SAL`,"
+            + " `EMP`.`COMM`, `EMP`.`DEPTNO`, COALESCE(COALESCE(`EMP`.`JOB`, `t`.`LOC`),"
+            + " `EMP`.`JOB`) `JOB`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LEFT JOIN (SELECT `DEPTNO`, `LOC`\n"
+            + "FROM `scott`.`DEPT`) `t` ON `EMP`.`DEPTNO` = `t`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Ignore
+  public void testMultipleLookupKeysAppend() {
+    String ppl =
+        "source=EMP | eval newNO = DEPTNO | lookup DEPT DEPTNO as newNO, DEPTNO append LOC as COMM";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testLookupAll() {
+    String ppl = "source=EMP | lookup DEPT DEPTNO";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        "EMPNO=7782; ENAME=CLARK; JOB=MANAGER; MGR=7839; HIREDATE=1981-06-09; SAL=2450.00;"
+            + " COMM=null; DEPTNO=10; DEPTNO0=10; DNAME=ACCOUNTING; LOC=NEW YORK\n"
+            + "EMPNO=7839; ENAME=KING; JOB=PRESIDENT; MGR=null; HIREDATE=1981-11-17; SAL=5000.00;"
+            + " COMM=null; DEPTNO=10; DEPTNO0=10; DNAME=ACCOUNTING; LOC=NEW YORK\n"
+            + "EMPNO=7934; ENAME=MILLER; JOB=CLERK; MGR=7782; HIREDATE=1982-01-23; SAL=1300.00;"
+            + " COMM=null; DEPTNO=10; DEPTNO0=10; DNAME=ACCOUNTING; LOC=NEW YORK\n"
+            + "EMPNO=7369; ENAME=SMITH; JOB=CLERK; MGR=7902; HIREDATE=1980-12-17; SAL=800.00;"
+            + " COMM=null; DEPTNO=20; DEPTNO0=20; DNAME=RESEARCH; LOC=DALLAS\n"
+            + "EMPNO=7566; ENAME=JONES; JOB=MANAGER; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00;"
+            + " COMM=null; DEPTNO=20; DEPTNO0=20; DNAME=RESEARCH; LOC=DALLAS\n"
+            + "EMPNO=7788; ENAME=SCOTT; JOB=ANALYST; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20; DEPTNO0=20; DNAME=RESEARCH; LOC=DALLAS\n"
+            + "EMPNO=7876; ENAME=ADAMS; JOB=CLERK; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00;"
+            + " COMM=null; DEPTNO=20; DEPTNO0=20; DNAME=RESEARCH; LOC=DALLAS\n"
+            + "EMPNO=7902; ENAME=FORD; JOB=ANALYST; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20; DEPTNO0=20; DNAME=RESEARCH; LOC=DALLAS\n"
+            + "EMPNO=7499; ENAME=ALLEN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-20; SAL=1600.00;"
+            + " COMM=300.00; DEPTNO=30; DEPTNO0=30; DNAME=SALES; LOC=CHICAGO\n"
+            + "EMPNO=7521; ENAME=WARD; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-22; SAL=1250.00;"
+            + " COMM=500.00; DEPTNO=30; DEPTNO0=30; DNAME=SALES; LOC=CHICAGO\n"
+            + "EMPNO=7654; ENAME=MARTIN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-28; SAL=1250.00;"
+            + " COMM=1400.00; DEPTNO=30; DEPTNO0=30; DNAME=SALES; LOC=CHICAGO\n"
+            + "EMPNO=7698; ENAME=BLAKE; JOB=MANAGER; MGR=7839; HIREDATE=1981-01-05; SAL=2850.00;"
+            + " COMM=null; DEPTNO=30; DEPTNO0=30; DNAME=SALES; LOC=CHICAGO\n"
+            + "EMPNO=7844; ENAME=TURNER; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-08; SAL=1500.00;"
+            + " COMM=0.00; DEPTNO=30; DEPTNO0=30; DNAME=SALES; LOC=CHICAGO\n"
+            + "EMPNO=7900; ENAME=JAMES; JOB=CLERK; MGR=7698; HIREDATE=1981-12-03; SAL=950.00;"
+            + " COMM=null; DEPTNO=30; DEPTNO0=30; DNAME=SALES; LOC=CHICAGO\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LEFT JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMathFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMathFunctionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLMathFunctionTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLMathFunctionTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testAbsWithOverriding() {
+    String ppl = "source=EMP | eval SAL = abs(-30) | head 10 | fields SAL";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(SAL0=[$7])\n"
+            + "  LogicalSort(fetch=[10])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " COMM=[$6], DEPTNO=[$7], SAL0=[ABS(-30)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        "SAL0=30\n"
+            + "SAL0=30\n"
+            + "SAL0=30\n"
+            + "SAL0=30\n"
+            + "SAL0=30\n"
+            + "SAL0=30\n"
+            + "SAL0=30\n"
+            + "SAL0=30\n"
+            + "SAL0=30\n"
+            + "SAL0=30\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql = "" + "SELECT ABS(-30) `SAL0`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLStringFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLStringFunctionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLStringFunctionTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLStringFunctionTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testLower() {
+    String ppl = "source=EMP | eval lower_name = lower(ENAME) | fields lower_name";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(lower_name=[LOWER($1)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        ""
+            + "lower_name=smith\n"
+            + "lower_name=allen\n"
+            + "lower_name=ward\n"
+            + "lower_name=jones\n"
+            + "lower_name=martin\n"
+            + "lower_name=blake\n"
+            + "lower_name=clark\n"
+            + "lower_name=scott\n"
+            + "lower_name=king\n"
+            + "lower_name=turner\n"
+            + "lower_name=adams\n"
+            + "lower_name=james\n"
+            + "lower_name=ford\n"
+            + "lower_name=miller\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql = "" + "SELECT LOWER(`ENAME`) `lower_name`\n" + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testLike() {
+    String ppl = "source=EMP | where like(JOB, 'SALE%') | stats count() as cnt";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{}], cnt=[COUNT()])\n"
+            + "  LogicalFilter(condition=[LIKE($2, 'SALE%')])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult = "cnt=4\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "" + "SELECT COUNT(*) `cnt`\n" + "FROM `scott`.`EMP`\n" + "WHERE `JOB` LIKE 'SALE%'";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -20,6 +20,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.defaultDedupArgs;
 import static org.opensearch.sql.ast.dsl.AstDSL.defaultFieldsArgs;
 import static org.opensearch.sql.ast.dsl.AstDSL.defaultSortFieldArgs;
 import static org.opensearch.sql.ast.dsl.AstDSL.defaultStatsArgs;
+import static org.opensearch.sql.ast.dsl.AstDSL.describe;
 import static org.opensearch.sql.ast.dsl.AstDSL.eval;
 import static org.opensearch.sql.ast.dsl.AstDSL.exprList;
 import static org.opensearch.sql.ast.dsl.AstDSL.field;
@@ -451,34 +452,34 @@ public class AstBuilderTest {
     assertEqual(
         "source=`log.2020.04.20.` a=1",
         filter(relation("log.2020.04.20."), compare("=", field("a"), intLiteral(1))));
-    assertEqual("describe `log.2020.04.20.`", relation(mappingTable("log.2020.04.20.")));
+    assertEqual("describe `log.2020.04.20.`", describe(mappingTable("log.2020.04.20.")));
   }
 
   @Test
   public void testIdentifierAsIndexNameStartWithDot() {
     assertEqual("source=.opensearch_dashboards", relation(".opensearch_dashboards"));
     assertEqual(
-        "describe .opensearch_dashboards", relation(mappingTable(".opensearch_dashboards")));
+        "describe .opensearch_dashboards", describe(mappingTable(".opensearch_dashboards")));
   }
 
   @Test
   public void testIdentifierAsIndexNameWithDotInTheMiddle() {
     assertEqual("source=log.2020.10.10", relation("log.2020.10.10"));
     assertEqual("source=log-7.10-2020.10.10", relation("log-7.10-2020.10.10"));
-    assertEqual("describe log.2020.10.10", relation(mappingTable("log.2020.10.10")));
-    assertEqual("describe log-7.10-2020.10.10", relation(mappingTable("log-7.10-2020.10.10")));
+    assertEqual("describe log.2020.10.10", describe(mappingTable("log.2020.10.10")));
+    assertEqual("describe log-7.10-2020.10.10", describe(mappingTable("log-7.10-2020.10.10")));
   }
 
   @Test
   public void testIdentifierAsIndexNameWithSlashInTheMiddle() {
     assertEqual("source=log-2020", relation("log-2020"));
-    assertEqual("describe log-2020", relation(mappingTable("log-2020")));
+    assertEqual("describe log-2020", describe(mappingTable("log-2020")));
   }
 
   @Test
   public void testIdentifierAsIndexNameContainStar() {
     assertEqual("source=log-2020-10-*", relation("log-2020-10-*"));
-    assertEqual("describe log-2020-10-*", relation(mappingTable("log-2020-10-*")));
+    assertEqual("describe log-2020-10-*", describe(mappingTable("log-2020-10-*")));
   }
 
   @Test
@@ -486,9 +487,9 @@ public class AstBuilderTest {
     assertEqual("source=log-2020.10.*", relation("log-2020.10.*"));
     assertEqual("source=log-2020.*.01", relation("log-2020.*.01"));
     assertEqual("source=log-2020.*.*", relation("log-2020.*.*"));
-    assertEqual("describe log-2020.10.*", relation(mappingTable("log-2020.10.*")));
-    assertEqual("describe log-2020.*.01", relation(mappingTable("log-2020.*.01")));
-    assertEqual("describe log-2020.*.*", relation(mappingTable("log-2020.*.*")));
+    assertEqual("describe log-2020.10.*", describe(mappingTable("log-2020.10.*")));
+    assertEqual("describe log-2020.*.01", describe(mappingTable("log-2020.*.01")));
+    assertEqual("describe log-2020.*.*", describe(mappingTable("log-2020.*.*")));
   }
 
   @Test
@@ -768,27 +769,27 @@ public class AstBuilderTest {
 
   @Test
   public void testDescribeCommand() {
-    assertEqual("describe t", relation(mappingTable("t")));
+    assertEqual("describe t", describe(mappingTable("t")));
   }
 
   @Test
   public void testDescribeMatchAllCrossClusterSearchCommand() {
-    assertEqual("describe *:t", relation(mappingTable("*:t")));
+    assertEqual("describe *:t", describe(mappingTable("*:t")));
   }
 
   @Test
   public void testDescribeCommandWithMultipleIndices() {
-    assertEqual("describe t,u", relation(mappingTable("t,u")));
+    assertEqual("describe t,u", describe(mappingTable("t,u")));
   }
 
   @Test
   public void testDescribeCommandWithFullyQualifiedTableName() {
     assertEqual(
         "describe prometheus.http_metric",
-        relation(qualifiedName("prometheus", mappingTable("http_metric"))));
+        describe(qualifiedName("prometheus", mappingTable("http_metric")).toString()));
     assertEqual(
         "describe prometheus.schema.http_metric",
-        relation(qualifiedName("prometheus", "schema", mappingTable("http_metric"))));
+        describe(qualifiedName("prometheus", "schema", mappingTable("http_metric")).toString()));
   }
 
   @Test
@@ -845,7 +846,7 @@ public class AstBuilderTest {
 
   @Test
   public void testShowDataSourcesCommand() {
-    assertEqual("show datasources", relation(DATASOURCES_TABLE_NAME));
+    assertEqual("show datasources", describe(DATASOURCES_TABLE_NAME));
   }
 
   protected void assertEqual(String query, Node expectedPlan) {
@@ -859,7 +860,7 @@ public class AstBuilderTest {
   }
 
   private Node plan(String query) {
-    AstBuilder astBuilder = new AstBuilder(new AstExpressionBuilder(), query);
+    AstBuilder astBuilder = new AstBuilder(query);
     return astBuilder.visit(parser.parse(query));
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstNowLikeFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstNowLikeFunctionTest.java
@@ -110,7 +110,7 @@ public class AstNowLikeFunctionTest {
   }
 
   private Node plan(String query) {
-    AstBuilder astBuilder = new AstBuilder(new AstExpressionBuilder(), query);
+    AstBuilder astBuilder = new AstBuilder(query);
     return astBuilder.visit(parser.parse(query));
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstStatementBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstStatementBuilderTest.java
@@ -65,7 +65,7 @@ public class AstStatementBuilderTest {
   private Node plan(String query, boolean isExplain) {
     final AstStatementBuilder builder =
         new AstStatementBuilder(
-            new AstBuilder(new AstExpressionBuilder(), query),
+            new AstBuilder(query),
             AstStatementBuilder.StatementBuilderContext.builder().isExplain(isExplain).build());
     return builder.visit(parser.parse(query));
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -18,7 +18,6 @@ import org.opensearch.sql.ast.statement.Statement;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
 import org.opensearch.sql.ppl.parser.AstBuilder;
-import org.opensearch.sql.ppl.parser.AstExpressionBuilder;
 import org.opensearch.sql.ppl.parser.AstStatementBuilder;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -185,7 +184,7 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   private String anonymize(String query) {
-    AstBuilder astBuilder = new AstBuilder(new AstExpressionBuilder(), query);
+    AstBuilder astBuilder = new AstBuilder(query);
     return anonymize(astBuilder.visit(parser.parse(query)));
   }
 
@@ -197,7 +196,7 @@ public class PPLQueryDataAnonymizerTest {
   private String anonymizeStatement(String query, boolean isExplain) {
     AstStatementBuilder builder =
         new AstStatementBuilder(
-            new AstBuilder(new AstExpressionBuilder(), query),
+            new AstBuilder(query),
             AstStatementBuilder.StatementBuilderContext.builder().isExplain(isExplain).build());
     Statement statement = builder.visit(parser.parse(query));
     PPLQueryDataAnonymizer anonymize = new PPLQueryDataAnonymizer();

--- a/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/implementor/PrometheusDefaultImplementor.java
+++ b/prometheus/src/main/java/org/opensearch/sql/prometheus/storage/implementor/PrometheusDefaultImplementor.java
@@ -118,7 +118,7 @@ public class PrometheusDefaultImplementor extends DefaultImplementor<PrometheusM
     PrometheusResponseFieldNames prometheusResponseFieldNames = new PrometheusResponseFieldNames();
     prometheusResponseFieldNames.setValueFieldName(node.getAggregatorList().get(0).getName());
     prometheusResponseFieldNames.setValueType(node.getAggregatorList().get(0).type());
-    prometheusResponseFieldNames.setTimestampFieldName(spanExpression.get().getNameOrAlias());
+    prometheusResponseFieldNames.setTimestampFieldName(spanExpression.get().getName());
     prometheusResponseFieldNames.setGroupByList(node.getGroupByList());
     context.setPrometheusResponseFieldNames(prometheusResponseFieldNames);
   }

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
@@ -27,11 +27,13 @@ import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.ast.tree.DescribeRelation;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Limit;
 import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
+import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
@@ -61,14 +63,14 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
   public UnresolvedPlan visitShowStatement(OpenSearchSQLParser.ShowStatementContext ctx) {
     final UnresolvedExpression tableFilter = visitAstExpression(ctx.tableFilter());
     return new Project(Collections.singletonList(AllFields.of()))
-        .attach(new Filter(tableFilter).attach(new Relation(qualifiedName(TABLE_INFO))));
+        .attach(new Filter(tableFilter).attach(new DescribeRelation(qualifiedName(TABLE_INFO))));
   }
 
   @Override
   public UnresolvedPlan visitDescribeStatement(OpenSearchSQLParser.DescribeStatementContext ctx) {
     final Function tableFilter = (Function) visitAstExpression(ctx.tableFilter());
     final String tableName = tableFilter.getFuncArgs().get(1).toString();
-    final Relation table = new Relation(qualifiedName(mappingTable(tableName.toString())));
+    final Relation table = new DescribeRelation(qualifiedName(mappingTable(tableName.toString())));
     if (ctx.columnFilter() == null) {
       return new Project(Collections.singletonList(AllFields.of())).attach(table);
     } else {
@@ -175,9 +177,10 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
 
   @Override
   public UnresolvedPlan visitTableAsRelation(TableAsRelationContext ctx) {
-    String tableAlias =
-        (ctx.alias() == null) ? null : StringUtils.unquoteIdentifier(ctx.alias().getText());
-    return new Relation(visitAstExpression(ctx.tableName()), tableAlias);
+    Relation relation = new Relation(visitAstExpression(ctx.tableName()));
+    return ctx.alias() != null
+        ? new SubqueryAlias(StringUtils.unquoteIdentifier(ctx.alias().getText()), relation)
+        : relation;
   }
 
   @Override
@@ -214,7 +217,7 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
       return new Alias(name, expr);
     } else {
       String alias = StringUtils.unquoteIdentifier(ctx.alias().getText());
-      return new Alias(name, expr, alias);
+      return new Alias(alias, expr);
     }
   }
 }

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -13,6 +13,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.aggregate;
 import static org.opensearch.sql.ast.dsl.AstDSL.alias;
 import static org.opensearch.sql.ast.dsl.AstDSL.argument;
 import static org.opensearch.sql.ast.dsl.AstDSL.booleanLiteral;
+import static org.opensearch.sql.ast.dsl.AstDSL.describe;
 import static org.opensearch.sql.ast.dsl.AstDSL.doubleLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.field;
 import static org.opensearch.sql.ast.dsl.AstDSL.filter;
@@ -477,7 +478,7 @@ class AstBuilderTest extends AstBuilderTestBase {
     assertEquals(
         project(
             filter(
-                relation(TABLE_INFO),
+                describe(TABLE_INFO),
                 function("like", qualifiedName("TABLE_NAME"), stringLiteral("%"))),
             AllFields.of()),
         buildAST("SHOW TABLES LIKE '%'"));
@@ -488,7 +489,7 @@ class AstBuilderTest extends AstBuilderTestBase {
     assertEquals(
         project(
             filter(
-                relation(TABLE_INFO),
+                describe(TABLE_INFO),
                 function("like", qualifiedName("TABLE_NAME"), stringLiteral("a_c%"))),
             AllFields.of()),
         buildAST("SHOW TABLES LIKE 'a_c%'"));
@@ -499,7 +500,7 @@ class AstBuilderTest extends AstBuilderTestBase {
     assertEquals(
         project(
             filter(
-                relation(TABLE_INFO),
+                describe(TABLE_INFO),
                 function("like", qualifiedName("TABLE_NAME"), stringLiteral("%"))),
             AllFields.of()),
         buildAST("SHOW TABLES LIKE '%'"));
@@ -508,7 +509,7 @@ class AstBuilderTest extends AstBuilderTestBase {
   @Test
   public void can_build_describe_selected_tables() {
     assertEquals(
-        project(relation(mappingTable("a_c%")), AllFields.of()),
+        project(describe(mappingTable("a_c%")), AllFields.of()),
         buildAST("DESCRIBE TABLES LIKE 'a_c%'"));
   }
 
@@ -517,7 +518,7 @@ class AstBuilderTest extends AstBuilderTestBase {
     assertEquals(
         project(
             filter(
-                relation(mappingTable("a_c%")),
+                describe(mappingTable("a_c%")),
                 function("like", qualifiedName("COLUMN_NAME"), stringLiteral("name%"))),
             AllFields.of()),
         buildAST("DESCRIBE TABLES LIKE 'a_c%' COLUMNS LIKE 'name%'"));


### PR DESCRIPTION
### Description
Build the development framework of Calcite Engine which includes 

**Parser:** Parse existing PPL ANTLR4 grammar to AST
**Catalog Binding:** Resolve and binding the OpenSearch Indics metadata as schema
**Plan Converter:** Convert the AST to Calcite logical plan (RelNode)

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3250

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
