### PR TITLE
[BugFix] Fix the join condition resolving bug introduced by IN subquery implementation

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -10,6 +10,7 @@ import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.TYPE_FACTOR
 import java.sql.Connection;
 import java.util.function.BiFunction;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.RelBuilder;
@@ -23,7 +24,7 @@ public class CalcitePlanContext {
   public final RelBuilder relBuilder;
   public final ExtendedRexBuilder rexBuilder;
 
-  @Getter private boolean isResolvingJoinCondition = false;
+  @Getter @Setter private boolean isResolvingJoinCondition = false;
 
   private CalcitePlanContext(FrameworkConfig config) {
     this.config = config;


### PR DESCRIPTION
### Description
Fix the join condition resolving bug introduced by IN subquery implementation
`CalcitePPLJoinTest.testJoinConditionWithoutTableName()` failed after merged #3371 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
