### PR TITLE
Disable a failed PPL query fallback to v2 by default

### DIFF
--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -749,9 +749,9 @@ plugins.calcite.enabled
 Description
 -----------
 
-This setting is present from 3.0.0-beta. You can enable Calcite as new query optimizer and execution engine to all coming requests.
+You can enable Calcite as new query optimizer and execution engine to all coming requests.
 
-1. The default value is false in 3.0.0-beta.
+1. The default value is false since 3.0.0.
 2. This setting is node scope.
 3. This setting can be updated dynamically.
 
@@ -764,9 +764,9 @@ plugins.calcite.fallback.allowed
 Description
 -----------
 
-This setting is present from 3.0.0-beta. If Calcite is enabled, you can use this setting to decide whether to allow fallback to v2 engine for some queries which are not supported by v3 engine.
+If Calcite is enabled, you can use this setting to decide whether to allow fallback to v2 engine for some queries which are not supported by v3 engine.
 
-1. The default value is true in 3.0.0-beta.
+1. The default value is false since 3.2.0.
 2. This setting is node scope.
 3. This setting can be updated dynamically.
 
@@ -776,9 +776,9 @@ plugins.calcite.pushdown.enabled
 Description
 -----------
 
-This setting is present from 3.0.0-beta. If Calcite is enabled, you can use this setting to decide whether to enable the operator pushdown optimization for v3 engine.
+If Calcite is enabled, you can use this setting to decide whether to enable the operator pushdown optimization for v3 engine.
 
-1. The default value is true in 3.0.0-beta.
+1. The default value is true since 3.0.0.
 2. This setting is node scope.
 3. This setting can be updated dynamically.
 
@@ -788,8 +788,8 @@ plugins.calcite.pushdown.rowcount.estimation.factor
 Description
 -----------
 
-This setting is present from 3.1.0. If Calcite pushdown optimization is enabled, this setting is used to estimate the row count of the query plan. The value is a factor to multiply the row count of the table scan to get the estimated row count.
+If Calcite pushdown optimization is enabled, this setting is used to estimate the row count of the query plan. The value is a factor to multiply the row count of the table scan to get the estimated row count.
 
-1. The default value is 0.9 in 3.1.0.
+1. The default value is 0.9 since 3.1.0.
 2. This setting is node scope.
 3. This setting can be updated dynamically.

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/2489.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/2489.yml
@@ -15,7 +15,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
 
 ---
 teardown:
@@ -24,7 +23,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Handle epoch field in string format":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3343.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3343.yml
@@ -16,7 +16,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
 
 ---
 teardown:
@@ -25,7 +24,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Handle struct field with dynamic mapping disabled":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3477.yml
@@ -4,7 +4,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
 
 ---
 teardown:
@@ -13,7 +12,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Handle flattened document value":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3570.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3570.yml
@@ -4,7 +4,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled: true
-            plugins.calcite.fallback.allowed: false
   - do:
       bulk:
         index: hdfs_logs
@@ -35,7 +34,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 
 ---

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3595.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3595.yml
@@ -4,7 +4,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
             plugins.query.size_limit : 1
 
 ---
@@ -14,7 +13,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Handle lookup command with query size limit is 1":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3607.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3607.yml
@@ -10,7 +10,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
             plugins.query.size_limit : 200
 
 ---
@@ -20,7 +19,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Handle aggregation with window_size_limit is less than query.size_limit":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3635.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3635.yml
@@ -4,7 +4,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
 
 ---
 teardown:
@@ -13,7 +12,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Push down filter with nested field":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3646.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3646.yml
@@ -32,7 +32,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
 
 ---
 teardown:
@@ -41,7 +40,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Path of alias type points to nested field":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3655.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3655.yml
@@ -34,7 +34,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Support match_only_text field type with Calcite enabled":
@@ -43,7 +42,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
 
   - do:
       headers:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3810.yml
@@ -4,7 +4,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
 
 ---
 teardown:
@@ -13,7 +12,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Decimal literal should convert to double in pushdown":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3881.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3881.yml
@@ -4,7 +4,6 @@ setup:
         body:
           transient:
             plugins.calcite.enabled : true
-            plugins.calcite.fallback.allowed : false
 
 ---
 teardown:
@@ -13,7 +12,6 @@ teardown:
         body:
           transient:
             plugins.calcite.enabled : false
-            plugins.calcite.fallback.allowed : true
 
 ---
 "Handle sag with nullAs":

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -109,7 +109,7 @@ public class OpenSearchSettings extends Settings {
   public static final Setting<?> CALCITE_FALLBACK_ALLOWED_SETTING =
       Setting.boolSetting(
           Key.CALCITE_FALLBACK_ALLOWED.getKeyValue(),
-          true,
+          false,
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 


### PR DESCRIPTION
### Description
Disable a failed PPL query fallback to v2 by default: plugins.calcite.fallback.allowed=false

### Related Issues
Resolves #3942

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
