### PR TITLE
Publish legacy module for downstream reuse in unified-ppl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ subprojects {
     }
 
     // Publish internal modules as Maven artifacts for external use, such as by opensearch-spark and opensearch-cli.
-    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol']
+    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol', 'datasources']
     if (publishedModules.contains(name)) {
         apply plugin: 'java-library'
         apply plugin: 'maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ subprojects {
     }
 
     // Publish internal modules as Maven artifacts for external use, such as by opensearch-spark and opensearch-cli.
-    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol', 'datasources']
+    def publishedModules = ['api', 'sql', 'ppl', 'core', 'opensearch', 'common', 'protocol', 'datasources', 'legacy']
     if (publishedModules.contains(name)) {
         apply plugin: 'java-library'
         apply plugin: 'maven-publish'


### PR DESCRIPTION
### Description
Adding `legacy` submodule because `datasources` depends on it.

```
./gradlew publishUnifiedQueryPublicationToMavenLocal   

tree -d ~/.m2/repository/org/opensearch/query/unified-query-legacy

└── 3.1.0.0-SNAPSHOT
```

### Related Issues
[3935](https://github.com/opensearch-project/sql/pull/3935)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
