### PR TITLE
Make query.size_limit only affect the final results

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -31,6 +31,7 @@ public class CalcitePlanContext {
   public final ExtendedRexBuilder rexBuilder;
   public final FunctionProperties functionProperties;
   public final QueryType queryType;
+  public final Integer querySizeLimit;
 
   @Getter @Setter private boolean isResolvingJoinCondition = false;
   @Getter @Setter private boolean isResolvingSubquery = false;
@@ -46,8 +47,9 @@ public class CalcitePlanContext {
   private final Stack<RexCorrelVariable> correlVar = new Stack<>();
   private final Stack<List<RexNode>> windowPartitions = new Stack<>();
 
-  private CalcitePlanContext(FrameworkConfig config, QueryType queryType) {
+  private CalcitePlanContext(FrameworkConfig config, Integer querySizeLimit, QueryType queryType) {
     this.config = config;
+    this.querySizeLimit = querySizeLimit;
     this.queryType = queryType;
     this.connection = CalciteToolsHelper.connect(config, TYPE_FACTORY);
     this.relBuilder = CalciteToolsHelper.create(config, TYPE_FACTORY, connection);
@@ -84,7 +86,8 @@ public class CalcitePlanContext {
     }
   }
 
-  public static CalcitePlanContext create(FrameworkConfig config, QueryType queryType) {
-    return new CalcitePlanContext(config, queryType);
+  public static CalcitePlanContext create(
+      FrameworkConfig config, Integer querySizeLimit, QueryType queryType) {
+    return new CalcitePlanContext(config, querySizeLimit, queryType);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/executor/ExecutionContext.java
+++ b/core/src/main/java/org/opensearch/sql/executor/ExecutionContext.java
@@ -12,16 +12,23 @@ import org.opensearch.sql.storage.split.Split;
 /** Execution context hold planning related information. */
 public class ExecutionContext {
   @Getter private final Optional<Split> split;
+  @Getter private final Integer querySizeLimit;
 
   public ExecutionContext(Split split) {
     this.split = Optional.of(split);
+    this.querySizeLimit = null;
   }
 
-  private ExecutionContext(Optional<Split> split) {
+  private ExecutionContext(Optional<Split> split, Integer querySizeLimit) {
     this.split = split;
+    this.querySizeLimit = querySizeLimit;
+  }
+
+  public static ExecutionContext querySizeLimit(Integer querySizeLimit) {
+    return new ExecutionContext(Optional.empty(), querySizeLimit);
   }
 
   public static ExecutionContext emptyExecutionContext() {
-    return new ExecutionContext(Optional.empty());
+    return new ExecutionContext(Optional.empty(), null);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -38,6 +38,7 @@ import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
 import org.opensearch.sql.calcite.OpenSearchSchema;
 import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.common.setting.Settings.Key;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.exception.CalciteUnsupportedException;
 import org.opensearch.sql.planner.PlanContext;
@@ -94,7 +95,10 @@ public class QueryService {
           (PrivilegedAction<Void>)
               () -> {
                 CalcitePlanContext context =
-                    CalcitePlanContext.create(buildFrameworkConfig(), queryType);
+                    CalcitePlanContext.create(
+                        buildFrameworkConfig(),
+                        settings.getSettingValue(Key.QUERY_SIZE_LIMIT),
+                        queryType);
                 RelNode relNode = analyze(plan, context);
                 RelNode optimized = optimize(relNode);
                 RelNode calcitePlan = convertToCalcitePlan(optimized);
@@ -126,7 +130,10 @@ public class QueryService {
           (PrivilegedAction<Void>)
               () -> {
                 CalcitePlanContext context =
-                    CalcitePlanContext.create(buildFrameworkConfig(), queryType);
+                    CalcitePlanContext.create(
+                        buildFrameworkConfig(),
+                        settings.getSettingValue(Key.QUERY_SIZE_LIMIT),
+                        queryType);
                 RelNode relNode = analyze(plan, context);
                 RelNode optimized = optimize(relNode);
                 RelNode calcitePlan = convertToCalcitePlan(optimized);
@@ -220,7 +227,10 @@ public class QueryService {
               split -> executionEngine.execute(plan(plan), new ExecutionContext(split), listener),
               () ->
                   executionEngine.execute(
-                      plan(plan), ExecutionContext.emptyExecutionContext(), listener));
+                      plan(plan),
+                      ExecutionContext.querySizeLimit(
+                          settings.getSettingValue(Key.QUERY_SIZE_LIMIT)),
+                      listener));
     } catch (Exception e) {
       listener.onFailure(e);
     }

--- a/core/src/testFixtures/java/org/opensearch/sql/executor/DefaultExecutionEngine.java
+++ b/core/src/testFixtures/java/org/opensearch/sql/executor/DefaultExecutionEngine.java
@@ -28,7 +28,8 @@ public class DefaultExecutionEngine implements ExecutionEngine {
       context.getSplit().ifPresent(plan::add);
       plan.open();
 
-      while (plan.hasNext()) {
+      Integer querySizeLimit = context.getQuerySizeLimit();
+      while (plan.hasNext() && (querySizeLimit == null || result.size() < querySizeLimit)) {
         result.add(plan.next());
       }
       QueryResponse response =

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSettingsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSettingsIT.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import java.io.IOException;
+import org.opensearch.sql.common.setting.Settings.Key;
 import org.opensearch.sql.ppl.SettingsIT;
 
 public class CalciteSettingsIT extends SettingsIT {
@@ -13,5 +15,19 @@ public class CalciteSettingsIT extends SettingsIT {
     super.init();
     enableCalcite();
     disallowCalciteFallback();
+  }
+
+  @Override
+  public void testQuerySizeLimit_NoPushdown() throws IOException {
+    withSettings(
+        Key.CALCITE_PUSHDOWN_ENABLED,
+        "false",
+        () -> {
+          try {
+            super.testQuerySizeLimit_NoPushdown();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SettingsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SettingsIT.java
@@ -19,20 +19,48 @@ public class SettingsIT extends PPLIntegTestCase {
   public void init() throws Exception {
     super.init();
     loadIndex(Index.BANK);
-    loadIndex(Index.DOG);
   }
 
   @Test
   public void testQuerySizeLimit() throws IOException {
-    // Default setting, fetch 200 rows from source
+    // Default setting, fetch 200 rows from query
     JSONObject result =
         executeQuery(String.format("search source=%s age>35 | fields firstname", TEST_INDEX_BANK));
     verifyDataRows(result, rows("Hattie"), rows("Elinor"), rows("Virginia"));
 
-    // Fetch 1 rows from source
+    // Fetch 1 rows from query
     setQuerySizeLimit(1);
     result =
         executeQuery(String.format("search source=%s age>35 | fields firstname", TEST_INDEX_BANK));
+    verifyDataRows(result, rows("Hattie"));
+  }
+
+  @Test
+  public void testQuerySizeLimit_NoPushdown() throws IOException {
+    // Default setting, fetch 200 rows from query
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "search source=%s | eval a = 1 | where age>35 | fields firstname",
+                TEST_INDEX_BANK));
+    verifyDataRows(result, rows("Hattie"), rows("Elinor"), rows("Virginia"));
+
+    // Fetch 2 rows from query
+    setQuerySizeLimit(2);
+    result =
+        executeQuery(
+            String.format(
+                "search source=%s | eval a = 1 | where age>35 | fields firstname",
+                TEST_INDEX_BANK));
+    verifyDataRows(result, rows("Hattie"), rows("Elinor"));
+
+    // Fetch 1 rows from query
+    setQuerySizeLimit(1);
+    result =
+        executeQuery(
+            String.format(
+                "search source=%s | eval a = 1 | where age>35 | fields firstname",
+                TEST_INDEX_BANK));
     verifyDataRows(result, rows("Hattie"));
   }
 }

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3595 .yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3595 .yml
@@ -1,0 +1,48 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+            plugins.calcite.fallback.allowed : false
+            plugins.query.size_limit : 1
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+            plugins.calcite.fallback.allowed : true
+
+---
+"Handle flattened document value":
+  - skip:
+      features:
+        - headers
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "logs"}}
+             {"regionId": "1", "action": "login_attempt", "timestamp": "2024-04-29T10:00:00Z"}
+             {"index": {"_index": "logs"}}
+             {"regionId": "2", "action": "file_upload", "timestamp": "2024-04-29T10:05:00Z"}'
+          - '{"index": {"_index": "region_info"}}
+             {"regionId": "0", "regionName": "eu"}
+             {"index": {"_index": "region_info"}}
+             {"regionId": "0", "regionName": "de"}
+             {"index": {"_index": "region_info"}}
+             {"regionId": "1", "regionName": "us-east-1"}
+             {"index": {"_index": "region_info"}}
+             {"regionId": "2", "regionName": "us-west-2"}'
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=logs | lookup region_info regionId'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "action", "type": "string"}, {"name": "regionId", "type": "string"}, {"name": "timestamp", "type": "timestamp"},  {"name": "regionName", "type": "string"}]}
+  - match: {"datarows": [["login_attempt", "1", "2024-04-29 10:00:00", "us-east-1"]]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -203,10 +203,8 @@ public class OpenSearchIndex extends OpenSearchTable {
 
   @Override
   public TableScanBuilder createScanBuilder() {
-    final int querySizeLimit = settings.getSettingValue(Settings.Key.QUERY_SIZE_LIMIT);
-
     final TimeValue cursorKeepAlive = settings.getSettingValue(Settings.Key.SQL_CURSOR_KEEP_ALIVE);
-    var builder = new OpenSearchRequestBuilder(querySizeLimit, createExprValueFactory(), settings);
+    var builder = createRequestBuilder();
     Function<OpenSearchRequestBuilder, OpenSearchIndexScan> createScanOperator =
         requestBuilder ->
             new OpenSearchIndexScan(
@@ -265,12 +263,9 @@ public class OpenSearchIndex extends OpenSearchTable {
     return new AbstractEnumerable<>() {
       @Override
       public Enumerator<Object> enumerator() {
-        final int querySizeLimit = settings.getSettingValue(Settings.Key.QUERY_SIZE_LIMIT);
-
         final TimeValue cursorKeepAlive =
             settings.getSettingValue(Settings.Key.SQL_CURSOR_KEEP_ALIVE);
-        var builder =
-            new OpenSearchRequestBuilder(querySizeLimit, createExprValueFactory(), settings);
+        var builder = createRequestBuilder();
         return new OpenSearchIndexEnumerator(
             client,
             List.copyOf(getFieldTypes().keySet()),
@@ -281,10 +276,7 @@ public class OpenSearchIndex extends OpenSearchTable {
   }
 
   public OpenSearchRequestBuilder createRequestBuilder() {
-    return new OpenSearchRequestBuilder(
-        settings.getSettingValue(Settings.Key.QUERY_SIZE_LIMIT),
-        this.createExprValueFactory(),
-        settings);
+    return new OpenSearchRequestBuilder(getMaxResultWindow(), createExprValueFactory(), settings);
   }
 
   public OpenSearchRequest buildRequest(OpenSearchRequestBuilder requestBuilder) {

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
@@ -36,6 +36,7 @@ import org.opensearch.sql.ast.statement.Query;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.common.setting.Settings.Key;
 import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
 import org.opensearch.sql.ppl.parser.AstBuilder;
 import org.opensearch.sql.ppl.parser.AstStatementBuilder;
@@ -73,7 +74,8 @@ public class CalcitePPLAbstractTest {
   /** Creates a CalcitePlanContext with transformed config. */
   private CalcitePlanContext createBuilderContext(UnaryOperator<RelBuilder.Config> transform) {
     config.context(Contexts.of(transform.apply(RelBuilder.Config.DEFAULT)));
-    return CalcitePlanContext.create(config.build(), PPL);
+    return CalcitePlanContext.create(
+        config.build(), settings.getSettingValue(Key.QUERY_SIZE_LIMIT), PPL);
   }
 
   /** Get the root RelNode of the given PPL query */


### PR DESCRIPTION
### Description
Make query.size_limit only affect the final results

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3595, https://github.com/opensearch-project/sql/issues/703

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
