### PR TITLE
Support merging object-type fields when fetching the schema from the index

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -448,8 +448,8 @@ integTest {
 
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
     if(getOSFamilyType() != "windows") {
-        //dependsOn startPrometheus
-        //finalizedBy stopPrometheus
+        dependsOn startPrometheus
+        finalizedBy stopPrometheus
     }
 
     // enable calcite codegen in IT

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -448,8 +448,8 @@ integTest {
 
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
     if(getOSFamilyType() != "windows") {
-        dependsOn startPrometheus
-        finalizedBy stopPrometheus
+        //dependsOn startPrometheus
+        //finalizedBy stopPrometheus
     }
 
     // enable calcite codegen in IT

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
@@ -566,23 +566,19 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
   }
 
   @Test
-  public void testMergeTwoObject() {
-    JSONObject result =
-        executeQuery(
-            String.format("source=%s | fields machine.os1 ", TEST_INDEX_MERGE_TEST_WILDCARD));
-    verifySchema(result, schema("original_col", "integer"), schema("alias_col", "integer"));
-    verifyDataRows(result, rows(2, 2), rows(3, 3));
-  }
-
-  @Test
-  public void testMergeTwoObjectReturn() {
+  public void testFieldsMergedObject() {
     JSONObject result =
         executeQuery(
             String.format(
                 "source=%s | fields machine.os1,  machine.os2, machine_array.os1, "
                     + " machine_array.os2",
                 TEST_INDEX_MERGE_TEST_WILDCARD));
-    verifySchema(result, schema("original_col", "integer"), schema("alias_col", "integer"));
-    verifyDataRows(result, rows(2, 2), rows(3, 3));
+    verifySchema(
+        result,
+        schema("machine.os1", "string"),
+        schema("machine.os2", "string"),
+        schema("machine_array.os1", "string"),
+        schema("machine_array.os2", "string"));
+    verifyDataRows(result, rows("linux", null, "linux", null), rows(null, "linux", null, "linux"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLBasicIT.java
@@ -5,9 +5,7 @@
 
 package org.opensearch.sql.calcite.standalone;
 
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ALIAS;
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.legacy.TestsConstants.*;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -38,6 +36,8 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
 
     loadIndex(Index.BANK);
     loadIndex(Index.DATA_TYPE_ALIAS);
+    loadIndex(Index.MERGE_TEST_1);
+    loadIndex(Index.MERGE_TEST_2);
   }
 
   @Test
@@ -563,5 +563,26 @@ public class CalcitePPLBasicIT extends CalcitePPLIntegTestCase {
                 executeQuery(
                     String.format("source=%s | stats count() as _score", TEST_INDEX_ACCOUNT)));
     verifyErrorMessageContains(e, "Cannot use metadata field [_score] as the alias.");
+  }
+
+  @Test
+  public void testMergeTwoObject() {
+    JSONObject result =
+        executeQuery(
+            String.format("source=%s | fields machine.os1 ", TEST_INDEX_MERGE_TEST_WILDCARD));
+    verifySchema(result, schema("original_col", "integer"), schema("alias_col", "integer"));
+    verifyDataRows(result, rows(2, 2), rows(3, 3));
+  }
+
+  @Test
+  public void testMergeTwoObjectReturn() {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | fields machine.os1,  machine.os2, machine_array.os1, "
+                    + " machine_array.os2",
+                TEST_INDEX_MERGE_TEST_WILDCARD));
+    verifySchema(result, schema("original_col", "integer"), schema("alias_col", "integer"));
+    verifyDataRows(result, rows(2, 2), rows(3, 3));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -818,6 +818,16 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         "hobbies",
         getHobbiesIndexMapping(),
         "src/test/resources/hobbies.json"),
+    MERGE_TEST_1(
+        TestsConstants.TEST_INDEX_MERGE_TEST_1,
+        "merge_test1",
+        getMappingFile("merge_test_1_mapping.json"),
+        "src/test/resources/merge_test_1.json"),
+    MERGE_TEST_2(
+        TestsConstants.TEST_INDEX_MERGE_TEST_2,
+        "merge_test2",
+        getMappingFile("merge_test_2_mapping.json"),
+        "src/test/resources/merge_test_2.json"),
     // It's "people" table in Spark PPL ITs, to avoid conflicts, rename to "worker" here
     WORKER(
         TestsConstants.TEST_INDEX_WORKER,

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -74,6 +74,9 @@ public class TestsConstants {
   public static final String TEST_INDEX_WORKER = TEST_INDEX + "_worker";
   public static final String TEST_INDEX_WORK_INFORMATION = TEST_INDEX + "_work_information";
   public static final String TEST_INDEX_DUPLICATION_NULLABLE = TEST_INDEX + "_duplication_nullable";
+  public static final String TEST_INDEX_MERGE_TEST_1 = TEST_INDEX + "_merge_test_1";
+  public static final String TEST_INDEX_MERGE_TEST_2 = TEST_INDEX + "_merge_test_2";
+  public static final String TEST_INDEX_MERGE_TEST_WILDCARD = TEST_INDEX + "_merge_test_*";
 
   public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   public static final String TS_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";

--- a/integ-test/src/test/resources/indexDefinitions/merge_test_1_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/merge_test_1_mapping.json
@@ -1,0 +1,27 @@
+{
+  "mappings": {
+    "properties": {
+      "machine": {
+        "properties": {
+          "os1": {
+            "type": "text"
+          },
+          "ram1": {
+            "type": "long"
+          }
+        }
+      },
+      "machine_array": {
+        "type": "nested",
+        "properties": {
+          "os1": {
+            "type": "text"
+          },
+          "ram1": {
+            "type": "long"
+          }
+        }
+      }
+    }
+  }
+}

--- a/integ-test/src/test/resources/indexDefinitions/merge_test_2_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/merge_test_2_mapping.json
@@ -1,0 +1,27 @@
+{
+  "mappings": {
+    "properties": {
+      "machine": {
+        "properties": {
+          "os2": {
+            "type": "text"
+          },
+          "ram2": {
+            "type": "long"
+          }
+        }
+      },
+      "machine_array": {
+        "type": "nested",
+        "properties": {
+          "os2": {
+            "type": "text"
+          },
+          "ram2": {
+            "type": "long"
+          }
+        }
+      }
+    }
+  }
+}

--- a/integ-test/src/test/resources/merge_test_1.json
+++ b/integ-test/src/test/resources/merge_test_1.json
@@ -1,0 +1,2 @@
+{"index":{"_id":"1"}}
+{"machine": {"os1": "linux", "ram1": 120}, "machine_array":  [{"os1": "linux", "ram1": 120}]}

--- a/integ-test/src/test/resources/merge_test_2.json
+++ b/integ-test/src/test/resources/merge_test_2.json
@@ -1,0 +1,2 @@
+{"index": {}}
+{"machine": {"os2": "linux", "ram2": 120}, "machine_array":  [{"os2": "linux", "ram2": 120}]}


### PR DESCRIPTION
### Description
This PR supports merging object-type fields when fetching the schema from the several. For example, we have 
```
PUT demo1
{
  "mappings": {
    "properties": {
      "machine": {
        "properties": {
          "os1": {
            "type": "text"
          },
          "ram1": {
            "type": "long"
          }
        }
      }
    }
  }
}
```
And 
```
PUT demo2
{
  "mappings": {
    "properties": {
      "machine": {
        "properties": {
          "os2": {
            "type": "text"
          },
          "ram2": {
            "type": "long"
          }
        }
      }
    }
  }
}
```
Now we support `source=demo1, demo2 | fields machine.os1, machine.os2`



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
#3625 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
