### PR TITLE
[Backport 2.19-dev] Implement type checking for aggregation functions with Calcite (#4024)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/TakeAggFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/TakeAggFunction.java
@@ -24,7 +24,7 @@ public class TakeAggFunction implements UserDefinedAggFunction<TakeAggFunction.T
   @Override
   public TakeAccumulator add(TakeAccumulator acc, Object... values) {
     Object candidateValue = values[0];
-    int size = 0;
+    int size;
     if (values.length > 1) {
       size = (int) values[1];
     } else {

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/UserDefinedFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/UserDefinedFunctionUtils.java
@@ -32,6 +32,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.impl.AggregateFunctionImpl;
+import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -79,27 +80,71 @@ public class UserDefinedFunctionUtils {
   public static Set<String> MULTI_FIELDS_RELEVANCE_FUNCTION_SET =
       ImmutableSet.of("simple_query_string", "query_string", "multi_match");
 
-  public static RelBuilder.AggCall TransferUserDefinedAggFunction(
-      Class<? extends UserDefinedAggFunction> UDAF,
+  /**
+   * Creates a SqlUserDefinedAggFunction that wraps a Java class implementing an aggregate function.
+   *
+   * @param udafClass The Java class that implements the UserDefinedAggFunction interface
+   * @param functionName The name of the function to be used in SQL statements
+   * @param returnType A SqlReturnTypeInference that determines the return type of the function
+   * @return A SqlUserDefinedAggFunction that can be used in SQL queries
+   */
+  public static SqlUserDefinedAggFunction createUserDefinedAggFunction(
+      Class<? extends UserDefinedAggFunction<?>> udafClass,
+      String functionName,
+      SqlReturnTypeInference returnType) {
+    return new SqlUserDefinedAggFunction(
+        new SqlIdentifier(functionName, SqlParserPos.ZERO),
+        SqlKind.OTHER_FUNCTION,
+        returnType,
+        null,
+        null,
+        AggregateFunctionImpl.create(udafClass),
+        false,
+        false,
+        Optionality.FORBIDDEN);
+  }
+
+  /**
+   * Creates an aggregate call using the provided SqlAggFunction and arguments.
+   *
+   * @param aggFunction The aggregate function to call
+   * @param fields The primary fields to aggregate
+   * @param argList Additional arguments for the aggregate function
+   * @param relBuilder The RelBuilder instance used for building relational expressions
+   * @return An AggCall object representing the aggregate function call
+   */
+  public static RelBuilder.AggCall makeAggregateCall(
+      SqlAggFunction aggFunction,
+      List<RexNode> fields,
+      List<RexNode> argList,
+      RelBuilder relBuilder) {
+    List<RexNode> addArgList = new ArrayList<>(fields);
+    addArgList.addAll(argList);
+    return relBuilder.aggregateCall(aggFunction, addArgList);
+  }
+
+  /**
+   * Creates and registers a User Defined Aggregate Function (UDAF) and returns an AggCall that can
+   * be used in query plans.
+   *
+   * @param udafClass The class implementing the aggregate function behavior
+   * @param functionName The name of the aggregate function
+   * @param returnType The return type inference for determining the result type
+   * @param fields The primary fields to aggregate
+   * @param argList Additional arguments for the aggregate function
+   * @param relBuilder The RelBuilder instance used for building relational expressions
+   * @return An AggCall object representing the aggregate function call
+   */
+  public static RelBuilder.AggCall createAggregateFunction(
+      Class<? extends UserDefinedAggFunction<?>> udafClass,
       String functionName,
       SqlReturnTypeInference returnType,
       List<RexNode> fields,
       List<RexNode> argList,
       RelBuilder relBuilder) {
-    SqlUserDefinedAggFunction sqlUDAF =
-        new SqlUserDefinedAggFunction(
-            new SqlIdentifier(functionName, SqlParserPos.ZERO),
-            SqlKind.OTHER_FUNCTION,
-            returnType,
-            null,
-            null,
-            AggregateFunctionImpl.create(UDAF),
-            false,
-            false,
-            Optionality.FORBIDDEN);
-    List<RexNode> addArgList = new ArrayList<>(fields);
-    addArgList.addAll(argList);
-    return relBuilder.aggregateCall(sqlUDAF, addArgList);
+    SqlUserDefinedAggFunction udaf =
+        createUserDefinedAggFunction(udafClass, functionName, returnType);
+    return makeAggregateCall(udaf, fields, argList, relBuilder);
   }
 
   public static SqlReturnTypeInference getReturnTypeInferenceForArray() {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
@@ -5,10 +5,6 @@
 
 package org.opensearch.sql.opensearch.executor;
 
-import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.convertRelDataTypeToExprType;
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.TransferUserDefinedAggFunction;
-import static org.opensearch.sql.expression.function.BuiltinFunctionName.DISTINCT_COUNT_APPROX;
-
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.sql.PreparedStatement;
@@ -31,9 +27,15 @@ import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlUserDefinedAggFunction;
+import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.ast.statement.Explain.ExplainFormat;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.utils.CalciteToolsHelper.OpenSearchRelRunners;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
@@ -51,6 +53,7 @@ import org.opensearch.sql.opensearch.functions.DistinctCountApproxAggFunction;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.PPLFuncImpTable;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.client.OpenSearchNodeClient;
 import org.opensearch.sql.opensearch.executor.protector.ExecutionProtector;
 import org.opensearch.sql.opensearch.functions.GeoIpFunction;
 import org.opensearch.sql.opensearch.util.JdbcOpenSearchDataTypeConvertor;
@@ -59,6 +62,7 @@ import org.opensearch.sql.storage.TableScanOperator;
 
 /** OpenSearch execution engine implementation. */
 public class OpenSearchExecutionEngine implements ExecutionEngine {
+  private static final Logger logger = LogManager.getLogger(OpenSearchExecutionEngine.class);
 
   private final OpenSearchClient client;
 
@@ -263,7 +267,7 @@ public OpenSearchExecutionEngine(
           exprType = ExprCoreType.UNDEFINED;
         }
       } else {
-        exprType = convertRelDataTypeToExprType(fieldType);
+        exprType = OpenSearchTypeFactory.convertRelDataTypeToExprType(fieldType);
       }
       columns.add(new Column(columnName, null, exprType));
     }
@@ -274,19 +278,22 @@ public OpenSearchExecutionEngine(
 
   /** Registers opensearch-dependent functions */
   private void registerOpenSearchFunctions() {
-    PPLFuncImpTable.INSTANCE.registerExternalAggFunction(
-        DISTINCT_COUNT_APPROX,
-        (distinct, field, argList, ctx) ->
-            TransferUserDefinedAggFunction(
-                DistinctCountApproxAggFunction.class,
-                "APPROX_DISTINCT_COUNT",
-                ReturnTypes.BIGINT_FORCE_NULLABLE,
-                List.of(field),
-                argList,
-                ctx.relBuilder));
-    PPLFuncImpTable.FunctionImp geoIpImpl =
-        (builder, args) ->
-            builder.makeCall(new GeoIpFunction(client.getNodeClient()).toUDF("GEOIP"), args);
-    PPLFuncImpTable.INSTANCE.registerExternalFunction(BuiltinFunctionName.GEOIP, geoIpImpl);
+    if (client instanceof OpenSearchNodeClient) {
+      SqlUserDefinedFunction geoIpFunction =
+          new GeoIpFunction(client.getNodeClient()).toUDF("GEOIP");
+      PPLFuncImpTable.INSTANCE.registerExternalOperator(BuiltinFunctionName.GEOIP, geoIpFunction);
+    } else {
+      logger.info(
+          "Function [GEOIP] not registered: incompatible client type {}",
+          client.getClass().getName());
+    }
+
+    SqlUserDefinedAggFunction approxDistinctCountFunction =
+        UserDefinedFunctionUtils.createUserDefinedAggFunction(
+            DistinctCountApproxAggFunction.class,
+            "APPROX_DISTINCT_COUNT",
+            ReturnTypes.BIGINT_FORCE_NULLABLE);
+    PPLFuncImpTable.INSTANCE.registerExternalAggOperator(
+        BuiltinFunctionName.DISTINCT_COUNT_APPROX, approxDistinctCountFunction);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
@@ -221,4 +221,73 @@ public class CalcitePPLFunctionTypeTest extends CalcitePPLAbstractTest {
     verifyErrorMessageContains(
         wrongArgException, "LOG2 function expects {[INTEGER],[DOUBLE]}, but got [STRING,STRING]");
   }
+
+  @Test
+  public void testAvgWithWrongArgType() {
+    Exception e =
+        Assert.assertThrows(
+            ExpressionEvaluationException.class,
+            () -> getRelNode("source=EMP | stats avg(ENAME) as avg_name"));
+    verifyErrorMessageContains(
+        e, "Aggregation function AVG expects field type {[INTEGER],[DOUBLE]}, but got [STRING]");
+  }
+
+  @Test
+  public void testVarsampWithWrongArgType() {
+    Exception e =
+        Assert.assertThrows(
+            ExpressionEvaluationException.class,
+            () -> getRelNode("source=EMP | stats var_samp(ENAME) as varsamp_name"));
+    verifyErrorMessageContains(
+        e,
+        "Aggregation function VARSAMP expects field type {[INTEGER],[DOUBLE]}, but got [STRING]");
+  }
+
+  @Test
+  public void testVarpopWithWrongArgType() {
+    Exception e =
+        Assert.assertThrows(
+            ExpressionEvaluationException.class,
+            () -> getRelNode("source=EMP | stats var_pop(ENAME) as varpop_name"));
+    verifyErrorMessageContains(
+        e, "Aggregation function VARPOP expects field type {[INTEGER],[DOUBLE]}, but got [STRING]");
+  }
+
+  @Test
+  public void testStddevSampWithWrongArgType() {
+    Exception e =
+        Assert.assertThrows(
+            ExpressionEvaluationException.class,
+            () -> getRelNode("source=EMP | stats stddev_samp(ENAME) as stddev_name"));
+    verifyErrorMessageContains(
+        e,
+        "Aggregation function STDDEV_SAMP expects field type {[INTEGER],[DOUBLE]}, but got"
+            + " [STRING]");
+  }
+
+  @Test
+  public void testStddevPopWithWrongArgType() {
+    Exception e =
+        Assert.assertThrows(
+            ExpressionEvaluationException.class,
+            () -> getRelNode("source=EMP | stats stddev_pop(ENAME) as stddev_name"));
+    verifyErrorMessageContains(
+        e,
+        "Aggregation function STDDEV_POP expects field type {[INTEGER],[DOUBLE]}, but got"
+            + " [STRING]");
+  }
+
+  @Test
+  public void testPercentileApproxWithWrongArgType() {
+    // First argument should be numeric
+    Exception e1 =
+        Assert.assertThrows(
+            ExpressionEvaluationException.class,
+            () -> getRelNode("source=EMP | stats percentile_approx(ENAME, 50) as percentile"));
+    verifyErrorMessageContains(
+        e1,
+        "Aggregation function PERCENTILE_APPROX expects field type and additional arguments"
+            + " {[INTEGER,INTEGER],[INTEGER,DOUBLE],[DOUBLE,INTEGER],[DOUBLE,DOUBLE],[INTEGER,INTEGER,INTEGER],[INTEGER,INTEGER,DOUBLE],[INTEGER,DOUBLE,INTEGER],[INTEGER,DOUBLE,DOUBLE],[DOUBLE,INTEGER,INTEGER],[DOUBLE,INTEGER,DOUBLE],[DOUBLE,DOUBLE,INTEGER],[DOUBLE,DOUBLE,DOUBLE]},"
+            + " but got [STRING,INTEGER]");
+  }
 }


### PR DESCRIPTION
### Description

Backport #4024 to 2.19-dev

### Commit Message

* Remove getTypeChecker from FunctionImp interface



* Refactor registerExternalFunction to registerExternalOperator



* Do not register GEOIP function if got incompatible client



* Create scaffold for type checking of aggregation functions



* Add type checkers for aggregation functions



* Test type checking for aggregation functions



---------


(cherry picked from commit d758163cb9087d23a4c96694c6af47818532001f)


### Related Issues
Resolves #4000 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
