### PR TITLE
Implement ppl `exists` subquery command with Calcite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -36,6 +36,7 @@ import org.opensearch.sql.ast.expression.UnresolvedAttribute;
 import org.opensearch.sql.ast.expression.When;
 import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.expression.Xor;
+import org.opensearch.sql.ast.expression.subquery.ExistsSubquery;
 import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.statement.Explain;
 import org.opensearch.sql.ast.statement.Query;
@@ -344,6 +345,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitSubqueryAlias(SubqueryAlias node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitExistsSubquery(ExistsSubquery node, C context) {
     return visitChildren(node, context);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/expression/subquery/ExistsSubquery.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/subquery/ExistsSubquery.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.ast.expression.subquery;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -17,22 +18,21 @@ import org.opensearch.sql.common.utils.StringUtils;
 @Getter
 @EqualsAndHashCode(callSuper = false)
 @RequiredArgsConstructor
-public class InSubquery extends UnresolvedExpression {
-  private final List<UnresolvedExpression> value;
+public class ExistsSubquery extends UnresolvedExpression {
   private final UnresolvedPlan query;
 
   @Override
-  public List<UnresolvedExpression> getChild() {
-    return value;
+  public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
+    return nodeVisitor.visitExistsSubquery(this, context);
   }
 
   @Override
-  public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
-    return nodeVisitor.visitInSubquery(this, context);
+  public List<UnresolvedExpression> getChild() {
+    return ImmutableList.of();
   }
 
   @Override
   public String toString() {
-    return StringUtils.format("%s in ( %s )", value, query);
+    return StringUtils.format("exists ( %s )", query);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -18,14 +18,17 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserUtil;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.And;
@@ -41,6 +44,7 @@ import org.opensearch.sql.ast.expression.Span;
 import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.Xor;
+import org.opensearch.sql.ast.expression.subquery.ExistsSubquery;
 import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.utils.BuiltinFunctionUtils;
@@ -156,40 +160,62 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
 
   @Override
   public RexNode visitQualifiedName(QualifiedName node, CalcitePlanContext context) {
+    // 1. resolve QualifiedName in join condition
     if (context.isResolvingJoinCondition()) {
       List<String> parts = node.getParts();
       if (parts.size() == 1) {
-        // Handle the case of `id = cid`
+        // 1.1 Handle the case of `id = cid`
         try {
           return context.relBuilder.field(2, 0, parts.getFirst());
         } catch (IllegalArgumentException ee) {
           return context.relBuilder.field(2, 1, parts.getFirst());
         }
       } else if (parts.size() == 2) {
-        // Handle the case of `t1.id = t2.id` or `alias1.id = alias2.id`
+        // 1.2 Handle the case of `t1.id = t2.id` or `alias1.id = alias2.id`
         return context.relBuilder.field(2, parts.get(0), parts.get(1));
       } else if (parts.size() == 3) {
         throw new UnsupportedOperationException("Unsupported qualified name: " + node);
       }
     }
+
+    // 2. resolve QualifiedName in non-join condition
     String qualifiedName = node.toString();
     List<String> currentFields = context.relBuilder.peek().getRowType().getFieldNames();
     if (currentFields.contains(qualifiedName)) {
+      // 2.1 resolve QualifiedName from stack top
       return context.relBuilder.field(qualifiedName);
     } else if (node.getParts().size() == 2) {
+      // 2.2 resolve QualifiedName with an alias or table name
       List<String> parts = node.getParts();
-      return context.relBuilder.field(parts.get(0), parts.get(1));
+      try {
+        return context.relBuilder.field(1, parts.get(0), parts.get(1));
+      } catch (IllegalArgumentException e) {
+        // 2.3 resolve QualifiedName with outer alias
+        return context
+            .peekCorrelVar()
+            .map(correlVar -> context.relBuilder.field(correlVar, parts.get(1)))
+            .orElseThrow(() -> e); // Re-throw the exception if no correlated variable exists
+      }
     } else if (currentFields.stream().noneMatch(f -> f.startsWith(qualifiedName))) {
-      return context.relBuilder.field(qualifiedName);
+      // 2.4 try resolving combination of 2.1 and 2.3 to resolve rest cases
+      return context
+          .peekCorrelVar()
+          .map(correlVar -> context.relBuilder.field(correlVar, qualifiedName))
+          .orElseGet(() -> context.relBuilder.field(qualifiedName));
     }
-    // Handle the overriding fields, for example, `eval SAL = SAL + 1` will delete the original SAL
-    // and add a SAL0
+    // 3. resolve overriding fields, for example, `eval SAL = SAL + 1` will delete the original SAL
+    // and add a SAL0. SAL0 in currentFields, but qualifiedName is SAL.
+    // TODO now we cannot handle the case using a overriding fields in subquery, for example
+    // source = EMP | eval DEPTNO = DEPTNO + 1 | where exists [ source = DEPT | where emp.DEPTNO =
+    // DEPTNO ]
     Map<String, String> fieldMap =
         currentFields.stream().collect(Collectors.toMap(s -> s.replaceAll("\\d", ""), s -> s));
     if (fieldMap.containsKey(qualifiedName)) {
       return context.relBuilder.field(fieldMap.get(qualifiedName));
     } else {
-      return null;
+      throw new IllegalArgumentException(
+          String.format(
+              "field [%s] not found; input fields are: %s", qualifiedName, currentFields));
     }
   }
 
@@ -256,20 +282,8 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   @Override
   public RexNode visitInSubquery(InSubquery node, CalcitePlanContext context) {
     List<RexNode> nodes = node.getChild().stream().map(child -> analyze(child, context)).toList();
-    // clear and store the outer state
-    boolean isResolvingJoinConditionOuter = context.isResolvingJoinCondition();
-    if (isResolvingJoinConditionOuter) {
-      context.setResolvingJoinCondition(false);
-    }
     UnresolvedPlan subquery = node.getQuery();
-
-    RelNode subqueryRel = subquery.accept(planVisitor, context);
-    // pop the inner plan
-    context.relBuilder.build();
-    // restore to the previous state
-    if (isResolvingJoinConditionOuter) {
-      context.setResolvingJoinCondition(true);
-    }
+    RelNode subqueryRel = resolveSubqueryPlan(subquery, false, context);
     try {
       return context.relBuilder.in(subqueryRel, nodes);
       // TODO
@@ -287,5 +301,33 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
           "The number of columns in the left hand side of an IN subquery does not match the number"
               + " of columns in the output of subquery");
     }
+  }
+
+  @Override
+  public RexNode visitExistsSubquery(ExistsSubquery node, CalcitePlanContext context) {
+    final Holder<@Nullable RexCorrelVariable> v = Holder.empty();
+    return context.relBuilder.exists(
+        b -> {
+          UnresolvedPlan subquery = node.getQuery();
+          return resolveSubqueryPlan(subquery, true, context);
+        });
+  }
+
+  private RelNode resolveSubqueryPlan(
+      UnresolvedPlan subquery, boolean isExists, CalcitePlanContext context) {
+    // clear and store the outer state
+    boolean isResolvingJoinConditionOuter = context.isResolvingJoinCondition();
+    if (isResolvingJoinConditionOuter) {
+      context.setResolvingJoinCondition(false);
+    }
+    RelNode subqueryRel = subquery.accept(planVisitor, context);
+    // pop the inner plan
+    context.relBuilder.build();
+    // clear the exists subquery resolving state
+    // restore to the previous state
+    if (isResolvingJoinConditionOuter) {
+      context.setResolvingJoinCondition(true);
+    }
+    return subqueryRel;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -144,6 +144,7 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
         return FLOAT;
       case DOUBLE:
         return DOUBLE;
+      case CHAR:
       case VARCHAR:
         return STRING;
       case BOOLEAN:

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLExistsSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLExistsSubqueryIT.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_OCCUPATION;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORKER;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORK_INFORMATION;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRowsInOrder;
+import static org.opensearch.sql.util.MatcherUtils.verifyNumOfRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.opensearch.client.Request;
+
+public class CalcitePPLExistsSubqueryIT extends CalcitePPLIntegTestCase {
+
+  @Override
+  public void init() throws IOException {
+    super.init();
+
+    loadIndex(Index.WORKER);
+    loadIndex(Index.WORK_INFORMATION);
+    loadIndex(Index.OCCUPATION);
+
+    // {"index":{"_id":"7"}}
+    // {"id":1006,"name":"Tommy","occupation":"Teacher","country":"USA","salary":30000}
+    Request request1 = new Request("PUT", "/" + TEST_INDEX_WORKER + "/_doc/7?refresh=true");
+    request1.setJsonEntity(
+        "{\"id\":1006,\"name\":\"Tommy\",\"occupation\":\"Teacher\",\"country\":\"USA\",\"salary\":30000}");
+    client().performRequest(request1);
+  }
+
+  @Test
+  public void testSimpleExistsSubquery() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where exists [
+                       source = %s | where id = uid
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+    verifySchema(
+        result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
+    verifyDataRowsInOrder(
+        result,
+        rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
+        rows(1000, "Jake", 100000),
+        rows(1005, "Jane", 90000),
+        rows(1006, "Tommy", 30000));
+  }
+
+  @Test
+  public void testSimpleExistsSubqueryInFilter() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s exists [
+                       source = %s | where id = uid
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+    verifySchema(
+        result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
+    verifyDataRowsInOrder(
+        result,
+        rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
+        rows(1000, "Jake", 100000),
+        rows(1005, "Jane", 90000),
+        rows(1006, "Tommy", 30000));
+  }
+
+  @Test
+  public void testNotExistsSubquery() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where not exists [
+                       source = %s | where id = uid
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+    verifySchema(
+        result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
+    verifyDataRowsInOrder(result, rows(1001, "Hello", 70000), rows(1004, "David", 0));
+  }
+
+  @Test
+  public void testNotExistsSubqueryInFilter() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s not exists [
+                       source = %s | where id = uid
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+    verifySchema(
+        result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
+    verifyDataRowsInOrder(result, rows(1001, "Hello", 70000), rows(1004, "David", 0));
+  }
+
+  @Test
+  public void testEmptyExistsSubquery() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where exists [
+                       source = %s | where uid = 0000 AND id = uid
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+    verifySchema(
+        result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
+    verifyNumOfRows(result, 0);
+  }
+
+  @Test
+  public void testUncorrelatedExistsSubquery() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where exists [
+                       source = %s | where name = 'Tom'
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+    verifySchema(
+        result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
+    verifyNumOfRows(result, 7);
+
+    result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where not exists [
+                       source = %s | where name = 'Tom'
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+    verifyNumOfRows(result, 0);
+  }
+
+  @Test
+  public void testUncorrelatedExistsSubqueryCheckTheReturnContentOfInnerTableIsEmptyOrNot() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where exists [
+                       source = %s
+                     ]
+                   | eval constant = "Bala"
+                   | fields constant
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+
+    verifyDataRows(
+        result,
+        rows("Bala"),
+        rows("Bala"),
+        rows("Bala"),
+        rows("Bala"),
+        rows("Bala"),
+        rows("Bala"),
+        rows("Bala"));
+
+    result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where exists [
+                       source = %s | where uid = 999
+                     ]
+                   | eval constant = "Bala"
+                   | fields constant
+                   """,
+                TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
+    verifyNumOfRows(result, 0);
+  }
+
+  @Test
+  public void testNestedExistsSubquery() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where exists [
+                       source = %s
+                       | where exists [
+                           source = %s
+                           | where %s.occupation = %s.occupation
+                         ]
+                       | where id = uid
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER,
+                TEST_INDEX_WORK_INFORMATION,
+                TEST_INDEX_OCCUPATION,
+                TEST_INDEX_OCCUPATION,
+                TEST_INDEX_WORK_INFORMATION));
+    verifySchema(
+        result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
+    verifyDataRowsInOrder(
+        result,
+        rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
+        rows(1000, "Jake", 100000),
+        rows(1005, "Jane", 90000),
+        rows(1006, "Tommy", 30000));
+  }
+
+  @Test
+  public void testExistsSubqueryWithConjunction() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s
+                   | where exists [
+                       source = %s
+                       | where id = uid AND
+                         %s.name = %s.name AND
+                         %s.occupation = %s.occupation
+                     ]
+                   | sort  - salary
+                   | fields id, name, salary
+                   """,
+                TEST_INDEX_WORKER,
+                TEST_INDEX_WORK_INFORMATION,
+                TEST_INDEX_WORKER,
+                TEST_INDEX_WORK_INFORMATION,
+                TEST_INDEX_WORKER,
+                TEST_INDEX_WORK_INFORMATION));
+    verifySchema(
+        result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
+    verifyDataRowsInOrder(result, rows(1003, "David", 120000), rows(1000, "Jake", 100000));
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLInSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLInSubqueryIT.java
@@ -11,12 +11,14 @@ import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORK_INFORMATI
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRowsInOrder;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.opensearch.client.Request;
 import org.opensearch.sql.exception.SemanticCheckException;
 
 public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
@@ -28,6 +30,13 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
     loadIndex(Index.WORKER);
     loadIndex(Index.WORK_INFORMATION);
     loadIndex(Index.OCCUPATION);
+
+    // {"index":{"_id":"7"}}
+    // {"id":1006,"name":"Tommy","occupation":"Teacher","country":"USA","salary":30000}
+    Request request1 = new Request("PUT", "/" + TEST_INDEX_WORKER + "/_doc/7?refresh=true");
+    request1.setJsonEntity(
+        "{\"id\":1006,\"name\":\"Tommy\",\"occupation\":\"Teacher\",\"country\":\"USA\",\"salary\":30000}");
+    client().performRequest(request1);
   }
 
   @Test
@@ -73,10 +82,10 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         result,
-        rows(1003, "David", 120000),
         rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
         rows(1000, "Jake", 100000),
         rows(1005, "Jane", 90000),
         rows(1006, "Tommy", 30000));
@@ -97,10 +106,10 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         result,
-        rows(1003, "David", 120000),
         rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
         rows(1000, "Jake", 100000),
         rows(1005, "Jane", 90000),
         rows(1006, "Tommy", 30000));
@@ -135,17 +144,17 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
         result1, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
     verifySchema(
         result2, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         result1,
-        rows(1003, "David", 120000),
         rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
         rows(1000, "Jake", 100000),
         rows(1005, "Jane", 90000),
         rows(1006, "Tommy", 30000));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         result2,
-        rows(1003, "David", 120000),
         rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
         rows(1000, "Jake", 100000),
         rows(1005, "Jane", 90000),
         rows(1006, "Tommy", 30000));
@@ -167,10 +176,10 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         result,
-        rows(1003, "David", 120000),
         rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
         rows(1000, "Jake", 100000),
         rows(1005, "Jane", 90000));
   }
@@ -191,7 +200,7 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(result, rows(1001, "Hello", 70000), rows(1004, "David", 0));
+    verifyDataRowsInOrder(result, rows(1001, "Hello", 70000), rows(1004, "David", 0));
   }
 
   @Test
@@ -209,7 +218,7 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(result, rows(1001, "Hello", 70000), rows(1004, "David", 0));
+    verifyDataRowsInOrder(result, rows(1001, "Hello", 70000), rows(1004, "David", 0));
   }
 
   @Test
@@ -228,8 +237,8 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(
-        result, rows(1001, "Hello", 70000), rows(1004, "David", 0), rows(1006, "Tommy", 30000));
+    verifyDataRowsInOrder(
+        result, rows(1001, "Hello", 70000), rows(1006, "Tommy", 30000), rows(1004, "David", 0));
   }
 
   @Test
@@ -247,15 +256,15 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         result,
-        rows(1000, "Jake", 100000),
-        rows(1001, "Hello", 70000),
         rows(1002, "John", 120000),
         rows(1003, "David", 120000),
-        rows(1004, "David", 0),
+        rows(1000, "Jake", 100000),
         rows(1005, "Jane", 90000),
-        rows(1006, "Tommy", 30000));
+        rows(1001, "Hello", 70000),
+        rows(1006, "Tommy", 30000),
+        rows(1004, "David", 0));
   }
 
   @Test
