### PR TITLE
fix varchar bug

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.calcite;
 
 import static org.opensearch.sql.ast.expression.SpanUnit.NONE;
 import static org.opensearch.sql.ast.expression.SpanUnit.UNKNOWN;
+import static org.opensearch.sql.calcite.utils.BuiltinFunctionUtils.VARCHAR_FORCE_NULLABLE;
 import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.TransferUserDefinedFunction;
 
 import java.math.BigDecimal;
@@ -205,7 +206,7 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
           TransferUserDefinedFunction(
               PostprocessDateToStringFunction.class,
               "PostprocessDateToString",
-              ReturnTypes.CHAR_FORCE_NULLABLE);
+                  VARCHAR_FORCE_NULLABLE);
       RexNode transferredStringNode =
           context.rexBuilder.makeCall(
               postToStringNode,

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -22,7 +22,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
@@ -206,7 +205,7 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
           TransferUserDefinedFunction(
               PostprocessDateToStringFunction.class,
               "PostprocessDateToString",
-                  VARCHAR_FORCE_NULLABLE);
+              VARCHAR_FORCE_NULLABLE);
       RexNode transferredStringNode =
           context.rexBuilder.makeCall(
               postToStringNode,

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
@@ -32,6 +32,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.opensearch.sql.calcite.CalcitePlanContext;
@@ -106,6 +107,9 @@ public interface BuiltinFunctionUtils {
   Set<String> TIME_EXCLUSIVE_OPS =
       Set.of("SECOND", "SECOND_OF_MINUTE", "MINUTE", "MINUTE_OF_HOUR", "HOUR", "HOUR_OF_DAY");
 
+  static SqlReturnTypeInference VARCHAR_FORCE_NULLABLE =
+      ReturnTypes.VARCHAR.andThen(SqlTypeTransforms.FORCE_NULLABLE);
+
   static SqlOperator translate(String op) {
     String capitalOP = op.toUpperCase(Locale.ROOT);
     switch (capitalOP) {
@@ -167,7 +171,8 @@ public interface BuiltinFunctionUtils {
       case "STRCMP":
         return SqlLibraryOperators.STRCMP;
       case "REPLACE":
-        return TransferUserDefinedFunction(ReplaceFunction.class, "REPLACE", ReturnTypes.CHAR);
+        return TransferUserDefinedFunction(
+            ReplaceFunction.class, "REPLACE", VARCHAR_FORCE_NULLABLE);
       case "LOCATE":
         return TransferUserDefinedFunction(
             LocateFunction.class,
@@ -189,7 +194,7 @@ public interface BuiltinFunctionUtils {
       case "CONV":
         // The CONV function in PPL converts between numerical bases,
         // while SqlStdOperatorTable.CONVERT converts between charsets.
-        return TransferUserDefinedFunction(ConvFunction.class, "CONVERT", ReturnTypes.VARCHAR);
+        return TransferUserDefinedFunction(ConvFunction.class, "CONVERT", VARCHAR_FORCE_NULLABLE);
       case "COS":
         return SqlStdOperatorTable.COS;
       case "COT":
@@ -287,10 +292,10 @@ public interface BuiltinFunctionUtils {
         return TransferUserDefinedFunction(FromDaysFunction.class, "FROM_DAYS", dateInference);
       case "DATE_FORMAT":
         return TransferUserDefinedFunction(
-            DateFormatFunction.class, "DATE_FORMAT", ReturnTypes.VARCHAR);
+            DateFormatFunction.class, "DATE_FORMAT", VARCHAR_FORCE_NULLABLE);
       case "GET_FORMAT":
         return TransferUserDefinedFunction(
-            GetFormatFunction.class, "GET_FORMAT", ReturnTypes.VARCHAR);
+            GetFormatFunction.class, "GET_FORMAT", VARCHAR_FORCE_NULLABLE);
       case "MAKETIME":
         return TransferUserDefinedFunction(MakeTimeFunction.class, "MAKETIME", timeInference);
       case "MAKEDATE":
@@ -334,9 +339,11 @@ public interface BuiltinFunctionUtils {
         return TransferUserDefinedFunction(
             TypeOfFunction.class, "typeof", ReturnTypes.VARCHAR_2000_NULLABLE);
       case "DAYNAME":
-        return TransferUserDefinedFunction(PeriodNameFunction.class, "DAYNAME", ReturnTypes.CHAR);
+        return TransferUserDefinedFunction(
+            PeriodNameFunction.class, "DAYNAME", VARCHAR_FORCE_NULLABLE);
       case "MONTHNAME":
-        return TransferUserDefinedFunction(PeriodNameFunction.class, "MONTHNAME", ReturnTypes.CHAR);
+        return TransferUserDefinedFunction(
+            PeriodNameFunction.class, "MONTHNAME", VARCHAR_FORCE_NULLABLE);
       case "LAST_DAY":
         return TransferUserDefinedFunction(LastDayFunction.class, "LAST_DAY", dateInference);
       case "UNIX_TIMESTAMP":
@@ -353,7 +360,7 @@ public interface BuiltinFunctionUtils {
             TimeToSecondFunction.class, "TIME_TO_SEC", ReturnTypes.BIGINT);
       case "TIME_FORMAT":
         return TransferUserDefinedFunction(
-            TimeFormatFunction.class, "TIME_FORMAT", ReturnTypes.CHAR);
+            TimeFormatFunction.class, "TIME_FORMAT", VARCHAR_FORCE_NULLABLE);
       case "TIMESTAMP":
         // return SqlLibraryOperators.TIMESTAMP;
         return TransferUserDefinedFunction(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -202,7 +202,7 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | where strict_date_optional_time > DATE_SUB(TIMESTAMP('1999-04-12"
+                "source=%s | where strict_date_optional_time > DATE_SUB(TIMESTAMP('1984-04-12"
                     + " 20:07:00'), INTERVAL 12 HOUR) | stats COUNT() AS CNT ",
                 TEST_INDEX_DATE_FORMATS));
     verifySchema(actual, schema("CNT", "long"));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -1345,8 +1345,7 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
             String.format(
                 "source=%s | where strict_date <= subdate(date('1998-12-01'), 90) | stats COUNT()",
                 TEST_INDEX_DATE_FORMATS));
-    verifyDataRows(
-            actual, rows(2));
+    verifyDataRows(actual, rows(2));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -1339,6 +1339,17 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
   }
 
   @Test
+  public void testTpchQueryDate() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where strict_date <= subdate(date('1998-12-01'), 90) | stats COUNT()",
+                TEST_INDEX_DATE_FORMATS));
+    verifyDataRows(
+            actual, rows(2));
+  }
+
+  @Test
   public void testExtractWithComplexFormats() {
     JSONObject actual =
         executeQuery(


### PR DESCRIPTION
### Description
Previously we use CHAR in some return type of udf, which will hard truncate return value. Now change it to var char.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
#3400 
#3520 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
