### PR TITLE
Feature: PPL command - WMA Trendline

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/tree/Trendline.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Trendline.java
@@ -66,6 +66,7 @@ public class Trendline extends UnresolvedPlan {
   }
 
   public enum TrendlineType {
-    SMA
+    SMA,
+    WMA
   }
 }

--- a/core/src/main/java/org/opensearch/sql/planner/physical/TrendlineOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/TrendlineOperator.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -205,13 +204,13 @@ public class TrendlineOperator extends PhysicalPlan {
     }
 
     static WmaTrendlineEvaluator getEvaluator(ExprCoreType type) {
-        return switch (type) {
-            case DOUBLE -> NumericWmaEvaluator.INSTANCE;
-            case DATE, TIMESTAMP -> TimeStampWmaEvaluator.INSTANCE;
-            case TIME -> TimeWmaEvaluator.INSTANCE;
-            default -> throw new IllegalArgumentException(
-                    String.format("Invalid type %s used for weighted moving average.", type.typeName()));
-        };
+      return switch (type) {
+        case DOUBLE -> NumericWmaEvaluator.INSTANCE;
+        case DATE, TIMESTAMP -> TimeStampWmaEvaluator.INSTANCE;
+        case TIME -> TimeWmaEvaluator.INSTANCE;
+        default -> throw new IllegalArgumentException(
+            String.format("Invalid type %s used for weighted moving average.", type.typeName()));
+      };
     }
 
     @Override
@@ -256,7 +255,10 @@ public class TrendlineOperator extends PhysicalPlan {
         long sum = 0L;
         int totalWeight = (receivedValues.size() * (receivedValues.size() + 1)) / 2;
         for (int i = 0; i < receivedValues.size(); i++) {
-          sum += (long) (receivedValues.get(i).timestampValue().toEpochMilli() * ((i + 1D) / totalWeight));
+          sum +=
+              (long)
+                  (receivedValues.get(i).timestampValue().toEpochMilli()
+                      * ((i + 1D) / totalWeight));
         }
 
         return ExprValueUtils.timestampValue(Instant.ofEpochMilli((sum)));
@@ -272,21 +274,19 @@ public class TrendlineOperator extends PhysicalPlan {
         long sum = 0L;
         int totalWeight = (receivedValues.size() * (receivedValues.size() + 1)) / 2;
         for (int i = 0; i < receivedValues.size(); i++) {
-          sum += (long) (MILLIS.between(LocalTime.MIN, receivedValues.get(i).timeValue()) * ((i + 1D) / totalWeight));
+          sum +=
+              (long)
+                  (MILLIS.between(LocalTime.MIN, receivedValues.get(i).timeValue())
+                      * ((i + 1D) / totalWeight));
         }
-        return ExprValueUtils.timeValue(
-                        LocalTime.MIN.plus(sum, MILLIS));
+        return ExprValueUtils.timeValue(LocalTime.MIN.plus(sum, MILLIS));
       }
     }
-
 
     private interface WmaTrendlineEvaluator {
       ExprValue evaluate(ArrayList<ExprValue> receivedValues);
     }
   }
-
-
-
 
   private interface ArithmeticEvaluator {
     Expression calculateFirstTotal(List<ExprValue> dataPoints);

--- a/core/src/test/java/org/opensearch/sql/planner/physical/TrendlineOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/TrendlineOperatorTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.opensearch.sql.ast.tree.Trendline.TrendlineType.SMA;
+import static org.opensearch.sql.ast.tree.Trendline.TrendlineType.WMA;
 
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
@@ -395,4 +396,292 @@ public class TrendlineOperatorTest {
         plan.next());
     assertFalse(plan.hasNext());
   }
