### PR TITLE
fix snapshot uploading

### DIFF
--- a/.github/maven-publish-utils.sh
+++ b/.github/maven-publish-utils.sh
@@ -91,11 +91,13 @@ generate_checksums() {
 publish_to_maven() {
   echo "Publishing artifacts to Maven repository..."
 
-  # Navigate to build directory and copy artifacts
+  mkdir -p build/resources/publish/
+  cp build/publish/publish-snapshot.sh build/resources/publish/
+  chmod +x build/resources/publish/publish-snapshot.sh
+
+  # Continue with the original flow
   cd build/resources/publish/
   cp -a $HOME/.m2/repository/* ./
-
-  # Run the publish script
   ./publish-snapshot.sh ./
 
   echo "Maven publishing completed"

--- a/.github/maven-publish-utils.sh
+++ b/.github/maven-publish-utils.sh
@@ -91,6 +91,7 @@ generate_checksums() {
 publish_to_maven() {
   echo "Publishing artifacts to Maven repository..."
 
+  # Make a temp directory for publish-snapshot.sh
   mkdir -p build/resources/publish/
   cp build/publish/publish-snapshot.sh build/resources/publish/
   chmod +x build/resources/publish/publish-snapshot.sh

--- a/.github/workflows/publish-async-query-core.yml
+++ b/.github/workflows/publish-async-query-core.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: 'opensearch-project/opensearch-build-libraries'
+          repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
       - name: Install required tools

--- a/.github/workflows/publish-grammar-files.yml
+++ b/.github/workflows/publish-grammar-files.yml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: 'opensearch-project/opensearch-build-libraries'
+          repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
       - name: Install required tools


### PR DESCRIPTION
Update snapshot uploading

I changed the path to fetch the publish-snapshot.sh(https://github.com/opensearch-project/opensearch-build/blob/main/publish/publish-snapshot.sh) from opensearch-build-libraries to opensearch-build since this file no longer exists in opensearch-build-libraries
