### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/get-sonatype-credentials.sh
+++ b/.github/get-sonatype-credentials.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Script to retrieve Sonatype credentials from AWS Secrets Manager
 
-SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+SONATYPE_USERNAME=op://opensearch-infra-secrets/maven-central-portal-credentials/username
+SONATYPE_PASSWORD=op://opensearch-infra-secrets/maven-central-portal-credentials/password
 echo "::add-mask::$SONATYPE_USERNAME"
 echo "::add-mask::$SONATYPE_PASSWORD"
 echo "SONATYPE_USERNAME=$SONATYPE_USERNAME" >> $GITHUB_ENV

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429,999  "./**/*.html" "./**/*.md" "./**/*.txt" --exclude "https://aws.oss.sonatype.*|http://localhost.*|https://localhost|https://odfe-node1:9200/|https://community.tableau.com/docs/DOC-17978|.*family.zzz|opensearch*|.*@amazon.com|.*email.com|.*@github.com|http://timestamp.verisign.com/scripts/timstamp.dll"
+          args: --accept=200,403,429,999  "./**/*.html" "./**/*.md" "./**/*.txt" --exclude "https://aws.oss.sonatype.*|https://central.sonatype.*|http://localhost.*|https://localhost|https://odfe-node1:9200/|https://community.tableau.com/docs/DOC-17978|.*family.zzz|opensearch*|.*@amazon.com|.*email.com|.*@github.com|http://timestamp.verisign.com/scripts/timstamp.dll"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -9,7 +9,7 @@ on:
       - 2.*
 
 env:
-  SNAPSHOT_REPO_URL: https://aws.oss.sonatype.org/content/repositories/snapshots/
+  SNAPSHOT_REPO_URL: https://central.sonatype.com/repository/maven-snapshots/
 
 jobs:
   build-and-publish-snapshots:
@@ -28,15 +28,15 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1.7.0
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
-
-      - name: get credentials
-        run: |
-          # Get credentials for publishing
-          .github/get-sonatype-credentials.sh
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
 
       - name: publish snapshots to maven
         run: |

--- a/.github/workflows/publish-async-query-core.yml
+++ b/.github/workflows/publish-async-query-core.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SNAPSHOT_REPO_URL: https://aws.oss.sonatype.org/content/repositories/snapshots/
+  SNAPSHOT_REPO_URL: https://central.sonatype.com/repository/maven-snapshots/
   COMMIT_MAP_FILENAME: commit-history-async-query-core.json
 
 jobs:
@@ -40,15 +40,15 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: aws-actions/configure-aws-credentials@v1.7.0
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
-
-      - name: Setup publishing credentials
-        id: creds
-        run: |
-          .github/get-sonatype-credentials.sh
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
 
       - name: Set commit ID
         id: set_commit

--- a/.github/workflows/publish-grammar-files.yml
+++ b/.github/workflows/publish-grammar-files.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SNAPSHOT_REPO_URL: https://aws.oss.sonatype.org/content/repositories/snapshots/
+  SNAPSHOT_REPO_URL: https://central.sonatype.com/repository/maven-snapshots/
   COMMIT_MAP_FILENAME: commit-history-language-grammar.json
 
 jobs:
@@ -44,15 +44,15 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: aws-actions/configure-aws-credentials@v1.7.0
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
-
-      - name: Setup publishing credentials
-        id: creds
-        run: |
-          .github/get-sonatype-credentials.sh
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
 
       - name: Set version
         id: set_version

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -70,7 +70,7 @@ ext {
     noticeFile = rootProject.file('NOTICE')
 
     getSecurityPluginDownloadLink = { ->
-        var repo = "https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/plugin/" +
+        var repo = "https://central.sonatype.com/repository/maven-snapshots/org/opensearch/plugin/" +
                    "opensearch-security/$opensearch_build_snapshot/"
         var metadataFile = Paths.get(projectDir.toString(), "build", "maven-metadata.xml").toAbsolutePath().toFile()
         download.run {

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -70,7 +70,7 @@ ext {
     noticeFile = rootProject.file('NOTICE')
 
     getSecurityPluginDownloadLink = { ->
-        var repo = "https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/" +
+        var repo = "https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/plugin/" +
                    "opensearch-security/$opensearch_build_snapshot/"
         var metadataFile = Paths.get(projectDir.toString(), "build", "maven-metadata.xml").toAbsolutePath().toFile()
         download.run {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -82,7 +82,7 @@ publishing {
     repositories {
         maven {
             name = "Snapshots" //  optional target repository name
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
             credentials {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"


### PR DESCRIPTION
### Description
Update the maven snapshot publish endpoint and credential

Previous description from #3806 :
> Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration.
[central.sonatype.org/publish/publish-portal-snapshots](https://central.sonatype.org/publish/publish-portal-snapshots/)
We have stored the onepassword token in this repo secrets and new credentials for Sonatypes username & password have been stored in onepassword. These credentials will be exported as env variables which used by maven publish.

### Related Issues
* Relate https://github.com/opensearch-project/opensearch-build/issues/5551
* Resolves #3856
* Resolves the conflict of #3806
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
