### PR TITLE
[Backport 2.19-dev] Convert like function call to wildcard query for Calcite filter pushdown (#3915)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -735,7 +735,6 @@ public class PPLFuncImpTable {
       registerOperator(REGEXP, SqlLibraryOperators.REGEXP);
       registerOperator(CONCAT, SqlLibraryOperators.CONCAT_FUNCTION);
       registerOperator(CONCAT_WS, SqlLibraryOperators.CONCAT_WS);
-      registerOperator(LIKE, SqlLibraryOperators.ILIKE);
       registerOperator(CONCAT_WS, SqlLibraryOperators.CONCAT_WS);
       registerOperator(REVERSE, SqlLibraryOperators.REVERSE);
       registerOperator(RIGHT, SqlLibraryOperators.RIGHT);
@@ -1014,6 +1013,18 @@ public class PPLFuncImpTable {
                               builder.makeLiteral(" "),
                               arg))),
               PPLTypeChecker.family(SqlTypeFamily.ANY)));
+      register(
+          LIKE,
+          createFunctionImpWithTypeChecker(
+              (builder, arg1, arg2) ->
+                  builder.makeCall(
+                      SqlLibraryOperators.ILIKE,
+                      arg1,
+                      arg2,
+                      // TODO: Figure out escaping solution. '\\' is used for JSON input but is not
+                      // necessary for SQL function input
+                      builder.makeLiteral("\\")),
+              PPLTypeChecker.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)));
     }
   }
 

--- a/docs/user/ppl/functions/string.rst
+++ b/docs/user/ppl/functions/string.rst
@@ -105,6 +105,8 @@ Example::
     +-------------------------------+
 
 
+Limitation: The pushdown of the LIKE function to a DSL wildcard query is supported only for keyword fields.
+
 LOCATE
 -------
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteLikeQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteLikeQueryIT.java
@@ -6,66 +6,22 @@
 package org.opensearch.sql.calcite.remote;
 
 import java.io.IOException;
-import org.junit.Ignore;
+import org.junit.Assume;
 import org.junit.Test;
 import org.opensearch.sql.ppl.LikeQueryIT;
 
