### PR TITLE
FollowUp: Retry annotation should work on class level

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/util/RetryProcessor.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/RetryProcessor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.util;
 
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.rules.TestWatcher;
@@ -17,7 +18,9 @@ public class RetryProcessor extends TestWatcher {
 
   @Override
   public Statement apply(Statement base, Description description) {
-    Retry retry = description.getAnnotation(Retry.class);
+    Retry retry =
+        Optional.ofNullable(description.getAnnotation(Retry.class))
+            .orElseGet(() -> description.getTestClass().getAnnotation(Retry.class));
     if (retry == null) {
       return base;
     }


### PR DESCRIPTION
### Description
This is a followup fixing of https://github.com/opensearch-project/sql/pull/4060. With the commit 95f32d0d8ea5e67abdb27523820ddca42b960538, the retry annotation cannot work on class level.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
