### PR TITLE
[POC]Support type checker For PPL functions

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/CalciteFuncSignature.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CalciteFuncSignature.java
@@ -5,26 +5,15 @@
 
 package org.opensearch.sql.expression.function;
 
-import static org.opensearch.sql.expression.function.PPLFuncImpTable.FunctionImp.ANY_TYPE;
-
 import java.util.List;
 import org.apache.calcite.rel.type.RelDataType;
 
 /** Function signature is composed by function name and arguments list. */
-public record CalciteFuncSignature(FunctionName functionName, List<RelDataType> funcArgTypes) {
+public record CalciteFuncSignature(FunctionName functionName, PPLTypeChecker typeChecker) {
 
   public boolean match(FunctionName functionName, List<RelDataType> paramTypeList) {
-    if (funcArgTypes == null) return true;
-    if (!functionName.equals(this.functionName()) || paramTypeList.size() != funcArgTypes.size()) {
-      return false;
-    }
-    for (int i = 0; i < paramTypeList.size(); i++) {
-      RelDataType paramType = paramTypeList.get(i);
-      RelDataType funcType = funcArgTypes.get(i);
-      if (ANY_TYPE != funcType && paramType.getFamily() != funcType.getFamily()) {
-        return false;
-      }
-    }
-    return true;
+    if (!functionName.equals(this.functionName())) return false;
+    if (typeChecker == null) return true;
+    return typeChecker.checkOperandTypes(paramTypeList);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.type.FamilyOperandTypeChecker;
+import org.apache.calcite.sql.type.ImplicitCastOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+public interface PPLTypeChecker {
+  boolean checkOperandTypes(List<RelDataType> types);
+
+  private static boolean validateOperands(
+      List<SqlTypeFamily> funcTypeFamilies, List<RelDataType> operandTypes) {
+    if (funcTypeFamilies.size() != operandTypes.size()) {
+      return true; // Skip checking if sizes do not match because some arguments may be optional
+    }
+    for (int i = 0; i < operandTypes.size(); i++) {
+      SqlTypeName paramType = operandTypes.get(i).getSqlTypeName();
+      SqlTypeFamily funcTypeFamily = funcTypeFamilies.get(i);
+      if (paramType.getFamily() == SqlTypeFamily.IGNORE || funcTypeFamily == SqlTypeFamily.IGNORE) {
+        continue;
+      }
+      if (!funcTypeFamily.getTypeNames().contains(paramType)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  class PPLFamilyTypeChecker implements PPLTypeChecker {
+    private final List<SqlTypeFamily> families;
+
+    public PPLFamilyTypeChecker(SqlTypeFamily... families) {
+      this.families = List.of(families);
+    }
+
+    public boolean checkOperandTypes(List<RelDataType> types) {
+      if (families.size() != types.size()) return false;
+      return validateOperands(families, types);
+    }
+  }
+
+  class PPLFamilyTypeCheckerWrapper implements PPLTypeChecker {
+    private final ImplicitCastOperandTypeChecker innerTypeChecker;
+
+    public PPLFamilyTypeCheckerWrapper(ImplicitCastOperandTypeChecker typeChecker) {
+      this.innerTypeChecker = typeChecker;
+    }
+
+    public boolean checkOperandTypes(List<RelDataType> types) {
+      if (innerTypeChecker instanceof FamilyOperandTypeChecker familyOperandTypeChecker
+          && !familyOperandTypeChecker.getOperandCountRange().isValidCount(types.size()))
+        return false;
+      List<SqlTypeFamily> families =
+          IntStream.range(0, types.size())
+              .mapToObj(innerTypeChecker::getOperandSqlTypeFamily)
+              .collect(Collectors.toList());
+      return validateOperands(families, types);
+    }
+  }
+
+  /** Creates a checker that passes if each operand is a member of a corresponding family */
+  static PPLFamilyTypeChecker family(SqlTypeFamily... families) {
+    return new PPLFamilyTypeChecker(families);
+  }
+
+  static PPLFamilyTypeCheckerWrapper familyWrapper(ImplicitCastOperandTypeChecker typeChecker) {
+    return new PPLFamilyTypeCheckerWrapper(typeChecker);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CalcitePPLFunctionTypeTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLFunctionTypeTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testLowerWithIntegerType() {
+    String ppl = "source=EMP | eval lower_name = lower(EMPNO) | fields lower_name";
+    Assert.assertThrows(Exception.class, () -> getRelNode(ppl));
+  }
+}


### PR DESCRIPTION
### Description
Calcite has its type checker mechanism to do validation for its function calls. However, this process happens in SqlNode level and its API only accepts SqlNode level objects like `SqlCallBinding`, `SqlNode` and etc. Since we use RelNode directly, this validation step has been ignored by our current process.

In order to reuse the definition of Calcite's builtin operators, we have to do validation by ourself with an approach to reuse the definition of Calcite's operators.

Luckily, in Calcite, almost all operators use `FamilyOperandTypeChecker` as their type checker with API `getOperandSqlTypeFamily` exposed to us to make use of. We can use this API to do validation conveniently.

 ### Note
This is a draft PR with only one test cases to verify the functionality. 

Before this PR, the test `CalcitePPLFunctionTypeTest::testLowerWithIntegerType` will return a incorrect plan for its PPL:

```
source=EMP | eval lower_name = lower(EMPNO) | fields lower_name


LogicalProject.NONE.[](input=LogicalTableScan#0,exprs=[LOWER($0)])
     LogicalTableScan.NONE.[0](table=[scott, EMP])
```
The above plan is incorrect because $0(i.e. EMPNO) has type of integer, so it shouldn't be passed into function `LOWER` which only allows `SqlTypeFamily.CHARACTOR`.  The error will only be thrown until execution step.
```
java.lang.RuntimeException: java.sql.SQLException: Error while preparing plan [LogicalProject(lower_name=[LOWER($0)])
  BindableTableScan(table=[[scott, EMP]])
]
```

With this PR, the ppl will throw exception in building logical plan because of unsupported function.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
