### PR TITLE
[Backport 2.19-dev] Migrate from sonatype snapshot to ci.opensearch.org snapshots (#4141)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,6 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
     }
 
@@ -90,7 +89,6 @@ apply plugin: 'opensearch.java'
 repositories {
     mavenLocal()
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
     maven { url 'https://jitpack.io' }
 }
@@ -159,7 +157,6 @@ subprojects {
     repositories {
         mavenLocal()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/" }
         maven { url 'https://jitpack.io' }

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
+        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/" }
         mavenCentral()
     }
 
@@ -89,6 +90,7 @@ apply plugin: 'opensearch.java'
 repositories {
     mavenLocal()
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/" }
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
     maven { url 'https://jitpack.io' }
 }
@@ -157,6 +159,7 @@ subprojects {
     repositories {
         mavenLocal()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
+        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/" }
         mavenCentral()
         maven { url "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/" }
         maven { url 'https://jitpack.io' }


### PR DESCRIPTION
(cherry picked from #4141 commit 80945963179d4dc24e77165ec928d64a4482d524)