### PR TITLE
Support accessing implicit timestamp field

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/expression/Span.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/Span.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.ast.expression;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -19,13 +20,16 @@ import org.opensearch.sql.ast.AbstractNodeVisitor;
 @RequiredArgsConstructor
 @ToString
 public class Span extends UnresolvedExpression {
-  private final UnresolvedExpression field;
+  @Nullable private final UnresolvedExpression field;
   private final UnresolvedExpression value;
   private final SpanUnit unit;
 
   @Override
   public List<UnresolvedExpression> getChild() {
-    return ImmutableList.of(field, value);
+    if (field == null) {
+      return ImmutableList.of(value);
+    }
+    return List.of(field, value);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
@@ -20,6 +20,8 @@ public interface OpenSearchConstants {
 
   String METADATA_FIELD_ROUTING = "_routing";
 
+  String IMPLICIT_FIELD_TIMESTAMP = "@timestamp";
+
   java.util.Map<String, ExprType> METADATAFIELD_TYPE_MAP =
       Map.of(
           METADATA_FIELD_ID, ExprCoreType.STRING,

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
@@ -21,6 +21,7 @@ public interface OpenSearchConstants {
   String METADATA_FIELD_ROUTING = "_routing";
 
   String IMPLICIT_FIELD_TIMESTAMP = "@timestamp";
+  String SPECIAL_FIELD_TIME = "_time";
 
   java.util.Map<String, ExprType> METADATAFIELD_TYPE_MAP =
       Map.of(

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -262,7 +262,12 @@ public class QueryService {
 
   private boolean isCalciteFallbackAllowed() {
     if (settings != null) {
-      return settings.getSettingValue(Settings.Key.CALCITE_FALLBACK_ALLOWED);
+      try {
+        return settings.getSettingValue(Settings.Key.CALCITE_FALLBACK_ALLOWED);
+      } catch (Exception e) {
+        // If failed to retrieve the setting, default fallback to false
+        return false;
+      }
     } else {
       return true;
     }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -14,6 +14,7 @@ import static org.opensearch.sql.util.MatcherUtils.assertJsonEquals;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyErrorMessageContains;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 import static org.opensearch.sql.util.MatcherUtils.verifySchemaInOrder;
 
@@ -24,6 +25,8 @@ import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
+import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class CalcitePPLAggregationIT extends PPLIntegTestCase {
@@ -38,6 +41,7 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
     loadIndex(Index.CALCS);
     loadIndex(Index.DATE_FORMATS);
     loadIndex(Index.DATA_TYPE_NUMERIC);
+    loadIndex(Index.BIG5);
   }
 
   @Test
@@ -513,6 +517,26 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
     verifySchema(
         actual, schema("time_span", "time"), schema("count(incomplete_custom_time)", "bigint"));
     verifyDataRows(actual, rows(1, "00:00:00"), rows(1, "12:00:00"));
+  }
+
+  // Only available in v3 with Calcite
+  @Test
+  public void testSpanByImplicitTimestamp() throws IOException {
+    JSONObject result = executeQuery("source=big5 | stats count() by span(1d) as span");
+    verifySchema(result, schema("count()", "bigint"), schema("span", "timestamp"));
+    verifyDataRows(result, rows(1, "2023-01-02 00:00:00"));
+
+    Throwable t =
+        assertThrowsWithReplace(
+            SemanticCheckException.class,
+            () ->
+                executeQuery(
+                    StringUtils.format(
+                        "source=%s | stats count() by span(5m)", TEST_INDEX_DATE_FORMATS)));
+    verifyErrorMessageContains(
+        t,
+        "SPAN operation requires an explicit field or an implicit '@timestamp' field, but"
+            + " '@timestamp' was not found in the input schema.");
   }
 
   @Test

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -381,7 +381,7 @@ bySpanClause
    ;
 
 spanClause
-   : SPAN LT_PRTHS fieldExpression COMMA value = literalValue (unit = timespanUnit)? RT_PRTHS
+   : SPAN LT_PRTHS (fieldExpression COMMA)? value = literalValue (unit = timespanUnit)? RT_PRTHS
    ;
 
 sortbyClause

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -523,7 +523,8 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitSpanClause(SpanClauseContext ctx) {
     String unit = ctx.unit != null ? ctx.unit.getText() : "";
-    return new Span(visit(ctx.fieldExpression()), visit(ctx.value), SpanUnit.of(unit));
+    var field = ctx.fieldExpression() != null ? visit(ctx.fieldExpression()) : null;
+    return new Span(field, visit(ctx.value), SpanUnit.of(unit));
   }
 
   @Override

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -553,9 +553,13 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
 
     @Override
     public String visitSpan(Span node, String context) {
-      String field = analyze(node.getField(), context);
+      String field = node.getField() != null ? analyze(node.getField(), context) : null;
       String value = analyze(node.getValue(), context);
-      return StringUtils.format("span(%s, %s %s)", field, value, node.getUnit().getName());
+      if (field != null) {
+        return StringUtils.format("span(%s, %s %s)", field, value, node.getUnit().getName());
+      } else {
+        return StringUtils.format("span(%s %s)", value, node.getUnit().getName());
+      }
     }
 
     @Override


### PR DESCRIPTION
### Description

- [x] Support referring to implicit `@timestamp` field in time-based aggregations
- [x] Support mapping `_time` field access to `@timestamp`
- [ ] Support shorthanded `@timestamp` access in time range operations

### Related Issues
Resolves #3969

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
