### PR TITLE
Add asc keyword to sort command

### DIFF
--- a/docs/user/ppl/cmd/sort.rst
+++ b/docs/user/ppl/cmd/sort.rst
@@ -19,10 +19,10 @@ Syntax
 sort [count] <[+|-] sort-field>... [desc|d]
 
 
-* count: optional. The number of results to return. **Default:** returns all results. Specifying a count of 0 or less than 0 also returns all results.
+* count (Since 3.3): optional. The number of results to return. **Default:** returns all results. Specifying a count of 0 or less than 0 also returns all results.
 * [+|-]: optional. The plus [+] stands for ascending order and NULL/MISSING first and a minus [-] stands for descending order and NULL/MISSING last. **Default:** ascending order and NULL/MISSING first.
 * sort-field: mandatory. The field used to sort. Can use ``auto(field)``, ``str(field)``, ``ip(field)``, or ``num(field)`` to specify how to interpret field values.
-* [desc|d]: optional. Reverses the sort results. If multiple fields are specified, reverses order of the first field then for all duplicate values of the first field, reverses the order of the values of the second field and so on.
+* [desc|d] (Since 3.3): optional. Reverses the sort results. If multiple fields are specified, reverses order of the first field then for all duplicate values of the first field, reverses the order of the values of the second field and so on.
 
 
 Example 1: Sort by one field

--- a/docs/user/ppl/cmd/sort.rst
+++ b/docs/user/ppl/cmd/sort.rst
@@ -16,13 +16,13 @@ Description
 
 Syntax
 ============
-sort [count] <[+|-] sort-field>... [desc|d]
+sort [count] <[+|-] sort-field>... [asc|a|desc|d]
 
 
 * count (Since 3.3): optional. The number of results to return. **Default:** returns all results. Specifying a count of 0 or less than 0 also returns all results.
 * [+|-]: optional. The plus [+] stands for ascending order and NULL/MISSING first and a minus [-] stands for descending order and NULL/MISSING last. **Default:** ascending order and NULL/MISSING first.
 * sort-field: mandatory. The field used to sort. Can use ``auto(field)``, ``str(field)``, ``ip(field)``, or ``num(field)`` to specify how to interpret field values.
