### PR TITLE
Support UDT for BINARY

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/type/ExprBinaryType.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/type/ExprBinaryType.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.type;
+
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
+
+public class ExprBinaryType extends ExprSqlType {
+  public ExprBinaryType(OpenSearchTypeFactory typeFactory) {
+    super(typeFactory, ExprUDT.EXPR_BINARY, SqlTypeName.VARCHAR);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.calcite.utils;
 
 import static org.opensearch.sql.data.type.ExprCoreType.ARRAY;
+import static org.opensearch.sql.data.type.ExprCoreType.BINARY;
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
 import static org.opensearch.sql.data.type.ExprCoreType.BYTE;
 import static org.opensearch.sql.data.type.ExprCoreType.DATE;
@@ -41,6 +42,7 @@ import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
+import org.opensearch.sql.calcite.type.ExprBinaryType;
 import org.opensearch.sql.calcite.type.ExprDateType;
 import org.opensearch.sql.calcite.type.ExprIPType;
 import org.opensearch.sql.calcite.type.ExprTimeStampType;
@@ -67,6 +69,7 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
     EXPR_DATE(DATE),
     EXPR_TIME(TIME),
     EXPR_TIMESTAMP(TIMESTAMP),
+    EXPR_BINARY(BINARY),
     EXPR_IP(IP);
 
     // Associated `ExprCoreType`
@@ -120,6 +123,8 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
             yield new ExprTimeType(this);
           case EXPR_TIMESTAMP:
             yield new ExprTimeStampType(this);
+          case EXPR_BINARY:
+            yield new ExprBinaryType(this);
           case EXPR_IP:
             yield new ExprIPType(this);
         };
@@ -180,7 +185,7 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
       }
     } else {
       if (fieldType.legacyTypeName().equalsIgnoreCase("binary")) {
-        return TYPE_FACTORY.createSqlType(SqlTypeName.BINARY, nullable);
+        return TYPE_FACTORY.createUDT(ExprUDT.EXPR_BINARY, nullable);
       } else if (fieldType.legacyTypeName().equalsIgnoreCase("timestamp")) {
         return TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, nullable);
       } else if (fieldType.legacyTypeName().equalsIgnoreCase("date")) {
@@ -243,20 +248,9 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
 
   /** Get legacy name for a RelDataType. */
   public static String getLegacyTypeName(RelDataType relDataType, QueryType queryType) {
-    if (relDataType instanceof AbstractExprRelDataType<?> udt) {
-      return udt.getExprType().legacyTypeName();
-    }
-    switch (relDataType.getSqlTypeName()) {
-      case BINARY:
-      case VARBINARY:
-        return "BINARY";
-      case GEOMETRY:
-        return "GEO_POINT";
-      default:
-        ExprType type = convertSqlTypeNameToExprType(relDataType.getSqlTypeName());
-        return (queryType == PPL ? PPL_SPEC.typeName(type) : type.legacyTypeName())
-            .toUpperCase(Locale.ROOT);
-    }
+    ExprType type = convertRelDataTypeToExprType(relDataType);
+    return (queryType == PPL ? PPL_SPEC.typeName(type) : type.legacyTypeName())
+        .toUpperCase(Locale.ROOT);
   }
 
   /** Converts a Calcite data type to OpenSearch ExprCoreType. */

--- a/core/src/main/java/org/opensearch/sql/data/type/ExprCoreType.java
+++ b/core/src/main/java/org/opensearch/sql/data/type/ExprCoreType.java
@@ -51,6 +51,8 @@ public enum ExprCoreType implements ExprType {
   /** Geometry. Only support point now. */
   GEO_POINT(UNDEFINED),
 
+  BINARY(UNDEFINED),
+
   /** Struct. */
   STRUCT(UNDEFINED),
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteDataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteDataTypeIT.java
@@ -5,9 +5,6 @@
 
 package org.opensearch.sql.calcite.remote.nonfallback;
 
-import java.io.IOException;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.opensearch.sql.calcite.remote.fallback.CalciteDataTypeIT;
 
 public class NonFallbackCalciteDataTypeIT extends CalciteDataTypeIT {
@@ -15,12 +12,5 @@ public class NonFallbackCalciteDataTypeIT extends CalciteDataTypeIT {
   public void init() throws Exception {
     super.init();
     disallowCalciteFallback();
-  }
-
-  @Override
-  @Test
-  @Ignore("ignore this class since IP type is unsupported in calcite engine")
-  public void test_nonnumeric_data_types() throws IOException {
-    super.test_nonnumeric_data_types();
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
@@ -17,6 +17,7 @@ import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -60,6 +61,21 @@ public class DataTypeIT extends PPLIntegTestCase {
         schema("object_value", "struct"),
         schema("nested_value", "array"),
         schema("geo_point_value", "geo_point"));
+    verifyDataRows(
+        result,
+        rows(
+            "text",
+            "2019-03-24 01:34:46.123456789",
+            "2020-10-13 13:00:00",
+            true,
+            "127.0.0.1",
+            new JSONArray(
+                "[{\"last\": \"Smith\", \"first\": \"John\"}, {\"last\": \"White\", \"first\":"
+                    + " \"Alice\"}]"),
+            new JSONObject("{\"last\": \"Dale\", \"first\": \"Dale\"}"),
+            "keyword",
+            new JSONObject("{\"lon\": 74, \"lat\": 40.71}"),
+            "U29tZSBiaW5hcnkgYmxvYg=="));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -12,9 +12,11 @@ import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 
 import java.io.IOException;
+import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.opensearch.sql.data.type.ExprCoreType;
 
 public class WhereCommandIT extends PPLIntegTestCase {
 
@@ -175,8 +177,11 @@ public class WhereCommandIT extends PPLIntegTestCase {
   }
 
   protected String getIncompatibleTypeErrMsg() {
-    return "function expected"
-               + " {[BYTE,BYTE],[SHORT,SHORT],[INTEGER,INTEGER],[LONG,LONG],[FLOAT,FLOAT],[DOUBLE,DOUBLE],[STRING,STRING],[BOOLEAN,BOOLEAN],[DATE,DATE],[TIME,TIME],[TIMESTAMP,TIMESTAMP],[INTERVAL,INTERVAL],[IP,IP],[GEO_POINT,GEO_POINT],[STRUCT,STRUCT],[ARRAY,ARRAY]},"
-               + " but got [LONG,STRING]";
+    return String.format(
+        "function expected %s, but got %s",
+        ExprCoreType.coreTypes().stream()
+            .map(type -> String.format("[%s,%s]", type.typeName(), type.typeName()))
+            .collect(Collectors.joining(",", "{", "}")),
+        "[LONG, STRING]");
   }
 }


### PR DESCRIPTION
### Description
We previous transform OpenSearch binary type to Calcite's SqlTypeName.BINARY. However, OpenSearch stores binary value as string while Calcite stores it as ByteString, the gap will lead to execution error if transforming directly.

This PR fixes it by viewing our OpenSearch binary type as a new UDT, which maps to SqlTypeName.VARCHAR

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3548

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
