### PR TITLE
[BugFix] Fix incorrect push down for Sarg with nullAs is TRUE

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
@@ -49,6 +49,8 @@ teardown:
   - match: {"datarows": [[{ "json" : { "status": "SUCCESS", "time": 100} }], [{ "json" : { "status": "SUCCESS", "time": 100} }], [{ "json" : { "status": "SUCCESS", "time": 100} }], [{ "json" : { "status": "SUCCESS", "time": 100} }], [{ "json" : { "status": "SUCCESS", "time": 100} }]]}
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3570.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3570.yml
@@ -101,7 +101,11 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
+
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3881.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3881.yml
@@ -16,7 +16,7 @@ teardown:
             plugins.calcite.fallback.allowed : true
 
 ---
-"Handle flattened document value":
+"Handle sag with nullAs":
   - skip:
       features:
         - headers

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3881.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3881.yml
@@ -1,0 +1,58 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+            plugins.calcite.fallback.allowed : false
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+            plugins.calcite.fallback.allowed : true
+
+---
+"Handle flattened document value":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"a": 1}'
+          - '{"index": {}}'
+          - '{"a": 2}'
+          - '{"index": {}}'
+          - '{}'
+
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | where a = 1 or a = 2 or isNull(a)'
+  - match: {"total": 3}
+  - match: {"schema": [{"name": "a", "type": "bigint"}]}
+  - match: {"datarows": [[1], [2], [null]]}
+
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | where (a = 1 or a = 2) and isNotNull(a)'
+  - match: { "total": 2 }
+  - match: { "schema": [ { "name": "a", "type": "bigint" } ] }
+  - match: {"datarows": [[1], [2]]}


### PR DESCRIPTION
### Description
Fix incorrect push down for Sarg with nullAs is TRUE

Before this PR, `PredicateAnalyzer` ignore the nullAs properties in Sarg and leads to incorrect results.
### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3881
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