-* [desc|d] (Since 3.3): optional. Reverses the sort results. If multiple fields are specified, reverses order of the first field then for all duplicate values of the first field, reverses the order of the values of the second field and so on.
+* [asc|a|desc|d] (Since 3.3): optional. asc/a keeps the sort order as specified. desc/d reverses the sort results. If multiple fields are specified with desc/d, reverses order of the first field then for all duplicate values of the first field, reverses the order of the values of the second field and so on. **Default:** asc.
 
 
 Example 1: Sort by one field

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLSortIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLSortIT.java
@@ -257,20 +257,20 @@ public class CalcitePPLSortIT extends PPLIntegTestCase {
   @Test
   public void testSortWithAKeyword() throws IOException {
     JSONObject result =
-            executeQuery(
-                    String.format(
-                            "source=%s | sort account_number a | fields account_number, firstname",
-                            TEST_INDEX_BANK));
+        executeQuery(
+            String.format(
+                "source=%s | sort account_number a | fields account_number, firstname",
+                TEST_INDEX_BANK));
     verifySchema(result, schema("account_number", "bigint"), schema("firstname", "string"));
     verifyDataRowsInOrder(
-            result,
-            rows(1, "Amber JOHnny"),
-            rows(6, "Hattie"),
-            rows(13, "Nanette"),
-            rows(18, "Dale"),
-            rows(20, "Elinor"),
-            rows(25, "Virginia"),
-            rows(32, "Dillard"));
+        result,
+        rows(1, "Amber JOHnny"),
+        rows(6, "Hattie"),
+        rows(13, "Nanette"),
+        rows(18, "Dale"),
+        rows(20, "Elinor"),
+        rows(25, "Virginia"),
+        rows(32, "Dillard"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLSortIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLSortIT.java
@@ -234,4 +234,81 @@ public class CalcitePPLSortIT extends PPLIntegTestCase {
         rows("Virginia", "2018-08-19 00:00:00"),
         rows("Dale", "2018-11-13 23:33:20"));
   }
+
+  @Test
+  public void testSortWithAscKeyword() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort account_number asc | fields account_number, firstname",
+                TEST_INDEX_BANK));
+    verifySchema(result, schema("account_number", "bigint"), schema("firstname", "string"));
+    verifyDataRowsInOrder(
+        result,
+        rows(1, "Amber JOHnny"),
+        rows(6, "Hattie"),
+        rows(13, "Nanette"),
+        rows(18, "Dale"),
+        rows(20, "Elinor"),
+        rows(25, "Virginia"),
+        rows(32, "Dillard"));
+  }
+
+  @Test
+  public void testSortWithDescKeyword() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort account_number desc | fields account_number, firstname",
+                TEST_INDEX_BANK));
+    verifySchema(result, schema("account_number", "bigint"), schema("firstname", "string"));
+    verifyDataRowsInOrder(
+        result,
+        rows(32, "Dillard"),
+        rows(25, "Virginia"),
+        rows(20, "Elinor"),
+        rows(18, "Dale"),
+        rows(13, "Nanette"),
+        rows(6, "Hattie"),
+        rows(1, "Amber JOHnny"));
+  }
+
+  @Test
+  public void testSortWithCount() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort 3 account_number | fields account_number, firstname",
+                TEST_INDEX_BANK));
+    verifySchema(result, schema("account_number", "bigint"), schema("firstname", "string"));
+    verifyDataRowsInOrder(result, rows(1, "Amber JOHnny"), rows(6, "Hattie"), rows(13, "Nanette"));
+  }
+
+  @Test
+  public void testSortWithStrCast() throws IOException {
+
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort STR(account_number) | fields account_number", TEST_INDEX_BANK));
+    verifyDataRowsInOrder(
+        result, rows(1), rows(13), rows(18), rows(20), rows(25), rows(32), rows(6));
+  }
+
+  @Test
+  public void testSortWithAutoCast() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format("source=%s | sort AUTO(age) | fields firstname, age", TEST_INDEX_BANK));
+    verifySchema(result, schema("firstname", "string"), schema("age", "int"));
+    verifyDataRowsInOrder(
+        result,
+        rows("Nanette", 28),
+        rows("Amber JOHnny", 32),
+        rows("Dale", 33),
+        rows("Dillard", 34),
+        rows("Hattie", 36),
+        rows("Elinor", 36),
+        rows("Virginia", 39));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLSortIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLSortIT.java
@@ -255,6 +255,25 @@ public class CalcitePPLSortIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testSortWithAKeyword() throws IOException {
+    JSONObject result =
+            executeQuery(
+                    String.format(
+                            "source=%s | sort account_number a | fields account_number, firstname",
+                            TEST_INDEX_BANK));
+    verifySchema(result, schema("account_number", "bigint"), schema("firstname", "string"));
+    verifyDataRowsInOrder(
+            result,
+            rows(1, "Amber JOHnny"),
+            rows(6, "Hattie"),
+            rows(13, "Nanette"),
+            rows(18, "Dale"),
+            rows(20, "Elinor"),
+            rows(25, "Virginia"),
+            rows(32, "Dillard"));
+  }
+
+  @Test
   public void testSortWithDescKeyword() throws IOException {
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
@@ -228,15 +228,6 @@ public class SortCommandIT extends PPLIntegTestCase {
   }
 
   @Test
-  public void testSortWithA() throws IOException {
-    JSONObject result =
-        executeQuery(
-            String.format(
-                "source=%s | sort account_number a | fields account_number", TEST_INDEX_BANK));
-    verifyOrder(result, rows(1), rows(6), rows(13), rows(18), rows(20), rows(25), rows(32));
-  }
-
-  @Test
   public void testSortWithAscMultipleFields() throws IOException {
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
@@ -228,6 +228,15 @@ public class SortCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testSortWithA() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort account_number a | fields account_number", TEST_INDEX_BANK));
+    verifyOrder(result, rows(1), rows(6), rows(13), rows(18), rows(20), rows(25), rows(32));
+  }
+
+  @Test
   public void testSortWithAscMultipleFields() throws IOException {
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
@@ -235,4 +235,22 @@ public class SortCommandIT extends PPLIntegTestCase {
                 "source=%s | sort account_number a | fields account_number", TEST_INDEX_BANK));
     verifyOrder(result, rows(1), rows(6), rows(13), rows(18), rows(20), rows(25), rows(32));
   }
+
+  @Test
+  public void testSortWithAscMultipleFields() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort age, account_number asc | fields age, account_number",
+                TEST_INDEX_BANK));
+    verifyOrder(
+        result,
+        rows(28, 13),
+        rows(32, 1),
+        rows(33, 18),
+        rows(34, 32),
+        rows(36, 6),
+        rows(36, 20),
+        rows(39, 25));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SortCommandIT.java
@@ -217,4 +217,22 @@ public class SortCommandIT extends PPLIntegTestCase {
     verifyOrder(
         result, rows("1234"), rows("3985"), rows("4085"), rows("4321"), rows("6245"), rows("9876"));
   }
+
+  @Test
+  public void testSortWithAsc() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort account_number asc | fields account_number", TEST_INDEX_BANK));
+    verifyOrder(result, rows(1), rows(6), rows(13), rows(18), rows(20), rows(25), rows(32));
+  }
+
+  @Test
+  public void testSortWithA() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | sort account_number a | fields account_number", TEST_INDEX_BANK));
+    verifyOrder(result, rows(1), rows(6), rows(13), rows(18), rows(20), rows(25), rows(32));
+  }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -70,6 +70,8 @@ AS:                                 'AS';
 BY:                                 'BY';
 SOURCE:                             'SOURCE';
 INDEX:                              'INDEX';
