### PR TITLE
Add unified query API module for external integration

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'java-library'
+    id 'jacoco'
+    id 'com.diffplug.spotless' version '6.22.0'
+}
+
+dependencies {
+    api project(':ppl')
+
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
+    testImplementation group: 'org.apache.calcite', name: 'calcite-testkit', version: '1.38.0'
+    // testImplementation(testFixtures(project(":core")))
+}
+
+spotless {
+    java {
+        target fileTree('.') {
+            include '**/*.java'
+            exclude '**/build/**', '**/build-*/**', 'src/main/gen/**'
+        }
+        importOrder()
+//        licenseHeader("/*\n" +
+//                " * Copyright OpenSearch Contributors\n" +
+//                " * SPDX-License-Identifier: Apache-2.0\n" +
+//                " */\n\n")
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+        googleJavaFormat('1.17.0').reflowLongStrings().groupArtifact('com.google.googlejavaformat:google-java-format')
+    }
+}
+
+test {
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+    }
+}
+
+jacocoTestReport {
+    reports {
+        html.required = true
+        xml.required = true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: ['**/antlr/parser/**'])
+        }))
+    }
+}
+test.finalizedBy(project.tasks.jacocoTestReport)
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.9
+            }
+
+        }
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: ['**/antlr/parser/**'])
+        }))
+    }
+}
+check.dependsOn jacocoTestCoverageVerification

