### PR TITLE
Fix: Long IN-lists causes crash

### DIFF
--- a/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/ExpressionAnalyzerTest.java
@@ -27,6 +27,8 @@ import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
 import static org.opensearch.sql.expression.DSL.ref;
 
 import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -399,6 +401,17 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
     assertThrows(
         SemanticCheckException.class,
         () -> analyze(AstDSL.in(field("integer_value"), Collections.emptyList())));
+  }
+
+  @Test
+  void visit_in_large_list() {
+    List<UnresolvedExpression> ints = new ArrayList<>();
+    for (int i = 0; i < 10000; i++) {
+      ints.add(intLiteral(i));
+    }
+
+    // Shouldn't crash
+    analyze(AstDSL.in(field("integer_value"), ints));
   }
 
   @Test


### PR DESCRIPTION
### Description
Per #1469, very large lists of expressions in IN clauses cause `StackOverflowError`s. Avoiding all recursion here is nontrivial because `DSL.or` can only take two arguments. This PR instead rewrites the method to have the recursion amount grow logarithmically, by building the `or` tree as a balanced tree instead. This avoids hitting any recursion limits unless there's well over 2²⁵⁶ items in the list.

Implementing something like `DSL.any` is on the table for future work if we need to optimize further, but it's more complex than this fix and it's not clear that this is a hot path.

### Related Issues
Resolves #1469

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
 - [X] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
