### PR TITLE
Support functions `isempty`, `isblank` and `ispresent` with Calcite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -227,6 +227,10 @@ public enum BuiltinFunctionName {
   NULLIF(FunctionName.of("nullif")),
   ISNULL(FunctionName.of("isnull")),
 
+  IS_PRESENT(FunctionName.of("ispresent")),
+  IS_EMPTY(FunctionName.of("isempty")),
+  IS_BLANK(FunctionName.of("isblank")),
+
   ROW_NUMBER(FunctionName.of("row_number")),
   RANK(FunctionName.of("rank")),
   DENSE_RANK(FunctionName.of("dense_rank")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -202,6 +202,7 @@ public class PPLFuncImpTable {
       registerOperator(IS_NULL, SqlStdOperatorTable.IS_NULL);
       registerOperator(IF, SqlStdOperatorTable.CASE);
       registerOperator(IFNULL, SqlStdOperatorTable.COALESCE);
+      registerOperator(IS_PRESENT, SqlStdOperatorTable.IS_NOT_NULL);
 
       // Register library operator
       registerOperator(REGEXP, SqlLibraryOperators.REGEXP);
@@ -371,6 +372,28 @@ public class PPLFuncImpTable {
                       builder.makeCall(SqlStdOperatorTable.EQUALS, arg1, arg2),
                       builder.makeNullLiteral(arg1.getType()),
                       arg1));
+      register(
+          IS_EMPTY,
+          ((FunctionImp1)
+              (builder, arg) ->
+                  builder.makeCall(
+                      SqlStdOperatorTable.OR,
+                      builder.makeCall(SqlStdOperatorTable.IS_NULL, arg),
+                      builder.makeCall(SqlStdOperatorTable.IS_EMPTY, arg))));
+      register(
+          IS_BLANK,
+          ((FunctionImp1)
+              (builder, arg) ->
+                  builder.makeCall(
+                      SqlStdOperatorTable.OR,
+                      builder.makeCall(SqlStdOperatorTable.IS_NULL, arg),
+                      builder.makeCall(
+                          SqlStdOperatorTable.IS_EMPTY,
+                          builder.makeCall(
+                              SqlStdOperatorTable.TRIM,
+                              builder.makeFlag(Flag.BOTH),
+                              builder.makeLiteral(" "),
+                              arg)))));
     }
   }
 

--- a/docs/user/ppl/functions/condition.rst
+++ b/docs/user/ppl/functions/condition.rst
@@ -241,10 +241,12 @@ Example::
     +-----------+----------+-----+
 
 ISPRESENT
-------
+---------
 
 Description
 >>>>>>>>>>>
+
+Version: 3.1.0
 
 Usage: ispresent(field) return true if the field exists.
 
@@ -267,10 +269,12 @@ Example::
     +----------+-----------+
 
 ISBLANK
-------
+-------
 
 Description
 >>>>>>>>>>>
+
+Version: 3.1.0
 
 Usage: isblank(field) returns true if the field is missing, an empty string, or contains only white space.
 
@@ -293,10 +297,12 @@ Example::
 
 
 ISEMPTY
-------
+-------
 
 Description
 >>>>>>>>>>>
+
+Version: 3.1.0
 
 Usage: isempty(field) returns true if the field is missing or is an empty string.
 

--- a/docs/user/ppl/functions/condition.rst
+++ b/docs/user/ppl/functions/condition.rst
@@ -276,7 +276,7 @@ Description
 
 Version: 3.1.0
 
-Usage: isblank(field) returns true if the field is missing, an empty string, or contains only white space.
+Usage: isblank(field) returns true if the field is null, an empty string, or contains only white space.
 
 Argument type: all the supported data type.
 
@@ -304,7 +304,7 @@ Description
 
 Version: 3.1.0
 
-Usage: isempty(field) returns true if the field is missing or is an empty string.
+Usage: isempty(field) returns true if the field is null or is an empty string.
 
 Argument type: all the supported data type.
 
@@ -312,13 +312,13 @@ Return type: BOOLEAN
 
 Example::
 
-    PPL> source=accounts | eval temp = ifnull(employer, '   ') | eval `isblank(employer)` = isblank(employer), `isblank(temp)` = isblank(temp) | fields `isblank(temp)`, temp, `isblank(employer)`, employer
+    PPL> source=accounts | eval temp = ifnull(employer, '   ') | eval `isempty(employer)` = isempty(employer), `isempty(temp)` = isempty(temp) | fields `isempty(temp)`, temp, `isempty(employer)`, employer
     fetched rows / total rows = 4/4
     +---------------+---------+-------------------+----------+
-    | isblank(temp) | temp    | isblank(employer) | employer |
+    | isempty(temp) | temp    | isempty(employer) | employer |
     |---------------+---------+-------------------+----------|
     | False         | Pyrami  | False             | Pyrami   |
     | False         | Netagy  | False             | Netagy   |
     | False         | Quility | False             | Quility  |
