### PR TITLE
Build: Cache Prometheus binary 

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -284,9 +284,14 @@ task startPrometheus(type: SpawnProcessTask) {
     mustRunAfter ':doctest:doctest'
 
     doFirst {
-        download.run {
-            src getPrometheusBinaryLocation()
-            dest new File("$projectDir/bin", 'prometheus.tar.gz')
+        File downloadedPrometheus = Paths.get("$projectDir/bin", 'prometheus.tar.gz').toFile()
+        if (!downloadedPrometheus.exists()) {
+            download.run {
+                src getPrometheusBinaryLocation()
+                dest new File("$projectDir/bin", 'prometheus.tar.gz')
+            }
+        } else {
+            println "Prometheus File Already Exists"
         }
         copy {
             from tarTree("$projectDir/bin/prometheus.tar.gz")

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -311,7 +311,6 @@ task startPrometheus(type: SpawnProcessTask) {
 task stopPrometheus(type: KillProcessTask) {
     doLast {
         file("$projectDir/bin/prometheus").deleteDir()
-        file("$projectDir/bin/prometheus.tar.gz").delete()
     }
 }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -290,8 +290,6 @@ task startPrometheus(type: SpawnProcessTask) {
                 src getPrometheusBinaryLocation()
                 dest prometheusFilePath
             }
-        } else {
-            println "Prometheus File Already Exists"
         }
         copy {
             from tarTree("$projectDir/bin/prometheus-${prometheus_binary_version}.tar.gz")

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -284,17 +284,17 @@ task startPrometheus(type: SpawnProcessTask) {
     mustRunAfter ':doctest:doctest'
 
     doFirst {
-        File downloadedPrometheus = Paths.get("$projectDir/bin", 'prometheus.tar.gz').toFile()
-        if (!downloadedPrometheus.exists()) {
+        File prometheusFilePath = Paths.get("$projectDir/bin", "prometheus-${prometheus_binary_version}.tar.gz").toFile()
+        if (!prometheusFilePath.exists()) {
             download.run {
                 src getPrometheusBinaryLocation()
-                dest new File("$projectDir/bin", 'prometheus.tar.gz')
+                dest prometheusFilePath
             }
         } else {
             println "Prometheus File Already Exists"
         }
         copy {
-            from tarTree("$projectDir/bin/prometheus.tar.gz")
+            from tarTree("$projectDir/bin/prometheus-${prometheus_binary_version}.tar.gz")
             into "$projectDir/bin"
         }
         file("$projectDir/bin").eachDir {


### PR DESCRIPTION
### Description
As per the current design of Gradle test workflow, Gradle task `startPrometheus` is designed to execute upon every integration test and docTest.
However the current implementation of `startPrometheus` and `stopPrometheus` will force and trigger the re-download of `Prometheus` binary, no matter that is a first run or subsequent run.  (~100 Mb)

This result in waste of bandwidth and reduce on developer productivity, as integration test will be executed frequently during the typical development process. 

Hence this is a PR to introduce FileExistCheck to only download Prometheus binary when it's absent. 

### Test plan:
 - To execute multiple `integTest` and make sure `Prometheus File Already Exists` printed on console and no additional files being downloaded on subsequent IT test execution. 


### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3257
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
