### PR TITLE
[Calcite Engine] Support In expression

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -52,7 +52,9 @@ import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.expression.subquery.ScalarSubquery;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.utils.BuiltinFunctionUtils;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
 import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.CalciteUnsupportedException;
 import org.opensearch.sql.exception.SemanticCheckException;
 
@@ -158,10 +160,12 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
           valueList.stream().map(value -> context.rexBuilder.makeCast(commonType, value)).toList();
       return context.rexBuilder.makeIn(field, newValueList);
     } else {
+      List<ExprType> exprTypes =
+          dataTypes.stream().map(OpenSearchTypeFactory::convertRelDataTypeToExprType).toList();
       throw new SemanticCheckException(
           StringUtils.format(
               "In expression types are incompatible: fields type %s, values type %s",
-              dataTypes.getLast(), dataTypes.subList(0, dataTypes.size() - 1)));
+              exprTypes.getLast(), exprTypes.subList(0, exprTypes.size() - 1)));
     }
   }
 
@@ -186,7 +190,9 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
       throw new SemanticCheckException(
           StringUtils.format(
               "BETWEEN expression types are incompatible: [%s, %s, %s]",
-              value.getType(), lowerBound.getType(), upperBound.getType()));
+              OpenSearchTypeFactory.convertRelDataTypeToExprType(value.getType()),
+              OpenSearchTypeFactory.convertRelDataTypeToExprType(lowerBound.getType()),
+              OpenSearchTypeFactory.convertRelDataTypeToExprType(upperBound.getType())));
     }
     return context.relBuilder.between(value, lowerBound, upperBound);
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -32,6 +32,7 @@ import org.opensearch.sql.ast.expression.And;
 import org.opensearch.sql.ast.expression.Compare;
 import org.opensearch.sql.ast.expression.EqualTo;
 import org.opensearch.sql.ast.expression.Function;
+import org.opensearch.sql.ast.expression.In;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Not;
@@ -137,6 +138,16 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   public RexNode visitNot(Not node, CalcitePlanContext context) {
     final RexNode expr = analyze(node.getExpression(), context);
     return context.relBuilder.not(expr);
+  }
+
+  @Override
+  public RexNode visitIn(In node, CalcitePlanContext context) {
+    final RexNode field = analyze(node.getField(), context);
+    return context.rexBuilder.makeIn(
+        field,
+        node.getValueList().stream()
+            .map(value -> analyze(value, context))
+            .collect(Collectors.toList()));
   }
 
   @Override

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -20,10 +20,8 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   @Ignore("https://github.com/opensearch-project/sql/issues/3428")
   @Override
   public void testIsNotNullFunction() throws IOException {}
-  ;
 
   @Ignore("https://github.com/opensearch-project/sql/issues/3333")
   @Override
   public void testWhereWithMetadataFields() throws IOException {}
-  ;
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -25,9 +25,9 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   @Override
   public void testWhereWithMetadataFields() throws IOException {}
 
-  /*
-  protected void assertExceptionForIncompatibleType() {
-    String message = "class java.math.BigDecimal cannot be cast to class java.lang.Double";
+  @Override
+  protected String getIncompatibleTypeErrMsg() {
+    return "In expression types are incompatible: fields type BIGINT, values type [INTEGER,"
+        + " INTEGER, CHAR(4)]";
   }
-   */
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -24,4 +24,10 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   @Ignore("https://github.com/opensearch-project/sql/issues/3333")
   @Override
   public void testWhereWithMetadataFields() throws IOException {}
