### PR TITLE
Add other functions to SQL query validator

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/FunctionType.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/FunctionType.java
@@ -32,7 +32,7 @@ public enum FunctionType {
   CSV("CSV"),
   MISC("Misc"),
   GENERATOR("Generator"),
-  UNCATEGORIZED("Uncategorized"),
+  OTHER("Other"),
   UDF("User Defined Function");
 
   private final String name;
@@ -424,7 +424,7 @@ public enum FunctionType {
                   "posexplode_outer",
                   "stack"))
           .put(
-              UNCATEGORIZED,
+              OTHER,
               Set.of(
                   "aggregate",
                   "array_size",

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/FunctionType.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/FunctionType.java
@@ -32,6 +32,7 @@ public enum FunctionType {
   CSV("CSV"),
   MISC("Misc"),
   GENERATOR("Generator"),
+  UNCATEGORIZED("Uncategorized"),
   UDF("User Defined Function");
 
   private final String name;
@@ -422,6 +423,51 @@ public enum FunctionType {
                   "posexplode",
                   "posexplode_outer",
                   "stack"))
+          .put(
+              UNCATEGORIZED,
+              Set.of(
+                  "aggregate",
+                  "array_size",
+                  "array_sort",
+                  "cardinality",
+                  "crc32",
+                  "exists",
+                  "filter",
+                  "forall",
+                  "hash",
+                  "ilike",
+                  "in",
+                  "like",
+                  "map_filter",
+                  "map_zip_with",
+                  "md5",
+                  "mod",
+                  "named_struct",
+                  "parse_url",
+                  "raise_error",
+                  "reduce",
+                  "reverse",
+                  "sha",
+                  "sha1",
+                  "sha2",
+                  "size",
+                  "struct",
+                  "transform",
+                  "transform_keys",
+                  "transform_values",
+                  "url_decode",
+                  "url_encode",
+                  "xpath",
+                  "xpath_boolean",
+                  "xpath_double",
+                  "xpath_float",
+                  "xpath_int",
+                  "xpath_long",
+                  "xpath_number",
+                  "xpath_short",
+                  "xpath_string",
+                  "xxhash64",
+                  "zip_with"))
           .build();
 
   private static final Map<String, FunctionType> FUNCTION_NAME_TO_FUNCTION_TYPE_MAP =

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLGrammarElement.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLGrammarElement.java
@@ -78,7 +78,7 @@ public enum SQLGrammarElement implements GrammarElement {
   CSV_FUNCTIONS("CSV functions"),
   GENERATOR_FUNCTIONS("Generator functions"),
   MISC_FUNCTIONS("Misc functions"),
-  UNCATEGORIZED_FUNCTIONS("Uncategorized functions"),
+  OTHER_FUNCTIONS("Other functions"),
 
   // UDF
   UDF("User Defined functions");

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLGrammarElement.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLGrammarElement.java
@@ -78,6 +78,7 @@ public enum SQLGrammarElement implements GrammarElement {
   CSV_FUNCTIONS("CSV functions"),
   GENERATOR_FUNCTIONS("Generator functions"),
   MISC_FUNCTIONS("Misc functions"),
+  UNCATEGORIZED_FUNCTIONS("Uncategorized functions"),
 
   // UDF
   UDF("User Defined functions");

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidationVisitor.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidationVisitor.java
@@ -560,30 +560,30 @@ public class SQLQueryValidationVisitor extends SqlBaseParserBaseVisitor<Void> {
     return super.visitFunctionName(ctx);
   }
 
-  private void validateFunctionAllowed(String function) {
-    String functionLower = function.toLowerCase();
-    FunctionType type = FunctionType.fromFunctionName(functionLower);
+  private void validateFunctionAllowed(String functionName) {
+    String lowerCaseFunctionName = functionName.toLowerCase();
+    FunctionType type = FunctionType.fromFunctionName(lowerCaseFunctionName);
     switch (type) {
       case MAP:
-        validateAllowed(SQLGrammarElement.MAP_FUNCTIONS, functionLower);
+        validateAllowed(SQLGrammarElement.MAP_FUNCTIONS, lowerCaseFunctionName);
         break;
       case BITWISE:
-        validateAllowed(SQLGrammarElement.BITWISE_FUNCTIONS, functionLower);
+        validateAllowed(SQLGrammarElement.BITWISE_FUNCTIONS, lowerCaseFunctionName);
         break;
       case CSV:
-        validateAllowed(SQLGrammarElement.CSV_FUNCTIONS, functionLower);
+        validateAllowed(SQLGrammarElement.CSV_FUNCTIONS, lowerCaseFunctionName);
         break;
       case MISC:
-        validateAllowed(SQLGrammarElement.MISC_FUNCTIONS, functionLower);
+        validateAllowed(SQLGrammarElement.MISC_FUNCTIONS, lowerCaseFunctionName);
         break;
       case GENERATOR:
-        validateAllowed(SQLGrammarElement.GENERATOR_FUNCTIONS, functionLower);
+        validateAllowed(SQLGrammarElement.GENERATOR_FUNCTIONS, lowerCaseFunctionName);
         break;
       case UNCATEGORIZED:
-        validateAllowed(SQLGrammarElement.UNCATEGORIZED_FUNCTIONS, functionLower);
+        validateAllowed(SQLGrammarElement.UNCATEGORIZED_FUNCTIONS, lowerCaseFunctionName);
         break;
       case UDF:
-        validateAllowed(SQLGrammarElement.UDF, functionLower);
+        validateAllowed(SQLGrammarElement.UDF, lowerCaseFunctionName);
         break;
     }
   }

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidationVisitor.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidationVisitor.java
@@ -561,25 +561,29 @@ public class SQLQueryValidationVisitor extends SqlBaseParserBaseVisitor<Void> {
   }
 
   private void validateFunctionAllowed(String function) {
-    FunctionType type = FunctionType.fromFunctionName(function.toLowerCase());
+    String functionLower = function.toLowerCase();
+    FunctionType type = FunctionType.fromFunctionName(functionLower);
     switch (type) {
       case MAP:
-        validateAllowed(SQLGrammarElement.MAP_FUNCTIONS);
+        validateAllowed(SQLGrammarElement.MAP_FUNCTIONS, functionLower);
         break;
       case BITWISE:
-        validateAllowed(SQLGrammarElement.BITWISE_FUNCTIONS);
+        validateAllowed(SQLGrammarElement.BITWISE_FUNCTIONS, functionLower);
         break;
       case CSV:
-        validateAllowed(SQLGrammarElement.CSV_FUNCTIONS);
+        validateAllowed(SQLGrammarElement.CSV_FUNCTIONS, functionLower);
         break;
       case MISC:
-        validateAllowed(SQLGrammarElement.MISC_FUNCTIONS);
+        validateAllowed(SQLGrammarElement.MISC_FUNCTIONS, functionLower);
         break;
       case GENERATOR:
-        validateAllowed(SQLGrammarElement.GENERATOR_FUNCTIONS);
+        validateAllowed(SQLGrammarElement.GENERATOR_FUNCTIONS, functionLower);
+        break;
+      case UNCATEGORIZED:
+        validateAllowed(SQLGrammarElement.UNCATEGORIZED_FUNCTIONS, functionLower);
         break;
       case UDF:
-        validateAllowed(SQLGrammarElement.UDF);
+        validateAllowed(SQLGrammarElement.UDF, functionLower);
         break;
     }
   }
@@ -587,6 +591,12 @@ public class SQLQueryValidationVisitor extends SqlBaseParserBaseVisitor<Void> {
   private void validateAllowed(SQLGrammarElement element) {
     if (!grammarElementValidator.isValid(element)) {
       throw new IllegalArgumentException(element + " is not allowed.");
+    }
+  }
+
+  private void validateAllowed(SQLGrammarElement element, String detail) {
+    if (!grammarElementValidator.isValid(element)) {
+      throw new IllegalArgumentException(String.format("%s (%s) is not allowed.", element, detail));
     }
   }
 

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidationVisitor.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/validator/SQLQueryValidationVisitor.java
@@ -579,8 +579,8 @@ public class SQLQueryValidationVisitor extends SqlBaseParserBaseVisitor<Void> {
       case GENERATOR:
         validateAllowed(SQLGrammarElement.GENERATOR_FUNCTIONS, lowerCaseFunctionName);
         break;
-      case UNCATEGORIZED:
-        validateAllowed(SQLGrammarElement.UNCATEGORIZED_FUNCTIONS, lowerCaseFunctionName);
+      case OTHER:
+        validateAllowed(SQLGrammarElement.OTHER_FUNCTIONS, lowerCaseFunctionName);
         break;
       case UDF:
         validateAllowed(SQLGrammarElement.UDF, lowerCaseFunctionName);

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
@@ -140,7 +140,7 @@ public class SQLQueryUtilsTest {
           + " WHERE elb_status_code = 500 "
           + " WITH (auto_refresh = true)",
       "DROP SKIPPING INDEX ON myS3.default.alb_logs",
-      "ALTER SKIPPING INDEX ON myS3.default.alb_logs WITH (auto_refresh = false)",
+      "ALTER SKIPPING INDEX ON myS3.default.alb_logs WITH (auto_refresh = false)"
     };
 
     for (String query : createSkippingIndexQueries) {

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/validator/FunctionTypeTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/validator/FunctionTypeTest.java
@@ -42,6 +42,8 @@ class FunctionTypeTest {
     assertEquals(FunctionType.MISC, FunctionType.fromFunctionName("version"));
     assertEquals(FunctionType.GENERATOR, FunctionType.fromFunctionName("explode"));
     assertEquals(FunctionType.GENERATOR, FunctionType.fromFunctionName("stack"));
+    assertEquals(FunctionType.UNCATEGORIZED, FunctionType.fromFunctionName("aggregate"));
+    assertEquals(FunctionType.UNCATEGORIZED, FunctionType.fromFunctionName("forall"));
     assertEquals(FunctionType.UDF, FunctionType.fromFunctionName("unknown"));
   }
 }

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/validator/FunctionTypeTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/validator/FunctionTypeTest.java
@@ -42,8 +42,8 @@ class FunctionTypeTest {
     assertEquals(FunctionType.MISC, FunctionType.fromFunctionName("version"));
     assertEquals(FunctionType.GENERATOR, FunctionType.fromFunctionName("explode"));
     assertEquals(FunctionType.GENERATOR, FunctionType.fromFunctionName("stack"));
-    assertEquals(FunctionType.UNCATEGORIZED, FunctionType.fromFunctionName("aggregate"));
-    assertEquals(FunctionType.UNCATEGORIZED, FunctionType.fromFunctionName("forall"));
+    assertEquals(FunctionType.OTHER, FunctionType.fromFunctionName("aggregate"));
+    assertEquals(FunctionType.OTHER, FunctionType.fromFunctionName("forall"));
     assertEquals(FunctionType.UDF, FunctionType.fromFunctionName("unknown"));
   }
 }

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/validator/SQLQueryValidatorTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/validator/SQLQueryValidatorTest.java
@@ -193,7 +193,7 @@ class SQLQueryValidatorTest {
     // Generator Functions
     GENERATOR_FUNCTIONS("SELECT explode(array(1, 2, 3));"),
 
-    // Ucategorized functions
+    // Other functions
     NAMED_STRUCT("SELECT named_struct('a', 1);"),
     PARSE_URL("SELECT parse_url(url) FROM my_table;"),
 
@@ -328,7 +328,7 @@ class SQLQueryValidatorTest {
     // Generator Functions
     v.ng(TestElement.GENERATOR_FUNCTIONS);
 
-    // Uncategorized Functions
+    // Other Functions
     v.ng(TestElement.NAMED_STRUCT);
     v.ng(TestElement.PARSE_URL);
 
@@ -449,7 +449,7 @@ class SQLQueryValidatorTest {
     // Generator Functions
     v.ok(TestElement.GENERATOR_FUNCTIONS);
 
-    // Uncategorized Functions
+    // Other Functions
     v.ok(TestElement.NAMED_STRUCT);
     v.ok(TestElement.PARSE_URL);
 
@@ -639,7 +639,7 @@ class SQLQueryValidatorTest {
     when(mockedProvider.getValidatorForDatasource(any())).thenReturn(element -> false);
     VerifyValidator v = new VerifyValidator(sqlQueryValidator, DataSourceType.S3GLUE);
 
-    v.ng("SELECT named_struct('a', 1);", "Uncategorized functions (named_struct) is not allowed.");
+    v.ng("SELECT named_struct('a', 1);", "Other functions (named_struct) is not allowed.");
   }
 
   @AllArgsConstructor


### PR DESCRIPTION
### Description
- Add other(uncategorized) functions to SQL query validator
- Those functions were originally not covered since it was not listed in [categorized list](https://spark.apache.org/docs/3.5.3/sql-ref-functions.html) , but actually documented in [full list](https://spark.apache.org/docs/3.5.3/api/sql/).

### Related Issues
Resolves #3237

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
