### PR TITLE
FollowUp: Disable GCedMemoryUsage if no concurrent GC MXBean

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/clickbench/PPLClickBenchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/clickbench/PPLClickBenchIT.java
@@ -14,6 +14,7 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.opensearch.common.collect.MapBuilder;
+import org.opensearch.sql.opensearch.monitor.GCedMemoryUsage;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 @FixMethodOrder(MethodSorters.JVM)
@@ -48,14 +49,15 @@ public class PPLClickBenchIT extends PPLIntegTestCase {
     System.out.println();
   }
 
-  /**
-   * Ignore queries that are not supported by Calcite.
-   *
-   * <p>q30 is ignored because it will trigger ResourceMonitory health check. TODO: should be
-   * addressed by: https://github.com/opensearch-project/sql/issues/3981
-   */
+  /** Ignore queries that are not supported by Calcite. */
   protected Set<Integer> ignored() {
-    return Set.of(29);
+    if (GCedMemoryUsage.initialized()) {
+      return Set.of(29);
+    } else {
+      // Ignore q30 when use RuntimeMemoryUsage,
+      // because of too much script push down, which will cause ResourceMonitor restriction.
+      return Set.of(29, 30);
+    }
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ResourceMonitorIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ResourceMonitorIT.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.opensearch.monitor.GCedMemoryUsage;
 
 public class ResourceMonitorIT extends PPLIntegTestCase {
 
@@ -27,11 +28,7 @@ public class ResourceMonitorIT extends PPLIntegTestCase {
     // update plugins.ppl.query.memory_limit to 1%
     updateClusterSettings(
         new ClusterSetting("persistent", Settings.Key.QUERY_MEMORY_LIMIT.getKeyValue(), "1%"));
-    // ClickBench Q30 is high memory consumption query.
-    String query = sanitize(loadFromFile("clickbench/queries/q30.ppl"));
-
-    ResponseException exception =
-        expectThrows(ResponseException.class, () -> executeQueryMultipleTimes(query));
+    ResponseException exception = expectThrows(ResponseException.class, this::executeQuery);
     assertEquals(500, exception.getResponse().getStatusLine().getStatusCode());
     assertThat(
         exception.getMessage(),
@@ -40,12 +37,21 @@ public class ResourceMonitorIT extends PPLIntegTestCase {
     // update plugins.ppl.query.memory_limit to default value 85%
     updateClusterSettings(
         new ClusterSetting("persistent", Settings.Key.QUERY_MEMORY_LIMIT.getKeyValue(), "85%"));
-    executeQueryMultipleTimes(query);
+    executeQuery();
   }
 
-  /** Run the same query multiple times in case GC can be triggered in integration test */
-  private void executeQueryMultipleTimes(String query) throws IOException {
-    for (int i = 0; i < 10; i++) {
+  private void executeQuery() throws IOException {
+    if (GCedMemoryUsage.initialized()) {
+      // ClickBench Q30 is a high memory consumption query. Run 5 times to ensure GC triggered.
+      String query = sanitize(loadFromFile("clickbench/queries/q30.ppl"));
+      for (int i = 0; i < 5; i++) {
+        JSONObject result = executeQuery(query);
+        verifyNumOfRows(result, 1);
+      }
+    } else {
+      // Q2 is not a high memory consumption query.
+      // It cannot run in 1% resource but passed in 85%.
+      String query = sanitize(loadFromFile("clickbench/queries/q2.ppl"));
       JSONObject result = executeQuery(query);
       verifyNumOfRows(result, 1);
     }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/GCedMemoryUsage.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/GCedMemoryUsage.java
@@ -24,6 +24,7 @@ public class GCedMemoryUsage implements MemoryUsage {
   private static final Logger LOG = LogManager.getLogger();
   private static final List<String> OLD_GEN_GC_ACTION_KEYWORDS =
       List.of("major", "concurrent", "old", "full", "marksweep");
+  private static boolean initialized = false;
 
   private GCedMemoryUsage() {
     registerGCListener();
@@ -55,6 +56,10 @@ public class GCedMemoryUsage implements MemoryUsage {
     usage.set(value);
   }
 
+  public static boolean initialized() {
+    return initialized;
+  }
+
   private void registerGCListener() {
     List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
     if (gcBeans.stream()
@@ -68,6 +73,7 @@ public class GCedMemoryUsage implements MemoryUsage {
     for (GarbageCollectorMXBean gcBean : gcBeans) {
       if (gcBean instanceof NotificationEmitter && isOldGenGc(gcBean.getName())) {
         LOG.info("{} listener registered for memory usage monitor.", gcBean.getName());
+        initialized = true;
         NotificationEmitter emitter = (NotificationEmitter) gcBean;
         emitter.addNotificationListener(
             new OldGenGCListener(),

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/GCedMemoryUsage.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/monitor/GCedMemoryUsage.java
@@ -56,12 +56,18 @@ public class GCedMemoryUsage implements MemoryUsage {
   }
 
   private void registerGCListener() {
-    boolean registered = false;
     List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
+    if (gcBeans.stream()
+        .filter(b -> b instanceof NotificationEmitter)
+        .noneMatch(b -> containConcurrentGcBean(b.getName()))) {
+      // Concurrent Garbage Collector MXBean only existed since Java 21.
+      // fallback to RuntimeMemoryUsage
+      LOG.info("No Concurrent Garbage Collector MXBean, fallback to RuntimeMemoryUsage");
+      throw new OpenSearchMemoryHealthy.MemoryUsageException();
+    }
     for (GarbageCollectorMXBean gcBean : gcBeans) {
       if (gcBean instanceof NotificationEmitter && isOldGenGc(gcBean.getName())) {
         LOG.info("{} listener registered for memory usage monitor.", gcBean.getName());
-        registered = true;
         NotificationEmitter emitter = (NotificationEmitter) gcBean;
         emitter.addNotificationListener(
             new OldGenGCListener(),
@@ -78,11 +84,10 @@ public class GCedMemoryUsage implements MemoryUsage {
             null);
       }
     }
-    if (!registered) {
-      // fallback to RuntimeMemoryUsage
-      LOG.info("No old gen GC listener registered, fallback to RuntimeMemoryUsage");
-      throw new OpenSearchMemoryHealthy.MemoryUsageException();
-    }
+  }
+
+  private boolean containConcurrentGcBean(String beanName) {
+    return beanName.toLowerCase(Locale.ROOT).contains("concurrent");
   }
 
   private boolean isOldGenGc(String gcKeyword) {


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/sql/pull/3983 enables `GCedMemoryUsage` for Calcite. But when the Java version is less than 21, there is no `ConcurrentMXBean` returned from `ManagementFactory.getGarbageCollectorMXBeans()`. Fallback it to `RuntimeMemoryUsage`.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
