### PR TITLE
Support `fillnull` command with Calcite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -593,20 +593,22 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
 
     ImmutableList.Builder<Pair<ReferenceExpression, Expression>> expressionsBuilder =
         new Builder<>();
-    for (FillNull.NullableFieldFill fieldFill : node.getNullableFieldFills()) {
-      Expression fieldExpr =
-          expressionAnalyzer.analyze(fieldFill.getNullableFieldReference(), context);
+    for (Pair<Field, UnresolvedExpression> fieldFill : node.getReplacementPairs()) {
+      Expression fieldExpr = expressionAnalyzer.analyze(fieldFill.getLeft(), context);
       ReferenceExpression ref =
-          DSL.ref(fieldFill.getNullableFieldReference().getField().toString(), fieldExpr.type());
+          DSL.ref(fieldFill.getLeft().getField().toString(), fieldExpr.type());
       FunctionExpression ifNullFunction =
-          DSL.ifnull(ref, expressionAnalyzer.analyze(fieldFill.getReplaceNullWithMe(), context));
+          DSL.ifnull(ref, expressionAnalyzer.analyze(fieldFill.getRight(), context));
       expressionsBuilder.add(new ImmutablePair<>(ref, ifNullFunction));
       TypeEnvironment typeEnvironment = context.peek();
       // define the new reference in type env.
       typeEnvironment.define(ref);
     }
-
-    return new LogicalEval(child, expressionsBuilder.build());
+    List<Pair<ReferenceExpression, Expression>> expressions = expressionsBuilder.build();
+    if (expressions.isEmpty()) {
+      throw new SemanticCheckException("At least one field is required for fillnull in V2.");
+    }
+    return new LogicalEval(child, expressions);
   }
 
   /** Build {@link LogicalML} for ml command. */

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -13,7 +13,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Alias;
@@ -524,21 +523,23 @@ public class AstDSL {
         input);
   }
 