+
+  @Test
+  public void calculates_weighted_moving_average_one_field_one_sample() {
+    when(inputPlan.hasNext()).thenReturn(true, false);
+    when(inputPlan.next())
+            .thenReturn(ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)));
+
+    var plan =
+            new TrendlineOperator(
+                    inputPlan,
+                    Collections.singletonList(
+                            Pair.of(
+                                    AstDSL.computation(1, AstDSL.field("distance"), "distance_alias", WMA),
+                                    ExprCoreType.DOUBLE)));
+
+    plan.open();
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of("distance", 100, "time", 10, "distance_alias", 100)),
+            plan.next());
+  }
+
+  @Test
+  public void calculates_weighted_moving_average_one_field_two_samples() {
+    when(inputPlan.hasNext()).thenReturn(true, true, false);
+    when(inputPlan.next())
+            .thenReturn(
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)));
+
+    var plan =
+            new TrendlineOperator(
+                    inputPlan,
+                    Collections.singletonList(
+                            Pair.of(
+                                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                                    ExprCoreType.DOUBLE)));
+
+    plan.open();
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 166.66666666666663)),
+            plan.next());
+    assertFalse(plan.hasNext());
+  }
+
+  @Test
+  public void calculates_weighted_moving_average_one_field_two_samples_three_rows() {
+    when(inputPlan.hasNext()).thenReturn(true, true, true, false);
+    when(inputPlan.next())
+            .thenReturn(
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)),
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)));
+
+    var plan =
+            new TrendlineOperator(
+                    inputPlan,
+                    Collections.singletonList(
+                            Pair.of(
+                                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                                    ExprCoreType.DOUBLE)));
+
+    plan.open();
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 166.66666666666663)),
+            plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 199.99999999999997)),
+            plan.next());
+    assertFalse(plan.hasNext());
+  }
+
+  @Test
+  public void calculates_weighted_moving_average_multiple_computations() {
+    when(inputPlan.hasNext()).thenReturn(true, true, true, false);
+    when(inputPlan.next())
+            .thenReturn(
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 20)),
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 20)));
+
+    var plan =
+            new TrendlineOperator(
+                    inputPlan,
+                    Arrays.asList(
+                            Pair.of(
+                                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                                    ExprCoreType.DOUBLE),
+                            Pair.of(
+                                    AstDSL.computation(2, AstDSL.field("time"), "time_alias", WMA),
+                                    ExprCoreType.DOUBLE)));
+
+    plan.open();
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of(
+                            "distance", 200, "time", 20, "distance_alias", 166.66666666666663, "time_alias", 16.666666666666664)),
+            plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of(
+                            "distance", 200, "time", 20, "distance_alias", 199.99999999999997, "time_alias", 20.0)),
+            plan.next());
+    assertFalse(plan.hasNext());
+  }
+
+
+  @Test
+  public void calculates_weighted_moving_average_one_field_two_samples_three_rows_null_value() {
+    when(inputPlan.hasNext()).thenReturn(true, true, true, false);
+    when(inputPlan.next())
+            .thenReturn(
+                    ExprValueUtils.tupleValue(ImmutableMap.of("time", 10)),
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)),
+                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 300, "time", 10)));
+
+    var plan =
+            new TrendlineOperator(
+                    inputPlan,
+                    Collections.singletonList(
+                            Pair.of(
+                                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                                    ExprCoreType.DOUBLE)));
+
+    plan.open();
+    assertTrue(plan.hasNext());
+    assertEquals(ExprValueUtils.tupleValue(ImmutableMap.of("time", 10)), plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)), plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of("distance", 300, "time", 10, "distance_alias", 266.66666666666663)),
+            plan.next());
+    assertFalse(plan.hasNext());
+  }
+
+  @Test
+  public void calculates_weighted_moving_average_date() {
+    when(inputPlan.hasNext()).thenReturn(true, true, true, false);
+    when(inputPlan.next())
+            .thenReturn(
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH))),
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(6)))),
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(12)))));
+
+    var plan =
+            new TrendlineOperator(
+                    inputPlan,
+                    Collections.singletonList(
+                            Pair.of(
+                                    AstDSL.computation(2, AstDSL.field("date"), "date_alias", WMA),
+                                    ExprCoreType.DATE)));
+
+    plan.open();
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH))),
+            plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of(
+                            "date",
+                            ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(6)),
+                            "date_alias",
+                            ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(4)))),
+            plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of(
+                            "date",
+                            ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(12)),
+                            "date_alias",
+                            ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(10)))),
+            plan.next());
+    assertFalse(plan.hasNext());
+  }
+
+  @Test
+  public void calculates_weighted_moving_average_time() {
+    when(inputPlan.hasNext()).thenReturn(true, true, true, false);
+    when(inputPlan.next())
+            .thenReturn(
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN))),
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN.plusHours(6)))),
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN.plusHours(12)))));
+
+    var plan =
+            new TrendlineOperator(
+                    inputPlan,
+                    Collections.singletonList(
+                            Pair.of(
+                                    AstDSL.computation(2, AstDSL.field("time"), "time_alias", WMA),
+                                    ExprCoreType.TIME)));
+
+    plan.open();
+    assertTrue(plan.hasNext());
+    assertEquals(ExprValueUtils.tupleValue(ImmutableMap.of("time", LocalTime.MIN)), plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of(
+                            "time", LocalTime.MIN.plusHours(6), "time_alias", LocalTime.MIN.plusHours(4))),
+            plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of(
+                            "time", LocalTime.MIN.plusHours(12), "time_alias", LocalTime.MIN.plusHours(10))),
+            plan.next());
+    assertFalse(plan.hasNext());
+  }
+
+  @Test
+  public void calculates_weighted_moving_average_timestamp() {
+    when(inputPlan.hasNext()).thenReturn(true, true, true, false);
+    when(inputPlan.next())
+            .thenReturn(
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of("timestamp", ExprValueUtils.timestampValue(Instant.EPOCH))),
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of(
+                                    "timestamp", ExprValueUtils.timestampValue(Instant.EPOCH.plusMillis(1000)))),
+                    ExprValueUtils.tupleValue(
+                            ImmutableMap.of(
+                                    "timestamp", ExprValueUtils.timestampValue(Instant.EPOCH.plusMillis(1500)))));
+
+    var plan =
+            new TrendlineOperator(
+                    inputPlan,
+                    Collections.singletonList(
+                            Pair.of(
+                                    AstDSL.computation(2, AstDSL.field("timestamp"), "timestamp_alias", WMA),
+                                    ExprCoreType.TIMESTAMP)));
+
+    plan.open();
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(ImmutableMap.of("timestamp", Instant.EPOCH)), plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of(
+                            "timestamp",
+                            Instant.EPOCH.plusMillis(1000),
+                            "timestamp_alias",
+                            Instant.EPOCH.plusMillis(666))),
+            plan.next());
+    assertTrue(plan.hasNext());
+    assertEquals(
+            ExprValueUtils.tupleValue(
+                    ImmutableMap.of(
+                            "timestamp",
+                            Instant.EPOCH.plusMillis(1500),
+                            "timestamp_alias",
+                            Instant.EPOCH.plusMillis(1333))),
+            plan.next());
+    assertFalse(plan.hasNext());
+  }
+
 }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/TrendlineOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/TrendlineOperatorTest.java
