### PR TITLE
Add count alias to count()

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -215,7 +215,6 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.XOR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.YEAR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.YEARWEEK;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -1070,9 +1070,15 @@ public class PPLFuncImpTable {
 
       register(
           COUNT,
-          (distinct, field, argList, ctx) ->
-              ctx.relBuilder.count(
-                  distinct, null, field == null ? ImmutableList.of() : ImmutableList.of(field)),
+          (distinct, field, argList, ctx) -> {
+            if (field == null) {
+              // count() without arguments should count all rows
+              return ctx.relBuilder.count(distinct, null);
+            } else {
+              // count(field) should count non-null values of the field
+              return ctx.relBuilder.count(distinct, null, field);
+            }
+          },
           wrapSqlOperandTypeChecker(
               SqlStdOperatorTable.COUNT.getOperandTypeChecker(), COUNT.name(), false));
 

--- a/docs/user/ppl/cmd/stats.rst
+++ b/docs/user/ppl/cmd/stats.rst
@@ -80,17 +80,17 @@ COUNT
 Description
 >>>>>>>>>>>
 
-Usage: Returns a count of the number of expr in the rows retrieved. The ``C()`` function and ``count`` can be used as abbreviations for ``COUNT()``. To perform a filtered counting, wrap the condition to satisfy in an `eval` expression.
+Usage: Returns a count of the number of expr in the rows retrieved. The ``C()`` function, ``c``, and ``count`` can be used as abbreviations for ``COUNT()``. To perform a filtered counting, wrap the condition to satisfy in an `eval` expression.
 
 Example::
 
-    os> source=accounts | stats count(), c(), count;
+    os> source=accounts | stats count(), c(), count, c;
     fetched rows / total rows = 1/1
-    +---------+-----+-------+
-    | count() | c() | count |
-    |---------+-----+-------|
-    | 4       | 4   | 4     |
-    +---------+-----+-------+
+    +---------+-----+-------+---+
+    | count() | c() | count | c |
+    |---------+-----+-------+---|
+    | 4       | 4   | 4     | 4 |
+    +---------+-----+-------+---+
 
 Example of filtered counting::
 

--- a/docs/user/ppl/cmd/stats.rst
+++ b/docs/user/ppl/cmd/stats.rst
@@ -80,17 +80,17 @@ COUNT
 Description
 >>>>>>>>>>>
 
-Usage: Returns a count of the number of expr in the rows retrieved. The ``C()`` function can be used as an abbreviation for ``COUNT()``. To perform a filtered counting, wrap the condition to satisfy in an `eval` expression.
+Usage: Returns a count of the number of expr in the rows retrieved. The ``C()`` function and ``count`` can be used as abbreviations for ``COUNT()``. To perform a filtered counting, wrap the condition to satisfy in an `eval` expression.
 
 Example::
 
-    os> source=accounts | stats count(), c();
+    os> source=accounts | stats count(), c(), count;
     fetched rows / total rows = 1/1
-    +---------+-----+
-    | count() | c() |
-    |---------+-----|
-    | 4       | 4   |
-    +---------+-----+
+    +---------+-----+-------+
+    | count() | c() | count |
+    |---------+-----+-------|
+    | 4       | 4   | 4     |
+    +---------+-----+-------+
 
 Example of filtered counting::
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -951,4 +951,45 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
     verifyDataRows(shortcut, rows(shortcutValue));
     verifyDataRows(standard, rows(standardValue));
   }