+
+  /*
+  protected void assertExceptionForIncompatibleType() {
+    String message = "class java.math.BigDecimal cannot be cast to class java.lang.Double";
+  }
+   */
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -27,7 +27,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Override
   protected String getIncompatibleTypeErrMsg() {
-    return "In expression types are incompatible: fields type BIGINT, values type [INTEGER,"
-        + " INTEGER, CHAR(4)]";
+    return "In expression types are incompatible: fields type LONG, values type [INTEGER, INTEGER,"
+        + " STRING]";
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import org.junit.Ignore;
 import org.opensearch.sql.ppl.WhereCommandIT;
 
-@Ignore("Not all boolean functions are supported in Calcite now")
 public class CalciteWhereCommandIT extends WhereCommandIT {
   @Override
   public void init() throws IOException {
@@ -17,4 +16,14 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
     disallowCalciteFallback();
     super.init();
   }
+
+  @Ignore("https://github.com/opensearch-project/sql/issues/3428")
+  @Override
+  public void testIsNotNullFunction() throws IOException {}
+  ;
+
+  @Ignore("https://github.com/opensearch-project/sql/issues/3333")
+  @Override
+  public void testWhereWithMetadataFields() throws IOException {}
+  ;
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -106,4 +106,20 @@ public class WhereCommandIT extends PPLIntegTestCase {
             String.format("source=%s | where _id='1' | fields firstname", TEST_INDEX_ACCOUNT));
     verifyDataRows(result, rows("Amber"));
   }
+
+  @Test
+  public void testWhereWithIn() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where firstname in ('Amber') | fields firstname", TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Amber"));
+
+    result =
+        executeQuery(
+            String.format(
+                "source=%s | where firstname in ('Amber', 'Dale') | fields firstname",
+                TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Amber"), rows("Dale"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -166,14 +166,15 @@ public class WhereCommandIT extends PPLIntegTestCase {
             () -> {
               executeQuery(
                   String.format(
-                      "source=%s | where balance in (4180, 5686.0, '6077') | fields firstname",
+                      "source=%s | where balance in (4180, 5686, '6077') | fields firstname",
                       TEST_INDEX_ACCOUNT));
             });
-    MatcherAssert.assertThat(
-        e.getMessage(),
-        containsString(
-            "function expected"
-                + " {[BYTE,BYTE],[SHORT,SHORT],[INTEGER,INTEGER],[LONG,LONG],[FLOAT,FLOAT],[DOUBLE,DOUBLE],[STRING,STRING],[BOOLEAN,BOOLEAN],[DATE,DATE],[TIME,TIME],[TIMESTAMP,TIMESTAMP],[INTERVAL,INTERVAL],[IP,IP],[STRUCT,STRUCT],[ARRAY,ARRAY]},"
-                + " but got"));
+    MatcherAssert.assertThat(e.getMessage(), containsString(getIncompatibleTypeErrMsg()));
+  }
+
+  protected String getIncompatibleTypeErrMsg() {
+    return "function expected"
+               + " {[BYTE,BYTE],[SHORT,SHORT],[INTEGER,INTEGER],[LONG,LONG],[FLOAT,FLOAT],[DOUBLE,DOUBLE],[STRING,STRING],[BOOLEAN,BOOLEAN],[DATE,DATE],[TIME,TIME],[TIMESTAMP,TIMESTAMP],[INTERVAL,INTERVAL],[IP,IP],[STRUCT,STRUCT],[ARRAY,ARRAY]},"
+               + " but got [LONG,STRING]";
   }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -330,19 +330,19 @@ expression
 
 // predicates
 logicalExpression
-   : NOT logicalExpression                                      # logicalNot
-   | LT_PRTHS logicalExpression RT_PRTHS                        # parentheticLogicalExpr
-   | comparisonExpression                                       # comparsion
-   | left = logicalExpression OR right = logicalExpression      # logicalOr
+   : LT_PRTHS logicalExpression RT_PRTHS                        # parentheticLogicalExpr
+   | NOT logicalExpression                                      # logicalNot
    | left = logicalExpression (AND)? right = logicalExpression  # logicalAnd
    | left = logicalExpression XOR right = logicalExpression     # logicalXor
+   | left = logicalExpression OR right = logicalExpression      # logicalOr
+   | comparisonExpression                                       # comparsion
    | booleanExpression                                          # booleanExpr
    | relevanceExpression                                        # relevanceExpr
    ;
 
 comparisonExpression
    : left = valueExpression comparisonOperator right = valueExpression  # compareExpr
