### PR TITLE
Dynamic source selector in PPL Grammar.

### DIFF
--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -318,6 +318,8 @@ fromClause
    | INDEX EQUAL tableOrSubqueryClause
    | SOURCE EQUAL tableFunction
    | INDEX EQUAL tableFunction
+   | SOURCE EQUAL dynamicSourceClause
+   | INDEX EQUAL dynamicSourceClause
    ;
 
 tableOrSubqueryClause
@@ -327,6 +329,27 @@ tableOrSubqueryClause
 
 tableSourceClause
    : tableSource (COMMA tableSource)* (AS alias = qualifiedName)?
+   ;
+
+dynamicSourceClause
+   : LT_SQR_PRTHS sourceReferences (COMMA sourceFilterArgs)? RT_SQR_PRTHS
+   ;
+
+sourceReferences
+   : sourceReference (COMMA sourceReference)*
+   ;
+
+sourceReference
+   : (CLUSTER)? wcQualifiedName
+   ;
+
+sourceFilterArgs
+   : sourceFilterArg (COMMA sourceFilterArg)*
+   ;
+
+sourceFilterArg
+   : ident EQUAL literalValue
+   | ident IN valueList
    ;
 
 // join

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -12,6 +12,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DedupCommandContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DescribeCommandContext;
+import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DynamicSourceClauseContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.EvalCommandContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.FieldsCommandContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.HeadCommandContext;
@@ -622,6 +623,12 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     return ctx.alias != null
         ? new SubqueryAlias(internalVisitExpression(ctx.alias).toString(), relation)
         : relation;
