### PR TITLE
[BugFix] support push down text field correctly.

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSortCommandIT.java
@@ -9,12 +9,6 @@ import java.io.IOException;
 import org.junit.Ignore;
 import org.opensearch.sql.ppl.SortCommandIT;
 
-/**
- * TODO there seems a bug in Calcite planner with sort. Fix {@link
- * org.opensearch.sql.calcite.standalone.CalcitePPLSortIT} first. then enable this IT and remove
- * this java doc.
- */
-@Ignore
 public class CalciteSortCommandIT extends SortCommandIT {
   @Override
   public void init() throws IOException {
@@ -22,4 +16,10 @@ public class CalciteSortCommandIT extends SortCommandIT {
     disallowCalciteFallback();
     super.init();
   }
+
+  // TODO: Unsupported conversion for OpenSearch Data type: IP, addressed by issue:
+  // https://github.com/opensearch-project/sql/issues/3322
+  @Ignore
+  @Override
+  public void testSortIpField() throws IOException {}
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSortCommandIT.java
@@ -22,4 +22,10 @@ public class CalciteSortCommandIT extends SortCommandIT {
   @Ignore
   @Override
   public void testSortIpField() throws IOException {}
+
+  // TODO: Fix incorrect results for NULL values, addressed by issue:
+  // https://github.com/opensearch-project/sql/issues/3375
+  @Ignore
+  @Override
+  public void testSortWithNullValue() throws IOException {}
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
@@ -84,6 +84,27 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
   }
 
   @Test
+  public void testFilterOnTextField() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where gender = 'F' | fields firstname, lastname", TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("lastname", "string"));
+    verifyDataRows(
+        actual, rows("Nanette", "Bates"), rows("Virginia", "Ayala"), rows("Dillard", "Mcpherson"));
+  }
+
+  @Test
+  public void testFilterOnTextFieldWithKeywordSubField() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where state = 'VA' | fields firstname, lastname", TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("lastname", "string"));
+    verifyDataRows(actual, rows("Nanette", "Bates"));
+  }
+
+  @Test
   public void testFilterQueryWithOr() {
     JSONObject actual =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLInSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLInSubqueryIT.java
@@ -30,8 +30,7 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
     loadIndex(Index.OCCUPATION);
   }
 
-  // TODO https://github.com/opensearch-project/sql/issues/3373
-  @Ignore
+  @Test
   public void testSelfInSubquery() {
     JSONObject result =
         executeQuery(
@@ -349,8 +348,7 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                     TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION)));
   }
 
-  // TODO https://github.com/opensearch-project/sql/issues/3373
-  @Ignore
+  @Test
   public void testInSubqueryWithTableAlias() {
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/resources/indexDefinitions/occupation_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/occupation_index_mapping.json
@@ -5,7 +5,7 @@
         "type": "keyword"
       },
       "occupation": {
-        "type": "keyword"
+        "type": "text"
       },
       "country": {
         "type": "text"

--- a/integ-test/src/test/resources/indexDefinitions/state_country_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/state_country_index_mapping.json
@@ -17,7 +17,7 @@
         }
       },
       "country": {
-        "type": "keyword"
+        "type": "text"
       },
       "year": {
         "type": "integer"

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -778,6 +778,10 @@ public class PredicateAnalyzer {
       return rel.getReference();
     }
 
+    private String getFieldReferenceForTermQuery() {
+      return rel.getReferenceForTermQuery();
+    }
+
     private SimpleQueryExpression(NamedFieldExpression rel) {
       this.rel = rel;
     }
@@ -841,7 +845,7 @@ public class PredicateAnalyzer {
                 .must(addFormatIfNecessary(literal, rangeQuery(getFieldReference()).gte(value)))
                 .must(addFormatIfNecessary(literal, rangeQuery(getFieldReference()).lte(value)));
       } else {
-        builder = termQuery(getFieldReference(), value);
+        builder = termQuery(getFieldReferenceForTermQuery(), value);
       }
       return this;
     }
