### PR TITLE
ML command supports category_field parameter

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/MLOperator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/MLOperator.java
@@ -5,7 +5,8 @@
 
 package org.opensearch.sql.opensearch.planner.physical;
 
-import java.util.ArrayList;
+import static org.opensearch.sql.utils.MLCommonsConstants.CATEGORY_FIELD;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -14,6 +15,7 @@ import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.ml.common.dataframe.DataFrame;
 import org.opensearch.ml.common.dataframe.Row;
 import org.opensearch.ml.common.output.MLOutput;
@@ -42,28 +44,40 @@ public class MLOperator extends MLCommonsOperatorActions {
   @Override
   public void open() {
     super.open();
-    DataFrame inputDataFrame = generateInputDataset(input);
     Map<String, Object> args = processArgs(arguments);
 
-    MLOutput mlOutput = getMLOutput(inputDataFrame, args, nodeClient);
-    final Iterator<Row> inputRowIter = inputDataFrame.iterator();
+    // Check if category_field is provided
+    String categoryField =
+        arguments.containsKey(CATEGORY_FIELD)
+            ? (String) arguments.get(CATEGORY_FIELD).getValue()
+            : null;
+
     // Only need to check train here, as action should be already checked in ml client.
     final boolean isPrediction = ((String) args.get("action")).equals("train") ? false : true;
-    // For train, only one row to return.
-    final Iterator<String> trainIter =
-        new ArrayList<String>() {
-          {
-            add("train");
-          }
-        }.iterator();
-    final Iterator<Row> resultRowIter =
-        isPrediction ? ((MLPredictionOutput) mlOutput).getPredictionResult().iterator() : null;
+    final Iterator<String> trainIter = Collections.singletonList("train").iterator();
+
+    // For prediction mode, handle both categorized and non-categorized cases
+    List<Pair<DataFrame, DataFrame>> inputDataFrames =
+        generateCategorizedInputDataset(input, categoryField);
+    List<MLOutput> mlOutputs =
+        inputDataFrames.stream()
+            .map(pair -> getMLOutput(pair.getRight(), args, nodeClient))
+            .toList();
+    Iterator<Pair<DataFrame, DataFrame>> inputDataFramesIter = inputDataFrames.iterator();
+    Iterator<MLOutput> mlOutputIter = mlOutputs.iterator();
+
     iterator =
-        new Iterator<ExprValue>() {
+        new Iterator<>() {
+          private DataFrame inputDataFrame = null;
+          private Iterator<Row> inputRowIter = null;
+          private MLOutput mlOutput = null;
+          private Iterator<Row> resultRowIter = null;
+
           @Override
           public boolean hasNext() {
             if (isPrediction) {
-              return inputRowIter.hasNext();
+              return (inputRowIter != null && inputRowIter.hasNext())
+                  || inputDataFramesIter.hasNext();
             } else {
               boolean res = trainIter.hasNext();
               if (res) {
@@ -75,8 +89,19 @@ public class MLOperator extends MLCommonsOperatorActions {
 
           @Override
           public ExprValue next() {
-            return buildPPLResult(
-                isPrediction, inputRowIter, inputDataFrame, mlOutput, resultRowIter);
+            if (isPrediction) {
+              if (inputRowIter == null || !inputRowIter.hasNext()) {
+                Pair<DataFrame, DataFrame> pair = inputDataFramesIter.next();
+                inputDataFrame = pair.getLeft();
+                inputRowIter = inputDataFrame.iterator();
+                mlOutput = mlOutputIter.next();
+                resultRowIter = ((MLPredictionOutput) mlOutput).getPredictionResult().iterator();
+              }
+              return buildPPLResult(true, inputRowIter, inputDataFrame, mlOutput, resultRowIter);
+            } else {
+              // train case
+              return buildPPLResult(false, null, null, mlOutputs.getFirst(), null);
+            }
           }
         };
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/planner/physical/MLOperatorTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/planner/physical/MLOperatorTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.opensearch.sql.utils.MLCommonsConstants.ACTION;
 import static org.opensearch.sql.utils.MLCommonsConstants.ALGO;
+import static org.opensearch.sql.utils.MLCommonsConstants.CATEGORY_FIELD;
 import static org.opensearch.sql.utils.MLCommonsConstants.KMEANS;
 import static org.opensearch.sql.utils.MLCommonsConstants.PREDICT;
 import static org.opensearch.sql.utils.MLCommonsConstants.TRAIN;
@@ -135,6 +136,21 @@ public class MLOperatorTest {
   @Test
   public void testOpenPredict() {
     setUpPredict();
+    try (MockedStatic<MLClient> mlClientMockedStatic = Mockito.mockStatic(MLClient.class)) {
+      when(MLClient.getMLClient(any(NodeClient.class))).thenReturn(machineLearningNodeClient);
+      mlOperator.open();
+      assertTrue(mlOperator.hasNext());
+      assertNotNull(mlOperator.next());
+      assertFalse(mlOperator.hasNext());
+    }
+  }
+
+  @Test
+  public void testOpenPredictWithCategoryField() {
+    setUpPredict();
+    // Add category_field parameter
+    arguments.put(CATEGORY_FIELD, AstDSL.stringLiteral("region"));
+
     try (MockedStatic<MLClient> mlClientMockedStatic = Mockito.mockStatic(MLClient.class)) {
       when(MLClient.getMLClient(any(NodeClient.class))).thenReturn(machineLearningNodeClient);
       mlOperator.open();


### PR DESCRIPTION
### Description

From the document of [ML command](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/cmd/ml.rst), it shows that ml supports `category_field` command, but actually it doesn't work. This PR makes ML command supports category_field parameter. 

Request:
```
POST _plugins/_ppl?format=jdbc
{
  "query":"source = abcd_test | eval value = cast(value as double) | fields value, category | ml action='trainandpredict' algorithm='rcf' input='value' category_field='category'"
}
```
Response:
```
{
  "schema": [
    {
      "name": "value",
      "type": "double"
    },
    {
      "name": "category",
      "type": "string"
    },
    {
      "name": "score",
      "type": "double"
    },
    {
      "name": "anomalous",
      "type": "boolean"
    }
  ],
  "datarows": [
    [
      1,
      "a",
      0,
      false
    ],
    [
      2,
      "b",
      0,
      false
    ]
  ],
  "total": 2,
  "size": 2
}
```


### Related Issues
https://github.com/opensearch-project/sql/issues/3406

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
