### PR TITLE
Support ppl BETWEEN operator within Calcite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -40,21 +40,33 @@ import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.subquery.SubqueryExpression;
+import org.opensearch.sql.ast.tree.AD;
 import org.opensearch.sql.ast.tree.Aggregation;
+import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.Eval;
+import org.opensearch.sql.ast.tree.FetchCursor;
+import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Join;
+import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.Lookup;
 import org.opensearch.sql.ast.tree.Lookup.OutputStrategy;
+import org.opensearch.sql.ast.tree.ML;
+import org.opensearch.sql.ast.tree.Paginate;
+import org.opensearch.sql.ast.tree.Parse;
 import org.opensearch.sql.ast.tree.Project;
+import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
+import org.opensearch.sql.ast.tree.TableFunction;
+import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.utils.JoinAndLookupUtils;
+import org.opensearch.sql.exception.CalciteUnsupportedException;
 import org.opensearch.sql.exception.SemanticCheckException;
 
 public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalcitePlanContext> {
@@ -446,5 +458,63 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
         context);
 
     return context.relBuilder.peek();
+  }
+
+  /*
+   * Unsupported Commands of PPL with Calcite for OpenSearch 3.0.0-beta
+   */
+  @Override
+  public RelNode visitAD(AD node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("AD command is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitCloseCursor(CloseCursor closeCursor, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Close cursor operation is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitFetchCursor(FetchCursor cursor, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Fetch cursor operation is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitML(ML node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("ML command is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitPaginate(Paginate paginate, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Paginate operation is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitKmeans(Kmeans node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Kmeans command is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitFillNull(FillNull fillNull, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("FillNull command is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitParse(Parse node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Parse command is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitRareTopN(RareTopN node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Rare and Top commands are unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitTableFunction(TableFunction node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Table function is unsupported in Calcite");
+  }
+
+  @Override
+  public RelNode visitTrendline(Trendline node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Trendline command is unsupported in Calcite");
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -20,6 +20,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserUtil;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -29,6 +30,8 @@ import org.apache.calcite.util.TimestampString;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.And;
+import org.opensearch.sql.ast.expression.Between;
+import org.opensearch.sql.ast.expression.Cast;
 import org.opensearch.sql.ast.expression.Compare;
 import org.opensearch.sql.ast.expression.EqualTo;
 import org.opensearch.sql.ast.expression.Function;
@@ -37,15 +40,19 @@ import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.Or;
 import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.RelevanceFieldList;
 import org.opensearch.sql.ast.expression.Span;
 import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.ast.expression.When;
 import org.opensearch.sql.ast.expression.Xor;
 import org.opensearch.sql.ast.expression.subquery.ExistsSubquery;
 import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.expression.subquery.ScalarSubquery;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.utils.BuiltinFunctionUtils;
+import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.exception.CalciteUnsupportedException;
 import org.opensearch.sql.exception.SemanticCheckException;
 
 @RequiredArgsConstructor
@@ -125,12 +132,9 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
 
   @Override
   public RexNode visitXor(Xor node, CalcitePlanContext context) {
-    final RelDataType booleanType =
-        context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN);
     final RexNode left = analyze(node.getLeft(), context);
     final RexNode right = analyze(node.getRight(), context);
-    return context.rexBuilder.makeCall(
-        booleanType, SqlStdOperatorTable.BIT_XOR, List.of(left, right));
+    return context.relBuilder.notEquals(left, right);
   }
 
   @Override
@@ -141,12 +145,28 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
 
   @Override
   public RexNode visitCompare(Compare node, CalcitePlanContext context) {
-    final RelDataType booleanType =
-        context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN);
+    SqlOperator op = BuiltinFunctionUtils.translate(node.getOperator());
     final RexNode left = analyze(node.getLeft(), context);
     final RexNode right = analyze(node.getRight(), context);
-    return context.rexBuilder.makeCall(
-        booleanType, BuiltinFunctionUtils.translate(node.getOperator()), List.of(left, right));
+    return context.relBuilder.call(op, left, right);
+  }
+
+  @Override
+  public RexNode visitBetween(Between node, CalcitePlanContext context) {
+    RexNode value = analyze(node.getValue(), context);
+    RexNode lowerBound = analyze(node.getLowerBound(), context);
+    RexNode upperBound = analyze(node.getUpperBound(), context);
+    RelDataType commonType = context.rexBuilder.commonType(value, lowerBound, upperBound);
+    if (commonType != null) {
+      lowerBound = context.rexBuilder.makeCast(commonType, lowerBound);
+      upperBound = context.rexBuilder.makeCast(commonType, upperBound);
+    } else {
+      throw new SemanticCheckException(
+          StringUtils.format(
+              "BETWEEN expression types are incompatible: [%s, %s, %s]",
+              value.getType(), lowerBound.getType(), upperBound.getType()));
+    }
+    return context.relBuilder.between(value, lowerBound, upperBound);
   }
 
   @Override
@@ -336,5 +356,23 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
       context.setResolvingJoinCondition(true);
     }
     return subqueryRel;
+  }
+
+  /*
+   * Unsupported Expressions of PPL with Calcite for OpenSearch 3.0.0-beta
+   */
+  @Override
+  public RexNode visitCast(Cast node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("CastWhen function is unsupported in Calcite");
+  }
+
+  @Override
+  public RexNode visitWhen(When node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("CastWhen function is unsupported in Calcite");
+  }
+
+  @Override
+  public RexNode visitRelevanceFieldList(RelevanceFieldList node, CalcitePlanContext context) {
+    throw new CalciteUnsupportedException("Relevance fields expression is unsupported in Calcite");
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.calcite;
 
+import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataType;
@@ -33,6 +34,11 @@ public class ExtendedRexBuilder extends RexBuilder {
   public RexNode and(RexNode left, RexNode right) {
     final RelDataType booleanType = this.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN);
     return this.makeCall(booleanType, SqlStdOperatorTable.AND, List.of(left, right));
+  }
+
+  public RelDataType commonType(RexNode... nodes) {
+    return this.getTypeFactory()
+        .leastRestrictive(Arrays.stream(nodes).map(RexNode::getType).toList());
   }
 
   public SqlIntervalQualifier createIntervalUntil(SpanUnit unit) {

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
@@ -34,12 +34,11 @@ public interface BuiltinFunctionUtils {
       case "NOT":
         return SqlStdOperatorTable.NOT;
       case "XOR":
-        return SqlStdOperatorTable.BIT_XOR;
+      case "!=":
+        return SqlStdOperatorTable.NOT_EQUALS;
       case "=":
         return SqlStdOperatorTable.EQUALS;
       case "<>":
-      case "!=":
-        return SqlStdOperatorTable.NOT_EQUALS;
       case ">":
         return SqlStdOperatorTable.GREATER_THAN;
       case ">=":
@@ -48,6 +47,8 @@ public interface BuiltinFunctionUtils {
         return SqlStdOperatorTable.LESS_THAN;
       case "<=":
         return SqlStdOperatorTable.LESS_THAN_OR_EQUAL;
+      case "REGEXP":
+        return SqlLibraryOperators.REGEXP;
       case "+":
         return SqlStdOperatorTable.PLUS;
       case "-":

--- a/core/src/main/java/org/opensearch/sql/exception/CalciteUnsupportedException.java
+++ b/core/src/main/java/org/opensearch/sql/exception/CalciteUnsupportedException.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.exception;
+
+public class CalciteUnsupportedException extends QueryEngineException {
+
+  public CalciteUnsupportedException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -92,7 +92,7 @@ public class QueryService {
             fallbackAllowed = settings.getSettingValue(Settings.Key.CALCITE_FALLBACK_ALLOWED);
           }
           if (!fallbackAllowed) {
-            throw e;
+            listener.onFailure(e);
           }
           LOG.warn("Fallback to V2 query engine since got exception", e);
           executePlan(analyze(plan), PlanContext.emptyPlanContext(), listener);

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteOperatorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteOperatorIT.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import java.io.IOException;
+import org.junit.Ignore;
+import org.opensearch.sql.ppl.OperatorIT;
+
+public class CalciteOperatorIT extends OperatorIT {
+
+  @Override
+  public void init() throws IOException {
+    enableCalcite();
+    disallowCalciteFallback();
+    super.init();
+  }
+
+  @Ignore("https://github.com/opensearch-project/sql/issues/3398")
+  @Override
+  public void testModuleOperator() throws IOException {
+    super.testModuleOperator();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
@@ -483,6 +483,17 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
     verifyDataRows(actual, rows("Nanette", 28));
   }
 
+  @Test
+  public void testNotBetween3() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where not age not between 35 and 38 | fields firstname, age",
+                TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
+    verifyDataRows(actual, rows("Hattie", 36), rows("Elinor", 36));
+  }
+
   @Ignore("https://github.com/opensearch-project/sql/issues/3400")
   public void testDateBetween() {
     JSONObject actual =

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
@@ -14,8 +14,10 @@ import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
 import org.json.JSONObject;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
+import org.opensearch.sql.exception.SemanticCheckException;
 
 public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
 
@@ -110,6 +112,20 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
         executeQuery("source=test | where age > 10 AND age < 100 | fields name, age");
     verifySchema(actual, schema("name", "string"), schema("age", "long"));
     verifyDataRows(actual, rows("hello", 20), rows("world", 30));
+  }
+
+  @Test
+  public void testFilterQuery4() {
+    JSONObject actual = executeQuery("source=test | where age = 20.0 | fields name, age");
+    verifySchema(actual, schema("name", "string"), schema("age", "long"));
+    verifyDataRows(actual, rows("hello", 20));
+  }
+
+  @Test
+  public void testRegexpFilter() {
+    JSONObject actual = executeQuery("source=test | where name REGEXP 'he.*' | fields name, age");
+    verifySchema(actual, schema("name", "string"), schema("age", "long"));
+    verifyDataRows(actual, rows("hello", 20));
   }
 
   @Test
@@ -386,5 +402,110 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
     JSONObject actual = executeQuery("source=a | fields name");
     verifySchema(actual, schema("name", "string"));
     verifyDataRows(actual, rows("hello"));
+  }
+
+  @Test
+  public void testBetween() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where age between 35 and 38 | fields firstname, age",
+                TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
+    verifyDataRows(actual, rows("Hattie", 36), rows("Elinor", 36));
+  }
+
+  @Test
+  public void testBetweenWithExpression() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where age between 36 - 1 and 37 + 1 | fields firstname, age",
+                TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
+    verifyDataRows(actual, rows("Hattie", 36), rows("Elinor", 36));
+  }
+
+  @Test
+  public void testBetweenWithDifferentTypes() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where age between 35.5 and 38.5 | fields firstname, age",
+                TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
+    verifyDataRows(actual, rows("Hattie", 36), rows("Elinor", 36));
+  }
+
+  @Test
+  public void testBetweenWithDifferentTypes2() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where age between 35 and 38.5 | fields firstname, age",
+                TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
+    verifyDataRows(actual, rows("Hattie", 36), rows("Elinor", 36));
+  }
+
+  @Test
+  public void testBetweenWithIncompatibleTypes() {
+    SemanticCheckException e =
+        assertThrows(
+            SemanticCheckException.class,
+            () ->
+                executeQuery(
+                    String.format(
+                        "source=%s | where age between '35' and 38.5 | fields firstname, age",
+                        TEST_INDEX_BANK)));
+    verifyErrorMessageContains(e, "BETWEEN expression types are incompatible");
+  }
+
+  @Test
+  public void testNotBetween() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where age not between 30 and 39 | fields firstname, age",
+                TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
+    verifyDataRows(actual, rows("Nanette", 28));
+  }
+
+  @Test
+  public void testNotBetween2() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where not age between 30 and 39 | fields firstname, age",
+                TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("age", "integer"));
+    verifyDataRows(actual, rows("Nanette", 28));
+  }
+
+  @Ignore("https://github.com/opensearch-project/sql/issues/3400")
+  public void testDateBetween() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                """
+                    source=%s
+                    | where birthdate between date('2018-06-01') and date('2018-06-30')
+                    | fields firstname, birthdate
+                    """,
+                TEST_INDEX_BANK));
+    verifySchema(actual, schema("firstname", "string"), schema("birthdate", "timestamp"));
+    verifyDataRows(
+        actual, rows("Nanette", "2018-06-23 00:00:00"), rows("Elinor", "2018-06-27 00:00:00"));
+  }
+
+  @Test
+  public void testXor() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where firstname='Hattie' xor age=36 | fields firstname, age",
+                TEST_INDEX_BANK));
+    verifyDataRows(result, rows("Elinor", 36));
   }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -342,6 +342,7 @@ LIKE:                               'LIKE';
 ISNULL:                             'ISNULL';
 ISNOTNULL:                          'ISNOTNULL';
 CIDRMATCH:                          'CIDRMATCH';