@@ -696,4 +696,19 @@ public class TrendlineOperatorTest {
         plan.next());
     assertFalse(plan.hasNext());
   }
+
+  @Test
+  public void use_illegal_core_type_wma() {
+    assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new TrendlineOperator(
+                      inputPlan,
+                      Collections.singletonList(
+                              Pair.of(
+                                      AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                                      ExprCoreType.ARRAY)));
+            });
+  }
+
 }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/TrendlineOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/TrendlineOperatorTest.java
@@ -700,15 +700,14 @@ public class TrendlineOperatorTest {
   @Test
   public void use_illegal_core_type_wma() {
     assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-              new TrendlineOperator(
-                      inputPlan,
-                      Collections.singletonList(
-                              Pair.of(
-                                      AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
-                                      ExprCoreType.ARRAY)));
-            });
+        IllegalArgumentException.class,
+        () -> {
+          new TrendlineOperator(
+              inputPlan,
+              Collections.singletonList(
+                  Pair.of(
+                      AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                      ExprCoreType.ARRAY)));
+        });
   }
-
 }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/TrendlineOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/TrendlineOperatorTest.java
@@ -401,49 +401,49 @@ public class TrendlineOperatorTest {
   public void calculates_weighted_moving_average_one_field_one_sample() {
     when(inputPlan.hasNext()).thenReturn(true, false);
     when(inputPlan.next())
-            .thenReturn(ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)));
+        .thenReturn(ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)));
 
     var plan =
-            new TrendlineOperator(
-                    inputPlan,
-                    Collections.singletonList(
-                            Pair.of(
-                                    AstDSL.computation(1, AstDSL.field("distance"), "distance_alias", WMA),
-                                    ExprCoreType.DOUBLE)));
+        new TrendlineOperator(
+            inputPlan,
+            Collections.singletonList(
+                Pair.of(
+                    AstDSL.computation(1, AstDSL.field("distance"), "distance_alias", WMA),
+                    ExprCoreType.DOUBLE)));
 
     plan.open();
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of("distance", 100, "time", 10, "distance_alias", 100)),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of("distance", 100, "time", 10, "distance_alias", 100)),
+        plan.next());
   }
 
   @Test
   public void calculates_weighted_moving_average_one_field_two_samples() {
     when(inputPlan.hasNext()).thenReturn(true, true, false);
     when(inputPlan.next())
-            .thenReturn(
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)));
+        .thenReturn(
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)));
 
     var plan =
