### PR TITLE
[Backport 2.19-dev]Push down QUERY_SIZE_LIMIT (#3880)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/plan/Scannable.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/Scannable.java
@@ -16,5 +16,5 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public interface Scannable {
 
-  public Enumerable<@Nullable Object> scan();
+  public Enumerable<@Nullable Object> scanWithLimit();
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
@@ -302,7 +302,7 @@ public class CalciteToolsHelper {
       RelDataType resultType = root.rel.getRowType();
       boolean isDml = root.kind.belongsTo(SqlKind.DML);
       if (root.rel instanceof Scannable) {
-        final Bindable bindable = dataContext -> ((Scannable) root.rel).scan();
+        final Bindable bindable = dataContext -> ((Scannable) root.rel).scanWithLimit();
 
         return new PreparedResultImpl(
             resultType,

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -98,9 +98,7 @@ public class QueryService {
               () -> {
                 CalcitePlanContext context =
                     CalcitePlanContext.create(
-                        buildFrameworkConfig(),
-                        settings.getSettingValue(Key.QUERY_SIZE_LIMIT),
-                        queryType);
+                        buildFrameworkConfig(), getQuerySizeLimit(), queryType);
                 RelNode relNode = analyze(plan, context);
                 RelNode optimized = optimize(relNode);
                 RelNode calcitePlan = convertToCalcitePlan(optimized);

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_limit_10from1_10from2_push.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_limit_10from1_10from2_push.json
@@ -1,6 +1,6 @@
 {
   "calcite": {
     "logical": "LogicalProject(age=[$8])\n  LogicalSort(offset=[2], fetch=[10])\n    LogicalSort(offset=[1], fetch=[10])\n      CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
-    "physical": "CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[LIMIT->10, LIMIT->10, PROJECT->[age]], OpenSearchRequestBuilder(sourceBuilder={\"from\":3,\"size\":8,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]}}, requestedTotalSize=8, pageSize=null, startFrom=3)])\n"
+    "physical": "CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[LIMIT->10, PROJECT->[age], LIMIT->10], OpenSearchRequestBuilder(sourceBuilder={\"from\":3,\"size\":8,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]}}, requestedTotalSize=8, pageSize=null, startFrom=3)])\n"
   }
 }

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_limit_5_10_push.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_limit_5_10_push.json
@@ -1,6 +1,6 @@
 {
   "calcite": {
     "logical": "LogicalProject(age=[$8])\n  LogicalSort(fetch=[10])\n    LogicalSort(fetch=[5])\n      CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
-    "physical": "EnumerableLimit(fetch=[10])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[LIMIT->5, PROJECT->[age]], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]}}, requestedTotalSize=5, pageSize=null, startFrom=0)])\n"
+    "physical": "CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[LIMIT->5, PROJECT->[age], LIMIT->10], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]}}, requestedTotalSize=5, pageSize=null, startFrom=0)])\n"
   }
 }


### PR DESCRIPTION
* Push down QUERY_SIZE_LIMIT



* Fix compiling



* Use QUERY_SIZE_LIMIT in osIndex settings directly



* Revert code



* SpotlessApply after resolving conflict



---------



(cherry picked from commit 0bded2aa4d9c80e07929fdc91bac1f74d1e18f7c)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
