### PR TITLE
Support struct field with dynamic disabled

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3343.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3343.yml
@@ -32,6 +32,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -41,12 +42,16 @@ teardown:
           - '{ "profile": { "age": 1 } }'
           - '{ "index": { "_index": "test" } }'
           - '{ "profile": { "address": "a" } }'
+          - '{ "index": { "_index": "test" } }'
+          - '{ "profile": { "name": null } }'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
         body:
           query: 'source=test'
-  - match: {"total": 2}
+  - match: {"total": 3}
   - match: {"schema": [{"name": "profile", "type": "struct"}]}
-  - match: {"datarows": [[{"age": 1}], [{"address": "a"}]]}
+  - match: {"datarows": [[{"age": 1}], [{"address": "a"}], [{"name": null}]]}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3343.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3343.yml
@@ -1,0 +1,52 @@
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              profile:
+                type: object
+                dynamic: false
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+            plugins.calcite.fallback.allowed : false
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+            plugins.calcite.fallback.allowed : true
+
+---
+"Handle struct field with dynamic mapping disabled":
+  - skip:
+      features:
+        - headers
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{ "index": { "_index": "test" } }'
+          - '{ "profile": { "age": 1 } }'
+          - '{ "index": { "_index": "test" } }'
+          - '{ "profile": { "address": "a" } }'
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test'
+  - match: {"total": 2}
+  - match: {"schema": [{"name": "profile", "type": "struct"}]}
+  - match: {"datarows": [[{"age": 1}], [{"address": "a"}]]}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3343.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3343.yml
@@ -42,8 +42,6 @@ teardown:
           - '{ "profile": { "age": 1 } }'
           - '{ "index": { "_index": "test" } }'
           - '{ "profile": { "address": "a" } }'
-          - '{ "index": { "_index": "test" } }'
-          - '{ "profile": { "name": null } }'
   - do:
       allowed_warnings:
         - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
@@ -52,6 +50,6 @@ teardown:
       ppl:
         body:
           query: 'source=test'
-  - match: {"total": 3}
+  - match: {"total": 2}
   - match: {"schema": [{"name": "profile", "type": "struct"}]}
-  - match: {"datarows": [[{"age": 1}], [{"address": "a"}], [{"name": null}]]}
+  - match: {"datarows": [[{"age": 1}], [{"address": "a"}]]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/Content.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/Content.java
@@ -32,6 +32,9 @@ public interface Content {
   /** Is double value. */
   boolean isDouble();
 
+  /** Is int value. */
+  boolean isInt();
+
   /** Is long value. */
   boolean isLong();
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
@@ -105,6 +105,11 @@ public class ObjectContent implements Content {
   }
 
   @Override
+  public boolean isInt() {
+    return value instanceof Integer;
+  }
+
+  @Override
   public boolean isFloat() {
     return value instanceof Float;
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -93,6 +93,11 @@ public class OpenSearchJsonContent implements Content {
   }
 
   @Override
+  public boolean isInt() {
+    return value.isInt();
+  }
+
+  @Override
   public boolean isLong() {
     return value().isLong();
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -191,6 +191,8 @@ public class OpenSearchExprValueFactory {
       return ExprNullValue.of();
     }
 
+    // Field type may be not defined in mapping if users have disabled dynamic mapping.
+    // Then try to parse content directly based on the value itself
     if (fieldType.isEmpty()) {
       return parseContent(content);
     }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -187,8 +187,12 @@ public class OpenSearchExprValueFactory {
 
   private ExprValue parse(
       Content content, String field, Optional<ExprType> fieldType, boolean supportArrays) {
-    if (content.isNull() || !fieldType.isPresent()) {
+    if (content.isNull()) {
       return ExprNullValue.of();
+    }
+
+    if (fieldType.isEmpty()) {
+      return parseContent(content);
     }
 
     final ExprType type = fieldType.get();
@@ -208,6 +212,31 @@ public class OpenSearchExprValueFactory {
           String.format(
               "Unsupported type: %s for value: %s.", type.typeName(), content.objectValue()));
     }
+  }
+
+  private ExprValue parseContent(Content content) {
+    if (content.isNumber()) {
+      if (content.isInt()) {
+        return new ExprIntegerValue(content.intValue());
+      } else if (content.isLong()) {
+        return new ExprLongValue(content.longValue());
+      } else if (content.isFloat()) {
+        return new ExprFloatValue(content.floatValue());
+      } else if (content.isDouble()) {
+        return new ExprDoubleValue(content.doubleValue());
+      } else {
+        // Default case for number, treat as double
+        return new ExprDoubleValue(content.doubleValue());
+      }
+    } else if (content.isString()) {
+      return new ExprStringValue(content.stringValue());
+    } else if (content.isBoolean()) {
+      return ExprBooleanValue.of(content.booleanValue());
+    } else if (content.isNull()) {
+      return ExprNullValue.of();
+    }
+    // Default case, treat as a string value
+    return new ExprStringValue(content.objectValue().toString());
   }
 
   /**

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -952,7 +952,7 @@ class OpenSearchExprValueFactoryTest {
   public void noTypeFoundForMapping() {
     assertEquals(nullValue(), tupleValue("{\"not_exist\":[]}").get("not_exist"));
     // Only for test coverage, It is impossible in OpenSearch.
-    assertEquals(nullValue(), tupleValue("{\"not_exist\":1}").get("not_exist"));
+    assertEquals(ExprValueUtils.integerValue(1), tupleValue("{\"not_exist\":1}").get("not_exist"));
   }
 
   @Test

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
@@ -23,13 +23,12 @@ public class ErrorFormatter {
                   SerializeUtils.getGsonBuilder()
                       .setPrettyPrinting()
                       .disableHtmlEscaping()
-                      .serializeNulls()
+                      // .serializeNulls()
                       .create());
   private static final Gson GSON =
       AccessController.doPrivileged(
           (PrivilegedAction<Gson>)
-              () ->
-                  SerializeUtils.getGsonBuilder().disableHtmlEscaping().serializeNulls().create());
+              () -> SerializeUtils.getGsonBuilder().disableHtmlEscaping().create());
 
   /** Util method to format {@link Throwable} response to JSON string in compact printing. */
   public static String compactFormat(Throwable t) {

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
@@ -23,11 +23,13 @@ public class ErrorFormatter {
                   SerializeUtils.getGsonBuilder()
                       .setPrettyPrinting()
                       .disableHtmlEscaping()
+                      .serializeNulls()
                       .create());
   private static final Gson GSON =
       AccessController.doPrivileged(
           (PrivilegedAction<Gson>)
-              () -> SerializeUtils.getGsonBuilder().disableHtmlEscaping().create());
+              () ->
+                  SerializeUtils.getGsonBuilder().disableHtmlEscaping().serializeNulls().create());
 
   /** Util method to format {@link Throwable} response to JSON string in compact printing. */
   public static String compactFormat(Throwable t) {

--- a/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
+++ b/protocol/src/main/java/org/opensearch/sql/protocol/response/format/ErrorFormatter.java
@@ -23,7 +23,6 @@ public class ErrorFormatter {
                   SerializeUtils.getGsonBuilder()
                       .setPrettyPrinting()
                       .disableHtmlEscaping()
-                      // .serializeNulls()
                       .create());
   private static final Gson GSON =
       AccessController.doPrivileged(


### PR DESCRIPTION
### Description
Support struct field with dynamic disabled

If dynamic mapping disabled, although information of type missed for the new added fields, we can still parse value from the content by itself only.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3343

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