-            new TrendlineOperator(
-                    inputPlan,
-                    Collections.singletonList(
-                            Pair.of(
-                                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
-                                    ExprCoreType.DOUBLE)));
+        new TrendlineOperator(
+            inputPlan,
+            Collections.singletonList(
+                Pair.of(
+                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                    ExprCoreType.DOUBLE)));
 
     plan.open();
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
+        ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 166.66666666666663)),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 166.66666666666663)),
+        plan.next());
     assertFalse(plan.hasNext());
   }
 
@@ -451,33 +451,33 @@ public class TrendlineOperatorTest {
   public void calculates_weighted_moving_average_one_field_two_samples_three_rows() {
     when(inputPlan.hasNext()).thenReturn(true, true, true, false);
     when(inputPlan.next())
-            .thenReturn(
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)),
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)));
+        .thenReturn(
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)));
 
     var plan =
-            new TrendlineOperator(
-                    inputPlan,
-                    Collections.singletonList(
-                            Pair.of(
-                                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
-                                    ExprCoreType.DOUBLE)));
+        new TrendlineOperator(
+            inputPlan,
+            Collections.singletonList(
+                Pair.of(
+                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                    ExprCoreType.DOUBLE)));
 
     plan.open();
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
+        ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 166.66666666666663)),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 166.66666666666663)),
+        plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 199.99999999999997)),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of("distance", 200, "time", 10, "distance_alias", 199.99999999999997)),
+        plan.next());
     assertFalse(plan.hasNext());
   }
 
@@ -485,70 +485,83 @@ public class TrendlineOperatorTest {
   public void calculates_weighted_moving_average_multiple_computations() {
     when(inputPlan.hasNext()).thenReturn(true, true, true, false);
     when(inputPlan.next())
-            .thenReturn(
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 20)),
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 20)));
+        .thenReturn(
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 20)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 20)));
 
     var plan =
-            new TrendlineOperator(
-                    inputPlan,
-                    Arrays.asList(
-                            Pair.of(
-                                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
-                                    ExprCoreType.DOUBLE),
-                            Pair.of(
-                                    AstDSL.computation(2, AstDSL.field("time"), "time_alias", WMA),
-                                    ExprCoreType.DOUBLE)));
+        new TrendlineOperator(
+            inputPlan,
+            Arrays.asList(
+                Pair.of(
+                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                    ExprCoreType.DOUBLE),
+                Pair.of(
+                    AstDSL.computation(2, AstDSL.field("time"), "time_alias", WMA),
+                    ExprCoreType.DOUBLE)));
 
     plan.open();
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
+        ExprValueUtils.tupleValue(ImmutableMap.of("distance", 100, "time", 10)), plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of(
-                            "distance", 200, "time", 20, "distance_alias", 166.66666666666663, "time_alias", 16.666666666666664)),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "distance",
+                200,
+                "time",
+                20,
+                "distance_alias",
+                166.66666666666663,
+                "time_alias",
+                16.666666666666664)),
+        plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of(
-                            "distance", 200, "time", 20, "distance_alias", 199.99999999999997, "time_alias", 20.0)),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "distance",
+                200,
+                "time",
+                20,
+                "distance_alias",
+                199.99999999999997,
+                "time_alias",
+                20.0)),
+        plan.next());
     assertFalse(plan.hasNext());
   }
-
 
   @Test
   public void calculates_weighted_moving_average_one_field_two_samples_three_rows_null_value() {
     when(inputPlan.hasNext()).thenReturn(true, true, true, false);
     when(inputPlan.next())
-            .thenReturn(
-                    ExprValueUtils.tupleValue(ImmutableMap.of("time", 10)),
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)),
-                    ExprValueUtils.tupleValue(ImmutableMap.of("distance", 300, "time", 10)));
+        .thenReturn(
+            ExprValueUtils.tupleValue(ImmutableMap.of("time", 10)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)),
+            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 300, "time", 10)));
 
     var plan =
-            new TrendlineOperator(
-                    inputPlan,
-                    Collections.singletonList(
-                            Pair.of(
-                                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
-                                    ExprCoreType.DOUBLE)));
+        new TrendlineOperator(
+            inputPlan,
+            Collections.singletonList(
+                Pair.of(
+                    AstDSL.computation(2, AstDSL.field("distance"), "distance_alias", WMA),
+                    ExprCoreType.DOUBLE)));
 
     plan.open();
     assertTrue(plan.hasNext());
     assertEquals(ExprValueUtils.tupleValue(ImmutableMap.of("time", 10)), plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)), plan.next());
