### PR TITLE
Fix GET_FORMAT UDF

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java
@@ -1510,10 +1510,12 @@ public class DateTimeFunctions {
    */
   public static ExprValue exprGetFormat(ExprValue type, ExprValue format) {
     if (formats.contains(
-        type.stringValue().toLowerCase(), format.stringValue().toLowerCase(Locale.ROOT))) {
+        type.stringValue().toLowerCase(Locale.ROOT),
+        format.stringValue().toLowerCase(Locale.ROOT))) {
       return new ExprStringValue(
           formats.get(
-              type.stringValue().toLowerCase(), format.stringValue().toLowerCase(Locale.ROOT)));
+              type.stringValue().toLowerCase(Locale.ROOT),
+              format.stringValue().toLowerCase(Locale.ROOT)));
     }
 
     return ExprNullValue.of();


### PR DESCRIPTION
### Problem Description

When locale is set using `-Dtests.locale=az-Cyrl`, `GET_FORMAT(TIME, [whatever])` and `GET_FORMAT(TIMESTAMP, [whatever])` will always return `NULL`.

### Root Cause

At [`DateTimeFunctions.java:L1511`](https://github.com/opensearch-project/sql/blob/e23a61dcd9f15864a6bf4a5daa7ac4263a890716/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java#L1511), when the local is set to Turkic languages (e.g. Turkish, Azerbaijani), `type.stringValue().toLowerCase` will return `tıme` for `TIME`, where ı is a dotless i, causing the key not existing in the predefined formats map.

### Fix

Specify locale as `Locale.ROOT` when converting this string to lowercase.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
