### PR TITLE
CI: Fix broken url for link-checker CI build

### DIFF
--- a/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.6.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.6.0.0.md
@@ -23,5 +23,5 @@
 ### Bugfixes
 * Bugfix [#310](https://github.com/opendistro-for-elasticsearch/sql/pull/310): Add DATETIME cast support (issue: [#268](https://github.com/opendistro-for-elasticsearch/sql/issues/268))
 * BugFix [#365](https://github.com/opendistro-for-elasticsearch/sql/pull/365): Return Correct Type Information for Fields (issue: [#316](https://github.com/opendistro-for-elasticsearch/sql/issues/316))
-* BugFix [#377](https://github.com/opendistro-for-elasticsearch/sql/pull/377): Return object type for field which has implicit object datatype when describe the table (issue:[sql-jdbc#57](https://github.com/opendistro-for-elasticsearch/sql-jdbc/issues/57))
+* BugFix [#377](https://github.com/opendistro-for-elasticsearch/sql/pull/377): Return object type for field which has implicit object datatype when describe the table (issue:[sql-jdbc#57](https://github.com/amazon-archives/sql-jdbc/issues/57))
 * BugFix [#381](https://github.com/opendistro-for-elasticsearch/sql/pull/381): FIX field function name letter case preserved in select with group by (issue: [#373](https://github.com/opendistro-for-elasticsearch/sql/issues/373))


### PR DESCRIPTION
### Description
URL  `https://github.com/opendistro-for-elasticsearch/sql-jdbc/issues/57` no longer return a proper HTTP redirect response, but return 404 instead.

At this stage we suspect there are some internal || JS level redirect happen, as if user enter the same url on browser, redirect continues to happen correctly to `https://github.com/amazon-archives/sql-jdbc/issues/57`

Hence this PR is to propose the url change in order to fix the build.



### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

