### PR TITLE
Publish datasources module for downstream reuse in unified-ppl-2.19-dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ allprojects {
         resolutionStrategy.force 'org.locationtech.jts:jts-core:1.19.0'
         resolutionStrategy.force 'com.google.errorprone:error_prone_annotations:2.28.0'
         resolutionStrategy.force 'org.checkerframework:checker-qual:3.43.0'
-        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.13.0'
+        resolutionStrategy.force 'org.apache.commons:commons-lang3:3.18.0'
         resolutionStrategy.force 'org.apache.commons:commons-text:1.11.0'
         resolutionStrategy.force 'commons-io:commons-io:2.15.0'
         resolutionStrategy.force 'org.yaml:snakeyaml:2.2'
@@ -163,7 +163,7 @@ subprojects {
     }
 
     // Publish internal modules as Maven artifacts for external use, such as by opensearch-spark and opensearch-cli.
-    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol', 'datasources']
+    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol', 'datasources', 'legacy']
     if (publishedModules.contains(name)) {
         apply plugin: 'java-library'
         apply plugin: 'maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ subprojects {
     }
 
     // Publish internal modules as Maven artifacts for external use, such as by opensearch-spark and opensearch-cli.
-    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol']
+    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol', 'datasources']
     if (publishedModules.contains(name)) {
         apply plugin: 'java-library'
         apply plugin: 'maven-publish'


### PR DESCRIPTION
### Description
Add `datasources` module 

**Local Publishing Test**
Example after running the local publish command:

```
./gradlew publishUnifiedQueryPublicationToMavenLocal

tree -d ~/.m2/repository/org/opensearch
└── query
    ├── unified-query-api
    │   └── 2.19.0.0-SNAPSHOT
    ├── unified-query-common
    │   └── 2.19.0.0-SNAPSHOT
    ├── unified-query-core
    │   └── 2.19.0.0-SNAPSHOT
    ├── unified-query-datasources <- adding datasources 
    │   └── 2.19.0.0-SNAPSHOT
    ├── unified-query-opensearch
    │   └── 2.19.0.0-SNAPSHOT
    ├── unified-query-ppl
    │   └── 2.19.0.0-SNAPSHOT
    ├── unified-query-protocol
    │   └── 2.19.0.0-SNAPSHOT
    └── unified-query-sql
        └── 2.19.0.0-SNAPSHOT

```
### Related Issues
[3763](https://github.com/opensearch-project/sql/pull/3763)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
