### PR TITLE
Support multiple table and index pattern

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -37,7 +37,6 @@ import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Let;
-import org.opensearch.sql.ast.expression.QualifiedName;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.subquery.SubqueryExpression;
 import org.opensearch.sql.ast.tree.Aggregation;
@@ -69,12 +68,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
 
   @Override
   public RelNode visitRelation(Relation node, CalcitePlanContext context) {
-    for (QualifiedName qualifiedName : node.getQualifiedNames()) {
-      context.relBuilder.scan(qualifiedName.getParts());
-    }
-    if (node.getQualifiedNames().size() > 1) {
-      context.relBuilder.union(true, node.getQualifiedNames().size());
-    }
+    context.relBuilder.scan(node.getTableQualifiedName().getParts());
     return context.relBuilder.peek();
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
@@ -27,6 +27,10 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
     Request request2 = new Request("PUT", "/test/_doc/2?refresh=true");
     request2.setJsonEntity("{\"name\": \"world\", \"age\": 30}");
     client().performRequest(request2);
+    // PUT index test1
+    Request request3 = new Request("PUT", "/test1/_doc/1?refresh=true");
+    request3.setJsonEntity("{\"name\": \"HELLO\", \"alias\": \"Hello\"}");
+    client().performRequest(request3);
 
     loadIndex(Index.BANK);
   }
@@ -47,11 +51,28 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
   }
 
   @Test
-  public void testMultipleSourceQuery() {
+  public void testMultipleSourceQuery_SameTable() {
     JSONObject actual = executeQuery("source=test, test");
     verifySchema(actual, schema("name", "string"), schema("age", "long"));
+    verifyDataRows(actual, rows("hello", 20), rows("world", 30));
+  }
+
+  @Test
+  public void testMultipleSourceQuery_DifferentTables() {
+    JSONObject actual = executeQuery("source=test, test1");
+    verifySchema(
+        actual, schema("name", "string"), schema("age", "long"), schema("alias", "string"));
     verifyDataRows(
-        actual, rows("hello", 20), rows("world", 30), rows("hello", 20), rows("world", 30));
+        actual, rows("hello", null, 20), rows("world", null, 30), rows("HELLO", "Hello", null));
+  }
+
+  @Test
+  public void testIndexPatterns() {
+    JSONObject actual = executeQuery("source=test*");
+    verifySchema(
+        actual, schema("name", "string"), schema("age", "long"), schema("alias", "string"));
+    verifyDataRows(
+        actual, rows("hello", null, 20), rows("world", null, 30), rows("HELLO", "Hello", null));
   }
 
   @Test
@@ -288,23 +309,48 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
   }
 
   @Test
