### PR TITLE
Fix field not found issue in join output when column names are ambiguous

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -6,6 +6,8 @@
 package org.opensearch.sql.calcite;
 
 import static org.apache.calcite.sql.SqlKind.AS;
+import static org.opensearch.sql.ast.tree.Join.JoinType.ANTI;
+import static org.opensearch.sql.ast.tree.Join.JoinType.SEMI;
 import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_FIRST;
 import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_LAST;
 import static org.opensearch.sql.ast.tree.Sort.SortOption.DEFAULT_DESC;
@@ -531,8 +533,42 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
         node.getJoinCondition()
             .map(c -> rexVisitor.analyzeJoinCondition(c, context))
             .orElse(context.relBuilder.literal(true));
-    context.relBuilder.join(
-        JoinAndLookupUtils.translateJoinType(node.getJoinType()), joinCondition);
+    if (node.getJoinType() == SEMI || node.getJoinType() == ANTI) {
+      // semi and anti join only return left table outputs
+      context.relBuilder.join(
+          JoinAndLookupUtils.translateJoinType(node.getJoinType()), joinCondition);
+    } else {
+      // Join condition could contain duplicated column name, Calcite will rename the duplicated
+      // column name with numeric suffix, e.g. ON t1.id = t2.id, the output contains `id` and `id0`
+      // when a new project add to stack. To avoid `id0`, we will rename the `id0` to `alias.id`
+      // or `tableIdentifier.id`:
+      List<String> leftColumns = context.relBuilder.peek(1).getRowType().getFieldNames();
+      List<String> rightColumns = context.relBuilder.peek().getRowType().getFieldNames();
+      List<String> rightTableName =
+          PlanUtils.findTable(context.relBuilder.peek()).getQualifiedName();
+      // Using `table.column` instead of `catalog.database.table.column` as column prefix because
+      // the schema for OpenSearch index is always `OpenSearch`. But if we reuse this logic in other
+      // query engines, the column can only be searched in current schema namespace. For example,
+      // If the plan convert to Spark plan, and there are two table1: database1.table1 and
+      // database2.table1. The query with column `table1.id` can only be resolved in the namespace
+      // of "database1". User should run `using database1` before the query which access `table1.id`
+      String rightTableQualifiedName = rightTableName.getLast();
+      // new columns with alias or table;
+      List<String> rightColumnsWithAliasIfConflict =
+          rightColumns.stream()
+              .map(
+                  col ->
+                      leftColumns.contains(col)
+                          ? node.getRightAlias()
+                              .map(a -> a + "." + col)
+                              .orElse(rightTableQualifiedName + "." + col)
+                          : col)
+              .toList();
+      context.relBuilder.join(
+          JoinAndLookupUtils.translateJoinType(node.getJoinType()), joinCondition);
+      JoinAndLookupUtils.renameToExpectedFields(
+          rightColumnsWithAliasIfConflict, leftColumns.size(), context);
+    }
     return context.relBuilder.peek();
   }
 

--- a/docs/user/ppl/cmd/join.rst
+++ b/docs/user/ppl/cmd/join.rst
@@ -13,7 +13,7 @@ Description
 ============
 | (Experimental)
 | (From 3.0.0)
-| Using ``join`` command to combines two datasets together. The left side could be an index or results from a piped commands, the right side could be either an index or a subquery.
+| Using ``join`` command to combines two datasets together. The left side could be an index or results from a piped commands, the right side could be either an index or a subsearch.
 
 Version
 =======
@@ -21,13 +21,13 @@ Version
 
 Syntax
 ======
-[joinType] JOIN [leftAlias] [rightAlias] ON <joinCriteria> <right-dataset>
+[joinType] join [leftAlias] [rightAlias] on <joinCriteria> <right-dataset>
 
 * joinType: optional. The type of join to perform. The default is ``INNER`` if not specified. Other option is ``LEFT [OUTER]``, ``RIGHT [OUTER]``, ``FULL [OUTER]``, ``CROSS``, ``[LEFT] SEMI``, ``[LEFT] ANTI``.
-* leftAlias: optional. The subquery alias to use with the left join side, to avoid ambiguous naming. Fixed pattern: ``left = <leftAlias>``
-* rightAlias: optional. The subquery alias to use with the right join side, to avoid ambiguous naming. Fixed pattern: ``right = <rightAlias>``
+* leftAlias: optional. The subsearch alias to use with the left join side, to avoid ambiguous naming. Fixed pattern: ``left = <leftAlias>``
+* rightAlias: optional. The subsearch alias to use with the right join side, to avoid ambiguous naming. Fixed pattern: ``right = <rightAlias>``
 * joinCriteria: mandatory. It could be any comparison expression.
-* right-dataset: mandatory. Right dataset could be either an index or a subquery with/without alias.
+* right-dataset: mandatory. Right dataset could be either an index or a subsearch with/without alias.
 
 Configuration
 =============

--- a/docs/user/ppl/cmd/join.rst
+++ b/docs/user/ppl/cmd/join.rst
@@ -10,7 +10,7 @@ join
 
 
 Description
-============
+===========
 | (Experimental)
 | (From 3.0.0)
 | Using ``join`` command to combines two datasets together. The left side could be an index or results from a piped commands, the right side could be either an index or a subsearch.
@@ -80,117 +80,61 @@ Example 1: Two indices join
 
 PPL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_plugins/_ppl -d '{
