### PR TITLE
CI: Eliminate redundant file wrapper 

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -536,37 +536,21 @@ task comparisonTest(type: RestIntegTestTask) {
             testDistribution = "ARCHIVE"
             versions = [baseVersion, opensearch_version]
             numberOfNodes = 3
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            if (new File("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion").exists()) {
-                                project.delete(files("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion"))
-                            }
-                            project.mkdir bwcJobSchedulerPath + bwcVersion
-                            ant.get(src: bwcOpenSearchJSDownload,
-                                    dest: bwcJobSchedulerPath + bwcVersion,
-                                    httpusecaches: false)
-                            return fileTree(bwcJobSchedulerPath + bwcVersion).getSingleFile()
-                        }
-                    }
+            plugin(provider { (RegularFile) (() -> {
+                if (new File("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion").exists()) {
+                    project.delete(files("$project.rootDir/$bwcFilePath/job-scheduler/$bwcVersion"))
                 }
-            }))
-            plugin(provider(new Callable<RegularFile>(){
-                @Override
-                RegularFile call() throws Exception {
-                    return new RegularFile() {
-                        @Override
-                        File getAsFile() {
-                            return configurations.zipArchive.asFileTree.matching {
-                                include '**/opensearch-sql-plugin*'
-                            }.singleFile
-                        }
-                    }
-                }
-            }))
+                project.mkdir bwcJobSchedulerPath + bwcVersion
+                ant.get(src: bwcOpenSearchJSDownload,
+                        dest: bwcJobSchedulerPath + bwcVersion,
+                        httpusecaches: false)
+                return fileTree(bwcJobSchedulerPath + bwcVersion).getSingleFile()
+            })})
+            plugin(provider { (RegularFile) (() -> {
+                return configurations.zipArchive.asFileTree.matching {
+                    include '**/opensearch-sql-plugin*'
+                }.singleFile
+            })})
             setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
             setting 'http.content_type.required', 'true'
         }
@@ -576,9 +560,11 @@ task comparisonTest(type: RestIntegTestTask) {
 List<Provider<RegularFile>> plugins = [
         getJobSchedulerPlugin(),
         provider { (RegularFile) (() ->
-                fileTree(bwcFilePath + project.version).getSingleFile() )
+                fileTree(bwcFilePath + project.version).getSingleFile())
         }
 ]
+
+
 
 // Creates 2 test clusters with 3 nodes of the old version.
 2.times { i ->

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -138,7 +138,8 @@ ext {
             cluster.setting name, value
         }
 
-        cluster.plugin provider((Callable<RegularFile>) (() -> (RegularFile) (() -> downloadedSecurityPlugin)))
+//        cluster.plugin provider((Callable<RegularFile>) (() -> (RegularFile) (() -> downloadedSecurityPlugin)))
+        cluster.plugin provider { (RegularFile) (() -> downloadedSecurityPlugin )}
     }
 
     bwcOpenSearchJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + baseVersion + '/latest/linux/x64/tar/builds/' +

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -138,7 +138,6 @@ ext {
             cluster.setting name, value
         }
 
-//        cluster.plugin provider((Callable<RegularFile>) (() -> (RegularFile) (() -> downloadedSecurityPlugin)))
         cluster.plugin provider { (RegularFile) (() -> downloadedSecurityPlugin )}
     }
 
@@ -563,8 +562,6 @@ List<Provider<RegularFile>> plugins = [
                 fileTree(bwcFilePath + project.version).getSingleFile())
         }
 ]
-
-
 
 // Creates 2 test clusters with 3 nodes of the old version.
 2.times { i ->

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -230,19 +230,11 @@ testClusters.all {
 }
 
 def getJobSchedulerPlugin() {
-    provider(new Callable<RegularFile>() {
-        @Override
-        RegularFile call() throws Exception {
-            return new RegularFile() {
-                @Override
-                File getAsFile() {
-                    return configurations.zipArchive.asFileTree.matching {
-                        include '**/opensearch-job-scheduler*'
-                    }.singleFile
-                }
-            }
-        }
-    })
+    provider { (RegularFile) (() ->
+            configurations.zipArchive.asFileTree.matching {
+                include '**/opensearch-job-scheduler*'
+            }.singleFile )
+    }
 }
 
 def getGeoSpatialPlugin() {
@@ -582,17 +574,9 @@ task comparisonTest(type: RestIntegTestTask) {
 
 List<Provider<RegularFile>> plugins = [
         getJobSchedulerPlugin(),
-        provider(new Callable<RegularFile>() {
-            @Override
-            RegularFile call() throws Exception {
-                return new RegularFile() {
-                    @Override
-                    File getAsFile() {
-                        return fileTree(bwcFilePath + project.version).getSingleFile()
-                    }
-                }
-            }
-        })
+        provider { (RegularFile) (() ->
+                fileTree(bwcFilePath + project.version).getSingleFile() )
+        }
 ]
 
 // Creates 2 test clusters with 3 nodes of the old version.


### PR DESCRIPTION
### Description
To eliminate redundant casting for `RegularFile` usage, which the aim to enhance the readability of Gradle build file. 

### Related Issues
Related to: https://github.com/opensearch-project/sql/issues/3257

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### Test plan:
Both integTestWithSecurity and bwcTestSuite should continue to work after the refactor. 
