### PR TITLE
Increase the precision of sum return type

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/tpch/CalcitePPLTpchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/tpch/CalcitePPLTpchIT.java
@@ -249,8 +249,8 @@ public class CalcitePPLTpchIT extends PPLIntegTestCase {
     verifySchemaInOrder(
         actual,
         schema("l_shipmode", "string"),
-        schema("high_line_count", "int"),
-        schema("low_line_count", "int"));
+        schema("high_line_count", "bigint"),
+        schema("low_line_count", "bigint"));
     verifyDataRows(actual, rows("MAIL", 5, 5), rows("SHIP", 5, 10));
   }
 

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3958.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3958.yml
@@ -1,0 +1,57 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+            plugins.calcite.fallback.allowed : false
+
+  - do:
+      indices.create:
+        index: tmp
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              demo:
+                type: short
+
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+            plugins.calcite.fallback.allowed : true
+
+---
+"Handle sum results exceeds the max value of short":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      bulk:
+        index: tmp
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"demo": 20000}'
+          - '{"index": {}}'
+          - '{"demo": 20000}'
+
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=tmp | stats sum(demo)'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "sum(demo)", "type": "bigint"}]}
+  - match: {"datarows": [[40000]]}


### PR DESCRIPTION
### Description
Increase the precision of sum return type

TINYINT, SMALLINT, INTEGER, BIGINT -> BIGINT

FLOAT, REAL, DOUBLE -> DOUBLE

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/3958

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
