### PR TITLE
[Hotpatch][Infra] Fix CI artifact sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
     }
 
@@ -93,7 +92,6 @@ apply plugin: 'opensearch.java-agent'
 repositories {
     mavenLocal()
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
     maven { url 'https://jitpack.io' }
 }
@@ -158,7 +156,6 @@ subprojects {
     repositories {
         mavenLocal()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }
         maven { url 'https://jitpack.io' }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -48,7 +48,7 @@ apply plugin: 'com.wiredforcode.spawn'
 // The next major version is only API compat w/ the last minor of the previous major.
 // baseVersion need to roll-froward accordingly, as new 2.x of OpenSearch being released.
 // See: https://github.com/opensearch-project/OpenSearch/issues/3615
-String baseVersion = "2.19.0"
+String baseVersion = "3.1.0"
 String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -48,7 +48,7 @@ apply plugin: 'com.wiredforcode.spawn'
 // The next major version is only API compat w/ the last minor of the previous major.
 // baseVersion need to roll-froward accordingly, as new 2.x of OpenSearch being released.
 // See: https://github.com/opensearch-project/OpenSearch/issues/3615
-String baseVersion = "3.2.0"
+String baseVersion = "2.19.0"
 String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -48,7 +48,7 @@ apply plugin: 'com.wiredforcode.spawn'
 // The next major version is only API compat w/ the last minor of the previous major.
 // baseVersion need to roll-froward accordingly, as new 2.x of OpenSearch being released.
 // See: https://github.com/opensearch-project/OpenSearch/issues/3615
-String baseVersion = "2.20.0"
+String baseVersion = "3.2.0"
 String bwcVersion = baseVersion + ".0";
 String baseName = "sqlBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"


### PR DESCRIPTION
### Description
Old sonatype repo was finally deactivated, turns out we implicitly still depended on some artifacts from it because we had fallback repositories configured, and many artifacts from the old repo were missing in the new one.

Removes the (now fully deprecated) fallback, and updates our base version in `main` to the latest version available in the newer snapshot repos.

### Related Issues
All CI broke from this

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
