### PR TITLE
Implement ppl relation subquery command with Calcite

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSortCommandIT.java
@@ -22,10 +22,4 @@ public class CalciteSortCommandIT extends SortCommandIT {
   @Ignore
   @Override
   public void testSortIpField() throws IOException {}
-
-  // TODO: Fix incorrect results for NULL values, addressed by issue:
-  // https://github.com/opensearch-project/sql/issues/3375
-  @Ignore
-  @Override
-  public void testSortWithNullValue() throws IOException {}
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLSortIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLSortIT.java
@@ -6,9 +6,11 @@
 package org.opensearch.sql.calcite.standalone;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyOrder;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
@@ -22,6 +24,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
     super.init();
 
     loadIndex(Index.BANK);
+    loadIndex(Index.BANK_WITH_NULL_VALUES);
   }
 
   @Test
@@ -190,5 +193,23 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
         rows("Dale", 33),
         rows("Amber JOHnny", 32),
         rows("Nanette", 28));
+  }
+
+  @Test
+  public void testSortWithNullValue() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort balance | fields firstname, balance",
+                TEST_INDEX_BANK_WITH_NULL_VALUES));
+    verifyOrder(
+        result,
+        rows("Dale", 4180),
+        rows("Nanette", 32838),
+        rows("Amber JOHnny", 39225),
+        rows("Dillard", 48086),
+        rows("Hattie", null),
+        rows("Elinor", null),
+        rows("Virginia", null));
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteOpenSearchIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteOpenSearchIndexScan.java
@@ -167,7 +167,7 @@ public class CalciteOpenSearchIndexScan extends OpenSearchTableScan {
       // TODO: handle the case where condition contains a score function
       return newScan;
     } catch (Exception e) {
-      LOG.warn("Cannot analyze the filter condition {}", filter.getCondition(), e);
+      LOG.warn("Cannot pushdown the filter condition {}, ", filter.getCondition());
     }
     return null;
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/util/JdbcOpenSearchDataTypeConvertor.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/util/JdbcOpenSearchDataTypeConvertor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.opensearch.util;
 
