### PR TITLE
Support `parse` command with Calcite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -11,7 +11,6 @@ import static org.opensearch.sql.calcite.utils.BuiltinFunctionUtils.translateArg
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.calcite.rel.RelNode;
@@ -248,16 +247,6 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
           .peekCorrelVar()
           .map(correlVar -> context.relBuilder.field(correlVar, qualifiedName))
           .orElseGet(() -> context.relBuilder.field(qualifiedName));
-    }
-    // 3. resolve overriding fields, for example, `eval SAL = SAL + 1` will delete the original SAL
-    // and add a SAL0. SAL0 in currentFields, but qualifiedName is SAL.
-    // TODO now we cannot handle the case using a overriding fields in subquery, for example
-    // source = EMP | eval DEPTNO = DEPTNO + 1 | where exists [ source = DEPT | where emp.DEPTNO =
-    // DEPTNO ]
-    Map<String, String> fieldMap =
-        currentFields.stream().collect(Collectors.toMap(s -> s.replaceAll("\\d", ""), s -> s));
-    if (fieldMap.containsKey(qualifiedName)) {
-      return context.relBuilder.field(fieldMap.get(qualifiedName));
     } else {
       throw new IllegalArgumentException(
           String.format(
@@ -312,13 +301,6 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   private boolean isTimeBased(SpanUnit unit) {
     return !(unit == NONE || unit == UNKNOWN);
   }
-
-  //    @Override
-  //    public RexNode visitAggregateFunction(AggregateFunction node, Context context) {
-  //        RexNode field = analyze(node.getField(), context);
-  //        AggregateCall aggregateCall = translateAggregateCall(node, field, relBuilder);
-  //        return new MyAggregateCall(aggregateCall);
-  //    }
 
   @Override
   public RexNode visitLet(Let node, CalcitePlanContext context) {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteParseCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteParseCommandIT.java
@@ -5,10 +5,8 @@
 
 package org.opensearch.sql.calcite.remote.nonfallback;
 
-import org.junit.Ignore;
 import org.opensearch.sql.calcite.remote.fallback.CalciteParseCommandIT;
 
-@Ignore("https://github.com/opensearch-project/sql/issues/3463")
 public class NonFallbackCalciteParseCommandIT extends CalciteParseCommandIT {
   @Override
   public void init() throws Exception {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDedupIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDedupIT.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
-public class CalciteDedupIT extends CalcitePPLIntegTestCase {
+public class CalcitePPLDedupIT extends CalcitePPLIntegTestCase {
 
   @Override
   public void init() throws IOException {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDedupPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDedupPushdownIT.java
@@ -7,7 +7,7 @@ package org.opensearch.sql.calcite.standalone;
 
 import org.opensearch.sql.common.setting.Settings;
 
-public class CalciteDedupPushdownIT extends CalciteDedupIT {
+public class CalcitePPLDedupPushdownIT extends CalcitePPLDedupIT {
 
   @Override
   protected Settings getSettings() {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLParseIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLParseIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyErrorMessageContains;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class CalcitePPLParseIT extends CalcitePPLIntegTestCase {
+  @Override
+  public void init() throws IOException {
+    super.init();
+
+    loadIndex(Index.BANK);
+    loadIndex(Index.BANK_WITH_NULL_VALUES);
+  }
+
+  @Test
+  public void testParseEmail() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s | parse email '.+@(?<host>.+)' | fields email, host
+                   """,
+                TEST_INDEX_BANK));
+    verifySchema(result, schema("email", "string"), schema("host", "string"));
+    verifyDataRows(
+        result,
+        rows("amberduke@pyrami.com", "pyrami.com"),
+        rows("hattiebond@netagy.com", "netagy.com"),
+        rows("nanettebates@quility.com", "quility.com"),
+        rows("daleadams@boink.com", "boink.com"),
+        rows("elinorratliff@scentric.com", "scentric.com"),
+        rows("virginiaayala@filodyne.com", "filodyne.com"),
+        rows("dillardmcpherson@quailcom.com", "quailcom.com"));
+  }
+
+  @Test
+  public void testParseOverriding() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s | parse email '.+@(?<email>.+)' | fields email
+                   """,
+                TEST_INDEX_BANK));
+    verifySchema(result, schema("email", "string"));
+    verifyDataRows(
+        result,
+        rows("pyrami.com"),
+        rows("netagy.com"),
+        rows("quility.com"),
+        rows("boink.com"),
+        rows("scentric.com"),
+        rows("filodyne.com"),
+        rows("quailcom.com"));
+  }
+
+  @Test
+  public void testParseEmailCountByHost() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s | parse email '.+@(?<host>.+)' | stats count() by host
+                   """,
+                TEST_INDEX_BANK));
+    verifySchema(result, schema("count()", "long"), schema("host", "string"));
+    verifyDataRows(
+        result,
+        rows(1, "pyrami.com"),
+        rows(1, "netagy.com"),
+        rows(1, "quility.com"),
+        rows(1, "boink.com"),
+        rows(1, "scentric.com"),
+        rows(1, "filodyne.com"),
+        rows(1, "quailcom.com"));
+  }
+
+  @Test
+  public void testParseStreetNumber() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                """
+                   source = %s | parse address '(?<streetNumber>\\d+)'
+                   | eval streetNumberInt = cast(streetNumber as integer)
+                   | where streetNumberInt > 500
+                   | sort streetNumberInt
+                   | fields streetNumberInt, address
+                   """,
+                TEST_INDEX_BANK));
+    verifySchema(result, schema("streetNumberInt", "integer"), schema("address", "string"));
+    verifyDataRows(
+        result,
+        rows(671, "671 Bristol Street"),
+        rows(702, "702 Quentin Street"),
+        rows(789, "789 Madison Street"),
+        rows(880, "880 Holmes Lane"));
+  }
+
+  // TODO Multiple capturing groups are not allowed in Calcite REGEXP_EXTRACT function.
+  // https://github.com/opensearch-project/sql/issues/3472
+  @Test
+  public void testParseMultipleGroups() {
+    RuntimeException e =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                executeQuery(
+                    String.format(
+                        """
+                    source = %s | parse address '(?<streetNumber>\\d+) (?<street>.+)'
+                    | fields streetNumber, street
+                    """,
+                        TEST_INDEX_BANK)));
+    verifyErrorMessageContains(
+        e, "Multiple capturing groups (count=2) not allowed in regex input for REGEXP_EXTRACT");
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLParsePushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLParsePushdownIT.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import org.opensearch.sql.common.setting.Settings;
+
+public class CalcitePPLParsePushdownIT extends CalcitePPLParseIT {
+  @Override
+  protected Settings getSettings() {
+    return enablePushdown();
+  }
+}

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -49,6 +49,7 @@ import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Lookup;
+import org.opensearch.sql.ast.tree.Parse;
 import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
@@ -291,6 +292,14 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
     String child = node.getChild().get(0).accept(this, context);
     Integer size = node.getSize();
     return StringUtils.format("%s | head %d", child, size);
+  }
+
+  @Override
+  public String visitParse(Parse node, String context) {
+    String child = node.getChild().get(0).accept(this, context);
+    String source = visitExpression(node.getSourceField());
+    String regrex = node.getPattern().toString();
+    return StringUtils.format("%s | parse %s '%s'", child, source, regrex);
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDedupTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDedupTest.java
@@ -9,9 +9,9 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.test.CalciteAssert;
 import org.junit.Test;
 
-public class CalciteDedupTest extends CalcitePPLAbstractTest {
+public class CalcitePPLDedupTest extends CalcitePPLAbstractTest {
 
-  public CalciteDedupTest() {
+  public CalcitePPLDedupTest() {
     super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
   }
 

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLParseTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLParseTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLParseTest extends CalcitePPLAbstractTest {
+  public CalcitePPLParseTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testParse() {
+    String ppl = "source=EMP | parse HIREDATE '(?<year>\\d{4})-\\d{2}-\\d{2}' | fields JOB, year";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(JOB=[$2], year=[REGEXP_EXTRACT($4, '(?<year>\\d{4})-\\d{2}-\\d{2}')])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `JOB`, REGEXP_EXTRACT(`HIREDATE`, '(?<year>\\d{4})-\\d{2}-\\d{2}') `year`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testParseOverriding() {
+    String ppl = "source=EMP | parse HIREDATE '(?<MGR>\\d{4})-\\d{2}-\\d{2}' | fields JOB, MGR";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        ""
+            + "LogicalProject(JOB=[$2], MGR=[REGEXP_EXTRACT($4, '(?<MGR>\\d{4})-\\d{2}-\\d{2}')])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        ""
+            + "SELECT `JOB`, REGEXP_EXTRACT(`HIREDATE`, '(?<MGR>\\d{4})-\\d{2}-\\d{2}') `MGR`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -301,6 +301,16 @@ public class PPLQueryDataAnonymizerTest {
         anonymize("source=t | eval id=CAST('1' AS DOUBLE) | fields id"));
   }
 
+  @Test
+  public void testParse() {
+    assertEquals(
+        "source=t | parse email '.+@(?<email>.+)'",
+        anonymize("source=t | parse email '.+@(?<email>.+)'"));
+    assertEquals(
+        "source=t | parse email '.+@(?<host>.+)' | fields + email,host",
+        anonymize("source=t | parse email '.+@(?<host>.+)' | fields email, host"));
+  }
+
   private String anonymize(String query) {
     AstBuilder astBuilder = new AstBuilder(query, settings);
     return anonymize(astBuilder.visit(parser.parse(query)));


### PR DESCRIPTION
### Description
Support `parse` command with Calcite

**Limitation:** 
Multiple capturing groups are not allowed in Calcite REGEXP_EXTRACT function.
`| parse address '(?<streetNumber>\d+) (?<street>.+)'` will fallback to V2.

### Related Issues
Resolves #3463 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
