### PR TITLE
Fix CalcitePPLJoinIT

### DIFF
--- a/integ-test/src/test/resources/indexDefinitions/occupation_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/occupation_index_mapping.json
@@ -5,7 +5,7 @@
         "type": "keyword"
       },
       "occupation": {
-        "type": "text"
+        "type": "keyword"
       },
       "country": {
         "type": "text"

--- a/integ-test/src/test/resources/indexDefinitions/state_country_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/state_country_index_mapping.json
@@ -17,7 +17,7 @@
         }
       },
       "country": {
-        "type": "text"
+        "type": "keyword"
       },
       "year": {
         "type": "integer"

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -41,6 +41,7 @@ import static org.opensearch.index.query.QueryBuilders.termsQuery;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Range;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -897,15 +898,15 @@ public class PredicateAnalyzer {
 
     @Override
     public QueryExpression in(LiteralExpression literal) {
-      Iterable<?> iterable = (Iterable<?>) literal.value();
-      builder = termsQuery(getFieldReference(), iterable);
+      Collection<?> collection = (Collection<?>) literal.value();
+      builder = termsQuery(getFieldReference(), collection);
       return this;
     }
 
     @Override
     public QueryExpression notIn(LiteralExpression literal) {
-      Iterable<?> iterable = (Iterable<?>) literal.value();
-      builder = boolQuery().mustNot(termsQuery(getFieldReference(), iterable));
+      Collection<?> collection = (Collection<?>) literal.value();
+      builder = boolQuery().mustNot(termsQuery(getFieldReference(), collection));
       return this;
     }
   }


### PR DESCRIPTION
### Description
This PR includes 2 changes:
1. Fix PredicateAnalyzer for in and notIn, it build the DSL query with redundant brackets because of calling wrong API.
2. For the tables used in this IT, change some fields from text type to keyword type as we don't support text push down for now. Issue https://github.com/opensearch-project/sql/issues/3334 will fix it.


`./gradlew :integ-test:integTest --tests '*Calcite*IT'` succeed locally except below 3 tests. They failed because of inconsistent order on the final results while it should not promise that order. Need another PR to fix the test themself.
- CalcitePPLJoinIT.testJoinTwoColumnsAndDisjointFilters
- CalcitePPLJoinIT.testJoinWithCondition
- CalcitePPLJoinIT.testJoinWithTwoJoinConditions

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3368

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
