### PR TITLE
disable commit-history

### DIFF
--- a/.github/workflows/publish-async-query-core.yml
+++ b/.github/workflows/publish-async-query-core.yml
@@ -72,7 +72,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: 'opensearch-project/opensearch-build-libraries'
+          repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
       - name: Install required tools

--- a/.github/workflows/publish-grammar-files.yml
+++ b/.github/workflows/publish-grammar-files.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: 'opensearch-project/opensearch-build-libraries'
+          repository: 'opensearch-project/opensearch-build'
           path: 'build'
 
       - name: Install required tools


### PR DESCRIPTION
## Description
Disable commit-history file creation in snapshot publishing workflow to comply with Maven Central repository restrictions.

## Why this change is needed
Maven Central Sonatype repository enforces strict rules about the types of files that can be uploaded to their snapshot repository. 

Our custom commit-history-*.json files are being rejected by Maven Central as they are non-standard artifacts

What still works

- Snapshot artifacts are published normally
- Commit IDs are still injected into maven-metadata.xml files for traceability
- All standard Maven repository operations continue to function

What is disabled

- Creation of commit-history JSON files in the artifact structure
- Upload of commit mapping files to the repository



