### PR TITLE
CI: Syntax fix for Jekyll build

### DIFF
--- a/docs/dev/datasource-prometheus.md
+++ b/docs/dev/datasource-prometheus.md
@@ -175,7 +175,7 @@ Since we don't have column names similar to relational databases, `@timestamp` a
 
 ### Passthrough PromQL Support.
 * PromQL is easy to use powerful language over metrics and we want to support promQL queries from catalogs with prometheus connectors.
-* Function signature: source = ``promcatalog.nativeQuery(`promQLCommand`, startTime = "{{startTime}}", endTime="{{endTime}", step="{{resolution}}")``
+* Function signature: source = ``promcatalog.nativeQuery(`promQLCommand`, startTime = "{{startTime}}", endTime="{{endTime}}", step="{{resolution}}")``
 
 
 


### PR DESCRIPTION
### Description
Missing close curly brace on `datasource-prmetheus.md` which result in Jeykll build fail at the moment on main branch.

https://github.com/opensearch-project/sql/actions/runs/12890965970/job/35941801363

<img width="1362" alt="image" src="https://github.com/user-attachments/assets/b64b2733-52f5-4bfc-946a-cf314c0c5eaf" />


### Related Issues
Partial resolves: https://github.com/opensearch-project/sql/issues/3168

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
