### PR TITLE
Support parsing documents with flattened value

### DIFF
--- a/core/src/main/java/org/opensearch/sql/data/model/ExprTupleValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprTupleValue.java
@@ -28,6 +28,11 @@ public class ExprTupleValue extends AbstractExprValue {
     return new ExprTupleValue(linkedHashMap);
   }
 
+  public static ExprTupleValue empty() {
+    LinkedHashMap<String, ExprValue> linkedHashMap = new LinkedHashMap<>();
+    return new ExprTupleValue(linkedHashMap);
+  }
+
   @Override
   public Object value() {
     LinkedHashMap<String, Object> resultMap = new LinkedHashMap<>();
@@ -106,5 +111,18 @@ public class ExprTupleValue extends AbstractExprValue {
   @Override
   public int hashCode() {
     return Objects.hashCode(valueMap);
+  }
+
+  /** Implements mergeTo by merging deeply */
+  @Override
+  public ExprTupleValue mergeTo(ExprValue base) {
+    if (base instanceof ExprTupleValue) {
+      base.tupleValue()
+          .forEach((key, value) -> this.tupleValue().merge(key, value, ExprValue::mergeTo));
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Cannot merge ExprTupleValue to %s", base.getClass().getSimpleName()));
+    }
+    return this;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprValue.java
@@ -170,6 +170,9 @@ public interface ExprValue extends Serializable, Comparable<ExprValue> {
   /**
    * Merge the value to the base value. By default, it overrides the base value with the current
    *
+   * <p>This method will be called when key conflict happens in the process of populating
+   * ExprTupleValue See {@link OpenSearchExprValueFactory::populateValueRecursive}.
+   *
    * @param base the target value to merge
    * @return The merged value
    */

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprValue.java
@@ -166,4 +166,14 @@ public interface ExprValue extends Serializable, Comparable<ExprValue> {
   default ExprValue keyValue(String key) {
     return ExprMissingValue.of();
   }
+
+  /**
+   * Merge the value to the base value. By default, it overrides the base value with the current
+   *
+   * @param base the target value to merge
+   * @return The merged value
+   */
+  default ExprValue mergeTo(ExprValue base) {
+    return this;
+  }
 }

--- a/core/src/test/java/org/opensearch/sql/data/model/ExprTupleValueTest.java
+++ b/core/src/test/java/org/opensearch/sql/data/model/ExprTupleValueTest.java
@@ -55,4 +55,21 @@ class ExprTupleValueTest {
         assertThrows(ExpressionEvaluationException.class, () -> compare(tupleValue, tupleValue));
     assertEquals("ExprTupleValue instances are not comparable", exception.getMessage());
   }
+
+  @Test
+  public void testMergeTo() {
+    ExprValue tupleValue1 =
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of("v1", 1, "inner_tuple", ImmutableMap.of("inner_v1", 1)));
+    ExprValue tupleValue2 =
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of("v2", 2, "inner_tuple", ImmutableMap.of("inner_v2", 2)));
+    ExprValue expectedMergedValue =
+        ExprValueUtils.tupleValue(
+            ImmutableMap.of(
+                "v1", 1,
+                "inner_tuple", ImmutableMap.of("inner_v1", 1, "inner_v2", 2),
+                "v2", 2));
+    assertEquals(expectedMergedValue, tupleValue1.mergeTo(tupleValue2));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteFlattenDocValueIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteFlattenDocValueIT.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import org.opensearch.sql.ppl.FlattenDocValueIT;
+
+public class CalciteFlattenDocValueIT extends FlattenDocValueIT {
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+    disallowCalciteFallback();
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -838,6 +838,11 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         "alias",
         getAliasIndexMapping(),
         "src/test/resources/alias.json"),
+    FLATTENED_VALUE(
+        TestsConstants.TEST_INDEX_FLATTENED_VALUE,
+        "flattened_value",
+        null,
+        "src/test/resources/flattened_value.json"),
     DUPLICATION_NULLABLE(
         TestsConstants.TEST_INDEX_DUPLICATION_NULLABLE,
         "duplication_nullable",

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -62,6 +62,7 @@ public class TestsConstants {
   public static final String TEST_INDEX_GEOPOINT = TEST_INDEX + "_geopoint";
   public static final String TEST_INDEX_JSON_TEST = TEST_INDEX + "_json_test";
   public static final String TEST_INDEX_ALIAS = TEST_INDEX + "_alias";
+  public static final String TEST_INDEX_FLATTENED_VALUE = TEST_INDEX + "_flattened_value";
   public static final String TEST_INDEX_GEOIP = TEST_INDEX + "_geoip";
   public static final String DATASOURCES = ".ql-datasources";
   public static final String TEST_INDEX_STATE_COUNTRY = TEST_INDEX + "_state_country";

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/FlattenDocValueIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/FlattenDocValueIT.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.ppl;
 
+import static org.opensearch.sql.legacy.SQLIntegTestCase.Index.FLATTENED_VALUE;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_FLATTENED_VALUE;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -20,29 +22,12 @@ public class FlattenDocValueIT extends PPLIntegTestCase {
   @Override
   public void init() throws Exception {
     super.init();
-    putDocument(
-        "test",
-        1,
-        "{\"log\": { \"json\" : { \"status\": \"SUCCESS\", \"time\": 100} } }"); // non-flatten
-    putDocument(
-        "test", 2, "{\"log.json\": { \"status\": \"SUCCESS\", \"time\": 100} }"); // partly-flatten
-    putDocument(
-        "test", 3, "{\"log.json.status\":  \"SUCCESS\", \"log.json.time\": 100 }"); // fully-flatten
-    putDocument(
-        "test",
-        4,
-        "{\"log.json\": { \"status\": \"SUCCESS\" }, \"log.json.time\": 100 }"); // partly-flatten +
-    // fully-flatten
-    putDocument(
-        "test",
-        7,
-        "{\"log\": { \"json\" : {} }, \"log.json\": { \"status\": \"SUCCESS\" }, \"log.json.time\":"
-            + " 100 }"); // all modes in one
+    loadIndex(FLATTENED_VALUE);
   }
 
   @Test
   public void testFlattenDocValue() throws IOException {
-    JSONObject result = executeQuery("source=test");
+    JSONObject result = executeQuery(String.format("source=%s", TEST_INDEX_FLATTENED_VALUE));
     verifySchema(result, schema("log", "struct"));
     TypeSafeMatcher<JSONArray> expectedRow =
         rows(new JSONObject("{ \"json\" : { \"status\": \"SUCCESS\", \"time\": 100} }"));
@@ -52,7 +37,10 @@ public class FlattenDocValueIT extends PPLIntegTestCase {
   @Test
   public void testFlattenDocValueWithFields() throws IOException {
     JSONObject result =
-        executeQuery("source=test | fields log, log.json, log.json.status, log.json.time");
+        executeQuery(
+            String.format(
+                "source=%s | fields log, log.json, log.json.status, log.json.time",
+                TEST_INDEX_FLATTENED_VALUE));
     verifySchema(
         result,
         schema("log", "struct"),

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/FlattenDocValueIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/FlattenDocValueIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.hamcrest.TypeSafeMatcher;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+public class FlattenDocValueIT extends PPLIntegTestCase {
+  @Override
+  public void init() throws Exception {
+    super.init();
+    putDocument(
+        "test",
+        1,
+        "{\"log\": { \"json\" : { \"status\": \"SUCCESS\", \"time\": 100} } }"); // non-flatten
+    putDocument(
+        "test", 2, "{\"log.json\": { \"status\": \"SUCCESS\", \"time\": 100} }"); // partly-flatten
+    putDocument(
+        "test", 3, "{\"log.json.status\":  \"SUCCESS\", \"log.json.time\": 100 }"); // fully-flatten
+    putDocument(
+        "test",
+        4,
+        "{\"log.json\": { \"status\": \"SUCCESS\" }, \"log.json.time\": 100 }"); // partly-flatten +
+    // fully-flatten
+    putDocument(
+        "test",
+        7,
+        "{\"log\": { \"json\" : {} }, \"log.json\": { \"status\": \"SUCCESS\" }, \"log.json.time\":"
+            + " 100 }"); // all modes in one
+  }
+
+  @Test
+  public void testFlattenDocValue() throws IOException {
+    JSONObject result = executeQuery("source=test");
+    verifySchema(result, schema("log", "struct"));
+    TypeSafeMatcher<JSONArray> expectedRow =
+        rows(new JSONObject("{ \"json\" : { \"status\": \"SUCCESS\", \"time\": 100} }"));
+    verifyDataRows(result, expectedRow, expectedRow, expectedRow, expectedRow, expectedRow);
+  }
+
+  @Test
+  public void testFlattenDocValueWithFields() throws IOException {
+    JSONObject result =
+        executeQuery("source=test | fields log, log.json, log.json.status, log.json.time");
+    verifySchema(
+        result,
+        schema("log", "struct"),
+        schema("log.json", "struct"),
+        schema("log.json.status", "string"),
+        schema("log.json.time", "bigint"));
+    TypeSafeMatcher<JSONArray> expectedRow =
+        rows(
+            new JSONObject("{ \"json\" : { \"status\": \"SUCCESS\", \"time\": 100} }"),
+            new JSONObject("{ \"status\": \"SUCCESS\", \"time\": 100}"),
+            "SUCCESS",
+            100);
+    verifyDataRows(result, expectedRow, expectedRow, expectedRow, expectedRow, expectedRow);
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
@@ -172,4 +172,10 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
       }
     }
   }
+
+  protected void putDocument(String index, int id, String json) throws IOException {
+    Request request = new Request("PUT", String.format("/%s/_doc/%d?refresh=true", index, id));
+    request.setJsonEntity(json);
+    client().performRequest(request);
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
@@ -172,10 +172,4 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
       }
     }
   }
-
-  protected void putDocument(String index, int id, String json) throws IOException {
-    Request request = new Request("PUT", String.format("/%s/_doc/%d?refresh=true", index, id));
-    request.setJsonEntity(json);
-    client().performRequest(request);
-  }
 }

--- a/integ-test/src/test/resources/flattened_value.json
+++ b/integ-test/src/test/resources/flattened_value.json
@@ -1,0 +1,10 @@
+{"index": {"_id":"1"}}
+{"log": { "json" : { "status": "SUCCESS", "time": 100} } }
+{"index": {"_id":"2"}}
+{"log.json": { "status": "SUCCESS", "time": 100} }
+{"index": {"_id":"3"}}
+{"log.json.status":  "SUCCESS", "log.json.time": 100 }
+{"index": {"_id":"4"}}
+{"log.json": { "status": "SUCCESS" }, "log.json.time": 100 }
+{"index": {"_id":"5"}}
+{"log": { "json" : {} }, "log.json": { "status": "SUCCESS" }, "log.json.time": 100 }

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
@@ -40,7 +40,17 @@ teardown:
         Content-Type: 'application/json'
       ppl:
         body:
-          query: 'source=test | fields log.json.status, log.json.time'
+          query: 'source=test'
   - match: {"total": 5}
-  - match: {"schema": [{"name": "log.json.status", "type": "string"}, {"name": "log.json.time", "type": "bigint"}]}
-  - match: {"datarows": [["SUCCESS", 100], ["SUCCESS", 100], ["SUCCESS", 100], ["SUCCESS", 100], ["SUCCESS", 100]]}
+  - match: {"schema": [{"name": "log", "type": "struct"}]}
+  - match: {"datarows": [[{ "json" : { "status": "SUCCESS", "time": 100} }], [{ "json" : { "status": "SUCCESS", "time": 100} }], [{ "json" : { "status": "SUCCESS", "time": 100} }], [{ "json" : { "status": "SUCCESS", "time": 100} }], [{ "json" : { "status": "SUCCESS", "time": 100} }]]}
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | fields log, log.json, log.json.status, log.json.time'
+  - match: {"total": 5}
+  - match: {"schema": [{"name": "log", "type": "struct"}, {"name": "log.json", "type": "struct"}, {"name": "log.json.status", "type": "string"}, {"name": "log.json.time", "type": "bigint"}]}
+  - match: {"datarows": [[{ "json" : { "status": "SUCCESS", "time": 100} }, { "status": "SUCCESS", "time": 100}, "SUCCESS", 100], [{ "json" : { "status": "SUCCESS", "time": 100} }, { "status": "SUCCESS", "time": 100}, "SUCCESS", 100], [{ "json" : { "status": "SUCCESS", "time": 100} }, { "status": "SUCCESS", "time": 100}, "SUCCESS", 100], [{ "json" : { "status": "SUCCESS", "time": 100} }, { "status": "SUCCESS", "time": 100}, "SUCCESS", 100], [{ "json" : { "status": "SUCCESS", "time": 100} }, { "status": "SUCCESS", "time": 100}, "SUCCESS", 100]]}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
@@ -1,0 +1,46 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+            plugins.calcite.fallback.allowed : false
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+            plugins.calcite.fallback.allowed : true
+
+---
+"Handle epoch field in string format":
+  - skip:
+      features:
+        - headers
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"log": { "json" : { "status": "SUCCESS", "time": 100} } }'
+          - '{"index": {}}'
+          - '{"log.json": { "status": "SUCCESS", "time": 100} }'
+          - '{"index": {}}'
+          - '{"log.json.status":  "SUCCESS", "log.json.time": 100 }'
+          - '{"index": {}}'
+          - '{"log.json": { "status": "SUCCESS" }, "log.json.time": 100 }'
+          - '{"index": {}}'
+          - '{"log": { "json" : {} }, "log.json": { "status": "SUCCESS" }, "log.json.time": 100 }'
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test'
+  - match: {"total": 5}
+  - match: {"schema": [{"name": "log", "type": "struct"}]}
+  - match: {"schema": [{"name": "log", "type": "struct"}]}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
@@ -40,7 +40,7 @@ teardown:
         Content-Type: 'application/json'
       ppl:
         body:
-          query: 'source=test'
+          query: 'source=test | fields log.json.status, log.json.time'
   - match: {"total": 5}
-  - match: {"schema": [{"name": "log", "type": "struct"}]}
-  - match: {"schema": [{"name": "log", "type": "struct"}]}
+  - match: {"schema": [{"name": "log.json.status", "type": "string"}, {"name": "log.json.time", "type": "bigint"}]}
+  - match: {"datarows": [["SUCCESS", 100], ["SUCCESS", 100], ["SUCCESS", 100], ["SUCCESS", 100], ["SUCCESS", 100]]}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
@@ -16,7 +16,7 @@ teardown:
             plugins.calcite.fallback.allowed : true
 
 ---
-"Handle epoch field in string format":
+"Handle flattened document value":
   - skip:
       features:
         - headers

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -340,7 +340,7 @@ public class OpenSearchExprValueFactory {
    *
    * <p>If there is existing vale for the JsonPath, we need to merge the new value to the old.
    */
-  private void populateValueRecursive(ExprTupleValue result, JsonPath path, ExprValue value) {
+  static void populateValueRecursive(ExprTupleValue result, JsonPath path, ExprValue value) {
     if (path.getPaths().size() == 1) {
       // Update the current ExprValue by using mergeTo if exists
       result
@@ -355,7 +355,7 @@ public class OpenSearchExprValueFactory {
   }
 
   @Getter
-  private static class JsonPath {
+  static class JsonPath {
     private final List<String> paths;
 
     public JsonPath(String rawPath) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/util/JdbcOpenSearchDataTypeConvertor.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/util/JdbcOpenSearchDataTypeConvertor.java
@@ -125,7 +125,7 @@ public class JdbcOpenSearchDataTypeConvertor {
           return ExprValueUtils.fromObjectValue(array);
 
         default:
-          LOG.warn(
+          LOG.debug(
               "Unchecked sql type: {}, return Object type {}",
               sqlType,
               value.getClass().getTypeName());

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -1010,7 +1010,9 @@ class OpenSearchExprValueFactoryTest {
         ExprValueUtils.tupleValue(Map.of("status", "SUCCESS")));
     expectedValue =
         ExprValueUtils.tupleValue(
-            Map.of("log", Map.of("json", Map.of("status", "SUCCESS", "time", 100))));
+            Map.of(
+                "log",
+                Map.of("json", new LinkedHashMap<>(Map.of("status", "SUCCESS", "time", 100)))));
     assertEquals(expectedValue, tupleValue);
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -1013,7 +1013,14 @@ class OpenSearchExprValueFactoryTest {
         ExprValueUtils.tupleValue(
             Map.of(
                 "log",
-                Map.of("json", new LinkedHashMap<>(Map.of("status", "SUCCESS", "time", 100)))));
+                Map.of(
+                    "json",
+                    new LinkedHashMap<>() {
+                      {
+                        put("status", "SUCCESS");
+                        put("time", 100);
+                      }
+                    })));
     assertEquals(expectedValue, tupleValue);
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -1001,13 +1001,14 @@ class OpenSearchExprValueFactoryTest {
     OpenSearchExprValueFactory.populateValueRecursive(
         tupleValue, new JsonPath("log.json.time"), ExprValueUtils.integerValue(100));
     ExprValue expectedValue =
-        ExprValueUtils.tupleValue(Map.of("log", Map.of("json", Map.of("time", 100))));
+        ExprValueUtils.tupleValue(
+            Map.of("log", Map.of("json", new LinkedHashMap<>(Map.of("time", 100)))));
     assertEquals(expectedValue, tupleValue);
 
     OpenSearchExprValueFactory.populateValueRecursive(
         tupleValue,
         new JsonPath("log.json"),
-        ExprValueUtils.tupleValue(Map.of("status", "SUCCESS")));
+        ExprValueUtils.tupleValue(new LinkedHashMap<>(Map.of("status", "SUCCESS"))));
     expectedValue =
         ExprValueUtils.tupleValue(
             Map.of(

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -1022,6 +1022,23 @@ class OpenSearchExprValueFactoryTest {
                       }
                     })));
     assertEquals(expectedValue, tupleValue);
+
+    // update the conflict value with the latest
+    OpenSearchExprValueFactory.populateValueRecursive(
+        tupleValue, new JsonPath("log.json.status"), ExprValueUtils.stringValue("FAILED"));
+    expectedValue =
+        ExprValueUtils.tupleValue(
+            Map.of(
+                "log",
+                Map.of(
+                    "json",
+                    new LinkedHashMap<>() {
+                      {
+                        put("status", "FAILED");
+                        put("time", 100);
+                      }
+                    })));
+    assertEquals(expectedValue, tupleValue);
   }
 
   public Map<String, ExprValue> tupleValue(String jsonString) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -57,10 +57,12 @@ import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDateType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.data.utils.OpenSearchJsonContent;
+import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory.JsonPath;
 
 class OpenSearchExprValueFactoryTest {
 
@@ -990,6 +992,26 @@ class OpenSearchExprValueFactoryTest {
         () -> assertTrue(mapping.containsKey("agg")),
         () -> assertEquals(OpenSearchDataType.of(INTEGER), mapping.get("value")),
         () -> assertEquals(OpenSearchDataType.of(DATE), mapping.get("agg")));
+  }
+
+  @Test
+  public void testPopulateValueRecursive() {
+    ExprTupleValue tupleValue = ExprTupleValue.empty();
+
+    OpenSearchExprValueFactory.populateValueRecursive(
+        tupleValue, new JsonPath("log.json.time"), ExprValueUtils.integerValue(100));
+    ExprValue expectedValue =
+        ExprValueUtils.tupleValue(Map.of("log", Map.of("json", Map.of("time", 100))));
+    assertEquals(expectedValue, tupleValue);
+
+    OpenSearchExprValueFactory.populateValueRecursive(
+        tupleValue,
+        new JsonPath("log.json"),
+        ExprValueUtils.tupleValue(Map.of("status", "SUCCESS")));
+    expectedValue =
+        ExprValueUtils.tupleValue(
+            Map.of("log", Map.of("json", Map.of("status", "SUCCESS", "time", 100))));
+    assertEquals(expectedValue, tupleValue);
   }
 
   public Map<String, ExprValue> tupleValue(String jsonString) {


### PR DESCRIPTION
### Description
It supports parsing flattened document value by populating the ExprTupleValue recursively, so we can access the nested fields as well as the root fields as before.

### Related Issues
Resolves  https://github.com/opensearch-project/sql/issues/3477


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
