### PR TITLE
[Backport 2.19-dev] Default to UTC for date/time functions across PPL and SQL

### DIFF
--- a/common/src/main/java/org/opensearch/sql/common/grok/GrokCompiler.java
+++ b/common/src/main/java/org/opensearch/sql/common/grok/GrokCompiler.java
@@ -117,7 +117,7 @@ public class GrokCompiler implements Serializable {
   }
 
   public Grok compile(final String pattern, boolean namedOnly) throws IllegalArgumentException {
-    return compile(pattern, ZoneOffset.systemDefault(), namedOnly);
+    return compile(pattern, ZoneOffset.UTC, namedOnly);
   }
 
   /**

--- a/common/src/test/java/org/opensearch/sql/common/grok/GrokTest.java
+++ b/common/src/test/java/org/opensearch/sql/common/grok/GrokTest.java
@@ -680,8 +680,7 @@ public class GrokTest {
     DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss");
     Grok grok = compiler.compile("%{DATESTAMP:timestamp;date;MM/dd/yyyy HH:mm:ss}", true);
     Instant instant = (Instant) grok.match(date).capture().get("timestamp");
-    assertEquals(
-        ZonedDateTime.parse(date, dtf.withZone(ZoneOffset.systemDefault())).toInstant(), instant);
+    assertEquals(ZonedDateTime.parse(date, dtf.withZone(ZoneOffset.UTC)).toInstant(), instant);
 
     // set default timezone to PST
     ZoneId pst = ZoneId.of("PST", ZoneId.SHORT_IDS);

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/UserDefinedFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/UserDefinedFunctionUtils.java
@@ -12,12 +12,13 @@ import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT.*;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.adapter.enumerable.NotNullImplementor;
@@ -137,8 +138,7 @@ public class UserDefinedFunctionUtils {
     Instant instant =
         Instant.ofEpochSecond(
             currentTimeInNanos / 1_000_000_000, currentTimeInNanos % 1_000_000_000);
-    TimeZone timeZone = TimeZone.getDefault();
-    ZoneId zoneId = timeZone.toZoneId();
+    ZoneId zoneId = ZoneOffset.UTC;
     return new FunctionProperties(instant, zoneId, QueryType.PPL);
   }
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/FunctionProperties.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/FunctionProperties.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.opensearch.sql.executor.QueryType;
@@ -17,7 +18,7 @@ import org.opensearch.sql.executor.QueryType;
 public class FunctionProperties implements Serializable {
 
   private final Instant nowInstant;
-  private final ZoneId currentZoneId;
+  @Getter private final ZoneId currentZoneId;
   @Getter private final QueryType queryType;
 
   /** By default, use current time and current timezone. */
@@ -26,7 +27,7 @@ public class FunctionProperties implements Serializable {
   }
 
   public FunctionProperties(QueryType queryType) {
-    this(Instant.now(), ZoneId.systemDefault(), queryType);
+    this(Instant.now(), ZoneOffset.UTC, queryType);
   }
 
   public FunctionProperties(Instant nowInstant, ZoneId currentZoneId) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/DatetimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/DatetimeFunction.java
