### PR TITLE
[Calcite Engine] Support alias type field

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.calcite.standalone;
 
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ALIAS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
@@ -35,6 +36,7 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
     client().performRequest(request3);
 
     loadIndex(Index.BANK);
+    loadIndex(Index.DATA_TYPE_ALIAS);
   }
 
   @Test
@@ -516,5 +518,16 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
                 "source=%s | where firstname='Hattie' xor age=36 | fields firstname, age",
                 TEST_INDEX_BANK));
     verifyDataRows(result, rows("Elinor", 36));
+  }
+
+  @Test
+  public void testAliasDataType() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where alias_col > 1 | fields original_col, alias_col ",
+                TEST_INDEX_ALIAS));
+    verifySchema(result, schema("original_col", "integer"), schema("alias_col", "integer"));
+    verifyDataRows(result, rows(2, 2), rows(3, 3));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -837,7 +837,7 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         TestsConstants.TEST_INDEX_ALIAS,
         "alias",
         getAliasIndexMapping(),
-        "src/test/resources/work_information.json"),
+        "src/test/resources/alias.json"),
     DUPLICATION_NULLABLE(
         TestsConstants.TEST_INDEX_DUPLICATION_NULLABLE,
         "duplication_nullable",

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
@@ -11,7 +11,9 @@ import static org.opensearch.sql.legacy.SQLIntegTestCase.Index.DATA_TYPE_NUMERIC
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ALIAS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATATYPE_NONNUMERIC;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATATYPE_NUMERIC;
+import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
@@ -85,8 +87,9 @@ public class DataTypeIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where alias_col > 1 " + "| fields original_col, alias_col ",
+                "source=%s | eval a = 1 | where alias_col > 1 | fields original_col, alias_col ",
                 TEST_INDEX_ALIAS));
     verifySchema(result, schema("original_col", "int"), schema("alias_col", "int"));
+    verifyDataRows(result, rows(2, 2), rows(3, 3));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
@@ -87,7 +87,7 @@ public class DataTypeIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | eval a = 1 | where alias_col > 1 | fields original_col, alias_col ",
+                "source=%s | where alias_col > 1 | fields original_col, alias_col ",
                 TEST_INDEX_ALIAS));
     verifySchema(result, schema("original_col", "int"), schema("alias_col", "int"));
     verifyDataRows(result, rows(2, 2), rows(3, 3));

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -10,7 +10,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.calcite.linq4j.AbstractEnumerable;
@@ -81,6 +83,9 @@ public class OpenSearchIndex extends OpenSearchTable {
   /** The cached ExprType of fields. */
   private Map<String, ExprType> cachedFieldTypes = null;
 
+  /** The cached mapping of alias type field to its original path. */
+  private Map<String, String> aliasMapping = null;
+
   /** The cached max result window setting of index. */
   private Integer cachedMaxResultWindow = null;
 
@@ -146,6 +151,22 @@ public class OpenSearchIndex extends OpenSearchTable {
   @Override
   public Map<String, ExprType> getReservedFieldTypes() {
     return METADATAFIELD_TYPE_MAP;
+  }
+
+  public Map<String, String> getAliasMapping() {
+    if (cachedFieldOpenSearchTypes == null) {
+      cachedFieldOpenSearchTypes =
+          new OpenSearchDescribeIndexRequest(client, indexName).getFieldTypes();
+    }
+    if (aliasMapping == null) {
+      aliasMapping =
+          cachedFieldOpenSearchTypes.entrySet().stream()
+              .filter(entry -> entry.getValue().getOriginalPath().isPresent())
+              .collect(
+                  Collectors.toUnmodifiableMap(
+                      Entry::getKey, entry -> entry.getValue().getOriginalPath().get()));
+    }
+    return aliasMapping;
   }
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteEnumerableIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteEnumerableIndexScan.java
@@ -94,10 +94,16 @@ public class CalciteEnumerableIndexScan extends CalciteIndexScan implements Enum
       public Enumerator<Object> enumerator() {
         return new OpenSearchIndexEnumerator(
             osIndex.getClient(),
-            List.copyOf(getRowType().getFieldNames()),
+            getFieldPath(),
             requestBuilder.getMaxResponseSize(),
             osIndex.buildRequest(requestBuilder));
       }
     };
+  }
+
+  private List<String> getFieldPath() {
+    return getRowType().getFieldNames().stream()
+        .map(f -> osIndex.getAliasMapping().getOrDefault(f, f))
+        .toList();
   }
 }


### PR DESCRIPTION
### Description
Support alias type. 

Since Calcite's logical fields is strictly binding to an offset of its physical array, we have to use an approach different from v2(https://github.com/opensearch-project/sql/pull/3246) but more like the implementation in opensearch-spark(https://github.com/opensearch-project/opensearch-spark/pull/1032).

### Related Issues
Resolves  https://github.com/opensearch-project/sql/issues/3397

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