-  public static FillNull fillNull(UnresolvedExpression replaceNullWithMe, Field... fields) {
-    return new FillNull(
-        FillNull.ContainNullableFieldFill.ofSameValue(
-            replaceNullWithMe, ImmutableList.copyOf(fields)));
+  public static FillNull fillNull(UnresolvedPlan input, UnresolvedExpression replacement) {
+    return FillNull.ofSameValue(replacement, ImmutableList.of()).attach(input);
   }
 
   public static FillNull fillNull(
-      List<ImmutablePair<Field, UnresolvedExpression>> fieldAndReplacements) {
-    ImmutableList.Builder<FillNull.NullableFieldFill> replacementsBuilder = ImmutableList.builder();
-    for (ImmutablePair<Field, UnresolvedExpression> fieldAndReplacement : fieldAndReplacements) {
+      UnresolvedPlan input, UnresolvedExpression replacement, Field... fields) {
+    return FillNull.ofSameValue(replacement, ImmutableList.copyOf(fields)).attach(input);
+  }
+
+  public static FillNull fillNull(
+      UnresolvedPlan input, List<Pair<Field, UnresolvedExpression>> fieldAndReplacements) {
+    ImmutableList.Builder<Pair<Field, UnresolvedExpression>> replacementsBuilder =
+        ImmutableList.builder();
+    for (Pair<Field, UnresolvedExpression> fieldAndReplacement : fieldAndReplacements) {
       replacementsBuilder.add(
-          new FillNull.NullableFieldFill(
-              fieldAndReplacement.getLeft(), fieldAndReplacement.getRight()));
+          Pair.of(fieldAndReplacement.getLeft(), fieldAndReplacement.getRight()));
     }
-    return new FillNull(
-        FillNull.ContainNullableFieldFill.ofVariousValue(replacementsBuilder.build()));
+    return FillNull.ofVariousValue(replacementsBuilder.build()).attach(input);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/ast/tree/FillNull.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/FillNull.java
@@ -6,70 +6,53 @@
 package org.opensearch.sql.ast.tree;
 
 import java.util.List;
-import java.util.Objects;
-import lombok.AllArgsConstructor;
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 
 /** AST node represent FillNull operation. */
-@RequiredArgsConstructor
-@AllArgsConstructor
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@ToString
 public class FillNull extends UnresolvedPlan {
 
-  @Getter
-  @RequiredArgsConstructor
-  public static class NullableFieldFill {
-    @NonNull private final Field nullableFieldReference;
-    @NonNull private final UnresolvedExpression replaceNullWithMe;
+  public static FillNull ofVariousValue(List<Pair<Field, UnresolvedExpression>> replacements) {
+    return new FillNull(replacements);
   }
 
-  public interface ContainNullableFieldFill {
-    List<NullableFieldFill> getNullFieldFill();
-
-    static ContainNullableFieldFill ofVariousValue(List<NullableFieldFill> replacements) {
-      return new VariousValueNullFill(replacements);
+  public static FillNull ofSameValue(UnresolvedExpression replacement, List<Field> fieldList) {
+    List<Pair<Field, UnresolvedExpression>> replacementPairs =
+        fieldList.stream().map(f -> Pair.of(f, replacement)).toList();
+    FillNull instance = new FillNull(replacementPairs);
+    if (replacementPairs.isEmpty()) {
+      // no field specified, the replacement value will be applied to all fields.
+      instance.replacementForAll = Optional.of(replacement);
     }
-
-    static ContainNullableFieldFill ofSameValue(
-        UnresolvedExpression replaceNullWithMe, List<Field> nullableFieldReferences) {
-      return new SameValueNullFill(replaceNullWithMe, nullableFieldReferences);
-    }
+    return instance;
   }
 
-  private static class SameValueNullFill implements ContainNullableFieldFill {
-    @Getter private final List<NullableFieldFill> nullFieldFill;
+  private Optional<UnresolvedExpression> replacementForAll = Optional.empty();
 
-    public SameValueNullFill(
-        UnresolvedExpression replaceNullWithMe, List<Field> nullableFieldReferences) {
-      Objects.requireNonNull(replaceNullWithMe, "Null replacement is required");
-      this.nullFieldFill =
-          Objects.requireNonNull(nullableFieldReferences, "Nullable field reference is required")
-              .stream()
-              .map(nullableReference -> new NullableFieldFill(nullableReference, replaceNullWithMe))
-              .toList();
-    }
-  }
+  private final List<Pair<Field, UnresolvedExpression>> replacementPairs;
 
-  @RequiredArgsConstructor
-  private static class VariousValueNullFill implements ContainNullableFieldFill {
-    @NonNull @Getter private final List<NullableFieldFill> nullFieldFill;
+  FillNull(List<Pair<Field, UnresolvedExpression>> replacementPairs) {
+    this.replacementPairs = replacementPairs;
   }
 
   private UnresolvedPlan child;
 
-  @NonNull private final ContainNullableFieldFill containNullableFieldFill;
-
-  public List<NullableFieldFill> getNullableFieldFills() {
-    return containNullableFieldFill.getNullFieldFill();
+  public List<Field> getFields() {
+    return getReplacementPairs().stream().map(Pair::getLeft).toList();
   }
 
   @Override
-  public UnresolvedPlan attach(UnresolvedPlan child) {
+  public FillNull attach(UnresolvedPlan child) {
     this.child = child;
     return this;
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.ViewExpanders;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexInputRef;
@@ -37,7 +38,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilder.AggCall;
 import org.apache.calcite.util.Holder;
-import org.apache.calcite.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
@@ -411,16 +412,16 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     //                   \- Scan t
     Pair<List<AggCall>, List<RexNode>> resolved = resolveAggCallAndGroupBy(node, context);
     List<RexInputRef> trimmedRefs = new ArrayList<>();
-    trimmedRefs.addAll(PlanUtils.getInputRefs(resolved.right)); // group-by keys first
-    trimmedRefs.addAll(PlanUtils.getInputRefsFromAggCall(resolved.left));
+    trimmedRefs.addAll(PlanUtils.getInputRefs(resolved.getRight())); // group-by keys first
+    trimmedRefs.addAll(PlanUtils.getInputRefsFromAggCall(resolved.getLeft()));
     context.relBuilder.project(trimmedRefs);
 
     // Re-resolve aggCalls and group-by list based on adding trimmed Project.
     // Using re-resolving rather than Calcite Mapping (ref Calcite ProjectTableScanRule)
     // because that Mapping only works for RexNode, but we need both AggCall and RexNode list.
     Pair<List<AggCall>, List<RexNode>> reResolved = resolveAggCallAndGroupBy(node, context);
-    List<AggCall> aggList = reResolved.left;
-    List<RexNode> groupByList = reResolved.right;
+    List<AggCall> aggList = reResolved.getLeft();
+    List<RexNode> groupByList = reResolved.getRight();
     context.relBuilder.aggregate(context.relBuilder.groupKey(groupByList), aggList);
 
     // schema reordering
@@ -670,6 +671,42 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     return context.relBuilder.peek();
   }
 
+  @Override
+  public RelNode visitFillNull(FillNull node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    if (node.getFields().size()
+        != new HashSet<>(node.getFields().stream().map(f -> f.getField().toString()).toList())
+            .size()) {
+      throw new IllegalArgumentException("The field list cannot be duplicated in fillnull");
+    }
+    List<RexNode> projects = new ArrayList<>();
+    List<RelDataTypeField> fieldsList = context.relBuilder.peek().getRowType().getFieldList();
+    for (RelDataTypeField field : fieldsList) {
+      RexNode fieldRef = context.rexBuilder.makeInputRef(field.getType(), field.getIndex());
+      boolean toReplace = false;
+      for (Pair<Field, UnresolvedExpression> pair : node.getReplacementPairs()) {
+        if (field.getName().equalsIgnoreCase(pair.getLeft().getField().toString())) {
+          RexNode replacement = rexVisitor.analyze(pair.getRight(), context);
+          RexNode coalesce = context.rexBuilder.coalesce(fieldRef, replacement);
+          RexNode coalesceWithAlias = context.relBuilder.alias(coalesce, field.getName());
+          projects.add(coalesceWithAlias);
+          toReplace = true;
+          break;
+        }
+      }
+      if (!toReplace && node.getReplacementForAll().isEmpty()) {
+        projects.add(fieldRef);
+      } else if (node.getReplacementForAll().isPresent()) {
+        RexNode replacement = rexVisitor.analyze(node.getReplacementForAll().get(), context);
+        RexNode coalesce = context.rexBuilder.coalesce(fieldRef, replacement);
+        RexNode coalesceWithAlias = context.relBuilder.alias(coalesce, field.getName());
+        projects.add(coalesceWithAlias);
+      }
+    }
+    context.relBuilder.project(projects);
+    return context.relBuilder.peek();
+  }
+
   /*
    * Unsupported Commands of PPL with Calcite for OpenSearch 3.0.0-beta
    */
@@ -701,11 +738,6 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   @Override
   public RelNode visitKmeans(Kmeans node, CalcitePlanContext context) {
     throw new CalciteUnsupportedException("Kmeans command is unsupported in Calcite");
-  }
-
-  @Override
-  public RelNode visitFillNull(FillNull fillNull, CalcitePlanContext context) {
-    throw new CalciteUnsupportedException("FillNull command is unsupported in Calcite");
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -181,6 +181,7 @@ public class PPLFuncImpTable {
       registerOperator(ASIN, SqlStdOperatorTable.ASIN);
       registerOperator(ATAN, SqlStdOperatorTable.ATAN);
       registerOperator(ATAN2, SqlStdOperatorTable.ATAN2);
+      registerOperator(CEIL, SqlStdOperatorTable.CEIL);
       registerOperator(CEILING, SqlStdOperatorTable.CEIL);
       registerOperator(COS, SqlStdOperatorTable.COS);
       registerOperator(COT, SqlStdOperatorTable.COT);

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -76,7 +76,6 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.DataType;
-import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.HighlightFunction;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.ParseMethod;
@@ -86,7 +85,6 @@ import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.AD;
 import org.opensearch.sql.ast.tree.CloseCursor;
 import org.opensearch.sql.ast.tree.FetchCursor;
-import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.ML;
 import org.opensearch.sql.ast.tree.Paginate;
@@ -1397,14 +1395,11 @@ class AnalyzerTest extends AnalyzerTestBase {
             ImmutablePair.of(
                 DSL.ref("int_null_value", INTEGER),
                 DSL.ifnull(DSL.ref("int_null_value", INTEGER), DSL.literal(0)))),
-        new FillNull(
+        AstDSL.fillNull(
             AstDSL.relation("schema"),
-            FillNull.ContainNullableFieldFill.ofSameValue(
-                AstDSL.intLiteral(0),
-                ImmutableList.<Field>builder()
-                    .add(AstDSL.field("integer_value"))
-                    .add(AstDSL.field("int_null_value"))
-                    .build())));
+            AstDSL.intLiteral(0),
+            AstDSL.field("integer_value"),
+            AstDSL.field("int_null_value")));
   }
 
   @Test
@@ -1418,14 +1413,11 @@ class AnalyzerTest extends AnalyzerTestBase {
             ImmutablePair.of(
                 DSL.ref("int_null_value", INTEGER),
                 DSL.ifnull(DSL.ref("int_null_value", INTEGER), DSL.literal(1)))),
-        new FillNull(
+        AstDSL.fillNull(
             AstDSL.relation("schema"),
-            FillNull.ContainNullableFieldFill.ofVariousValue(
-                ImmutableList.of(
-                    new FillNull.NullableFieldFill(
-                        AstDSL.field("integer_value"), AstDSL.intLiteral(0)),
-                    new FillNull.NullableFieldFill(
-                        AstDSL.field("int_null_value"), AstDSL.intLiteral(1))))));
+            List.of(
+                Pair.of(AstDSL.field("integer_value"), AstDSL.intLiteral(0)),
+                Pair.of(AstDSL.field("int_null_value"), AstDSL.intLiteral(1)))));
   }
 
   @Test

--- a/docs/user/ppl/cmd/fillnull.rst
+++ b/docs/user/ppl/cmd/fillnull.rst
@@ -16,19 +16,19 @@ Using ``fillnull`` command to fill null with provided value in one or more field
 
 Syntax
 ============
-`fillnull [with <null-replacement> in <nullable-field>["," <nullable-field>]] | [using <source-field> = <null-replacement> [","<source-field> = <null-replacement>]]`
+fillnull with <replacement> [in <field-list>]
 
-* null-replacement: mandatory. The value used to replace `null`s.
-* nullable-field: mandatory. Field reference. The `null` values in the field referred to by the property will be replaced with the values from the null-replacement.
+fillnull using <field> = <replacement> [, <field> = <replacement>]
 
-Example 1: fillnull one field
-======================================================================
+* replacement: mandatory. The value used to replace `null`s.
+* field-list: optional. The comma-delimited field list. The `null` values in the field will be replaced with the values from the replacement. In v2, at least one field is required. In v3, if no field specified, the replacement is applied to all fields.
 
-The example show fillnull one field.
+Example 1: replace null values with a specified value on one field
+==================================================================
 
 PPL query::
 
-    os> source=accounts | fields email, employer | fillnull with '<not found>' in email ;
+    os> source=accounts | fields email, employer | fillnull with '<not found>' in email;
     fetched rows / total rows = 4/4
     +-----------------------+----------+
     | email                 | employer |
@@ -39,14 +39,46 @@ PPL query::
     | daleadams@boink.com   | null     |
     +-----------------------+----------+
 
-Example 2: fillnull applied to multiple fields
+Example 2: replace null values with a specified value on multiple fields
 ========================================================================
-
-The example show fillnull applied to multiple fields.
 
 PPL query::
 
-    os> source=accounts | fields email, employer | fillnull using email = '<not found>', employer = '<no employer>' ;
+    os> source=accounts | fields email, employer | fillnull with '<not found>' in email, employer;
+    fetched rows / total rows = 4/4
+    +-----------------------+-------------+
+    | email                 | employer    |
+    |-----------------------+-------------|
+    | amberduke@pyrami.com  | Pyrami      |
+    | hattiebond@netagy.com | Netagy      |
+    | <not found>           | Quility     |
+    | daleadams@boink.com   | <not found> |
+    +-----------------------+-------------+
+
+Example 3: replace null values with a specified value on all fields
+===================================================================
+
+This example only works when Calcite enabled.
+
+PPL query::
+
+    PPL> source=accounts | fields email, employer | fillnull with '<not found>';
+    fetched rows / total rows = 4/4
+    +-----------------------+-------------+
+    | email                 | employer    |
+    |-----------------------+-------------|
+    | amberduke@pyrami.com  | Pyrami      |
+    | hattiebond@netagy.com | Netagy      |
+    | <not found>           | Quility     |
+    | daleadams@boink.com   | <not found> |
+    +-----------------------+-------------+
+
+Example 4: replace null values with multiple specified values on multiple fields
+================================================================================
+
+PPL query::
+
+    os> source=accounts | fields email, employer | fillnull using email = '<not found>', employer = '<no employer>';
     fetched rows / total rows = 4/4
     +-----------------------+---------------+
     | email                 | employer      |
@@ -57,6 +89,8 @@ PPL query::
     | daleadams@boink.com   | <no employer> |
     +-----------------------+---------------+
 
+
 Limitation
 ==========
-The ``fillnull`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.
+* The ``fillnull`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.
+* In v2, at least one field is required.

--- a/docs/user/ppl/cmd/fillnull.rst
+++ b/docs/user/ppl/cmd/fillnull.rst
@@ -21,7 +21,7 @@ fillnull with <replacement> [in <field-list>]
 fillnull using <field> = <replacement> [, <field> = <replacement>]
 
 * replacement: mandatory. The value used to replace `null`s.
-* field-list: optional. The comma-delimited field list. The `null` values in the field will be replaced with the values from the replacement. In v2, at least one field is required. In v3, if no field specified, the replacement is applied to all fields.
+* field-list: optional. The comma-delimited field list. The `null` values in the field will be replaced with the values from the replacement. From 3.1.0, when ``plugins.calcite.enabled`` is true, if no field specified, the replacement is applied to all fields.
 
 Example 1: replace null values with a specified value on one field
 ==================================================================
@@ -93,4 +93,4 @@ PPL query::
 Limitation
 ==========
 * The ``fillnull`` command is not rewritten to OpenSearch DSL, it is only executed on the coordination node.
-* In v2, at least one field is required.
+* Before 3.1.0, at least one field is required.

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -18,19 +18,6 @@ public class CalciteExplainIT extends ExplainIT {
   }
 
   @Override
-  public void testFillNullPushDownExplain() throws Exception {
-    withFallbackEnabled(
-        () -> {
-          try {
-            super.testFillNullPushDownExplain();
-          } catch (Exception e) {
-            throw new RuntimeException(e);
-          }
-        },
-        "https://github.com/opensearch-project/sql/issues/3461");
-  }
-
-  @Override
   public void testTrendlinePushDownExplain() throws Exception {
     withFallbackEnabled(
         () -> {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteFillNullCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteFillNullCommandIT.java
@@ -12,7 +12,6 @@ public class CalciteFillNullCommandIT extends FillNullCommandIT {
   public void init() throws Exception {
     super.init();
     enableCalcite();
-    // TODO: "https://github.com/opensearch-project/sql/issues/3461"
-    // disallowCalciteFallback();
+    disallowCalciteFallback();
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLFillnullIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLFillnullIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.standalone;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_STATE_COUNTRY_WITH_NULL;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class CalcitePPLFillnullIT extends CalcitePPLIntegTestCase {
+
+  @Override
+  public void init() throws IOException {
+    super.init();
+    loadIndex(Index.STATE_COUNTRY_WITH_NULL);
+  }
+
+  @Test
+  public void testFillnullWith() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | fillnull with 'N/A' in name, state, country | fields name, age, state,"
+                    + " country, year, month",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+    verifySchema(
+        actual,
+        schema("name", "string"),
+        schema("age", "integer"),
+        schema("state", "string"),
+        schema("country", "string"),
+        schema("year", "integer"),
+        schema("month", "integer"));
+    verifyDataRows(
+        actual,
+        rows("Jake", 70, "California", "USA", 2023, 4),
+        rows("Hello", 30, "New York", "USA", 2023, 4),
+        rows("John", 25, "Ontario", "Canada", 2023, 4),
+        rows("Jane", 20, "Quebec", "Canada", 2023, 4),
+        rows("Kevin", null, "N/A", "N/A", 2023, 4),
+        rows("N/A", 10, "N/A", "Canada", 2023, 4));
+  }
+
+  @Test
+  public void testFillnullUsing() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | fillnull using name='N/A', state='N/A', country='N/A' | fields name,"
+                    + " age, state, country, year, month",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+    verifySchema(
+        actual,
+        schema("name", "string"),
+        schema("age", "integer"),
+        schema("state", "string"),
+        schema("country", "string"),
+        schema("year", "integer"),
+        schema("month", "integer"));
+    verifyDataRows(
+        actual,
+        rows("Jake", 70, "California", "USA", 2023, 4),
+        rows("Hello", 30, "New York", "USA", 2023, 4),
+        rows("John", 25, "Ontario", "Canada", 2023, 4),
+        rows("Jane", 20, "Quebec", "Canada", 2023, 4),
+        rows("Kevin", null, "N/A", "N/A", 2023, 4),
+        rows("N/A", 10, "N/A", "Canada", 2023, 4));
+  }
+
+  @Test
+  public void testFillnullWithoutFieldList() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | fields name, state, country | fillnull with 'N/A'",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+    verifySchema(
+        actual, schema("name", "string"), schema("state", "string"), schema("country", "string"));
+    verifyDataRows(
+        actual,
+        rows("Jake", "California", "USA"),
+        rows("Hello", "New York", "USA"),
+        rows("John", "Ontario", "Canada"),
+        rows("Jane", "Quebec", "Canada"),
+        rows("Kevin", "N/A", "N/A"),
+        rows("N/A", "N/A", "Canada"));
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
@@ -112,7 +112,10 @@ public class ExplainIT extends PPLIntegTestCase {
 
   @Test
   public void testFillNullPushDownExplain() throws Exception {
-    String expected = loadFromFile("expectedOutput/ppl/explain_fillnull_push.json");
+    String expected =
+        isCalciteEnabled()
+            ? loadFromFile("expectedOutput/calcite/explain_fillnull_push.json")
+            : loadFromFile("expectedOutput/ppl/explain_fillnull_push.json");
 
     assertJsonEqualsIgnoreRelId(
         expected,

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_fillnull_push.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_fillnull_push.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalProject(age=[COALESCE($8, -1)], balance=[COALESCE($3, -1)])\n  CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableCalc(expr#0..1=[{inputs}], expr#2=[-1], expr#3=[COALESCE($t0, $t2)], expr#4=[COALESCE($t1, $t2)], $f0=[$t3], $f1=[$t4])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[PROJECT->[age, balance]], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\",\"balance\"],\"excludes\":[]}}, requestedTotalSize=10000, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -209,20 +209,20 @@ lookupPair
    ;
 
 fillnullCommand
-   : FILLNULL (fillNullWithTheSameValue
-   | fillNullWithFieldVariousValues)
+   : FILLNULL fillNullWith
+   | FILLNULL fillNullUsing
    ;
 
-fillNullWithTheSameValue
-   : WITH nullReplacement = valueExpression IN nullableFieldList = fieldList
+fillNullWith
+   : WITH replacement = valueExpression (IN fieldList)?
    ;
 
-fillNullWithFieldVariousValues
-   : USING nullReplacementExpression (COMMA nullReplacementExpression)*
+fillNullUsing
+   : USING replacementPair (COMMA replacementPair)*
    ;
 
-nullReplacementExpression
-   : nullableField = fieldExpression EQUAL nullReplacement = valueExpression
+replacementPair
+   : fieldExpression EQUAL replacement = valueExpression
    ;
 
 trendlineCommand

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.AllFieldsExcludeMeta;
@@ -623,30 +624,31 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
 
   /** fillnull command. */
   @Override
-  public UnresolvedPlan visitFillNullWithTheSameValue(
-      OpenSearchPPLParser.FillNullWithTheSameValueContext ctx) {
-    return new FillNull(
-        FillNull.ContainNullableFieldFill.ofSameValue(
-            internalVisitExpression(ctx.nullReplacement),
-            ctx.nullableFieldList.fieldExpression().stream()
-                .map(f -> (Field) internalVisitExpression(f))
-                .toList()));
+  public UnresolvedPlan visitFillNullWith(OpenSearchPPLParser.FillNullWithContext ctx) {
+    if (ctx.IN() != null) {
+      return FillNull.ofSameValue(
+          internalVisitExpression(ctx.replacement),
+          ctx.fieldList().fieldExpression().stream()
+              .map(f -> (Field) internalVisitExpression(f))
+              .toList());
+    } else {
+      return FillNull.ofSameValue(internalVisitExpression(ctx.replacement), List.of());
+    }
   }
 
   /** fillnull command. */
   @Override
-  public UnresolvedPlan visitFillNullWithFieldVariousValues(
-      OpenSearchPPLParser.FillNullWithFieldVariousValuesContext ctx) {
-    ImmutableList.Builder<FillNull.NullableFieldFill> replacementsBuilder = ImmutableList.builder();
-    for (int i = 0; i < ctx.nullReplacementExpression().size(); i++) {
+  public UnresolvedPlan visitFillNullUsing(OpenSearchPPLParser.FillNullUsingContext ctx) {
+    ImmutableList.Builder<Pair<Field, UnresolvedExpression>> replacementsBuilder =
+        ImmutableList.builder();
+    for (int i = 0; i < ctx.replacementPair().size(); i++) {
       replacementsBuilder.add(
-          new FillNull.NullableFieldFill(
-              (Field) internalVisitExpression(ctx.nullReplacementExpression(i).nullableField),
-              internalVisitExpression(ctx.nullReplacementExpression(i).nullReplacement)));
+          Pair.of(
+              (Field) internalVisitExpression(ctx.replacementPair(i).fieldExpression()),
+              internalVisitExpression(ctx.replacementPair(i).replacement)));
     }
 
-    return new FillNull(
-        FillNull.ContainNullableFieldFill.ofVariousValue(replacementsBuilder.build()));
+    return FillNull.ofVariousValue(replacementsBuilder.build());
   }
 
   /** trendline command. */

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -369,26 +369,25 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
   @Override
   public String visitFillNull(FillNull node, String context) {
     String child = node.getChild().get(0).accept(this, context);
-    List<FillNull.NullableFieldFill> fieldFills = node.getNullableFieldFills();
-    final UnresolvedExpression firstReplacement = fieldFills.getFirst().getReplaceNullWithMe();
-    if (fieldFills.stream().allMatch(n -> firstReplacement == n.getReplaceNullWithMe())) {
+    List<Pair<Field, UnresolvedExpression>> fieldFills = node.getReplacementPairs();
+    if (fieldFills.isEmpty()) {
+      return StringUtils.format("%s | fillnull with %s", child, MASK_LITERAL);
+    }
+    final UnresolvedExpression firstReplacement = fieldFills.getFirst().getRight();
+    if (fieldFills.stream().allMatch(n -> firstReplacement == n.getRight())) {
       return StringUtils.format(
           "%s | fillnull with %s in %s",
           child,
-          firstReplacement,
-          node.getNullableFieldFills().stream()
-              .map(n -> visitExpression(n.getNullableFieldReference()))
+          MASK_LITERAL,
+          node.getReplacementPairs().stream()
+              .map(n -> visitExpression(n.getLeft()))
               .collect(Collectors.joining(", ")));
     } else {
       return StringUtils.format(
           "%s | fillnull using %s",
           child,
-          node.getNullableFieldFills().stream()
-              .map(
-                  n ->
-                      StringUtils.format(
-                          "%s = %s",
-                          visitExpression(n.getNullableFieldReference()), n.getReplaceNullWithMe()))
+          node.getReplacementPairs().stream()
+              .map(n -> StringUtils.format("%s = %s", visitExpression(n.getLeft()), MASK_LITERAL))
               .collect(Collectors.joining(", ")));
     }
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFillnullTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFillnullTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLFillnullTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLFillnullTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testFillnullWith() {
+    String ppl = "source=EMP | fillnull with 0 in MGR, COMM";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[COALESCE($3, 0)], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[COALESCE($6, 0)], DEPTNO=[$7])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        "EMPNO=7369; ENAME=SMITH; JOB=CLERK; MGR=7902; HIREDATE=1980-12-17; SAL=800.00; COMM=0;"
+            + " DEPTNO=20\n"
+            + "EMPNO=7499; ENAME=ALLEN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-20; SAL=1600.00;"
+            + " COMM=300.00; DEPTNO=30\n"
+            + "EMPNO=7521; ENAME=WARD; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-22; SAL=1250.00;"
+            + " COMM=500.00; DEPTNO=30\n"
+            + "EMPNO=7566; ENAME=JONES; JOB=MANAGER; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00;"
+            + " COMM=0; DEPTNO=20\n"
+            + "EMPNO=7654; ENAME=MARTIN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-28; SAL=1250.00;"
+            + " COMM=1400.00; DEPTNO=30\n"
+            + "EMPNO=7698; ENAME=BLAKE; JOB=MANAGER; MGR=7839; HIREDATE=1981-01-05; SAL=2850.00;"
+            + " COMM=0; DEPTNO=30\n"
+            + "EMPNO=7782; ENAME=CLARK; JOB=MANAGER; MGR=7839; HIREDATE=1981-06-09; SAL=2450.00;"
+            + " COMM=0; DEPTNO=10\n"
+            + "EMPNO=7788; ENAME=SCOTT; JOB=ANALYST; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00;"
+            + " COMM=0; DEPTNO=20\n"
+            + "EMPNO=7839; ENAME=KING; JOB=PRESIDENT; MGR=0; HIREDATE=1981-11-17; SAL=5000.00;"
+            + " COMM=0; DEPTNO=10\n"
+            + "EMPNO=7844; ENAME=TURNER; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-08; SAL=1500.00;"
+            + " COMM=0.00; DEPTNO=30\n"
+            + "EMPNO=7876; ENAME=ADAMS; JOB=CLERK; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00;"
+            + " COMM=0; DEPTNO=20\n"
+            + "EMPNO=7900; ENAME=JAMES; JOB=CLERK; MGR=7698; HIREDATE=1981-12-03; SAL=950.00;"
+            + " COMM=0; DEPTNO=30\n"
+            + "EMPNO=7902; ENAME=FORD; JOB=ANALYST; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00;"
+            + " COMM=0; DEPTNO=20\n"
+            + "EMPNO=7934; ENAME=MILLER; JOB=CLERK; MGR=7782; HIREDATE=1982-01-23; SAL=1300.00;"
+            + " COMM=0; DEPTNO=10\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, COALESCE(`MGR`, 0) `MGR`, `HIREDATE`, `SAL`,"
+            + " COALESCE(`COMM`, 0) `COMM`, `DEPTNO`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testFillnullUsing() {
+    String ppl = "source=EMP | fillnull using MGR=7000, COMM=0.00";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[COALESCE($3, 7000)], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[COALESCE($6, 0.0E0:DOUBLE)], DEPTNO=[$7])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        "EMPNO=7369; ENAME=SMITH; JOB=CLERK; MGR=7902; HIREDATE=1980-12-17; SAL=800.00; COMM=0.0;"
+            + " DEPTNO=20\n"
+            + "EMPNO=7499; ENAME=ALLEN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-20; SAL=1600.00;"
+            + " COMM=300.0; DEPTNO=30\n"
+            + "EMPNO=7521; ENAME=WARD; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-22; SAL=1250.00;"
+            + " COMM=500.0; DEPTNO=30\n"
+            + "EMPNO=7566; ENAME=JONES; JOB=MANAGER; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00;"
+            + " COMM=0.0; DEPTNO=20\n"
+            + "EMPNO=7654; ENAME=MARTIN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-28; SAL=1250.00;"
+            + " COMM=1400.0; DEPTNO=30\n"
+            + "EMPNO=7698; ENAME=BLAKE; JOB=MANAGER; MGR=7839; HIREDATE=1981-01-05; SAL=2850.00;"
+            + " COMM=0.0; DEPTNO=30\n"
+            + "EMPNO=7782; ENAME=CLARK; JOB=MANAGER; MGR=7839; HIREDATE=1981-06-09; SAL=2450.00;"
+            + " COMM=0.0; DEPTNO=10\n"
+            + "EMPNO=7788; ENAME=SCOTT; JOB=ANALYST; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00;"
+            + " COMM=0.0; DEPTNO=20\n"
+            + "EMPNO=7839; ENAME=KING; JOB=PRESIDENT; MGR=7000; HIREDATE=1981-11-17; SAL=5000.00;"
+            + " COMM=0.0; DEPTNO=10\n"
+            + "EMPNO=7844; ENAME=TURNER; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-08; SAL=1500.00;"
+            + " COMM=0.0; DEPTNO=30\n"
+            + "EMPNO=7876; ENAME=ADAMS; JOB=CLERK; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00;"
+            + " COMM=0.0; DEPTNO=20\n"
+            + "EMPNO=7900; ENAME=JAMES; JOB=CLERK; MGR=7698; HIREDATE=1981-12-03; SAL=950.00;"
+            + " COMM=0.0; DEPTNO=30\n"
+            + "EMPNO=7902; ENAME=FORD; JOB=ANALYST; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00;"
+            + " COMM=0.0; DEPTNO=20\n"
+            + "EMPNO=7934; ENAME=MILLER; JOB=CLERK; MGR=7782; HIREDATE=1982-01-23; SAL=1300.00;"
+            + " COMM=0.0; DEPTNO=10\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, COALESCE(`MGR`, 7000) `MGR`, `HIREDATE`, `SAL`,"
+            + " COALESCE(`COMM`, 0E0) `COMM`, `DEPTNO`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testFillnullAll() {
+    String ppl = "source=EMP | fields EMPNO, MGR, SAL, COMM, DEPTNO | fillnull with 0";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], MGR=[COALESCE($3, 0)], SAL=[COALESCE($5, 0)],"
+            + " COMM=[COALESCE($6, 0)], DEPTNO=[COALESCE($7, 0)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedResult =
+        "EMPNO=7369; MGR=7902; SAL=800.00; COMM=0; DEPTNO=20\n"
+            + "EMPNO=7499; MGR=7698; SAL=1600.00; COMM=300.00; DEPTNO=30\n"
+            + "EMPNO=7521; MGR=7698; SAL=1250.00; COMM=500.00; DEPTNO=30\n"
+            + "EMPNO=7566; MGR=7839; SAL=2975.00; COMM=0; DEPTNO=20\n"
+            + "EMPNO=7654; MGR=7698; SAL=1250.00; COMM=1400.00; DEPTNO=30\n"
+            + "EMPNO=7698; MGR=7839; SAL=2850.00; COMM=0; DEPTNO=30\n"
+            + "EMPNO=7782; MGR=7839; SAL=2450.00; COMM=0; DEPTNO=10\n"
+            + "EMPNO=7788; MGR=7566; SAL=3000.00; COMM=0; DEPTNO=20\n"
+            + "EMPNO=7839; MGR=0; SAL=5000.00; COMM=0; DEPTNO=10\n"
+            + "EMPNO=7844; MGR=7698; SAL=1500.00; COMM=0.00; DEPTNO=30\n"
+            + "EMPNO=7876; MGR=7788; SAL=1100.00; COMM=0; DEPTNO=20\n"
+            + "EMPNO=7900; MGR=7698; SAL=950.00; COMM=0; DEPTNO=30\n"
+            + "EMPNO=7902; MGR=7566; SAL=3000.00; COMM=0; DEPTNO=20\n"
+            + "EMPNO=7934; MGR=7782; SAL=1300.00; COMM=0; DEPTNO=10\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, COALESCE(`MGR`, 0) `MGR`, COALESCE(`SAL`, 0) `SAL`, COALESCE(`COMM`, 0)"
+            + " `COMM`, COALESCE(`DEPTNO`, 0) `DEPTNO`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -25,6 +25,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.describe;
 import static org.opensearch.sql.ast.dsl.AstDSL.eval;
 import static org.opensearch.sql.ast.dsl.AstDSL.exprList;
 import static org.opensearch.sql.ast.dsl.AstDSL.field;
+import static org.opensearch.sql.ast.dsl.AstDSL.fillNull;
 import static org.opensearch.sql.ast.dsl.AstDSL.filter;
 import static org.opensearch.sql.ast.dsl.AstDSL.function;
 import static org.opensearch.sql.ast.dsl.AstDSL.head;
@@ -49,10 +50,11 @@ import static org.opensearch.sql.ast.tree.Trendline.TrendlineType.SMA;
 import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
 import static org.opensearch.sql.utils.SystemIndexUtils.DATASOURCES_TABLE_NAME;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,13 +63,11 @@ import org.mockito.Mockito;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.DataType;
-import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.ParseMethod;
 import org.opensearch.sql.ast.expression.PatternMethod;
 import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.AD;
-import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.ML;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
@@ -653,29 +653,19 @@ public class AstBuilderTest {
   public void testFillNullCommandSameValue() {
     assertEqual(
         "source=t | fillnull with 0 in a, b, c",
-        new FillNull(
-            relation("t"),
-            FillNull.ContainNullableFieldFill.ofSameValue(
-                intLiteral(0),
-                ImmutableList.<Field>builder()
-                    .add(field("a"))
-                    .add(field("b"))
-                    .add(field("c"))
-                    .build())));
+        fillNull(relation("t"), intLiteral(0), field("a"), field("b"), field("c")));
   }
 
   @Test
   public void testFillNullCommandVariousValues() {
     assertEqual(
         "source=t | fillnull using a = 1, b = 2, c = 3",
-        new FillNull(
+        fillNull(
             relation("t"),
-            FillNull.ContainNullableFieldFill.ofVariousValue(
-                ImmutableList.<FillNull.NullableFieldFill>builder()
-                    .add(new FillNull.NullableFieldFill(field("a"), intLiteral(1)))
-                    .add(new FillNull.NullableFieldFill(field("b"), intLiteral(2)))
-                    .add(new FillNull.NullableFieldFill(field("c"), intLiteral(3)))
-                    .build())));
+            List.of(
+                Pair.of(field("a"), intLiteral(1)),
+                Pair.of(field("b"), intLiteral(2)),
+                Pair.of(field("c"), intLiteral(3)))));
   }
 
   public void testTrendline() {

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -145,14 +145,20 @@ public class PPLQueryDataAnonymizerTest {
   @Test
   public void testFillNullSameValue() {
     assertEquals(
-        "source=t | fillnull with 0 in f1, f2", anonymize("source=t | fillnull with 0 in f1, f2"));
+        "source=t | fillnull with *** in f1, f2",
+        anonymize("source=t | fillnull with 0 in f1, f2"));
   }
 
   @Test
   public void testFillNullVariousValues() {
     assertEquals(
-        "source=t | fillnull using f1 = 0, f2 = -1",
+        "source=t | fillnull using f1 = ***, f2 = ***",
         anonymize("source=t | fillnull using f1 = 0, f2 = -1"));
+  }
+
+  @Test
+  public void testFillNullWithoutFields() {
+    assertEquals("source=t | fillnull with ***", anonymize("source=t | fillnull with 0"));
   }
 
   @Test


### PR DESCRIPTION
### Description
- Migrate `fillnull` command implemented in https://github.com/opensearch-project/sql/pull/3075 to Calcite implementation.
  - Keep the syntax consistency with the current existing.
- Support no specified field list (which is a missing feature in  https://github.com/opensearch-project/sql/pull/3075)
  - if no field specified, the replacement is applied to all fields.

### Related Issues
Resolves #3461 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
