### PR TITLE
[Backport 2.19-dev] CVE-2025-48924: upgrade commons-lang3 to 3.18.0 (#3895)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ buildscript {
         mockito_version = "5.7.0"
         commons_io_version = "2.14.0"
         commons_text_version = "1.10.0"
-        commons_lang3_version = "3.12.0"
+        commons_lang3_version = "3.18.0"
         // enforce 1.13, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
         commons_codec_version = "1.13"
         commons_logging_version = "1.2"
@@ -145,7 +145,7 @@ allprojects {
         resolutionStrategy.force 'org.locationtech.jts:jts-core:1.19.0'
         resolutionStrategy.force 'com.google.errorprone:error_prone_annotations:2.28.0'
         resolutionStrategy.force 'org.checkerframework:checker-qual:3.43.0'
-        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.13.0'
+        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.18.0'
         resolutionStrategy.force 'org.apache.commons:commons-text:1.11.0'
         resolutionStrategy.force 'commons-io:commons-io:2.15.0'
         resolutionStrategy.force 'org.yaml:snakeyaml:2.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     api "net.minidev:json-smart:2.5.2"
     api('org.apache.calcite:calcite-core:1.38.0') {
         exclude group: 'net.minidev', module: 'json-smart'
+        exclude group: 'commons-lang', module: 'commons-lang'
     }
     api 'org.apache.calcite:calcite-linq4j:1.38.0'
     api project(':common')


### PR DESCRIPTION
* CVE-2025-48924: upgrade commons-lang3 to 3.18.0



* Exclude the dependency commons-lang



---------


(cherry picked from commit 96d0d1434f7736f8e697722ec8ddd95122be7d2a)