### PR TITLE
Add enforce-labels action

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,13 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        REQUIRED_LABELS_ANY: "breaking,feature,enhancement,bug,infrastructure,dependencies,documentation,maintenance,skip-changelog"
+        REQUIRED_LABELS_ANY_DESCRIPTION: "A release label is required: ['breaking', 'bug', 'dependencies', 'documentation', 'enhancement', 'feature', 'infrastructure', 'maintenance', 'skip-changelog']"


### PR DESCRIPTION
### Description
In the [3.1 release notes](https://github.com/opensearch-project/sql/blob/main/release-notes/opensearch-sql.release-notes-3.1.0.0.md), there were ~20 PRs that didn't have release labels, so I had to manually figure out which categories they go into. I [automated the release note generation process](https://github.com/Swiddis/opensearch-utils/tree/main/release) 2 years ago on my old team, but the script requires the labels in order to be fully automated. This PR introduces an action for checking these labels exist.

This same action has been used with success on dashboards-observability for ~2y.

### Related Issues
Humans shouldn't need to manually create lists of the PRs in their release. (If we had annotated release notes that would be a different story, but org-wide we don't really bother to annotate the notes.)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
