### PR TITLE
CVE-2025-48924: upgrade commons-lang3 to 3.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ buildscript {
         mockito_version = "5.7.0"
         commons_io_version = "2.14.0"
         commons_text_version = "1.10.0"
-        commons_lang3_version = "3.12.0"
+        commons_lang3_version = "3.18.0"
         // enforce 1.13, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
         commons_codec_version = "1.13"
         commons_logging_version = "1.2"
@@ -145,7 +145,7 @@ allprojects {
         resolutionStrategy.force 'org.locationtech.jts:jts-core:1.19.0'
         resolutionStrategy.force 'com.google.errorprone:error_prone_annotations:2.28.0'
         resolutionStrategy.force 'org.checkerframework:checker-qual:3.43.0'
-        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.13.0'
+        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.18.0'
         resolutionStrategy.force 'org.apache.commons:commons-text:1.11.0'
         resolutionStrategy.force 'commons-io:commons-io:2.15.0'
         resolutionStrategy.force 'org.yaml:snakeyaml:2.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     api "net.minidev:json-smart:${versions.json_smart}"
     api('org.apache.calcite:calcite-core:1.38.0') {
         exclude group: 'net.minidev', module: 'json-smart'
+        exclude group: 'commons-lang', module: 'commons-lang'
     }
     api 'org.apache.calcite:calcite-linq4j:1.38.0'
     api project(':common')


### PR DESCRIPTION
### Description
Fix [CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v)

https://github.com/opensearch-project/opensearch-build/issues/5637

- upgrade commons-lang3 to 3.18.0
- remove commons-lang (introduced by net.hydromatic:aggdesigner-algorithm:6.0 which is not used in our code. aggdesigner is used when the schema contains Lattice entities)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
