### PR TITLE
Fix: CSV handling of embedded crlf

### DIFF
--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/FlatResponseBase.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/FlatResponseBase.java
@@ -84,7 +84,10 @@ public class FlatResponseBase {
 
   protected String quoteIfRequired(String separator, String cell) {
     final String quote = "\"";
-    if (cell.contains(separator) || cell.contains(quote)) {
+    if (cell.contains(separator)
+        || cell.contains(quote)
+        || cell.contains("\r")
+        || cell.contains("\n")) {
       return quote + cell.replaceAll(quote, quote + quote) + quote;
     } else {
       return cell;

--- a/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatterTest.java
+++ b/protocol/src/test/java/org/opensearch/sql/protocol/response/format/CsvResponseFormatterTest.java
@@ -110,9 +110,11 @@ public class CsvResponseFormatterTest {
             schema,
             Arrays.asList(
                 tupleValue(ImmutableMap.of("na,me", "John,Smith", ",,age", "30,,,")),
+                tupleValue(ImmutableMap.of("na,me", "Line\nBreak", ",,age", "28,,,")),
                 tupleValue(ImmutableMap.of("na,me", "\"Janice Jones", ",,age", "26\""))));
     String expected =
-        "\"na,me\",\",,age\"%n\"John,Smith\",\"30,,,\"%n\"\"\"Janice Jones\",\"26\"\"\"";
+        "\"na,me\",\",,age\"%n\"John,Smith\",\"30,,,\"%n\"Line\nBreak\",\"28,,,\"%n"
+            + "\"\"\"Janice Jones\",\"26\"\"\"";
     assertEquals(format(expected), formatter.format(response));
   }
 


### PR DESCRIPTION
### Description

According to RFC 4180 for the CSV file format,
section 2, item 6, if a CSV cell contains a
carriage return ('\r') or line feed ('\n') it
must be quoted.

### Related Issues
Resolves #3514

### Check List
- [x ] New functionality includes testing.
- [ ] New functionality has been documented.  (N/A, bug fix)
 - [ ] New functionality has javadoc added.  (N/A, bug fix)
 - [ ] New functionality has a user manual doc added.  (N/A, bug fix)
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). (N/A, bug fix)
- [x ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose). (N/A, bug fix)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