--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Programs;
+import org.opensearch.sql.ast.statement.Query;
+import org.opensearch.sql.ast.statement.Statement;
+import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
+import org.opensearch.sql.common.antlr.Parser;
+import org.opensearch.sql.executor.OpenSearchTypeSystem;
+import org.opensearch.sql.executor.QueryType;
+import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
+import org.opensearch.sql.ppl.parser.AstBuilder;
+import org.opensearch.sql.ppl.parser.AstStatementBuilder;
+
+/**
+ * {@code UnifiedQueryPlanner} provides a high-level API for parsing and analyzing queries using the
+ * Calcite-based query engine. It serves as the primary integration point for external consumers
+ * such as Spark or command-line tools, abstracting away Calcite internals.
+ */
+public class UnifiedQueryPlanner {
+  /** The type of query language being used (e.g., PPL). */
+  private final QueryType queryType;
+
+  /** The parser instance responsible for converting query text into a parse tree. */
+  private final Parser parser;
+
+  /** Calcite framework configuration used during logical plan construction. */
+  private final FrameworkConfig config;
+
+  /** AST-to-RelNode visitor that builds logical plans from the parsed AST. */
+  private final CalciteRelNodeVisitor relNodeVisitor = new CalciteRelNodeVisitor();
+
+  /**
+   * Constructs a UnifiedQueryPlanner for a given query type and schema root.
+   *
+   * @param queryType the query language type (e.g., PPL)
+   * @param rootSchema the root Calcite schema containing all catalogs and tables
+   */
+  public UnifiedQueryPlanner(QueryType queryType, SchemaPlus rootSchema) {
+    this.queryType = queryType;
+    this.parser = buildQueryParser(queryType);
+    this.config = buildCalciteConfig(rootSchema);
+  }
+
+  /**
+   * Parses and analyzes a query string into a Calcite logical plan (RelNode). TODO: Generate
+   * optimal physical plan to fully unify query execution and leverage Calcite's optimzer.
+   *
+   * @param query the raw query string in PPL or other supported syntax
+   * @return a logical plan representing the query
+   */
+  public RelNode plan(String query) {
+    // Parse query and build AST
+    ParseTree cst = parser.parse(query);
+    AstStatementBuilder astStmtBuilder =
+        new AstStatementBuilder(
+            new AstBuilder(query), AstStatementBuilder.StatementBuilderContext.builder().build());
+    Statement statement = cst.accept(astStmtBuilder);
+    UnresolvedPlan ast = ((Query) statement).getPlan();
+
+    // Analyze the ASt and convert to Calcite logical plan
+    CalcitePlanContext calcitePlanContext = CalcitePlanContext.create(config, 100, queryType);
+    RelNode logical = relNodeVisitor.analyze(ast, calcitePlanContext);
+
+    // Add redundant sort if necessary to preserve collation.
+    RelNode calcitePlan = logical;
+    RelCollation collation = logical.getTraitSet().getCollation();
+    if (!(logical instanceof Sort) && collation != RelCollations.EMPTY) {
+      calcitePlan = LogicalSort.create(logical, collation, null, null);
+    }
+    return calcitePlan;
+  }
+
+  private Parser buildQueryParser(QueryType queryType) {
+    if (queryType == QueryType.PPL) {
+      return new PPLSyntaxParser();
+    }
+    throw new UnsupportedOperationException("Unsupported query type: " + queryType);
+  }
+
+  private FrameworkConfig buildCalciteConfig(SchemaPlus defaultSchema) {
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT) // TODO check
+        .defaultSchema(defaultSchema)
+        .traitDefs((List<RelTraitDef>) null)
+        .programs(Programs.calc(DefaultRelMetadataProvider.INSTANCE))
+        .typeSystem(OpenSearchTypeSystem.INSTANCE)
+        .build();
+  }
+
+  /** Builder for {@link UnifiedQueryPlanner}, supporting declarative fluent API. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for {@link UnifiedQueryPlanner}, supporting both declarative and dynamic schema
+   * registration for use in query planning.
+   */
+  public static class Builder {
+    private QueryType queryType;
+    private SchemaPlus rootSchema;
+
+    public Builder() {
+      this.rootSchema = CalciteSchema.createRootSchema(true, false).plus();
+    }
+
+    /**
+     * Sets the query language frontend to be used by the planner.
+     *
+     * @param queryType the {@link QueryType}, such as PPL
+     * @return this builder instance
+     */
+    public Builder language(QueryType queryType) {
+      this.queryType = queryType;
+      return this;
+    }
+
+    /**
+     * Registers a catalog and its databases.
+     *
+     * @param catalogName the name of the catalog
+     * @param databases a map of database name → schema
+     * @return this builder instance
+     */
+    public Builder catalog(String catalogName, Map<String, Schema> databases) {
+      SchemaPlus catalog = rootSchema.add(catalogName, new AbstractSchema());
+      for (Map.Entry<String, Schema> e : databases.entrySet()) {
+        catalog.add(e.getKey(), e.getValue());
+      }
+      return this;
+    }
+
+    /**
+     * Builds a {@link UnifiedQueryPlanner} with the configuration.
+     *
+     * @return a new instance of {@link UnifiedQueryPlanner}
+     */
+    public UnifiedQueryPlanner build() {
+      Objects.requireNonNull(queryType, "Must specify language before build");
+      return new UnifiedQueryPlanner(queryType, rootSchema);
+    }
+  }
+}

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Test;
+import org.opensearch.sql.executor.QueryType;
+
+public class UnifiedQueryPlannerTest {
+
+  /** Test database with a test table with id and name columns */
+  private AbstractSchema testDatabase =
+      new AbstractSchema() {
+        @Override
+        protected Map<String, Table> getTableMap() {
+          return Map.of(
+              "test",
+              new AbstractTable() {
+                @Override
+                public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+                  final RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+                  final RelDataType stringType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+                  return typeFactory.createStructType(
+                      List.of(intType, stringType), List.of("id", "name"));
+                }
+              });
+        }
+      };
+
+  @Test
+  public void testSimpleQuery() {
+    UnifiedQueryPlanner planner =
+        UnifiedQueryPlanner.builder()
+            .language(QueryType.PPL)
+            .catalog("opensearch", Map.of("default", testDatabase))
+            .build();
+
+    RelNode plan = planner.plan("source = opensearch.default.test | eval f = abs(123)");
+    assertNotNull("Plan should not be null", plan);
+  }
+
+  @Test
+  public void testJoinQuery() {
+    UnifiedQueryPlanner planner =
+        UnifiedQueryPlanner.builder()
+            .language(QueryType.PPL)
+            .catalog("opensearch", Map.of("default", testDatabase))
+            .catalog("spark_catalog", Map.of("default", testDatabase))
+            .build();
+
+    RelNode plan =
+        planner.plan(
+            "source = opensearch.default.test |"
+                + "lookup spark_catalog.default.test id |"
+                + "eval f = abs(123)");
+    assertNotNull("Plan should not be null", plan);
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ subprojects {
     }
 
     // Publish internal modules as Maven artifacts for external use, such as by opensearch-spark and opensearch-cli.
-    def publishedModules = ['sql', 'ppl', 'core', 'opensearch', 'common', 'protocol']
+    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol']
     if (publishedModules.contains(name)) {
         apply plugin: 'java-library'
         apply plugin: 'maven-publish'

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ include 'datasources'
 include 'async-query-core'
 include 'async-query'
 include 'language-grammar'
+include 'api'
 
 // exclude integ-test/doctest in case of offline build since they need downloads
 if (!gradle.startParameter.offline) {


### PR DESCRIPTION
### Description

This PR introduces a new api module containing the `UnifiedQueryPlanner` class, which provides a high-level interface for parsing and planning PPL queries. This module is designed to support external consumers such as Spark and CLI without exposing Calcite or OpenSearch internals. Unit tests are included to document usage and verify correctness.

TODO: update issue with long term. add README. address query limit.

### Related Issues

Resolves https://github.com/opensearch-project/sql/issues/3734

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
