### PR TITLE
[Backport 2.19-dev] Add missing command in index.rst (#3943)

### DIFF
--- a/docs/user/ppl/cmd/expand.rst
+++ b/docs/user/ppl/cmd/expand.rst
@@ -11,7 +11,7 @@ expand
 
 Description
 ============
-     (From 3.1.0)
+| (Experimental)
 
 Use the ``expand`` command on a nested array field to transform a single
 document into multiple documents—each containing one element from the array.

--- a/docs/user/ppl/index.rst
+++ b/docs/user/ppl/index.rst
@@ -40,25 +40,49 @@ The query start with search command and then flowing a set of command delimited 
 
   - `Cross-Cluster Search <admin/cross_cluster_search.rst>`_
 
+* **Language Structure**
+
+  - `Identifiers <general/identifiers.rst>`_
+
+  - `Data Types <general/datatypes.rst>`_
+
 * **Commands**
 
   - `Syntax <cmd/syntax.rst>`_
 
   - `ad command <cmd/ad.rst>`_
 
+  - `appendcol command <cmd/appendcol.rst>`_
+
   - `dedup command <cmd/dedup.rst>`_
 
   - `describe command <cmd/describe.rst>`_
 
-  - `show datasources command <cmd/showdatasources.rst>`_
-
   - `eval command <cmd/eval.rst>`_
+
+  - `eventstats command <cmd/eventstats.rst>`_
+
+  - `expand command <cmd/expand.rst>`_
+
+  - `explain command <cmd/explain.rst>`_
 
   - `fields command <cmd/fields.rst>`_
 
+  - `fillnull command <cmd/fillnull.rst>`_
+
+  - `flatten command  <cmd/flatten.rst>`_
+
   - `grok command <cmd/grok.rst>`_
 
+  - `head command <cmd/head.rst>`_
+  
+  - `join command  <cmd/join.rst>`_
+
   - `kmeans command <cmd/kmeans.rst>`_
+
+  - `lookup command <cmd/lookup.rst>`_
+
+  - `metadata commands <cmd/information_schema.rst>`_
 
   - `ml command <cmd/ml.rst>`_
 
@@ -66,33 +90,25 @@ The query start with search command and then flowing a set of command delimited 
 
   - `patterns command <cmd/patterns.rst>`_
 
+  - `rare command <cmd/rare.rst>`_
+
   - `rename command <cmd/rename.rst>`_
 
   - `search command <cmd/search.rst>`_
+
+  - `show datasources command <cmd/showdatasources.rst>`_
 
   - `sort command <cmd/sort.rst>`_
 
   - `stats command <cmd/stats.rst>`_
 
-  - `trendline command <cmd/trendline.rst>`_
-
-  - `where command <cmd/where.rst>`_
-
-  - `head command <cmd/head.rst>`_
-  
-  - `rare command <cmd/rare.rst>`_
+  - `subquery (aka subsearch) command <cmd/subquery.rst>`_
 
   - `top command <cmd/top.rst>`_
 
-  - `metadata commands <cmd/information_schema.rst>`_
+  - `trendline command <cmd/trendline.rst>`_
 
-  - `(Experimental)(From 3.0.0) join command <cmd/join.rst>`_
-
-  - `(Experimental)(From 3.0.0) lookup command <cmd/lookup.rst>`_
-
-  - `(Experimental)(From 3.0.0) subquery (aka subsearch) command <cmd/subquery.rst>`_
-
-  - `(Experimental)(From 3.1.0) eventstats command <cmd/eventstats.rst>`_
+  - `where command <cmd/where.rst>`_
 
 * **Functions**
 
@@ -117,12 +133,6 @@ The query start with search command and then flowing a set of command delimited 
 * **Optimization**
 
   - `Optimization <../../user/optimization/optimization.rst>`_
-
-* **Language Structure**
-
-  - `Identifiers <general/identifiers.rst>`_
-
-  - `Data Types <general/datatypes.rst>`_
 
 * **Limitations**
 

--- a/docs/user/ppl/limitations/limitations.rst
+++ b/docs/user/ppl/limitations/limitations.rst
@@ -84,3 +84,21 @@ plugins.query.field_type_tolerance setting is enabled, the SQL/PPL plugin will h
 scalar data types, allowing basic queries (e.g., source = tbl | where condition). However, using multi-value
 fields in expressions or functions will result in exceptions. If this setting is disabled or absent, only the
 first element of an array is returned, preserving the default behavior.
+
+Unsupported Functionalities in Calcite Engine
+=============================================
+
+Since 3.0.0, we introduce Apache Calcite as an experimental query engine. Please see `introduce v3 engine <../../../dev/intro-v3-engine.md>`_.
+For the following functionalities, the query will be forwarded to the V2 query engine.
+
+* All SQL queries
+
+* ``dedup`` with ``consecutive=true``
+
+* Search relevant commands
+
+    * AD
+    * ML
+    * Kmeans
+
+* Commands with ``fetch_size`` parameter


### PR DESCRIPTION
(cherry picked from commit 0da93a38ab2cd51a825eb27b2c4dbf5ed49ae2a5)

### Description
Backport https://github.com/opensearch-project/sql/pull/3943

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
