### PR TITLE
[POC] Make PPL execute successfully on Calcite engine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -24,9 +24,7 @@ public class CalcitePlanContext {
   public static class OSRelBuilder extends RelBuilder {
 
     protected OSRelBuilder(
-        @Nullable Context context,
-        RelOptCluster cluster,
-        @Nullable RelOptSchema relOptSchema) {
+        @Nullable Context context, RelOptCluster cluster, @Nullable RelOptSchema relOptSchema) {
       super(context, cluster, relOptSchema);
     }
   }
@@ -49,9 +47,12 @@ public class CalcitePlanContext {
       throw new RuntimeException("create statement failed", e);
     }
     this.prepare = new CalcitePrepareImpl();
-    this.relBuilder = prepare.perform(statement, config,
-        (cluster, relOptSchema, rootSchema, statement) -> new OSRelBuilder(config.getContext(),
-            cluster, relOptSchema));
+    this.relBuilder =
+        prepare.perform(
+            statement,
+            config,
+            (cluster, relOptSchema, rootSchema, statement) ->
+                new OSRelBuilder(config.getContext(), cluster, relOptSchema));
     this.rexBuilder = new ExtendedRexBuilder(relBuilder.getRexBuilder());
   }
 

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -24,7 +24,6 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilder.AggCall;
 import org.opensearch.sql.ast.AbstractNodeVisitor;

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -63,10 +63,6 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   @Override
   public RelNode visitRelation(Relation node, CalcitePlanContext context) {
     for (QualifiedName qualifiedName : node.getQualifiedNames()) {
-      SchemaPlus schema = context.config.getDefaultSchema();
-      if (schema != null && schema.getName().equals(OpenSearchSchema.OPEN_SEARCH_SCHEMA_NAME)) {
-        schema.unwrap(OpenSearchSchema.class).registerTable(qualifiedName);
-      }
       context.relBuilder.scan(qualifiedName.getParts());
     }
     if (node.getQualifiedNames().size() > 1) {

--- a/core/src/main/java/org/opensearch/sql/calcite/OpenSearchSchema.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/OpenSearchSchema.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.calcite;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +13,7 @@ import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver;
+import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.datasource.DataSourceService;
 
 @Getter
@@ -28,15 +28,15 @@ public class OpenSearchSchema extends AbstractSchema {
         @Override
         public Table get(Object key) {
           if (!super.containsKey(key)) {
-            registerTable((String) key);
+            registerTable(new QualifiedName((String) key));
           }
           return super.get(key);
         }
       };
 
-  public void registerTable(String name) {
+  public void registerTable(QualifiedName qualifiedName) {
     DataSourceSchemaIdentifierNameResolver nameResolver =
-        new DataSourceSchemaIdentifierNameResolver(dataSourceService, List.of(name.split("\\.")));
+        new DataSourceSchemaIdentifierNameResolver(dataSourceService, qualifiedName.getParts());
     org.opensearch.sql.storage.Table table =
         dataSourceService
             .getDataSource(nameResolver.getDataSourceName())
@@ -45,6 +45,6 @@ public class OpenSearchSchema extends AbstractSchema {
                 new DataSourceSchemaName(
                     nameResolver.getDataSourceName(), nameResolver.getSchemaName()),
                 nameResolver.getIdentifierName());
-    tableMap.put(name, (org.apache.calcite.schema.Table) table);
+    tableMap.put(qualifiedName.toString(), (org.apache.calcite.schema.Table) table);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/OpenSearchSchema.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/OpenSearchSchema.java
@@ -23,15 +23,16 @@ public class OpenSearchSchema extends AbstractSchema {
 
   private final DataSourceService dataSourceService;
 
-  private final Map<String, Table> tableMap = new HashMap<>() {
-    @Override
-    public Table get(Object key) {
-      if (!super.containsKey(key)) {
-        registerTable((String) key);
-      }
-      return super.get(key);
-    }
-  };
+  private final Map<String, Table> tableMap =
+      new HashMap<>() {
+        @Override
+        public Table get(Object key) {
+          if (!super.containsKey(key)) {
+            registerTable((String) key);
+          }
+          return super.get(key);
+        }
+      };
 
   public void registerTable(String name) {
     DataSourceSchemaIdentifierNameResolver nameResolver =

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchTable.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchTable.java
@@ -5,29 +5,21 @@
 
 package org.opensearch.sql.calcite.plan;
 
-import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Type;
 import org.apache.calcite.adapter.java.AbstractQueryableTable;
-import org.apache.calcite.linq4j.AbstractQueryable;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.QueryProvider;
 import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.linq4j.tree.Expression;
-import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.schema.QueryableTable;
-import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.TranslatableTable;
-import org.apache.calcite.schema.impl.AbstractTable;
 import org.opensearch.sql.calcite.utils.OpenSearchRelDataTypes;
-import org.opensearch.sql.data.model.ExprValue;
 
 public abstract class OpenSearchTable extends AbstractQueryableTable
     implements TranslatableTable, org.opensearch.sql.storage.Table {
@@ -44,7 +36,8 @@ public abstract class OpenSearchTable extends AbstractQueryableTable
   @Override
   public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable relOptTable) {
     final RelOptCluster cluster = context.getCluster();
-    // return new LogicalTableScan(cluster, cluster.traitSetOf(Convention.NONE), ImmutableList.of(), relOptTable);
+    // return new LogicalTableScan(cluster, cluster.traitSetOf(Convention.NONE), ImmutableList.of(),
+    // relOptTable);
     return new OpenSearchTableScan(cluster, relOptTable, this);
   }
 

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchTable.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchTable.java
@@ -5,17 +5,23 @@
 
 package org.opensearch.sql.calcite.plan;
 
+import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Type;
+import org.apache.calcite.adapter.java.AbstractQueryableTable;
+import org.apache.calcite.linq4j.AbstractQueryable;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.QueryProvider;
 import org.apache.calcite.linq4j.Queryable;
 import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.QueryableTable;
+import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.TranslatableTable;
@@ -23,8 +29,12 @@ import org.apache.calcite.schema.impl.AbstractTable;
 import org.opensearch.sql.calcite.utils.OpenSearchRelDataTypes;
 import org.opensearch.sql.data.model.ExprValue;
 
-public abstract class OpenSearchTable extends AbstractTable
-    implements TranslatableTable, QueryableTable, org.opensearch.sql.storage.Table {
+public abstract class OpenSearchTable extends AbstractQueryableTable
+    implements TranslatableTable, org.opensearch.sql.storage.Table {
+
+  protected OpenSearchTable(Type elementType) {
+    super(elementType);
+  }
 
   @Override
   public RelDataType getRowType(RelDataTypeFactory relDataTypeFactory) {
@@ -34,6 +44,7 @@ public abstract class OpenSearchTable extends AbstractTable
   @Override
   public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable relOptTable) {
     final RelOptCluster cluster = context.getCluster();
+    // return new LogicalTableScan(cluster, cluster.traitSetOf(Convention.NONE), ImmutableList.of(), relOptTable);
     return new OpenSearchTableScan(cluster, relOptTable, this);
   }
 
@@ -53,5 +64,5 @@ public abstract class OpenSearchTable extends AbstractTable
     return Schemas.tableExpression(schema, getElementType(), tableName, clazz);
   }
 
-  public abstract Enumerable<ExprValue> search();
+  public abstract Enumerable<Object> search();
 }

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -65,11 +65,17 @@ public class QueryService {
     try {
       try {
         // Use simple calcite schema since we don't compute tables in advance of the query.
-        CalciteSchema rootSchema= CalciteSchema.createRootSchema(true, false);
+        CalciteSchema rootSchema = CalciteSchema.createRootSchema(true, false);
         CalciteJdbc41Factory factory = new CalciteJdbc41Factory();
-        CalciteConnection connection = factory.newConnection(new Driver(), factory, "",  new java.util.Properties(), rootSchema, null);
-        final SchemaPlus defaultSchema = connection.getRootSchema().add(
-            OpenSearchSchema.OPEN_SEARCH_SCHEMA_NAME, new OpenSearchSchema(dataSourceService));
+        CalciteConnection connection =
+            factory.newConnection(
+                new Driver(), factory, "", new java.util.Properties(), rootSchema, null);
+        final SchemaPlus defaultSchema =
+            connection
+                .getRootSchema()
+                .add(
+                    OpenSearchSchema.OPEN_SEARCH_SCHEMA_NAME,
+                    new OpenSearchSchema(dataSourceService));
         // Set opensearch schema as the default schema in config, otherwise we need to explicitly
         // add schema path 'OpenSearch' before the opensearch table name
         final FrameworkConfig config = buildFrameworkConfig(defaultSchema);

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -11,6 +11,10 @@ package org.opensearch.sql.executor;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.jdbc.CalciteJdbc41Factory;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.schema.SchemaPlus;
@@ -60,8 +64,16 @@ public class QueryService {
       UnresolvedPlan plan, ResponseListener<ExecutionEngine.QueryResponse> listener) {
     try {
       try {
-        final FrameworkConfig config = buildFrameworkConfig();
-        final CalcitePlanContext context = new CalcitePlanContext(config);
+        // Use simple calcite schema since we don't compute tables in advance of the query.
+        CalciteSchema rootSchema= CalciteSchema.createRootSchema(true, false);
+        CalciteJdbc41Factory factory = new CalciteJdbc41Factory();
+        CalciteConnection connection = factory.newConnection(new Driver(), factory, "",  new java.util.Properties(), rootSchema, null);
+        final SchemaPlus defaultSchema = connection.getRootSchema().add(
+            OpenSearchSchema.OPEN_SEARCH_SCHEMA_NAME, new OpenSearchSchema(dataSourceService));
+        // Set opensearch schema as the default schema in config, otherwise we need to explicitly
+        // add schema path 'OpenSearch' before the opensearch table name
+        final FrameworkConfig config = buildFrameworkConfig(defaultSchema);
+        final CalcitePlanContext context = new CalcitePlanContext(config, connection);
         executePlanByCalcite(analyze(plan, context), context, listener);
       } catch (Exception e) {
         LOG.warn("Fallback to V2 query engine since got exception", e);
@@ -134,14 +146,10 @@ public class QueryService {
     return relNodeVisitor.analyze(plan, context);
   }
 
-  private FrameworkConfig buildFrameworkConfig() {
-    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
-    final SchemaPlus opensearchSchema =
-        rootSchema.add(
-            OpenSearchSchema.OPEN_SEARCH_SCHEMA_NAME, new OpenSearchSchema(dataSourceService));
+  private FrameworkConfig buildFrameworkConfig(SchemaPlus defaultSchema) {
     return Frameworks.newConfigBuilder()
         .parserConfig(SqlParser.Config.DEFAULT) // TODO check
-        .defaultSchema(opensearchSchema)
+        .defaultSchema(defaultSchema)
         .traitDefs((List<RelTraitDef>) null)
         .programs(Programs.heuristicJoinOrder(Programs.RULE_SET, true, 2))
         .build();

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
@@ -15,9 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.tools.RelRunner;
@@ -111,8 +109,6 @@ public class OpenSearchExecutionEngine implements ExecutionEngine {
   public void execute(
       RelNode rel, CalcitePlanContext context, ResponseListener<QueryResponse> listener) {
     Connection connection = context.connection;
-    final RelShuttle shuttle = new RelHomogeneousShuttle();
-    rel = rel.accept(shuttle);
     try {
       RelRunner runner = connection.unwrap(RelRunner.class);
       PreparedStatement statement = runner.prepareStatement(rel);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
@@ -5,23 +5,34 @@
 
 package org.opensearch.sql.opensearch.executor;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.tools.RelRunner;
 import org.apache.calcite.tools.RelRunners;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.data.model.ExprStringValue;
+import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.executor.ExecutionContext;
 import org.opensearch.sql.executor.ExecutionEngine;
+import org.opensearch.sql.executor.ExecutionEngine.Schema.Column;
 import org.opensearch.sql.executor.Explain;
 import org.opensearch.sql.executor.pagination.PlanSerializer;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
@@ -102,30 +113,50 @@ public class OpenSearchExecutionEngine implements ExecutionEngine {
   @Override
   public void execute(
       RelNode rel, CalcitePlanContext context, ResponseListener<QueryResponse> listener) {
-    try (PreparedStatement statement = RelRunners.run(rel)) {
+    Connection connection = context.connection;
+    final RelShuttle shuttle = new RelHomogeneousShuttle();
+    rel = rel.accept(shuttle);
+    try {
+      RelRunner runner = connection.unwrap(RelRunner.class);
+      PreparedStatement statement = runner.prepareStatement(rel);
       ResultSet result = statement.executeQuery();
-      printResultSet(result);
+      printResultSet(result, listener);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
   // for testing only
-  private void printResultSet(ResultSet resultSet) throws SQLException {
+  private void printResultSet(ResultSet resultSet, ResponseListener<QueryResponse> listener) throws SQLException {
     // Get the ResultSet metadata to know about columns
     ResultSetMetaData metaData = resultSet.getMetaData();
     int columnCount = metaData.getColumnCount();
 
+    List<ExprValue> values = new ArrayList<>();
     // Iterate through the ResultSet
     while (resultSet.next()) {
+      Map<String, ExprValue> row = new LinkedHashMap<String, ExprValue>();
       // Loop through each column
       for (int i = 1; i <= columnCount; i++) {
         String columnName = metaData.getColumnName(i);
         String value = resultSet.getString(i);
         System.out.println(columnName + ": " + value);
+
+        row.put(columnName, new ExprStringValue(value));
       }
+      values.add(ExprTupleValue.fromExprValueMap(row));
       System.out.println("-------------------"); // Separator between rows
     }
+
+    List<Column> columns = new ArrayList<>(metaData.getColumnCount());
+    for (int i = 1; i <= columnCount; ++i) {
+      // TODO: mapping RelDataType to ExprType or deprecate ExprType
+      columns.add(new Column(metaData.getColumnName(i), null, ExprCoreType.STRING));
+    }
+    Schema schema = new Schema(columns);
+    QueryResponse response =
+        new QueryResponse(schema, values, null);
+    listener.onResponse(response);
   }
 
   private RelDataType makeStruct(RelDataTypeFactory typeFactory, RelDataType type) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
@@ -15,21 +15,18 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.tools.RelRunner;
-import org.apache.calcite.tools.RelRunners;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.executor.ExecutionContext;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.ExecutionEngine.Schema.Column;
@@ -127,7 +124,8 @@ public class OpenSearchExecutionEngine implements ExecutionEngine {
   }
 
   // for testing only
-  private void printResultSet(ResultSet resultSet, ResponseListener<QueryResponse> listener) throws SQLException {
+  private void printResultSet(ResultSet resultSet, ResponseListener<QueryResponse> listener)
+      throws SQLException {
     // Get the ResultSet metadata to know about columns
     ResultSetMetaData metaData = resultSet.getMetaData();
     int columnCount = metaData.getColumnCount();
@@ -154,8 +152,7 @@ public class OpenSearchExecutionEngine implements ExecutionEngine {
       columns.add(new Column(metaData.getColumnName(i), null, ExprCoreType.STRING));
     }
     Schema schema = new Schema(columns);
-    QueryResponse response =
-        new QueryResponse(schema, values, null);
+    QueryResponse response = new QueryResponse(schema, values, null);
     listener.onResponse(response);
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -11,9 +11,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
+import org.apache.calcite.DataContext;
 import org.apache.calcite.linq4j.AbstractEnumerable;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Enumerator;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.sql.calcite.plan.OpenSearchTable;
 import org.opensearch.sql.common.setting.Settings;
@@ -79,6 +81,7 @@ public class OpenSearchIndex extends OpenSearchTable {
 
   /** Constructor. */
   public OpenSearchIndex(OpenSearchClient client, Settings settings, String indexName) {
+    super(null);
     this.client = client;
     this.settings = settings;
     this.indexName = new OpenSearchRequest.IndexName(indexName);
@@ -190,6 +193,16 @@ public class OpenSearchIndex extends OpenSearchTable {
     return settings.getSettingValue(Settings.Key.FIELD_TYPE_TOLERANCE);
   }
 
+  //@Override
+  public Enumerable<Object[]> scan(DataContext root) {
+    return new AbstractEnumerable<@Nullable Object[]>() {
+      @Override public Enumerator<@Nullable Object[]> enumerator() {
+        return null;
+        // return search().toMap(v -> new Object[] {v});
+      }
+    };
+  }
+
   @VisibleForTesting
   @RequiredArgsConstructor
   public static class OpenSearchDefaultImplementor extends DefaultImplementor<OpenSearchIndexScan> {
@@ -217,10 +230,10 @@ public class OpenSearchIndex extends OpenSearchTable {
   }
 
   @Override
-  public Enumerable<ExprValue> search() {
-    return new AbstractEnumerable<ExprValue>() {
+  public Enumerable<Object> search() {
+    return new AbstractEnumerable<Object>() {
       @Override
-      public Enumerator<ExprValue> enumerator() {
+      public Enumerator<Object> enumerator() {
         final int querySizeLimit = settings.getSettingValue(Settings.Key.QUERY_SIZE_LIMIT);
 
         final TimeValue cursorKeepAlive =

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -19,7 +19,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.sql.calcite.plan.OpenSearchTable;
 import org.opensearch.sql.common.setting.Settings;
-import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
@@ -193,10 +192,11 @@ public class OpenSearchIndex extends OpenSearchTable {
     return settings.getSettingValue(Settings.Key.FIELD_TYPE_TOLERANCE);
   }
 
-  //@Override
+  // @Override
   public Enumerable<Object[]> scan(DataContext root) {
     return new AbstractEnumerable<@Nullable Object[]>() {
-      @Override public Enumerator<@Nullable Object[]> enumerator() {
+      @Override
+      public Enumerator<@Nullable Object[]> enumerator() {
         return null;
         // return search().toMap(v -> new Object[] {v});
       }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
@@ -15,7 +15,7 @@ import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.request.OpenSearchRequest;
 import org.opensearch.sql.opensearch.response.OpenSearchResponse;
 
-public class OpenSearchIndexEnumerator implements Enumerator<ExprValue> {
+public class OpenSearchIndexEnumerator implements Enumerator<Object> {
 
   /** OpenSearch client. */
   private final OpenSearchClient client;
@@ -50,9 +50,9 @@ public class OpenSearchIndexEnumerator implements Enumerator<ExprValue> {
   }
 
   @Override
-  public ExprValue current() {
+  public Object current() {
     queryCount++;
-    return iterator.next();
+    return iterator.next().tupleValue().values().stream().map(ExprValue::value).toArray();
   }
 
   @Override


### PR DESCRIPTION
### Description
Before this PR, PPL plan will fail executing on calcite engine and fallback to the original v2 engine. This PR aims to make the plan execute successfully on calcite engine. 

The changes includes:
- Replace RelRunners with CalciteConnection to do execution
- Add OpenSearchSchema to the rootSchema of above connection
- Change ExprValue to Object in OpenSearchTable


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
