### PR TITLE
[Backport 2.19-dev] PPL percentile function shortcut `perc()` and `p()` support

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/PercentileApproxFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/PercentileApproxFunction.java
@@ -34,7 +34,7 @@ public class PercentileApproxFunction
     if (Objects.isNull(targetValue)) {
       return acc;
     }
-    percentile = ((Number) values[1]).intValue() / 100.0;
+    percentile = ((Number) values[1]).doubleValue() / 100.0;
     returnType = (SqlTypeName) values[values.length - 1];
     if (values.length > 3) { // have compression
       compression = ((Number) values[values.length - 2]).doubleValue();

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -389,6 +389,34 @@ Example::
     | M      | 36  |
     +--------+-----+
 
+Percentile Shortcut Functions
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+For convenience, OpenSearch PPL provides shortcut functions for common percentiles:
+
+- ``PERC<percent>(expr)`` - Equivalent to ``PERCENTILE(expr, <percent>)``
+- ``P<percent>(expr)`` - Equivalent to ``PERCENTILE(expr, <percent>)``
+
+Both integer and decimal percentiles from 0 to 100 are supported (e.g., ``PERC95``, ``P99.5``).
+
+Example::
+
+    ppl> source=accounts | stats perc99.5(age);
+    fetched rows / total rows = 1/1
+    +---------------+
+    | perc99.5(age) |
+    |---------------|
+    | 36            |
+    +---------------+
+
+    ppl> source=accounts | stats p50(age);
+    fetched rows / total rows = 1/1
+    +---------+
+    | p50(age) |
+    |---------|
+    | 32      |
+    +---------+
+
 HAVING Clause
 =============
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -841,7 +841,7 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
         schema("perc25.5(balance)", "bigint"),
         schema("p75.25(balance)", "bigint"),
         schema("perc0.1(balance)", "bigint"));
-    verifyDataRows(actual, rows(5686, 40540, 4180));
+    verifyDataRows(actual, rows(8744, 40234, 4180));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -811,4 +811,70 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
                 TEST_INDEX_DATATYPE_NUMERIC));
     verifyDataRows(response, rows(1, 4));
   }
