### PR TITLE
Fix error when pushing down script filter with struct field

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/ReferenceExpression.java
+++ b/core/src/main/java/org/opensearch/sql/expression/ReferenceExpression.java
@@ -25,7 +25,7 @@ public class ReferenceExpression implements Expression {
 
   @Getter private final List<String> paths;
 
-  private final ExprType type;
+  @Getter private final ExprType type;
 
   /**
    * Constructor of ReferenceExpression.

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3312.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3312.yml
@@ -1,0 +1,20 @@
+"Push down filter with struct field":
+  - skip:
+      features:
+        - headers
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"log": {"url": {"message": "/e2e/h/zap"} } }'
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | where isNotNull(log)'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "log", "type": "struct"}]}
+  - match: {"datarows": [[{"url": {"message": "/e2e/h/zap"}}]]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/core/ExpressionScript.java
@@ -78,7 +78,7 @@ public class ExpressionScript {
             });
   }
 
-  private Set<ReferenceExpression> extractFields(Expression expr) {
+  public static Set<ReferenceExpression> extractFields(Expression expr) {
     Set<ReferenceExpression> fields = new HashSet<>();
     expr.accept(
         new ExpressionNodeVisitor<Object, Set<ReferenceExpression>>() {


### PR DESCRIPTION
### Description
Fix error when pushing down script filter with struct field.  This bug only happens in v2 engine, since calcite engine doesn't support script pushing down currently.

It's caused by that the `FilterScript::getDoc` only provides the capability of looking up leaf node, thus it will throw exception `No field found for [xxx] in mapping` when using fields of struct type. We could mitigate this issue by preventing push down script filter with fields of struct type.

https://github.com/opensearch-project/OpenSearch/blob/9bca961b799625438d024491320323b310dc531f/server/src/main/java/org/opensearch/script/FilterScript.java#L73

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3312
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
