### PR TITLE
ResourceMonitor only checks the memory health by calculating the memory usage after GC of old gen in v3

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -112,11 +112,14 @@ public class QueryService {
         log.warn("Fallback to V2 query engine since got exception", t);
         executeWithLegacy(plan, queryType, listener, Optional.of(t));
       } else {
-        if (t instanceof Error) {
+        if (t instanceof Exception) {
+          listener.onFailure((Exception) t);
+        } else if (t instanceof VirtualMachineError) {
+          // throw and fast fail the VM errors such as OOM (same with v2).
+          throw t;
+        } else {
           // Calcite may throw AssertError during query execution.
           listener.onFailure(new CalciteUnsupportedException(t.getMessage(), t));
-        } else {
-          listener.onFailure((Exception) t);
         }
       }
     }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/clickbench/PPLClickBenchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/clickbench/PPLClickBenchIT.java
@@ -53,7 +53,7 @@ public class PPLClickBenchIT extends PPLIntegTestCase {
    * down, which will cause ResourceMonitor restriction.
    */
   protected Set<Integer> ignored() {
-    return Set.of(29, 30);
+    return Set.of(29);
   }
 
   @Test

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/GCedMemoryUsage.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/GCedMemoryUsage.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.monitor;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** Get memory usage from GC notification listener, which is used in Calcite engine. */
+public class GCedMemoryUsage implements MemoryUsage {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private GCedMemoryUsage() {
+    registerGCListener();
+  }
+
+  // Lazy initialize the instance to avoid register GCListener in v2.
+  private static class Holder {
+    static final MemoryUsage INSTANCE = new GCedMemoryUsage();
+  }
+
+  /**
+   * Get the singleton instance of GCedMemoryUsage.
+   *
+   * @return GCedMemoryUsage instance
+   */
+  public static MemoryUsage getInstance() {
+    return Holder.INSTANCE;
+  }
+
+  private final AtomicLong usage = new AtomicLong(-1);
+
+  @Override
+  public long usage() {
+    return usage.get();
+  }
+
+  @Override
+  public void setUsage(long value) {
+    usage.set(value);
+  }
+
+  private void registerGCListener() {
+    List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
+    for (GarbageCollectorMXBean gcBean : gcBeans) {
+      if (gcBean instanceof NotificationEmitter) {
+        NotificationEmitter emitter = (NotificationEmitter) gcBean;
+        emitter.addNotificationListener(new FullGCListener(), null, null);
+      }
+    }
+  }
+
+  private static class FullGCListener implements NotificationListener {
+    @Override
+    public void handleNotification(Notification notification, Object handback) {
+      if (notification
+          .getType()
+          .equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
+        CompositeData cd = (CompositeData) notification.getUserData();
+        GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from(cd);
+
+        String gcAction = info.getGcAction();
+        LOG.info("gcAction: {}", gcAction);
+        if (gcAction.contains("major")
+            || gcAction.contains("concurrent")
+            || gcAction.contains("old")
+            || gcAction.contains("full")) {
+          Map<String, java.lang.management.MemoryUsage> memoryUsageAfterGc =
+              info.getGcInfo().getMemoryUsageAfterGc();
+          String possibleOldGenKey = findOldGenKey(memoryUsageAfterGc.keySet());
+          if (possibleOldGenKey != null) {
+            java.lang.management.MemoryUsage oldGenUsage =
+                memoryUsageAfterGc.get(possibleOldGenKey);
+            getInstance().setUsage(oldGenUsage.getUsed());
+            LOG.info("Full GC detected, memory usage after GC is {} bytes.", getInstance().usage());
+          }
+        }
+      }
+    }
+
+    private String findOldGenKey(Set<String> memoryPoolNames) {
+      LOG.info("Memory pool names: {}", memoryPoolNames);
+      List<String> possibleOldGenKeys =
+          Arrays.asList("G1 Old Gen", "PS Old Gen", "CMS Old Gen", "Tenured Gen", "Old Gen");
+      for (String key : possibleOldGenKeys) {
+        if (memoryPoolNames.contains(key)) {
+          return key;
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/MemoryUsage.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/MemoryUsage.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.monitor;
+
+public interface MemoryUsage {
+  long usage();
+
+  void setUsage(long usage);
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/RuntimeMemoryUsage.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/RuntimeMemoryUsage.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.monitor;
+
+/** Get memory usage from runtime, which is used in v2. */
+public class RuntimeMemoryUsage implements MemoryUsage {
+  private RuntimeMemoryUsage() {}
+
+  private static class Holder {
+    static final MemoryUsage INSTANCE = new RuntimeMemoryUsage();
+  }
+
+  public static MemoryUsage getInstance() {
+    return Holder.INSTANCE;
+  }
+
+  @Override
+  public long usage() {
+    final long freeMemory = Runtime.getRuntime().freeMemory();
+    final long totalMemory = Runtime.getRuntime().totalMemory();
+    return totalMemory - freeMemory;
+  }
+
+  @Override
+  public void setUsage(long usage) {
+    throw new UnsupportedOperationException("Cannot set usage in RuntimeMemoryUsage");
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchIndex.java
@@ -260,7 +260,7 @@ public class OpenSearchIndex extends AbstractOpenSearchTable {
   }
 
   public OpenSearchResourceMonitor createOpenSearchResourceMonitor() {
-    return new OpenSearchResourceMonitor(getSettings(), new OpenSearchMemoryHealthy());
+    return new OpenSearchResourceMonitor(getSettings(), new OpenSearchMemoryHealthy(settings));
   }
 
   public OpenSearchRequest buildRequest(OpenSearchRequestBuilder requestBuilder) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
@@ -28,7 +28,7 @@ public class OpenSearchStorageEngine implements StorageEngine {
   @Override
   public Table getTable(DataSourceSchemaName dataSourceSchemaName, String name) {
     if (isSystemIndex(name)) {
-      return new OpenSearchSystemIndex(client, name);
+      return new OpenSearchSystemIndex(client, settings, name);
     } else {
       return new OpenSearchIndex(client, settings, name);
     }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexEnumerator.java
@@ -120,13 +120,19 @@ public class OpenSearchIndexEnumerator implements Enumerator<Object> {
 
   @Override
   public void reset() {
-    iterator = Collections.emptyIterator();
+    OpenSearchResponse response = client.search(request);
+    if (!response.isEmpty()) {
+      iterator = response.iterator();
+    } else {
+      iterator = Collections.emptyIterator();
+    }
     queryCount = 0;
   }
 
   @Override
   public void close() {
-    reset();
+    iterator = Collections.emptyIterator();
+    queryCount = 0;
     client.cleanup(request);
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/system/CalciteEnumerableSystemIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/system/CalciteEnumerableSystemIndexScan.java
@@ -69,7 +69,9 @@ public class CalciteEnumerableSystemIndexScan extends AbstractCalciteSystemIndex
       @Override
       public Enumerator<Object> enumerator() {
         return new OpenSearchSystemIndexEnumerator(
-            getFieldPath(), sysIndex.getSystemIndexBundle().getRight());
+            getFieldPath(),
+            sysIndex.getSystemIndexBundle().getRight(),
+            sysIndex.createOpenSearchResourceMonitor());
       }
     };
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndex.java
@@ -16,8 +16,11 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.calcite.plan.AbstractOpenSearchTable;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.monitor.OpenSearchMemoryHealthy;
+import org.opensearch.sql.opensearch.monitor.OpenSearchResourceMonitor;
 import org.opensearch.sql.opensearch.request.system.OpenSearchCatIndicesRequest;
 import org.opensearch.sql.opensearch.request.system.OpenSearchDescribeIndexRequest;
 import org.opensearch.sql.opensearch.request.system.OpenSearchSystemRequest;
@@ -33,8 +36,11 @@ public class OpenSearchSystemIndex extends AbstractOpenSearchTable {
   /** System Index Name. */
   private final Pair<OpenSearchSystemIndexSchema, OpenSearchSystemRequest> systemIndexBundle;
 
-  public OpenSearchSystemIndex(OpenSearchClient client, String indexName) {
+  @Getter private final Settings settings;
+
+  public OpenSearchSystemIndex(OpenSearchClient client, Settings settings, String indexName) {
     this.systemIndexBundle = buildIndexBundle(client, indexName);
+    this.settings = settings;
   }
 
   @Override
@@ -62,6 +68,10 @@ public class OpenSearchSystemIndex extends AbstractOpenSearchTable {
   @Override
   public PhysicalPlan implement(LogicalPlan plan) {
     return plan.accept(new OpenSearchSystemIndexDefaultImplementor(), null);
+  }
+
+  public OpenSearchResourceMonitor createOpenSearchResourceMonitor() {
+    return new OpenSearchResourceMonitor(getSettings(), new OpenSearchMemoryHealthy(settings));
   }
 
   @VisibleForTesting

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/monitor/OpenSearchMemoryHealthyTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/monitor/OpenSearchMemoryHealthyTest.java
@@ -21,7 +21,7 @@ class OpenSearchMemoryHealthyTest {
 
   @Mock private OpenSearchMemoryHealthy.RandomFail randomFail;
 
-  @Mock private OpenSearchMemoryHealthy.MemoryUsage memoryUsage;
+  @Mock private MemoryUsage memoryUsage;
 
   private OpenSearchMemoryHealthy monitor;
 
@@ -59,7 +59,7 @@ class OpenSearchMemoryHealthyTest {
 
   @Test
   void constructOpenSearchMemoryMonitorWithoutArguments() {
-    OpenSearchMemoryHealthy monitor = new OpenSearchMemoryHealthy();
+    OpenSearchMemoryHealthy monitor = new OpenSearchMemoryHealthy(null);
     assertNotNull(monitor);
   }
 
@@ -70,8 +70,14 @@ class OpenSearchMemoryHealthyTest {
   }
 
   @Test
-  void setMemoryUsage() {
-    OpenSearchMemoryHealthy.MemoryUsage usage = new OpenSearchMemoryHealthy.MemoryUsage();
+  void getMemoryUsage() {
+    MemoryUsage usage = RuntimeMemoryUsage.getInstance();
     assertTrue(usage.usage() > 0);
+  }
+
+  @Test
+  void setMemoryUsage() {
+    MemoryUsage usage = RuntimeMemoryUsage.getInstance();
+    assertThrows(UnsupportedOperationException.class, () -> usage.setUsage(10L));
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/system/OpenSearchSystemIndexTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
@@ -38,9 +39,11 @@ class OpenSearchSystemIndexTest {
 
   @Mock private Table table;
 
+  @Mock private Settings settings;
+
   @Test
   void testGetFieldTypesOfMetaTable() {
-    OpenSearchSystemIndex systemIndex = new OpenSearchSystemIndex(client, TABLE_INFO);
+    OpenSearchSystemIndex systemIndex = new OpenSearchSystemIndex(client, settings, TABLE_INFO);
     final Map<String, ExprType> fieldTypes = systemIndex.getFieldTypes();
     assertThat(fieldTypes, anyOf(hasEntry("TABLE_CAT", STRING)));
   }
@@ -48,26 +51,26 @@ class OpenSearchSystemIndexTest {
   @Test
   void testGetFieldTypesOfMappingTable() {
     OpenSearchSystemIndex systemIndex =
-        new OpenSearchSystemIndex(client, mappingTable("test_index"));
+        new OpenSearchSystemIndex(client, settings, mappingTable("test_index"));
     final Map<String, ExprType> fieldTypes = systemIndex.getFieldTypes();
     assertThat(fieldTypes, anyOf(hasEntry("COLUMN_NAME", STRING)));
   }
 
   @Test
   void testIsExist() {
-    Table systemIndex = new OpenSearchSystemIndex(client, TABLE_INFO);
+    Table systemIndex = new OpenSearchSystemIndex(client, settings, TABLE_INFO);
     assertTrue(systemIndex.exists());
   }
 
   @Test
   void testCreateTable() {
-    Table systemIndex = new OpenSearchSystemIndex(client, TABLE_INFO);
+    Table systemIndex = new OpenSearchSystemIndex(client, settings, TABLE_INFO);
     assertThrows(UnsupportedOperationException.class, () -> systemIndex.create(ImmutableMap.of()));
   }
 
   @Test
   void implement() {
-    OpenSearchSystemIndex systemIndex = new OpenSearchSystemIndex(client, TABLE_INFO);
+    OpenSearchSystemIndex systemIndex = new OpenSearchSystemIndex(client, settings, TABLE_INFO);
     NamedExpression projectExpr = named("TABLE_NAME", ref("TABLE_NAME", STRING));
 
     final PhysicalPlan plan =

--- a/plugin/src/main/java/org/opensearch/sql/plugin/config/OpenSearchPluginModule.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/config/OpenSearchPluginModule.java
@@ -65,7 +65,7 @@ public class OpenSearchPluginModule extends AbstractModule {
 
   @Provides
   public ResourceMonitor resourceMonitor(Settings settings) {
-    return new OpenSearchResourceMonitor(settings, new OpenSearchMemoryHealthy());
+    return new OpenSearchResourceMonitor(settings, new OpenSearchMemoryHealthy(settings));
   }
 
   @Provides


### PR DESCRIPTION
### Description
In v2, `ResourceMonitor` gets the memory usage by using total memory - free memory of runtime.
But in v3, Calcite will produce lots of **recyclable** memory garbage during its planning and implementation process. For q30, it produces around 70 mb in optimizing + 30 mb in implementation on local test, which can all be GC, ref https://github.com/opensearch-project/sql/pull/3971#discussion_r2251784085

This PR changes the behaviour of `ResourceMonitor` for v3:
ResourceMonitor only checks the memory health by calculating the memory usage after GC of old gen.

### Related Issues
Also can improve/resolve the issue of #3750 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
