### PR TITLE
[Backport 2.x] CVE-2025-48924: upgrade commons-lang3 to 3.18.0 (#3895)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ allprojects {
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0"
         resolutionStrategy.force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0"
         resolutionStrategy.force "net.bytebuddy:byte-buddy:1.14.9"
+        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.18.0'
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     api "org.antlr:antlr4-runtime:4.7.1"
     api group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     api group: 'org.apache.logging.log4j', name: 'log4j-core', version:"${versions.log4j}"
-    api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    api group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.3'
     api group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation 'com.github.babbel:okhttp-aws-signer:1.0.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
     api group: 'com.google.guava', name: 'guava', version: "${guava_version}"
-    api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    api group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     api group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     api group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     }
     implementation group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     implementation group: 'org.json', name: 'json', version:'20231013'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     // add geo module as dependency. https://github.com/opensearch-project/OpenSearch/pull/4180/.


### PR DESCRIPTION
Manually backport https://github.com/opensearch-project/sql/pull/3895