-	  "query" : """
-	  source = state_country
-	  | inner join left=a right=b ON a.name = b.name occupation
-	  | stats avg(salary) by span(age, 10) as age_span, b.country
-	  """
-	}'
-
-Result set::
-
-    {
-      "schema": [
-        {
-          "name": "avg(salary)",
-          "type": "double"
-        },
-        {
-          "name": "age_span",
-          "type": "integer"
-        },
-        {
-          "name": "b.country",
-          "type": "string"
-        }
-      ],
-      "datarows": [
-        [
-          120000.0,
-          40,
-          "USA"
-        ],
-        [
-          105000.0,
-          20,
-          "Canada"
-        ],
-        [
-          0.0,
-          40,
-          "Canada"
-        ],
-        [
-          70000.0,
-          30,
-          "USA"
-        ],
-        [
-          100000.0,
-          70,
-          "England"
-        ]
-      ],
-      "total": 5,
-      "size": 5
-    }
+    PPL> source = state_country | inner join left=a right=b ON a.name = b.name occupation | stats avg(salary) by span(age, 10) as age_span, b.country;
+    fetched rows / total rows = 5/5
+    +-------------+----------+-----------+
+    | avg(salary) | age_span | b.country |
+    |-------------+----------+-----------|
+    | 120000.0    | 40       | USA       |
+    | 105000.0    | 20       | Canada    |
+    |  0.0        | 40       | Canada    |
+    | 70000.0     | 30       | USA       |
+    | 100000.0    | 70       | England   |
+    +-------------+----------+-----------+
 
 Example 2: Join with subsearch
 ==============================
 
 PPL query::
 
-	>> curl -H 'Content-Type: application/json' -X POST localhost:9200/_plugins/_ppl -d '{
-	  "query" : """
-          source = state_country as a
-          | where country = 'USA' OR country = 'England'
-          | left join ON a.name = b.name [
-              source = occupation
-              | where salary > 0
-              | fields name, country, salary
-              | sort salary
-              | head 3
-            ] as b
-          | stats avg(salary) by span(age, 10) as age_span, b.country
-	  """
-	}'
+    PPL> source = state_country as a
+         | where country = 'USA' OR country = 'England'
+         | left join ON a.name = b.name [
+             source = occupation
+             | where salary > 0
+             | fields name, country, salary
+             | sort salary
+             | head 3
+           ] as b
+         | stats avg(salary) by span(age, 10) as age_span, b.country;
+    fetched rows / total rows = 5/5
+    +-------------+----------+-----------+
+    | avg(salary) | age_span | b.country |
+    |-------------+----------+-----------|
+    | null        | 40       | null      |
+    | 70000.0     | 30       | USA       |
+    | 100000.0    | 70       | England   |
+    +-------------+----------+-----------+
 
-Result set::
+Limitation
+==========
+If fields in the left outputs and right outputs have the same name. Typically, in the join criteria
+``ON t1.id = t2.id``, the names ``id`` in output are ambiguous. To avoid ambiguous, the ambiguous
+fields in output rename to ``<alias>.id``, or else ``<tableName>.id`` if no alias existing.
 
-    {
-      "schema": [
-        {
-          "name": "avg(salary)",
-          "type": "double"
-        },
-        {
-          "name": "age_span",
-          "type": "integer"
-        },
-        {
-          "name": "b.country",
-          "type": "string"
-        }
-      ],
-      "datarows": [
-        [
-          null,
-          40,
-          null
-        ],
-        [
-          70000.0,
-          30,
-          "USA"
-        ],
-        [
-          100000.0,
-          70,
-          "England"
-        ]
-      ],
-      "total": 3,
-      "size": 3
-    }
+Assume table1 and table2 only contain field ``id``, following PPL queries and their outputs are:
 
+.. list-table::
+   :widths: 75 25
+   :header-rows: 1
+
+   * - Query
+     - Output
+   * - source=table1 | join left=t1 right=t2 on t1.id=t2.id table2 | eval a = 1
+     - t1.id, t2.id, a
+   * - source=table1 | join on table1.id=table2.id table2 | eval a = 1
+     - table1.id, table2.id, a
+   * - source=table1 | join on table1.id=t2.id table2 as t2 | eval a = 1
+     - table1.id, t2.id, a
+   * - source=table1 | join right=tt on table1.id=t2.id [ source=table2 as t2 | eval b = id ] | eval a = 1
+     - table1.id, tt.id, tt.b, a

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLJoinIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLJoinIT.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.calcite.standalone;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_HOBBIES;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_OCCUPATION;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_STATE_COUNTRY;
+import static org.opensearch.sql.util.MatcherUtils.assertJsonEquals;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -68,7 +69,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("state", "string"),
         schema("country", "string"),
         schema("occupation", "string"),
