### PR TITLE
disable commit-history uploading to maven

### DIFF
--- a/.github/maven-publish-utils.sh
+++ b/.github/maven-publish-utils.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# Flag to disable commit mapping functionality
+# Set to "true" to disable commit mapping operations
+DISABLE_COMMIT_MAPPING="${DISABLE_COMMIT_MAPPING:-true}"
+
 # Function to execute curl commands with retry and error handling
 execute_curl_with_retry() {
   local url="$1"
@@ -111,6 +115,11 @@ update_version_metadata() {
   local commit_id="$3"
   local snapshot_repo_url="${4:-$SNAPSHOT_REPO_URL}"
 
+  if [ "$DISABLE_COMMIT_MAPPING" = "true" ]; then
+    echo "Skipping version metadata update (commit mapping disabled)"
+    return 0
+  fi
+
   echo "Updating version metadata for ${artifact_id} version ${version} with commit ID ${commit_id}"
 
   TEMP_DIR=$(mktemp -d)
@@ -203,6 +212,11 @@ update_commit_mapping() {
   local extension="$4"  # jar, zip, etc.
   local commit_map_filename="${5:-$COMMIT_MAP_FILENAME}"
   local snapshot_repo_url="${6:-$SNAPSHOT_REPO_URL}"
+
+  if [ "$DISABLE_COMMIT_MAPPING" = "true" ]; then
+    echo "Skipping commit-version mapping update (commit mapping disabled)"
+    return 0
+  fi
 
   echo "Updating commit-version mapping for ${artifact_id}"
 


### PR DESCRIPTION
## Description
Disable commit-history file creation in snapshot publishing workflow to comply with Maven Central repository restrictions.

## Why this change is needed
Maven Central Sonatype repository enforces strict rules about the types of files that can be uploaded to their snapshot repository. 

Our custom commit-history-*.json files are being rejected by Maven Central as they are non-standard artifacts

What still works

- Snapshot artifacts are published normally
- Commit IDs are still injected into maven-metadata.xml files for traceability
- All standard Maven repository operations continue to function

What is disabled

- Creation of commit-history JSON files in the artifact structure
- Upload of commit mapping files to the repository

Tested on #4087 