@@ -280,10 +289,10 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION, TEST_INDEX_OCCUPATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         result,
-        rows(1003, "David", 120000),
         rows(1002, "John", 120000),
+        rows(1003, "David", 120000),
         rows(1006, "Tommy", 30000));
   }
 
@@ -304,7 +313,7 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_OCCUPATION, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         result,
         rows(1003, "David", 120000),
         rows(1002, "John", 120000),
@@ -366,6 +375,6 @@ public class CalcitePPLInSubqueryIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_WORKER, TEST_INDEX_WORK_INFORMATION));
     verifySchema(
         result, schema("id", "integer"), schema("name", "string"), schema("salary", "integer"));
-    verifyDataRows(result, rows(1002, "John", 120000), rows(1005, "Jane", 90000));
+    verifyDataRowsInOrder(result, rows(1002, "John", 120000), rows(1005, "Jane", 90000));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLJoinIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLJoinIT.java
@@ -11,6 +11,7 @@ import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_STATE_COUNTRY;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRowsInOrder;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
@@ -210,7 +211,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("occupation", "string"),
         schema("country0", "string"),
         schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Jane", 20, "Quebec", "Canada", "Scientist", "Canada", 90000),
         rows("John", 25, "Ontario", "Canada", "Doctor", "Canada", 120000),