+BETWEEN:                            'BETWEEN';
 
 // FLOWCONTROL FUNCTIONS
 IFNULL:                             'IFNULL';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -390,8 +390,9 @@ logicalExpression
    ;
 
 comparisonExpression
-   : left = valueExpression comparisonOperator right = valueExpression  # compareExpr
-   | valueExpression IN valueList                                       # inExpr
+   : left = valueExpression comparisonOperator right = valueExpression      # compareExpr
+   | valueExpression NOT? IN valueList                                      # inExpr
+   | valueExpression NOT? BETWEEN valueExpression AND valueExpression       # between
    ;
 
 valueExpressionList
@@ -965,6 +966,7 @@ keywordsCanBeId
    | comparisonOperator
    // commands assist keywords
    | IN
+   | BETWEEN
    | EXISTS
    | SOURCE
    | INDEX

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -439,6 +439,16 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     return new ExistsSubquery(astBuilder.visitSubSearch(ctx.subSearch()));
   }
 
+  @Override
+  public UnresolvedExpression visitBetween(OpenSearchPPLParser.BetweenContext ctx) {
+    UnresolvedExpression betweenExpr =
+        new Between(
+            visit(ctx.valueExpression(0)),
+            visit(ctx.valueExpression(1)),
+            visit(ctx.valueExpression(2)));
+    return ctx.NOT() != null ? new Not(betweenExpr) : betweenExpr;
+  }
+
   private QualifiedName visitIdentifiers(List<? extends ParserRuleContext> ctx) {
     return new QualifiedName(
         ctx.stream()

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -19,6 +19,7 @@ import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.And;
 import org.opensearch.sql.ast.expression.Argument;
+import org.opensearch.sql.ast.expression.Between;
 import org.opensearch.sql.ast.expression.Compare;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Function;
@@ -410,6 +411,14 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
       String left = analyze(node.getLeft(), context);
       String right = analyze(node.getRight(), context);
       return StringUtils.format("%s %s %s", left, node.getOperator(), right);
+    }
+
+    @Override
+    public String visitBetween(Between node, String context) {
+      String value = analyze(node.getValue(), context);
+      String left = analyze(node.getLowerBound(), context);
+      String right = analyze(node.getUpperBound(), context);
+      return StringUtils.format("%s between %s and %s", value, left, right);
     }
 
     @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
@@ -65,6 +65,25 @@ public class CalcitePPLBasicTest extends CalcitePPLAbstractTest {
   }
 
   @Test
+  public void testFilterQueryWithBetween() {
+    String ppl = "source=EMP | where DEPTNO between 20 and 30 | fields EMPNO, ENAME";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalFilter(condition=[SEARCH($7, Sarg[[20..30]])])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE `DEPTNO` >= 20 AND `DEPTNO` <= 30";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
   public void testFilterQueryWithOr() {
     String ppl =
         "source=EMP | where (DEPTNO = 20 or MGR = 30) and SAL > 1000 | fields EMPNO, ENAME";

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
@@ -84,6 +84,25 @@ public class CalcitePPLBasicTest extends CalcitePPLAbstractTest {
   }
 
   @Test
+  public void testFilterQueryWithBetween2() {
+    String ppl = "source=EMP | where DEPTNO between 20 and 30.0 | fields EMPNO, ENAME";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+            + "  LogicalFilter(condition=[SEARCH($7,"
+            + " Sarg[[20.0E0:DOUBLE..30.0E0:DOUBLE]]:DOUBLE)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `EMPNO`, `ENAME`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE `DEPTNO` >= 2.00E1 AND `DEPTNO` <= 3.00E1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
   public void testFilterQueryWithOr() {
     String ppl =
         "source=EMP | where (DEPTNO = 20 or MGR = 30) and SAL > 1000 | fields EMPNO, ENAME";

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -184,6 +184,16 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testBetween() {
+    assertEquals(
+        "source=t | where id between *** and *** | fields + id",
+        anonymize("source=t | where id between 1 and 2 | fields id"));
+    assertEquals(
+        "source=t | where not id between *** and *** | fields + id",
+        anonymize("source=t | where id not between 1 and 2 | fields id"));
+  }
+
+  @Test
   public void testSubqueryAlias() {
     assertEquals("source=t as t1", anonymize("source=t as t1"));
   }


### PR DESCRIPTION
### Description
1. Support ppl `BETWEEN` operator within Calcite
2. Add all unsupported visit callings in code (PPL only)
3. Support `REGEXP` function
4. Fix `xor` operator issue.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3432

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
