### PR TITLE
Separate with/without pushdown ITs

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLAggregationIT.java
@@ -413,7 +413,7 @@ public class CalcitePPLAggregationIT extends CalcitePPLIntegTestCase {
             + "  ],\n"
             + "  \"datarows\": [\n"
             + "    [\n"
-            + "      0\n"
+            + (isPushdownEnabled() ? "      0\n" : "      null\n")
             + "    ]\n"
             + "  ],\n"
             + "  \"total\": 1,\n"

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLAggregationPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLAggregationPushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLAggregationPushdownIT extends CalcitePPLAggregationIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicPushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLBasicPushdownIT extends CalcitePPLBasicIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBuiltinFunctionPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBuiltinFunctionPushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLBuiltinFunctionPushdownIT extends CalcitePPLBuiltinFunctionIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLExistsSubqueryPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLExistsSubqueryPushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLExistsSubqueryPushdownIT extends CalcitePPLExistsSubqueryIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLInSubqueryPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLInSubqueryPushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLInSubqueryPushdownIT extends CalcitePPLInSubqueryIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLIntegTestCase.java
@@ -84,7 +84,7 @@ public abstract class CalcitePPLIntegTestCase extends PPLIntegTestCase {
     DataSourceService dataSourceService =
         new DataSourceServiceImpl(
             new ImmutableSet.Builder<DataSourceFactory>()
-                .add(new OpenSearchDataSourceFactory(client, defaultSettings()))
+                .add(new OpenSearchDataSourceFactory(client, getSettings()))
                 .build(),
             getDataSourceMetadataStorage(),
             getDataSourceUserRoleHelper());
@@ -94,13 +94,43 @@ public abstract class CalcitePPLIntegTestCase extends PPLIntegTestCase {
     modules.add(
         new CalcitePPLIntegTestCase.StandaloneModule(
             new CalcitePPLIntegTestCase.InternalRestHighLevelClient(client()),
-            defaultSettings(),
+            getSettings(),
             dataSourceService));
     Injector injector = modules.createInjector();
     pplService = SecurityAccess.doPrivileged(() -> injector.getInstance(PPLService.class));
   }
 
+  protected Settings getSettings() {
+    return defaultSettings();
+  }
+
   private Settings defaultSettings() {
+    System.out.println(Settings.Key.CALCITE_PUSHDOWN_ENABLED.name() + " disabled");
+    return new Settings() {
+      private final Map<Key, Object> defaultSettings =
+          new ImmutableMap.Builder<Key, Object>()
+              .put(Key.QUERY_SIZE_LIMIT, 200)
+              .put(Key.SQL_PAGINATION_API_SEARCH_AFTER, true)
+              .put(Key.FIELD_TYPE_TOLERANCE, true)
+              .put(Key.CALCITE_ENGINE_ENABLED, true)
+              .put(Key.CALCITE_FALLBACK_ALLOWED, false)
+              .put(Key.CALCITE_PUSHDOWN_ENABLED, false)
+              .build();
+
+      @Override
+      public <T> T getSettingValue(Key key) {
+        return (T) defaultSettings.get(key);
+      }
+
+      @Override
+      public List<?> getSettings() {
+        return (List<?>) defaultSettings;
+      }
+    };
+  }
+
+  protected Settings enablePushdown() {
+    System.out.println(Settings.Key.CALCITE_PUSHDOWN_ENABLED.name() + " enabled");
     return new Settings() {
       private final Map<Key, Object> defaultSettings =
           new ImmutableMap.Builder<Key, Object>()
@@ -122,6 +152,10 @@ public abstract class CalcitePPLIntegTestCase extends PPLIntegTestCase {
         return (List<?>) defaultSettings;
       }
     };
+  }
+
+  public boolean isPushdownEnabled() {
+    return getSettings().getSettingValue(Settings.Key.CALCITE_PUSHDOWN_ENABLED);
   }
 
   protected String execute(String query) {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLJoinPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLJoinPushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLJoinPushdownIT extends CalcitePPLJoinIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLRenamePushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLRenamePushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLRenamePushdownIT extends CalcitePPLRenameIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLScalarSubqueryPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLScalarSubqueryPushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLScalarSubqueryPushdownIT extends CalcitePPLScalarSubqueryIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLSortPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLSortPushdownIT.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLSortPushdownIT extends CalcitePPLSortIT {
+
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
@@ -135,11 +135,13 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
     updateClusterSettings(
         new SQLIntegTestCase.ClusterSetting(
             "persistent", Settings.Key.CALCITE_FALLBACK_ALLOWED.getKeyValue(), "true"));
+    System.out.println(Settings.Key.CALCITE_FALLBACK_ALLOWED.name() + " enabled");
   }
 
   protected static void disallowCalciteFallback() throws IOException {
     updateClusterSettings(
         new SQLIntegTestCase.ClusterSetting(
             "persistent", Settings.Key.CALCITE_FALLBACK_ALLOWED.getKeyValue(), "false"));
+    System.out.println(Settings.Key.CALCITE_FALLBACK_ALLOWED.name() + " disabled");
   }
 }


### PR DESCRIPTION
### Description

Current, all ITs of Calcite are running with pushdown. It means in some cases, the original execution of Calcite Enumerator does't take effort if the plan is pushed down to OpenSearch. So we need all ITs work without pushdown as well.


### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3411

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