@@ -237,7 +238,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("occupation", "string"),
         schema("country0", "string"),
         schema("salary", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Jane", 20, "Quebec", "Canada", "Scientist", "Canada", 90000),
         rows("John", 25, "Ontario", "Canada", "Doctor", "Canada", 120000),
@@ -263,7 +264,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("month", "integer"),
         schema("year", "integer"),
         schema("age", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Jane", "Canada", "Quebec", 4, 2023, 20),
         rows("John", "Canada", "Ontario", 4, 2023, 25));
@@ -285,7 +286,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("month", "integer"),
         schema("year", "integer"),
         schema("age", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Jim", "Canada", "B.C", 4, 2023, 27),
         rows("Peter", "Canada", "B.C", 4, 2023, 57),
@@ -301,7 +302,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
                     + " right=b %s | sort a.age | stats count()",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
     verifySchema(actual, schema("count()", "long"));
-    verifyDataRows(actual, rows(30));
+    verifyDataRowsInOrder(actual, rows(30));
   }
 
   @Test
@@ -718,7 +719,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("b.country", "string"),
         schema("age_span", "double"),
         schema("avg(salary)", "double"));
-    verifyDataRows(actual, rows("USA", 30, 70000.0), rows("England", 70, 100000));
+    verifyDataRowsInOrder(actual, rows("England", 70, 100000), rows("USA", 30, 70000.0));
   }
 
   @Test
