### PR TITLE
Remove unneeded dependency on commons-validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,6 @@ allprojects {
         resolutionStrategy.force 'org.apache.commons:commons-text:1.11.0'
         resolutionStrategy.force 'commons-io:commons-io:2.15.0'
         resolutionStrategy.force 'org.yaml:snakeyaml:2.2'
-        resolutionStrategy.force 'org.apache.commons:commons-beanutils:2.0.0'
     }
 }
 

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -27,7 +27,6 @@ dependencies {
         exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
     }
     implementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
-    implementation group: 'commons-validator', name: 'commons-validator', version: '1.7'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')


### PR DESCRIPTION
### Description

Well, that was fun.

After #3782 didn't actually update the beanutils dep, I did a bunch of tracing how we depend on it, such that the resolution isn't actually changing anything. It turns out we import this dependency via `apache.commons.validator`, which [has an open issue to update beanutils as of a couple weeks ago](https://issues.apache.org/jira/browse/VALIDATOR-500). So I went to figure out what we depend on the validator for.

Answer: we don't. The last ref was removed in #2130 ([diff](https://github.com/opensearch-project/sql/pull/2130/files#diff-b9c313c1ef71065a4f4a166763b18b244b1c6d5908cf4ed3512337ce6a4ca98eL11)).

So removing it will remove pointless CVE chasing, and make our bundle smaller.

### Related Issues
Same CVE as the last one.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
