### PR TITLE
[BUG] Fix flaky tests related to WeekOfYear in CalcitePPLDateTimeBuiltinFunctionIT

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -418,20 +418,33 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         schema("WEEK(DATE('2008-02-20'))", "int"),
         schema("WEEK(DATE('2008-02-20'), 1)", "int"));
 
-    verifyDataRows(actual, rows(15, 15, 15, 15, 7, 8));
+    int week19840412 = getYearWeek(LocalDate.of(1984, 4, 12), 0) % 100;
+    int week19840412Mode1 = getYearWeek(LocalDate.of(1984, 4, 12), 1) % 100;
+    int week20080220 = getYearWeek(LocalDate.of(2008, 2, 20), 0) % 100;
+    int week20080220Mode1 = getYearWeek(LocalDate.of(2008, 2, 20), 1) % 100;
+    verifyDataRows(
+        actual,
+        rows(
+            week19840412,
+            week19840412,
+            week19840412Mode1,
+            week19840412Mode1,
+            week20080220,
+            week20080220Mode1));
   }
 
   @Test
-  public void testWeekAndWeekOfYearWithFilter() throws IOException {
+  public void testWeekAndWeekOfYearWithFilter() {
+    int week19840412 = getYearWeek(LocalDate.of(1984, 4, 12), 0) % 100;
     JSONObject actual =
         executeQuery(
             String.format(
                 "source=%s | fields  strict_date_optional_time"
                     + "| where YEAR(strict_date_optional_time) < 2000"
-                    + "| where WEEK(DATE(strict_date_optional_time)) = 15"
+                    + "| where WEEK(DATE(strict_date_optional_time)) = %d"
                     + "| stats COUNT() AS CNT "
                     + "| head 1 ",
-                TEST_INDEX_DATE_FORMATS));
+                TEST_INDEX_DATE_FORMATS, week19840412));
 
     verifySchema(actual, schema("CNT", "bigint"));
 
@@ -464,13 +477,14 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
   }
 
   @Test
-  public void testYearWeek() throws IOException {
+  public void testYearWeek() {
     int currentYearWeek =
-        exprYearweek(
-                new ExprDateValue(
-                    LocalDateTime.now(new FunctionProperties().getQueryStartClock()).toLocalDate()),
-                new ExprIntegerValue(0))
-            .integerValue();
+        getYearWeek(
+            LocalDateTime.now(new FunctionProperties().getQueryStartClock()).toLocalDate(), 0);
+    int yearWeek19840412 = getYearWeek(LocalDate.of(1984, 4, 12), 0);
+    int yearWeek20200826 = getYearWeek(LocalDate.of(2020, 8, 26), 0);
+    int yearWeek20190105 = getYearWeek(LocalDate.of(2019, 1, 5), 1);
+    // Write to a tmp file
     JSONObject actual =
         executeQuery(
             String.format(
@@ -491,7 +505,14 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         schema("YEARWEEK('2020-08-26')", "int"),
         schema("YEARWEEK('2019-01-05', 1)", "int"));
 
-    verifyDataRows(actual, rows(198415, currentYearWeek, 198415, 202034, 201901));
+    verifyDataRows(
+        actual,
+        rows(
+            yearWeek19840412,
+            currentYearWeek,
+            yearWeek19840412,
+            yearWeek20200826,
+            yearWeek20190105));
   }
 
   @Test
@@ -1004,6 +1025,8 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         offsetUTC.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     String expectedDatetimeAtPlus8 =
         offsetPlus8.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    int week19840412 = getYearWeek(LocalDate.of(1984, 4, 12), 0) % 100;
+    int week19840412Mode1 = getYearWeek(LocalDate.of(1984, 4, 12), 1) % 100;
 
     verifyDataRows(
         actual,
@@ -1016,8 +1039,8 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
             "2017-11-02",
             expectedDatetimeAtPlus8,
             expectedDatetimeAtUTC,
-            "15 1984 15",
-            "15 15 1984",
+            String.format("%d 1984 %d", week19840412, week19840412),
+            String.format("%d %d 1984", week19840412Mode1, week19840412Mode1),
             "09:07:42.000123"));
   }
 
@@ -1451,5 +1474,9 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         schema("m4", "int"),
         schema("m5", "int"));
     verifyDataRows(actual, rows(0, 0, 0, 123456, 123456));
+  }
+
+  private static int getYearWeek(LocalDate date, int mode) {
+    return exprYearweek(new ExprDateValue(date), new ExprIntegerValue(mode)).integerValue();
   }
 }


### PR DESCRIPTION
### Description
This fixes flaky tests related to `YEARWEEK` function in certain locales.

This fix assumes that the existing implementation is correct, and only fixes tests.

The problem arises from https://github.com/opensearch-project/sql/blob/b610ce96f5a7772d7ebf15f0bea27d1103c63c92/core/src/main/java/org/opensearch/sql/expression/datetime/CalendarLookup.java#L62

When locale is in `ja-JP-u-ca-japanese-x-lvariant-JP`, the calendar implementation is `JapanImperialCalender`. Retrieving week of the year with this calendar on 1984-04-12 results in 14; while in `en-US` locale it returns 15.
 
### Related Issues
Resolves #3814 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
