### PR TITLE
Fix alias type points to nested field

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3646.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3646.yml
@@ -1,0 +1,67 @@
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              log:
+                properties:
+                  url:
+                    properties:
+                      message:
+                        type: text
+                        fields:
+                          keyword:
+                            type: keyword
+                            ignore_above: 256
+                      time:
+                        type: long
+              message_alias:
+                type: alias
+                path: log.url.message
+              time_alias:
+                type: alias
+                path: log.url.time
+
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+            plugins.calcite.fallback.allowed : false
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+            plugins.calcite.fallback.allowed : true
+
+---
+"Path of alias type points to nested field":
+  - skip:
+      features:
+        - headers
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"log": {"url": {"message": "/e2e/h/zap", "time": 1} } }'
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | where message_alias = "/e2e/h/zap" | fields message_alias, time_alias'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "message_alias", "type": "string"}, {"name": "time_alias", "type": "bigint"}]}
+  - match: {"datarows": [["/e2e/h/zap", 1]]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1006,17 +1006,21 @@ public class PredicateAnalyzer {
     }
 
     boolean isTextType() {
-      return type != null && type instanceof OpenSearchTextType;
+      return type != null && type.getOriginalExprType() instanceof OpenSearchTextType;
     }
 
     String toKeywordSubField() {
+      ExprType type = this.type.getOriginalExprType();
       if (type instanceof OpenSearchTextType) {
         OpenSearchTextType textType = (OpenSearchTextType) type;
+        // For OpenSearch Alias type which maps to the field of text type,
+        // we have to use its original path
+        String path = this.type.getOriginalPath().orElse(this.name);
         // Find the first subfield with type keyword, return null if non-exist.
         return textType.getFields().entrySet().stream()
             .filter(e -> e.getValue().getMappingType() == MappingType.Keyword)
             .findFirst()
-            .map(e -> name + "." + e.getKey())
+            .map(e -> path + "." + e.getKey())
             .orElse(null);
       }
       return null;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteLogicalIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteLogicalIndexScan.java
@@ -121,12 +121,17 @@ public class CalciteLogicalIndexScan extends AbstractCalciteIndexScan {
     }
     RelDataType newSchema = builder.build();
     CalciteLogicalIndexScan newScan = this.copyWithNewSchema(newSchema);
+    Map<String, String> aliasMapping = this.osIndex.getAliasMapping();
+    // For alias types, we need to push down its original path instead of the alias name.
+    List<String> projectedFields =
+        newSchema.getFieldNames().stream()
+            .map(fieldName -> aliasMapping.getOrDefault(fieldName, fieldName))
+            .toList();
     newScan.pushDownContext.add(
         PushDownAction.of(
             PushDownType.PROJECT,
             newSchema.getFieldNames(),
-            requestBuilder ->
-                requestBuilder.pushDownProjectStream(newSchema.getFieldNames().stream())));
+            requestBuilder -> requestBuilder.pushDownProjectStream(projectedFields.stream())));
     return newScan;
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -109,7 +109,7 @@ public abstract class LuceneQuery {
     Expression expr = func.getArguments().get(1);
     ExprValue literalValue =
         expr instanceof LiteralExpression ? expr.valueOf() : cast((FunctionExpression) expr, ref);
-    return doBuild(ref.getAttr(), ref.type(), literalValue);
+    return doBuild(ref.getRawPath(), ref.type(), literalValue);
   }
 
   private ExprValue cast(FunctionExpression castFunction, ReferenceExpression ref) {


### PR DESCRIPTION
### Description
Fix the bugs related to alias type, which includes:
- Support alias type whose path points to a nested field, see details in issue: https://github.com/opensearch-project/sql/issues/3646

- For Calcite engine, make push down projects with the original path of alias type instead of alias name itself.
For the example in above issue, it will return hits with empty source content if pushing down using alias name,
```
POST /test/_search
{
   "query": {
     "term": {
        "log.url.message.keyword": {"value": "/e2e/h/zap"}
     }
   },
   "_source": ["message_alias"]
}

-----
{
  "took": 14,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1.0,
    "hits": [
      {
        "_index": "test",
        "_id": "o3DjC5cBzm8WW6d_tOff",
        "_score": 1.0,
        "_source": {}
      }
    ]
  }
}
```

- For both v2 and calcite engine, when pushing down filter with alias type field whose original fields is text type, we need to use its original field's keyword. Otherwise, it will return no hits.
Still using above index for example, it will return no hits when using DSL:
```
POST /test/_search
{
   "query": {
     "term": {
        "message_alias.keyword": {"value": "/e2e/h/zap"}
     }
   }
}

-----
{
  "took": 4,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 0,
      "relation": "eq"
    },
    "max_score": null,
    "hits": []
  }
}
```
But it could return the correct results if using its original fields:
```
POST /test/_search
{
   "query": {
     "term": {
        "message_alias.keyword": {"value": "/e2e/h/zap"}
     }
   }
}

-----
{
  "took": 1,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1.0,
    "hits": [
      {
        "_index": "test",
        "_id": "o3DjC5cBzm8WW6d_tOff",
        "_score": 1.0,
        "_source": {
          "log": {
            "url": {
              "message": "/e2e/h/zap",
              "time": 1
            }
          }
        }
      }
    ]
  }
}
```

However, for alias field points to non-text type field, it could work using alias field in the filter directly:
```
POST /test/_search

{
   "query": {
     "term": {
        "time_alias": {"value": 1}
     }
   }
}
----
{
  "took": 15,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1.0,
    "hits": [
      {
        "_index": "test",
        "_id": "o3DjC5cBzm8WW6d_tOff",
        "_score": 1.0,
        "_source": {
          "log": {
            "url": {
              "message": "/e2e/h/zap",
              "time": 1
            }
          }
        }
      }
    ]
  }
}
```

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3646

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
