### PR TITLE
Shift some 3.1 release notes categories

### DIFF
--- a/release-notes/opensearch-sql.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-sql.release-notes-3.1.0.0.md
@@ -2,11 +2,9 @@
 
 Compatible with OpenSearch and OpenSearch Dashboards version 3.1.0
 
-### Breaking
+### Features
 * Switch percentile implementation to MergingDigest to align with OpenSearch ([#3698](https://github.com/opensearch-project/sql/pull/3698))
 * Support decimal literal with Calcite ([#3673](https://github.com/opensearch-project/sql/pull/3673))
-
-### Features
 * Support ResourceMonitor with Calcite ([#3738](https://github.com/opensearch-project/sql/pull/3738))
 * Support `flatten` command with Calcite ([#3747](https://github.com/opensearch-project/sql/pull/3747))
 * Support `expand` command with Calcite ([#3745](https://github.com/opensearch-project/sql/pull/3745))


### PR DESCRIPTION
### Description
Breaking changes turn out to be forbidden for minor releases. I see why they're technically labeled as breaking, but it doesn't really match the spirit of what the release team means by it. ¯\\\_(ツ)\_/¯

To prevent similar release blockers down the road, I [updated my release note generator script to warn about this](https://github.com/Swiddis/opensearch-utils/commit/778778bd4dde6972648664d7e68817abb507ae8a).

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