-// TODO Like function behaviour in V2 is not correct. Remove when it was fixed in V2.
 public class CalciteLikeQueryIT extends LikeQueryIT {
   @Override
   public void init() throws Exception {
     super.init();
     enableCalcite();
-    // TODO: "https://github.com/opensearch-project/sql/issues/3428"
-    // disallowCalciteFallback();
+    disallowCalciteFallback();
   }
 
   @Override
   @Test
-  @Ignore("https://github.com/opensearch-project/sql/issues/3428")
-  public void test_like_with_escaped_percent() throws IOException, IOException {
-    super.test_like_with_escaped_percent();
-  }
-
-  @Override
-  @Test
-  @Ignore("https://github.com/opensearch-project/sql/issues/3428")
-  public void test_like_in_where_with_escaped_underscore() throws IOException {
-    super.test_like_in_where_with_escaped_underscore();
-  }
-
-  @Override
-  @Test
-  @Ignore("https://github.com/opensearch-project/sql/issues/3428")
-  public void test_like_on_text_field_with_one_word() throws IOException {
-    super.test_like_on_text_field_with_one_word();
-  }
-
-  @Override
-  @Test
-  @Ignore("https://github.com/opensearch-project/sql/issues/3428")
-  public void test_like_on_text_keyword_field_with_one_word() throws IOException {
-    super.test_like_on_text_keyword_field_with_one_word();
-  }
-
-  @Override
-  @Test
-  @Ignore("https://github.com/opensearch-project/sql/issues/3428")
-  public void test_like_on_text_keyword_field_with_greater_than_one_word() throws IOException {
-    super.test_like_on_text_keyword_field_with_greater_than_one_word();
-  }
-
-  @Override
-  @Test
-  @Ignore("https://github.com/opensearch-project/sql/issues/3428")
-  public void test_like_on_text_field_with_greater_than_one_word() throws IOException {
-    super.test_like_on_text_field_with_greater_than_one_word();
-  }
-
-  @Override
-  @Test
-  @Ignore("https://github.com/opensearch-project/sql/issues/3428")
   public void test_convert_field_text_to_keyword() throws IOException {
+    Assume.assumeTrue("Pushdown is not enabled, skipping this test.", isPushdownEnabled());
     super.test_convert_field_text_to_keyword();
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import java.io.IOException;
 import org.opensearch.sql.ppl.WhereCommandIT;
 
 public class CalciteWhereCommandIT extends WhereCommandIT {
@@ -14,19 +13,6 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
     super.init();
     enableCalcite();
     disallowCalciteFallback();
-  }
-
-  @Override
-  public void testIsNotNullFunction() throws IOException {
-    withFallbackEnabled(
-        () -> {
-          try {
-            super.testIsNotNullFunction();
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        },
-        "https://github.com/opensearch-project/sql/issues/3428");
   }
 
   @Override

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
@@ -434,6 +434,24 @@ public class ExplainIT extends PPLIntegTestCase {
                 + " default_operator='or', analyzer=english)"));
   }
 
+  @Test
+  public void testKeywordLikeFunctionExplain() throws IOException {
+    String expected = loadExpectedPlan("explain_keyword_like_function.json");
+    assertJsonEqualsIgnoreId(
+        expected,
+        explainQueryToString(
+            "source=opensearch-sql_test_index_account | where like(firstname, '%mbe%')"));
+  }
+
+  @Test
+  public void testTextLikeFunctionExplain() throws IOException {
+    String expected = loadExpectedPlan("explain_text_like_function.json");
+    assertJsonEqualsIgnoreId(
+        expected,
+        explainQueryToString(
+            "source=opensearch-sql_test_index_account | where like(address, '%Holmes%')"));
+  }
+
   @Ignore("The serialized string is unstable because of function properties")
   @Test
   public void testFilterScriptPushDownExplain() throws Exception {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/LikeQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/LikeQueryIT.java
@@ -62,9 +62,9 @@ public class LikeQueryIT extends PPLIntegTestCase {
   @Test
   public void test_like_on_text_field_with_one_word() throws IOException {
     String query =
-        "source=" + TEST_INDEX_WILDCARD + " | WHERE Like(TextBody, 'test*') | fields TextBody";
+        "source=" + TEST_INDEX_WILDCARD + " | WHERE Like(TextBody, 'test%') | fields TextBody";
     JSONObject result = executeQuery(query);
-    assertEquals(9, result.getInt("total"));
+    assertEquals(8, result.getInt("total"));
   }
 
   @Test
@@ -72,7 +72,7 @@ public class LikeQueryIT extends PPLIntegTestCase {
     String query =
         "source="
             + TEST_INDEX_WILDCARD
-            + " | WHERE Like(TextKeywordBody, 'test*') | fields TextKeywordBody";
+            + " | WHERE Like(TextKeywordBody, 'test%') | fields TextKeywordBody";
     JSONObject result = executeQuery(query);
     assertEquals(8, result.getInt("total"));
   }
@@ -82,7 +82,7 @@ public class LikeQueryIT extends PPLIntegTestCase {
     String query =
         "source="
             + TEST_INDEX_WILDCARD
-            + " | WHERE Like(TextKeywordBody, 'test wild*') | fields TextKeywordBody";
+            + " | WHERE Like(TextKeywordBody, 'test wild%') | fields TextKeywordBody";
     JSONObject result = executeQuery(query);
     assertEquals(7, result.getInt("total"));
   }
@@ -90,9 +90,9 @@ public class LikeQueryIT extends PPLIntegTestCase {
   @Test
   public void test_like_on_text_field_with_greater_than_one_word() throws IOException {
     String query =
-        "source=" + TEST_INDEX_WILDCARD + " | WHERE Like(TextBody, 'test wild*') | fields TextBody";
+        "source=" + TEST_INDEX_WILDCARD + " | WHERE Like(TextBody, 'test wild%') | fields TextBody";
     JSONObject result = executeQuery(query);
-    assertEquals(0, result.getInt("total"));
+    assertEquals(7, result.getInt("total"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -89,6 +89,16 @@ public class WhereCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testLikeFunctionNoHit() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where like(firstname, 'Duk_') | fields lastname",
+                TEST_INDEX_BANK_WITH_NULL_VALUES));
+    assertEquals(0, result.getInt("total"));
+  }
+
+  @Test
   public void testIsNullFunction() throws IOException {
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/sql/LikeQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/LikeQueryIT.java
@@ -117,14 +117,14 @@ public class LikeQueryIT extends SQLIntegTestCase {
 
   @Test
   public void test_like_on_text_field_with_one_word() throws IOException {
-    String query = "SELECT * FROM " + TEST_INDEX_WILDCARD + " WHERE TextBody LIKE 'test*'";
+    String query = "SELECT * FROM " + TEST_INDEX_WILDCARD + " WHERE TextBody LIKE 'test%'";
     JSONObject result = executeJdbcRequest(query);
-    assertEquals(9, result.getInt("total"));
+    assertEquals(8, result.getInt("total"));
   }
 
   @Test
   public void test_like_on_text_keyword_field_with_one_word() throws IOException {
-    String query = "SELECT * FROM " + TEST_INDEX_WILDCARD + " WHERE TextKeywordBody LIKE 'test*'";
+    String query = "SELECT * FROM " + TEST_INDEX_WILDCARD + " WHERE TextKeywordBody LIKE 'test%'";
     JSONObject result = executeJdbcRequest(query);
     assertEquals(8, result.getInt("total"));
   }
@@ -134,7 +134,7 @@ public class LikeQueryIT extends SQLIntegTestCase {
     String query =
         "SELECT * FROM " + TEST_INDEX_WILDCARD + " WHERE TextKeywordBody LIKE 'test wild*'";
     JSONObject result = executeJdbcRequest(query);
-    assertEquals(7, result.getInt("total"));
+    assertEquals(0, result.getInt("total"));
   }
 
   @Test

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_keyword_like_function.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_keyword_like_function.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalProject(account_number=[$0], firstname=[$1], address=[$2], balance=[$3], gender=[$4], city=[$5], employer=[$6], state=[$7], age=[$8], email=[$9], lastname=[$10])\n  LogicalFilter(condition=[ILIKE($1, '%mbe%':VARCHAR, '\\')])\n    CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[PROJECT->[account_number, firstname, address, balance, gender, city, employer, state, age, email, lastname], FILTER->ILIKE($1, '%mbe%':VARCHAR, '\\')], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"timeout\":\"1m\",\"query\":{\"wildcard\":{\"firstname.keyword\":{\"wildcard\":\"*mbe*\",\"case_insensitive\":true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"account_number\",\"firstname\",\"address\",\"balance\",\"gender\",\"city\",\"employer\",\"state\",\"age\",\"email\",\"lastname\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_text_like_function.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_text_like_function.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalProject(account_number=[$0], firstname=[$1], address=[$2], balance=[$3], gender=[$4], city=[$5], employer=[$6], state=[$7], age=[$8], email=[$9], lastname=[$10])\n  LogicalFilter(condition=[ILIKE($2, '%Holmes%':VARCHAR, '\\')])\n    CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableCalc(expr#0..10=[{inputs}], expr#11=['%Holmes%':VARCHAR], expr#12=['\\'], expr#13=[ILIKE($t2, $t11, $t12)], proj#0..10=[{exprs}], $condition=[$t13])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[PROJECT->[account_number, firstname, address, balance, gender, city, employer, state, age, email, lastname]], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"account_number\",\"firstname\",\"address\",\"balance\",\"gender\",\"city\",\"employer\",\"state\",\"age\",\"email\",\"lastname\"],\"excludes\":[]}}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_keyword_like_function.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_keyword_like_function.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalProject(account_number=[$0], firstname=[$1], address=[$2], balance=[$3], gender=[$4], city=[$5], employer=[$6], state=[$7], age=[$8], email=[$9], lastname=[$10])\n  LogicalFilter(condition=[ILIKE($1, '%mbe%':VARCHAR, '\\')])\n    CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableCalc(expr#0..16=[{inputs}], expr#17=['%mbe%':VARCHAR], expr#18=['\\'], expr#19=[ILIKE($t1, $t17, $t18)], proj#0..10=[{exprs}], $condition=[$t19])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_text_like_function.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_text_like_function.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalProject(account_number=[$0], firstname=[$1], address=[$2], balance=[$3], gender=[$4], city=[$5], employer=[$6], state=[$7], age=[$8], email=[$9], lastname=[$10])\n  LogicalFilter(condition=[ILIKE($2, '%Holmes%':VARCHAR, '\\')])\n    CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableCalc(expr#0..16=[{inputs}], expr#17=['%Holmes%':VARCHAR], expr#18=['\\'], expr#19=[ILIKE($t2, $t17, $t18)], proj#0..10=[{exprs}], $condition=[$t19])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_keyword_like_function.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_keyword_like_function.json
@@ -1,0 +1,15 @@
+{
+  "root": {
+    "name": "ProjectOperator",
+    "description": {
+      "fields": "[account_number, firstname, address, balance, gender, city, employer, state, age, email, lastname]"
+    },
+    "children": [{
+      "name": "OpenSearchIndexScan",
+      "description": {
+        "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"wildcard\":{\"firstname.keyword\":{\"wildcard\":\"*mbe*\",\"case_insensitive\":true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"account_number\",\"firstname\",\"address\",\"balance\",\"gender\",\"city\",\"employer\",\"state\",\"age\",\"email\",\"lastname\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false, pitId=*, cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+      },
+      "children": []
+    }]
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_text_like_function.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_text_like_function.json
@@ -1,0 +1,21 @@
+{
+  "root": {
+    "name": "ProjectOperator",
+    "description": {
+      "fields": "[account_number, firstname, address, balance, gender, city, employer, state, age, email, lastname]"
+    },
+    "children": [{
+      "name": "FilterOperator",
+      "description": {
+        "conditions": "like(address, \"%Holmes%\")"
+      },
+      "children": [{
+        "name": "OpenSearchIndexScan",
+        "description": {
+          "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\"}, needClean=true, searchDone=false, pitId=*, cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+        },
+        "children": []
+      }]
+    }]
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LikeQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LikeQuery.java
@@ -10,8 +10,12 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.storage.script.StringUtils;
+import org.opensearch.sql.opensearch.storage.script.filter.FilterQueryBuilder.ScriptQueryUnSupportedException;
 
 public class LikeQuery extends LuceneQuery {
   @Override
@@ -26,7 +30,35 @@ public class LikeQuery extends LuceneQuery {
    * ReferenceExpression while wildcard_query are of type NamedArgumentExpression
    */
   protected WildcardQueryBuilder createBuilder(String field, String query) {
-    String matchText = StringUtils.convertSqlWildcardToLucene(query);
+    String matchText = StringUtils.convertSqlWildcardToLuceneSafe(query);
     return QueryBuilders.wildcardQuery(field, matchText).caseInsensitive(true);
+  }
+
+  /**
+   * Verify if the function supports like/wildcard query. Prefer to run wildcard query for keyword
+   * type field. For text type field, it doesn't support cross term match because OpenSearch
+   * internally break text to multiple terms and apply wildcard matching one by one, which is not
+   * same behavior with regular like function without pushdown.
+   *
+   * @param func function Input function expression
+   * @return boolean
+   */
+  @Override
+  public boolean canSupport(FunctionExpression func) {
+    if (func.getArguments().size() == 2
+        && (func.getArguments().get(0) instanceof ReferenceExpression)
+        && (func.getArguments().get(1) instanceof LiteralExpression
+            || literalExpressionWrappedByCast(func))) {
+      ReferenceExpression ref = (ReferenceExpression) func.getArguments().get(0);
+      // Only support keyword type field
+      if (OpenSearchTextType.toKeywordSubField(ref.getRawPath(), ref.getType()) != null) {
+        return true;
+      } else {
+        // Script pushdown is not supported for text type field
+        throw new ScriptQueryUnSupportedException(
+            "text field wildcard doesn't support script query");
+      }
+    }
+    return false;
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/LuceneQuery.java
@@ -84,7 +84,7 @@ public abstract class LuceneQuery {
   /**
    * Check if the second argument of the function is a literal expression wrapped by cast function.
    */
-  private boolean literalExpressionWrappedByCast(FunctionExpression func) {
+  protected boolean literalExpressionWrappedByCast(FunctionExpression func) {
     if (func.getArguments().get(1) instanceof FunctionExpression) {
       FunctionExpression expr = (FunctionExpression) func.getArguments().get(1);
       return castMap.containsKey(expr.getFunctionName())

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
@@ -561,16 +561,15 @@ public class PredicateAnalyzerTest {
     QueryBuilder result = PredicateAnalyzer.analyze(call, schema, fieldTypes);
     assertInstanceOf(WildcardQueryBuilder.class, result);
     assertEquals(
-        """
-            {
-              "wildcard" : {
-                "b.keyword" : {
-                  "wildcard" : "*Hi*",
-                  "case_insensitive" : true,
-                  "boost" : 1.0
-                }
-              }
-            }""",
+        "{\n"
+            + "  \"wildcard\" : {\n"
+            + "    \"b.keyword\" : {\n"
+            + "      \"wildcard\" : \"*Hi*\",\n"
+            + "      \"case_insensitive\" : true,\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
         result.toString());
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/StringUtilsTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/StringUtilsTest.java
@@ -26,4 +26,25 @@ public class StringUtilsTest {
     assertEquals("?_?", StringUtils.convertSqlWildcardToLucene("_\\__"));
     assertEquals("%\\*_\\?", StringUtils.convertSqlWildcardToLucene("\\%\\*\\_\\?"));
   }
+
+  @Test
+  public void test_escape_sql_wildcards_safe() {
+    assertEquals("%", StringUtils.convertSqlWildcardToLuceneSafe("\\%"));
+    assertEquals("\\*", StringUtils.convertSqlWildcardToLuceneSafe("\\*"));
+    assertEquals("_", StringUtils.convertSqlWildcardToLuceneSafe("\\_"));
+    assertEquals("\\?", StringUtils.convertSqlWildcardToLuceneSafe("\\?"));
+    assertEquals("%*", StringUtils.convertSqlWildcardToLuceneSafe("\\%%"));
+    assertEquals("*%", StringUtils.convertSqlWildcardToLuceneSafe("%\\%"));
+    assertEquals("%*%", StringUtils.convertSqlWildcardToLuceneSafe("\\%%\\%"));
+    assertEquals("*%*", StringUtils.convertSqlWildcardToLuceneSafe("%\\%%"));
+    assertEquals("_?", StringUtils.convertSqlWildcardToLuceneSafe("\\__"));
+    assertEquals("?_", StringUtils.convertSqlWildcardToLuceneSafe("_\\_"));
+    assertEquals("_?_", StringUtils.convertSqlWildcardToLuceneSafe("\\__\\_"));
+    assertEquals("?_?", StringUtils.convertSqlWildcardToLuceneSafe("_\\__"));
+    assertEquals("%\\*_\\?", StringUtils.convertSqlWildcardToLuceneSafe("\\%\\*\\_\\?"));
+    assertEquals("\\*", StringUtils.convertSqlWildcardToLuceneSafe("*"));
+    assertEquals("\\?", StringUtils.convertSqlWildcardToLuceneSafe("?"));
+    assertEquals("foo\\*bar", StringUtils.convertSqlWildcardToLuceneSafe("foo*bar"));
+    assertEquals("foo\\?bar", StringUtils.convertSqlWildcardToLuceneSafe("foo?bar"));
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLStringFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLStringFunctionTest.java
@@ -53,14 +53,17 @@ public class CalcitePPLStringFunctionTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         ""
             + "LogicalAggregate(group=[{}], cnt=[COUNT()])\n"
-            + "  LogicalFilter(condition=[ILIKE($2, 'SALE%':VARCHAR)])\n"
+            + "  LogicalFilter(condition=[ILIKE($2, 'SALE%':VARCHAR, '\\')])\n"
             + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult = "cnt=4\n";
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
-        "" + "SELECT COUNT(*) `cnt`\n" + "FROM `scott`.`EMP`\n" + "WHERE `JOB` ILIKE 'SALE%'";
+        ""
+            + "SELECT COUNT(*) `cnt`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE `JOB` ILIKE 'SALE%' ESCAPE '\\'";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }


### PR DESCRIPTION
Convert like function call to wildcard query for Calcite filter pushdown (#3915)

* Convert like function call to wildcard query for Calcite filter pushdown



* Fix V2 expression like function bug and match its behavior in Calcite



* Fix like default escape in Calcite



* Fix tests



* Fix spotless check



* Address comments



* Fix SQL IT correctness



* Remove test log



* Minor improve one CalciteLikeQueryIT



---------


(cherry picked from commit cd389833420aee5af31b850a6bbf6a309e861024)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