-   | valueExpression IN valueList                                       # inExpr
+   | valueExpression NOT? IN valueList                                  # inExpr
    ;
 
 valueExpressionList

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -138,11 +138,13 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
 
   @Override
   public UnresolvedExpression visitInExpr(InExprContext ctx) {
-    return new In(
-        visit(ctx.valueExpression()),
-        ctx.valueList().literalValue().stream()
-            .map(this::visitLiteralValue)
-            .collect(Collectors.toList()));
+    UnresolvedExpression expr =
+        new In(
+            visit(ctx.valueExpression()),
+            ctx.valueList().literalValue().stream()
+                .map(this::visitLiteralValue)
+                .collect(Collectors.toList()));
+    return ctx.NOT() != null ? new Not(expr) : expr;
   }
 
   /** Value Expression. */

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -21,6 +21,7 @@ import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Compare;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Function;
+import org.opensearch.sql.ast.expression.In;
 import org.opensearch.sql.ast.expression.Interval;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
@@ -384,6 +385,12 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
       String left = analyze(node.getLeft(), context);
       String right = analyze(node.getRight(), context);
       return StringUtils.format("%s %s %s", left, node.getOperator(), right);
+    }
+
+    @Override
+    public String visitIn(In node, String context) {
+      String field = analyze(node.getField(), context);
+      return StringUtils.format("%s in (%s)", field, MASK_LITERAL);
     }
 
     @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
@@ -104,6 +104,20 @@ public class CalcitePPLBasicTest extends CalcitePPLAbstractTest {
   }
 
   @Test
+  public void testFilterQueryWithIn() {
+    String ppl = "source=scott.products_temporal | where ID in ('1000', '2000')";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalFilter(condition=[SEARCH($0, Sarg['1000', '2000']:CHAR(4))])\n"
+            + "  LogicalTableScan(table=[[scott, products_temporal]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT *\nFROM `scott`.`products_temporal`\nWHERE `ID` IN ('1000', '2000')";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
   public void testQueryWithFields() {
     String ppl = "source=products_temporal | fields SUPPLIER, ID";
     RelNode root = getRelNode(ppl);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
@@ -146,12 +146,26 @@ public class CalcitePPLBasicTest extends CalcitePPLAbstractTest {
     String ppl = "source=scott.products_temporal | where ID in ('1000', '2000')";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        "LogicalFilter(condition=[SEARCH($0, Sarg['1000', '2000']:CHAR(4))])\n"
+        "LogicalFilter(condition=[SEARCH($0, Sarg['1000':VARCHAR(32),"
+            + " '2000':VARCHAR(32)]:VARCHAR(32))])\n"
             + "  LogicalTableScan(table=[[scott, products_temporal]])\n";
     verifyLogical(root, expectedLogical);
 
     String expectedSparkSql =
         "SELECT *\nFROM `scott`.`products_temporal`\nWHERE `ID` IN ('1000', '2000')";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testFilterQueryWithIn2() {
+    String ppl = "source=EMP |  where DEPTNO in (20, 30.0)";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalFilter(condition=[SEARCH($7, Sarg[20.0E0:DOUBLE, 30.0E0:DOUBLE]:DOUBLE)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql = "SELECT *\nFROM `scott`.`EMP`\nWHERE `DEPTNO` IN (2.00E1, 3.00E1)";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -155,6 +155,11 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testInExpression() {
+    assertEquals("source=t | where a in (***)", anonymize("source=t | where a in (1, 2, 3) "));
+  }
+
+  @Test
   public void testQualifiedName() {
     assertEquals("source=t | fields + field0", anonymize("source=t | fields field0"));
   }


### PR DESCRIPTION
### Description
Support In expression, also add data anonymizer for it.

`./gradlew :integ-test:integTest --tests '*Calcite*IT` succeed locally.

`../../../ppl/src/test/java/org/opensearch/sql/ppl/calcite/*` UT succeed locally.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3420

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
