### PR TITLE
[Backport 2.x] Resolve commons beanutils to 1.11.0 (#3782)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ allprojects {
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0"
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0"
         resolutionStrategy.force "net.bytebuddy:byte-buddy:1.14.9"
+        resolutionStrategy.force 'org.apache.commons:commons-beanutils:2.0.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ allprojects {
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0"
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0"
         resolutionStrategy.force "net.bytebuddy:byte-buddy:1.14.9"
-        resolutionStrategy.force 'org.apache.commons:commons-beanutils:2.0.0'
+        resolutionStrategy.force 'commons-beanutils:commons-beanutils:1.11.0'
     }
 }
 


### PR DESCRIPTION
https://github.com/opensearch-project/sql/pull/3782 not works for 2.x. Upgrade `commons-beanutils` to `1.11.0 `