+A:                                  'A';
+ASC:                                'ASC';
 D:                                  'D';
 DESC:                               'DESC';
 DATASOURCES:                        'DATASOURCES';

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -70,6 +70,7 @@ AS:                                 'AS';
 BY:                                 'BY';
 SOURCE:                             'SOURCE';
 INDEX:                              'INDEX';
+A:                                  'A';
 ASC:                                'ASC';
 D:                                  'D';
 DESC:                               'DESC';

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -70,7 +70,6 @@ AS:                                 'AS';
 BY:                                 'BY';
 SOURCE:                             'SOURCE';
 INDEX:                              'INDEX';
-A:                                  'A';
 ASC:                                'ASC';
 D:                                  'D';
 DESC:                               'DESC';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -158,7 +158,7 @@ dedupCommand
    ;
 
 sortCommand
-   : SORT (count = integerLiteral)? sortbyClause (DESC | D)?
+   : SORT (count = integerLiteral)? sortbyClause (ASC | A | DESC | D)?
    ;
 
 reverseCommand

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -158,7 +158,7 @@ dedupCommand
    ;
 
 sortCommand
-   : SORT (count = integerLiteral)? sortbyClause (ASC | A | DESC | D)?
+   : SORT (count = integerLiteral)? sortbyClause (ASC | DESC | D)?
    ;
 
 reverseCommand

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -158,7 +158,7 @@ dedupCommand
    ;
 
 sortCommand
-   : SORT (count = integerLiteral)? sortbyClause (ASC | DESC | D)?
+   : SORT (count = integerLiteral)? sortbyClause (ASC | A | DESC | D)?
    ;
 
 reverseCommand
@@ -1201,6 +1201,8 @@ keywordsCanBeId
    | EXISTS
    | SOURCE
    | INDEX
+   | A
+   | ASC
    | DESC
    | DATASOURCES
    | FROM

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -515,6 +515,17 @@ public class AstBuilderTest {
   }
 
   @Test
+  public void testSortCommandWithA() {
+    assertEqual(
+        "source=t | sort f1 a",
+        sort(
+            relation("t"),
+            field(
+                "f1",
+                exprList(argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
+  }
+
+  @Test
   public void testSortCommandWithMultipleFieldsAndAsc() {
     assertEqual(
         "source=t | sort f1, f2 asc",

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -504,6 +504,30 @@ public class AstBuilderTest {
   }
 
   @Test
+  public void testSortCommandWithAsc() {
+    assertEqual(
+        "source=t | sort f1 asc",
+        sort(
+            relation("t"),
+            field(
+                "f1",
+                exprList(
+                    argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
+  }
+
+  @Test
+  public void testSortCommandWithA() {
+    assertEqual(
+        "source=t | sort f1 a",
+        sort(
+            relation("t"),
+            field(
+                "f1",
+                exprList(
+                    argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
+  }
+
+  @Test
   public void testEvalCommand() {
     assertEqual(
         "source=t | eval r=abs(f)",

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -515,17 +515,6 @@ public class AstBuilderTest {
   }
 
   @Test
-  public void testSortCommandWithA() {
-    assertEqual(
-        "source=t | sort f1 a",
-        sort(
-            relation("t"),
-            field(
-                "f1",
-                exprList(argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
-  }
-
-  @Test
   public void testSortCommandWithMultipleFieldsAndAsc() {
     assertEqual(
         "source=t | sort f1, f2 asc",

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -511,8 +511,7 @@ public class AstBuilderTest {
             relation("t"),
             field(
                 "f1",
-                exprList(
-                    argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
+                exprList(argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
   }
 
   @Test
@@ -523,8 +522,21 @@ public class AstBuilderTest {
             relation("t"),
             field(
                 "f1",
-                exprList(
-                    argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
+                exprList(argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
+  }
+
+  @Test
+  public void testSortCommandWithMultipleFieldsAndAsc() {
+    assertEqual(
+        "source=t | sort f1, f2 asc",
+        sort(
+            relation("t"),
+            field(
+                "f1",
+                exprList(argument("asc", booleanLiteral(true)), argument("type", nullLiteral()))),
+            field(
+                "f2",
+                exprList(argument("asc", booleanLiteral(true)), argument("type", nullLiteral())))));
   }
 
   @Test


### PR DESCRIPTION
### Description
- Adds asc/a keyword as option in sort command, Specifying asc does not change behavior, sort direction of each field remains as specified (ascending as default)
- Adds missing tests to ```CaclitePPlSortIT``` for desc keyword, count, and type casting enhancements

## Changes
  - Added `ASC` and `A` tokens to PPL lexer and parser grammar
  - Updated sort command to accept `asc`/`a` keywords alongside existing `desc`/`d`

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