+
+  @Test
+  public void testPercentileShortcuts() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format("source=%s | stats perc50(balance), p95(balance)", TEST_INDEX_BANK));
+    verifySchema(actual, schema("perc50(balance)", "bigint"), schema("p95(balance)", "bigint"));
+    verifyDataRows(actual, rows(32838, 48086));
+  }
+
+  @Test
+  public void testPercentileShortcutsWithDecimals() throws IOException {
+    JSONObject actual =
+        executeQuery(String.format("source=%s | stats perc99.5(balance)", TEST_INDEX_BANK));
+    verifySchema(actual, schema("perc99.5(balance)", "bigint"));
+    verifyDataRows(actual, rows(48086));
+  }
+
+  @Test
+  public void testPercentileShortcutsFloatingPoint() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | stats perc25.5(balance), p75.25(balance), perc0.1(balance)",
+                TEST_INDEX_BANK));
+    verifySchema(
+        actual,
+        schema("perc25.5(balance)", "bigint"),
+        schema("p75.25(balance)", "bigint"),
+        schema("perc0.1(balance)", "bigint"));
+    verifyDataRows(actual, rows(5686, 40540, 4180));
+  }
+
+  @Test
+  public void testPercentileShortcutsFloatingEquivalence() throws IOException {
+    JSONObject shortcut =
+        executeQuery(String.format("source=%s | stats perc25.5(balance)", TEST_INDEX_BANK));
+    JSONObject standard =
+        executeQuery(String.format("source=%s | stats percentile(balance, 25.5)", TEST_INDEX_BANK));
+
+    verifySchema(shortcut, schema("perc25.5(balance)", "bigint"));
+    verifySchema(standard, schema("percentile(balance, 25.5)", "bigint"));
+
+    Object shortcutValue = shortcut.getJSONArray("datarows").getJSONArray(0).get(0);
+    Object standardValue = standard.getJSONArray("datarows").getJSONArray(0).get(0);
+
+    verifyDataRows(shortcut, rows(shortcutValue));
+    verifyDataRows(standard, rows(standardValue));
+  }
+
+  @Test
+  public void testPercentileShortcutsEquivalentToStandard() throws IOException {
+    JSONObject shortcut =
+        executeQuery(String.format("source=%s | stats perc50(balance)", TEST_INDEX_BANK));
+    JSONObject standard =
+        executeQuery(String.format("source=%s | stats percentile(balance, 50)", TEST_INDEX_BANK));
+
+    verifySchema(shortcut, schema("perc50(balance)", "bigint"));
+    verifySchema(standard, schema("percentile(balance, 50)", "bigint"));
+
+    Object shortcutValue = shortcut.getJSONArray("datarows").getJSONArray(0).get(0);
+    Object standardValue = standard.getJSONArray("datarows").getJSONArray(0).get(0);
+
+    verifyDataRows(shortcut, rows(shortcutValue));
+    verifyDataRows(standard, rows(standardValue));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/security/CrossClusterSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/security/CrossClusterSearchIT.java
@@ -206,6 +206,15 @@ public class CrossClusterSearchIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testCrossClusterPercentileShortcuts() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "search source=%s | stats perc50(balance), p95(balance)", TEST_INDEX_BANK_REMOTE));
+    verifyColumn(result, columnName("perc50(balance)"), columnName("p95(balance)"));
+  }
+
+  @Test
   public void testCrossClusterMultiMatchWithoutFields() throws IOException {
     // Test multi_match without fields parameter on remote cluster
     JSONObject result =

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -235,6 +235,7 @@ VAR_SAMP:                           'VAR_SAMP';
 VAR_POP:                            'VAR_POP';
 STDDEV_SAMP:                        'STDDEV_SAMP';
 STDDEV_POP:                         'STDDEV_POP';
+PERC:                               'PERC';
 PERCENTILE:                         'PERCENTILE';
 PERCENTILE_APPROX:                  'PERCENTILE_APPROX';
 EARLIEST:                           'EARLIEST';
@@ -479,6 +480,10 @@ W:                                  'W';
 Q:                                  'Q';
 Y:                                  'Y';
 
+
+// PERCENTILE SHORTCUT FUNCTIONS
+// Must precede ID to avoid conflicts with identifier matching
+PERCENTILE_SHORTCUT:                PERC(INTEGER_LITERAL | DECIMAL_LITERAL) | 'P'(INTEGER_LITERAL | DECIMAL_LITERAL);
 
 // LITERALS AND VALUES
 //STRING_LITERAL:                     DQUOTA_STRING | SQUOTA_STRING | BQUOTA_STRING;

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -430,6 +430,7 @@ statsAggTerm
 statsFunction
    : statsFunctionName LT_PRTHS valueExpression RT_PRTHS        # statsFunctionCall
    | COUNT LT_PRTHS RT_PRTHS                                    # countAllFunctionCall
+   | PERCENTILE_SHORTCUT LT_PRTHS valueExpression RT_PRTHS      # percentileShortcutFunctionCall
    | (DISTINCT_COUNT | DC | DISTINCT_COUNT_APPROX) LT_PRTHS valueExpression RT_PRTHS    # distinctCountFunctionCall
    | takeAggFunction                                            # takeAggFunctionCall
    | percentileApproxFunction                                   # percentileApproxFunctionCall
@@ -450,6 +451,8 @@ statsFunctionName
    | EARLIEST
    | LATEST
    ;
+
+
 
 takeAggFunction
    : TAKE LT_PRTHS fieldExpression (COMMA size = integerLiteral)? RT_PRTHS
@@ -1276,4 +1279,5 @@ keywordsCanBeId
    | ANTI
    | LEFT_HINT
    | RIGHT_HINT
+   | PERCENTILE_SHORTCUT
    ;

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -6,38 +6,6 @@
 package org.opensearch.sql.ppl.parser;
 
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.*;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BinaryArithmeticContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BooleanLiteralContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BySpanClauseContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.CompareExprContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.ConvertedDataTypeContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.CountAllFunctionCallContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DataTypeFunctionCallContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DecimalLiteralContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DistinctCountFunctionCallContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DoubleLiteralContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.EvalClauseContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.EvalFunctionCallContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.FieldExpressionContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.FloatLiteralContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IdentsAsQualifiedNameContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IdentsAsTableQualifiedNameContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IdentsAsWildcardQualifiedNameContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.InExprContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IntegerLiteralContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IntervalLiteralContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalAndContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalNotContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalOrContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalXorContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.MultiFieldRelevanceFunctionContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SingleFieldRelevanceFunctionContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SortFieldContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SpanClauseContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StatsFunctionCallContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StringLiteralContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TableSourceContext;
-import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.WcFieldExpressionContext;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -62,6 +30,38 @@ import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BinaryArithmeticContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BooleanLiteralContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BySpanClauseContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.CompareExprContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.ConvertedDataTypeContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.CountAllFunctionCallContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DataTypeFunctionCallContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DecimalLiteralContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DistinctCountFunctionCallContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.DoubleLiteralContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.EvalClauseContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.EvalFunctionCallContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.FieldExpressionContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.FloatLiteralContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IdentsAsQualifiedNameContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IdentsAsTableQualifiedNameContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IdentsAsWildcardQualifiedNameContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.InExprContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IntegerLiteralContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.IntervalLiteralContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalAndContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalNotContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalOrContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.LogicalXorContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.MultiFieldRelevanceFunctionContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SingleFieldRelevanceFunctionContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SortFieldContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SpanClauseContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StatsFunctionCallContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StringLiteralContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TableSourceContext;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.WcFieldExpressionContext;
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParserBaseVisitor;
 import org.opensearch.sql.ppl.utils.ArgumentFactory;
 
@@ -260,6 +260,27 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
                 : AstDSL.intLiteral(DEFAULT_TAKE_FUNCTION_SIZE_VALUE)));
     return new AggregateFunction(
         "take", visit(ctx.takeAggFunction().fieldExpression()), builder.build());
