### PR TITLE
Speed up aggregation pushdown for single group-by expression

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/BucketAggregationParser.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/BucketAggregationParser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.response.agg;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import org.opensearch.search.aggregations.Aggregation;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+
+/**
+ * Use BucketAggregationParser only when there is a single group-by key, it returns multiple
+ * buckets. {@link CompositeAggregationParser} is used for multiple group by keys
+ */
+@EqualsAndHashCode
+public class BucketAggregationParser implements OpenSearchAggregationResponseParser {
+  private final MetricParserHelper metricsParser;
+
+  public BucketAggregationParser(MetricParser... metricParserList) {
+    metricsParser = new MetricParserHelper(Arrays.asList(metricParserList));
+  }
+
+  public BucketAggregationParser(List<MetricParser> metricParserList) {
+    metricsParser = new MetricParserHelper(metricParserList);
+  }
+
+  @Override
+  public List<Map<String, Object>> parse(Aggregations aggregations) {
+    Aggregation agg = aggregations.asList().getFirst();
+    return ((MultiBucketsAggregation) agg)
+        .getBuckets().stream().map(b -> parse(b, agg.getName())).collect(Collectors.toList());
+  }
+
+  private Map<String, Object> parse(MultiBucketsAggregation.Bucket bucket, String keyName) {
+    Map<String, Object> resultMap = new LinkedHashMap<>();
+    resultMap.put(keyName, bucket.getKey());
+    resultMap.putAll(metricsParser.parse(bucket.getAggregations()));
+    return resultMap;
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/CompositeAggregationParser.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/response/agg/CompositeAggregationParser.java
@@ -22,7 +22,11 @@ import lombok.EqualsAndHashCode;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.aggregations.bucket.composite.CompositeAggregation;
 
-/** Composite Aggregation Parser which include composite aggregation and metric parsers. */
+/**
+ * Composite Aggregation Parser which include composite aggregation and metric parsers. This is only
+ * for the aggregation with multiple group-by keys. Use {@link BucketAggregationParser} when there
+ * is only one group-by key.
+ */
 @EqualsAndHashCode
 public class CompositeAggregationParser implements OpenSearchAggregationResponseParser {
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilder.java
@@ -29,11 +29,13 @@ import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.expression.aggregation.NamedAggregator;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
+import org.opensearch.sql.opensearch.response.agg.BucketAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.CompositeAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.MetricParser;
 import org.opensearch.sql.opensearch.response.agg.NoBucketAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.OpenSearchAggregationResponseParser;
 import org.opensearch.sql.opensearch.storage.script.aggregation.dsl.BucketAggregationBuilder;
+import org.opensearch.sql.opensearch.storage.script.aggregation.dsl.CompositeAggregationBuilder;
 import org.opensearch.sql.opensearch.storage.script.aggregation.dsl.MetricAggregationBuilder;
 import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
 
@@ -50,12 +52,16 @@ public class AggregationQueryBuilder extends ExpressionNodeVisitor<AggregationBu
   /** Bucket Aggregation builder. */
   private final BucketAggregationBuilder bucketBuilder;
 
+  /** Composite Aggregation builder for multiple buckets. */
+  private final CompositeAggregationBuilder compositeBuilder;
+
   /** Metric Aggregation builder. */
   private final MetricAggregationBuilder metricBuilder;
 
   /** Aggregation Query Builder Constructor. */
   public AggregationQueryBuilder(ExpressionSerializer serializer) {
     this.bucketBuilder = new BucketAggregationBuilder(serializer);
+    this.compositeBuilder = new CompositeAggregationBuilder(serializer);
     this.metricBuilder = new MetricAggregationBuilder(serializer);
   }
 
@@ -74,13 +80,20 @@ public class AggregationQueryBuilder extends ExpressionNodeVisitor<AggregationBu
       return Pair.of(
           ImmutableList.copyOf(metrics.getLeft().getAggregatorFactories()),
           new NoBucketAggregationParser(metrics.getRight()));
+    } else if (groupByList.size() == 1) {
+      // one bucket, use values source bucket builder for getting better performance
+      return Pair.of(
+          Collections.singletonList(
+              bucketBuilder.build(groupByList.getFirst()).subAggregations(metrics.getLeft())),
+          new BucketAggregationParser(metrics.getRight()));
     } else {
+      // multiple bucket, use composite builder
       GroupSortOrder groupSortOrder = new GroupSortOrder(sortList);
       return Pair.of(
           Collections.singletonList(
               AggregationBuilders.composite(
                       "composite_buckets",
-                      bucketBuilder.build(
+                      compositeBuilder.build(
                           groupByList.stream()
                               .sorted(groupSortOrder)
                               .map(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/BucketAggregationBuilder.java
@@ -8,18 +8,15 @@ package org.opensearch.sql.opensearch.storage.script.aggregation.dsl;
 import static org.opensearch.sql.data.type.ExprCoreType.DATE;
 import static org.opensearch.sql.data.type.ExprCoreType.TIME;
 import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
+import static org.opensearch.sql.opensearch.storage.script.aggregation.AggregationQueryBuilder.AGGREGATION_BUCKET_SIZE;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
-import org.apache.commons.lang3.tuple.Triple;
-import org.opensearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
-import org.opensearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
-import org.opensearch.search.aggregations.bucket.composite.HistogramValuesSourceBuilder;
-import org.opensearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
+import org.opensearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.support.ValueType;
-import org.opensearch.search.sort.SortOrder;
+import org.opensearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.expression.span.SpanExpression;
@@ -35,65 +32,43 @@ public class BucketAggregationBuilder {
     this.helper = new AggregationBuilderHelper(serializer);
   }
 
-  /** Build the list of CompositeValuesSourceBuilder. */
-  public List<CompositeValuesSourceBuilder<?>> build(
-      List<Triple<NamedExpression, SortOrder, MissingOrder>> groupList) {
-    ImmutableList.Builder<CompositeValuesSourceBuilder<?>> resultBuilder =
-        new ImmutableList.Builder<>();
-    for (Triple<NamedExpression, SortOrder, MissingOrder> groupPair : groupList) {
-      resultBuilder.add(
-          buildCompositeValuesSourceBuilder(
-              groupPair.getLeft(), groupPair.getMiddle(), groupPair.getRight()));
-    }
-    return resultBuilder.build();
-  }
-
-  // todo, Expression should implement buildCompositeValuesSourceBuilder() interface.
-  private CompositeValuesSourceBuilder<?> buildCompositeValuesSourceBuilder(
-      NamedExpression expr, SortOrder sortOrder, MissingOrder missingOrder) {
+  /** Build the list of ValuesSourceAggregationBuilder. */
+  public ValuesSourceAggregationBuilder<?> build(NamedExpression expr) {
     if (expr.getDelegated() instanceof SpanExpression) {
       SpanExpression spanExpr = (SpanExpression) expr.getDelegated();
       return buildHistogram(
           expr.getName(),
           spanExpr.getField().toString(),
           spanExpr.getValue().valueOf().doubleValue(),
-          spanExpr.getUnit(),
-          missingOrder);
+          spanExpr.getUnit());
     } else {
-      CompositeValuesSourceBuilder<?> sourceBuilder =
-          new TermsValuesSourceBuilder(expr.getName())
-              .missingBucket(true)
-              .missingOrder(missingOrder)
-              .order(sortOrder);
+      TermsAggregationBuilder sourceBuilder = new TermsAggregationBuilder(expr.getName());
+      sourceBuilder.size(AGGREGATION_BUCKET_SIZE);
       // Time types values are converted to LONG in ExpressionAggregationScript::execute
       if ((expr.getDelegated().type() instanceof OpenSearchDateType
               && List.of(TIMESTAMP, TIME, DATE)
                   .contains(((OpenSearchDateType) expr.getDelegated().type()).getExprCoreType()))
           || List.of(TIMESTAMP, TIME, DATE).contains(expr.getDelegated().type())) {
-        sourceBuilder.userValuetypeHint(ValueType.LONG);
+        sourceBuilder.userValueTypeHint(ValueType.LONG);
       }
       return helper.build(expr.getDelegated(), sourceBuilder::field, sourceBuilder::script);
     }
   }
 
-  private CompositeValuesSourceBuilder<?> buildHistogram(
-      String name, String field, Double value, SpanUnit unit, MissingOrder missingOrder) {
+  private ValuesSourceAggregationBuilder<?> buildHistogram(
+      String name, String field, Double value, SpanUnit unit) {
     switch (unit) {
       case NONE:
-        return new HistogramValuesSourceBuilder(name)
-            .field(field)
-            .interval(value)
-            .missingBucket(true)
-            .missingOrder(missingOrder);
+        return new HistogramAggregationBuilder(name).field(field).interval(value);
       case UNKNOWN:
         throw new IllegalStateException("Invalid span unit");
       default:
-        return buildDateHistogram(name, field, value.intValue(), unit, missingOrder);
+        return buildDateHistogram(name, field, value.intValue(), unit);
     }
   }
 
-  private CompositeValuesSourceBuilder<?> buildDateHistogram(
-      String name, String field, Integer value, SpanUnit unit, MissingOrder missingOrder) {
+  private ValuesSourceAggregationBuilder<?> buildDateHistogram(
+      String name, String field, Integer value, SpanUnit unit) {
     String spanValue = value + unit.getName();
     switch (unit) {
       case MILLISECOND:
@@ -106,16 +81,13 @@ public class BucketAggregationBuilder {
       case H:
       case DAY:
       case D:
-        return new DateHistogramValuesSourceBuilder(name)
+        return new DateHistogramAggregationBuilder(name)
             .field(field)
-            .missingBucket(true)
-            .missingOrder(missingOrder)
-            .fixedInterval(new DateHistogramInterval(spanValue));
+            .fixedInterval(
+                new DateHistogramInterval(spanValue)); // TODO extracted from span expression
       default:
-        return new DateHistogramValuesSourceBuilder(name)
+        return new DateHistogramAggregationBuilder(name)
             .field(field)
-            .missingBucket(true)
-            .missingOrder(missingOrder)
             .calendarInterval(new DateHistogramInterval(spanValue));
     }
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/CompositeAggregationBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/CompositeAggregationBuilder.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.aggregation.dsl;
+
+import static org.opensearch.sql.data.type.ExprCoreType.DATE;
+import static org.opensearch.sql.data.type.ExprCoreType.TIME;
+import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Triple;
+import org.opensearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
+import org.opensearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
+import org.opensearch.search.aggregations.bucket.composite.HistogramValuesSourceBuilder;
+import org.opensearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
+import org.opensearch.search.aggregations.support.ValueType;
+import org.opensearch.search.sort.SortOrder;
+import org.opensearch.sql.ast.expression.SpanUnit;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.span.SpanExpression;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDateType;
+import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
+
+/** Composite Aggregation Builder. */
+public class CompositeAggregationBuilder {
+
+  private final AggregationBuilderHelper helper;
+
+  public CompositeAggregationBuilder(ExpressionSerializer serializer) {
+    this.helper = new AggregationBuilderHelper(serializer);
+  }
+
+  /** Build the list of CompositeValuesSourceBuilder. */
+  public List<CompositeValuesSourceBuilder<?>> build(
+      List<Triple<NamedExpression, SortOrder, MissingOrder>> groupList) {
+    ImmutableList.Builder<CompositeValuesSourceBuilder<?>> resultBuilder =
+        new ImmutableList.Builder<>();
+    for (Triple<NamedExpression, SortOrder, MissingOrder> groupPair : groupList) {
+      resultBuilder.add(
+          buildCompositeValuesSourceBuilder(
+              groupPair.getLeft(), groupPair.getMiddle(), groupPair.getRight()));
+    }
+    return resultBuilder.build();
+  }
+
+  // todo, Expression should implement buildCompositeValuesSourceBuilder() interface.
+  private CompositeValuesSourceBuilder<?> buildCompositeValuesSourceBuilder(
+      NamedExpression expr, SortOrder sortOrder, MissingOrder missingOrder) {
+    if (expr.getDelegated() instanceof SpanExpression) {
+      SpanExpression spanExpr = (SpanExpression) expr.getDelegated();
+      return buildHistogram(
+          expr.getName(),
+          spanExpr.getField().toString(),
+          spanExpr.getValue().valueOf().doubleValue(),
+          spanExpr.getUnit(),
+          missingOrder);
+    } else {
+      CompositeValuesSourceBuilder<?> sourceBuilder =
+          new TermsValuesSourceBuilder(expr.getName())
+              .missingBucket(true)
+              .missingOrder(missingOrder)
+              .order(sortOrder);
+      // Time types values are converted to LONG in ExpressionAggregationScript::execute
+      if ((expr.getDelegated().type() instanceof OpenSearchDateType
+              && List.of(TIMESTAMP, TIME, DATE)
+                  .contains(((OpenSearchDateType) expr.getDelegated().type()).getExprCoreType()))
+          || List.of(TIMESTAMP, TIME, DATE).contains(expr.getDelegated().type())) {
+        sourceBuilder.userValuetypeHint(ValueType.LONG);
+      }
+      return helper.build(expr.getDelegated(), sourceBuilder::field, sourceBuilder::script);
+    }
+  }
+
+  private CompositeValuesSourceBuilder<?> buildHistogram(
+      String name, String field, Double value, SpanUnit unit, MissingOrder missingOrder) {
+    switch (unit) {
+      case NONE:
+        return new HistogramValuesSourceBuilder(name)
+            .field(field)
+            .interval(value)
+            .missingBucket(true)
+            .missingOrder(missingOrder);
+      case UNKNOWN:
+        throw new IllegalStateException("Invalid span unit");
+      default:
+        return buildDateHistogram(name, field, value.intValue(), unit, missingOrder);
+    }
+  }
+
+  private CompositeValuesSourceBuilder<?> buildDateHistogram(
+      String name, String field, Integer value, SpanUnit unit, MissingOrder missingOrder) {
+    String spanValue = value + unit.getName();
+    switch (unit) {
+      case MILLISECOND:
+      case MS:
+      case SECOND:
+      case S:
+      case MINUTE:
+      case m:
+      case HOUR:
+      case H:
+      case DAY:
+      case D:
+        return new DateHistogramValuesSourceBuilder(name)
+            .field(field)
+            .missingBucket(true)
+            .missingOrder(missingOrder)
+            .fixedInterval(new DateHistogramInterval(spanValue));
+      default:
+        return new DateHistogramValuesSourceBuilder(name)
+            .field(field)
+            .missingBucket(true)
+            .missingOrder(missingOrder)
+            .calendarInterval(new DateHistogramInterval(spanValue));
+    }
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchAggregationResponseParserTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/response/OpenSearchAggregationResponseParserTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.opensearch.search.aggregations.metrics.ExtendedStats;
+import org.opensearch.sql.opensearch.response.agg.BucketAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.CompositeAggregationParser;
 import org.opensearch.sql.opensearch.response.agg.FilterParser;
 import org.opensearch.sql.opensearch.response.agg.NoBucketAggregationParser;
@@ -64,24 +65,19 @@ class OpenSearchAggregationResponseParserTest {
   void one_bucket_one_metric_should_pass() {
     String response =
         "{\n"
-            + "  \"composite#composite_buckets\": {\n"
-            + "    \"after_key\": {\n"
-            + "      \"type\": \"sale\"\n"
-            + "    },\n"
+            + "  \"sterms#type\": {\n"
+            + "    \"doc_count_error_upper_bound\": 0,\n"
+            + "    \"sum_other_doc_count\": 0,\n"
             + "    \"buckets\": [\n"
             + "      {\n"
-            + "        \"key\": {\n"
-            + "          \"type\": \"cost\"\n"
-            + "        },\n"
+            + "        \"key\": \"cost\",\n"
             + "        \"doc_count\": 2,\n"
             + "        \"avg#avg\": {\n"
             + "          \"value\": 20\n"
             + "        }\n"
             + "      },\n"
             + "      {\n"
-            + "        \"key\": {\n"
-            + "          \"type\": \"sale\"\n"
-            + "        },\n"
+            + "        \"key\": \"sale\",\n"
             + "        \"doc_count\": 2,\n"
             + "        \"avg#avg\": {\n"
             + "          \"value\": 105\n"
@@ -92,7 +88,7 @@ class OpenSearchAggregationResponseParserTest {
             + "}";
 
     OpenSearchAggregationResponseParser parser =
-        new CompositeAggregationParser(new SingleValueParser("avg"));
+        new BucketAggregationParser(new SingleValueParser("avg"));
     assertThat(
         parse(parser, response),
         containsInAnyOrder(
@@ -182,15 +178,12 @@ class OpenSearchAggregationResponseParserTest {
   void filter_aggregation_group_by_should_pass() {
     String response =
         "{\n"
-            + "  \"composite#composite_buckets\":{\n"
-            + "    \"after_key\":{\n"
-            + "      \"gender\":\"m\"\n"
-            + "    },\n"
+            + "  \"sterms#gender\": {\n"
+            + "    \"doc_count_error_upper_bound\": 0,\n"
+            + "    \"sum_other_doc_count\": 0,\n"
             + "    \"buckets\":[\n"
             + "      {\n"
-            + "        \"key\":{\n"
-            + "          \"gender\":\"f\"\n"
-            + "        },\n"
+            + "        \"key\":\"f\",\n"
             + "        \"doc_count\":3,\n"
             + "        \"filter#filter\":{\n"
             + "          \"doc_count\":1,\n"
@@ -200,9 +193,7 @@ class OpenSearchAggregationResponseParserTest {
             + "        }\n"
             + "      },\n"
             + "      {\n"
-            + "        \"key\":{\n"
-            + "          \"gender\":\"m\"\n"
-            + "        },\n"
+            + "        \"key\":\"m\",\n"
             + "        \"doc_count\":4,\n"
             + "        \"filter#filter\":{\n"
             + "          \"doc_count\":2,\n"
@@ -215,7 +206,7 @@ class OpenSearchAggregationResponseParserTest {
             + "  }\n"
             + "}";
     OpenSearchAggregationResponseParser parser =
-        new CompositeAggregationParser(
+        new BucketAggregationParser(
             FilterParser.builder()
                 .name("filter")
                 .metricsParser(new SingleValueParser("avg"))
@@ -352,15 +343,12 @@ class OpenSearchAggregationResponseParserTest {
   void one_bucket_one_metric_percentile_should_pass() {
     String response =
         "{\n"
-            + "  \"composite#composite_buckets\": {\n"
-            + "    \"after_key\": {\n"
-            + "      \"type\": \"sale\"\n"
-            + "    },\n"
+            + "  \"sterms#type\": {\n"
+            + "    \"doc_count_error_upper_bound\": 0,\n"
+            + "    \"sum_other_doc_count\": 0,\n"
             + "    \"buckets\": [\n"
             + "      {\n"
-            + "        \"key\": {\n"
-            + "          \"type\": \"cost\"\n"
-            + "        },\n"
+            + "        \"key\": \"cost\",\n"
             + "        \"doc_count\": 2,\n"
             + "        \"percentiles#percentile\": {\n"
             + "          \"values\": {\n"
@@ -369,9 +357,7 @@ class OpenSearchAggregationResponseParserTest {
             + "        }\n"
             + "      },\n"
             + "      {\n"
-            + "        \"key\": {\n"
-            + "          \"type\": \"sale\"\n"
-            + "        },\n"
+            + "        \"key\": \"sale\",\n"
             + "        \"doc_count\": 2,\n"
             + "        \"percentiles#percentile\": {\n"
             + "          \"values\": {\n"
@@ -384,7 +370,7 @@ class OpenSearchAggregationResponseParserTest {
             + "}";
 
     OpenSearchAggregationResponseParser parser =
-        new CompositeAggregationParser(new SinglePercentileParser("percentile"));
+        new BucketAggregationParser(new SinglePercentileParser("percentile"));
     assertThat(
         parse(parser, response),
         containsInAnyOrder(
@@ -470,15 +456,12 @@ class OpenSearchAggregationResponseParserTest {
   void one_bucket_percentiles_should_pass() {
     String response =
         "{\n"
-            + "  \"composite#composite_buckets\": {\n"
-            + "    \"after_key\": {\n"
-            + "      \"type\": \"sale\"\n"
-            + "    },\n"
+            + "  \"sterms#type\": {\n"
+            + "    \"doc_count_error_upper_bound\": 0,\n"
+            + "    \"sum_other_doc_count\": 0,\n"
             + "    \"buckets\": [\n"
             + "      {\n"
-            + "        \"key\": {\n"
-            + "          \"type\": \"cost\"\n"
-            + "        },\n"
+            + "        \"key\": \"cost\",\n"
             + "        \"doc_count\": 2,\n"
             + "        \"percentiles#percentiles\": {\n"
             + "          \"values\": {\n"
@@ -493,9 +476,7 @@ class OpenSearchAggregationResponseParserTest {
             + "        }\n"
             + "      },\n"
             + "      {\n"
-            + "        \"key\": {\n"
-            + "          \"type\": \"sale\"\n"
-            + "        },\n"
+            + "        \"key\": \"sale\",\n"
             + "        \"doc_count\": 2,\n"
             + "        \"percentiles#percentiles\": {\n"
             + "          \"values\": {\n"
@@ -514,7 +495,7 @@ class OpenSearchAggregationResponseParserTest {
             + "}";
 
     OpenSearchAggregationResponseParser parser =
-        new CompositeAggregationParser(new PercentilesParser("percentiles"));
+        new BucketAggregationParser(new PercentilesParser("percentiles"));
     assertThat(
         parse(parser, response),
         containsInAnyOrder(

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilderTest.java
@@ -85,6 +85,16 @@ class AggregationQueryBuilderTest {
                 + "            \"order\" : \"asc\"%n"
                 + "          }%n"
                 + "        }%n"
+                + "      }, {%n"
+                + "        \"date\" : {%n"
+                + "          \"terms\" : {%n"
+                + "            \"field\" : \"date\",%n"
+                + "            \"missing_bucket\" : true,%n"
+                + "            \"value_type\" : \"long\",%n"
+                + "            \"missing_order\" : \"first\",%n"
+                + "            \"order\" : \"asc\"%n"
+                + "          }%n"
+                + "        }%n"
                 + "      } ]%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
@@ -99,7 +109,7 @@ class AggregationQueryBuilderTest {
         buildQuery(
             Arrays.asList(
                 named("avg(age)", new AvgAggregator(Arrays.asList(ref("age", INTEGER)), INTEGER))),
-            Arrays.asList(named("name", ref("name", STRING)))));
+            Arrays.asList(named("name", ref("name", STRING)), named("date", ref("date", DATE)))));
   }
 
   @Test
@@ -119,6 +129,16 @@ class AggregationQueryBuilderTest {
                 + "            \"order\" : \"desc\"%n"
                 + "          }%n"
                 + "        }%n"
+                + "      }, {%n"
+                + "        \"date\" : {%n"
+                + "          \"terms\" : {%n"
+                + "            \"field\" : \"date\",%n"
+                + "            \"missing_bucket\" : true,%n"
+                + "            \"value_type\" : \"long\",%n"
+                + "            \"missing_order\" : \"first\",%n"
+                + "            \"order\" : \"asc\"%n"
+                + "          }%n"
+                + "        }%n"
                 + "      } ]%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
@@ -133,7 +153,7 @@ class AggregationQueryBuilderTest {
         buildQuery(
             Arrays.asList(
                 named("avg(age)", new AvgAggregator(Arrays.asList(ref("age", INTEGER)), INTEGER))),
-            Arrays.asList(named("name", ref("name", STRING))),
+            Arrays.asList(named("name", ref("name", STRING)), named("date", ref("date", DATE))),
             sort(ref("name", STRING), Sort.SortOption.DEFAULT_DESC)));
   }
 
@@ -204,6 +224,16 @@ class AggregationQueryBuilderTest {
                 + "            \"order\" : \"asc\"%n"
                 + "          }%n"
                 + "        }%n"
+                + "      }, {%n"
+                + "        \"date\" : {%n"
+                + "          \"terms\" : {%n"
+                + "            \"field\" : \"date\",%n"
+                + "            \"missing_bucket\" : true,%n"
+                + "            \"value_type\" : \"long\",%n"
+                + "            \"missing_order\" : \"first\",%n"
+                + "            \"order\" : \"asc\"%n"
+                + "          }%n"
+                + "        }%n"
                 + "      } ]%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
@@ -226,8 +256,8 @@ class AggregationQueryBuilderTest {
                         OpenSearchTextType.of(
                             Map.of(
                                 "words",
-                                OpenSearchDataType.of(
-                                    OpenSearchDataType.MappingType.Keyword))))))));
+                                OpenSearchDataType.of(OpenSearchDataType.MappingType.Keyword))))),
+                named("date", ref("date", DATE)))));
   }
 
   @Test
@@ -269,6 +299,18 @@ class AggregationQueryBuilderTest {
                 + "            \"order\" : \"asc\"%n"
                 + "          }%n"
                 + "        }%n"
+                + "      }, {%n"
+                + "        \"date\" : {%n"
+                + "          \"terms\" : {%n"
+                + "            \"script\" : {%n"
+                + "              \"source\" : \"dayname(date)\",%n"
+                + "              \"lang\" : \"opensearch_query_expression\"%n"
+                + "            },%n"
+                + "            \"missing_bucket\" : true,%n"
+                + "            \"missing_order\" : \"first\",%n"
+                + "            \"order\" : \"asc\"%n"
+                + "          }%n"
+                + "        }%n"
                 + "      } ]%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
@@ -288,7 +330,9 @@ class AggregationQueryBuilderTest {
                 named(
                     "avg(balance)",
                     new AvgAggregator(Arrays.asList(DSL.abs(ref("balance", INTEGER))), INTEGER))),
-            Arrays.asList(named("age", DSL.asin(ref("age", INTEGER))))));
+            Arrays.asList(
+                named("age", DSL.asin(ref("age", INTEGER))),
+                named("date", DSL.dayname(ref("date", DATE))))));
   }
 
   @Test
@@ -411,18 +455,17 @@ class AggregationQueryBuilderTest {
     assertEquals(
         format(
             "{%n"
-                + "  \"composite_buckets\" : {%n"
-                + "    \"composite\" : {%n"
+                + "  \"gender\" : {%n"
+                + "    \"terms\" : {%n"
+                + "      \"field\" : \"gender\",%n"
                 + "      \"size\" : 1000,%n"
-                + "      \"sources\" : [ {%n"
-                + "        \"gender\" : {%n"
-                + "          \"terms\" : {%n"
-                + "            \"field\" : \"gender\",%n"
-                + "            \"missing_bucket\" : true,%n"
-                + "            \"missing_order\" : \"first\",%n"
-                + "            \"order\" : \"asc\"%n"
-                + "          }%n"
-                + "        }%n"
+                + "      \"min_doc_count\" : 1,%n"
+                + "      \"shard_min_doc_count\" : 0,%n"
+                + "      \"show_term_doc_count_error\" : false,%n"
+                + "      \"order\" : [ {%n"
+                + "        \"_count\" : \"desc\"%n"
+                + "      }, {%n"
+                + "        \"_key\" : \"asc\"%n"
                 + "      } ]%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
@@ -475,20 +518,16 @@ class AggregationQueryBuilderTest {
     assertEquals(
         format(
             "{%n"
-                + "  \"composite_buckets\" : {%n"
-                + "    \"composite\" : {%n"
-                + "      \"size\" : 1000,%n"
-                + "      \"sources\" : [ {%n"
-                + "        \"SpanExpression(field=age, value=10, unit=NONE)\" : {%n"
-                + "          \"histogram\" : {%n"
-                + "            \"field\" : \"age\",%n"
-                + "            \"missing_bucket\" : true,%n"
-                + "            \"missing_order\" : \"first\",%n"
-                + "            \"order\" : \"asc\",%n"
-                + "            \"interval\" : 10.0%n"
-                + "          }%n"
-                + "        }%n"
-                + "      } ]%n"
+                + "  \"SpanExpression(field=age, value=10, unit=NONE)\" : {%n"
+                + "    \"histogram\" : {%n"
+                + "      \"field\" : \"age\",%n"
+                + "      \"interval\" : 10.0,%n"
+                + "      \"offset\" : 0.0,%n"
+                + "      \"order\" : {%n"
+                + "        \"_key\" : \"asc\"%n"
+                + "      },%n"
+                + "      \"keyed\" : false,%n"
+                + "      \"min_doc_count\" : 0%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
                 + "      \"count(a)\" : {%n"
@@ -510,20 +549,16 @@ class AggregationQueryBuilderTest {
     assertEquals(
         format(
             "{%n"
-                + "  \"composite_buckets\" : {%n"
-                + "    \"composite\" : {%n"
-                + "      \"size\" : 1000,%n"
-                + "      \"sources\" : [ {%n"
-                + "        \"SpanExpression(field=age, value=10, unit=NONE)\" : {%n"
-                + "          \"histogram\" : {%n"
-                + "            \"field\" : \"age\",%n"
-                + "            \"missing_bucket\" : true,%n"
-                + "            \"missing_order\" : \"first\",%n"
-                + "            \"order\" : \"asc\",%n"
-                + "            \"interval\" : 10.0%n"
-                + "          }%n"
-                + "        }%n"
-                + "      } ]%n"
+                + "  \"SpanExpression(field=age, value=10, unit=NONE)\" : {%n"
+                + "    \"histogram\" : {%n"
+                + "      \"field\" : \"age\",%n"
+                + "      \"interval\" : 10.0,%n"
+                + "      \"offset\" : 0.0,%n"
+                + "      \"order\" : {%n"
+                + "        \"_key\" : \"asc\"%n"
+                + "      },%n"
+                + "      \"keyed\" : false,%n"
+                + "      \"min_doc_count\" : 0%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
                 + "      \"count(a)\" : {%n"
@@ -551,20 +586,16 @@ class AggregationQueryBuilderTest {
     assertEquals(
         format(
             "{%n"
-                + "  \"composite_buckets\" : {%n"
-                + "    \"composite\" : {%n"
-                + "      \"size\" : 1000,%n"
-                + "      \"sources\" : [ {%n"
-                + "        \"SpanExpression(field=timestamp, value=1, unit=H)\" : {%n"
-                + "          \"date_histogram\" : {%n"
-                + "            \"field\" : \"timestamp\",%n"
-                + "            \"missing_bucket\" : true,%n"
-                + "            \"missing_order\" : \"first\",%n"
-                + "            \"order\" : \"asc\",%n"
-                + "            \"fixed_interval\" : \"1h\"%n"
-                + "          }%n"
-                + "        }%n"
-                + "      } ]%n"
+                + "  \"SpanExpression(field=timestamp, value=1, unit=H)\" : {%n"
+                + "    \"date_histogram\" : {%n"
+                + "      \"field\" : \"timestamp\",%n"
+                + "      \"fixed_interval\" : \"1h\",%n"
+                + "      \"offset\" : 0,%n"
+                + "      \"order\" : {%n"
+                + "        \"_key\" : \"asc\"%n"
+                + "      },%n"
+                + "      \"keyed\" : false,%n"
+                + "      \"min_doc_count\" : 0%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
                 + "      \"count(a)\" : {%n"
@@ -586,20 +617,16 @@ class AggregationQueryBuilderTest {
     assertEquals(
         format(
             "{%n"
-                + "  \"composite_buckets\" : {%n"
-                + "    \"composite\" : {%n"
-                + "      \"size\" : 1000,%n"
-                + "      \"sources\" : [ {%n"
-                + "        \"SpanExpression(field=date, value=1, unit=W)\" : {%n"
-                + "          \"date_histogram\" : {%n"
-                + "            \"field\" : \"date\",%n"
-                + "            \"missing_bucket\" : true,%n"
-                + "            \"missing_order\" : \"first\",%n"
-                + "            \"order\" : \"asc\",%n"
-                + "            \"calendar_interval\" : \"1w\"%n"
-                + "          }%n"
-                + "        }%n"
-                + "      } ]%n"
+                + "  \"SpanExpression(field=date, value=1, unit=W)\" : {%n"
+                + "    \"date_histogram\" : {%n"
+                + "      \"field\" : \"date\",%n"
+                + "      \"calendar_interval\" : \"1w\",%n"
+                + "      \"offset\" : 0,%n"
+                + "      \"order\" : {%n"
+                + "        \"_key\" : \"asc\"%n"
+                + "      },%n"
+                + "      \"keyed\" : false,%n"
+                + "      \"min_doc_count\" : 0%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
                 + "      \"count(a)\" : {%n"
@@ -621,20 +648,16 @@ class AggregationQueryBuilderTest {
     assertEquals(
         format(
             "{%n"
-                + "  \"composite_buckets\" : {%n"
-                + "    \"composite\" : {%n"
-                + "      \"size\" : 1000,%n"
-                + "      \"sources\" : [ {%n"
-                + "        \"SpanExpression(field=age, value=1, unit=NONE)\" : {%n"
-                + "          \"histogram\" : {%n"
-                + "            \"field\" : \"age\",%n"
-                + "            \"missing_bucket\" : true,%n"
-                + "            \"missing_order\" : \"first\",%n"
-                + "            \"order\" : \"asc\",%n"
-                + "            \"interval\" : 1.0%n"
-                + "          }%n"
-                + "        }%n"
-                + "      } ]%n"
+                + "  \"SpanExpression(field=age, value=1, unit=NONE)\" : {%n"
+                + "    \"histogram\" : {%n"
+                + "      \"field\" : \"age\",%n"
+                + "      \"interval\" : 1.0,%n"
+                + "      \"offset\" : 0.0,%n"
+                + "      \"order\" : {%n"
+                + "        \"_key\" : \"asc\"%n"
+                + "      },%n"
+                + "      \"keyed\" : false,%n"
+                + "      \"min_doc_count\" : 0%n"
                 + "    },%n"
                 + "    \"aggregations\" : {%n"
                 + "      \"count(a)\" : {%n"

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/CompositeAggregationBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/CompositeAggregationBuilderTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.aggregation.dsl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+import static org.opensearch.sql.expression.DSL.literal;
+import static org.opensearch.sql.expression.DSL.named;
+import static org.opensearch.sql.expression.DSL.ref;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.tuple.Triple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
+import org.opensearch.search.aggregations.bucket.missing.MissingOrder;
+import org.opensearch.search.sort.SortOrder;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.NamedExpression;
+import org.opensearch.sql.expression.parse.ParseExpression;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
+import org.opensearch.sql.opensearch.data.type.OpenSearchDateType;
+import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
+import org.opensearch.sql.opensearch.storage.serialization.ExpressionSerializer;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class CompositeAggregationBuilderTest {
+
+  @Mock private ExpressionSerializer serializer;
+
+  private CompositeAggregationBuilder compositeBuilder;
+
+  @BeforeEach
+  void set_up() {
+    compositeBuilder = new CompositeAggregationBuilder(serializer);
+  }
+
+  @Test
+  void should_build_bucket_with_field() {
+    assertEquals(
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"field\" : \"age\",\n"
+            + "    \"missing_bucket\" : true,\n"
+            + "    \"missing_order\" : \"first\",\n"
+            + "    \"order\" : \"asc\"\n"
+            + "  }\n"
+            + "}",
+        buildQuery(Arrays.asList(asc(named("age", ref("age", INTEGER))))));
+  }
+
+  @Test
+  void should_build_bucket_with_literal() {
+    var literal = literal(1);
+    when(serializer.serialize(literal)).thenReturn("mock-serialize");
+    assertEquals(
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"script\" : {\n"
+            + "      \"source\" : \"mock-serialize\",\n"
+            + "      \"lang\" : \"opensearch_query_expression\"\n"
+            + "    },\n"
+            + "    \"missing_bucket\" : true,\n"
+            + "    \"missing_order\" : \"first\",\n"
+            + "    \"order\" : \"asc\"\n"
+            + "  }\n"
+            + "}",
+        buildQuery(Arrays.asList(asc(named(literal)))));
+  }
+
+  @Test
+  void should_build_bucket_with_keyword_field() {
+    assertEquals(
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"field\" : \"name.keyword\",\n"
+            + "    \"missing_bucket\" : true,\n"
+            + "    \"missing_order\" : \"first\",\n"
+            + "    \"order\" : \"asc\"\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            Arrays.asList(
+                asc(
+                    named(
+                        "name",
+                        ref(
+                            "name",
+                            OpenSearchTextType.of(
+                                Map.of(
+                                    "words",
+                                    OpenSearchDataType.of(
+                                        OpenSearchDataType.MappingType.Keyword)))))))));
+  }
+
+  @Test
+  void should_build_bucket_with_parse_expression() {
+    ParseExpression parseExpression =
+        DSL.regex(ref("name.keyword", STRING), DSL.literal("(?<name>\\w+)"), DSL.literal("name"));
+    when(serializer.serialize(parseExpression)).thenReturn("mock-serialize");
+    assertEquals(
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"script\" : {\n"
+            + "      \"source\" : \"mock-serialize\",\n"
+            + "      \"lang\" : \"opensearch_query_expression\"\n"
+            + "    },\n"
+            + "    \"missing_bucket\" : true,\n"
+            + "    \"missing_order\" : \"first\",\n"
+            + "    \"order\" : \"asc\"\n"
+            + "  }\n"
+            + "}",
+        buildQuery(Arrays.asList(asc(named("name", parseExpression)))));
+  }
+
+  @Test
+  void terms_bucket_for_opensearchdate_type_uses_long() {
+    OpenSearchDateType dataType = OpenSearchDateType.of(ExprCoreType.TIMESTAMP);
+
+    assertEquals(
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"field\" : \"date\",\n"
+            + "    \"missing_bucket\" : true,\n"
+            + "    \"value_type\" : \"long\",\n"
+            + "    \"missing_order\" : \"first\",\n"
+            + "    \"order\" : \"asc\"\n"
+            + "  }\n"
+            + "}",
+        buildQuery(Arrays.asList(asc(named("date", ref("date", dataType))))));
+  }
+
+  @Test
+  void terms_bucket_for_opensearchdate_type_uses_long_false() {
+    OpenSearchDateType dataType = OpenSearchDateType.of(STRING);
+
+    assertEquals(
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"field\" : \"date\",\n"
+            + "    \"missing_bucket\" : true,\n"
+            + "    \"missing_order\" : \"first\",\n"
+            + "    \"order\" : \"asc\"\n"
+            + "  }\n"
+            + "}",
+        buildQuery(Arrays.asList(asc(named("date", ref("date", dataType))))));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(
+      value = ExprCoreType.class,
+      names = {"TIMESTAMP", "TIME", "DATE"})
+  void terms_bucket_for_datetime_types_uses_long(ExprType dataType) {
+    assertEquals(
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"field\" : \"date\",\n"
+            + "    \"missing_bucket\" : true,\n"
+            + "    \"value_type\" : \"long\",\n"
+            + "    \"missing_order\" : \"first\",\n"
+            + "    \"order\" : \"asc\"\n"
+            + "  }\n"
+            + "}",
+        buildQuery(Arrays.asList(asc(named("date", ref("date", dataType))))));
+  }
+
+  @SneakyThrows
+  private String buildQuery(
+      List<Triple<NamedExpression, SortOrder, MissingOrder>> groupByExpressions) {
+    XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+    builder.startObject();
+    CompositeValuesSourceBuilder<?> sourceBuilder =
+        compositeBuilder.build(groupByExpressions).get(0);
+    sourceBuilder.toXContent(builder, EMPTY_PARAMS);
+    builder.endObject();
+    return BytesReference.bytes(builder).utf8ToString();
+  }
+
+  private Triple<NamedExpression, SortOrder, MissingOrder> asc(NamedExpression expression) {
+    return Triple.of(expression, SortOrder.ASC, MissingOrder.FIRST);
+  }
+}


### PR DESCRIPTION
### Description
Currently, the aggregation pushdown implementation build a composite aggregation builder which is [expensive](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html).

This PR is refactoring the implementation of **single group-by** aggregation pushdown which could get 100x faster than current implementation. See the usage case in #3528 

### Related Issues
Resolves #3528 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
