### PR TITLE
Support `reverse` command with Calcite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -80,6 +80,7 @@ import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Reverse;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
@@ -680,6 +681,12 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   public LogicalPlan visitFlatten(Flatten node, AnalysisContext context) {
     throw new UnsupportedOperationException(
         "FLATTEN is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+  }
+
+  @Override
+  public LogicalPlan visitReverse(Reverse node, AnalysisContext context) {
+    throw new UnsupportedOperationException(
+        "REVERSE is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -69,6 +69,7 @@ import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Reverse;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
@@ -241,6 +242,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitSort(Sort node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitReverse(Reverse node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Reverse.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Reverse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+
+/** AST node represent Reverse operation. */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class Reverse extends UnresolvedPlan {
+
+  private UnresolvedPlan child;
+
+  @Override
+  public Reverse attach(UnresolvedPlan child) {
+    this.child = child;
+    return this;
+  }
+
+  @Override
+  public List<UnresolvedPlan> getChild() {
+    return this.child == null ? ImmutableList.of() : ImmutableList.of(this.child);
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitReverse(this, context);
+  }
+}

--- a/docs/user/ppl/cmd/reverse.rst
+++ b/docs/user/ppl/cmd/reverse.rst
@@ -11,7 +11,7 @@ reverse
 
 Description
 ============
-| Using ``reverse`` command to reverse the order of search results. The reverse command returns results in the opposite order from how they would normally be displayed, but does not affect which results are returned by the search.
+| Using ``reverse`` command to reverse the display order of search results. The same results are returned, but in reverse order.
 
 
 Syntax

--- a/docs/user/ppl/cmd/reverse.rst
+++ b/docs/user/ppl/cmd/reverse.rst
@@ -1,0 +1,114 @@
+=============
+reverse
+=============
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Description
+============
+| Using ``reverse`` command to reverse the order of search results. The reverse command returns results in the opposite order from how they would normally be displayed, but does not affect which results are returned by the search.
+
+
+Syntax
+============
+reverse
+
+
+* No parameters: The reverse command takes no arguments or options.
+
+
+Example 1: Basic reverse operation
+==================================
+
+The example shows reversing the order of all documents.
+
+PPL query::
+
+    os> source=accounts | fields account_number, age | reverse;
+    fetched rows / total rows = 4/4
+    +----------------+-----+
+    | account_number | age |
+    |----------------+-----|
+    | 6              | 36  |
+    | 18             | 33  |
+    | 1              | 32  |
+    | 13             | 28  |
+    +----------------+-----+
+
+
+Example 2: Reverse with sort
+============================
+
+The example shows reversing results after sorting by age in ascending order, effectively giving descending order.
+
+PPL query::
+
+    os> source=accounts | sort age | fields account_number, age | reverse;
+    fetched rows / total rows = 4/4
+    +----------------+-----+
+    | account_number | age |
+    |----------------+-----|
+    | 6              | 36  |
+    | 18             | 33  |
+    | 1              | 32  |
+    | 13             | 28  |
+    +----------------+-----+
+
+
+Example 3: Reverse with head
+============================
+
+The example shows using reverse with head to get the last 2 records from the original order.
+
+PPL query::
+
+    os> source=accounts | reverse | head 2 | fields account_number, age;
+    fetched rows / total rows = 2/2
+    +----------------+-----+
+    | account_number | age |
+    |----------------+-----|
+    | 6              | 36  |
+    | 18             | 33  |
+    +----------------+-----+
+
+
+Example 4: Double reverse
+=========================
+
+The example shows that applying reverse twice returns to the original order.
+
+PPL query::
+
+    os> source=accounts | reverse | reverse | fields account_number, age;
+    fetched rows / total rows = 4/4
+    +----------------+-----+
+    | account_number | age |
+    |----------------+-----|
+    | 13             | 28  |
+    | 1              | 32  |
+    | 18             | 33  |
+    | 6              | 36  |
+    +----------------+-----+
+
+
+Example 5: Reverse with complex pipeline
+=======================================
+
+The example shows reverse working with filtering and field selection.
+
+PPL query::
+
+    os> source=accounts | where age > 30 | fields account_number, age | reverse;
+    fetched rows / total rows = 3/3
+    +----------------+-----+
+    | account_number | age |
+    |----------------+-----|
+    | 6              | 36  |
+    | 18             | 33  |
+    | 1              | 32  |
+    +----------------+-----+

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteReverseCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteReverseCommandIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRowsInOrder;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+public class CalciteReverseCommandIT extends PPLIntegTestCase {
+
+    @Override
+    public void init() throws Exception {
+        super.init();
+        enableCalcite();
+        disallowCalciteFallback();
+        loadIndex(Index.BANK);
+    }
+
+    @Test
+    public void testReverse() throws IOException {
+        JSONObject result = executeQuery(String.format("source=%s | fields account_number | reverse", TEST_INDEX_BANK));
+        verifySchema(result, schema("account_number", "bigint"));
+        verifyDataRowsInOrder(result, rows(32), rows(25), rows(20), rows(18), rows(13), rows(6), rows(1));
+    }
+
+    @Test
+    public void testReverseWithFields() throws IOException {
+        JSONObject result = executeQuery(String.format("source=%s | fields account_number, firstname | reverse", TEST_INDEX_BANK));
+        verifySchema(result, schema("account_number", "bigint"), schema("firstname", "string"));
+        verifyDataRowsInOrder(
+                result,
+                rows(32, "Dillard"),
+                rows(25, "Virginia"),
+                rows(20, "Elinor"),
+                rows(18, "Dale"),
+                rows(13, "Nanette"),
+                rows(6, "Hattie"),
+                rows(1, "Amber JOHnny"));
+    }
+
+    @Test
+    public void testReverseWithSort() throws IOException {
+        JSONObject result = executeQuery(String.format("source=%s | sort account_number | fields account_number | reverse", TEST_INDEX_BANK));
+        verifySchema(result, schema("account_number", "bigint"));
+        verifyDataRowsInOrder(result, rows(32), rows(25), rows(20), rows(18), rows(13), rows(6), rows(1));
+    }
+
+    @Test
+    public void testDoubleReverse() throws IOException {
+        JSONObject result = executeQuery(String.format("source=%s | fields account_number | reverse | reverse", TEST_INDEX_BANK));
+        verifySchema(result, schema("account_number", "bigint"));
+        verifyDataRowsInOrder(result, rows(1), rows(6), rows(13), rows(18), rows(20), rows(25), rows(32));
+    }
+
+    @Test
+    public void testReverseWithHead() throws IOException {
+        JSONObject result = executeQuery(String.format("source=%s | fields account_number | reverse | head 3", TEST_INDEX_BANK));
+        verifySchema(result, schema("account_number", "bigint"));
+        verifyDataRowsInOrder(result, rows(32), rows(25), rows(20));
+    }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -73,6 +73,7 @@ commands
    | appendcolCommand
    | expandCommand
    | flattenCommand
+   | reverseCommand
    ;
 
 commandName
@@ -103,6 +104,7 @@ commandName
    | FLATTEN
    | TRENDLINE
    | EXPLAIN
+   | REVERSE
    ;
 
 searchCommand
@@ -145,6 +147,10 @@ dedupCommand
 
 sortCommand
    : SORT sortbyClause
+   ;
+
+reverseCommand
+   : REVERSE
    ;
 
 evalCommand

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -76,6 +76,7 @@ import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Reverse;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
@@ -377,6 +378,12 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
         ctx.sortbyClause().sortField().stream()
             .map(sort -> (Field) internalVisitExpression(sort))
             .collect(Collectors.toList()));
+  }
+
+  /** Reverse command. */
+  @Override
+  public UnresolvedPlan visitReverseCommand(OpenSearchPPLParser.ReverseCommandContext ctx) {
+    return new Reverse();
   }
 
   /** Eval command. */

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -70,6 +70,7 @@ import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Reverse;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
@@ -349,6 +350,12 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
     String child = node.getChild().get(0).accept(this, context);
     Integer size = node.getSize();
     return StringUtils.format("%s | head %d", child, size);
+  }
+
+  @Override
+  public String visitReverse(Reverse node, String context) {
+    String child = node.getChild().get(0).accept(this, context);
+    return StringUtils.format("%s | reverse", child);
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLReverseTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLReverseTest.java
@@ -201,6 +201,22 @@ public class CalcitePPLReverseTest extends CalcitePPLAbstractTest {
                 """;
         verifyResult(root, expectedResult);
     }
+    @Test
+    public void testReverseMultipleSortsSplEquivalent() {
+        // Composite sort: DEPT ASC, LEVEL ASC, NAME ASC — all in one 'sort' clause.
+        String ppl = "source=EMPLOYEES | sort DEPT, LEVEL, NAME | reverse";
+        RelNode root = getRelNode(ppl);
+
+        String expectedResult = """
+            ID=6; DEPT=Sales; LEVEL=Junior; NAME=Frank
+            ID=3; DEPT=Marketing; LEVEL=Senior; NAME=Charlie
+            ID=4; DEPT=Marketing; LEVEL=Junior; NAME=Diana
+            ID=5; DEPT=Engineering; LEVEL=Senior; NAME=Eve
+            ID=1; DEPT=Engineering; LEVEL=Senior; NAME=Alice
+            ID=2; DEPT=Engineering; LEVEL=Junior; NAME=Bob
+            """;
+        verifyResult(root, expectedResult);
+    }
 
     @RequiredArgsConstructor
     public static class EmployeeTable implements ScannableTable {

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLReverseTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLReverseTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import com.google.common.collect.ImmutableList;
+import lombok.RequiredArgsConstructor;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.Statistics;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.Frameworks;
+import org.junit.Test;
+
+/** Unit tests for {@code reverse} command in PPL. */
+public class CalcitePPLReverseTest extends CalcitePPLAbstractTest {
+    public CalcitePPLReverseTest() {
+        super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+    }
+
+    @Override
+    protected Frameworks.ConfigBuilder config(CalciteAssert.SchemaSpec... schemaSpecs) {
+        final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+        final SchemaPlus schema = CalciteAssert.addSchema(rootSchema, schemaSpecs);
+
+        // Main test table with multi-field data
+        ImmutableList<Object[]> rows = ImmutableList.of(
+                new Object[] {1, "Engineering", "Senior", "Alice"},
+                new Object[] {2, "Engineering", "Junior", "Bob"},
+                new Object[] {3, "Marketing", "Senior", "Charlie"},
+                new Object[] {4, "Marketing", "Junior", "Diana"},
+                new Object[] {5, "Engineering", "Senior", "Eve"},
+                new Object[] {6, "Sales", "Junior", "Frank"});
+        schema.add("EMPLOYEES", new EmployeeTable(rows));
+        
+        // Empty table for edge case testing
+        schema.add("EMPTY", new EmployeeTable(ImmutableList.of()));
+        
+        // Single row table
+        schema.add("SINGLE", new EmployeeTable(ImmutableList.of(new Object[] {99, "IT", "Manager", "Solo"})));
+
+        return Frameworks.newConfigBuilder()
+                .defaultSchema(schema);
+    }
+
+    @Test
+    public void testReverse() {
+        String ppl = "source=EMPLOYEES | fields ID, NAME | reverse";
+        RelNode root = getRelNode(ppl);
+
+        String expectedResult = """
+                ID=6; NAME=Frank
+                ID=5; NAME=Eve
+                ID=4; NAME=Diana
+                ID=3; NAME=Charlie
+                ID=2; NAME=Bob
+                ID=1; NAME=Alice
+                """;
+        verifyResult(root, expectedResult);
+    }
+
+    @Test
+    public void testReverseWithSort() {
+        String ppl = "source=EMPLOYEES | sort NAME | fields ID, NAME | reverse";
+        RelNode root = getRelNode(ppl);
+
+        String expectedResult = """
+                ID=6; NAME=Frank
+                ID=5; NAME=Eve
+                ID=4; NAME=Diana
+                ID=3; NAME=Charlie
+                ID=2; NAME=Bob
+                ID=1; NAME=Alice
+                """;
+        verifyResult(root, expectedResult);
+    }
+
+    @Test
+    public void testDoubleReverse() {
+        String ppl = "source=EMPLOYEES | fields ID, NAME | reverse | reverse";
+        RelNode root = getRelNode(ppl);
+
+        String expectedResult = """
+                ID=1; NAME=Alice
+                ID=2; NAME=Bob
+                ID=3; NAME=Charlie
+                ID=4; NAME=Diana
+                ID=5; NAME=Eve
+                ID=6; NAME=Frank
+                """;
+        verifyResult(root, expectedResult);
+    }
+
+    @Test
+    public void testReverseWithHead() {
+        String ppl = "source=EMPLOYEES | fields ID, NAME | reverse | head 2";
+        RelNode root = getRelNode(ppl);
+
+        String expectedResult = """
+                ID=6; NAME=Frank
+                ID=5; NAME=Eve
+                """;
+        verifyResult(root, expectedResult);
+    }
+
+    @Test
+    public void testReverseWithFields() {
+        String ppl = "source=EMPLOYEES | fields ID | reverse";
+        RelNode root = getRelNode(ppl);
+
+        String expectedResult = """
+                ID=6
+                ID=5
+                ID=4
+                ID=3
+                ID=2
+                ID=1
+                """;
+        verifyResult(root, expectedResult);
+    }
+
+    @Test
+    public void testReverseEmptyTable() {
+        String ppl = "source=EMPTY | reverse";
+        RelNode root = getRelNode(ppl);
+        
+        String expectedResult = "";
+        verifyResult(root, expectedResult);
+    }
+
+    @Test
+    public void testReverseSingleRow() {
+        String ppl = "source=SINGLE | fields ID, NAME | reverse";
+        RelNode root = getRelNode(ppl);
+
+        String expectedResult = "ID=99; NAME=Solo\n";
+        verifyResult(root, expectedResult);
+    }
+
+    @Test
+    public void testReverseWithComplexPipeline() {
+        String ppl = "source=EMPLOYEES | where ID > 3 | fields ID, NAME | reverse | head 1";
+        RelNode root = getRelNode(ppl);
+
+        String expectedResult = "ID=6; NAME=Frank\n";
+        verifyResult(root, expectedResult);
+    }
+
+    @Test(expected = Exception.class)
+    public void testReverseWithNumberShouldFail() {
+        String ppl = "source=EMPLOYEES | reverse 2";
+        getRelNode(ppl);
+    }
+
+    @Test(expected = Exception.class)
+    public void testReverseWithFieldShouldFail() {
+        String ppl = "source=EMPLOYEES | reverse ID";
+        getRelNode(ppl);
+    }
+
+    @Test(expected = Exception.class)
+    public void testReverseWithStringShouldFail() {
+        String ppl = "source=EMPLOYEES | reverse \"desc\"";
+        getRelNode(ppl);
+    }
+
+    @Test(expected = Exception.class)
+    public void testReverseWithExpressionShouldFail() {
+        String ppl = "source=EMPLOYEES | reverse ID + 1";
+        getRelNode(ppl);
+    }
+
+    @Test
+    public void testReverseWithMultipleSorts() {
+        // Expected: Complete reversal of the final sorted order (NAME->LEVEL->DEPT precedence)
+        // NOT: Flipped sort directions which would give (NAME DESC, LEVEL DESC, DEPT DESC)
+        String ppl = "source=EMPLOYEES | sort DEPT | sort LEVEL | sort NAME | reverse";
+        RelNode root = getRelNode(ppl);
+
+
+        String expectedResult = """
+                ID=6; DEPT=Sales; LEVEL=Junior; NAME=Frank
+                ID=5; DEPT=Engineering; LEVEL=Senior; NAME=Eve
+                ID=4; DEPT=Marketing; LEVEL=Junior; NAME=Diana
+                ID=3; DEPT=Marketing; LEVEL=Senior; NAME=Charlie
+                ID=2; DEPT=Engineering; LEVEL=Junior; NAME=Bob
+                ID=1; DEPT=Engineering; LEVEL=Senior; NAME=Alice
+                """;
+        verifyResult(root, expectedResult);
+    }
+
+    @RequiredArgsConstructor
+    public static class EmployeeTable implements ScannableTable {
+        private final ImmutableList<Object[]> rows;
+
+        protected final RelProtoDataType protoRowType = factory ->
+                factory.builder()
+                        .add("ID", SqlTypeName.INTEGER)
+                        .add("DEPT", SqlTypeName.VARCHAR)
+                        .add("LEVEL", SqlTypeName.VARCHAR)
+                        .add("NAME", SqlTypeName.VARCHAR)
+                        .build();
+
+        @Override
+        public Enumerable<Object[]> scan(DataContext root) {
+            return Linq4j.asEnumerable(rows);
+        }
+
+        @Override
+        public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+            return protoRowType.apply(typeFactory);
+        }
+
+        @Override
+        public Statistic getStatistic() {
+            return Statistics.of(0d, ImmutableList.of(), RelCollations.createSingleton(0));
+        }
+
+        @Override
+        public Schema.TableType getJdbcTableType() {
+            return Schema.TableType.TABLE;
+        }
+
+        @Override
+        public boolean isRolledUp(String column) {
+            return false;
+        }
+
+        @Override
+        public boolean rolledUpColumnValidInsideAgg(String column, org.apache.calcite.sql.SqlCall call,
+                                                    org.apache.calcite.sql.SqlNode parent,
+                                                    org.apache.calcite.config.CalciteConnectionConfig config) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Description
Implement the `reverse` command in PPL to flip the result order of records. This command does not take any parameters and reverses the order of rows as they appear at that point in the pipeline.

Example:
```ppl
source=accounts | reverse
```
### Related Issues
N/A 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