@@ -746,7 +747,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("b.country", "string"),
         schema("age_span", "double"),
         schema("avg(salary)", "double"));
-    verifyDataRows(
-        actual, rows("USA", 30, 70000.0), rows("England", 70, 100000), rows(null, 40, 0));
+    verifyDataRowsInOrder(
+        actual, rows(null, 40, 0), rows("England", 70, 100000), rows("USA", 30, 70000.0));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLSortIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLSortIT.java
@@ -9,8 +9,7 @@ import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
-import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
-import static org.opensearch.sql.util.MatcherUtils.verifyOrder;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRowsInOrder;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
@@ -39,7 +38,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
         schema("firstname", "string"),
         schema("gender", "string"),
         schema("account_number", "long"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Dillard", "F", 32),
         rows("Virginia", "F", 25),
@@ -55,7 +54,8 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
     JSONObject actual =
         executeQuery(String.format("source=%s | fields age | sort - age", TEST_INDEX_BANK));
     verifySchema(actual, schema("age", "integer"));
-    verifyDataRows(actual, rows(39), rows(36), rows(36), rows(34), rows(33), rows(32), rows(28));
+    verifyDataRowsInOrder(
+        actual, rows(39), rows(36), rows(36), rows(34), rows(33), rows(32), rows(28));
   }
 
   @Test
@@ -71,7 +71,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
         schema("firstname", "string"),
         schema("gender", "string"),
         schema("account_number", "long"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Dillard", "F", 32),
         rows("Virginia", "F", 25),
@@ -95,7 +95,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
         schema("firstname", "string"),
         schema("gender", "string"),
         schema("account_number", "long"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Dillard", "F", 32),
         rows("Virginia", "F", 25),
@@ -111,7 +111,8 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
             String.format(
                 "source=%s | sort - account_number | fields account_number", TEST_INDEX_BANK));
     verifySchema(actual, schema("account_number", "long"));
-    verifyDataRows(actual, rows(32), rows(25), rows(20), rows(18), rows(13), rows(6), rows(1));
+    verifyDataRowsInOrder(
+        actual, rows(32), rows(25), rows(20), rows(18), rows(13), rows(6), rows(1));
   }
 
   @Test
@@ -122,7 +123,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
                 "source=%s | sort - account_number | fields firstname, account_number",
                 TEST_INDEX_BANK));
     verifySchema(actual, schema("firstname", "string"), schema("account_number", "long"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Dillard", 32),
         rows("Virginia", 25),
@@ -141,7 +142,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
                 "source=%s | sort - account_number | fields account_number, firstname",
                 TEST_INDEX_BANK));
     verifySchema(actual, schema("account_number", "long"), schema("firstname", "string"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows(32, "Dillard"),
         rows(25, "Virginia"),
@@ -157,7 +158,8 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
     JSONObject actual =
         executeQuery(String.format("source=%s | sort - age | fields age", TEST_INDEX_BANK));
     verifySchema(actual, schema("age", "integer"));
-    verifyDataRows(actual, rows(39), rows(36), rows(36), rows(34), rows(33), rows(32), rows(28));
+    verifyDataRowsInOrder(
+        actual, rows(39), rows(36), rows(36), rows(34), rows(33), rows(32), rows(28));
   }
 
   @Test
@@ -166,7 +168,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
         executeQuery(
             String.format("source=%s | sort - age | fields firstname, age", TEST_INDEX_BANK));
     verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Virginia", 39),
         rows("Hattie", 36),
@@ -184,7 +186,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
             String.format(
                 "source=%s | sort - age, - firstname | fields firstname, age", TEST_INDEX_BANK));
     verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