-  public void testMultipleTables() {
+  public void testMultipleTables_SameTable() {
     JSONObject actual =
         executeQuery(
             String.format("source=%s, %s | stats count() as c", TEST_INDEX_BANK, TEST_INDEX_BANK));
     verifySchema(actual, schema("c", "long"));
-    verifyDataRows(actual, rows(14));
+    verifyDataRows(actual, rows(7));
   }
 
   @Test
-  public void testMultipleTablesAndFilters() {
+  public void testMultipleTablesAndFilters_SameTable() {
     JSONObject actual =
         executeQuery(
             String.format(
                 "source=%s, %s gender = 'F' | stats count() as c",
                 TEST_INDEX_BANK, TEST_INDEX_BANK));
     verifySchema(actual, schema("c", "long"));
-    verifyDataRows(actual, rows(6));
+    verifyDataRows(actual, rows(3));
+  }
+
+  @Test
+  public void testMultipleTables_DifferentTables() {
+    JSONObject actual =
+        executeQuery(String.format("source=%s, test | stats count() as c", TEST_INDEX_BANK));
+    verifySchema(actual, schema("c", "long"));
+    verifyDataRows(actual, rows(9));
+  }
+
+  @Test
+  public void testMultipleTables_WithIndexPattern() {
+    JSONObject actual =
+        executeQuery(String.format("source=%s, test* | stats count() as c", TEST_INDEX_BANK));
+    verifySchema(actual, schema("c", "long"));
+    verifyDataRows(actual, rows(10));
+  }
+
+  @Test
+  public void testMultipleTablesAndFilters_WithIndexPattern() {
+    JSONObject actual =
+        executeQuery(
+            String.format("source=%s, test* gender = 'F' | stats count() as c", TEST_INDEX_BANK));
+    verifySchema(actual, schema("c", "long"));
+    verifyDataRows(actual, rows(3));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
@@ -246,42 +246,23 @@ public class CalcitePPLBasicTest extends CalcitePPLAbstractTest {
   @Test
   public void testMultipleTables() {
     String ppl = "source=EMP, EMP";
-    RelNode root = getRelNode(ppl);
-    String expectedLogical =
-        ""
-            + "LogicalUnion(all=[true])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n";
-    verifyLogical(root, expectedLogical);
-    verifyResultCount(root, 28);
+    try {
+      RelNode root = getRelNode(ppl);
+      fail("expected error, got " + root);
+    } catch (Exception e) {
+      assertThat(e.getMessage(), is("Table 'EMP,EMP' not found"));
+    }
   }
 
   @Test
   public void testMultipleTablesAndFilters() {
     String ppl = "source=EMP, EMP DEPTNO = 20 | fields EMPNO, DEPTNO, SAL";
-    RelNode root = getRelNode(ppl);
-    String expectedLogical =
-        ""
-            + "LogicalProject(EMPNO=[$0], DEPTNO=[$7], SAL=[$5])\n"
-            + "  LogicalFilter(condition=[=($7, 20)])\n"
-            + "    LogicalUnion(all=[true])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
-    verifyLogical(root, expectedLogical);
-    String expectedResult =
-        ""
-            + "EMPNO=7369; DEPTNO=20; SAL=800.00\n"
-            + "EMPNO=7566; DEPTNO=20; SAL=2975.00\n"
-            + "EMPNO=7788; DEPTNO=20; SAL=3000.00\n"
-            + "EMPNO=7876; DEPTNO=20; SAL=1100.00\n"
-            + "EMPNO=7902; DEPTNO=20; SAL=3000.00\n"
-            + "EMPNO=7369; DEPTNO=20; SAL=800.00\n"
-            + "EMPNO=7566; DEPTNO=20; SAL=2975.00\n"
-            + "EMPNO=7788; DEPTNO=20; SAL=3000.00\n"
-            + "EMPNO=7876; DEPTNO=20; SAL=1100.00\n"
-            + "EMPNO=7902; DEPTNO=20; SAL=3000.00\n";
-
-    verifyResult(root, expectedResult);
+    try {
+      RelNode root = getRelNode(ppl);
+      fail("expected error, got " + root);
+    } catch (Exception e) {
+      assertThat(e.getMessage(), is("Table 'EMP,EMP' not found"));
+    }
   }
 
   @Ignore

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLStringFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLStringFunctionTest.java
@@ -53,14 +53,14 @@ public class CalcitePPLStringFunctionTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalAggregate(group=[{}], cnt=[COUNT()])\n"
-            + "  LogicalFilter(condition=[LIKE($2, 'SALE%')])\n"
+            + "  LogicalFilter(condition=[ILIKE($2, 'SALE%')])\n"
             + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult = "cnt=4\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
-        "" + "SELECT COUNT(*) `cnt`\n" + "FROM `scott`.`EMP`\n" + "WHERE `JOB` LIKE 'SALE%'";
+        "" + "SELECT COUNT(*) `cnt`\n" + "FROM `scott`.`EMP`\n" + "WHERE `JOB` ILIKE 'SALE%'";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }


### PR DESCRIPTION
### Description
This PR change to use table qualified name instead of qualified name list. By that, one table scan will support scanning multiple tables and index pattern itself, thus we no need to leverage on union to do multiple table scanning.

`./gradlew :integ-test:integTest --tests '*Calcite*IT'` succeed locally.

`../../../ppl/src/test/java/org/opensearch/sql/ppl/calcite/*` UT succeed locally.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3347

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
