### PR TITLE
Final version for main

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -46,23 +46,6 @@ jobs:
           echo "SONATYPE_USERNAME=$SONATYPE_USERNAME" >> $GITHUB_ENV
           echo "SONATYPE_PASSWORD=$SONATYPE_PASSWORD" >> $GITHUB_ENV
 
-      # Create the initial directory structure in repository
-      - name: Create grammar-poc directory structure in repository
-        run: |
-          # Create a placeholder file
-          TEMP_DIR=$(mktemp -d)
-          echo "Directory placeholder - $(date)" > "${TEMP_DIR}/.placeholder"
-          
-          # Upload the placeholder file to create the directory structure
-          echo "Creating initial directory structure..."
-          curl -X PUT -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" \
-            --upload-file "${TEMP_DIR}/.placeholder" \
-            "https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/language-grammar/.placeholder"
-          
-          # Clean up
-          rm -rf "${TEMP_DIR}"
-          echo "Directory structure created"
-
       # Extract version information - using a simpler method for grammar files
       - name: Set version
         id: set_version
@@ -270,8 +253,7 @@ jobs:
           ./gradlew :async-query-core:shadowJar
           
           # Define constants
-          ARTIFACT_ID="direct-query" 
-          JAR_NAME="async-query-core"
+          ARTIFACT_ID="async-query-core" 
           GROUP_PATH="org/opensearch"
           VERSION="${{ steps.extract_version.outputs.VERSION }}"
           
@@ -288,18 +270,18 @@ jobs:
           mkdir -p "${MAVEN_LOCAL_PATH}"
           
           # Copy the shadow JAR to the local Maven repository with proper naming
-          MAVEN_JAR_NAME="${JAR_NAME}-${VERSION}.jar"
+          MAVEN_JAR_NAME="${ARTIFACT_ID}-${VERSION}.jar"
           cp "${SHADOW_JAR}" "${MAVEN_LOCAL_PATH}/${MAVEN_JAR_NAME}"
           
           # Generate a POM file
-          cat > "${MAVEN_LOCAL_PATH}/${JAR_NAME}-${VERSION}.pom" << EOF
+          cat > "${MAVEN_LOCAL_PATH}/${ARTIFACT_ID}-${VERSION}.pom" << EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <project xmlns="http://maven.apache.org/POM/4.0.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.opensearch</groupId>
-              <artifactId>${JAR_NAME}</artifactId>
+              <artifactId>${ARTIFACT_ID}</artifactId>
               <version>${VERSION}</version>
           </project>
           EOF
@@ -332,22 +314,22 @@ jobs:
       - name: Update version metadata with commit ID
         run: |
           COMMIT_ID="${{ steps.set_commit.outputs.commit_id }}"
-          ARTIFACT_ID="direct-query"  
+          ARTIFACT_ID="async-query-core"  
           VERSION="${{ steps.extract_version.outputs.VERSION }}"
-          
+
           # Add commit ID to version-specific metadata file
           echo "Processing commit ID for version: ${VERSION}"
-          
+
           TEMP_DIR=$(mktemp -d)
           METADATA_FILE="${TEMP_DIR}/maven-metadata.xml"
-          
+
           # Download metadata from repository
           META_URL="${SNAPSHOT_REPO_URL}org/opensearch/${ARTIFACT_ID}/${VERSION}/maven-metadata.xml"
           echo "Downloading metadata from ${META_URL}"
-          
+
           # Try to download the metadata file
           curl -s -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" -o "${METADATA_FILE}" "${META_URL}"
-          
+
           # Debug: Check if file exists and has content
           if [ -f "${METADATA_FILE}" ]; then
             echo "Metadata file found. Size: $(stat -c%s ${METADATA_FILE}) bytes"
@@ -355,16 +337,16 @@ jobs:
             echo "Metadata file not found"
             exit 1
           fi
-          
+
           # If successful, modify and upload back
           if [ -s "${METADATA_FILE}" ]; then
             echo "Modifying metadata for ${VERSION}"
             cp "${METADATA_FILE}" "${METADATA_FILE}.bak"
-          
+
             # Debug: Show first few lines before modification
             echo "First 10 lines before modification:"
             head -n 10 "${METADATA_FILE}"
-          
+
             # Apply same awk command from working example
             awk -v commit="${COMMIT_ID}" '
               /<versioning>/ {
@@ -374,32 +356,32 @@ jobs:
               }
               {print}
             ' "${METADATA_FILE}.bak" > "${METADATA_FILE}"
-          
+
             # Debug: Show first few lines after modification
             echo "First 10 lines after modification:"
             head -n 10 "${METADATA_FILE}"
-          
+
             # Upload modified file back
             echo "Uploading modified metadata to ${META_URL}"
             curl -X PUT -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" --upload-file "${METADATA_FILE}" "${META_URL}"
-          
+
             # Update the SHA checksums
             cd "${TEMP_DIR}"
             sha256sum "maven-metadata.xml" | awk '{print $1}' > "maven-metadata.xml.sha256"
             sha512sum "maven-metadata.xml" | awk '{print $1}' > "maven-metadata.xml.sha512"
-          
+
             # Upload the checksums
             curl -X PUT -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" --upload-file "maven-metadata.xml.sha256" "${META_URL}.sha256"
             curl -X PUT -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" --upload-file "maven-metadata.xml.sha512" "${META_URL}.sha512"
             cd -
-          
+
             echo "Updated metadata and checksums for ${VERSION}"
           else
             echo "Failed to download metadata for ${VERSION} or file is empty"
             exit 1
           fi
-          
+
           # Clean up
           rm -rf "${TEMP_DIR}"
-          
+
           echo "Version metadata updated with commit ID"


### PR DESCRIPTION
This PR modifies GitHub Actions workflow that automates the publishing of two critical components to Maven snapshots:

Language Grammar Files - Packages and publishes ANTLR4 grammar files as a ZIP archive
Async Query Core - Builds and publishes a shadow JAR with all dependencies included

Key Features

Collects all .g4 files from language-grammar/src/main/antlr4
Packages files into a versioned ZIP archive (0.1.0-SNAPSHOT)
Creates proper Maven artifacts with POM and checksums
Makes grammar files available for dependent projects without requiring the full SQL plugin

Async Query Core Publishing

Builds a shadow JAR using Gradle for the async-query-core component
Extracts version information dynamically from build.gradle
Publishes JAR with proper Maven metadata

This workflow enables:

Better reuse of core language components across OpenSearch projects
Simplified dependency management for projects requiring grammar files
Improved traceability with last commit_id in metadata
Consistent versioning with the main OpenSearch releases