+  }
+
+  @Override
+  public UnresolvedPlan visitDynamicSourceClause(DynamicSourceClauseContext ctx) {
+    throw new UnsupportedOperationException(
+        "Dynamic source clause with metadata filters is not supported.");
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -5,17 +5,23 @@
 
 package org.opensearch.sql.ppl.antlr;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.opensearch.sql.common.antlr.CaseInsensitiveCharStream;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLLexer;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser;
 
 public class PPLSyntaxParserTest {
 
@@ -91,6 +97,184 @@ public class PPLSyntaxParserTest {
   public void testSearchFieldsCommandCrossClusterShouldPass() {
     ParseTree tree = new PPLSyntaxParser().parse("search source=c:t a=1 b=2 | fields a,b");
     assertNotEquals(null, tree);
+  }
+
+  @Test
+  public void testDynamicSourceClauseParseTreeStructure() {
+    String query = "source=[myindex, logs, fieldIndex=\"test\", count=100]";
+    OpenSearchPPLLexer lexer = new OpenSearchPPLLexer(new CaseInsensitiveCharStream(query));
+    OpenSearchPPLParser parser = new OpenSearchPPLParser(new CommonTokenStream(lexer));
+
+    OpenSearchPPLParser.RootContext root = parser.root();
+    assertNotNull(root);
+
+    // Navigate to dynamic source clause
+    OpenSearchPPLParser.SearchFromContext searchFrom =
+        (OpenSearchPPLParser.SearchFromContext)
+            root.pplStatement().queryStatement().pplCommands().searchCommand();
+    OpenSearchPPLParser.DynamicSourceClauseContext dynamicSource =
+        searchFrom.fromClause().dynamicSourceClause();
+
+    // Verify source references size and text
+    assertEquals(
+        "Should have 2 source references",
+        2,
+        dynamicSource.sourceReferences().sourceReference().size());
+    assertEquals(
+        "Source references text should match",
+        "myindex,logs",
+        dynamicSource.sourceReferences().getText());
+
+    // Verify filter args size and text
+    assertEquals(
+        "Should have 2 filter args", 2, dynamicSource.sourceFilterArgs().sourceFilterArg().size());
+    assertEquals(
+        "Filter args text should match",
+        "fieldIndex=\"test\",count=100",
+        dynamicSource.sourceFilterArgs().getText());
+  }
+
+  @Test
+  public void testDynamicSourceWithComplexFilters() {
+    String query =
+        "source=[vpc.flow_logs, api.gateway, region=\"us-east-1\", env=\"prod\", count=5]";
+    OpenSearchPPLLexer lexer = new OpenSearchPPLLexer(new CaseInsensitiveCharStream(query));
+    OpenSearchPPLParser parser = new OpenSearchPPLParser(new CommonTokenStream(lexer));
+
+    OpenSearchPPLParser.RootContext root = parser.root();
+    OpenSearchPPLParser.SearchFromContext searchFrom =
+        (OpenSearchPPLParser.SearchFromContext)
+            root.pplStatement().queryStatement().pplCommands().searchCommand();
+    OpenSearchPPLParser.DynamicSourceClauseContext dynamicSource =
+        searchFrom.fromClause().dynamicSourceClause();
+
+    // Verify source references
+    assertEquals(
+        "Should have 2 source references",
+        2,
+        dynamicSource.sourceReferences().sourceReference().size());
+    assertEquals(
+        "Source references text",
+        "vpc.flow_logs,api.gateway",
+        dynamicSource.sourceReferences().getText());
+
+    // Verify filter args
+    assertEquals(
+        "Should have 3 filter args", 3, dynamicSource.sourceFilterArgs().sourceFilterArg().size());
+    assertEquals(
+        "Filter args text",
+        "region=\"us-east-1\",env=\"prod\",count=5",
+        dynamicSource.sourceFilterArgs().getText());
+  }
+
+  @Test
+  public void testDynamicSourceWithSingleSource() {
+    String query = "source=[ds:myindex, fieldIndex=\"test\"]";
+    OpenSearchPPLLexer lexer = new OpenSearchPPLLexer(new CaseInsensitiveCharStream(query));
+    OpenSearchPPLParser parser = new OpenSearchPPLParser(new CommonTokenStream(lexer));
+
+    OpenSearchPPLParser.RootContext root = parser.root();
+    OpenSearchPPLParser.SearchFromContext searchFrom =
+        (OpenSearchPPLParser.SearchFromContext)
+            root.pplStatement().queryStatement().pplCommands().searchCommand();
+    OpenSearchPPLParser.DynamicSourceClauseContext dynamicSource =
+        searchFrom.fromClause().dynamicSourceClause();
+
+    assertEquals(
+        "Should have 1 source reference",
+        1,
+        dynamicSource.sourceReferences().sourceReference().size());
+    assertEquals("Source reference text", "ds:myindex", dynamicSource.sourceReferences().getText());
+
+    assertEquals(
+        "Should have 1 filter arg", 1, dynamicSource.sourceFilterArgs().sourceFilterArg().size());
+    assertEquals(
+        "Filter arg text", "fieldIndex=\"test\"", dynamicSource.sourceFilterArgs().getText());
+  }
+
+  @Test
+  public void testDynamicSourceRequiresAtLeastOneSource() {
+    // The grammar requires at least one source reference before optional filter args
+    // This test documents that behavior
+    exceptionRule.expect(RuntimeException.class);
+    new PPLSyntaxParser().parse("source=[fieldIndex=\"httpStatus\", region=\"us-west-2\"]");
+  }
+
+  @Test
+  public void testDynamicSourceWithDottedNames() {
+    String query = "source=[vpc.flow_logs, api.gateway.logs, env=\"prod\"]";
+    OpenSearchPPLLexer lexer = new OpenSearchPPLLexer(new CaseInsensitiveCharStream(query));
+    OpenSearchPPLParser parser = new OpenSearchPPLParser(new CommonTokenStream(lexer));
+
+    OpenSearchPPLParser.RootContext root = parser.root();
+    OpenSearchPPLParser.SearchFromContext searchFrom =
+        (OpenSearchPPLParser.SearchFromContext)
+            root.pplStatement().queryStatement().pplCommands().searchCommand();
+    OpenSearchPPLParser.DynamicSourceClauseContext dynamicSource =
+        searchFrom.fromClause().dynamicSourceClause();
+
+    assertEquals(
+        "Should have 2 source references",
+        2,
+        dynamicSource.sourceReferences().sourceReference().size());
+    assertEquals(
+        "Source references text",
+        "vpc.flow_logs,api.gateway.logs",
+        dynamicSource.sourceReferences().getText());
+
+    assertEquals(
+        "Should have 1 filter arg", 1, dynamicSource.sourceFilterArgs().sourceFilterArg().size());
+    assertEquals("Filter arg text", "env=\"prod\"", dynamicSource.sourceFilterArgs().getText());
+  }
+
+  @Test
+  public void testDynamicSourceWithSimpleFilter() {
+    String query = "source=[logs, count=100]";
+    OpenSearchPPLLexer lexer = new OpenSearchPPLLexer(new CaseInsensitiveCharStream(query));
+    OpenSearchPPLParser parser = new OpenSearchPPLParser(new CommonTokenStream(lexer));
+
+    OpenSearchPPLParser.RootContext root = parser.root();
+    OpenSearchPPLParser.SearchFromContext searchFrom =
+        (OpenSearchPPLParser.SearchFromContext)
+            root.pplStatement().queryStatement().pplCommands().searchCommand();
+    OpenSearchPPLParser.DynamicSourceClauseContext dynamicSource =
+        searchFrom.fromClause().dynamicSourceClause();
+
+    assertEquals(
+        "Should have 1 source reference",
+        1,
+        dynamicSource.sourceReferences().sourceReference().size());
+    assertEquals("Source reference text", "logs", dynamicSource.sourceReferences().getText());
+
+    assertEquals(
+        "Should have 1 filter arg", 1, dynamicSource.sourceFilterArgs().sourceFilterArg().size());
+    assertEquals("Filter arg text", "count=100", dynamicSource.sourceFilterArgs().getText());
+  }
+
+  @Test
+  public void testDynamicSourceWithInClause() {
+    // Note: The valueList rule expects literalValue which includes strings
+    String query = "source=[myindex, fieldIndex IN (\"httpStatus\", \"requestId\")]";
+    OpenSearchPPLLexer lexer = new OpenSearchPPLLexer(new CaseInsensitiveCharStream(query));
+    OpenSearchPPLParser parser = new OpenSearchPPLParser(new CommonTokenStream(lexer));
+
+    OpenSearchPPLParser.RootContext root = parser.root();
+    assertNotNull("Query should parse successfully", root);
+
+    // Verify IN clause is parsed
+    OpenSearchPPLParser.SearchFromContext searchFrom =
+        (OpenSearchPPLParser.SearchFromContext)
+            root.pplStatement().queryStatement().pplCommands().searchCommand();
+    OpenSearchPPLParser.DynamicSourceClauseContext dynamicSource =
+        searchFrom.fromClause().dynamicSourceClause();
+
+    assertNotNull("Dynamic source should exist", dynamicSource);
+    assertNotNull("Filter args should exist", dynamicSource.sourceFilterArgs());
+
+    // The IN clause should be parsed as a sourceFilterArg
+    assertTrue(
+        "Should have at least one filter arg with IN clause",
+        dynamicSource.sourceFilterArgs().sourceFilterArg().size() >= 1);
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -87,6 +87,17 @@ public class AstBuilderTest {
   private final Settings settings = Mockito.mock(Settings.class);
 
   @Test
+  public void testDynamicSourceClauseThrowsUnsupportedException() {
+    String query = "source=[myindex, logs, fieldIndex=\"test\"]";
+
+    UnsupportedOperationException exception =
+        assertThrows(UnsupportedOperationException.class, () -> plan(query));
+
+    assertEquals(
+        "Dynamic source clause with metadata filters is not supported.", exception.getMessage());
+  }
+
+  @Test
   public void testSearchCommand() {
     assertEqual(
         "search source=t a=1", filter(relation("t"), compare("=", field("a"), intLiteral(1))));


### PR DESCRIPTION
### Description
Introduces grammar support for dynamic source clause syntax in PPL that allows
  specifying metadata filters alongside source references: source=[sourceList, key=value
   filters]

  Changes

  - Grammar: Added dynamicSourceClause in fromClause with support for:
    - Source references: myindex, logs*, vpc.flow_logs
    - Filter arguments: key=value and key IN (values)
    - Optional namespace prefixes: namespace:identifier
  - Implementation: visitDynamicSourceClause throws UnsupportedOperationException
  (execution not implemented)

  Examples
```
  source=[myindex, logs, fieldIndex="httpStatus", count=100]
  source=[vpc.flow_logs, region IN ("us-east-1", "us-west-2")]
```
  Design
  
  - Backward compatible - existing queries unchanged
  - Grammar-only support - execution deferred to future implementation

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
