### PR TITLE
Extract getOnlyForCalciteException

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -10,7 +10,7 @@ import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_FIRST;
 import static org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_LAST;
 import static org.opensearch.sql.ast.tree.Sort.SortOrder.ASC;
 import static org.opensearch.sql.ast.tree.Sort.SortOrder.DESC;
-import static org.opensearch.sql.common.setting.Settings.Key.CALCITE_ENGINE_ENABLED;
+import static org.opensearch.sql.calcite.utils.CalciteUtils.getOnlyForCalciteException;
 import static org.opensearch.sql.data.type.ExprCoreType.DATE;
 import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
 import static org.opensearch.sql.data.type.ExprCoreType.TIME;
@@ -181,8 +181,7 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
           STRUCT);
       return child;
     } else {
-      throw new UnsupportedOperationException(
-          "Subsearch is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+      throw getOnlyForCalciteException("Subsearch");
     }
   }
 
@@ -672,14 +671,12 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
 
   @Override
   public LogicalPlan visitBin(Bin node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "Bin command is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("Bin");
   }
 
   @Override
   public LogicalPlan visitExpand(Expand expand, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "Expand is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("Expand");
   }
 
   /** Build {@link LogicalTrendline} for Trendline command. */
@@ -733,14 +730,12 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
 
   @Override
   public LogicalPlan visitFlatten(Flatten node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "FLATTEN is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("FLATTEN");
   }
 
   @Override
   public LogicalPlan visitReverse(Reverse node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "REVERSE is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("REVERSE");
   }
 
   @Override
@@ -763,21 +758,19 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
 
   @Override
   public LogicalPlan visitJoin(Join node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "Join is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("Join");
   }
 
   @Override
   public LogicalPlan visitLookup(Lookup node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "Lookup is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("Lookup");
   }
 
   @Override
   public LogicalPlan visitAppendCol(AppendCol node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "AppendCol is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("AppendCol");
   }
+
 
   private LogicalSort buildSort(
       LogicalPlan child, AnalysisContext context, Integer count, List<Field> sortFields) {

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -7,7 +7,7 @@ package org.opensearch.sql.analysis;
 
 import static org.opensearch.sql.ast.dsl.AstDSL.and;
 import static org.opensearch.sql.ast.dsl.AstDSL.compare;
-import static org.opensearch.sql.common.setting.Settings.Key.CALCITE_ENGINE_ENABLED;
+import static org.opensearch.sql.calcite.utils.CalciteUtils.getOnlyForCalciteException;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -435,20 +435,17 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
 
   @Override
   public Expression visitScalarSubquery(ScalarSubquery node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "Subsearch is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("Subsearch");
   }
 
   @Override
   public Expression visitExistsSubquery(ExistsSubquery node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "Subsearch is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("Subsearch");
   }
 
   @Override
   public Expression visitInSubquery(InSubquery node, AnalysisContext context) {
-    throw new UnsupportedOperationException(
-        "Subsearch is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+    throw getOnlyForCalciteException("Subsearch");
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteUtils.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.utils;
+
+import static org.opensearch.sql.common.setting.Settings.Key.CALCITE_ENGINE_ENABLED;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class CalciteUtils {
+
+  public static UnsupportedOperationException getOnlyForCalciteException(String feature) {
+    return new UnsupportedOperationException(
+        feature + " is supported only when " + CALCITE_ENGINE_ENABLED.getKeyValue() + "=true");
+  }
+}

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -9,6 +9,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.opensearch.sql.ast.dsl.AstDSL.booleanLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
+import static org.opensearch.sql.calcite.utils.CalciteUtils.getOnlyForCalciteException;
 import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BinCommandContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DedupCommandContext;
@@ -294,10 +295,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
                   : new Argument("exclude", new Literal(false, DataType.BOOLEAN)));
       return buildProjectCommand(ctx.fieldsCommandBody(), arguments);
     }
-    throw new UnsupportedOperationException(
-        "Table command is supported only when "
-            + Key.CALCITE_ENGINE_ENABLED.getKeyValue()
-            + "=true");
+    throw getOnlyForCalciteException("Table command");
   }
 
   private UnresolvedPlan buildProjectCommand(
@@ -308,10 +306,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     if (settings != null
         && Boolean.FALSE.equals(settings.getSettingValue(Key.CALCITE_ENGINE_ENABLED))) {
       if (hasEnhancedFieldFeatures(bodyCtx, fields)) {
-        throw new UnsupportedOperationException(
-            "Enhanced fields features are supported only when "
-                + Key.CALCITE_ENGINE_ENABLED.getKeyValue()
-                + "=true");
+        throw getOnlyForCalciteException("Enhanced fields features");
       }
     }
 


### PR DESCRIPTION
### Description
- Refactor to extract getOnlyForCalciteException

### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/DEVELOPER_GUIDE.rst#new-ppl-command-checklist) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
