### PR TITLE
Fix value parsing bug.

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.common.Numbers;
 import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.geo.GeoUtils;
 import org.opensearch.common.xcontent.json.JsonXContentParser;
@@ -29,32 +30,32 @@ public class OpenSearchJsonContent implements Content {
 
   @Override
   public Integer intValue() {
-    return value().intValue();
+    return (int) parseLongValue(value());
   }
 
   @Override
   public Long longValue() {
-    return value().longValue();
+    return parseLongValue(value());
   }
 
   @Override
   public Short shortValue() {
-    return value().shortValue();
+    return (short) parseLongValue(value());
   }
 
   @Override
   public Byte byteValue() {
-    return (byte) value().shortValue();
+    return (byte) parseLongValue(value());
   }
 
   @Override
   public Float floatValue() {
-    return value().floatValue();
+    return (float) parseDoubleValue(value());
   }
 
   @Override
   public Double doubleValue() {
-    return value().doubleValue();
+    return parseDoubleValue(value());
   }
 
   @Override
@@ -64,7 +65,7 @@ public class OpenSearchJsonContent implements Content {
 
   @Override
   public Boolean booleanValue() {
-    return value().booleanValue();
+    return parseBooleanValue(value());
   }
 
   @Override
@@ -162,5 +163,39 @@ public class OpenSearchJsonContent implements Content {
   /** Getter for value. If value is array the whole array is returned. */
   private JsonNode value() {
     return value;
+  }
+
+  /** Parse long value from JsonNode. */
+  private long parseLongValue(JsonNode node) {
+    if (node.isNumber()) {
+      return node.longValue();
+    } else if (node.isTextual()) {
+      return Numbers.toLong(node.textValue(), true);
+    } else {
+      throw new OpenSearchParseException("node must be a number");
+    }
+  }
+
+  /** Parse double value from JsonNode. */
+  private double parseDoubleValue(JsonNode node) {
+    if (node.isNumber()) {
+      return node.doubleValue();
+    } else if (node.isTextual()) {
+      return Double.parseDouble(node.textValue());
+    } else {
+      throw new OpenSearchParseException("node must be a number");
+    }
+  }
+
+  /** Parse boolean value from JsonNode. */
+  private boolean parseBooleanValue(JsonNode node) {
+    if (node.isBoolean()) {
+      return node.booleanValue();
+    } else if (node.isTextual()) {
+      String textValue = node.textValue().trim().toLowerCase();
+      return Boolean.parseBoolean(textValue);
+    } else {
+      throw new OpenSearchParseException("node must be a boolean");
+    }
   }
 }


### PR DESCRIPTION
### Description
**Problem:**
Certain fields in JSON content were not correctly parsed when numeric or boolean values were represented as strings.

**What I did:**
Added `parseLongValue`, `parseDoubleValue`, and `parseBooleanValue` methods to safely handle:

- Numeric strings (e.g., "123" → 123)

- Boolean strings ("true", "TRUE" → true; "false", "FALSE" → false)

### Related Issues
Resolves #3001
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
