### PR TITLE
Remove aviator dep

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -64,7 +64,6 @@ dependencies {
     api project(':common')
     implementation "com.github.seancfoley:ipaddress:5.4.2"
     implementation "com.jayway.jsonpath:json-path:2.9.0"
-    implementation "com.googlecode.aviator:aviator:5.4.3"
 
     annotationProcessor('org.immutables:value:2.8.8')
     compileOnly('org.immutables:value-annotations:2.8.8')


### PR DESCRIPTION
### Description
Removes another unused dep which is causing CVE tooling to complain. Since the CVE is rated 9.8, policy won't allow an exemption here.

We should really do a full unused dependency audit at some point, seems like we have a lot of these.

### Related Issues
3.1 release blocker.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