+  }
+
+  @Override
+  public UnresolvedExpression visitPercentileShortcutFunctionCall(
+      OpenSearchPPLParser.PercentileShortcutFunctionCallContext ctx) {
+    String functionName = ctx.getStart().getText();
+
+    int prefixLength = functionName.toLowerCase().startsWith("perc") ? 4 : 1;
+    String percentileValue = functionName.substring(prefixLength);
+
+    double percent = Double.parseDouble(percentileValue);
+    if (percent < 0.0 || percent > 100.0) {
+      throw new SyntaxCheckException(
+          String.format("Percentile value must be between 0 and 100, got: %s", percent));
+    }
+
+    return new AggregateFunction(
+        "percentile",
+        visit(ctx.valueExpression()),
+        Collections.singletonList(
+            new UnresolvedArgument("percent", AstDSL.doubleLiteral(percent))));
   }
 
   /** Case function. */

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
@@ -543,4 +543,92 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
             + "GROUP BY `MGR`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
+
+  @Test
+  public void testPercentileShortcuts() {
+    String ppl = "source=EMP | stats perc50(SAL), p95(SAL)";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalAggregate(group=[{}], perc50(SAL)=[percentile_approx($0, $1, $2)],"
+            + " p95(SAL)=[percentile_approx($0, $3, $2)])\n"
+            + "  LogicalProject(SAL=[$5], $f2=[50.0E0:DOUBLE], $f3=[FLAG(DECIMAL)],"
+            + " $f4=[95.0E0:DOUBLE])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `percentile_approx`(`SAL`, 5.00E1, DECIMAL) `perc50(SAL)`,"
+            + " `percentile_approx`(`SAL`, 9.50E1, DECIMAL) `p95(SAL)`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testPercentileShortcutsWithDecimals() {
+    String ppl = "source=EMP | stats perc25.5(SAL), p99.9(SAL)";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalAggregate(group=[{}], perc25.5(SAL)=[percentile_approx($0, $1, $2)],"
+            + " p99.9(SAL)=[percentile_approx($0, $3, $2)])\n"
+            + "  LogicalProject(SAL=[$5], $f2=[25.5E0:DOUBLE], $f3=[FLAG(DECIMAL)],"
+            + " $f4=[99.9E0:DOUBLE])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `percentile_approx`(`SAL`, 2.55E1, DECIMAL) `perc25.5(SAL)`,"
+            + " `percentile_approx`(`SAL`, 9.99E1, DECIMAL) `p99.9(SAL)`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testPercentileShortcutsByField() {
+    String ppl = "source=EMP | stats perc75(SAL) by DEPTNO";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(perc75(SAL)=[$1], DEPTNO=[$0])\n"
+            + "  LogicalAggregate(group=[{0}], perc75(SAL)=[percentile_approx($1, $2, $3)])\n"
+            + "    LogicalProject(DEPTNO=[$7], SAL=[$5], $f2=[75.0E0:DOUBLE],"
+            + " $f3=[FLAG(DECIMAL)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `percentile_approx`(`SAL`, 7.50E1, DECIMAL) `perc75(SAL)`, `DEPTNO`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testPercentileShortcutsBoundaryValues() {
+    String ppl = "source=EMP | stats perc0(SAL), p100(SAL)";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalAggregate(group=[{}], perc0(SAL)=[percentile_approx($0, $1, $2)],"
+            + " p100(SAL)=[percentile_approx($0, $3, $2)])\n"
+            + "  LogicalProject(SAL=[$5], $f2=[0.0E0:DOUBLE], $f3=[FLAG(DECIMAL)],"
+            + " $f4=[100.0E0:DOUBLE])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `percentile_approx`(`SAL`, 0E0, DECIMAL) `perc0(SAL)`,"
+            + " `percentile_approx`(`SAL`, 1.000E2, DECIMAL) `p100(SAL)`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test(expected = Exception.class)
+  public void testPercentileShortcutInvalidValueAbove100() {
+    String ppl = "source=EMP | stats p101(SAL)";
+    getRelNode(ppl);
+  }
+
+  @Test(expected = Exception.class)
+  public void testPercentileShortcutInvalidDecimalValueAbove100() {
+    String ppl = "source=EMP | stats perc100.1(SAL)";
+    getRelNode(ppl);
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -6,6 +6,7 @@ package org.opensearch.sql.ppl.parser;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.opensearch.sql.ast.dsl.AstDSL.agg;
 import static org.opensearch.sql.ast.dsl.AstDSL.aggregate;
 import static org.opensearch.sql.ast.dsl.AstDSL.alias;
@@ -50,9 +51,11 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.RelevanceFieldList;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
 
 public class AstExpressionBuilderTest extends AstBuilderTest {
   @Test
@@ -1107,5 +1110,114 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                     stringLiteral("YEAR"),
                     stringLiteral("1997-01-01 00:00:00"),
                     stringLiteral("2001-03-06 00:00:00")))));
+  }
+
+  @Test
+  public void testPercentileShortcutFunctions() {
+    // Test integer percentile shortcuts
+    assertEqual(
+        "source=t | stats perc50(a)",
+        agg(
+            relation("t"),
+            exprList(
+                alias(
+                    "perc50(a)",
+                    aggregate(
+                        "percentile", field("a"), unresolvedArg("percent", doubleLiteral(50.0))))),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()));
+
+    assertEqual(
+        "source=t | stats p95(a)",
+        agg(
+            relation("t"),
+            exprList(
+                alias(
+                    "p95(a)",
+                    aggregate(
+                        "percentile", field("a"), unresolvedArg("percent", doubleLiteral(95.0))))),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()));
+  }
+
+  @Test
+  public void testPercentileShortcutFunctionsWithDecimals() {
+    // Test decimal percentile shortcuts
+    assertEqual(
+        "source=t | stats perc25.5(a)",
+        agg(
+            relation("t"),
+            exprList(
+                alias(
+                    "perc25.5(a)",
+                    aggregate(
+                        "percentile", field("a"), unresolvedArg("percent", doubleLiteral(25.5))))),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()));
+
+    assertEqual(
+        "source=t | stats p99.9(a)",
+        agg(
+            relation("t"),
+            exprList(
+                alias(
+                    "p99.9(a)",
+                    aggregate(
+                        "percentile", field("a"), unresolvedArg("percent", doubleLiteral(99.9))))),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()));
+  }
+
+  @Test
+  public void testPercentileShortcutFunctionsBoundaryValues() {
+    // Test boundary values (0 and 100)
+    assertEqual(
+        "source=t | stats perc0(a)",
+        agg(
+            relation("t"),
+            exprList(
+                alias(
+                    "perc0(a)",
+                    aggregate(
+                        "percentile", field("a"), unresolvedArg("percent", doubleLiteral(0.0))))),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()));
+
+    assertEqual(
+        "source=t | stats p100(a)",
+        agg(
+            relation("t"),
+            exprList(
+                alias(
+                    "p100(a)",
+                    aggregate(
+                        "percentile", field("a"), unresolvedArg("percent", doubleLiteral(100.0))))),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()));
+  }
+
+  @Test
+  public void testPercentileShortcutFunctionInvalidNegativeValue() {
+    assertThrows(
+        SyntaxCheckException.class, () -> assertEqual("source=t | stats perc-1(a)", (Node) null));
+  }
+
+  @Test
+  public void testPercentileShortcutFunctionInvalidValueAbove100() {
+    assertThrows(
+        SyntaxCheckException.class, () -> assertEqual("source=t | stats p101(a)", (Node) null));
+  }
+
+  @Test
+  public void testPercentileShortcutFunctionInvalidDecimalValueAbove100() {
+    assertThrows(
+        SyntaxCheckException.class,
+        () -> assertEqual("source=t | stats perc100.1(a)", (Node) null));
   }
 }


### PR DESCRIPTION
Backport https://github.com/opensearch-project/sql/commit/aecca57878d9ddee5036c31dc9288cff7e818598 from https://github.com/opensearch-project/sql/pull/4085.