+        ExprValueUtils.tupleValue(ImmutableMap.of("distance", 200, "time", 10)), plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of("distance", 300, "time", 10, "distance_alias", 266.66666666666663)),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of("distance", 300, "time", 10, "distance_alias", 266.66666666666663)),
+        plan.next());
     assertFalse(plan.hasNext());
   }
 
@@ -556,46 +569,46 @@ public class TrendlineOperatorTest {
   public void calculates_weighted_moving_average_date() {
     when(inputPlan.hasNext()).thenReturn(true, true, true, false);
     when(inputPlan.next())
-            .thenReturn(
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH))),
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(6)))),
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(12)))));
+        .thenReturn(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH))),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(6)))),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(12)))));
 
     var plan =
-            new TrendlineOperator(
-                    inputPlan,
-                    Collections.singletonList(
-                            Pair.of(
-                                    AstDSL.computation(2, AstDSL.field("date"), "date_alias", WMA),
-                                    ExprCoreType.DATE)));
+        new TrendlineOperator(
+            inputPlan,
+            Collections.singletonList(
+                Pair.of(
+                    AstDSL.computation(2, AstDSL.field("date"), "date_alias", WMA),
+                    ExprCoreType.DATE)));
 
     plan.open();
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH))),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of("date", ExprValueUtils.dateValue(LocalDate.EPOCH))),
+        plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of(
-                            "date",
-                            ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(6)),
-                            "date_alias",
-                            ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(4)))),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "date",
+                ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(6)),
+                "date_alias",
+                ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(4)))),
+        plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of(
-                            "date",
-                            ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(12)),
-                            "date_alias",
-                            ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(10)))),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "date",
+                ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(12)),
+                "date_alias",
+                ExprValueUtils.dateValue(LocalDate.EPOCH.plusDays(10)))),
+        plan.next());
     assertFalse(plan.hasNext());
   }
 
@@ -603,37 +616,37 @@ public class TrendlineOperatorTest {
   public void calculates_weighted_moving_average_time() {
     when(inputPlan.hasNext()).thenReturn(true, true, true, false);
     when(inputPlan.next())
-            .thenReturn(
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN))),
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN.plusHours(6)))),
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN.plusHours(12)))));
+        .thenReturn(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN))),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN.plusHours(6)))),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("time", ExprValueUtils.timeValue(LocalTime.MIN.plusHours(12)))));
 
     var plan =
-            new TrendlineOperator(
-                    inputPlan,
-                    Collections.singletonList(
-                            Pair.of(
-                                    AstDSL.computation(2, AstDSL.field("time"), "time_alias", WMA),
-                                    ExprCoreType.TIME)));
+        new TrendlineOperator(
+            inputPlan,
+            Collections.singletonList(
+                Pair.of(
+                    AstDSL.computation(2, AstDSL.field("time"), "time_alias", WMA),
+                    ExprCoreType.TIME)));
 
     plan.open();
     assertTrue(plan.hasNext());
     assertEquals(ExprValueUtils.tupleValue(ImmutableMap.of("time", LocalTime.MIN)), plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of(
-                            "time", LocalTime.MIN.plusHours(6), "time_alias", LocalTime.MIN.plusHours(4))),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "time", LocalTime.MIN.plusHours(6), "time_alias", LocalTime.MIN.plusHours(4))),
+        plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of(
-                            "time", LocalTime.MIN.plusHours(12), "time_alias", LocalTime.MIN.plusHours(10))),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "time", LocalTime.MIN.plusHours(12), "time_alias", LocalTime.MIN.plusHours(10))),
+        plan.next());
     assertFalse(plan.hasNext());
   }
 
@@ -641,47 +654,46 @@ public class TrendlineOperatorTest {
   public void calculates_weighted_moving_average_timestamp() {
     when(inputPlan.hasNext()).thenReturn(true, true, true, false);
     when(inputPlan.next())
-            .thenReturn(
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of("timestamp", ExprValueUtils.timestampValue(Instant.EPOCH))),
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of(
-                                    "timestamp", ExprValueUtils.timestampValue(Instant.EPOCH.plusMillis(1000)))),
-                    ExprValueUtils.tupleValue(
-                            ImmutableMap.of(
-                                    "timestamp", ExprValueUtils.timestampValue(Instant.EPOCH.plusMillis(1500)))));
+        .thenReturn(
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of("timestamp", ExprValueUtils.timestampValue(Instant.EPOCH))),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "timestamp", ExprValueUtils.timestampValue(Instant.EPOCH.plusMillis(1000)))),
+            ExprValueUtils.tupleValue(
+                ImmutableMap.of(
+                    "timestamp", ExprValueUtils.timestampValue(Instant.EPOCH.plusMillis(1500)))));
 
     var plan =