@@ -16,9 +16,11 @@ import org.apache.calcite.sql.type.CompositeOperandTypeChecker;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.opensearch.sql.calcite.utils.PPLReturnTypes;
+import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
+import org.opensearch.sql.expression.function.FunctionProperties;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 
@@ -57,20 +59,23 @@ public class DatetimeFunction extends ImplementorUDF {
     @Override
     public Expression implement(
         RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
-      return Expressions.call(DatetimeImplementor.class, "datetime", translatedOperands);
+      List<Expression> operandsWithProperties =
+          UserDefinedFunctionUtils.prependFunctionProperties(translatedOperands, translator);
+      return Expressions.call(DatetimeImplementor.class, "datetime", operandsWithProperties);
     }
 
-    public static String datetime(String timestamp) {
+    public static String datetime(FunctionProperties properties, String timestamp) {
       ExprValue argTimestampExpr = new ExprStringValue(timestamp);
       ExprValue datetimeExpr;
-      datetimeExpr = DateTimeFunctions.exprDateTimeNoTimezone(argTimestampExpr);
+      datetimeExpr = DateTimeFunctions.exprDateTimeNoTimezone(properties, argTimestampExpr);
       return (String) datetimeExpr.valueForCalcite();
     }
 
-    public static String datetime(String timestamp, String timezone) {
+    public static String datetime(
+        FunctionProperties properties, String timestamp, String timezone) {
       ExprValue timestampExpr = new ExprStringValue(timestamp);
       ExprValue datetimeExpr =
-          DateTimeFunctions.exprDateTime(timestampExpr, new ExprStringValue(timezone));
+          DateTimeFunctions.exprDateTime(properties, timestampExpr, new ExprStringValue(timezone));
       return (String) datetimeExpr.valueForCalcite();
     }
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/SysdateFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/SysdateFunction.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.expression.function.udf.datetime;
 
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.prependFunctionProperties;
 import java.time.Clock;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -19,6 +20,7 @@ import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.calcite.utils.PPLReturnTypes;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
+import org.opensearch.sql.expression.function.FunctionProperties;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 
@@ -55,16 +57,18 @@ public class SysdateFunction extends ImplementorUDF {
     @Override
     public Expression implement(
         RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
-      return Expressions.call(SysdateImplementor.class, "sysdate", translatedOperands);
+      List<Expression> operandsWithProperties =
+          prependFunctionProperties(translatedOperands, translator);
+      return Expressions.call(SysdateImplementor.class, "sysdate", operandsWithProperties);
     }
 
-    public static String sysdate() {
-      var localDateTime = DateTimeFunctions.formatNow(Clock.systemDefaultZone(), 0);
+    public static String sysdate(FunctionProperties properties) {
+      var localDateTime = DateTimeFunctions.formatNow(properties.getSystemClock(), 0);
       return (String) new ExprTimestampValue(localDateTime.toInstant(ZoneOffset.UTC)).valueForCalcite();
     }
 
-    public static String sysdate(int precision) {
-      var localDateTime = DateTimeFunctions.formatNow(Clock.systemDefaultZone(), precision);
+    public static String sysdate(FunctionProperties properties, int precision) {
+      var localDateTime = DateTimeFunctions.formatNow(properties.getSystemClock(), precision);
       return (String) new ExprTimestampValue(localDateTime.toInstant(ZoneOffset.UTC)).valueForCalcite();
     }
   }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTest.java
@@ -11,9 +11,9 @@ import static org.opensearch.sql.data.type.ExprCoreType.DATETIME;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.data.model.ExprDatetimeValue;
 import org.opensearch.sql.expression.DSL;
@@ -44,21 +44,19 @@ class DateTimeTest extends ExpressionTestBase {
     assertEquals(new ExprDatetimeValue("2008-05-15 14:00:00"), expr.valueOf());
   }
 
-  // When no timezone argument is passed inside the datetime field, it assumes local time.
+  // When no timezone argument is passed inside the datetime field, it assumes UTC time.
   @Test
   public void localDateTimeConversion() {
-    // needs to work for all time zones because it defaults to local timezone.
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     String dt = "2008-05-15 22:00:00";
     String timeZone = "America/Los_Angeles";
-    LocalDateTime timeConverted = LocalDateTime.parse(dt, formatter);
-    ZonedDateTime timeZoneLocal =
-        timeConverted
-            .atZone(ZoneId.of(TimeZone.getDefault().getID()))
-            .withZoneSameInstant(ZoneId.of(timeZone));
+    LocalDateTime utcDatetime = LocalDateTime.parse(dt, formatter);
+    ZonedDateTime laDatetime =
+        utcDatetime.atZone(ZoneOffset.UTC).withZoneSameInstant(ZoneId.of(timeZone));
+    // Convert dt (assumed to be in UTC) to the specified time zone.
     FunctionExpression expr = DSL.datetime(DSL.literal(dt), DSL.literal(timeZone));
     assertEquals(DATETIME, expr.type());
-    assertEquals(new ExprDatetimeValue(timeZoneLocal.toLocalDateTime()), expr.valueOf());
+    assertEquals(new ExprDatetimeValue(laDatetime.toLocalDateTime()), expr.valueOf());
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/ExtractTest.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.IsoFields;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -137,7 +138,7 @@ class ExtractTest extends ExpressionTestBase {
   public void testExtractWeekPartWithTimeType(String arg) {
 
     // setup default date/time properties for the extract function
-    ZoneId currentZoneId = ZoneId.systemDefault();
+    ZoneId currentZoneId = ZoneOffset.UTC;
     Instant nowInstant =
         LocalDate.parse(arg).atTime(LocalTime.parse(timeInput)).atZone(currentZoneId).toInstant();
     FunctionProperties properties = new FunctionProperties(nowInstant, currentZoneId);

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/NowLikeFunctionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/NowLikeFunctionTest.java
@@ -16,12 +16,12 @@ import static org.opensearch.sql.utils.DateTimeUtils.UTC_ZONE_ID;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalUnit;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -133,9 +133,8 @@ class NowLikeFunctionTest extends ExpressionTestBase {
 
   private static LocalDateTime utcDateTimeNow(FunctionProperties functionProperties) {
     ZonedDateTime zonedDateTime =
-        LocalDateTime.now(functionProperties.getQueryStartClock())
-            .atZone(TimeZone.getDefault().toZoneId());
-    return zonedDateTime.withZoneSameInstant(UTC_ZONE_ID).toLocalDateTime();
+        LocalDateTime.now(functionProperties.getQueryStartClock()).atZone(ZoneOffset.UTC);
+    return zonedDateTime.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
   }
 
   /**

--- a/core/src/test/java/org/opensearch/sql/expression/function/FunctionPropertiesTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/FunctionPropertiesTest.java
@@ -16,7 +16,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +33,7 @@ class FunctionPropertiesTest {
   @BeforeEach
   void init() {
     startTime = Instant.now();
-    functionProperties = new FunctionProperties(startTime, ZoneId.systemDefault());
+    functionProperties = new FunctionProperties(startTime, ZoneOffset.UTC);
   }
 
   @Test
@@ -50,7 +50,7 @@ class FunctionPropertiesTest {
 
   @Test
   void getSystemClock_is_systemClock() {
-    assertEquals(Clock.systemDefaultZone(), functionProperties.getSystemClock());
+    assertEquals(Clock.system(ZoneOffset.UTC), functionProperties.getSystemClock());
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/utils/DateTimeUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/utils/DateTimeUtilsTest.java
@@ -11,7 +11,7 @@ import static org.opensearch.sql.utils.DateTimeUtils.getRelativeZonedDateTime;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
@@ -22,13 +22,13 @@ public class DateTimeUtilsTest {
   void round() {
     long actual =
         LocalDateTime.parse("2021-09-28T23:40:00")
-            .atZone(ZoneId.systemDefault())
+            .atZone(ZoneOffset.UTC)
             .toInstant()
             .toEpochMilli();
     long rounded = DateTimeUtils.roundFloor(actual, TimeUnit.HOURS.toMillis(1));
     assertEquals(
         LocalDateTime.parse("2021-09-28T23:00:00")
-            .atZone(ZoneId.systemDefault())
+            .atZone(ZoneOffset.UTC)
             .toInstant()
             .toEpochMilli(),
         Instant.ofEpochMilli(rounded).toEpochMilli());
@@ -36,7 +36,7 @@ public class DateTimeUtilsTest {
 
   @Test
   void testRelativeZonedDateTimeWithNow() {
-    ZonedDateTime now = ZonedDateTime.ofInstant(Instant.now(), ZoneId.systemDefault());
+    ZonedDateTime now = ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
     assertEquals(getRelativeZonedDateTime("now", now), now);
     assertEquals(getRelativeZonedDateTime("now()", now), now);
   }
@@ -47,7 +47,7 @@ public class DateTimeUtilsTest {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
+    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
     ZonedDateTime snap1 = getRelativeZonedDateTime("-1d@d", zonedDateTime);
     ZonedDateTime snap2 = getRelativeZonedDateTime("-3d-2h@h", zonedDateTime);
     assertEquals(snap1.toLocalDateTime().toString(), "2025-10-21T00:00");
@@ -60,7 +60,7 @@ public class DateTimeUtilsTest {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
+    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
     ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@mon", zonedDateTime);
     ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2h+10m@h", zonedDateTime);
     assertEquals(snap1.toLocalDateTime().toString(), "2026-10-01T00:00");
@@ -73,7 +73,7 @@ public class DateTimeUtilsTest {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
+    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
     ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@Month", zonedDateTime);
     ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2h+10m@hours", zonedDateTime);
     assertEquals(snap1.toLocalDateTime().toString(), "2026-10-01T00:00");
@@ -86,7 +86,7 @@ public class DateTimeUtilsTest {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
+    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
     ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@W5", zonedDateTime);
     ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2q+10m@quarter", zonedDateTime);
     assertEquals(snap1.toLocalDateTime().toString(), "2026-10-16T00:00");
@@ -99,7 +99,7 @@ public class DateTimeUtilsTest {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
+    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class, () -> getRelativeZonedDateTime("1d+1y", zonedDateTime));

--- a/docs/user/ppl/functions/datetime.rst
+++ b/docs/user/ppl/functions/datetime.rst
@@ -8,6 +8,12 @@ Date and Time Functions
    :local:
    :depth: 1
 
+.. note::
+
+    All PPL date and time functions use the UTC time zone. Both input and output values are interpreted as UTC.
+    For instance, an input timestamp literal like '2020-08-26 01:01:01' is assumed to be in UTC, and the now()
+    function also returns the current date and time in UTC.
+
 ADDDATE
 -------
 
@@ -112,7 +118,7 @@ Description
 
 Usage: convert_tz(datetime, from_timezone, to_timezone) constructs a local datetime converted from the from_timezone to the to_timezone. CONVERT_TZ returns null when any of the three function arguments are invalid, i.e. datetime is not in the format yyyy-MM-dd HH:mm:ss or the timeszone is not in (+/-)HH:mm. It also is invalid for invalid dates, such as February 30th and invalid timezones, which are ones outside of -13:59 and +14:00.
 
-Argument type: DATETIME, STRING, STRING
+Argument type: DATETIME/STRING, STRING, STRING
 
 Return type: DATETIME
 
@@ -244,8 +250,9 @@ CURDATE
 Description
 >>>>>>>>>>>
 
-Returns the current time as a value in 'YYYY-MM-DD'.
-CURDATE() returns the time at which it executes as `SYSDATE() <#sysdate>`_ does.
+Returns the current date as a value in 'YYYY-MM-DD' format.
+CURDATE() returns the current date in UTC at the time the statement is executed.
+
 
 Return type: DATE
 
@@ -268,7 +275,7 @@ CURRENT_DATE
 Description
 >>>>>>>>>>>
 
-`CURRENT_DATE()` are synonyms for `CURDATE() <#curdate>`_.
+`CURRENT_DATE()` is a synonym for `CURDATE() <#curdate>`_.
 
 Example::
 
@@ -287,7 +294,7 @@ CURRENT_TIME
 Description
 >>>>>>>>>>>
 
-`CURRENT_TIME()` are synonyms for `CURTIME() <#curtime>`_.
+`CURRENT_TIME()` is a synonym for `CURTIME() <#curtime>`_.
 
 Example::
 
@@ -306,7 +313,7 @@ CURRENT_TIMESTAMP
 Description
 >>>>>>>>>>>
 
-`CURRENT_TIMESTAMP()` are synonyms for `NOW() <#now>`_.
+`CURRENT_TIMESTAMP()` is a synonym for `NOW() <#now>`_.
 
 Example::
 
@@ -325,7 +332,7 @@ CURTIME
 Description
 >>>>>>>>>>>
 
-Returns the current time as a value in 'hh:mm:ss'.
+Returns the current time as a value in 'hh:mm:ss' format in the UTC time zone.
 CURTIME() returns the time at which the statement began to execute as `NOW() <#now>`_ does.
 
 Return type: TIME
@@ -1188,7 +1195,7 @@ Example::
 
 
 MINUTE_OF_DAY
-------
+-------------
 
 Description
 >>>>>>>>>>>
@@ -1314,7 +1321,7 @@ NOW
 Description
 >>>>>>>>>>>
 
-Returns the current date and time as a value in 'YYYY-MM-DD hh:mm:ss' format. The value is expressed in the cluster time zone.
+Returns the current date and time as a value in 'YYYY-MM-DD hh:mm:ss' format. The value is expressed in the UTC time zone.
 `NOW()` returns a constant time that indicates the time at which the statement began to execute. This differs from the behavior for `SYSDATE() <#sysdate>`_, which returns the exact time at which it executes.
 
 Return type: DATETIME
@@ -1605,8 +1612,8 @@ Description
 >>>>>>>>>>>
 
 Returns the current date and time as a value in 'YYYY-MM-DD hh:mm:ss[.nnnnnn]'.
-SYSDATE() returns the time at which it executes. This differs from the behavior for `NOW() <#now>`_, which returns a constant time that indicates the time at which the statement began to execute.
-If the argument is given, it specifies a fractional seconds precision from 0 to 6, the return value includes a fractional seconds part of that many digits.
+SYSDATE() returns the date and time at which it executes in UTC. This differs from the behavior for `NOW() <#now>`_, which returns a constant time that indicates the time at which the statement began to execute.
+If an argument is given, it specifies a fractional seconds precision from 0 to 6, the return value includes a fractional seconds part of that many digits.
 
 Optional argument type: INTEGER
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteDateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteDateTimeFunctionIT.java
@@ -19,6 +19,7 @@ public class CalciteDateTimeFunctionIT extends DateTimeFunctionIT {
   }
 
   // TODO: Remove this when supporting type coercion and casting with Calcite
+  //  https://github.com/opensearch-project/sql/issues/3761
   @Ignore
   @Override
   public void testUnixTimestampWithTimestampString() throws IOException {}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -51,8 +51,7 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
   }
 
   private static String getFormattedLocalDate() {
-    return LocalDateTime.now(ZoneId.systemDefault())
-        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    return LocalDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
   }
 
   void verifyDateFormat(String date, String type, String format, String formatted)
@@ -105,7 +104,7 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
 
   @Test
   public void testTimestampWithTimeInput() throws IOException {
-    String utcTomorrow = LocalDate.now().plusDays(1).toString();
+    String utcTomorrow = LocalDate.now(ZoneOffset.UTC).plusDays(1).toString();
     JSONObject actual =
         executeQuery(
             String.format(
@@ -927,7 +926,7 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
     final String thu = DayOfWeek.THURSDAY.getDisplayName(TextStyle.FULL, Locale.getDefault());
     final String apr = Month.APRIL.getDisplayName(TextStyle.FULL, Locale.getDefault());
     final String dec = Month.DECEMBER.getDisplayName(TextStyle.FULL, Locale.getDefault());
-    LocalDate today = LocalDate.now(ZoneId.systemDefault());
+    LocalDate today = LocalDate.now(ZoneOffset.UTC);
     LocalDate lastDayOfToday =
         LocalDate.of(
             today.getYear(), today.getMonth(), today.getMonth().length(today.isLeapYear()));
@@ -1021,7 +1020,7 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         schema("d13", "string"));
 
     Instant expectedInstant =
-        LocalDateTime.parse("1984-04-12T09:07:42").atZone(ZoneOffset.systemDefault()).toInstant();
+        LocalDateTime.parse("1984-04-12T09:07:42").atZone(ZoneOffset.UTC).toInstant();
     LocalDateTime offsetUTC = LocalDateTime.ofInstant(expectedInstant, ZoneOffset.UTC);
     LocalDateTime offsetPlus8 = LocalDateTime.ofInstant(expectedInstant, ZoneId.of("+08:00"));
     String expectedDatetimeAtUTC =
@@ -1077,7 +1076,7 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         schema("d9", "bigint"),
         schema("t", "time"));
 
-    LocalDate today = LocalDate.now(ZoneId.systemDefault());
+    LocalDate today = LocalDate.now(ZoneOffset.UTC);
     long dateDiffWithToday = ChronoUnit.DAYS.between(LocalDate.parse("1984-04-12"), today);
     verifyDataRows(
         actual,

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
@@ -15,7 +15,9 @@ import static org.opensearch.sql.util.MatcherUtils.verifySome;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.TimeZone;
 import org.json.JSONObject;
@@ -23,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
 import org.opensearch.sql.common.utils.StringUtils;
 
 @SuppressWarnings("unchecked")
@@ -1608,5 +1611,32 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
                 TEST_INDEX_DATE));
     verifySchema(result, schema("f1", null, "bigint"), schema("f2", null, "bigint"));
     verifySome(result.getJSONArray("datarows"), rows(1997L, 17L));
+  }
+
+  @Test
+  public void testCompareAgainstUTCDate() throws IOException {
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    String isoTimestamp = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+    String pplTimestamp = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    // a random ID that did not exist in the index bank
+    int DOC_ID = 40;
+    Request putRequest =
+        new Request("PUT", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_BANK, DOC_ID));
+    putRequest.setJsonEntity(String.format("{\"birthdate\":\"%s\"}", isoTimestamp));
+    client().performRequest(putRequest);
+
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where birthdate > date_sub(now(), interval 1 hour) and birthdate <"
+                    + " date_add(now(), interval 1 hour) | fields birthdate",
+                TEST_INDEX_BANK));
+
+    Request deleteRequest =
+        new Request("DELETE", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_BANK, DOC_ID));
+    client().performRequest(deleteRequest);
+
+    verifySchema(result, schema("birthdate", "timestamp"));
+    verifyDataRows(result, rows(pplTimestamp));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/NowLikeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/NowLikeFunctionIT.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
@@ -91,7 +92,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 false,
                 false,
                 true,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -99,7 +100,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 false,
                 false,
                 true,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -107,7 +108,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 false,
                 false,
                 true,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -115,7 +116,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 false,
                 false,
                 true,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -123,7 +124,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 true,
                 false,
                 false,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -131,7 +132,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 false,
                 false,
                 false,
-                (Supplier<Temporal>) LocalTime::now,
+                (Supplier<Temporal>) () -> LocalTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
                 "HH:mm:ss"),
             $(
@@ -139,7 +140,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 false,
                 false,
                 false,
-                (Supplier<Temporal>) LocalTime::now,
+                (Supplier<Temporal>) () -> LocalTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
                 "HH:mm:ss"),
             $(
@@ -147,7 +148,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 false,
                 false,
                 false,
-                (Supplier<Temporal>) LocalDate::now,
+                (Supplier<Temporal>) () -> LocalDate.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
                 "uuuu-MM-dd"),
             $(
@@ -155,7 +156,7 @@ public class NowLikeFunctionIT extends PPLIntegTestCase {
                 false,
                 false,
                 false,
-                (Supplier<Temporal>) LocalDate::now,
+                (Supplier<Temporal>) () -> LocalDate.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
                 "uuuu-MM-dd"),
             $(

--- a/integ-test/src/test/java/org/opensearch/sql/sql/NowLikeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/NowLikeFunctionIT.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -96,7 +97,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 false,
                 false,
                 true,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -104,7 +105,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 false,
                 false,
                 true,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -112,7 +113,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 false,
                 false,
                 true,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -120,7 +121,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 false,
                 false,
                 true,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -128,7 +129,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 true,
                 false,
                 false,
-                (Supplier<Temporal>) LocalDateTime::now,
+                (Supplier<Temporal>) () -> LocalDateTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDateTime::parse,
                 "uuuu-MM-dd HH:mm:ss"),
             $(
@@ -136,7 +137,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 false,
                 false,
                 false,
-                (Supplier<Temporal>) LocalTime::now,
+                (Supplier<Temporal>) () -> LocalTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
                 "HH:mm:ss"),
             $(
@@ -144,7 +145,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 false,
                 false,
                 false,
-                (Supplier<Temporal>) LocalTime::now,
+                (Supplier<Temporal>) () -> LocalTime.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalTime::parse,
                 "HH:mm:ss"),
             $(
@@ -152,7 +153,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 false,
                 false,
                 false,
-                (Supplier<Temporal>) LocalDate::now,
+                (Supplier<Temporal>) () -> LocalDate.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
                 "uuuu-MM-dd"),
             $(
@@ -160,7 +161,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
                 false,
                 false,
                 false,
-                (Supplier<Temporal>) LocalDate::now,
+                (Supplier<Temporal>) () -> LocalDate.now(ZoneOffset.UTC),
                 (BiFunction<CharSequence, DateTimeFormatter, Temporal>) LocalDate::parse,
                 "uuuu-MM-dd"),
             $(
@@ -197,7 +198,7 @@ public class NowLikeFunctionIT extends SQLIntegTestCase {
   }
 
   public static LocalDateTime utcDateTimeNow() {
-    ZonedDateTime zonedDateTime = LocalDateTime.now().atZone(TimeZone.getDefault().toZoneId());
+    ZonedDateTime zonedDateTime = LocalDateTime.now(ZoneOffset.UTC).atZone(ZoneOffset.UTC);
     return zonedDateTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime();
   }
 


### PR DESCRIPTION
### Description
Backport  #3854 to 2.19-dev

### Related Issues
#3725

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
