### PR TITLE
[Backport 2.19-dev] Fix DOUBLE to STRING cast rendering zero values in scientific notation (#3982)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
@@ -107,28 +107,29 @@ public class ExtendedRexBuilder extends RexBuilder {
       boolean safe,
       RexLiteral format) {
     final SqlTypeName sqlType = type.getSqlTypeName();
+    RelDataType sourceType = exp.getType();
     // Calcite bug which doesn't consider to cast literal to boolean
     if (exp instanceof RexLiteral && sqlType == SqlTypeName.BOOLEAN) {
       if (exp.equals(makeLiteral("1", typeFactory.createSqlType(SqlTypeName.CHAR, 1)))) {
         return makeLiteral(true, type);
       } else if (exp.equals(makeLiteral("0", typeFactory.createSqlType(SqlTypeName.CHAR, 1)))) {
         return makeLiteral(false, type);
-      } else if (SqlTypeUtil.isExactNumeric(exp.getType())) {
+      } else if (SqlTypeUtil.isExactNumeric(sourceType)) {
         return makeCall(
             type,
             SqlStdOperatorTable.NOT_EQUALS,
-            ImmutableList.of(exp, makeZeroLiteral(exp.getType())));
+            ImmutableList.of(exp, makeZeroLiteral(sourceType)));
         // TODO https://github.com/opensearch-project/sql/issues/3443
         // Current, we align the behaviour of Spark and Postgres, to align with OpenSearch V2,
         // enable following commented codes.
         //      } else {
         //        return makeCall(type,
         //            SqlStdOperatorTable.NOT_EQUALS,
-        //            ImmutableList.of(exp, makeZeroLiteral(exp.getType())));
+        //            ImmutableList.of(exp, makeZeroLiteral(sourceType)));
       }
     } else if (OpenSearchTypeFactory.isUserDefinedType(type)) {
       var udt = ((AbstractExprRelDataType<?>) type).getUdt();
-      var argExprType = OpenSearchTypeFactory.convertRelDataTypeToExprType(exp.getType());
+      var argExprType = OpenSearchTypeFactory.convertRelDataTypeToExprType(sourceType);
       switch (udt) {
           case EXPR_DATE:
               return makeCall(type, PPLBuiltinOperators.DATE, List.of(exp));
@@ -154,7 +155,14 @@ public class ExtendedRexBuilder extends RexBuilder {
             throw new SemanticCheckException(
                     String.format(Locale.ROOT, "Cannot cast from %s to %s", argExprType, udt.name()));
                 }
-      }
+    }
+    // Use a custom operator when casting floating point or decimal number to a character type.
+    // This patch is necessary because in Calcite, 0.0F is cast to 0E0, decimal 0.x to x
+    else if ((SqlTypeUtil.isApproximateNumeric(sourceType) || SqlTypeUtil.isDecimal(sourceType))
+            && SqlTypeUtil.isCharacter(type)) {
+        // NUMBER_TO_STRING uses java's built-in method to get the string representation of a number
+        return makeCall(type, PPLBuiltinOperators.NUMBER_TO_STRING, List.of(exp));
+    }
     return super.makeCast(pos, type, exp, matchNullability, safe, format);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -79,6 +79,7 @@ import org.opensearch.sql.expression.function.udf.math.ConvFunction;
 import org.opensearch.sql.expression.function.udf.math.DivideFunction;
 import org.opensearch.sql.expression.function.udf.math.EulerFunction;
 import org.opensearch.sql.expression.function.udf.math.ModFunction;
+import org.opensearch.sql.expression.function.udf.math.NumberToStringFunction;
 
 /** Defines functions and operators that are implemented only by PPL */
 public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
@@ -376,6 +377,8 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
       RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("query_string", false);
   public static final SqlOperator MULTI_MATCH =
       RELEVANCE_QUERY_FUNCTION_INSTANCE.toUDF("multi_match", false);
+  public static final SqlOperator NUMBER_TO_STRING =
+      new NumberToStringFunction().toUDF("NUMBER_TO_STRING");
 
   /**
    * Returns the PPL specific operator table, creating it if necessary.

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/math/NumberToStringFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/math/NumberToStringFunction.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function.udf.math;
+
+import java.util.List;
+import org.apache.calcite.adapter.enumerable.NotNullImplementor;
+import org.apache.calcite.adapter.enumerable.NullPolicy;
+import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.opensearch.sql.calcite.utils.PPLOperandTypes;
+import org.opensearch.sql.calcite.utils.PPLReturnTypes;
+import org.opensearch.sql.expression.function.ImplementorUDF;
+import org.opensearch.sql.expression.function.UDFOperandMetadata;
+
+/**
+ * A custom implementation of number to string cast.
+ *
+ * <p>This operator is necessary because Calcite's built-in CAST converts floating point 0.0 to 0E0,
+ * and converts decimal 0.123 to .123 when casting them to string.
+ */
+public class NumberToStringFunction extends ImplementorUDF {
+  public NumberToStringFunction() {
+    super(new NumberToStringImplementor(), NullPolicy.ANY);
+  }
+
+  @Override
+  public SqlReturnTypeInference getReturnTypeInference() {
+    return PPLReturnTypes.STRING_FORCE_NULLABLE;
+  }
+
+  @Override
+  public UDFOperandMetadata getOperandMetadata() {
+    return PPLOperandTypes.NUMERIC;
+  }
+
+  public static class NumberToStringImplementor implements NotNullImplementor {
+
+    @Override
+    public Expression implement(
+        RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
+      Expression operand = translatedOperands.get(0);
+      return Expressions.call(Expressions.box(operand), "toString");
+    }
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/CastFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/CastFunctionIT.java
@@ -18,6 +18,7 @@ import static org.opensearch.sql.util.MatcherUtils.verifyErrorMessageContains;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
+import java.util.Locale;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
@@ -274,6 +275,24 @@ public class CastFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testCastDecimal() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval s = cast(0.99 as string), f = cast(12.9 as float), "
+                    + "d = cast(100.00 as double), i = cast(2.9 as int) "
+                    + "| fields s, f, d, i",
+                TEST_INDEX_DATATYPE_NONNUMERIC));
+    verifySchema(
+        actual,
+        schema("s", "string"),
+        schema("f", "float"),
+        schema("d", "double"),
+        schema("i", "int"));
+    verifyDataRows(actual, rows("0.99", 12.9f, 100.0d, 2));
+  }
+
+  @Test
   public void testCastDate() throws IOException {
     JSONObject actual =
         executeQuery(
@@ -423,5 +442,18 @@ public class CastFunctionIT extends PPLIntegTestCase {
         t,
         "IP address string 'invalid_ip' is not valid. Error details: invalid_ip IP Address error:"
             + " validation options do not allow you to specify a non-segmented single value");
+  }
+
+  @Test
+  public void testCastDoubleAsString() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                Locale.ROOT,
+                "source=%s | head 1 | eval d = cast(0 as double) | eval s = cast(d as string) |"
+                    + " fields s",
+                TEST_INDEX_STATE_COUNTRY));
+    verifySchema(actual, schema("s", "string"));
+    verifyDataRows(actual, rows("0.0"));
   }
 }


### PR DESCRIPTION
### Description

Backport #3982 to 2.19-dev

### Commit Message

* Fix casting double 0.0 to string



* Fix float to string casting precision lost with custom FormatNumberFunction

This commit fixes float to string casting by replacing the use of SqlLibraryOperators.FORMAT_NUMBER with a custom FormatNumberFunction implementation. The new implementation converts the number to a BigDecimal before formatting to preserve precision and avoid issues like 6.2 becoming 6.199999809265137.



* Simplify the implementation of fp number to string cast



* Update implementation of NumberToStringFunction



* Cast decimal with NUMBER_TO_STRING function



* Test cast decimal



---------


(cherry picked from commit 19770838fb11738e85d75f39d99365276c9b5c8b)

### Related Issues
Resolves #3947 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