-        schema("country0", "string"),
+        schema("b.country", "string"),
         schema("salary", "integer"));
     verifyDataRows(
         actual,
@@ -97,7 +98,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("state", "string"),
         schema("country", "string"),
         schema("occupation", "string"),
-        schema("country0", "string"),
+        schema("b.country", "string"),
         schema("salary", "integer"));
     verifyDataRows(
         actual,
@@ -124,7 +125,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("state", "string"),
         schema("country", "string"),
         schema("occupation", "string"),
-        schema("country0", "string"),
+        schema("b.country", "string"),
         schema("salary", "integer"));
     verifyDataRows(
         actual,
@@ -205,7 +206,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("state", "string"),
         schema("country", "string"),
         schema("occupation", "string"),
-        schema("country0", "string"),
+        schema("b.country", "string"),
         schema("salary", "integer"));
     verifyDataRowsInOrder(
         actual,
@@ -232,7 +233,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("state", "string"),
         schema("country", "string"),
         schema("occupation", "string"),
-        schema("country0", "string"),
+        schema("b.country", "string"),
         schema("salary", "integer"));
     verifyDataRowsInOrder(
         actual,
@@ -318,7 +319,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
         schema("state", "string"),
         schema("country", "string"),
         schema("occupation", "string"),
-        schema("country0", "string"),
+        schema("b.country", "string"),
         schema("salary", "integer"));
     verifyDataRows(
         actual,
@@ -456,7 +457,10 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
                 TEST_INDEX_OCCUPATION,
                 TEST_INDEX_HOBBIES));
     verifySchema(
-        actual, schema("name", "string"), schema("name0", "string"), schema("name1", "string"));
+        actual,
+        schema("name", "string"),
+        schema(TEST_INDEX_OCCUPATION + ".name", "string"),
+        schema(TEST_INDEX_HOBBIES + ".name", "string"));
     verifyDataRows(
         actual,
         rows("David", "David", "David"),
@@ -476,7 +480,7 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
                     + " ON t1.name = t3.name %s | fields t1.name, t2.name, t3.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION, TEST_INDEX_HOBBIES));
     verifySchema(
-        actual, schema("name", "string"), schema("name0", "string"), schema("name1", "string"));
+        actual, schema("name", "string"), schema("t2.name", "string"), schema("t3.name", "string"));
     verifyDataRows(
         actual,
         rows("David", "David", "David"),
@@ -502,9 +506,9 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
     verifySchema(
         actual,
         schema("name", "string"),
-        schema("name0", "string"),
-        schema("name1", "string"),
-        schema("name2", "string"));
+        schema("t2.name", "string"),
+        schema("t3.name", "string"),
+        schema("t4.name", "string"));
     verifyDataRows(
         actual,
         rows("David", "David", "David", "David"),
@@ -530,9 +534,9 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
     verifySchema(
         actual,
         schema("name", "string"),
-        schema("name0", "string"),
-        schema("name1", "string"),
-        schema("name2", "string"));
+        schema("t2.name", "string"),
+        schema("t3.name", "string"),
+        schema("t4.name", "string"));
     verifyDataRows(
         actual,
         rows("David", "David", "David", "David"),
@@ -545,149 +549,161 @@ public class CalcitePPLJoinIT extends CalcitePPLIntegTestCase {
 
   @Test
   public void testCheckAccessTheReferenceByAliases() {
-    String res1 =
-        execute(
+    JSONObject res1 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 ON t1.name = t2.name %s as t2 | fields t1.name,"
                     + " t2.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res2 =
-        execute(
+    JSONObject res2 =
+        executeQuery(
             String.format(
                 "source = %s as t1 | JOIN ON t1.name = t2.name %s as t2 | fields t1.name, t2.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    assertEquals(res1, res2);
+    assertJsonEquals(
+        res1.getJSONArray("datarows").toString(), res2.getJSONArray("datarows").toString());
 
-    String res3 =
-        execute(
+    JSONObject res3 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name %s as tt | fields"
                     + " tt.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res4 =
-        execute(
+    JSONObject res4 =
+        executeQuery(
             String.format(
                 "source = %s as tt | JOIN left = t1 right = t2 ON t1.name = t2.name %s | fields"
-                    + " tt.name",
+                    + " t1.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res5 =
-        execute(
+    JSONObject res5 =
+        executeQuery(
             String.format(
                 "source = %s as tt | JOIN left = t1 ON t1.name = t2.name %s as t2 | fields"
-                    + " tt.name",
+                    + " t1.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    assertEquals(res3, res4);
-    assertEquals(res4, res5);
+    assertJsonEquals(
+        res3.getJSONArray("datarows").toString(), res4.getJSONArray("datarows").toString());
+    assertJsonEquals(
+        res4.getJSONArray("datarows").toString(), res5.getJSONArray("datarows").toString());
   }
 
   @Test
   public void testCheckAccessTheReferenceBySubqueryAliases() {
-    String res1 =
-        execute(
+    JSONObject res1 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 ON t1.name = t2.name [ source = %s ] as t2 | fields"
                     + " t1.name, t2.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res2 =
-        execute(
+    JSONObject res2 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 ON t1.name = t2.name [ source = %s as t2 ] | fields"
                     + " t1.name, t2.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    assertEquals(res1, res2);
+    assertJsonEquals(
+        res1.getJSONArray("datarows").toString(), res2.getJSONArray("datarows").toString());
 
-    String res3 =
-        execute(
+    JSONObject res3 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = %s as"
                     + " tt ] | fields tt.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res4 =
-        execute(
+    JSONObject res4 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 ON t1.name = t2.name [ source = %s as tt ] as t2"
                     + " | fields tt.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res5 =
-        execute(
+    JSONObject res5 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = %s ]"
                     + " as tt | fields tt.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    assertEquals(res3, res4);
-    assertEquals(res4, res5);
+    assertJsonEquals(
+        res3.getJSONArray("datarows").toString(), res4.getJSONArray("datarows").toString());
+    assertJsonEquals(
+        res4.getJSONArray("datarows").toString(), res5.getJSONArray("datarows").toString());
   }
 
   @Test
   public void testCheckAccessTheReferenceByOverrideAliases() {
-    String res1 =
-        execute(
+    JSONObject res1 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name %s as tt | fields"
                     + " tt.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res2 =
-        execute(
+    JSONObject res2 =
+        executeQuery(
             String.format(
                 "source = %s as tt | JOIN left = t1 right = t2 ON t1.name = t2.name %s | fields"
-                    + " tt.name",
+                    + " t1.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res3 =
-        execute(
+    JSONObject res3 =
+        executeQuery(
             String.format(
                 "source = %s as tt | JOIN left = t1 ON t1.name = t2.name %s as t2 | fields"
-                    + " tt.name",
+                    + " t1.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    assertEquals(res1, res2);
-    assertEquals(res1, res3);
+    assertJsonEquals(
+        res1.getJSONArray("datarows").toString(), res2.getJSONArray("datarows").toString());
+    assertJsonEquals(
+        res1.getJSONArray("datarows").toString(), res3.getJSONArray("datarows").toString());
   }
 
   @Test
   public void testCheckAccessTheReferenceByOverrideSubqueryAliases() {
-    String res1 =
-        execute(
+    JSONObject res1 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = %s as tt ]"
                     + " | fields tt.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res2 =
-        execute(
+    JSONObject res2 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = %s as tt ]"
                     + " as t2 | fields tt.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res3 =
-        execute(
+    JSONObject res3 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = %s ] as tt"
                     + " | fields tt.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    assertEquals(res1, res2);
-    assertEquals(res1, res3);
+    assertJsonEquals(
+        res1.getJSONArray("datarows").toString(), res2.getJSONArray("datarows").toString());
+    assertJsonEquals(
+        res1.getJSONArray("datarows").toString(), res3.getJSONArray("datarows").toString());
   }
 
   @Test
   public void testCheckAccessTheReferenceByOverrideSubqueryAliases2() {
-    String res1 =
-        execute(
+    JSONObject res1 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = %s as tt ]"
                     + " | fields t2.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res2 =
-        execute(
+    JSONObject res2 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = %s as tt ]"
                     + " as t2 | fields t2.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    String res3 =
-        execute(
+    JSONObject res3 =
+        executeQuery(
             String.format(
                 "source = %s | JOIN left = t1 right = t2 ON t1.name = t2.name [ source = %s ] as tt"
                     + " | fields t2.name",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    assertEquals(res1, res2);
-    assertEquals(res1, res3);
+    assertJsonEquals(
+        res1.getJSONArray("datarows").toString(), res2.getJSONArray("datarows").toString());
+    assertJsonEquals(
+        res1.getJSONArray("datarows").toString(), res3.getJSONArray("datarows").toString());
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/tpch/CalcitePPLTpchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/tpch/CalcitePPLTpchIT.java
@@ -21,7 +21,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONObject;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.sql.calcite.standalone.CalcitePPLIntegTestCase;
@@ -211,7 +210,6 @@ public class CalcitePPLTpchIT extends CalcitePPLIntegTestCase {
     verifyDataRows(actual, rows(77949.9186));
   }
 
-  @Ignore("https://github.com/opensearch-project/sql/issues/3617")
   public void testQ7() {
     String ppl = loadFromFile("tpch/queries/q7.ppl");
     JSONObject actual = executeQuery(ppl);
@@ -224,7 +222,6 @@ public class CalcitePPLTpchIT extends CalcitePPLIntegTestCase {
     verifyNumOfRows(actual, 0);
   }
 
-  @Ignore("https://github.com/opensearch-project/sql/issues/3617")
   public void testQ8() {
     String ppl = loadFromFile("tpch/queries/q8.ppl");
     JSONObject actual = executeQuery(ppl);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLBasicTest.java
@@ -412,17 +412,19 @@ public class CalcitePPLBasicTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP as e | join on e.DEPTNO = d.DEPTNO [ source=DEPT | head 10 ] as d";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalSort(fetch=[10])\n"
-            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalSort(fetch=[10])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `t`.`DEPTNO` `d.DEPTNO`, `t`.`DNAME`,"
+            + " `t`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "INNER JOIN (SELECT `DEPTNO`, `DNAME`, `LOC`\n"
             + "FROM `scott`.`DEPT`\n"

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLInSubqueryTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLInSubqueryTest.java
@@ -215,16 +215,17 @@ public class CalcitePPLInSubqueryTest extends CalcitePPLAbstractTest {
         """;
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
+        "LogicalProject(EMPNO=[$0], ENAME=[$1])\n"
             + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
-            + "    LogicalJoin(condition=[AND(=($7, $8), IN($1, {\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "      LogicalJoin(condition=[AND(=($7, $8), IN($1, {\n"
             + "LogicalProject(ENAME=[$0])\n"
             + "  LogicalFilter(condition=[>($2, 1000)])\n"
             + "    LogicalTableScan(table=[[scott, BONUS]])\n"
             + "}))], joinType=[inner])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n"
-            + "      LogicalTableScan(table=[[scott, DEPT]])\n";
+            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+            + "        LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
 
     String expectedSparkSql =

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
@@ -20,16 +20,18 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP | join on EMP.DEPTNO = DEPT.DEPTNO DEPT";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
@@ -37,21 +39,29 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
 
   @Test
   public void testJoinConditionWithAlias() {
-    String ppl = "source=EMP as e | join on e.DEPTNO = d.DEPTNO DEPT as d";
+    String ppl =
+        "source=EMP as e | join on e.DEPTNO = d.DEPTNO DEPT as d | where LOC = 'CHICAGO' | fields"
+            + " d.DEPTNO";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(d.DEPTNO=[$8])\n"
+            + "  LogicalFilter(condition=[=($10, 'CHICAGO':VARCHAR)])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "      LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+            + "        LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
-    verifyResultCount(root, 14);
+    verifyResultCount(root, 6);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `d.DEPTNO`\n"
+            + "FROM (SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`,"
+            + " `EMP`.`HIREDATE`, `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO`"
+            + " `d.DEPTNO`, `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
-            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`) `t`\n"
+            + "WHERE `t`.`LOC` = 'CHICAGO'";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -60,16 +70,18 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP | join on ENAME = DNAME DEPT";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($1, $9)], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($1, $9)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 0);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "INNER JOIN `scott`.`DEPT` ON `EMP`.`ENAME` = `DEPT`.`DNAME`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
@@ -80,16 +92,18 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP | join left = l right = r on l.DEPTNO = r.DEPTNO DEPT";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `r.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
@@ -102,15 +116,19 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + " < 3000 DEPT";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[AND(=($7, $8), >($7, 10), <($5, 3000))], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[AND(=($7, $8), >($7, 10), <($5, 3000))],"
+            + " joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 9);
 
     String expectedSparkSql =
-        "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `r.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO` AND `EMP`.`DEPTNO` >"
             + " 10 AND `EMP`.`SAL` < 3000";
@@ -122,16 +140,18 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP as e | left join on e.DEPTNO = d.DEPTNO DEPT as d";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `d.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "LEFT JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
@@ -142,16 +162,18 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP as e | right join on e.DEPTNO = d.DEPTNO DEPT as d";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($7, $8)], joinType=[right])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[right])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 15);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `d.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "RIGHT JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
@@ -206,16 +228,18 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP as e | full outer join on e.DEPTNO = d.DEPTNO DEPT as d";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($7, $8)], joinType=[full])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[full])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 15);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `d.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "FULL JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
@@ -226,15 +250,20 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP as e | cross join DEPT as d";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[true], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[true], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 56);
 
     String expectedSparkSql =
-        "" + "SELECT *\n" + "FROM `scott`.`EMP`\n" + "CROSS JOIN `scott`.`DEPT`";
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `d.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "CROSS JOIN `scott`.`DEPT`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -243,16 +272,18 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP as e | cross join on e.DEPTNO = d.DEPTNO DEPT as d";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `d.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
@@ -263,16 +294,18 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP as e | join on e.DEPTNO > d.DEPTNO DEPT as d";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[>($7, $8)], joinType=[inner])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n"
-            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[>($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 17);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `d.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
             + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` > `DEPT`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
@@ -285,21 +318,24 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + " right = r ON l.SAL = r.HISAL SALGRADE";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
-            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "    LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalTableScan(table=[[scott, DEPT]])\n"
+        "LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n"
             + "  LogicalTableScan(table=[[scott, SALGRADE]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT *\n"
+            + "FROM (SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`,"
+            + " `EMP`.`HIREDATE`, `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO`"
+            + " `r.DEPTNO`, `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
-            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`\n"
-            + "LEFT JOIN `scott`.`SALGRADE` ON `EMP`.`SAL` = `SALGRADE`.`HISAL`";
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`) `t`\n"
+            + "LEFT JOIN `scott`.`SALGRADE` ON `t`.`SAL` = `SALGRADE`.`HISAL`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -310,21 +346,24 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + " t3.HISAL SALGRADE as t3";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
-            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "    LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalTableScan(table=[[scott, DEPT]])\n"
+        "LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], t2.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n"
             + "  LogicalTableScan(table=[[scott, SALGRADE]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT *\n"
+            + "FROM (SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`,"
+            + " `EMP`.`HIREDATE`, `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO`"
+            + " `t2.DEPTNO`, `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
-            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`\n"
-            + "LEFT JOIN `scott`.`SALGRADE` ON `EMP`.`SAL` = `SALGRADE`.`HISAL`";
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`) `t`\n"
+            + "LEFT JOIN `scott`.`SALGRADE` ON `t`.`SAL` = `SALGRADE`.`HISAL`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -335,21 +374,24 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + " SALGRADE";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
-            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "    LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalTableScan(table=[[scott, DEPT]])\n"
+        "LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n"
             + "  LogicalTableScan(table=[[scott, SALGRADE]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT *\n"
+            + "FROM (SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`,"
+            + " `EMP`.`HIREDATE`, `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO`"
+            + " `DEPT.DEPTNO`, `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
-            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`\n"
-            + "LEFT JOIN `scott`.`SALGRADE` ON `EMP`.`SAL` = `SALGRADE`.`HISAL`";
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`) `t`\n"
+            + "LEFT JOIN `scott`.`SALGRADE` ON `t`.`SAL` = `SALGRADE`.`HISAL`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -360,21 +402,24 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + " t3 ON t1.SAL = t3.HISAL SALGRADE";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
-            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "    LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalTableScan(table=[[scott, DEPT]])\n"
+        "LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], t2.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalTableScan(table=[[scott, DEPT]])\n"
             + "  LogicalTableScan(table=[[scott, SALGRADE]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT *\n"
+            + "FROM (SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`,"
+            + " `EMP`.`HIREDATE`, `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO`"
+            + " `t2.DEPTNO`, `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
-            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`\n"
-            + "LEFT JOIN `scott`.`SALGRADE` ON `EMP`.`SAL` = `SALGRADE`.`HISAL`";
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`) `t`\n"
+            + "LEFT JOIN `scott`.`SALGRADE` ON `t`.`SAL` = `SALGRADE`.`HISAL`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -386,25 +431,28 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + " fields t1.ENAME, t2.DNAME, t3.GRADE, t4.EMPNO";
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalProject(ENAME=[$1], DNAME=[$9], GRADE=[$11], EMPNO=[$14])\n"
+        "LogicalProject(ENAME=[$1], DNAME=[$9], GRADE=[$11], t4.EMPNO=[$14])\n"
             + "  LogicalJoin(condition=[=($7, $21)], joinType=[inner])\n"
             + "    LogicalJoin(condition=[=($5, $13)], joinType=[left])\n"
-            + "      LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n"
-            + "        LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], t2.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "        LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "          LogicalTableScan(table=[[scott, EMP]])\n"
+            + "          LogicalTableScan(table=[[scott, DEPT]])\n"
             + "      LogicalTableScan(table=[[scott, SALGRADE]])\n"
             + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 70);
 
     String expectedSparkSql =
-        ""
-            + "SELECT `EMP`.`ENAME`, `DEPT`.`DNAME`, `SALGRADE`.`GRADE`, `EMP0`.`EMPNO`\n"
+        "SELECT `t`.`ENAME`, `t`.`DNAME`, `SALGRADE`.`GRADE`, `EMP0`.`EMPNO` `t4.EMPNO`\n"
+            + "FROM (SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`,"
+            + " `EMP`.`HIREDATE`, `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO`"
+            + " `t2.DEPTNO`, `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
             + "FROM `scott`.`EMP`\n"
-            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`\n"
-            + "LEFT JOIN `scott`.`SALGRADE` ON `EMP`.`SAL` = `SALGRADE`.`HISAL`\n"
-            + "INNER JOIN `scott`.`EMP` `EMP0` ON `EMP`.`DEPTNO` = `EMP0`.`DEPTNO`";
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`) `t`\n"
+            + "LEFT JOIN `scott`.`SALGRADE` ON `t`.`SAL` = `SALGRADE`.`HISAL`\n"
+            + "INNER JOIN `scott`.`EMP` `EMP0` ON `t`.`DEPTNO` = `EMP0`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -479,16 +527,20 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
         """;
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[true], joinType=[inner])\n"
-            + "  LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
-            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "      LogicalSort(fetch=[10])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n"
-            + "      LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO':VARCHAR))])\n"
-            + "        LogicalTableScan(table=[[scott, DEPT]])\n"
-            + "    LogicalFilter(condition=[=($1, 'SALESMAN':VARCHAR)])\n"
-            + "      LogicalTableScan(table=[[scott, BONUS]])\n"
+        "LogicalJoin(condition=[true], joinType=[inner])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10],"
+            + " r.ENAME=[$11], r.JOB=[$12], r.SAL=[$13], r.COMM=[$14])\n"
+            + "    LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
+            + "      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "        LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "          LogicalSort(fetch=[10])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n"
+            + "          LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO':VARCHAR))])\n"
+            + "            LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "      LogicalFilter(condition=[=($1, 'SALESMAN':VARCHAR)])\n"
+            + "        LogicalTableScan(table=[[scott, BONUS]])\n"
             + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
             + "    LogicalFilter(condition=[<=($1, 1500)])\n"
             + "      LogicalTableScan(table=[[scott, SALGRADE]])\n";
@@ -496,21 +548,28 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     verifyResultCount(root, 15);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT *\n"
+            + "FROM (SELECT `t1`.`EMPNO`, `t1`.`ENAME`, `t1`.`JOB`, `t1`.`MGR`, `t1`.`HIREDATE`,"
+            + " `t1`.`SAL`, `t1`.`COMM`, `t1`.`DEPTNO`, `t1`.`r.DEPTNO`, `t1`.`DNAME`, `t1`.`LOC`,"
+            + " `t2`.`ENAME` `r.ENAME`, `t2`.`JOB` `r.JOB`, `t2`.`SAL` `r.SAL`, `t2`.`COMM`"
+            + " `r.COMM`\n"
+            + "FROM (SELECT `t`.`EMPNO`, `t`.`ENAME`, `t`.`JOB`, `t`.`MGR`, `t`.`HIREDATE`,"
+            + " `t`.`SAL`, `t`.`COMM`, `t`.`DEPTNO`, `t0`.`DEPTNO` `r.DEPTNO`, `t0`.`DNAME`,"
+            + " `t0`.`LOC`\n"
             + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
             + "LIMIT 10) `t`\n"
             + "INNER JOIN (SELECT *\n"
             + "FROM `scott`.`DEPT`\n"
-            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`\n"
+            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`)"
+            + " `t1`\n"
             + "LEFT JOIN (SELECT *\n"
             + "FROM `scott`.`BONUS`\n"
-            + "WHERE `JOB` = 'SALESMAN') `t1` ON `t`.`JOB` = `t1`.`JOB`\n"
+            + "WHERE `JOB` = 'SALESMAN') `t2` ON `t1`.`JOB` = `t2`.`JOB`) `t3`\n"
             + "CROSS JOIN (SELECT `GRADE`, `LOSAL`, `HISAL`\n"
             + "FROM `scott`.`SALGRADE`\n"
             + "WHERE `LOSAL` <= 1500\n"
-            + "ORDER BY `GRADE` DESC NULLS FIRST) `t3`";
+            + "ORDER BY `GRADE` DESC NULLS FIRST) `t5`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -540,16 +599,21 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
 
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[true], joinType=[inner])\n"
-            + "  LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
-            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "      LogicalSort(fetch=[10])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n"
-            + "      LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO':VARCHAR))])\n"
-            + "        LogicalTableScan(table=[[scott, DEPT]])\n"
-            + "    LogicalFilter(condition=[=($1, 'SALESMAN':VARCHAR)])\n"
-            + "      LogicalTableScan(table=[[scott, BONUS]])\n"
+        "LogicalJoin(condition=[true], joinType=[inner])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10],"
+            + " BONUS.ENAME=[$11], BONUS.JOB=[$12], BONUS.SAL=[$13],"
+            + " BONUS.COMM=[$14])\n"
+            + "    LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
+            + "      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "        LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "          LogicalSort(fetch=[10])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n"
+            + "          LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO':VARCHAR))])\n"
+            + "            LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "      LogicalFilter(condition=[=($1, 'SALESMAN':VARCHAR)])\n"
+            + "        LogicalTableScan(table=[[scott, BONUS]])\n"
             + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
             + "    LogicalFilter(condition=[<=($1, 1500)])\n"
             + "      LogicalTableScan(table=[[scott, SALGRADE]])\n";
@@ -558,21 +622,28 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     verifyResultCount(root, 15);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT *\n"
+            + "FROM (SELECT `t1`.`EMPNO`, `t1`.`ENAME`, `t1`.`JOB`, `t1`.`MGR`, `t1`.`HIREDATE`,"
+            + " `t1`.`SAL`, `t1`.`COMM`, `t1`.`DEPTNO`, `t1`.`DEPT.DEPTNO`, `t1`.`DNAME`,"
+            + " `t1`.`LOC`, `t2`.`ENAME` `BONUS.ENAME`, `t2`.`JOB` `BONUS.JOB`,"
+            + " `t2`.`SAL` `BONUS.SAL`, `t2`.`COMM` `BONUS.COMM`\n"
+            + "FROM (SELECT `t`.`EMPNO`, `t`.`ENAME`, `t`.`JOB`, `t`.`MGR`, `t`.`HIREDATE`,"
+            + " `t`.`SAL`, `t`.`COMM`, `t`.`DEPTNO`, `t0`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `t0`.`DNAME`, `t0`.`LOC`\n"
             + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
             + "LIMIT 10) `t`\n"
             + "INNER JOIN (SELECT *\n"
             + "FROM `scott`.`DEPT`\n"
-            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`\n"
+            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`)"
+            + " `t1`\n"
             + "LEFT JOIN (SELECT *\n"
             + "FROM `scott`.`BONUS`\n"
-            + "WHERE `JOB` = 'SALESMAN') `t1` ON `t`.`JOB` = `t1`.`JOB`\n"
+            + "WHERE `JOB` = 'SALESMAN') `t2` ON `t1`.`JOB` = `t2`.`JOB`) `t3`\n"
             + "CROSS JOIN (SELECT `GRADE`, `LOSAL`, `HISAL`\n"
             + "FROM `scott`.`SALGRADE`\n"
             + "WHERE `LOSAL` <= 1500\n"
-            + "ORDER BY `GRADE` DESC NULLS FIRST) `t3`";
+            + "ORDER BY `GRADE` DESC NULLS FIRST) `t5`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -601,16 +672,20 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
         """;
     RelNode root = getRelNode(ppl);
     String expectedLogical =
-        ""
-            + "LogicalJoin(condition=[true], joinType=[inner])\n"
-            + "  LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
-            + "    LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
-            + "      LogicalSort(fetch=[10])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n"
-            + "      LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO':VARCHAR))])\n"
-            + "        LogicalTableScan(table=[[scott, DEPT]])\n"
-            + "    LogicalFilter(condition=[=($1, 'SALESMAN':VARCHAR)])\n"
-            + "      LogicalTableScan(table=[[scott, BONUS]])\n"
+        "LogicalJoin(condition=[true], joinType=[inner])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10],"
+            + " r.ENAME=[$11], r.JOB=[$12], r.SAL=[$13], r.COMM=[$14])\n"
+            + "    LogicalJoin(condition=[=($2, $12)], joinType=[left])\n"
+            + "      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "        LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "          LogicalSort(fetch=[10])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n"
+            + "          LogicalFilter(condition=[AND(>($0, 10), =($2, 'CHICAGO':VARCHAR))])\n"
+            + "            LogicalTableScan(table=[[scott, DEPT]])\n"
+            + "      LogicalFilter(condition=[=($1, 'SALESMAN':VARCHAR)])\n"
+            + "        LogicalTableScan(table=[[scott, BONUS]])\n"
             + "  LogicalSort(sort0=[$0], dir0=[DESC])\n"
             + "    LogicalFilter(condition=[<=($1, 1500)])\n"
             + "      LogicalTableScan(table=[[scott, SALGRADE]])\n";
@@ -619,21 +694,28 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     verifyResultCount(root, 15);
 
     String expectedSparkSql =
-        ""
-            + "SELECT *\n"
+        "SELECT *\n"
+            + "FROM (SELECT `t1`.`EMPNO`, `t1`.`ENAME`, `t1`.`JOB`, `t1`.`MGR`, `t1`.`HIREDATE`,"
+            + " `t1`.`SAL`, `t1`.`COMM`, `t1`.`DEPTNO`, `t1`.`r.DEPTNO`, `t1`.`DNAME`, `t1`.`LOC`,"
+            + " `t2`.`ENAME` `r.ENAME`, `t2`.`JOB` `r.JOB`, `t2`.`SAL` `r.SAL`, `t2`.`COMM`"
+            + " `r.COMM`\n"
+            + "FROM (SELECT `t`.`EMPNO`, `t`.`ENAME`, `t`.`JOB`, `t`.`MGR`, `t`.`HIREDATE`,"
+            + " `t`.`SAL`, `t`.`COMM`, `t`.`DEPTNO`, `t0`.`DEPTNO` `r.DEPTNO`, `t0`.`DNAME`,"
+            + " `t0`.`LOC`\n"
             + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`\n"
             + "FROM `scott`.`EMP`\n"
             + "LIMIT 10) `t`\n"
             + "INNER JOIN (SELECT *\n"
             + "FROM `scott`.`DEPT`\n"
-            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`\n"
+            + "WHERE `DEPTNO` > 10 AND `LOC` = 'CHICAGO') `t0` ON `t`.`DEPTNO` = `t0`.`DEPTNO`)"
+            + " `t1`\n"
             + "LEFT JOIN (SELECT *\n"
             + "FROM `scott`.`BONUS`\n"
-            + "WHERE `JOB` = 'SALESMAN') `t1` ON `t`.`JOB` = `t1`.`JOB`\n"
+            + "WHERE `JOB` = 'SALESMAN') `t2` ON `t1`.`JOB` = `t2`.`JOB`) `t3`\n"
             + "CROSS JOIN (SELECT `GRADE`, `LOSAL`, `HISAL`\n"
             + "FROM `scott`.`SALGRADE`\n"
             + "WHERE `LOSAL` <= 1500\n"
-            + "ORDER BY `GRADE` DESC NULLS FIRST) `t3`";
+            + "ORDER BY `GRADE` DESC NULLS FIRST) `t5`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -302,14 +302,15 @@ public class PPLQueryDataAnonymizerTest {
         "source=t | left join right = r on id = uid s as r | fields + id",
         anonymize("source=t | left join right = r on id = uid s | fields id"));
     assertEquals(
-        "source=t as t1 | inner join on id = uid s as t2 | fields + t1.id",
+        "source=t as t1 | inner join left = t1 right = t2 on id = uid s as t2 | fields + t1.id",
         anonymize("source=t as t1 | inner join on id = uid s as t2 | fields t1.id"));
     assertEquals(
-        "source=t as t1 | right join on t1.id = t2.id s as t2 | fields + t1.id",
+        "source=t as t1 | right join left = t1 right = t2 on t1.id = t2.id s as t2 | fields +"
+            + " t1.id",
         anonymize("source=t as t1 | right join on t1.id = t2.id s as t2 | fields t1.id"));
     assertEquals(
-        "source=t as t1 | right join right = t2 on t1.id = t2.id [ source=s | fields + id ] as t2 |"
-            + " fields + t1.id",
+        "source=t as t1 | right join left = t1 right = t2 on t1.id = t2.id [ source=s | fields + id"
+            + " ] as t2 | fields + t1.id",
         anonymize(
             "source=t as t1 | right join on t1.id = t2.id [ source=s | fields id] as t2 | fields"
                 + " t1.id"));


### PR DESCRIPTION
### Description
```
source=table1 | join left=t1 right=t2 on t1.id=t2.id table2 | eval a = 1 | fields t1.id, t2.id
```
Fail with {alias=t2, fieldName=id} field not found

#### Explanation
Join outputs could contain duplicated column name, typically the join criteria `ON t1.id = t2.id`. The `id` in output of join operator is ambiguous. Calcite will rename the ambiguous column name with numeric suffix, the output generates `id` and `id0` when a new project add to stack.

#### Solution
To avoid `id0`, this PR renames the `id0` to `<alias>.id`, or `<tableName>.id` if no alias existing.

#### Example
table1:
| id   |
| --- |
| 1 |
| 2 |

table2
| id   |
| --- |
| 1 |
| 3 |
```
source=table1 | join left=t1 right=t2 on t1.id=t2.id table2 | eval a = 1
```
outputs `t1.id`, `t2.id` and `a`

```
source=table1 | join on table1.id=table2.id table2 | eval a = 1
```
outputs `table1.id`, `table2.id` and `a`

```
source=table1 | join on table1.id=t2.id table2 as t2 | eval a = 1
```
outputs `table1.id`, `t2.id` and `a`

```
source=table1 | join right=tt on table1.id=t2.id [ source=table2 as t2 | eval b = id ] | eval a = 1
```
outputs `table1.id`, `tt.id`, `tt.b` and `a`

### Related Issues
Resolves #3717 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
