### PR TITLE
Revert result ordering of `stats-by`

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -35,7 +35,6 @@ import org.apache.calcite.util.Holder;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
-import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Field;
@@ -294,44 +293,9 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
 
     context.relBuilder.aggregate(context.relBuilder.groupKey(groupByList), aggList);
 
-    // handle normal aggregate
-    // TODO Should we keep alignment with V2 behaviour in new Calcite implementation?
-    // TODO how about add a legacy enable config to control behaviour in Calcite?
-    // Some behaviours between PPL and Databases are different.
-    // As an example, in command `stats count() by colA, colB`:
-    // 1. the sequence of output schema is different:
-    // In PPL v2, the sequence of output schema is "count, colA, colB".
-    // But in most databases, the sequence of output schema is "colA, colB, count".
-    // 2. the output order is different:
-    // In PPL v2, the order of output results is ordered by "colA + colB".
-    // But in most databases, the output order is random.
-    // User must add ORDER BY clause after GROUP BY clause to keep the results aligning.
-    // Following logic is to align with the PPL legacy behaviour.
-
-    // alignment for 1.sequence of output schema: adding order-by
-    // we use the groupByList instead of node.getSortExprList as input because
-    // the groupByList may include span column.
-    node.getGroupExprList()
-        .forEach(
-            g -> {
-              // node.getGroupExprList() should all be instance of Alias
-              // which defined in AstBuilder.
-              assert g instanceof Alias;
-            });
-    List<String> aliasesFromGroupByList =
-        groupByList.stream()
-            .map(this::extractAliasLiteral)
-            .flatMap(Optional::stream)
-            .map(ref -> ((RexLiteral) ref).getValueAs(String.class))
-            .toList();
-    List<RexNode> aliasedGroupByList =
-        aliasesFromGroupByList.stream()
-            .map(context.relBuilder::field)
-            .map(f -> (RexNode) f)
-            .toList();
-    context.relBuilder.sort(aliasedGroupByList);
-
-    // alignment for 2.the output order: schema reordering
+    // schema reordering
+    // As an example, in command `stats count() by colA, colB`,
+    // the sequence of output schema is "count, colA, colB".
     List<RexNode> outputFields = context.relBuilder.fields();
     int numOfOutputFields = outputFields.size();
     int numOfAggList = aggList.size();
@@ -341,6 +305,14 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
         outputFields.subList(numOfOutputFields - numOfAggList, numOfOutputFields);
     reordered.addAll(aggRexList);
     // Add group by columns
+    List<RexNode> aliasedGroupByList =
+        groupByList.stream()
+            .map(this::extractAliasLiteral)
+            .flatMap(Optional::stream)
+            .map(ref -> ((RexLiteral) ref).getValueAs(String.class))
+            .map(context.relBuilder::field)
+            .map(f -> (RexNode) f)
+            .toList();
     reordered.addAll(aliasedGroupByList);
     context.relBuilder.project(reordered);
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLAggregationIT.java
@@ -10,7 +10,6 @@ import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_WITH_NULL
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
-import static org.opensearch.sql.util.MatcherUtils.verifyDataRowsInOrder;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 import static org.opensearch.sql.util.MatcherUtils.verifySchemaInOrder;
 
@@ -124,7 +123,7 @@ public class CalcitePPLAggregationIT extends CalcitePPLIntegTestCase {
         schema("avg(balance)", "double"),
         schema("gender", "string"),
         schema("city", "string"));
