### PR TITLE
[Fix CVE-2025-47273]Bump setuptools to 78.1.1

### DIFF
--- a/doctest/requirements.txt
+++ b/doctest/requirements.txt
@@ -1,2 +1,2 @@
 zc.customdoctests==1.0.1
-setuptools>=70.0.0
+setuptools>=78.1.1


### PR DESCRIPTION
### Description
[Fix CVE-2025-47273]Bump setuptools to 78.1.1

### Related Issues
* Resolve https://advisories.opensearch.org/advisory/CVE-2025-47273

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
