### PR TITLE
Add auto-increment id to dynamic function signature

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
@@ -42,7 +42,7 @@ public class ExtendedRexBuilder extends RexBuilder {
 
   // For test only. Reset id to avoid unstable explain output of query.
   public static void resetId() {
-    threadCounter.get().set(0);
+    threadCounter.remove();
   }
 
   public ExtendedRexBuilder(RexBuilder rexBuilder) {

--- a/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
@@ -40,6 +40,11 @@ public class ExtendedRexBuilder extends RexBuilder {
     return threadCounter.get().getAndIncrement();
   }
 
+  // For test only. Reset id to avoid unstable explain output of query.
+  public static void resetId() {
+    threadCounter.get().set(0);
+  }
+
   public ExtendedRexBuilder(RexBuilder rexBuilder) {
     super(rexBuilder.getTypeFactory());
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
+import org.apache.calcite.sql.validate.SqlMonotonicity;
 import org.apache.calcite.util.BuiltInMethod;
 import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.calcite.utils.PPLReturnTypes;
@@ -180,11 +181,15 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
   public static final SqlOperator SECOND = new DatePartFunction(TimeUnit.SECOND).toUDF("SECOND");
   public static final SqlOperator MICROSECOND =
       new DatePartFunction(TimeUnit.MICROSECOND).toUDF("MICROSECOND");
-  public static final SqlOperator NOW = new CurrentFunction(ExprCoreType.TIMESTAMP).toUDF("NOW");
+  public static final SqlOperator NOW =
+      new CurrentFunction(ExprCoreType.TIMESTAMP)
+          .toUDF("NOW", false, false, SqlMonotonicity.INCREASING);
   public static final SqlOperator CURRENT_TIME =
-      new CurrentFunction(ExprCoreType.TIME).toUDF("CURRENT_TIME");
+      new CurrentFunction(ExprCoreType.TIME)
+          .toUDF("CURRENT_TIME", false, false, SqlMonotonicity.INCREASING);
   public static final SqlOperator CURRENT_DATE =
-      new CurrentFunction(ExprCoreType.DATE).toUDF("CURRENT_DATE");
+      new CurrentFunction(ExprCoreType.DATE)
+          .toUDF("CURRENT_DATE", false, false, SqlMonotonicity.INCREASING);
   public static final SqlOperator DATE_FORMAT =
       new FormatFunction(ExprCoreType.DATE).toUDF("DATE_FORMAT");
   public static final SqlOperator TIME_FORMAT =
@@ -272,7 +277,8 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
               NullPolicy.ANY,
               PPLOperandTypes.STRING_STRING)
           .toUDF("STR_TO_DATE");
-  public static final SqlOperator SYSDATE = new SysdateFunction().toUDF("SYSDATE");
+  public static final SqlOperator SYSDATE =
+      new SysdateFunction().toUDF("SYSDATE", false, true, SqlMonotonicity.INCREASING);
   public static final SqlOperator SEC_TO_TIME = new SecToTimeFunction().toUDF("SEC_TO_TIME");
   public static final SqlOperator TIME =
       adaptExprMethodToUDF(
@@ -357,11 +363,11 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
   public static final SqlOperator MATCH_PHRASE_PREFIX =
       RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("match_phrase_prefix");
   public static final SqlOperator SIMPLE_QUERY_STRING =
-      RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("simple_query_string", false);
+      RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("simple_query_string", false, false);
   public static final SqlOperator QUERY_STRING =
-      RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("query_string", false);
+      RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("query_string", false, false);
   public static final SqlOperator MULTI_MATCH =
-      RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("multi_match", false);
+      RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("multi_match", false, false);
 
   /**
    * Returns the PPL specific operator table, creating it if necessary.

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/SysdateFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/SysdateFunction.java
@@ -61,12 +61,12 @@ public class SysdateFunction extends ImplementorUDF {
       return Expressions.call(SysdateImplementor.class, "sysdate", operandsWithProperties);
     }
 
-    public static String sysdate(FunctionProperties properties) {
+    public static String sysdate(FunctionProperties properties, int ignored) {
       var localDateTime = DateTimeFunctions.formatNow(properties.getSystemClock(), 0);
       return (String) new ExprTimestampValue(localDateTime).valueForCalcite();
     }
 
-    public static String sysdate(FunctionProperties properties, int precision) {
+    public static String sysdate(FunctionProperties properties, int precision, int ignored) {
       var localDateTime = DateTimeFunctions.formatNow(properties.getSystemClock(), precision);
       return (String) new ExprTimestampValue(localDateTime).valueForCalcite();
     }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteNoPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteNoPushdownIT.java
@@ -63,7 +63,7 @@ import org.opensearch.sql.ppl.PPLIntegTestCase;
   CalcitePPLDedupIT.class,
   CalcitePPLEventstatsIT.class,
   CalcitePPLExistsSubqueryIT.class,
-  CalcitePPLExplainIT.class,
+  CalcitePPLExplainCommandIT.class,
   CalcitePPLFillnullIT.class,
   CalcitePPLGrokIT.class,
   CalcitePPLInSubqueryIT.class,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -109,6 +109,17 @@ public class CalciteExplainIT extends ExplainIT {
     assertJsonEqualsIgnoreId(expected, result);
   }
 
+  // Only for Calcite
+  @Test
+  public void testDynamicFunctionSysdate() throws IOException {
+    String query =
+        "source=opensearch-sql_test_index_account | eval a = sysdate(6) | sort age | eval b ="
+            + " sysdate(6) | fields a, b";
+    var result = explainQueryToString(query);
+    String expected = loadExpectedPlan("explain_dynamic_function_sysdate.json");
+    assertJsonEqualsIgnoreId(expected, result);
+  }
+
   // Only for Calcite, as v2 gets unstable serialized string for function
   @Test
   public void testFilterScriptPushDownExplain() throws Exception {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.opensearch.sql.calcite.ExtendedRexBuilder;
 import org.opensearch.sql.ppl.ExplainIT;
 
 public class CalciteExplainIT extends ExplainIT {
@@ -19,6 +20,7 @@ public class CalciteExplainIT extends ExplainIT {
     super.init();
     enableCalcite();
     disallowCalciteFallback();
+    ExtendedRexBuilder.resetId();
   }
 
   @Override

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLExplainCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLExplainCommandIT.java
@@ -12,7 +12,11 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
-public class CalcitePPLExplainIT extends PPLIntegTestCase {
+/**
+ * This IT is just for explain command only. If you want to test the explain result of PPL query,
+ * use {@link org.opensearch.sql.ppl.ExplainIT}.
+ */
+public class CalcitePPLExplainCommandIT extends PPLIntegTestCase {
 
   @Override
   public void init() throws Exception {

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_dynamic_function_sysdate.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_dynamic_function_sysdate.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSort(sort0=[$1], dir0=[ASC])\n  LogicalProject(a=[$17], b=[SYSDATE(6, 1)])\n    LogicalSort(sort0=[$8], dir0=[ASC-nulls-first])\n      LogicalProject(account_number=[$0], firstname=[$1], address=[$2], balance=[$3], gender=[$4], city=[$5], employer=[$6], state=[$7], age=[$8], email=[$9], lastname=[$10], _id=[$11], _index=[$12], _score=[$13], _maxscore=[$14], _sort=[$15], _routing=[$16], a=[SYSDATE(6, 0)])\n        CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableCalc(expr#0=[{inputs}], expr#1=[6], expr#2=[0], expr#3=[SYSDATE($t1, $t2)], expr#4=[1], expr#5=[SYSDATE($t1, $t4)], a=[$t3], b=[$t5])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[PROJECT->[age], SORT->[{\n  \"age\" : {\n    \"order\" : \"asc\",\n    \"missing\" : \"_first\"\n  }\n}]], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_dynamic_function_sysdate.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_dynamic_function_sysdate.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSort(sort0=[$1], dir0=[ASC])\n  LogicalProject(a=[$17], b=[SYSDATE(6, 1)])\n    LogicalSort(sort0=[$8], dir0=[ASC-nulls-first])\n      LogicalProject(account_number=[$0], firstname=[$1], address=[$2], balance=[$3], gender=[$4], city=[$5], employer=[$6], state=[$7], age=[$8], email=[$9], lastname=[$10], _id=[$11], _index=[$12], _score=[$13], _maxscore=[$14], _sort=[$15], _routing=[$16], a=[SYSDATE(6, 0)])\n        CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableCalc(expr#0..1=[{inputs}], expr#2=[6], expr#3=[1], expr#4=[SYSDATE($t2, $t3)], a=[$t1], b=[$t4])\n  EnumerableSort(sort0=[$0], dir0=[ASC-nulls-first])\n    EnumerableCalc(expr#0..16=[{inputs}], expr#17=[6], expr#18=[0], expr#19=[SYSDATE($t17, $t18)], age=[$t8], a=[$t19])\n      CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n"
+  }
+}


### PR DESCRIPTION
### Description
`SYSDATE` is a dynamic function which cannot be resolved correctly in rule `ProjectToCalcRule`:
`ProjectToCalcRule` created a RexProgram in LogicalCalc but the `exprMap` to build RexProgram uses digest of RexCall as map key. Dynamic function such as `sysdate(6)` cannot be identified to diff expressions since their digests are same in PPL:
```
source=dates | eval sd1 = sysdate(6) | sort date | eval sd2 = sysdate(6) | fields sd1, sd2
```
Check the issue details in #3938.

The optimal solution should be fixed in Calcite side that `ProjectToCalcRule` identifies dynamic function with a special key instead of using digest of RexCall directly. But this PR workarounds the issue by adding an auto-increment id as one of operand of RexCall (function).

### Related Issues
Resolves #3938 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
