### PR TITLE
Support ResourceMonitor with Calcite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/exception/NonFallbackCalciteException.java
+++ b/core/src/main/java/org/opensearch/sql/exception/NonFallbackCalciteException.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.exception;
+
+/** Non-fallback to v2 exception for Calcite. */
+public class NonFallbackCalciteException extends QueryEngineException {
+
+  public NonFallbackCalciteException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -41,6 +41,7 @@ import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.common.setting.Settings.Key;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.exception.CalciteUnsupportedException;
+import org.opensearch.sql.exception.NonFallbackCalciteException;
 import org.opensearch.sql.planner.PlanContext;
 import org.opensearch.sql.planner.Planner;
 import org.opensearch.sql.planner.logical.LogicalPaginate;
@@ -107,7 +108,7 @@ public class QueryService {
                 return null;
               });
     } catch (Throwable t) {
-      if (isCalciteFallbackAllowed()) {
+      if (isCalciteFallbackAllowed() && !(t instanceof NonFallbackCalciteException)) {
         log.warn("Fallback to V2 query engine since got exception", t);
         executeWithLegacy(plan, queryType, listener, Optional.of(t));
       } else {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteResourceMonitorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteResourceMonitorIT.java
@@ -5,10 +5,8 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import org.junit.Ignore;
 import org.opensearch.sql.ppl.ResourceMonitorIT;
 
-@Ignore("https://github.com/opensearch-project/sql/issues/3454")
 public class CalciteResourceMonitorIT extends ResourceMonitorIT {
   @Override
   public void init() throws Exception {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/OpenSearchResourceMonitor.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/OpenSearchResourceMonitor.java
@@ -48,6 +48,11 @@ public class OpenSearchResourceMonitor extends ResourceMonitor {
   public boolean isHealthy() {
     try {
       ByteSizeValue limit = settings.getSettingValue(Settings.Key.QUERY_MEMORY_LIMIT);
+      if (limit == null) {
+        // undefined, be always healthy, this is useful in Calcite standalone ITs
+        // since AlwaysHealthyMonitor is not work within Calcite tests.
+        return true;
+      }
       Supplier<Boolean> booleanSupplier =
           Retry.decorateSupplier(retry, () -> memoryMonitor.isMemoryHealthy(limit.getBytes()));
       return booleanSupplier.get();

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -25,6 +25,8 @@ import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
+import org.opensearch.sql.opensearch.monitor.OpenSearchMemoryHealthy;
+import org.opensearch.sql.opensearch.monitor.OpenSearchResourceMonitor;
 import org.opensearch.sql.opensearch.planner.physical.ADOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLCommonsOperator;
 import org.opensearch.sql.opensearch.planner.physical.MLOperator;
@@ -259,6 +261,10 @@ public class OpenSearchIndex extends AbstractOpenSearchTable {
 
   public OpenSearchRequestBuilder createRequestBuilder() {
     return new OpenSearchRequestBuilder(createExprValueFactory(), settings);
+  }
+
+  public OpenSearchResourceMonitor createOpenSearchResourceMonitor() {
+    return new OpenSearchResourceMonitor(getSettings(), new OpenSearchMemoryHealthy());
   }
 
   public OpenSearchRequest buildRequest(OpenSearchRequestBuilder requestBuilder) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteEnumerableIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteEnumerableIndexScan.java
@@ -101,7 +101,8 @@ public class CalciteEnumerableIndexScan extends AbstractCalciteIndexScan impleme
             osIndex.getClient(),
             getFieldPath(),
             requestBuilder.getMaxResponseSize(),
-            osIndex.buildRequest(requestBuilder));
+            osIndex.buildRequest(requestBuilder),
+            osIndex.createOpenSearchResourceMonitor());
       }
     };
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAppendcolTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAppendcolTest.java
@@ -145,9 +145,9 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "count()=5; DEPTNO=20; avg(SAL)=2175.00\n"
-            + "count()=3; DEPTNO=10; avg(SAL)=2916.66\n"
-            + "count()=6; DEPTNO=30; avg(SAL)=1566.66\n";
+            + "count()=5; DEPTNO=20; avg(SAL)=2175.\n"
+            + "count()=3; DEPTNO=10; avg(SAL)=2916.666666\n"
+            + "count()=6; DEPTNO=30; avg(SAL)=1566.666666\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
@@ -185,9 +185,9 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
-            + "count()=5; DEPTNO=20; avg(SAL)=2175.00\n"
-            + "count()=3; DEPTNO=10; avg(SAL)=2916.66\n"
-            + "count()=6; DEPTNO=30; avg(SAL)=1566.66\n";
+            + "count()=5; DEPTNO=20; avg(SAL)=2175.\n"
+            + "count()=3; DEPTNO=10; avg(SAL)=2916.666666\n"
+            + "count()=6; DEPTNO=30; avg(SAL)=1566.666666\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =


### PR DESCRIPTION
### Description
- Support ResourceMonitor with Calcite
  - Currently, the `CalciteEnumerableIndexScan` is the only physical operator we implemented. The rests are all default implementations of Calcite. Resource monitor can only be added in scan operator. But for memory checker, it‘s fine.
- Fix the failed UTs related to #3673 

### Related Issues
Resolves #3454 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