+
+  @Test
+  public void testStatsCountAliasWithMultipleAggregatesAndSort() throws IOException {
+    JSONObject response =
+        executeQuery(
+            String.format(
+                "source=%s | stats sum(balance), count, avg(balance) by state | sort - `count`",
+                TEST_INDEX_BANK));
+    verifySchema(
+        response,
+        schema("sum(balance)", "bigint"),
+        schema("count", "bigint"),
+        schema("avg(balance)", "double"),
+        schema("state", "string"));
+    verifyDataRows(
+        response,
+        rows(39225, 1, 39225.0, "IL"),
+        rows(48086, 1, 48086.0, "IN"),
+        rows(4180, 1, 4180.0, "MD"),
+        rows(40540, 1, 40540.0, "PA"),
+        rows(5686, 1, 5686.0, "TN"),
+        rows(32838, 1, 32838.0, "VA"),
+        rows(16418, 1, 16418.0, "WA"));
+  }
+
+  @Test
+  public void testStatsCountAliasByGroupWithSort() throws IOException {
+    JSONObject response =
+        executeQuery(
+            String.format("source=%s | stats count by state | sort - `count`", TEST_INDEX_BANK));
+    verifySchema(response, schema("count", "bigint"), schema("state", "string"));
+    verifyDataRows(
+        response,
+        rows(1, "IL"),
+        rows(1, "IN"),
+        rows(1, "MD"),
+        rows(1, "PA"),
+        rows(1, "TN"),
+        rows(1, "VA"),
+        rows(1, "WA"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -64,6 +64,10 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
     actual = executeQuery(String.format("source=%s | stats c() as count_emp", TEST_INDEX_BANK));
     verifySchema(actual, schema("count_emp", "bigint"));
     verifyDataRows(actual, rows(7));
+
+    actual = executeQuery(String.format("source=%s | stats count as count_alias", TEST_INDEX_BANK));
+    verifySchema(actual, schema("count_alias", "bigint"));
+    verifyDataRows(actual, rows(7));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/StatsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/StatsCommandIT.java
@@ -104,6 +104,26 @@ public class StatsCommandIT extends PPLIntegTestCase {
       verifySchema(response, schema("count", null, "int"));
     }
     verifyDataRows(response, rows(1000));
+
+    response = executeQuery(String.format("source=%s | stats c", TEST_INDEX_ACCOUNT));
+    if (isCalciteEnabled()) {
+      verifySchema(response, schema("c", null, "bigint"));
+    } else {
+      verifySchema(response, schema("c", null, "int"));
+    }
+    verifyDataRows(response, rows(1000));
+  }
+
+  @Test
+  public void testStatsCBy() throws IOException {
+    JSONObject response =
+        executeQuery(String.format("source=%s | stats c by gender", TEST_INDEX_ACCOUNT));
+    if (isCalciteEnabled()) {
+      verifySchema(response, schema("c", null, "bigint"), schema("gender", null, "string"));
+    } else {
+      verifySchema(response, schema("c", null, "int"), schema("gender", null, "string"));
+    }
+    verifyDataRows(response, rows(493, "F"), rows(507, "M"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/StatsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/StatsCommandIT.java
@@ -96,6 +96,14 @@ public class StatsCommandIT extends PPLIntegTestCase {
       verifySchema(response, schema("c()", null, "int"));
     }
     verifyDataRows(response, rows(1000));
+
+    response = executeQuery(String.format("source=%s | stats count", TEST_INDEX_ACCOUNT));
+    if (isCalciteEnabled()) {
+      verifySchema(response, schema("count", null, "bigint"));
+    } else {
+      verifySchema(response, schema("count", null, "int"));
+    }
+    verifyDataRows(response, rows(1000));
   }
 
   @Test

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -484,6 +484,7 @@ statsFunction
    : statsFunctionName LT_PRTHS valueExpression RT_PRTHS        # statsFunctionCall
    | (COUNT | C) LT_PRTHS evalExpression RT_PRTHS               # countEvalFunctionCall
    | (COUNT | C) LT_PRTHS RT_PRTHS                              # countAllFunctionCall
+   | COUNT                                                      # countAllFunctionCall
    | PERCENTILE_SHORTCUT LT_PRTHS valueExpression RT_PRTHS      # percentileShortcutFunctionCall
    | (DISTINCT_COUNT | DC | DISTINCT_COUNT_APPROX) LT_PRTHS valueExpression RT_PRTHS    # distinctCountFunctionCall
    | takeAggFunction                                            # takeAggFunctionCall

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -483,8 +483,7 @@ statsAggTerm
 statsFunction
    : statsFunctionName LT_PRTHS valueExpression RT_PRTHS        # statsFunctionCall
    | (COUNT | C) LT_PRTHS evalExpression RT_PRTHS               # countEvalFunctionCall
-   | (COUNT | C) LT_PRTHS RT_PRTHS                              # countAllFunctionCall
-   | COUNT                                                      # countAllFunctionCall
+   | (COUNT | C) (LT_PRTHS RT_PRTHS)?                           # countAllFunctionCall
    | PERCENTILE_SHORTCUT LT_PRTHS valueExpression RT_PRTHS      # percentileShortcutFunctionCall
    | (DISTINCT_COUNT | DC | DISTINCT_COUNT_APPROX) LT_PRTHS valueExpression RT_PRTHS    # distinctCountFunctionCall
    | takeAggFunction                                            # takeAggFunctionCall

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
@@ -43,6 +43,19 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
 
     expectedSparkSql = "" + "SELECT COUNT(*) `count_emp`\n" + "FROM `scott`.`EMP`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
+
+    ppl = "source=EMP | stats count as cnt";
+    root = getRelNode(ppl);
+    expectedLogical =
+        ""
+            + "LogicalAggregate(group=[{}], cnt=[COUNT()])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    expectedResult = "cnt=14\n";
+    verifyResult(root, expectedResult);
+
+    expectedSparkSql = "" + "SELECT COUNT(*) `cnt`\n" + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
   @Test
@@ -115,6 +128,24 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     verifyResult(root, expectedResult);
 
     String expectedSparkSql =
+        "SELECT AVG(`SAL`) `avg_sal`, MAX(`SAL`) `max_sal`, MIN(`SAL`) `min_sal`, COUNT(*) `cnt`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+
+    ppl =
+        "source=EMP | stats avg(SAL) as avg_sal, max(SAL) as max_sal, min(SAL) as min_sal, count as"
+            + " cnt";
+    root = getRelNode(ppl);
+    expectedLogical =
+        "LogicalAggregate(group=[{}], avg_sal=[AVG($0)], max_sal=[MAX($0)], min_sal=[MIN($0)],"
+            + " cnt=[COUNT()])\n"
+            + "  LogicalProject(SAL=[$5])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    expectedResult = "avg_sal=2073.214285; max_sal=5000.00; min_sal=800.00; cnt=14\n";
+    verifyResult(root, expectedResult);
+
+    expectedSparkSql =
         "SELECT AVG(`SAL`) `avg_sal`, MAX(`SAL`) `max_sal`, MIN(`SAL`) `min_sal`, COUNT(*) `cnt`\n"
             + "FROM `scott`.`EMP`";
     verifyPPLToSparkSQL(root, expectedSparkSql);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -254,6 +254,18 @@ public class AstBuilderTest {
   }
 
   @Test
+  public void testStatsCommandWithCountAlias() {
+    assertEqual(
+        "source=t | stats count",
+        agg(
+            relation("t"),
+            exprList(alias("count", aggregate("count", AstDSL.allFields()))),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()));
+  }
+
+  @Test
   public void testStatsCommandWithByClause() {
     assertEqual(
         "source=t | stats count(a) by b DEDUP_SPLITVALUES=false",


### PR DESCRIPTION
### Description
Add count alias to count()
Supports count syntax without parentheses in stats PPL function.

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
