### PR TITLE
Ignore useless timestamp cast

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -69,7 +69,6 @@ import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.expression.subquery.ScalarSubquery;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.type.ExprSqlType;
-import org.opensearch.sql.calcite.type.ExprTimeStampType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
 import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.common.utils.StringUtils;
@@ -232,9 +231,10 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   private RexNode transferCompareForDateRelated(
       RexNode candidate, CalcitePlanContext context, boolean whetherCompareByTime) {
     if (whetherCompareByTime) {
-      if (!(candidate.getType() instanceof ExprSqlType && ((ExprSqlType) candidate.getType()).getUdt() == EXPR_TIMESTAMP)) {
+      if (!(candidate.getType() instanceof ExprSqlType
+          && ((ExprSqlType) candidate.getType()).getUdt() == EXPR_TIMESTAMP)) {
         RexNode transferredStringNode =
-                context.rexBuilder.makeCall(PPLBuiltinOperators.TIMESTAMP, candidate);
+            context.rexBuilder.makeCall(PPLBuiltinOperators.TIMESTAMP, candidate);
         return transferredStringNode;
       }
     }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -10,6 +10,7 @@ import static org.apache.calcite.sql.SqlKind.AS;
 import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 import static org.opensearch.sql.ast.expression.SpanUnit.NONE;
 import static org.opensearch.sql.ast.expression.SpanUnit.UNKNOWN;
+import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT.EXPR_TIMESTAMP;
 import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.TYPE_FACTORY;
 
 import java.math.BigDecimal;
@@ -68,6 +69,7 @@ import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.expression.subquery.ScalarSubquery;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.type.ExprSqlType;
+import org.opensearch.sql.calcite.type.ExprTimeStampType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
 import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.common.utils.StringUtils;
@@ -230,12 +232,13 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   private RexNode transferCompareForDateRelated(
       RexNode candidate, CalcitePlanContext context, boolean whetherCompareByTime) {
     if (whetherCompareByTime) {
-      RexNode transferredStringNode =
-          context.rexBuilder.makeCall(PPLBuiltinOperators.TIMESTAMP, candidate);
-      return transferredStringNode;
-    } else {
-      return candidate;
+      if (!(candidate.getType() instanceof ExprSqlType && ((ExprSqlType) candidate.getType()).getUdt() == EXPR_TIMESTAMP)) {
+        RexNode transferredStringNode =
+                context.rexBuilder.makeCall(PPLBuiltinOperators.TIMESTAMP, candidate);
+        return transferredStringNode;
+      }
     }
+    return candidate;
   }
 
   @Override


### PR DESCRIPTION
### Description
The PR skip the redundant timestamp function in comparison so it can be pushed down.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