+import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -58,55 +59,67 @@ public class JdbcOpenSearchDataTypeConvertor {
 
   public static ExprValue getExprValueFromSqlType(
       ResultSet rs, int i, int sqlType, RelDataType fieldType) throws SQLException {
-    Object value;
-    switch (sqlType) {
-      case Types.VARCHAR:
-      case Types.CHAR:
-      case Types.LONGVARCHAR:
-        value = rs.getString(i);
-        break;
-      case Types.INTEGER:
-        value = rs.getInt(i);
-        break;
-      case Types.BIGINT:
-        value = rs.getLong(i);
-        break;
-      case Types.DECIMAL:
-      case Types.NUMERIC:
-        value = rs.getBigDecimal(i);
-        break;
-      case Types.DOUBLE:
-        value = rs.getDouble(i);
-        break;
-      case Types.FLOAT:
-        value = rs.getFloat(i);
-        break;
-      case Types.DATE:
-        value = rs.getString(i);
-        return value == null ? ExprNullValue.of() : new ExprDateValue((String) value);
-      case Types.TIME:
-        value = rs.getString(i);
-        return value == null ? ExprNullValue.of() : new ExprTimeValue((String) value);
-      case Types.TIMESTAMP:
-        value = rs.getString(i);
-        return value == null ? ExprNullValue.of() : new ExprTimestampValue((String) value);
-      case Types.BOOLEAN:
-        value = rs.getBoolean(i);
-        break;
-      case Types.ARRAY:
-        value = rs.getArray(i);
-        // For calcite
-        if (value instanceof ArrayImpl) {
-          value = Arrays.asList((Object[]) ((ArrayImpl) value).getArray());
-        }
-        break;
-      default:
-        value = rs.getObject(i);
-        LOG.warn(
-            "Unchecked sql type: {}, return Object type {}",
-            sqlType,
-            value.getClass().getTypeName());
+    Object value = rs.getObject(i);
+    if (value == null) {
+      return ExprNullValue.of();
     }
-    return value == null ? ExprNullValue.of() : ExprValueUtils.fromObjectValue(value);
+
+    try {
+      switch (sqlType) {
+        case Types.VARCHAR:
+        case Types.CHAR:
+        case Types.LONGVARCHAR:
+          return ExprValueUtils.fromObjectValue(rs.getString(i));
+
+        case Types.INTEGER:
+          return ExprValueUtils.fromObjectValue(rs.getInt(i));
+
+        case Types.BIGINT:
+          return ExprValueUtils.fromObjectValue(rs.getLong(i));
+
+        case Types.DECIMAL:
+        case Types.NUMERIC:
+          return ExprValueUtils.fromObjectValue(rs.getBigDecimal(i));
+
+        case Types.DOUBLE:
+          return ExprValueUtils.fromObjectValue(rs.getDouble(i));
+
+        case Types.FLOAT:
+          return ExprValueUtils.fromObjectValue(rs.getFloat(i));
+
+        case Types.DATE:
+          String dateStr = rs.getString(i);
+          return new ExprDateValue(dateStr);
+
+        case Types.TIME:
+          String timeStr = rs.getString(i);
+          return new ExprTimeValue(timeStr);
+
+        case Types.TIMESTAMP:
+          String timestampStr = rs.getString(i);
+          return new ExprTimestampValue(timestampStr);
+
+        case Types.BOOLEAN:
+          return ExprValueUtils.fromObjectValue(rs.getBoolean(i));
+
+        case Types.ARRAY:
+          Array array = rs.getArray(i);
+          if (array instanceof ArrayImpl) {
+            return ExprValueUtils.fromObjectValue(
+                Arrays.asList((Object[]) ((ArrayImpl) value).getArray()));
+          }
+          return ExprValueUtils.fromObjectValue(array);
+
+        default:
+          LOG.warn(
+              "Unchecked sql type: {}, return Object type {}",
+              sqlType,
+              value.getClass().getTypeName());
+          return ExprValueUtils.fromObjectValue(value);
+      }
+    } catch (SQLException e) {
+      LOG.error("Error converting SQL type {}: {}", sqlType, e.getMessage());
+      throw e;
+    }
   }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -202,10 +202,15 @@ mlArg
 
 // clauses
 fromClause
-   : SOURCE EQUAL tableSourceClause
-   | INDEX EQUAL tableSourceClause
+   : SOURCE EQUAL tableOrSubqueryClause
+   | INDEX EQUAL tableOrSubqueryClause
    | SOURCE EQUAL tableFunction
    | INDEX EQUAL tableFunction
+   ;
+
+tableOrSubqueryClause
+   : LT_SQR_PRTHS subSearch RT_SQR_PRTHS (AS alias = qualifiedName)?
+   | tableSourceClause
    ;
 
 tableSourceClause
@@ -214,7 +219,7 @@ tableSourceClause
 
 // join
 joinCommand
-   : (joinType) JOIN sideAlias joinHintList? joinCriteria? right = tableSourceClause
+   : (joinType) JOIN sideAlias joinHintList? joinCriteria? right = tableOrSubqueryClause
    ;
 
 joinType

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
@@ -407,4 +407,233 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + "INNER JOIN `scott`.`EMP` `EMP0` ON `EMP`.`DEPTNO` = `EMP0`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
+
+  // +-----------------------------+
+  // | join with relation subquery |
+  // +-----------------------------+
+
+  @Test
+  public void testJoinWithRelationSubquery() {
+    String ppl =
+        """
+        source=EMP | join left = t1 right = t2 ON t1.DEPTNO = t2.DEPTNO
+          [
+            source = DEPT
+            | where DEPTNO > 10 and LOC = 'CHICAGO'
+            | fields DEPTNO, DNAME
+            | sort - DEPTNO
+            | head 10
+          ]
+        | stats count(MGR) as cnt by JOB
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{2}], cnt=[COUNT($3)])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalSort(sort0=[$0], dir0=[DESC], fetch=[10])\n"
+            + "      LogicalProject(DEPTNO=[$0], DNAME=[$1])\n"
+            + "        LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO'))])\n"
+            + "          LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        "" + "JOB=SALESMAN; cnt=4\n" + "JOB=CLERK; cnt=1\n" + "JOB=MANAGER; cnt=1\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMP`.`JOB`, COUNT(`EMP`.`MGR`) `cnt`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN (SELECT `DEPTNO`, `DNAME`\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO'\n"
+            + "ORDER BY `DEPTNO` DESC NULLS FIRST\n"
+            + "LIMIT 10) `t1` ON `EMP`.`DEPTNO` = `t1`.`DEPTNO`\n"
+            + "GROUP BY `EMP`.`JOB`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMultipleJoinsWithRelationSubquery() {
+    String ppl =
+        """
+        source=EMP
+        | head 10
+        | inner join left = l right = r ON l.DEPTNO = r.DEPTNO
+          [
+            source = DEPT
+            | where DEPTNO > 10 and LOC = 'CHICAGO'
+          ]
+        | left join left = l right = r ON l.JOB = r.JOB
+          [
+            source = BONUS
+            | where JOB = 'SALESMAN'
+          ]
+        | cross join left = l right = r
+          [
+            source = SALGRADE
+            | where LOSAL <= 1500
+            | sort - GRADE
+          ]
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[true], joinType=[inner])\n"
+            + "  LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
+            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "      LogicalSort(fetch=[10])\n"
+            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO'))])\n"
+            + "        LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "    LogicalFilter(condition=[=($1, 'SALESMAN')])\n"
+            + "      LogicalTableScan(table=[[scott, BONUS]])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[<=($1, 1500)])\n"
+            + "      LogicalTableScan(table=[[scott, SALGRADE]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 15);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 10) `t`\n"
+            + "INNER JOIN (SELECT *\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`\n"
+            + "LEFT JOIN (SELECT *\n"
+            + "FROM `scott`.`BONUS`\n"
+            + "WHERE `JOB` = 'SALESMAN') `t1` ON `t`.`JOB` = `t1`.`JOB`\n"
+            + "CROSS JOIN (SELECT `GRADE`, `LOSAL`, `HISAL`\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `LOSAL` <= 1500\n"
+            + "ORDER BY `GRADE` DESC NULLS FIRST) `t3`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMultipleJoinsWithRelationSubqueryWithAlias() {
+    String ppl =
+        """
+        source=EMP as t1
+        | head 10
+        | inner join ON t1.DEPTNO = t2.DEPTNO
+          [
+            source = DEPT as t2
+            | where DEPTNO > 10 and LOC = 'CHICAGO'
+          ]
+        | left join ON t1.JOB = t3.JOB
+          [
+            source = BONUS as t3
+            | where JOB = 'SALESMAN'
+          ]
+        | cross join
+          [
+            source = SALGRADE as t4
+            | where LOSAL <= 1500
+            | sort - GRADE
+          ]
+        """;
+
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[true], joinType=[inner])\n"
+            + "  LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
+            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "      LogicalSort(fetch=[10])\n"
+            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO'))])\n"
+            + "        LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "    LogicalFilter(condition=[=($1, 'SALESMAN')])\n"
+            + "      LogicalTableScan(table=[[scott, BONUS]])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[<=($1, 1500)])\n"
+            + "      LogicalTableScan(table=[[scott, SALGRADE]])\n";
+    verifyLogical(root, expectedLogical);
+
+    verifyResultCount(root, 15);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 10) `t`\n"
+            + "INNER JOIN (SELECT *\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`\n"
+            + "LEFT JOIN (SELECT *\n"
+            + "FROM `scott`.`BONUS`\n"
+            + "WHERE `JOB` = 'SALESMAN') `t1` ON `t`.`JOB` = `t1`.`JOB`\n"
+            + "CROSS JOIN (SELECT `GRADE`, `LOSAL`, `HISAL`\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `LOSAL` <= 1500\n"
+            + "ORDER BY `GRADE` DESC NULLS FIRST) `t3`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMultipleJoinsWithRelationSubqueryWithAlias2() {
+    String ppl =
+        """
+        source=EMP as t1
+        | head 10
+        | inner join left = l right = r ON t1.DEPTNO = t2.DEPTNO
+          [
+            source = DEPT as t2
+            | where DEPTNO > 10 and LOC = 'CHICAGO'
+          ]
+        | left join left = l right = r ON t1.JOB = t3.JOB
+          [
+            source = BONUS as t3
+            | where JOB = 'SALESMAN'
+          ]
+        | cross join
+          [
+            source = SALGRADE as t4
+            | where LOSAL <= 1500
+            | sort - GRADE
+          ]
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalJoin(condition=[true], joinType=[inner])\n"
+            + "  LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
+            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "      LogicalSort(fetch=[10])\n"
+            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO'))])\n"
+            + "        LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "    LogicalFilter(condition=[=($1, 'SALESMAN')])\n"
+            + "      LogicalTableScan(table=[[scott, BONUS]])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[<=($1, 1500)])\n"
+            + "      LogicalTableScan(table=[[scott, SALGRADE]])\n";
+    verifyLogical(root, expectedLogical);
+
+    verifyResultCount(root, 15);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT *\n"
+            + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 10) `t`\n"
+            + "INNER JOIN (SELECT *\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`\n"
+            + "LEFT JOIN (SELECT *\n"
+            + "FROM `scott`.`BONUS`\n"
+            + "WHERE `JOB` = 'SALESMAN') `t1` ON `t`.`JOB` = `t1`.`JOB`\n"
+            + "CROSS JOIN (SELECT `GRADE`, `LOSAL`, `HISAL`\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `LOSAL` <= 1500\n"
+            + "ORDER BY `GRADE` DESC NULLS FIRST) `t3`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
 }


### PR DESCRIPTION
### Description
Core Syntax: Implement ppl relation subquery command with Calcite

`./gradlew :integ-test:integTest --tests '*Calcite*IT' succeed in local`

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3362 and https://github.com/opensearch-project/sql/issues/3375

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
