### PR TITLE
use correct timezone name

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java
@@ -1332,7 +1332,7 @@ public class DateTimeFunctions {
    * @return ExprValue of date type.
    */
   public static ExprValue exprDateTime(ExprValue timestamp, ExprValue timeZone) {
-    String defaultTimeZone = TimeZone.getDefault().getID();
+    String defaultTimeZone = TimeZone.getDefault().toZoneId().toString();
 
     try {
       LocalDateTime ldtFormatted =


### PR DESCRIPTION
### Description
Previously, we use getID() and it will return some three-letter time zone IDs like "PLT" which is already deprecated (see [here](https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html)). But toZoneId().toString() will return the full name like 'Asia/Karachi'.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
#3516 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
