### PR TITLE
Adding big5 `coalesce` queries

### DIFF
--- a/integ-test/src/test/resources/big5/queries/coalesce_empty_string_priority.ppl
+++ b/integ-test/src/test/resources/big5/queries/coalesce_empty_string_priority.ppl
@@ -1,0 +1,3 @@
+source = big5
+| eval result = coalesce('', `host.name`)
+| head 10

--- a/integ-test/src/test/resources/big5/queries/coalesce_nonexistent_field_fallback.ppl
+++ b/integ-test/src/test/resources/big5/queries/coalesce_nonexistent_field_fallback.ppl
@@ -1,0 +1,3 @@
+source = big5
+| eval result = coalesce(`host.name`, dummy_field, 'unknown')
+| head 10

--- a/integ-test/src/test/resources/big5/queries/coalesce_numeric_fallback.ppl
+++ b/integ-test/src/test/resources/big5/queries/coalesce_numeric_fallback.ppl
@@ -1,0 +1,3 @@
+source = big5
+| eval result = coalesce(`host.name`, 123, 'fallback')
+| head 10


### PR DESCRIPTION
### Description
Adding big5 queries for the new `coalesce` function enhancements.

### Related Issues
https://github.com/opensearch-project/sql/issues/4005

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
