### PR TITLE
Allow equal expression as a function argument

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLConditionBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLConditionBuiltinFunctionIT.java
@@ -195,6 +195,19 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testIfWithEquals() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval jake = if(name='Jake', 1, 0) | fields name, jake",
+                TEST_INDEX_STATE_COUNTRY));
+
+    verifySchema(actual, schema("name", "string"), schema("jake", "int"));
+
+    verifyDataRows(actual, rows("Jake", 1), rows("Hello", 0), rows("John", 0), rows("Jane", 0));
+  }
+
+  @Test
   public void testIsPresent() throws IOException {
     JSONObject actual =
         executeQuery(

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -518,7 +518,7 @@ tableSource
    ;
 
 tableFunction
-   : qualifiedName LT_PRTHS functionArgs RT_PRTHS
+   : qualifiedName LT_PRTHS namedFunctionArgs RT_PRTHS
    ;
 
 // fields
@@ -593,10 +593,17 @@ functionArgs
    : (functionArg (COMMA functionArg)*)?
    ;
 
-functionArg
-   : (ident EQUAL)? functionArgExpression
+namedFunctionArgs
+   : (namedFunctionArg (COMMA namedFunctionArg)*)?
    ;
 
+functionArg
+   : functionArgExpression
+   ;
+
+namedFunctionArg
+   : (ident EQUAL)? functionArgExpression
+   ;
 
 functionArgExpression
    : lambda

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -551,8 +551,8 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitTableFunction(TableFunctionContext ctx) {
     ImmutableList.Builder<UnresolvedExpression> builder = ImmutableList.builder();
-    ctx.functionArgs()
-        .functionArg()
+    ctx.namedFunctionArgs()
+        .namedFunctionArg()
         .forEach(
             arg -> {
               String argName = (arg.ident() != null) ? arg.ident().getText() : null;


### PR DESCRIPTION
### Description

This PR allows comparison expressions with equal as a function argument.

Previously, arguments in expressions like `eval res = foo(param1=1, param2='b')` would be treated as named arguments. They would match the following rule:

```antlr
functionArg
   : (ident EQUAL)? functionArgExpression
   ;
```

However, this prevented users from passing comparison expressions like `filed=target` as a parameter, which are widely used in condition functions like `IF`, `CASE`, etc.

I found that named parameters are used exclusively in table functions. This PR fixes the problem by eliminating name parameters in other functions.

### Related Issues
Resolves #3992

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
