### PR TITLE
Publish internal modules separately for downstream reuse

### DIFF
--- a/.github/workflows/maven-publish-modules.yml
+++ b/.github/workflows/maven-publish-modules.yml
@@ -1,0 +1,44 @@
+name: Publish unified query modules to maven
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - 1.*
+      - 2.*
+      - feature/unified-ppl # Temporarily added for testing
+
+env:
+  SNAPSHOT_REPO_URL: https://aws.oss.sonatype.org/content/repositories/snapshots/
+
+jobs:
+  publish-unified-query-modules:
+    strategy:
+      fail-fast: false
+    if: github.repository == 'opensearch-project/sql'
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 21
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+
+      - name: get credentials
+        run: |
+          # Get credentials for publishing
+          .github/get-sonatype-credentials.sh
+
+      - name: publish unified query modules to maven
+        run: |
+          ./gradlew publishUnifiedQueryPublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,52 @@ subprojects {
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }
         maven { url 'https://jitpack.io' }
     }
+
+    // Publish internal modules as Maven artifacts for external use, such as by opensearch-spark and opensearch-cli.
+    def publishedModules = ['sql', 'ppl', 'core', 'opensearch', 'common', 'protocol']
+    if (publishedModules.contains(name)) {
+        apply plugin: 'java-library'
+        apply plugin: 'maven-publish'
+
+        def fullArtifactId = "unified-query-${project.name}"
+        publishing {
+            publications {
+                mavenJava(MavenPublication) {
+                    from components.java
+                    groupId = "org.opensearch.sql"
+                    artifactId = fullArtifactId
+
+                    pom {
+                        name = fullArtifactId
+                        description = "OpenSearch unified query ${project.name} module"
+                        licenses {
+                            license {
+                                name = 'The Apache License, Version 2.0'
+                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            }
+                        }
+                        developers {
+                            developer {
+                                name = 'OpenSearch'
+                                url = 'https://github.com/opensearch-project/sql'
+                            }
+                        }
+                    }
+                }
+            }
+
+            repositories {
+                maven {
+                    name = "Snapshots"
+                    url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+                    credentials {
+                        username = "$System.env.SONATYPE_USERNAME"
+                        password = "$System.env.SONATYPE_PASSWORD"
+                    }
+                }
+            }
+        }
+    }
 }
 
 // TODO: fix compiler warnings

--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ subprojects {
         def fullArtifactId = "unified-query-${project.name}"
         publishing {
             publications {
-                mavenJava(MavenPublication) {
+                unifiedQuery(MavenPublication) {
                     from components.java
                     groupId = "org.opensearch.sql"
                     artifactId = fullArtifactId


### PR DESCRIPTION
### Description

This PR implements **Option A: Modular Publishing** from the Granularity section of the design. It introduces the ability to publish internal modules (e.g., `core`, `ppl`, `opensearch`) as separate Maven artifacts. This enables downstream consumers such as Spark to depend only on the components they require.

Example after running the local publish command:

```
$ ./gradlew publishUnifiedQueryPublicationToMavenLocal

$ pwd
~/.m2/repository/org/opensearch
$ tree .
.
├── plugin
│   └── opensearch-sql-plugin
│       └── 3.1.0.0-SNAPSHOT
└── sql
    ├── unified-query-common
    │   └── 3.1.0.0-SNAPSHOT
    ├── unified-query-core
    │   └── 3.1.0.0-SNAPSHOT
    ├── unified-query-opensearch
    │   └── 3.1.0.0-SNAPSHOT
    ├── unified-query-ppl
    │   └── 3.1.0.0-SNAPSHOT
    ├── unified-query-protocol
    │   └── 3.1.0.0-SNAPSHOT
    └── unified-query-sql
        └── 3.1.0.0-SNAPSHOT
```

### Related Issues

Resolves part 1 in https://github.com/opensearch-project/sql/issues/3734.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
