### PR TITLE
Decimal literal should convert to double in pushdown

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
@@ -36,3 +36,13 @@ teardown:
   - match: {"total": 1}
   - match: {"schema": [{"name": "avg(balance)", "type": "double"}]}
   - match: {"datarows": [[1000.0]]}
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | where balance in (999.0, 1000.0) | stats avg(balance)'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "avg(balance)", "type": "double"}]}
+  - match: {"datarows": [[1000.0]]}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
@@ -1,0 +1,38 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+            plugins.calcite.fallback.allowed : false
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+            plugins.calcite.fallback.allowed : true
+
+---
+"Decimal literal should convert to double in pushdown":
+  - skip:
+      features:
+        - headers
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"balance": 1000.0}'
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | where balance >= 1000.0 | stats avg(balance)'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "avg(balance)", "type": "double"}]}
+  - match: {"datarows": [[1000.0]]}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
@@ -26,7 +26,7 @@ teardown:
         refresh: true
         body:
           - '{"index": {}}'
-          - '{"balance": 1000.0}'
+          - '{"balance": 1000}'
   - do:
       headers:
         Content-Type: 'application/json'

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -40,7 +40,6 @@ import static org.opensearch.index.query.QueryBuilders.termsQuery;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Range;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1057,7 +1057,7 @@ public class PredicateAnalyzer {
         return sargValue();
       } else if (isIntegral()) {
         return longValue();
-      } else if (isFloatingPoint()) {
+      } else if (isFractional()) {
         return doubleValue();
       } else if (isBoolean()) {
         return booleanValue();
@@ -1072,8 +1072,8 @@ public class PredicateAnalyzer {
       return SqlTypeName.INT_TYPES.contains(literal.getType().getSqlTypeName());
     }
 
-    boolean isFloatingPoint() {
-      return SqlTypeName.APPROX_TYPES.contains(literal.getType().getSqlTypeName());
+    boolean isFractional() {
+      return SqlTypeName.FRACTIONAL_TYPES.contains(literal.getType().getSqlTypeName());
     }
 
     boolean isBoolean() {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -40,6 +40,8 @@ import static org.opensearch.index.query.QueryBuilders.termsQuery;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Range;
+
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.GregorianCalendar;
@@ -1124,6 +1126,8 @@ public class PredicateAnalyzer {
         case CHAR:
         case VARCHAR:
           return ((NlsString) point).getValue();
+        case DECIMAL:
+          return ((BigDecimal) point).doubleValue();
         default:
           return point;
       }


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/sql/pull/3673 introduced a decimal literal in plan, decimal literal in expression can not be pushed down since the decimal literal in Calcite is not converted to double in pushdown, and only double/float data type supported in DSL. This PR converts decimal type to double type in handling pushdown.

Note, this bug is only triggered when the field type in expression is integer + decimal literal.
For example, following query failed when `balance` is integer type in mapping, but success if `balance` is double.
```
source=%s | where balance > 40000.00 | stats avg(balance)
```

### Related Issues
Resolves #3810 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