-    | True          |         | True              | null     |
+    | False         |         | True              | null     |
     +---------------+---------+-------------------+----------+

--- a/docs/user/ppl/functions/condition.rst
+++ b/docs/user/ppl/functions/condition.rst
@@ -45,6 +45,8 @@ Argument type: all the supported data type.
 
 Return type: BOOLEAN
 
+Synonyms: `ISPRESENT`_
+
 Example::
 
     os> source=accounts | where not isnotnull(employer) | fields account_number, employer
@@ -238,3 +240,79 @@ Example::
     | Dale      | Adams    | 33  |
     +-----------+----------+-----+
 
+ISPRESENT
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: ispresent(field) return true if the field exists.
+
+Argument type: all the supported data type.
+
+Return type: BOOLEAN
+
+Synonyms: `ISNOTNULL`_
+
+Example::
+
+    PPL> source=accounts | where ispresent(employer) | fields employer, firstname
+    fetched rows / total rows = 3/3
+    +----------+-----------+
+    | employer | firstname |
+    |----------+-----------|
+    | Pyrami   | Amber     |
+    | Netagy   | Hattie    |
+    | Quility  | Nanette   |
+    +----------+-----------+
+
+ISBLANK
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: isblank(field) returns true if the field is missing, an empty string, or contains only white space.
+
+Argument type: all the supported data type.
+
+Return type: BOOLEAN
+
+Example::
+
+    PPL> source=accounts | eval temp = ifnull(employer, '   ') | eval `isblank(employer)` = isblank(employer), `isblank(temp)` = isblank(temp) | fields `isblank(temp)`, temp, `isblank(employer)`, employer
+    fetched rows / total rows = 4/4
+    +---------------+---------+-------------------+----------+
+    | isblank(temp) | temp    | isblank(employer) | employer |
+    |---------------+---------+-------------------+----------|
+    | False         | Pyrami  | False             | Pyrami   |
+    | False         | Netagy  | False             | Netagy   |
+    | False         | Quility | False             | Quility  |
+    | True          |         | True              | null     |
+    +---------------+---------+-------------------+----------+
+
+
+ISEMPTY
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: isempty(field) returns true if the field is missing or is an empty string.
+
+Argument type: all the supported data type.
+
+Return type: BOOLEAN
+
+Example::
+
+    PPL> source=accounts | eval temp = ifnull(employer, '   ') | eval `isblank(employer)` = isblank(employer), `isblank(temp)` = isblank(temp) | fields `isblank(temp)`, temp, `isblank(employer)`, employer
+    fetched rows / total rows = 4/4
+    +---------------+---------+-------------------+----------+
+    | isblank(temp) | temp    | isblank(employer) | employer |
+    |---------------+---------+-------------------+----------|
+    | False         | Pyrami  | False             | Pyrami   |
+    | False         | Netagy  | False             | Netagy   |
+    | False         | Quility | False             | Quility  |
+    | True          |         | True              | null     |
+    +---------------+---------+-------------------+----------+

--- a/docs/user/ppl/functions/cryptographic.rst
+++ b/docs/user/ppl/functions/cryptographic.rst
@@ -14,6 +14,7 @@ MD5
 Description
 >>>>>>>>>>>
 
+Version: 3.1.0
 
 Usage: ``md5(str)`` calculates the MD5 digest and returns the value as a 32 character hex string.
 
@@ -37,6 +38,8 @@ SHA1
 Description
 >>>>>>>>>>>
 
+Version: 3.1.0
+
 Usage: ``sha1(str)`` returns the hex string result of SHA-1.
 
 Argument type: STRING
@@ -58,6 +61,8 @@ SHA2
 
 Description
 >>>>>>>>>>>
+
+Version: 3.1.0
 
 Usage: ``sha2(str, numBits)`` returns the hex string result of SHA-2 family of hash functions (SHA-224, SHA-256, SHA-384, and SHA-512).
 The numBits indicates the desired bit length of the result, which must have a value of 224, 256, 384, or 512.

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLConditionBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLConditionBuiltinFunctionIT.java
@@ -13,6 +13,7 @@ import static org.opensearch.sql.util.MatcherUtils.rows;
 import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
 
 public class CalcitePPLConditionBuiltinFunctionIT extends CalcitePPLIntegTestCase {
   @Override
@@ -20,6 +21,17 @@ public class CalcitePPLConditionBuiltinFunctionIT extends CalcitePPLIntegTestCas
     super.init();
     loadIndex(Index.STATE_COUNTRY);
     loadIndex(Index.STATE_COUNTRY_WITH_NULL);
+    Request request1 =
+        new Request("PUT", "/" + TEST_INDEX_STATE_COUNTRY_WITH_NULL + "/_doc/7?refresh=true");
+    request1.setJsonEntity(
+        "{\"name\":\"   "
+            + " \",\"age\":27,\"state\":\"B.C\",\"country\":\"Canada\",\"year\":2023,\"month\":4}");
+    client().performRequest(request1);
+    Request request2 =
+        new Request("PUT", "/" + TEST_INDEX_STATE_COUNTRY_WITH_NULL + "/_doc/8?refresh=true");
+    request2.setJsonEntity(
+        "{\"name\":\"\",\"age\":57,\"state\":\"B.C\",\"country\":\"Canada\",\"year\":2023,\"month\":4}");
+    client().performRequest(request2);
   }
 
   @Test
