### PR TITLE
Update commons-lang exclude rule to exclude it everywhere

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,7 +59,6 @@ dependencies {
     api "net.minidev:json-smart:${versions.json_smart}"
     api('org.apache.calcite:calcite-core:1.38.0') {
         exclude group: 'net.minidev', module: 'json-smart'
-        exclude group: 'commons-lang', module: 'commons-lang'
     }
     api 'org.apache.calcite:calcite-linq4j:1.38.0'
     api project(':common')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     api "net.minidev:json-smart:${versions.json_smart}"
     api('org.apache.calcite:calcite-core:1.38.0') {
         exclude group: 'net.minidev', module: 'json-smart'
+        exclude group: 'commons-lang', module: 'commons-lang'
     }
     api 'org.apache.calcite:calcite-linq4j:1.38.0'
     api project(':common')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -40,6 +40,11 @@ configurations {
     compile {
         extendsFrom = extendsFrom.findAll { it != configurations.antlr }
     }
+    configureEach {
+        resolutionStrategy {
+            exclude group: 'commons-lang', module: 'commons-lang'
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### Description
`commons-lang` was excluded as part of the `calcite-core` import for the `core` config, but still was being pulled in via another transient dependency chain in `ppl`. This PR updates the exclude to remove `commons-lang` everywhere.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
