### PR TITLE
Allow warning header for yaml test

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/2489.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/2489.yml
@@ -31,6 +31,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -39,6 +40,8 @@ teardown:
           - '{"index": {}}'
           - '{"timestamp": "1705642934886"}'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -47,4 +50,3 @@ teardown:
   - match: {"total": 1}
   - match: {"schema": [{"name": "timestamp", "type": "timestamp"}]}
   - match: {"datarows": [["2024-01-19 05:42:14.886"]]}
-

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3102.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3102.yml
@@ -2,6 +2,7 @@ setup:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       indices.create:
         index: test
@@ -23,6 +24,8 @@ setup:
 ---
 "Prevent push down limit if the offset reach max_result_window":
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -33,6 +36,8 @@ setup:
   - match: {"datarows": [[2]]}
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3312.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3312.yml
@@ -2,6 +2,7 @@
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -10,6 +11,8 @@
           - '{"index": {}}'
           - '{"log": {"url": {"message": "/e2e/h/zap"} } }'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
@@ -20,6 +20,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -36,6 +37,8 @@ teardown:
           - '{"index": {}}'
           - '{"log": { "json" : {} }, "log.json": { "status": "SUCCESS" }, "log.json.time": 100 }'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3570.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3570.yml
@@ -132,7 +132,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3595.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3595.yml
@@ -21,6 +21,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         refresh: true
@@ -38,6 +39,8 @@ teardown:
              {"index": {"_index": "region_info"}}
              {"regionId": "2", "regionName": "us-west-2"}'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3607.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3607.yml
@@ -27,6 +27,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         refresh: true
@@ -37,6 +38,8 @@ teardown:
              {"regionId": "2", "action": "file_upload", "timestamp": "2024-04-29T10:05:00Z"}'
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3635.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3635.yml
@@ -20,6 +20,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -28,6 +29,8 @@ teardown:
           - '{"index": {}}'
           - '{"log": {"url": {"message": "/e2e/h/zap"} } }'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3646.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3646.yml
@@ -48,6 +48,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -57,6 +58,8 @@ teardown:
           - '{"log": {"url": {"message": "/e2e/h/zap", "time": 1} } }'
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3655.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3655.yml
@@ -2,6 +2,7 @@ setup:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       indices.create:
         index: test
@@ -77,6 +78,8 @@ teardown:
   - match: {"datarows": [["This is a match_only_text field 1"]]}
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
@@ -20,6 +20,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -28,6 +29,8 @@ teardown:
           - '{"index": {}}'
           - '{"balance": 1000}'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -38,6 +41,8 @@ teardown:
   - match: {"datarows": [[1000.0]]}
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:


### PR DESCRIPTION
### Description
Allow warning header for yaml test. Only see such failure for `3102.yml` and `3312.yml` so far.

OpenSearchQueryRequest relies on `_id` to preserve sort location for PIT search:
https://github.com/opensearch-project/sql/blob/74b4de067cefc821055076bd108249cef777c3f9/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchQueryRequest.java#L195-L197

However, OpenSearch has deprecated the sort or aggregation behavior on `id`:
https://github.com/opensearch-project/OpenSearch/blob/36c2d5930ab3c036f19760942f95ea4bdb126137/server/src/main/java/org/opensearch/index/mapper/IdFieldMapper.java#L84-L87

So it will has warning message in the header of response, but the reason why it's flakey remains unclear. This PR make it workaround by allowing this warning header in yaml test.

For long term consideration, this issue should be addressed by this one: https://github.com/opensearch-project/sql/issues/3064

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3845

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