@@ -44,7 +56,15 @@ public class CalcitePPLConditionBuiltinFunctionIT extends CalcitePPLIntegTestCas
 
     verifySchema(actual, schema("name", "string"));
 
-    verifyDataRows(actual, rows("John"), rows("Jane"), rows("Jake"), rows("Hello"), rows("Kevin"));
+    verifyDataRows(
+        actual,
+        rows("John"),
+        rows("Jane"),
+        rows("Jake"),
+        rows("Hello"),
+        rows("Kevin"),
+        rows("    "),
+        rows(""));
   }
 
   @Test
@@ -64,7 +84,9 @@ public class CalcitePPLConditionBuiltinFunctionIT extends CalcitePPLIntegTestCas
         rows(null, 10),
         rows("Jake", 70),
         rows("Kevin", null),
-        rows("Hello", 30));
+        rows("Hello", 30),
+        rows("    ", 27),
+        rows("", 57));
   }
 
   @Test
@@ -85,7 +107,9 @@ public class CalcitePPLConditionBuiltinFunctionIT extends CalcitePPLIntegTestCas
         rows(null, null),
         rows("Jake", "HJake"),
         rows("Kevin", "HKevin"),
-        rows("Hello", null));
+        rows("Hello", null),
+        rows("    ", "H    "),
+        rows("", "H"));
   }
 
   @Test
@@ -105,7 +129,9 @@ public class CalcitePPLConditionBuiltinFunctionIT extends CalcitePPLIntegTestCas
         rows("Unknown", 10),
         rows("Jake", 70),
         rows("Kevin", null),
-        rows("Hello", 30));
+        rows("Hello", 30),
+        rows("    ", 27),
+        rows("", 57));
   }
 
   @Test
@@ -125,7 +151,9 @@ public class CalcitePPLConditionBuiltinFunctionIT extends CalcitePPLIntegTestCas
         rows("young", 20),
         rows("young", 10),
         rows("old", 70),
-        rows("young", 30));
+        rows("young", 30),
+        rows("young", 27),
+        rows("old", 57));
   }
 
   @Test
@@ -140,5 +168,52 @@ public class CalcitePPLConditionBuiltinFunctionIT extends CalcitePPLIntegTestCas
 
     verifyDataRows(
         actual, rows(0.0, "John"), rows(0.0, "Jane"), rows(0.0, "Jake"), rows(1.0, "Hello"));
+  }
+
+  @Test
+  public void testIsPresent() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where ispresent(name) | fields name, age",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+
+    verifySchema(actual, schema("name", "string"), schema("age", "integer"));
+
+    verifyDataRows(
+        actual,
+        rows("Jake", 70),
+        rows("Hello", 30),
+        rows("John", 25),
+        rows("Jane", 20),
+        rows("Kevin", null),
+        rows("    ", 27),
+        rows("", 57));
+  }
+
+  @Test
+  public void testIsEmpty() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where isempty(name) | fields name, age",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+
+    verifySchema(actual, schema("name", "string"), schema("age", "integer"));
+
+    verifyDataRows(actual, rows(null, 10), rows("", 57));
+  }
+
+  @Test
+  public void testIsBlank() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where isblank(name) | fields name, age",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+
+    verifySchema(actual, schema("name", "string"), schema("age", "integer"));
+
+    verifyDataRows(actual, rows(null, 10), rows("    ", 27), rows("", 57));
   }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -366,6 +366,9 @@ ISNULL:                             'ISNULL';
 ISNOTNULL:                          'ISNOTNULL';
 CIDRMATCH:                          'CIDRMATCH';
 BETWEEN:                            'BETWEEN';
+ISPRESENT:                          'ISPRESENT';
+ISEMPTY:                            'ISEMPTY';
+ISBLANK:                            'ISBLANK';
 
 // JSON FUNCTIONS
 JSON_VALID:                         'JSON_VALID';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -834,6 +834,9 @@ conditionFunctionName
    | ISNOTNULL
    | CIDRMATCH
    | JSON_VALID
+   | ISPRESENT
+   | ISEMPTY
+   | ISBLANK
    ;
 
 // flow control function return non-boolean value


### PR DESCRIPTION
### Description
Support functions `isempty`, `isblank` and `ispresent` with Calcite.

Function behaviors aligned with https://github.com/opensearch-project/opensearch-spark/pull/1170

### Related Issues
Resolves #3609 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
