### PR TITLE
[Backport 2.19-dev] Support match_only_text field type 

### DIFF
--- a/docs/user/ppl/general/datatypes.rst
+++ b/docs/user/ppl/general/datatypes.rst
@@ -88,6 +88,8 @@ The table below list the mapping between OpenSearch Data Type, PPL Data Type and
 +-----------------+---------------+-----------+
 | text            | string        | VARCHAR   |
 +-----------------+---------------+-----------+
+| match_only_text | string        | VARCHAR   |
++-----------------+---------------+-----------+
 | date            | timestamp     | TIMESTAMP |
 +-----------------+---------------+-----------+
 | ip              | ip            | VARCHAR   |

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/api/ppl.explain.json
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/api/ppl.explain.json
@@ -1,0 +1,22 @@
+{
+  "ppl.explain": {
+    "documentation": {
+      "url": "https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/index.rst",
+      "description": "OpenSearch PPL Reference Manual"
+    },
+    "stability" : "stable",
+    "url": {
+      "paths": [
+        {
+          "path" : "/_plugins/_ppl/_explain",
+          "methods" : ["POST"]
+        }
+      ]
+    },
+    "params": {},
+    "body": {
+      "description": "PPL Explain Query",
+      "required":true
+    }
+  }
+}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3655.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3655.yml
@@ -1,0 +1,106 @@
+setup:
+  - skip:
+      features:
+        - headers
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_replicas: 0
+            number_of_shards: 1
+          mappings:
+            properties:
+              id:
+                type: integer
+              body:
+                type: match_only_text
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"id": 1, "body": "This is a match_only_text field 1"}'
+          - '{"index": {}}'
+          - '{"id": 2, "body": "This is a match_only_text field 2"}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+            plugins.calcite.fallback.allowed : true
+
+---
+"Support match_only_text field type with Calcite enabled":
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+            plugins.calcite.fallback.allowed : false
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | sort id | fields body | head 1'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "body", "type": "string"}]}
+  - match: {"datarows": [["This is a match_only_text field 1"]]}
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=test | where like(body, '%field 2%') | fields body"
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "body", "type": "string"}]}
+  - match: {"datarows": [["This is a match_only_text field 2"]]}
+
+---
+"Support match_only_text field type with Calcite disabled":
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | sort id | fields body | head 1'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "body", "type": "string"}]}
+  - match: {"datarows": [["This is a match_only_text field 1"]]}
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=test | where match_phrase(body, 'field 2') | fields body"
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "body", "type": "string"}]}
+  - match: {"datarows": [["This is a match_only_text field 2"]]}
+
+---
+"Support match_only_text field type function push down with Calcite disabled":
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl.explain:
+        body:
+          query: "source=test | where match_phrase(body, 'field 2') | fields body"
+  - match: { root.children.0.description.request: "OpenSearchQueryRequest(indexName=test, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"match_phrase\":{\"body\":{\"query\":\"field 2\",\"slop\":0,\"zero_terms_query\":\"NONE\",\"boost\":1.0}}},\"_source\":{\"includes\":[\"body\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false, pitId=null, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"}
+
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl.explain:
+        body:
+          query: "source=test | where like(body, '%field 2%') | fields body"
+  - match: { root.children.0.description.request: "OpenSearchQueryRequest(indexName=test, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"wildcard\":{\"body\":{\"wildcard\":\"*field 2*\",\"case_insensitive\":true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"body\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false, pitId=null, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
@@ -25,6 +25,7 @@ public class OpenSearchDataType implements ExprType, Serializable {
   public enum MappingType {
     Invalid(null, ExprCoreType.UNKNOWN),
     Text("text", ExprCoreType.UNKNOWN),
+    MatchOnlyText("match_only_text", ExprCoreType.UNKNOWN),
     Keyword("keyword", ExprCoreType.STRING),
     Ip("ip", ExprCoreType.UNKNOWN),
     GeoPoint("geo_point", ExprCoreType.UNKNOWN),
@@ -151,6 +152,7 @@ public class OpenSearchDataType implements ExprType, Serializable {
         OpenSearchDataType objectDataType = res.cloneEmpty();
         objectDataType.properties = properties;
         return objectDataType;
+      case MatchOnlyText:
       case Text:
         // TODO update these 2 below #1038 https://github.com/opensearch-project/sql/issues/1038
         Map<String, OpenSearchDataType> fields =

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -64,7 +64,7 @@ import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchBinaryType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDateType;
-import org.opensearch.sql.opensearch.data.type.OpenSearchIpType;
+import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.data.utils.Content;
 import org.opensearch.sql.opensearch.data.utils.ObjectContent;
 import org.opensearch.sql.opensearch.data.utils.OpenSearchJsonContent;
@@ -120,9 +120,7 @@ public class OpenSearchExprValueFactory {
           .put(
               OpenSearchDataType.of(OpenSearchDataType.MappingType.Double),
               (c, dt) -> new ExprDoubleValue(c.doubleValue()))
-          .put(
-              OpenSearchDataType.of(OpenSearchDataType.MappingType.Text),
-              (c, dt) -> new OpenSearchExprTextValue(c.stringValue()))
+          .put(OpenSearchTextType.of(), (c, dt) -> new OpenSearchExprTextValue(c.stringValue()))
           .put(
               OpenSearchDataType.of(OpenSearchDataType.MappingType.Keyword),
               (c, dt) -> new ExprStringValue(c.stringValue()))


### PR DESCRIPTION
* Support match_only_text field type
#3663


(cherry picked from commit 85bad198227264084298597025f70da002e41359)
