### PR TITLE
Build: Centralise dependencies version - Pt1

### DIFF
--- a/async-query/build.gradle
+++ b/async-query/build.gradle
@@ -28,13 +28,13 @@ dependencies {
     implementation group: 'org.json', name: 'json', version: '20231013'
     api group: 'com.amazonaws', name: 'aws-java-sdk-emr', version: "${aws_java_sdk_version}"
     api group: 'com.amazonaws', name: 'aws-java-sdk-emrserverless', version: "${aws_java_sdk_version}"
-    implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
+    implementation group: 'commons-io', name: 'commons-io', version: "${commons_io_version}"
 
     testImplementation(platform("org.junit:junit-bom:5.9.3"))
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
 
     testCompileOnly('junit:junit:4.13.1') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'

--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,9 @@ buildscript {
         getPrometheusBinaryLocation = { ->
             return "https://github.com/prometheus/prometheus/releases/download/v${prometheus_binary_version}/prometheus-${prometheus_binary_version}."+ getOSFamilyType() + "-" + getArchType() + ".tar.gz"
         }
+        // TODO: Migrate following to Gradle version catalog || Read from OpenSearch BOM in the future.
         aws_java_sdk_version = "1.12.651"
         guava_version = "32.1.3-jre"
-        // TODO: Migrate following Gradle version catalog || Read from OpenSearch BOM in the future.
         resilience4j_version = "1.5.0"
         hamcrest_version = "2.1"
         mockito_version = "5.7.0"

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,16 @@ buildscript {
         }
         aws_java_sdk_version = "1.12.651"
         guava_version = "32.1.3-jre"
+        // TODO: Migrate following Gradle version catalog || Read from OpenSearch BOM in the future.
+        resilience4j_version = "1.5.0"
+        hamcrest_version = "2.1"
+        mockito_version = "5.7.0"
+        commons_io_version = "2.14.0"
+        commons_text_version = "1.10.0"
+        commons_lang3_version = "3.12.0"
+        // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
+        commons_codec_version = "1.13"
+        commons_logging_version = "1.2"
     }
 
     repositories {
@@ -192,7 +202,7 @@ configurations.all {
     resolutionStrategy.force 'junit:junit:4.13.2'
     exclude group: "commons-logging", module: "commons-logging"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
-    resolutionStrategy.force 'commons-codec:commons-codec:1.13'
+    resolutionStrategy.force "commons-codec:commons-codec:${commons_codec_version}"
     resolutionStrategy.force "com.google.guava:guava:${guava_version}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ buildscript {
             return "https://github.com/prometheus/prometheus/releases/download/v${prometheus_binary_version}/prometheus-${prometheus_binary_version}."+ getOSFamilyType() + "-" + getArchType() + ".tar.gz"
         }
         // TODO: Migrate following to Gradle version catalog || Read from OpenSearch BOM in the future.
+        // See: https://github.com/opensearch-project/sql/issues/3257
         aws_java_sdk_version = "1.12.651"
         guava_version = "32.1.3-jre"
         resilience4j_version = "1.5.0"
@@ -58,7 +59,7 @@ buildscript {
         commons_io_version = "2.14.0"
         commons_text_version = "1.10.0"
         commons_lang3_version = "3.12.0"
-        // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
+        // enforce 1.13, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
         commons_codec_version = "1.13"
         commons_logging_version = "1.2"
     }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     api "org.antlr:antlr4-runtime:4.7.1"
     api group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     api group: 'org.apache.logging.log4j', name: 'log4j-core', version:"${versions.log4j}"
-    api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
-    api group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+    api group: 'org.apache.commons', name: 'commons-lang3', version: "${commons_lang3_version}"
+    api group: 'org.apache.commons', name: 'commons-text', version: "${commons_text_version}"
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
     implementation 'com.github.babbel:okhttp-aws-signer:1.0.2'
     api group: 'com.amazonaws', name: 'aws-java-sdk-core', version: "${aws_java_sdk_version}"
@@ -47,10 +47,10 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.9.1'
     testImplementation group: 'com.google.guava', name: 'guava', version: "${guava_version}"
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
     testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.12.0'
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -47,8 +47,8 @@ pitest {
 
 dependencies {
     api group: 'com.google.guava', name: 'guava', version: "${guava_version}"
-    api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
-    api group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+    api group: 'org.apache.commons', name: 'commons-lang3', version: "${commons_lang3_version}"
+    api group: 'org.apache.commons', name: 'commons-text', version: "${commons_text_version}"
     api group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
@@ -60,9 +60,9 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.4.2"
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
 }
 
 spotless {

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
-    implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
+    implementation group: 'commons-io', name: 'commons-io', version: "${commons_io_version}"
     // FIXME. upgrade aws-encryption-sdk-java once the bouncycastle dependency update to 1.78.
     implementation ('com.amazonaws:aws-encryption-sdk-java:2.4.1') {
         exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
@@ -33,9 +33,9 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.14.9'
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -156,9 +156,9 @@ loggerUsageCheck.enabled = false
 
 configurations.all {
     resolutionStrategy.force 'junit:junit:4.13.2'
-    resolutionStrategy.force "commons-logging:commons-logging:1.2"
+    resolutionStrategy.force "commons-logging:commons-logging:${commons_logging_version}"
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
-    resolutionStrategy.force 'commons-codec:commons-codec:1.13'
+    resolutionStrategy.force "commons-codec:commons-codec:${commons_codec_version}"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${versions.jackson}"
@@ -183,7 +183,7 @@ dependencies {
     testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
     testImplementation group: 'org.opensearch.driver', name: 'opensearch-sql-jdbc', version: System.getProperty("jdbcDriverVersion", '1.2.0.0')
-    testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest', version: "${hamcrest_version}"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:"${versions.log4j}"
     testImplementation project(':opensearch-sql-plugin')
     testImplementation project(':legacy')

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -103,14 +103,14 @@ dependencies {
     implementation group: "org.opensearch.plugin", name: 'parent-join-client', version: "${opensearch_version}"
     implementation group: "org.opensearch.plugin", name: 'reindex-client', version: "${opensearch_version}"
     constraints {
-        implementation('commons-codec:commons-codec:1.13') {
+        implementation("commons-codec:commons-codec:${commons_codec_version}") {
             because 'https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379'
         }
     }
     implementation group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     implementation group: 'org.json', name: 'json', version:'20231013'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${commons_lang3_version}"
+    implementation group: 'org.apache.commons', name: 'commons-text', version: "${commons_text_version}"
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     // add geo module as dependency. https://github.com/opensearch-project/OpenSearch/pull/4180/.
     implementation group: 'org.opensearch.plugin', name: 'geo', version: "${opensearch_version}"
@@ -124,7 +124,7 @@ dependencies {
     compileOnly group: 'javax.servlet', name: 'servlet-api', version:'2.5'
 
     testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version:'2.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 
 }

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -33,7 +33,7 @@ plugins {
 dependencies {
     api project(':core')
     api group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
-    implementation "io.github.resilience4j:resilience4j-retry:1.5.0"
+    implementation "io.github.resilience4j:resilience4j-retry:${resilience4j_version}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
@@ -47,9 +47,9 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.9.3')
     testRuntimeOnly('org.junit.platform:junit-platform-launcher:1.9.3')
 
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
     testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     testImplementation group: 'org.opensearch.test', name: 'framework', version: "${opensearch_version}"
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -96,11 +96,10 @@ thirdPartyAudit.enabled = false
 
 configurations.all {
     // conflict with spring-jcl
-    resolutionStrategy.force "commons-logging:commons-logging:1.2"
+    resolutionStrategy.force "commons-logging:commons-logging:${commons_logging_version}"
     // enforce 2.12.6, https://github.com/opensearch-project/sql/issues/424
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-    // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
-    resolutionStrategy.force 'commons-codec:commons-codec:1.13'
+    resolutionStrategy.force "commons-codec:commons-codec:${commons_codec_version}"
     resolutionStrategy.force "com.google.guava:guava:${guava_version}"
     resolutionStrategy.force 'com.google.guava:failureaccess:1.0.2'
     resolutionStrategy.force "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
@@ -165,7 +164,7 @@ dependencies {
     api project(':async-query')
 
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.14.9'
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "${versions.mockito}"
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${versions.mockito}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -56,8 +56,8 @@ dependencies {
     api project(':protocol')
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
     testImplementation(testFixtures(project(":core")))
 }
 

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -18,16 +18,16 @@ dependencies {
     implementation project(':datasources')
 
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
-    implementation "io.github.resilience4j:resilience4j-retry:1.5.0"
+    implementation "io.github.resilience4j:resilience4j-retry:${resilience4j_version}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
     implementation group: 'org.json', name: 'json', version: '20231013'
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
     testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '4.12.0'
 }
 

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     implementation project(':opensearch')
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
 }
 
 configurations.all {

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -21,13 +21,13 @@ dependencies {
     implementation group: 'org.json', name: 'json', version: '20231013'
     api group: 'com.amazonaws', name: 'aws-java-sdk-emr', version: "${aws_java_sdk_version}"
     api group: 'com.amazonaws', name: 'aws-java-sdk-emrserverless', version: "${aws_java_sdk_version}"
-    implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
+    implementation group: 'commons-io', name: 'commons-io', version: "${commons_io_version}"
 
     testImplementation(platform("org.junit:junit-bom:5.9.3"))
 
     testCompileOnly('org.junit.jupiter:junit-jupiter')
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine") {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     api project(':protocol')
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.7.0'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.7.0'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
     testImplementation(testFixtures(project(":core")))
 }
 


### PR DESCRIPTION
### Description
This PR aims to centralise certain dependencies which are commonly used across the project, and also **serve as a perquisites to eventually migrate all versions declaration to Gradle version catalog**, in order to avoid version conflict in the future, as the project codebase grows. 

NO breaking change would be expected, as there is NO version upgrade || downgrade happen on any of the dependencies at this point. 


### Related Issues
Related to: https://github.com/opensearch-project/sql/issues/3257

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
