### PR TITLE
[2.19-dev] CVE-2025-8916: upgrade bcprov-jdk18on to 1.79

### DIFF
--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     implementation ('com.amazonaws:aws-encryption-sdk-java:2.4.1') {
         exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
     }
-    // Use OpenSearch bouncycastle version. https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/version.properties
-    implementation "org.bouncycastle:bcprov-jdk18on:${versions.bouncycastle}"
+    // CVE-2025-8916
+    implementation "org.bouncycastle:bcprov-jdk18on:1.79"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')


### PR DESCRIPTION
### Description
[CVE-2025-8916](https://www.mend.io/vulnerability-database/CVE-2025-8916): upgrade bcprov-jdk18on to 1.79


### Related Issues
Resolves CVE-2025-8916

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
