### PR TITLE
CI: BWC testsuite

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -44,7 +44,9 @@ apply plugin: 'java'
 apply plugin: 'io.freefair.lombok'
 apply plugin: 'com.wiredforcode.spawn'
 
-String baseVersion = "2.17.0"
+// The next major version is only API compat w/ the last minor of the previous major.
+// baseVersion need to roll-froward accordingly, as new 2.x of OpenSearch being released.
+String baseVersion = "2.19.0"
 String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -46,6 +46,7 @@ apply plugin: 'com.wiredforcode.spawn'
 
 // The next major version is only API compat w/ the last minor of the previous major.
 // baseVersion need to roll-froward accordingly, as new 2.x of OpenSearch being released.
+// See: https://github.com/opensearch-project/OpenSearch/issues/3615
 String baseVersion = "2.19.0"
 String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"


### PR DESCRIPTION
### Description
As per the discussion from https://github.com/opensearch-project/OpenSearch/issues/3615, the next major version (3.0.0-SNAPSHOT) is only API compat w/ the last minor of the previous major, hence bumping variable `baseversion` to make sure the test-cases for mixed cluster (`mixedClusterTask` and `rollingUpgradeClusterTask`) pass.

### Related Issues
Partially resolve: https://github.com/opensearch-project/sql/issues/3168, https://github.com/opensearch-project/sql/issues/3184

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
