### PR TITLE
[Followup] fix text function IT for locate and strcmp

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/udf/textUDF/LocateFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/textUDF/LocateFunction.java
@@ -14,8 +14,8 @@ public class LocateFunction implements UserDefinedFunction {
       return new IllegalArgumentException(
           "Invalid number of arguments, locate function expects 2 or 3 arguments");
     }
-    String stringText = (String) args[0];
-    String targetText = (String) args[1];
+    String stringText = (String) args[1];
+    String targetText = (String) args[0];
     if (stringText == null || targetText == null) {
       return null;
     }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
@@ -243,6 +243,9 @@ public interface BuiltinFunctionUtils {
                     context.rexBuilder.makeLiteral(" ")));
         RTrimArgs.addAll(argList);
         return RTrimArgs;
+      case "STRCMP":
+        List<RexNode> StrcmpArgs = List.of(argList.get(1), argList.get(0));
+        return StrcmpArgs;
       case "ATAN":
         List<RexNode> AtanArgs = new ArrayList<>(argList);
         if (AtanArgs.size() == 1) {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteTextFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteTextFunctionIT.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.calcite.remote.nonfallback;
 
-import org.junit.Ignore;
 import org.opensearch.sql.calcite.remote.fallback.CalciteTextFunctionIT;
 
 public class NonFallbackCalciteTextFunctionIT extends CalciteTextFunctionIT {
@@ -14,28 +13,4 @@ public class NonFallbackCalciteTextFunctionIT extends CalciteTextFunctionIT {
     super.init();
     disallowCalciteFallback();
   }
-
-  @Ignore("https://github.com/opensearch-project/sql/issues/3467")
-  @Override
-  public void testAscii() {}
-
-  @Ignore("https://github.com/opensearch-project/sql/issues/3467")
-  @Override
-  public void testLeft() {}
-
-  @Ignore("https://github.com/opensearch-project/sql/issues/3467")
-  @Override
-  public void testLocate() {}
-
-  @Ignore("https://github.com/opensearch-project/sql/issues/3467")
-  @Override
-  public void testReplace() {}
-
-  @Ignore("https://github.com/opensearch-project/sql/issues/3467")
-  @Override
-  public void testStrcmp() {}
-
-  @Ignore("https://github.com/opensearch-project/sql/issues/3467")
-  @Override
-  public void testSubstr() {}
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLStringBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLStringBuiltinFunctionIT.java
@@ -157,7 +157,7 @@ public class CalcitePPLStringBuiltinFunctionIT extends CalcitePPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | where locate(name, 'Ja')=1 | fields name, age",
+                "source=%s | where locate('Ja', name)=1 | fields name, age",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("name", "string"), schema("age", "integer"));


### PR DESCRIPTION
### Description
fix text function IT for locate and strcmp, also, enable nonfallback IT.
All calcite IT pass: 
`./gradlew :integ-test:integTest --tests '*Calcite*IT'`


### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3481

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
