### PR TITLE
fix timestamp bug

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimestampFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimestampFunction.java
@@ -7,7 +7,6 @@ package org.opensearch.sql.calcite.udf.datetimeUDF;
 
 import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.restoreFunctionProperties;
 import static org.opensearch.sql.calcite.utils.datetime.DateTimeApplyUtils.transferInputToExprTimestampValue;
-import static org.opensearch.sql.calcite.utils.datetime.DateTimeApplyUtils.transferInputToExprValue;
 import static org.opensearch.sql.expression.datetime.DateTimeFunctions.exprAddTime;
 
 import java.util.Objects;
@@ -20,7 +19,8 @@ import org.opensearch.sql.expression.function.FunctionProperties;
 /**
  * We need to write our own since we are actually implement timestamp add here
  * (STRING/DATE/TIME/DATETIME/TIMESTAMP) -> TIMESTAMP (STRING/DATE/TIME/DATETIME/TIMESTAMP,
- * STRING/DATE/TIME/DATETIME/TIMESTAMP) -> TIMESTAMP
+ * STRING/DATE/TIME/DATETIME/TIMESTAMP) -> TIMESTAMP It's implicitly transferred into timestamp, so
+ * we need to do the same thing
  */
 public class TimestampFunction implements UserDefinedFunction {
   @Override
@@ -37,8 +37,10 @@ public class TimestampFunction implements UserDefinedFunction {
       return transferInputToExprTimestampValue(args[0], sqlTypeName, restored).valueForCalcite();
     } else {
       SqlTypeName sqlTypeName = (SqlTypeName) args[2];
-      ExprValue dateTimeBase = transferInputToExprValue(args[0], sqlTypeName);
-      ExprValue addTime = transferInputToExprValue(args[1], (SqlTypeName) args[3]);
+      FunctionProperties restored = restoreFunctionProperties(args[args.length - 1]);
+      ExprValue dateTimeBase = transferInputToExprTimestampValue(args[0], sqlTypeName, restored);
+      ExprValue addTime =
+          transferInputToExprTimestampValue(args[1], (SqlTypeName) args[3], restored);
       return exprAddTime(FunctionProperties.None, dateTimeBase, addTime).valueForCalcite();
     }
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimestampFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimestampFunction.java
@@ -18,9 +18,11 @@ import org.opensearch.sql.expression.function.FunctionProperties;
 
 /**
  * We need to write our own since we are actually implement timestamp add here
- * (STRING/DATE/TIME/DATETIME/TIMESTAMP) -> TIMESTAMP (STRING/DATE/TIME/DATETIME/TIMESTAMP,
- * STRING/DATE/TIME/DATETIME/TIMESTAMP) -> TIMESTAMP It's implicitly transferred into timestamp, so
- * we need to do the same thing
+ * _FUNC_(STRING/DATE/TIME/TIMESTAMP) -> TIMESTAMP
+ *
+ * <p>_FUNC_(STRING/DATE/TIME/TIMESTAMP, STRING/DATE/TIME/TIMESTAMP) -> TIMESTAMP
+ *
+ * <p>In v2, it's implicitly transferred into timestamp, so we need to do the same thing
  */
 public class TimestampFunction implements UserDefinedFunction {
   @Override

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -101,6 +101,7 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
             Date.valueOf("1984-04-12")));
   }
 
+  // TODO: Add Hook to fix the input timestamp. We should actually add HOOK in init.
   @Test
   public void testTimestampWithTimeInput() {
     String utcTomorrow = LocalDate.now().plusDays(1).toString();

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -102,6 +102,20 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
   }
 
   @Test
+  public void testTimestampWithTimeInput() {
+    String utcTomorrow = LocalDate.now().plusDays(1).toString();
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s "
+                    + "| eval timestamp = timestamp(time('12:00:00'), time('12:00:00'))"
+                    + "| fields timestamp | head 1",
+                TEST_INDEX_DATE_FORMATS));
+    verifySchema(actual, schema("timestamp", "timestamp"));
+    verifyDataRows(actual, rows(utcTomorrow + " 00:00:00"));
+  }
+
+  @Test
   public void testTimestamp() {
     JSONObject actual =
         executeQuery(


### PR DESCRIPTION
### Description
This pr fix the timestamp bug when take time argument. It uses the current function properties. We now follow the same logic as https://github.com/opensearch-project/sql/blob/e23a61dcd9f15864a6bf4a5daa7ac4263a890716/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java#L880 to firstly transfer it to timestamp.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/sql/issues/3545

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
