### PR TITLE
Skipping codegen and compile for Scan only plan

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/plan/Scannable.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/Scannable.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.plan;
+
+import org.apache.calcite.linq4j.Enumerable;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface Scannable {
+
+  public Enumerable<@Nullable Object[]> scan();
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/Scannable.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/Scannable.java
@@ -8,6 +8,12 @@ package org.opensearch.sql.calcite.plan;
 import org.apache.calcite.linq4j.Enumerable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * The customized table scan is implemented in OpenSearch module, to invoke this scan() method in
+ * core module, we add this interface. Now the only implementation is CalciteEnumerableIndexScan.
+ * When a RelNode after optimization is a Scannable, we can directly invoke scan() method to get the
+ * result of the scan instead of codegen and compile via Linq4j expression.
+ */
 public interface Scannable {
 
   public Enumerable<@Nullable Object> scan();

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/Scannable.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/Scannable.java
@@ -10,5 +10,5 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface Scannable {
 
-  public Enumerable<@Nullable Object[]> scan();
+  public Enumerable<@Nullable Object> scan();
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
@@ -37,7 +37,6 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Properties;
 import java.util.function.Consumer;
-import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.enumerable.EnumerableConvention;
 import org.apache.calcite.adapter.enumerable.EnumerableRel;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
@@ -53,7 +52,6 @@ import org.apache.calcite.jdbc.CalciteJdbc41Factory;
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.Driver;
-import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.function.Function0;
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.Contexts;
@@ -75,10 +73,8 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.runtime.ArrayBindable;
 import org.apache.calcite.runtime.Bindable;
 import org.apache.calcite.runtime.Hook;
-import org.apache.calcite.runtime.Typed;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.server.CalciteServerStatement;
 import org.apache.calcite.sql.SqlAggFunction;
@@ -91,7 +87,6 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelRunner;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.Util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.plan.Scannable;
 import org.opensearch.sql.calcite.udf.udaf.NullableSqlAvgAggFunction;
@@ -307,18 +302,7 @@ public class CalciteToolsHelper {
       RelDataType resultType = root.rel.getRowType();
       boolean isDml = root.kind.belongsTo(SqlKind.DML);
       if (root.rel instanceof Scannable scannable) {
-        final Bindable bindable =
-            new ArrayBindable() {
-              @Override
-              public Enumerable<@Nullable Object[]> bind(DataContext dataContext) {
-                return scannable.scan();
-              }
-
-              @Override
-              public Class<Object[]> getElementType() {
-                return Object[].class;
-              }
-            };
+        final Bindable bindable = dataContext -> scannable.scan();
 
         return new PreparedResultImpl(
             resultType,
@@ -342,7 +326,7 @@ public class CalciteToolsHelper {
 
           @Override
           public Type getElementType() {
-            return ((Typed) bindable).getElementType();
+            return Object.class;
           }
         };
       }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
@@ -27,26 +27,37 @@
 
 package org.opensearch.sql.calcite.utils;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableList;
+import java.lang.reflect.Type;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Properties;
 import java.util.function.Consumer;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.adapter.enumerable.EnumerableConvention;
+import org.apache.calcite.adapter.enumerable.EnumerableRel;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaFactory;
+import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.UnregisteredDriver;
 import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.interpreter.BindableConvention;
 import org.apache.calcite.interpreter.Bindables;
 import org.apache.calcite.jdbc.CalciteFactory;
 import org.apache.calcite.jdbc.CalciteJdbc41Factory;
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.Driver;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.function.Function0;
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptSchema;
@@ -55,30 +66,39 @@ import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.prepare.CalcitePrepareImpl;
 import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.ArrayBindable;
+import org.apache.calcite.runtime.Bindable;
 import org.apache.calcite.runtime.Hook;
+import org.apache.calcite.runtime.Typed;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.server.CalciteServerStatement;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelRunner;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.Util;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.calcite.plan.Scannable;
 import org.opensearch.sql.calcite.udf.udaf.NullableSqlAvgAggFunction;
 
 /**
  * Calcite Tools Helper. This class is used to create customized: 1. Connection 2. JavaTypeFactory
- * 3. RelBuilder 4. RelRunner TODO delete it in future if possible.
+ * 3. RelBuilder 4. RelRunner 5. CalcitePreparingStmt. TODO delete it in future if possible.
  */
 public class CalciteToolsHelper {
 
@@ -153,6 +173,11 @@ public class CalciteToolsHelper {
       this.handler.onConnectionInit(connection);
       return connection;
     }
+
+    @Override
+    protected Function0<CalcitePrepare> createPrepareFactory() {
+      return OpenSearchPrepareImpl::new;
+    }
   }
 
   /** do nothing, just extend for a public construct for new */
@@ -213,6 +238,115 @@ public class CalciteToolsHelper {
               prepareContext, Contexts.of(prepareContext.config()), config.getCostFactory());
       final RelOptCluster cluster = createCluster(planner, rexBuilder);
       return action.apply(cluster, catalogReader, prepareContext.getRootSchema().plus(), statement);
+    }
+
+    /**
+     * Customize CalcitePreparingStmt. Override {@link CalcitePrepareImpl#getPreparingStmt} and
+     * return {@link OpenSearchCalcitePreparingStmt}
+     */
+    @Override
+    protected CalcitePrepareImpl.CalcitePreparingStmt getPreparingStmt(
+        CalcitePrepare.Context context,
+        Type elementType,
+        CalciteCatalogReader catalogReader,
+        RelOptPlanner planner) {
+      final JavaTypeFactory typeFactory = context.getTypeFactory();
+      final EnumerableRel.Prefer prefer;
+      if (elementType == Object[].class) {
+        prefer = EnumerableRel.Prefer.ARRAY;
+      } else {
+        prefer = EnumerableRel.Prefer.CUSTOM;
+      }
+      final Convention resultConvention =
+          enableBindable ? BindableConvention.INSTANCE : EnumerableConvention.INSTANCE;
+      return new OpenSearchCalcitePreparingStmt(
+          this,
+          context,
+          catalogReader,
+          typeFactory,
+          context.getRootSchema(),
+          prefer,
+          createCluster(planner, new RexBuilder(typeFactory)),
+          resultConvention,
+          createConvertletTable());
+    }
+  }
+
+  /**
+   * Similar to {@link CalcitePrepareImpl.CalcitePreparingStmt}. Customize the logic to convert an
+   * EnumerableTableScan to BindableTableScan.
+   */
+  public static class OpenSearchCalcitePreparingStmt
+      extends CalcitePrepareImpl.CalcitePreparingStmt {
+
+    public OpenSearchCalcitePreparingStmt(
+        CalcitePrepareImpl prepare,
+        CalcitePrepare.Context context,
+        CatalogReader catalogReader,
+        RelDataTypeFactory typeFactory,
+        CalciteSchema schema,
+        EnumerableRel.Prefer prefer,
+        RelOptCluster cluster,
+        Convention resultConvention,
+        SqlRexConvertletTable convertletTable) {
+      super(
+          prepare,
+          context,
+          catalogReader,
+          typeFactory,
+          schema,
+          prefer,
+          cluster,
+          resultConvention,
+          convertletTable);
+    }
+
+    @Override
+    protected PreparedResult implement(RelRoot root) {
+      Hook.PLAN_BEFORE_IMPLEMENTATION.run(root);
+      RelDataType resultType = root.rel.getRowType();
+      boolean isDml = root.kind.belongsTo(SqlKind.DML);
+      if (root.rel instanceof Scannable scannable) {
+        final Bindable bindable =
+            new ArrayBindable() {
+              @Override
+              public Enumerable<@Nullable Object[]> bind(DataContext dataContext) {
+                return scannable.scan();
+              }
+
+              @Override
+              public Class<Object[]> getElementType() {
+                return Object[].class;
+              }
+            };
+
+        return new PreparedResultImpl(
+            resultType,
+            requireNonNull(parameterRowType, "parameterRowType"),
+            requireNonNull(fieldOrigins, "fieldOrigins"),
+            root.collation.getFieldCollations().isEmpty()
+                ? ImmutableList.of()
+                : ImmutableList.of(root.collation),
+            root.rel,
+            mapTableModOp(isDml, root.kind),
+            isDml) {
+          @Override
+          public String getCode() {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public Bindable getBindable(Meta.CursorFactory cursorFactory) {
+            return bindable;
+          }
+
+          @Override
+          public Type getElementType() {
+            return ((Typed) bindable).getElementType();
+          }
+        };
+      }
+      return super.implement(root);
     }
   }
 

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
@@ -326,7 +326,7 @@ public class CalciteToolsHelper {
 
           @Override
           public Type getElementType() {
-            return Object.class;
+            return resultType.getFieldList().size() == 1 ? Object.class : Object[].class;
           }
         };
       }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLExplainIT.java
@@ -44,10 +44,22 @@ public class CalcitePPLExplainIT extends PPLIntegTestCase {
   }
 
   @Test
-  public void testExplainCommandExtended() throws IOException {
+  public void testExplainCommandExtendedWithCodegen() throws IOException {
+    var result =
+        executeWithReplace(
+            "explain extended source=test | where age = 20 | join left=l right=r on l.age=r.age"
+                + " test");
+    assertTrue(
+        result.contains(
+            "public org.apache.calcite.linq4j.Enumerable bind(final"
+                + " org.apache.calcite.DataContext root)"));
+  }
+
+  @Test
+  public void testExplainCommandExtendedWithoutCodegen() throws IOException {
     var result =
         executeWithReplace("explain extended source=test | where age = 20 | fields name, age");
-    assertTrue(
+    assertFalse(
         result.contains(
             "public org.apache.calcite.linq4j.Enumerable bind(final"
                 + " org.apache.calcite.DataContext root)"));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLExplainIT.java
@@ -59,10 +59,17 @@ public class CalcitePPLExplainIT extends PPLIntegTestCase {
   public void testExplainCommandExtendedWithoutCodegen() throws IOException {
     var result =
         executeWithReplace("explain extended source=test | where age = 20 | fields name, age");
-    assertFalse(
-        result.contains(
-            "public org.apache.calcite.linq4j.Enumerable bind(final"
-                + " org.apache.calcite.DataContext root)"));
+    if (isPushdownEnabled()) {
+      assertFalse(
+          result.contains(
+              "public org.apache.calcite.linq4j.Enumerable bind(final"
+                  + " org.apache.calcite.DataContext root)"));
+    } else {
+      assertTrue(
+          result.contains(
+              "public org.apache.calcite.linq4j.Enumerable bind(final"
+                  + " org.apache.calcite.DataContext root)"));
+    }
   }
 
   @Test

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/EnumerableIndexScanRule.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/EnumerableIndexScanRule.java
@@ -27,7 +27,7 @@ public class EnumerableIndexScanRule extends ConverterRule {
               "EnumerableIndexScanRule")
           .withRuleFactory(EnumerableIndexScanRule::new);
 
-  /** Creates an EnumerableProjectRule. */
+  /** Creates an EnumerableIndexScanRule. */
   protected EnumerableIndexScanRule(Config config) {
     super(config);
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteEnumerableIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteEnumerableIndexScan.java
@@ -28,11 +28,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.sql.calcite.plan.OpenSearchRules;
+import org.opensearch.sql.calcite.plan.Scannable;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.opensearch.storage.OpenSearchIndex;
 
 /** The physical relational operator representing a scan of an OpenSearchIndex type. */
-public class CalciteEnumerableIndexScan extends AbstractCalciteIndexScan implements EnumerableRel {
+public class CalciteEnumerableIndexScan extends AbstractCalciteIndexScan
+    implements Scannable, EnumerableRel {
   private static final Logger LOG = LogManager.getLogger(CalciteEnumerableIndexScan.class);
 
   /**
@@ -85,10 +87,11 @@ public class CalciteEnumerableIndexScan extends AbstractCalciteIndexScan impleme
    * each time to avoid reusing source builder. That's because the source builder has stats like PIT
    * or SearchAfter recorded during previous search.
    */
-  public Enumerable<@Nullable Object> scan() {
+  @Override
+  public Enumerable<@Nullable Object[]> scan() {
     return new AbstractEnumerable<>() {
       @Override
-      public Enumerator<Object> enumerator() {
+      public Enumerator<Object[]> enumerator() {
         OpenSearchRequestBuilder requestBuilder = osIndex.createRequestBuilder();
         pushDownContext.forEach(action -> action.apply(requestBuilder));
         return new OpenSearchIndexEnumerator(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteEnumerableIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteEnumerableIndexScan.java
@@ -88,10 +88,10 @@ public class CalciteEnumerableIndexScan extends AbstractCalciteIndexScan
    * or SearchAfter recorded during previous search.
    */
   @Override
-  public Enumerable<@Nullable Object[]> scan() {
+  public Enumerable<@Nullable Object> scan() {
     return new AbstractEnumerable<>() {
       @Override
-      public Enumerator<Object[]> enumerator() {
+      public Enumerator<Object> enumerator() {
         OpenSearchRequestBuilder requestBuilder = osIndex.createRequestBuilder();
         pushDownContext.forEach(action -> action.apply(requestBuilder));
         return new OpenSearchIndexEnumerator(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
@@ -26,7 +26,7 @@ import org.opensearch.sql.opensearch.response.OpenSearchResponse;
  * has been modified it is only optional that an implementation of the Enumerator interface detects
  * it and throws a {@link java.util.ConcurrentModificationException}.
  */
-public class OpenSearchIndexEnumerator implements Enumerator<Object[]> {
+public class OpenSearchIndexEnumerator implements Enumerator<Object> {
 
   /** OpenSearch client. */
   private final OpenSearchClient client;
@@ -81,14 +81,12 @@ public class OpenSearchIndexEnumerator implements Enumerator<Object[]> {
   }
 
   @Override
-  public Object[] current() {
+  public Object current() {
     /* In Calcite enumerable operators, row of single column will be optimized to a scalar value.
      * See {@link PhysTypeImpl}
      */
     if (fields.size() == 1) {
-      Object[] arr = new Object[1];
-      arr[0] = resolveForCalcite(current, fields.getFirst());
-      return arr;
+      return resolveForCalcite(current, fields.getFirst());
     }
     return fields.stream().map(field -> resolveForCalcite(current, field)).toArray();
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
@@ -26,7 +26,7 @@ import org.opensearch.sql.opensearch.response.OpenSearchResponse;
  * has been modified it is only optional that an implementation of the Enumerator interface detects
  * it and throws a {@link java.util.ConcurrentModificationException}.
  */
-public class OpenSearchIndexEnumerator implements Enumerator<Object> {
+public class OpenSearchIndexEnumerator implements Enumerator<Object[]> {
 
   /** OpenSearch client. */
   private final OpenSearchClient client;
@@ -81,12 +81,14 @@ public class OpenSearchIndexEnumerator implements Enumerator<Object> {
   }
 
   @Override
-  public Object current() {
+  public Object[] current() {
     /* In Calcite enumerable operators, row of single column will be optimized to a scalar value.
      * See {@link PhysTypeImpl}
      */
     if (fields.size() == 1) {
-      return resolveForCalcite(current, fields.getFirst());
+      Object[] arr = new Object[1];
+      arr[0] = resolveForCalcite(current, fields.getFirst());
+      return arr;
     }
     return fields.stream().map(field -> resolveForCalcite(current, field)).toArray();
   }


### PR DESCRIPTION
### Description
Currently, when the Calcite engine is enabled, **​​all query plans**​​ -- regardless of their structure -- are converted to `EnumerableRel`. This means the plan is transformed into a `Linq4j` Expression, generates Java code, and undergoes just-in-time (JIT) compilation before execution.

For ​​simple or fully pushdown-compatible queries​​ (e.g., `source=t`, `source=t | where a=1`, `source=t | sort a`, or `source=t | where a=1 | sort b | head 10`), the optimized plans only contain node `EnumerableTableScan`. Despite their simplicity, these plans ​​unnecessarily undergo code generation and dynamic compilation​​, introducing overhead.

To ​​reduce codegen and compilation time​​, we propose converting such plans to `BindableRel` instead of `EnumerableRel`. This bypasses code generation and compilation entirely, ​​improving plan execution time by **~30%** (By benchmarking the simple queries by https://github.com/opensearch-project/sql/pull/3822)

### Related Issues
Resolves #3852 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