-    verifyDataRows(
+    verifyDataRowsInOrder(
         actual,
         rows("Virginia", 39),
         rows("Hattie", 36),
@@ -202,7 +204,7 @@ public class CalcitePPLSortIT extends CalcitePPLIntegTestCase {
             String.format(
                 "source=%s | sort balance | fields firstname, balance",
                 TEST_INDEX_BANK_WITH_NULL_VALUES));
-    verifyOrder(
+    verifyDataRowsInOrder(
         result,
         rows("Dale", 4180),
         rows("Nanette", 32838),

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -766,6 +766,7 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         "hobbies",
         getHobbiesIndexMapping(),
         "src/test/resources/hobbies.json"),
+    // It's "people" table in Spark PPL ITs, to avoid conflicts, rename to "worker" here
     WORKER(
         TestsConstants.TEST_INDEX_WORKER,
         "worker",

--- a/integ-test/src/test/java/org/opensearch/sql/util/MatcherUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/MatcherUtils.java
@@ -180,6 +180,10 @@ public class MatcherUtils {
     verifyInOrder(response.getJSONArray("datarows"), matchers);
   }
 
+  public static void verifyNumOfRows(JSONObject response, int numOfRow) {
+    assertEquals(numOfRow, response.getJSONArray("datarows").length());
+  }
+
   @SuppressWarnings("unchecked")
   public static <T> void verify(JSONArray array, Matcher<T>... matchers) {
     List<T> objects = new ArrayList<>();

--- a/integ-test/src/test/resources/worker.json
+++ b/integ-test/src/test/resources/worker.json
@@ -10,5 +10,3 @@
 {"id":1004,"name":"David","country":"Canada","salary":0}
 {"index":{"_id":"6"}}
 {"id":1005,"name":"Jane","occupation":"Scientist","country":"Canada","salary":90000}
-{"index":{"_id":"7"}}
-{"id":1006,"name":"Tommy","occupation":"Teacher","country":"USA","salary":30000}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -98,6 +98,7 @@ ANOMALY_SCORE_THRESHOLD:            'ANOMALY_SCORE_THRESHOLD';
 // COMPARISON FUNCTION KEYWORDS
 CASE:                               'CASE';
 IN:                                 'IN';
+EXISTS:                             'EXISTS';
 
 // LOGICAL KEYWORDS
 NOT:                                'NOT';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -343,7 +343,6 @@ logicalExpression
 comparisonExpression
    : left = valueExpression comparisonOperator right = valueExpression  # compareExpr
    | valueExpression IN valueList                                       # inExpr
-   | valueExpressionList NOT? IN LT_SQR_PRTHS subSearch RT_SQR_PRTHS    # inSubqueryExpr
    ;
 
 valueExpressionList
@@ -374,7 +373,9 @@ positionFunction
    ;
 
 booleanExpression
-   : booleanFunctionCall
+   : booleanFunctionCall                                                # booleanFunctionCallExpr
+   | valueExpressionList NOT? IN LT_SQR_PRTHS subSearch RT_SQR_PRTHS    # inSubqueryExpr
+   | EXISTS LT_SQR_PRTHS subSearch RT_SQR_PRTHS                         # existsSubqueryExpr
    ;
 
 relevanceExpression
@@ -941,6 +942,8 @@ keywordsCanBeId
    | ML
    | TRENDLINE
    // commands assist keywords
+   | IN
+   | EXISTS
    | SOURCE
    | INDEX
    | DESC

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -53,6 +53,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.*;
+import org.opensearch.sql.ast.expression.subquery.ExistsSubquery;
 import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
@@ -423,6 +424,12 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
                 .collect(Collectors.toList()),
             astBuilder.visitSubSearch(ctx.subSearch()));
     return ctx.NOT() != null ? new Not(expr) : expr;
+  }
+
+  @Override
+  public UnresolvedExpression visitExistsSubqueryExpr(
+      OpenSearchPPLParser.ExistsSubqueryExprContext ctx) {
+    return new ExistsSubquery(astBuilder.visitSubSearch(ctx.subSearch()));
   }
 
   private QualifiedName visitIdentifiers(List<? extends ParserRuleContext> ctx) {

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -29,6 +29,8 @@ import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.Xor;
+import org.opensearch.sql.ast.expression.subquery.ExistsSubquery;
+import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.statement.Explain;
 import org.opensearch.sql.ast.statement.Query;
 import org.opensearch.sql.ast.statement.Statement;
@@ -38,11 +40,13 @@ import org.opensearch.sql.ast.tree.Eval;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
+import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
+import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
@@ -64,7 +68,7 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
   private final AnonymizerExpressionAnalyzer expressionAnalyzer;
 
   public PPLQueryDataAnonymizer() {
-    this.expressionAnalyzer = new AnonymizerExpressionAnalyzer();
+    this.expressionAnalyzer = new AnonymizerExpressionAnalyzer(this);
   }
 
   /**
@@ -95,6 +99,34 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
   @Override
   public String visitRelation(Relation node, String context) {
     return StringUtils.format("source=%s", node.getTableQualifiedName().toString());
+  }
+
+  @Override
+  public String visitJoin(Join node, String context) {
+    String left = node.getLeft().accept(this, context);
+    String rightTableOrSubquery = node.getRight().accept(this, context);
+    String right =
+        rightTableOrSubquery.startsWith("source=")
+            ? rightTableOrSubquery.substring("source=".length())
+            : rightTableOrSubquery;
+    String joinType = node.getJoinType().name().toLowerCase(Locale.ROOT);
+    String leftAlias = node.getLeftAlias().map(l -> " left = " + l).orElse("");
+    String rightAlias = node.getRightAlias().map(r -> " right = " + r).orElse("");
+    String condition =
+        node.getJoinCondition().map(c -> expressionAnalyzer.analyze(c, context)).orElse("true");
+    return StringUtils.format(
+        "%s | %s join%s%s on %s %s", left, joinType, leftAlias, rightAlias, condition, right);
+  }
+
+  @Override
+  public String visitSubqueryAlias(SubqueryAlias node, String context) {
+    String child = node.getChild().get(0).accept(this, context);
+    if (node.getChild().get(0).getChild().isEmpty()) {
+      return StringUtils.format("%s as %s", child, node.getAlias());
+    } else {
+      // add "[]" only if its child is not a root
+      return StringUtils.format("[ %s ] as %s", child, node.getAlias());
+    }
   }
 
   @Override
@@ -282,6 +314,11 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
 
   /** Expression Anonymizer. */
   private static class AnonymizerExpressionAnalyzer extends AbstractNodeVisitor<String, String> {
+    private final PPLQueryDataAnonymizer queryAnonymizer;
+
+    public AnonymizerExpressionAnalyzer(PPLQueryDataAnonymizer queryAnonymizer) {
+      this.queryAnonymizer = queryAnonymizer;
+    }
 
     public String analyze(UnresolvedExpression unresolved, String context) {
       return unresolved.accept(this, context);
@@ -366,6 +403,20 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
       final String computationType = node.getComputationType().name().toLowerCase(Locale.ROOT);
       return StringUtils.format(
           "%s(%d, %s)%s", computationType, node.getNumberOfDataPoints(), dataField, aliasClause);
+    }
+
+    @Override
+    public String visitInSubquery(InSubquery node, String context) {
+      String nodes =
+          node.getChild().stream().map(c -> analyze(c, context)).collect(Collectors.joining(","));
+      String subquery = queryAnonymizer.anonymizeData(node.getQuery());
+      return StringUtils.format("(%s) in [ %s ]", nodes, subquery);
+    }
+
+    @Override
+    public String visitExistsSubquery(ExistsSubquery node, String context) {
+      String subquery = queryAnonymizer.anonymizeData(node.getQuery());
+      return StringUtils.format("exists [ %s ]", subquery);
     }
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
@@ -38,13 +38,11 @@ import org.opensearch.sql.ppl.parser.AstStatementBuilder;
 
 public class CalcitePPLAbstractTest {
   @Getter private final Frameworks.ConfigBuilder config;
-  @Getter private final CalcitePlanContext context;
   private final CalciteRelNodeVisitor planTransformer;
   private final RelToSqlConverter converter;
 
   public CalcitePPLAbstractTest(CalciteAssert.SchemaSpec... schemaSpecs) {
     this.config = config(schemaSpecs);
-    this.context = createBuilderContext();
     this.planTransformer = new CalciteRelNodeVisitor();
     this.converter = new RelToSqlConverter(SparkSqlDialect.DEFAULT);
   }
@@ -74,6 +72,7 @@ public class CalcitePPLAbstractTest {
 
   /** Get the root RelNode of the given PPL query */
   public RelNode getRelNode(String ppl) {
+    CalcitePlanContext context = createBuilderContext();
     Query query = (Query) plan(pplParser, ppl);
     planTransformer.analyze(query.getPlan(), context);
     RelNode root = context.relBuilder.build();

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEvalTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEvalTest.java
@@ -168,19 +168,19 @@ public class CalcitePPLEvalTest extends CalcitePPLAbstractTest {
         "source=EMP | eval SAL = DEPTNO + 10000 | sort - EMPNO | fields EMPNO, SAL | head 3";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        "LogicalProject(EMPNO=[$0], SAL0=[$7])\n"
+        "LogicalProject(EMPNO=[$0], SAL=[$7])\n"
             + "  LogicalSort(sort0=[$0], dir0=[DESC], fetch=[3])\n"
             + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
-            + " COMM=[$6], DEPTNO=[$7], SAL0=[+($7, 10000)])\n"
+            + " COMM=[$6], DEPTNO=[$7], SAL=[+($7, 10000)])\n"
             + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
-        "" + "EMPNO=7934; SAL0=10010\n" + "EMPNO=7902; SAL0=10020\n" + "EMPNO=7900; SAL0=10030\n";
+        "" + "EMPNO=7934; SAL=10010\n" + "EMPNO=7902; SAL=10020\n" + "EMPNO=7900; SAL=10030\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
         ""
-            + "SELECT `EMPNO`, `DEPTNO` + 10000 `SAL0`\n"
+            + "SELECT `EMPNO`, `DEPTNO` + 10000 `SAL`\n"
             + "FROM `scott`.`EMP`\n"
             + "ORDER BY `EMPNO` DESC NULLS FIRST\n"
             + "LIMIT 3";

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLExistsSubqueryTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLExistsSubqueryTest.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLExistsSubqueryTest extends CalcitePPLAbstractTest {
+  public CalcitePPLExistsSubqueryTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testCorrelatedExistsSubqueryWithoutAlias() {
+    String ppl =
+        """
+        source=EMP
+        | where exists [
+            source=SALGRADE
+            | where SAL = HISAL
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($cor0.SAL, $2)])\n"
+            + "  LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "})], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `EMP`.`SAL` = `HISAL`)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testCorrelatedExistsSubqueryWithAlias() {
+    String ppl =
+        """
+        source=EMP
+        | where exists [
+            source=SALGRADE
+            | where EMP.SAL = HISAL
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($cor0.SAL, $2)])\n"
+            + "  LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "})], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `EMP`.`SAL` = `HISAL`)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testUncorrelatedExistsSubquery() {
+    String ppl =
+        """
+        source=EMP
+        | where exists [
+            source=DEPT
+            | where DNAME = 'Accounting'
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($1, 'Accounting')])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "})], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `DNAME` = 'Accounting')\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testCorrelatedNotExistsSubqueryWithoutAlias() {
+    String ppl =
+        """
+        source=EMP
+        | where not exists [
+            source=SALGRADE
+            | where SAL = HISAL
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[NOT(EXISTS({\n"
+            + "LogicalFilter(condition=[=($cor0.SAL, $2)])\n"
+            + "  LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "}))], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE NOT EXISTS (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `EMP`.`SAL` = `HISAL`)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testCorrelatedNotExistsSubqueryWithTableNames() {
+    String ppl =
+        """
+        source=EMP
+        | where not exists [
+            source=SALGRADE
+            | where EMP.SAL = SALGRADE.HISAL
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[NOT(EXISTS({\n"
+            + "LogicalFilter(condition=[=($cor0.SAL, $2)])\n"
+            + "  LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "}))], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE NOT EXISTS (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `EMP`.`SAL` = `HISAL`)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testUncorrelatedNotExistsSubquery() {
+    String ppl =
+        """
+        source=EMP
+        | where not exists [
+            source=DEPT
+            | where DNAME = 'Accounting'
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[NOT(EXISTS({\n"
+            + "LogicalFilter(condition=[=($1, 'Accounting')])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "}))], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE NOT EXISTS (SELECT *\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `DNAME` = 'Accounting')\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testExistsSubqueryInFilter() {
+    String ppl =
+        """
+        source=EMP exists [
+            source=SALGRADE
+            | where SAL = HISAL
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($cor0.SAL, $2)])\n"
+            + "  LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "})], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `EMP`.`SAL` = `HISAL`)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testNotExistsSubqueryInFilter() {
+    String ppl =
+        """
+        source=EMP not exists [
+            source=SALGRADE
+            | where SAL = HISAL
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[NOT(EXISTS({\n"
+            + "LogicalFilter(condition=[=($cor0.SAL, $2)])\n"
+            + "  LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "}))], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE NOT EXISTS (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE `EMP`.`SAL` = `HISAL`)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testNestedCorrelatedExistsSubquery() {
+    String ppl =
+        """
+        source=EMP as outer
+        | where exists [
+            source=SALGRADE as inner
+            | where exists [
+                source=EMP as nested
+                | where nested.SAL = inner.HISAL
+              ]
+            | where outer.SAL = inner.HISAL
+          ]
+        | sort - outer.EMPNO | fields outer.EMPNO, outer.ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($cor0.SAL, $2)])\n"
+            + "  LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($5, $cor1.HISAL)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "})], variablesSet=[[$cor1]])\n"
+            + "    LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "})], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE `SAL` = `SALGRADE`.`HISAL`)) `t0`\n"
+            + "WHERE `EMP`.`SAL` = `HISAL`)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testNestedUncorrelatedExistsSubquery() {
+    String ppl =
+        """
+        source=EMP as outer
+        | where exists [
+            source=SALGRADE as inner
+            | where exists [
+                source=EMP as nested
+                | where nested.SAL > 1000.0
+              ]
+            | where inner.HISAL > 1000.0
+          ]
+        | sort - outer.EMPNO | fields outer.EMPNO, outer.ENAME
+        """;
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[>($2, 1000.0E0:DOUBLE)])\n"
+            + "  LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[>($5, 1000.0E0:DOUBLE)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "})], variablesSet=[[$cor1]])\n"
+            + "    LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "})], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE `SAL` > 1.0000E3)) `t0`\n"
+            + "WHERE `HISAL` > 1.0000E3)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testNestedMixedExistsSubquery() {
+    String ppl =
+        """
+        source=EMP as e1
+        | where exists [
+            source=SALGRADE as s2
+            | where exists [
+                source=EMP as e3
+                | where exists [
+                  source=SALGRADE as s4
+                  | where exists [
+                      source=EMP
+                      | where SAL = s4.HISAL
+                    ]
+                  | where s3.SAL > 1000.0
+                ]
+                | where SAL = s2.HISAL
+              ]
+            | where e1.SAL > 1000.0
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode plan1 = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
+            + "    LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[>($cor0.SAL, 1000.0E0:DOUBLE)])\n"
+            + "  LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($5, $cor1.HISAL)])\n"
+            + "  LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[>($cor2.SAL, 1000.0E0:DOUBLE)])\n"
+            + "  LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($5, $cor3.HISAL)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "})], variablesSet=[[$cor3]])\n"
+            + "    LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "})], variablesSet=[[$cor2]])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "})], variablesSet=[[$cor1]])\n"
+            + "    LogicalTableScan(table=[[scott, SALGRADE]])\n"
+            + "})], variablesSet=[[$cor0]])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(plan1, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM (SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM (SELECT *\n"
+            + "FROM `scott`.`SALGRADE`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE `SAL` = `SALGRADE0`.`HISAL`)) `t0`\n"
+            + "WHERE `EMP0`.`SAL` > 1.0000E3)) `t2`\n"
+            + "WHERE `SAL` = `SALGRADE`.`HISAL`)) `t4`\n"
+            + "WHERE `EMP`.`SAL` > 1.0000E3)\n"
+            + "ORDER BY `EMPNO` DESC NULLS FIRST";
+    verifyPPLToSparkSQL(plan1, expectedSparkSql);
+
+    String pplWithoutAlias =
+        """
+        source=EMP
+        | where exists [
+            source=SALGRADE
+            | where exists [
+                source=EMP
+                | where exists [
+                  source=SALGRADE
+                  | where exists [
+                      source=EMP
+                      | where SAL = HISAL
+                    ]
+                  | where SAL > 1000.0
+                ]
+                | where SAL = HISAL
+              ]
+            | where SAL > 1000.0
+          ]
+        | sort - EMPNO | fields EMPNO, ENAME
+        """;
+    RelNode plan2 = getRelNode(pplWithoutAlias);
+    verifyLogical(plan2, expectedLogical);
+  }
+
+  @Test
+  public void testCorrelatedExistsSubqueryWithOverridingFields() {
+    String overriding =
+        """
+        source=EMP | eval DEPTNO = DEPTNO + 1
+        | where exists [
+            source=DEPT
+            | where emp.DEPTNO = DEPTNO
+          ]
+        """;
+    RelNode root = getRelNode(overriding);
+    String expectedLogical =
+        "LogicalFilter(condition=[EXISTS({\n"
+            + "LogicalFilter(condition=[=($cor0.DEPTNO, $0)])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "})], variablesSet=[[$cor0]])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[+($7, 1)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT *\n"
+            + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO` + 1"
+            + " `DEPTNO`\n"
+            + "FROM `scott`.`EMP`) `t`\n"
+            + "WHERE EXISTS (SELECT *\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `t`.`DEPTNO` = `DEPTNO`)";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMathFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMathFunctionTest.java
@@ -20,26 +20,27 @@ public class CalcitePPLMathFunctionTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP | eval SAL = abs(-30) | head 10 | fields SAL";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        "LogicalProject(SAL0=[$7])\n"
+        "LogicalProject(SAL=[$7])\n"
             + "  LogicalSort(fetch=[10])\n"
             + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
-            + " COMM=[$6], DEPTNO=[$7], SAL0=[ABS(-30)])\n"
+            + " COMM=[$6], DEPTNO=[$7], SAL=[ABS(-30)])\n"
             + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
-        "SAL0=30\n"
-            + "SAL0=30\n"
-            + "SAL0=30\n"
-            + "SAL0=30\n"
-            + "SAL0=30\n"
-            + "SAL0=30\n"
-            + "SAL0=30\n"
-            + "SAL0=30\n"
-            + "SAL0=30\n"
-            + "SAL0=30\n";
+        ""
+            + "SAL=30\n"
+            + "SAL=30\n"
+            + "SAL=30\n"
+            + "SAL=30\n"
+            + "SAL=30\n"
+            + "SAL=30\n"
+            + "SAL=30\n"
+            + "SAL=30\n"
+            + "SAL=30\n"
+            + "SAL=30\n";
     verifyResult(root, expectedResult);
 
-    String expectedSparkSql = "" + "SELECT ABS(-30) `SAL0`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 10";
+    String expectedSparkSql = "" + "SELECT ABS(-30) `SAL`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 10";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -183,6 +183,53 @@ public class PPLQueryDataAnonymizerTest {
         anonymize(projectWithArg(relation("t"), Collections.emptyList(), field("f"))));
   }
 
+  @Test
+  public void testSubqueryAlias() {
+    assertEquals("source=t as t1", anonymize("source=t as t1"));
+  }
+
+  @Test
+  public void testJoin() {
+    assertEquals(
+        "source=t | cross join on true s | fields + id",
+        anonymize("source=t | cross join s | fields id"));
+    assertEquals(
+        "source=t | inner join on id = uid s | fields + id",
+        anonymize("source=t | inner join on id = uid s | fields id"));
+    assertEquals(
+        "source=t as l | inner join left = l right = r on id = uid s as r | fields + id",
+        anonymize("source=t | join left = l right = r on id = uid s | fields id"));
+    assertEquals(
+        "source=t | left join right = r on id = uid s as r | fields + id",
+        anonymize("source=t | left join right = r on id = uid s | fields id"));
+    assertEquals(
+        "source=t as t1 | inner join on id = uid s as t2 | fields + t1.id",
+        anonymize("source=t as t1 | inner join on id = uid s as t2 | fields t1.id"));
+    assertEquals(
+        "source=t as t1 | right join on t1.id = t2.id s as t2 | fields + t1.id",
+        anonymize("source=t as t1 | right join on t1.id = t2.id s as t2 | fields t1.id"));
+    assertEquals(
+        "source=t as t1 | right join right = t2 on t1.id = t2.id [ source=s | fields + id ] as t2 |"
+            + " fields + t1.id",
+        anonymize(
+            "source=t as t1 | right join on t1.id = t2.id [ source=s | fields id] as t2 | fields"
+                + " t1.id"));
+  }
+
+  @Test
+  public void testInSubquery() {
+    assertEquals(
+        "source=t | where (id) in [ source=s | fields + uid ] | fields + id",
+        anonymize("source=t | where id in [source=s | fields uid] | fields id"));
+  }
+
+  @Test
+  public void testExistsSubquery() {
+    assertEquals(
+        "source=t | where exists [ source=s | where id = uid ] | fields + id",
+        anonymize("source=t | where exists [source=s | where id = uid ] | fields id"));
+  }
+
   private String anonymize(String query) {
     AstBuilder astBuilder = new AstBuilder(query);
     return anonymize(astBuilder.visit(parser.parse(query)));


### PR DESCRIPTION
### Description
### Description
Core Syntax: Implement ppl `Exists` subquery command with Calcite

`./gradlew :integ-test:integTest --tests '*Calcite*IT'` succeed in local

Changes include:
1. Support Exists Subquery, the syntax check https://github.com/opensearch-project/opensearch-spark/blob/main/docs/ppl-lang/ppl-subquery-command.md
2. Fix the overriding field name issue, `eval a = a +1` won't create `a0` anymore.
3. Replace `verifyDataRowsInOrder` to `verifyDataRows` in some ITs if the tests contain `sort` command.
4. Add anonymizer logical for all new commands.

### Related Issues
Resolves #3360 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