-            new TrendlineOperator(
-                    inputPlan,
-                    Collections.singletonList(
-                            Pair.of(
-                                    AstDSL.computation(2, AstDSL.field("timestamp"), "timestamp_alias", WMA),
-                                    ExprCoreType.TIMESTAMP)));
+        new TrendlineOperator(
+            inputPlan,
+            Collections.singletonList(
+                Pair.of(
+                    AstDSL.computation(2, AstDSL.field("timestamp"), "timestamp_alias", WMA),
+                    ExprCoreType.TIMESTAMP)));
 
     plan.open();
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(ImmutableMap.of("timestamp", Instant.EPOCH)), plan.next());
+        ExprValueUtils.tupleValue(ImmutableMap.of("timestamp", Instant.EPOCH)), plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of(
-                            "timestamp",
-                            Instant.EPOCH.plusMillis(1000),
-                            "timestamp_alias",
-                            Instant.EPOCH.plusMillis(666))),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "timestamp",
+                Instant.EPOCH.plusMillis(1000),
+                "timestamp_alias",
+                Instant.EPOCH.plusMillis(666))),
+        plan.next());
     assertTrue(plan.hasNext());
     assertEquals(
-            ExprValueUtils.tupleValue(
-                    ImmutableMap.of(
-                            "timestamp",
-                            Instant.EPOCH.plusMillis(1500),
-                            "timestamp_alias",
-                            Instant.EPOCH.plusMillis(1333))),
-            plan.next());
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "timestamp",
+                Instant.EPOCH.plusMillis(1500),
+                "timestamp_alias",
+                Instant.EPOCH.plusMillis(1333))),
+        plan.next());
     assertFalse(plan.hasNext());
   }
-
 }

--- a/docs/user/ppl/cmd/trendline.rst
+++ b/docs/user/ppl/cmd/trendline.rst
@@ -13,7 +13,7 @@ Description
 ============
 | Using ``trendline`` command to calculate moving averages of fields.
 
-Syntax
+Syntax - SMA (Simple Moving Average)
 ============
 `TRENDLINE [sort <[+|-] sort-field>] SMA(number-of-datapoints, field) [AS alias] [SMA(number-of-datapoints, field) [AS alias]]...`
 
@@ -22,8 +22,6 @@ Syntax
 * number-of-datapoints: mandatory. The number of datapoints to calculate the moving average (must be greater than zero).
 * field: mandatory. The name of the field the moving average should be calculated for.
 * alias: optional. The name of the resulting column containing the moving average (defaults to the field name with "_trendline").
-
-At the moment only the Simple Moving Average (SMA) type is supported.
 
 It is calculated like
 
@@ -70,7 +68,7 @@ PPL query::
     | 15.5 | 30.5      |
     +------+-----------+
 
-Example 4: Calculate the moving average on one field without specifying an alias.
+Example 3: Calculate the moving average on one field without specifying an alias.
 =================================================================================
 
 The example shows how to calculate the moving average on one field.
@@ -86,5 +84,79 @@ PPL query::
     | 3.5                      |
     | 9.5                      |
     | 15.5                     |