@@ -859,7 +863,7 @@ public class PredicateAnalyzer {
             boolQuery()
                 // NOT LIKE should return false when field is NULL
                 .must(existsQuery(getFieldReference()))
-                .mustNot(termQuery(getFieldReference(), value));
+                .mustNot(termQuery(getFieldReferenceForTermQuery(), value));
       }
       return this;
     }
@@ -899,21 +903,21 @@ public class PredicateAnalyzer {
 
     @Override
     public QueryExpression isTrue() {
-      builder = termQuery(getFieldReference(), true);
+      builder = termQuery(getFieldReferenceForTermQuery(), true);
       return this;
     }
 
     @Override
     public QueryExpression in(LiteralExpression literal) {
       Collection<?> collection = (Collection<?>) literal.value();
-      builder = termsQuery(getFieldReference(), collection);
+      builder = termsQuery(getFieldReferenceForTermQuery(), collection);
       return this;
     }
 
     @Override
     public QueryExpression notIn(LiteralExpression literal) {
       Collection<?> collection = (Collection<?>) literal.value();
-      builder = boolQuery().mustNot(termsQuery(getFieldReference(), collection));
+      builder = boolQuery().mustNot(termsQuery(getFieldReferenceForTermQuery(), collection));
       return this;
     }
   }
@@ -1018,6 +1022,10 @@ public class PredicateAnalyzer {
     }
 
     String getReference() {
+      return getRootName();
+    }
+
+    String getReferenceForTermQuery() {
       if (isTextType()) {
         return toKeywordSubField();
       }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1005,7 +1005,7 @@ public class PredicateAnalyzer {
     }
 
     String toKeywordSubField() {
-      if (isTextType()) {
+      if (type instanceof OpenSearchTextType) {
         OpenSearchTextType textType = (OpenSearchTextType) type;
         // Find the first subfield with type keyword, return null if non-exist.
         return textType.getFields().entrySet().stream()

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteOpenSearchIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteOpenSearchIndexScan.java
@@ -9,6 +9,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayDeque;
 import java.util.List;
+import java.util.Map;
 import org.apache.calcite.adapter.enumerable.EnumerableRelImplementor;
 import org.apache.calcite.adapter.enumerable.PhysType;
 import org.apache.calcite.adapter.enumerable.PhysTypeImpl;
@@ -35,6 +36,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.sql.calcite.plan.OpenSearchTableScan;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.planner.physical.OpenSearchIndexRules;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.opensearch.request.PredicateAnalyzer;
@@ -153,7 +155,9 @@ public class CalciteOpenSearchIndexScan extends OpenSearchTableScan {
     try {
       CalciteOpenSearchIndexScan newScan = this.copyWithNewSchema(filter.getRowType());
       List<String> schema = this.getRowType().getFieldNames();
-      QueryBuilder filterBuilder = PredicateAnalyzer.analyze(filter.getCondition(), schema);
+      Map<String, OpenSearchDataType> typeMapping = this.osIndex.getFieldOpenSearchTypes();
+      QueryBuilder filterBuilder =
+          PredicateAnalyzer.analyze(filter.getCondition(), schema, typeMapping);
       newScan.pushDownContext.add(
           PushDownAction.of(
               PushDownType.FILTER,


### PR DESCRIPTION
### Description
When pushing filter with text field, I should construct QueryBuilder by using its subfield of keyword type; Otherwise, we cannot push down this field.

This PR includes change:
1. In PredicateAnalyzer, using keyword subfield as the reference for NamedFieldExpression if it's type is text type. It will return null if no such keyword subfield and throw PredicateAnalyzerException, and then scan won't really do filter push down later.
2. remove the @Ignore annotation for `CalciteSortCommandIT` since we already addressed the issue of order perseverance for PPL in this PR: https://github.com/opensearch-project/sql/pull/3350.

`./gradlew :integ-test:integTest --tests '*Calcite*IT'` succeed locally.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3334, https://github.com/opensearch-project/sql/issues/3373

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