-    verifyDataRowsInOrder(
+    verifyDataRows(
         actual1,
         rows(40540.0, "F", "Nicholson"),
         rows(32838.0, "F", "Nogal"),
@@ -142,7 +141,7 @@ public class CalcitePPLAggregationIT extends CalcitePPLIntegTestCase {
         schema("avg(balance)", "double"),
         schema("city", "string"),
         schema("gender", "string"));
-    verifyDataRowsInOrder(
+    verifyDataRows(
         actual2,
         rows(39225.0, "Brogan", "M"),
         rows(5686.0, "Dante", "M"),
@@ -165,7 +164,7 @@ public class CalcitePPLAggregationIT extends CalcitePPLIntegTestCase {
         schema("span(age,10)", null, "integer"),
         schema("gender", null, "string"),
         schema("state", null, "string"));
-    verifyDataRowsInOrder(
+    verifyDataRows(
         response,
         rows(1, 20, "F", "VA"),
         rows(1, 30, "F", "IN"),
@@ -178,7 +177,7 @@ public class CalcitePPLAggregationIT extends CalcitePPLIntegTestCase {
 
   @Test
   public void testStatsByMultipleFieldsAndSpan() throws IOException {
-    // Use verifySchemaInOrder() and verifyDataRowsInOrder() to check that the span column is always
+    // Use verifySchemaInOrder() and verifyDataRows() to check that the span column is always
     // the first column in result whatever the order of span in query is first or last one
     JSONObject response =
         executeQuery(
@@ -190,7 +189,7 @@ public class CalcitePPLAggregationIT extends CalcitePPLIntegTestCase {
         schema("span(age,10)", null, "integer"),
         schema("gender", null, "string"),
         schema("state", null, "string"));
-    verifyDataRowsInOrder(
+    verifyDataRows(
         response,
         rows(1, 20, "F", "VA"),
         rows(1, 30, "F", "IN"),

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLJoinIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLJoinIT.java
@@ -743,7 +743,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("b.country", "string"),
         schema("age_span", "integer"),
         schema("avg(salary)", "double"));
-    verifyDataRowsInOrder(
+    verifyDataRows(
         actual, rows(70000.0, 30, "USA"), rows(null, 40, null), rows(100000, 70, "England"));
   }
 }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -301,7 +301,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     Aggregation aggregation =
         new Aggregation(
             aggListBuilder.build(),
-            groupList,
+            Collections.emptyList(),
             groupList,
             span,
             ArgumentFactory.getArgumentList(ctx));

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
@@ -96,16 +96,14 @@ public class CalcitePPLAbstractTest {
 
   /** Verify the logical plan of the given RelNode */
   public void verifyLogical(RelNode rel, String expectedLogical) {
-    String normalized = expectedLogical.replace("\n", System.lineSeparator());
-    assertThat(rel, hasTree(normalized));
+    assertThat(rel, hasTree(expectedLogical));
   }
 
   /** Execute and verify the result of the given RelNode */
   public void verifyResult(RelNode rel, String expectedResult) {
-    String normalized = expectedResult.replace("\n", System.lineSeparator());
     try (PreparedStatement preparedStatement = RelRunners.run(rel)) {
       String s = CalciteAssert.toString(preparedStatement.executeQuery());
-      assertThat(s, is(normalized));
+      assertThat(s, is(expectedResult));
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
@@ -96,14 +96,16 @@ public class CalcitePPLAbstractTest {
 
   /** Verify the logical plan of the given RelNode */
   public void verifyLogical(RelNode rel, String expectedLogical) {
-    assertThat(rel, hasTree(expectedLogical));
+    String normalized = expectedLogical.replace("\n", System.lineSeparator());
+    assertThat(rel, hasTree(normalized));
   }
 
   /** Execute and verify the result of the given RelNode */
   public void verifyResult(RelNode rel, String expectedResult) {
+    String normalized = expectedResult.replace("\n", System.lineSeparator());
     try (PreparedStatement preparedStatement = RelRunners.run(rel)) {
       String s = CalciteAssert.toString(preparedStatement.executeQuery());
-      assertThat(s, is(expectedResult));
+      assertThat(s, is(normalized));
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
@@ -120,9 +122,10 @@ public class CalcitePPLAbstractTest {
 
   /** Verify the generated Spark SQL of the given RelNode */
   public void verifyPPLToSparkSQL(RelNode rel, String expected) {
+    String normalized = expected.replace("\n", System.lineSeparator());
     SqlImplementor.Result result = converter.visitRoot(rel);
     final SqlNode sqlNode = result.asStatement();
     final String sql = sqlNode.toSqlString(SparkSqlDialect.DEFAULT).getSql();
-    assertThat(sql, is(expected));
+    assertThat(sql, is(normalized));
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
@@ -10,13 +10,6 @@ import org.apache.calcite.test.CalciteAssert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-/**
- * Notice: PPL aggregation will add sort by default, for example:
- *
- * <p>{@code | stats count() by deptno,job} equals to
- *
- * <p>{@code GROUP BY deptno,job ORDER BY deptno,job}
- */
 public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
 
   public CalcitePPLAggregationTest() {
@@ -101,15 +94,14 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(avg_sal=[$1], max_sal=[$2], min_sal=[$3], cnt=[$4], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{7}], avg_sal=[AVG($5)], max_sal=[MAX($5)],"
+            + "  LogicalAggregate(group=[{7}], avg_sal=[AVG($5)], max_sal=[MAX($5)],"
             + " min_sal=[MIN($5)], cnt=[COUNT()])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "avg_sal=2916.66; max_sal=5000.00; min_sal=1300.00; cnt=3; DEPTNO=10\n"
             + "avg_sal=2175.00; max_sal=3000.00; min_sal=800.00; cnt=5; DEPTNO=20\n"
+            + "avg_sal=2916.66; max_sal=5000.00; min_sal=1300.00; cnt=3; DEPTNO=10\n"
             + "avg_sal=1566.66; max_sal=2850.00; min_sal=950.00; cnt=6; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
@@ -117,8 +109,7 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
         "SELECT AVG(`SAL`) `avg_sal`, MAX(`SAL`) `max_sal`, MIN(`SAL`) `min_sal`,"
             + " COUNT(*) `cnt`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -129,14 +120,13 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(avg(SAL)=[$1], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{7}], avg(SAL)=[AVG($5)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{7}], avg(SAL)=[AVG($5)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "avg(SAL)=2916.66; DEPTNO=10\n"
             + "avg(SAL)=2175.00; DEPTNO=20\n"
+            + "avg(SAL)=2916.66; DEPTNO=10\n"
             + "avg(SAL)=1566.66; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
@@ -144,8 +134,7 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
         ""
             + "SELECT AVG(`SAL`) `avg(SAL)`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -156,17 +145,15 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical1 =
         ""
             + "LogicalProject(avg(SAL)=[$2], JOB=[$0], DEPTNO=[$1])\n"
-            + "  LogicalSort(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[ASC])\n"
-            + "    LogicalAggregate(group=[{2, 7}], avg(SAL)=[AVG($5)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{2, 7}], avg(SAL)=[AVG($5)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root1, expectedLogical1);
 
     String expectedSparkSql1 =
         ""
             + "SELECT AVG(`SAL`) `avg(SAL)`, `JOB`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `JOB`, `DEPTNO`\n"
-            + "ORDER BY `JOB` NULLS LAST, `DEPTNO` NULLS LAST";
+            + "GROUP BY `JOB`, `DEPTNO`";
     verifyPPLToSparkSQL(root1, expectedSparkSql1);
 
     String ppl2 = "source=EMP | stats avg(SAL) by DEPTNO, JOB";
@@ -174,17 +161,15 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical2 =
         ""
             + "LogicalProject(avg(SAL)=[$2], DEPTNO=[$1], JOB=[$0])\n"
-            + "  LogicalSort(sort0=[$1], sort1=[$0], dir0=[ASC], dir1=[ASC])\n"
-            + "    LogicalAggregate(group=[{2, 7}], avg(SAL)=[AVG($5)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{2, 7}], avg(SAL)=[AVG($5)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root2, expectedLogical2);
 
     String expectedSparkSql2 =
         ""
             + "SELECT AVG(`SAL`) `avg(SAL)`, `DEPTNO`, `JOB`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `JOB`, `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST, `JOB` NULLS LAST";
+            + "GROUP BY `JOB`, `DEPTNO`";
     verifyPPLToSparkSQL(root2, expectedSparkSql2);
   }
 
@@ -195,19 +180,18 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(avg(SAL)=[$1], empno_span=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{1}], avg(SAL)=[AVG($0)])\n"
-            + "      LogicalProject(SAL=[$5], empno_span=[*(FLOOR(/($0, 100)), 100)])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{1}], avg(SAL)=[AVG($0)])\n"
+            + "    LogicalProject(SAL=[$5], empno_span=[*(FLOOR(/($0, 100)), 100)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "avg(SAL)=800.00; empno_span=7300\n"
-            + "avg(SAL)=1600.00; empno_span=7400\n"
-            + "avg(SAL)=2112.50; empno_span=7500\n"
             + "avg(SAL)=2050.00; empno_span=7600\n"
+            + "avg(SAL)=800.00; empno_span=7300\n"
             + "avg(SAL)=2725.00; empno_span=7700\n"
+            + "avg(SAL)=1600.00; empno_span=7400\n"
             + "avg(SAL)=2533.33; empno_span=7800\n"
+            + "avg(SAL)=2112.50; empno_span=7500\n"
             + "avg(SAL)=1750.00; empno_span=7900\n";
     verifyResult(root, expectedResult);
   }
@@ -222,11 +206,10 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
         ""
             + "LogicalSort(sort0=[$2], sort1=[$1], dir0=[ASC], dir1=[ASC])\n"
             + "  LogicalProject(avg(SAL)=[$2], empno_span=[$1], DEPTNO=[$0])\n"
-            + "    LogicalSort(sort0=[$1], sort1=[$0], dir0=[ASC], dir1=[ASC])\n"
-            + "      LogicalAggregate(group=[{1, 2}], avg(SAL)=[AVG($0)])\n"
-            + "        LogicalProject(SAL=[$5], DEPTNO=[$7], empno_span=[*(FLOOR(/($0, 500)),"
+            + "    LogicalAggregate(group=[{1, 2}], avg(SAL)=[AVG($0)])\n"
+            + "      LogicalProject(SAL=[$5], DEPTNO=[$7], empno_span=[*(FLOOR(/($0, 500)),"
             + " 500)])\n"
-            + "          LogicalTableScan(table=[[scott, EMP]])\n";
+            + "        LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
@@ -238,13 +221,11 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
-        "SELECT `avg(SAL)`, `empno_span`, `DEPTNO`\n"
-            + "FROM (SELECT `DEPTNO`, FLOOR(`EMPNO` / 500) * 500 `empno_span`, AVG(`SAL`)"
-            + " `avg(SAL)`\n"
+        ""
+            + "SELECT AVG(`SAL`) `avg(SAL)`, FLOOR(`EMPNO` / 500) * 500 `empno_span`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
             + "GROUP BY `DEPTNO`, FLOOR(`EMPNO` / 500) * 500\n"
-            + "ORDER BY 2 NULLS LAST, `DEPTNO` NULLS LAST) `t1`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST, `empno_span` NULLS LAST";
+            + "ORDER BY `DEPTNO` NULLS LAST, 2 NULLS LAST";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -262,11 +243,10 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
         ""
             + "LogicalSort(sort0=[$2], sort1=[$1], dir0=[ASC], dir1=[ASC])\n"
             + "  LogicalProject(avg(SAL)=[$2], hiredate_span=[$1], DEPTNO=[$0])\n"
-            + "    LogicalSort(sort0=[$1], sort1=[$0], dir0=[ASC], dir1=[ASC])\n"
-            + "      LogicalAggregate(group=[{1, 2}], avg(SAL)=[AVG($0)])\n"
-            + "        LogicalProject(SAL=[$5], DEPTNO=[$7], hiredate_span=[86400000:INTERVAL"
+            + "    LogicalAggregate(group=[{1, 2}], avg(SAL)=[AVG($0)])\n"
+            + "      LogicalProject(SAL=[$5], DEPTNO=[$7], hiredate_span=[86400000:INTERVAL"
             + " DAY])\n"
-            + "          LogicalTableScan(table=[[scott, EMP]])\n";
+            + "        LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
 
     String expectedResult =
@@ -277,13 +257,10 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
-            + "FROM (SELECT AVG(`SAL`) `avg(SAL)`, INTERVAL '1' DAY `hiredate_span`, `DEPTNO`\n"
+        "SELECT AVG(`SAL`) `avg(SAL)`, INTERVAL '1' DAY `hiredate_span`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
             + "GROUP BY `DEPTNO`, INTERVAL '1' DAY\n"
-            + "ORDER BY INTERVAL '1' DAY NULLS LAST, `DEPTNO` NULLS LAST) `t2`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST, `hiredate_span` NULLS LAST";
+            + "ORDER BY `DEPTNO` NULLS LAST, INTERVAL '1' DAY NULLS LAST";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -294,14 +271,13 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(distinct_count(JOB)=[$1], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{7}], distinct_count(JOB)=[COUNT(DISTINCT $2)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{7}], distinct_count(JOB)=[COUNT(DISTINCT $2)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "distinct_count(JOB)=3; DEPTNO=10\n"
             + "distinct_count(JOB)=3; DEPTNO=20\n"
+            + "distinct_count(JOB)=3; DEPTNO=10\n"
             + "distinct_count(JOB)=3; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
@@ -309,8 +285,7 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
         ""
             + "SELECT COUNT(DISTINCT `JOB`) `distinct_count(JOB)`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -321,19 +296,17 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(dc=[$1], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{7}], dc=[COUNT(DISTINCT $2)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{7}], dc=[COUNT(DISTINCT $2)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
-    String expectedResult = "dc=3; DEPTNO=10\ndc=3; DEPTNO=20\ndc=3; DEPTNO=30\n";
+    String expectedResult = "dc=3; DEPTNO=20\ndc=3; DEPTNO=10\ndc=3; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
         ""
             + "SELECT COUNT(DISTINCT `JOB`) `dc`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -368,14 +341,13 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(stddev_samp(SAL)=[$1], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{7}], stddev_samp(SAL)=[STDDEV_SAMP($5)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{7}], stddev_samp(SAL)=[STDDEV_SAMP($5)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "stddev_samp(SAL)=1893.62; DEPTNO=10\n"
             + "stddev_samp(SAL)=1123.33; DEPTNO=20\n"
+            + "stddev_samp(SAL)=1893.62; DEPTNO=10\n"
             + "stddev_samp(SAL)=668.33; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
@@ -383,8 +355,7 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
         ""
             + "SELECT STDDEV_SAMP(`SAL`) `stddev_samp(SAL)`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -395,28 +366,26 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(samp=[$1], empno_span=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{1}], samp=[STDDEV_SAMP($0)])\n"
-            + "      LogicalProject(SAL=[$5], empno_span=[*(FLOOR(/($0, 100)), 100)])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{1}], samp=[STDDEV_SAMP($0)])\n"
+            + "    LogicalProject(SAL=[$5], empno_span=[*(FLOOR(/($0, 100)), 100)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "samp=null; empno_span=7300\n"
-            + "samp=null; empno_span=7400\n"
-            + "samp=1219.75; empno_span=7500\n"
             + "samp=1131.37; empno_span=7600\n"
+            + "samp=null; empno_span=7300\n"
             + "samp=388.90; empno_span=7700\n"
+            + "samp=null; empno_span=7400\n"
             + "samp=2145.53; empno_span=7800\n"
+            + "samp=1219.75; empno_span=7500\n"
             + "samp=1096.58; empno_span=7900\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
         ""
-            + "SELECT `samp`, `empno_span`\n"
-            + "FROM (SELECT FLOOR(`EMPNO` / 100) * 100 `empno_span`, STDDEV_SAMP(`SAL`) `samp`\n"
+            + "SELECT STDDEV_SAMP(`SAL`) `samp`, FLOOR(`EMPNO` / 100) * 100 `empno_span`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY FLOOR(`EMPNO` / 100) * 100\nORDER BY 1 NULLS LAST) `t1`";
+            + "GROUP BY FLOOR(`EMPNO` / 100) * 100";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -427,14 +396,13 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(stddev_pop(SAL)=[$1], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{7}], stddev_pop(SAL)=[STDDEV_POP($5)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{7}], stddev_pop(SAL)=[STDDEV_POP($5)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "stddev_pop(SAL)=1546.14; DEPTNO=10\n"
             + "stddev_pop(SAL)=1004.73; DEPTNO=20\n"
+            + "stddev_pop(SAL)=1546.14; DEPTNO=10\n"
             + "stddev_pop(SAL)=610.10; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
@@ -442,8 +410,7 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
         ""
             + "SELECT STDDEV_POP(`SAL`) `stddev_pop(SAL)`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -454,20 +421,18 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(pop=[$1], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{7}], pop=[STDDEV_POP($5)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{7}], pop=[STDDEV_POP($5)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
-        "pop=1546.14; DEPTNO=10\npop=1004.73; DEPTNO=20\npop=610.10; DEPTNO=30\n";
+        "pop=1004.73; DEPTNO=20\npop=1546.14; DEPTNO=10\npop=610.10; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
         ""
             + "SELECT STDDEV_POP(`SAL`) `pop`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -495,20 +460,15 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(avg_a=[$1], b=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{1}], avg_a=[AVG($0)])\n"
-            + "      LogicalProject(a=[1], b=[1])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{1}], avg_a=[AVG($0)])\n"
+            + "    LogicalProject(a=[1], b=[1])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult = "avg_a=1.0; b=1\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
-        ""
-            + "SELECT AVG(1) `avg_a`, 1 `b`\n"
-            + "FROM `scott`.`EMP`\n"
-            + "GROUP BY 1\n"
-            + "ORDER BY '1' NULLS LAST";
+        "" + "SELECT AVG(1) `avg_a`, 1 `b`\n" + "FROM `scott`.`EMP`\n" + "GROUP BY 1";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -559,23 +519,21 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(avg_avg_sal=[$1], MGR=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{1}], avg_avg_sal=[AVG($0)])\n"
-            + "      LogicalProject(avg_sal=[$2], MGR=[$0])\n"
-            + "        LogicalSort(sort0=[$1], sort1=[$0], dir0=[ASC], dir1=[ASC])\n"
-            + "          LogicalAggregate(group=[{3, 7}], avg_sal=[AVG($5)])\n"
-            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{1}], avg_avg_sal=[AVG($0)])\n"
+            + "    LogicalProject(avg_sal=[$2], MGR=[$0])\n"
+            + "      LogicalAggregate(group=[{3, 7}], avg_sal=[AVG($5)])\n"
+            + "        LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
 
     String expectedResult =
         ""
-            + "avg_avg_sal=3000.00; MGR=7566\n"
+            + "avg_avg_sal=5000.00; MGR=null\n"
             + "avg_avg_sal=1310.00; MGR=7698\n"
             + "avg_avg_sal=1300.00; MGR=7782\n"
             + "avg_avg_sal=1100.00; MGR=7788\n"
-            + "avg_avg_sal=2758.33; MGR=7839\n"
             + "avg_avg_sal=800.00; MGR=7902\n"
-            + "avg_avg_sal=5000.00; MGR=null\n";
+            + "avg_avg_sal=3000.00; MGR=7566\n"
+            + "avg_avg_sal=2758.33; MGR=7839\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
@@ -583,10 +541,8 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
             + "SELECT AVG(`avg_sal`) `avg_avg_sal`, `MGR`\n"
             + "FROM (SELECT AVG(`SAL`) `avg_sal`, `MGR`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `MGR`, `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST, `MGR` NULLS LAST) `t1`\n"
-            + "GROUP BY `MGR`\n"
-            + "ORDER BY `MGR` NULLS LAST";
+            + "GROUP BY `MGR`, `DEPTNO`) `t0`\n"
+            + "GROUP BY `MGR`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEvalTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEvalTest.java
@@ -287,20 +287,18 @@ public class CalcitePPLEvalTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(avg(a)=[$1], b=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{1}], avg(a)=[AVG($0)])\n"
-            + "      LogicalProject(a=[$5], b=[$7])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{1}], avg(a)=[AVG($0)])\n"
+            + "    LogicalProject(a=[$5], b=[$7])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
-    String expectedResult = "avg(a)=2916.66; b=10\navg(a)=2175.00; b=20\navg(a)=1566.66; b=30\n";
+    String expectedResult = "avg(a)=2175.00; b=20\navg(a)=2916.66; b=10\navg(a)=1566.66; b=30\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
         ""
             + "SELECT AVG(`SAL`) `avg(a)`, `DEPTNO` `b`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -311,15 +309,14 @@ public class CalcitePPLEvalTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(avg(b)=[$1], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{0}], avg(b)=[AVG($1)])\n"
-            + "      LogicalProject(DEPTNO=[$7], b=[+($5, 10000)])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{0}], avg(b)=[AVG($1)])\n"
+            + "    LogicalProject(DEPTNO=[$7], b=[+($5, 10000)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "avg(b)=12916.66; DEPTNO=10\n"
             + "avg(b)=12175.00; DEPTNO=20\n"
+            + "avg(b)=12916.66; DEPTNO=10\n"
             + "avg(b)=11566.66; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
@@ -327,8 +324,7 @@ public class CalcitePPLEvalTest extends CalcitePPLAbstractTest {
         ""
             + "SELECT AVG(`SAL` + 10000) `avg(b)`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -339,15 +335,14 @@ public class CalcitePPLEvalTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(avg(b)=[$1], DEPTNO=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{0}], avg(b)=[AVG($1)])\n"
-            + "      LogicalProject(DEPTNO=[$7], b=[+($5, 10000)])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalAggregate(group=[{0}], avg(b)=[AVG($1)])\n"
+            + "    LogicalProject(DEPTNO=[$7], b=[+($5, 10000)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "avg(b)=12916.66; DEPTNO=10\n"
             + "avg(b)=12175.00; DEPTNO=20\n"
+            + "avg(b)=12916.66; DEPTNO=10\n"
             + "avg(b)=11566.66; DEPTNO=30\n";
     verifyResult(root, expectedResult);
 
@@ -355,8 +350,7 @@ public class CalcitePPLEvalTest extends CalcitePPLAbstractTest {
         ""
             + "SELECT AVG(`SAL` + 10000) `avg(b)`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`\n"
-            + "ORDER BY `DEPTNO` NULLS LAST";
+            + "GROUP BY `DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
@@ -430,16 +430,15 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalProject(cnt=[$1], JOB=[$0])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{2}], cnt=[COUNT($3)])\n"
-            + "      LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n"
-            + "        LogicalSort(sort0=[$0], dir0=[DESC], fetch=[10])\n"
-            + "          LogicalProject(DEPTNO=[$0], DNAME=[$1])\n"
-            + "            LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO'))])\n"
-            + "              LogicalTableScan(table=[[scott, DEPT]])\n";
+            + "  LogicalAggregate(group=[{2}], cnt=[COUNT($3)])\n"
+            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalSort(sort0=[$0], dir0=[DESC], fetch=[10])\n"
+            + "        LogicalProject(DEPTNO=[$0], DNAME=[$1])\n"
+            + "          LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO'))])\n"
+            + "            LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
-    String expectedResult = "cnt=1; JOB=CLERK\ncnt=1; JOB=MANAGER\ncnt=4; JOB=SALESMAN\n";
+    String expectedResult = "cnt=4; JOB=SALESMAN\ncnt=1; JOB=CLERK\ncnt=1; JOB=MANAGER\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
@@ -451,8 +450,7 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO'\n"
             + "ORDER BY `DEPTNO` DESC NULLS FIRST\n"
             + "LIMIT 10) `t1` ON `EMP`.`DEPTNO` = `t1`.`DEPTNO`\n"
-            + "GROUP BY `EMP`.`JOB`\n"
-            + "ORDER BY `EMP`.`JOB` NULLS LAST";
+            + "GROUP BY `EMP`.`JOB`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLScalarSubqueryTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLScalarSubqueryTest.java
@@ -298,14 +298,13 @@ public class CalcitePPLScalarSubqueryTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalFilter(condition=[=($5, $SCALAR_QUERY({\n"
-            + "LogicalProject(max_hisal=[$1])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC], fetch=[1])\n"
+            + "LogicalSort(fetch=[1])\n"
+            + "  LogicalProject(max_hisal=[$1])\n"
             + "    LogicalAggregate(group=[{0}], max_hisal=[MAX($2)])\n"
             + "      LogicalFilter(condition=[=($2, $SCALAR_QUERY({\n"
             + "LogicalProject(max_sal=[$1])\n"
-            + "  LogicalSort(sort0=[$0], dir0=[ASC])\n"
-            + "    LogicalAggregate(group=[{2}], max_sal=[MAX($5)])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalAggregate(group=[{2}], max_sal=[MAX($5)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
             + "}))], variablesSet=[[$cor1]])\n"
             + "        LogicalTableScan(table=[[scott, SALGRADE]])\n"
             + "}))], variablesSet=[[$cor0]])\n"
@@ -333,10 +332,8 @@ public class CalcitePPLScalarSubqueryTest extends CalcitePPLAbstractTest {
             + "FROM `scott`.`SALGRADE`\n"
             + "WHERE `HISAL` = (((SELECT MAX(`SAL`) `max_sal`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `JOB`\n"
-            + "ORDER BY `JOB` NULLS LAST)))\n"
+            + "GROUP BY `JOB`)))\n"
             + "GROUP BY `GRADE`\n"
-            + "ORDER BY `GRADE` NULLS LAST\n"
             + "LIMIT 1)))";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -229,7 +229,7 @@ public class AstBuilderTest {
             defaultStatsArgs()));
   }
 
-  @Ignore(value = "disable sortby from the dedup command syntax")
+  @Test
   public void testStatsCommandWithByClause() {
     assertEqual(
         "source=t | stats count(a) by b DEDUP_SPLITVALUES=false",
@@ -241,7 +241,7 @@ public class AstBuilderTest {
             defaultStatsArgs()));
   }
 
-  @Ignore(value = "disable sortby from the dedup command syntax")
+  @Test
   public void testStatsCommandWithByClauseInBackticks() {
     assertEqual(
         "source=t | stats count(a) by `b` DEDUP_SPLITVALUES=false",
@@ -288,7 +288,7 @@ public class AstBuilderTest {
             defaultStatsArgs()));
   }
 
-  @Ignore(value = "disable sortby from the dedup command syntax")
+  @Test
   public void testStatsCommandWithSpan() {
     assertEqual(
         "source=t | stats avg(price) by span(timestamp, 1h)",

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -387,7 +387,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                 argument("type", stringLiteral("str")))));
   }
 
-  @Ignore("https://github.com/opensearch-project/sql/pull/3405")
+  @Test
   public void testAggFuncCallExpr() {
     assertEqual(
         "source=t | stats avg(a) by b",
@@ -399,7 +399,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
             defaultStatsArgs()));
   }
 
-  @Ignore("https://github.com/opensearch-project/sql/pull/3405")
+  @Test
   public void testVarAggregationShouldPass() {
     assertEqual(
         "source=t | stats var_samp(a) by b",
@@ -411,7 +411,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
             defaultStatsArgs()));
   }
 
-  @Ignore("https://github.com/opensearch-project/sql/pull/3405")
+  @Test
   public void testVarpAggregationShouldPass() {
     assertEqual(
         "source=t | stats var_pop(a) by b",
@@ -423,7 +423,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
             defaultStatsArgs()));
   }
 
-  @Ignore("https://github.com/opensearch-project/sql/pull/3405")
+  @Test
   public void testStdDevAggregationShouldPass() {
     assertEqual(
         "source=t | stats stddev_samp(a) by b",
@@ -435,7 +435,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
             defaultStatsArgs()));
   }
 
-  @Ignore("https://github.com/opensearch-project/sql/pull/3405")
+  @Test
   public void testStdDevPAggregationShouldPass() {
     assertEqual(
         "source=t | stats stddev_pop(a) by b",
@@ -489,7 +489,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
             defaultStatsArgs()));
   }
 
-  @Ignore("https://github.com/opensearch-project/sql/pull/3405")
+  @Test
   public void testCountFuncCallExpr() {
     assertEqual(
         "source=t | stats count() by b",
@@ -781,7 +781,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
   }
 
   // https://github.com/opensearch-project/sql/issues/1318
-  @Ignore("https://github.com/opensearch-project/sql/pull/3405")
+  @Test
   public void indexCanBeId() {
     assertEqual(
         "source = index | stats count() by index",


### PR DESCRIPTION
### Description
1. Revert aggregation result ordering of stats-by introduced by https://github.com/opensearch-project/sql/pull/3405.
2. Fix the CR-LF issue

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3426 and https://github.com/opensearch-project/sql/issues/3425

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