+    +--------------------------+
+
+Syntax - WMA (Weighted Moving Average)
+============
+`TRENDLINE [sort <[+|-] sort-field>] WMA(number-of-datapoints, field) [AS alias] [WMA(number-of-datapoints, field) [AS alias]]...`
+
+* [+|-]: optional. The plus [+] stands for ascending order and NULL/MISSING first and a minus [-] stands for descending order and NULL/MISSING last. **Default:** ascending order and NULL/MISSING first.
+* sort-field: mandatory when sorting is used. The field used to sort.
+* number-of-datapoints: mandatory. The number of datapoints to calculate the moving average (must be greater than zero).
+* field: mandatory. The name of the field the moving average should be calculated for.
+* alias: optional. The name of the resulting column containing the moving average (defaults to the field name with "_trendline").
+
+It is calculated like
+
+    f[i]: The value of field 'f' in the i-th data point
+    n: The number of data points in the moving window (period)
+    t: The current time index
+    w[i]: The weight assigned to the i-th data point, typically increasing for more recent points
+
+    WMA(t) = ( Σ from i=t−n+1 to t of (w[i] * f[i]) ) / ( Σ from i=t−n+1 to t of w[i] )
+
+Example 1: Calculate the weighted moving average on one field.
+=====================================================
+
+The example shows how to calculate the weighted moving average on one field.
+
+PPL query::
+
+    os> source=accounts | trendline wma(2, account_number) as an | fields an;
+    fetched rows / total rows = 4/4
+    +--------------------+
+    | an                 |
+    |--------------------|
+    | null               |
+    | 4.333333333333333  |
+    | 10.666666666666666 |
+    | 16.333333333333332 |
+    +--------------------+
+
+Example 2: Calculate the weighted moving average on multiple fields.
+===========================================================
+
+The example shows how to calculate the weighted moving average on multiple fields.
+
+PPL query::
+
+    os> source=accounts | trendline wma(2, account_number) as an sma(2, age) as age_trend | fields an, age_trend ;
+    fetched rows / total rows = 4/4
+    +--------------------+-----------+
+    | an                 | age_trend |
+    |--------------------+-----------|
+    | null               | null      |
+    | 4.333333333333333  | 34.0      |
+    | 10.666666666666666 | 32.0      |
+    | 16.333333333333332 | 30.5      |
+    +--------------------+-----------+
+
+
+Example 3: Calculate the weighted moving average on one field without specifying an alias.
+=================================================================================
+
+The example shows how to calculate the weighted moving average on one field.
+
+PPL query::
+
+    os> source=accounts | trendline wma(2, account_number)  | fields account_number_trendline;
+    fetched rows / total rows = 4/4
+    +--------------------------+
+    | account_number_trendline |
+    |--------------------------|
+    | null                     |
+    | 4.333333333333333        |
+    | 10.666666666666666       |
+    | 16.333333333333332       |
     +--------------------------+
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/TrendlineCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/TrendlineCommandIT.java
@@ -79,61 +79,67 @@ public class TrendlineCommandIT extends PPLIntegTestCase {
   @Test
   public void testTrendlineWma() throws IOException {
     final JSONObject result =
-            executeQuery(
-                    String.format(
-                            "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
-                                    + " balance_trend | fields balance_trend",
-                            TEST_INDEX_BANK));
+        executeQuery(
+            String.format(
+                "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
+                    + " balance_trend | fields balance_trend",
+                TEST_INDEX_BANK));
     System.out.println("Result (Base): " + result.toString());
-    verifyDataRows(result, rows(new Object[] {null}), rows(45570.666666666664), rows(40101.666666666664));
+    verifyDataRows(
+        result, rows(new Object[] {null}), rows(45570.666666666664), rows(40101.666666666664));
   }
 
   @Test
   public void testTrendlineMultipleFieldsWma() throws IOException {
     final JSONObject result =
-            executeQuery(
-                    String.format(
-                            "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
-                                    + " balance_trend wma(2, account_number) as account_number_trend | fields"
-                                    + " balance_trend, account_number_trend",
-                            TEST_INDEX_BANK));
-    verifyDataRows(result, rows(null, null),
-            rows(40101.666666666664,16.999999999999996),
-            rows(45570.666666666664,29.666666666666664));
+        executeQuery(
+            String.format(
+                "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
+                    + " balance_trend wma(2, account_number) as account_number_trend | fields"
+                    + " balance_trend, account_number_trend",
+                TEST_INDEX_BANK));
+    verifyDataRows(
+        result,
+        rows(null, null),
+        rows(40101.666666666664, 16.999999999999996),
+        rows(45570.666666666664, 29.666666666666664));
   }
 
   @Test
   public void testTrendlineOverwritesExistingFieldWma() throws IOException {
     final JSONObject result =
-            executeQuery(
-                    String.format(
-                            "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
-                                    + " age | fields age",
-                            TEST_INDEX_BANK));
+        executeQuery(
+            String.format(
+                "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
+                    + " age | fields age",
+                TEST_INDEX_BANK));
     System.out.println("Result (Overwrite) : " + result.toString());
-    verifyDataRows(result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
+    verifyDataRows(
+        result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
   }
 
   @Test
   public void testTrendlineNoAliasWma() throws IOException {
     final JSONObject result =
-            executeQuery(
-                    String.format(
-                            "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) |"
-                                    + " fields balance_trendline",
-                            TEST_INDEX_BANK));
-    verifyDataRows(result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
+        executeQuery(
+            String.format(
+                "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) |"
+                    + " fields balance_trendline",
+                TEST_INDEX_BANK));
+    verifyDataRows(
+        result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
   }
 
   @Test
   public void testTrendlineWithSortWma() throws IOException {
     final JSONObject result =
-            executeQuery(
-                    String.format(
-                            "source=%s | where balance > 39000 | trendline sort balance wma(2, balance) |"
-                                    + " fields balance_trendline",
-                            TEST_INDEX_BANK));
+        executeQuery(
+            String.format(
+                "source=%s | where balance > 39000 | trendline sort balance wma(2, balance) |"
+                    + " fields balance_trendline",
+                TEST_INDEX_BANK));
     System.out.println("Result (WithSortWma): " + result.toString());
-    verifyDataRows(result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
+    verifyDataRows(
+        result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/TrendlineCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/TrendlineCommandIT.java
@@ -75,4 +75,65 @@ public class TrendlineCommandIT extends PPLIntegTestCase {
                 TEST_INDEX_BANK));
     verifyDataRows(result, rows(new Object[] {null}), rows(44313.0), rows(39882.5));
   }
+
+  @Test
+  public void testTrendlineWma() throws IOException {
+    final JSONObject result =
+            executeQuery(
+                    String.format(
+                            "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
+                                    + " balance_trend | fields balance_trend",
+                            TEST_INDEX_BANK));
+    System.out.println("Result (Base): " + result.toString());
+    verifyDataRows(result, rows(new Object[] {null}), rows(45570.666666666664), rows(40101.666666666664));
+  }
+
+  @Test
+  public void testTrendlineMultipleFieldsWma() throws IOException {
+    final JSONObject result =
+            executeQuery(
+                    String.format(
+                            "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
+                                    + " balance_trend wma(2, account_number) as account_number_trend | fields"
+                                    + " balance_trend, account_number_trend",
+                            TEST_INDEX_BANK));
+    verifyDataRows(result, rows(null, null),
+            rows(40101.666666666664,16.999999999999996),
+            rows(45570.666666666664,29.666666666666664));
+  }
+
+  @Test
+  public void testTrendlineOverwritesExistingFieldWma() throws IOException {
+    final JSONObject result =
+            executeQuery(
+                    String.format(
+                            "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) as"
+                                    + " age | fields age",
+                            TEST_INDEX_BANK));
+    System.out.println("Result (Overwrite) : " + result.toString());
+    verifyDataRows(result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
+  }
+
+  @Test
+  public void testTrendlineNoAliasWma() throws IOException {
+    final JSONObject result =
+            executeQuery(
+                    String.format(
+                            "source=%s | where balance > 39000 | sort balance | trendline wma(2, balance) |"
+                                    + " fields balance_trendline",
+                            TEST_INDEX_BANK));
+    verifyDataRows(result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
+  }
+
+  @Test
+  public void testTrendlineWithSortWma() throws IOException {
+    final JSONObject result =
+            executeQuery(
+                    String.format(
+                            "source=%s | where balance > 39000 | trendline sort balance wma(2, balance) |"
+                                    + " fields balance_trendline",
+                            TEST_INDEX_BANK));
+    System.out.println("Result (WithSortWma): " + result.toString());
+    verifyDataRows(result, rows(new Object[] {null}), rows(40101.666666666664), rows(45570.666666666664));
+  }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -60,6 +60,7 @@ NUM:                                'NUM';
 
 // TRENDLINE KEYWORDS
 SMA:                                'SMA';
+WMA:                                'WMA';
 
 // ARGUMENT KEYWORDS
 KEEPEMPTY:                          'KEEPEMPTY';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -156,6 +156,7 @@ trendlineClause
 
 trendlineType
    : SMA
+   | WMA
    ;
 
 kmeansCommand


### PR DESCRIPTION
### Description
This PR introduce a new varient (Weighted Moving Average - WMA) for existing PPL trendline command, with corresponded test-cases and documentation for usage examples.

Reference:
WMA calculation: https://corporatefinanceinstitute.com/resources/career-map/sell-side/capital-markets/weighted-moving-average-wma/
WMA implementation on Spark: https://github.com/opensearch-project/opensearch-spark/pull/872

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3011, https://github.com/opensearch-project/sql/issues/3277

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
