### PR TITLE
Starter implementation for `spath` command (#4120)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -70,6 +70,7 @@ import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Reverse;
+import org.opensearch.sql.ast.tree.SPath;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
@@ -234,6 +235,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitParse(Parse node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitSpath(SPath node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/org/opensearch/sql/ast/dsl/AstDSL.java
@@ -10,9 +10,6 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Locale;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.tuple.Pair;
@@ -68,6 +65,7 @@ import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.SPath;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
@@ -523,6 +521,9 @@ public class AstDSL {
     return new Parse(parseMethod, sourceField, pattern, arguments, input);
   }
 
+  public static SPath spath(UnresolvedPlan input, String inField, String outField, String path) {
+    return new SPath(input, inField, outField, path);
+  }
 
   public static Patterns patterns(
       UnresolvedPlan input,

--- a/core/src/main/java/org/opensearch/sql/ast/tree/SPath.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/SPath.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/opensearch/sql/ast/tree/SPath.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/SPath.java
@@ -1,0 +1,55 @@
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.dsl.AstDSL;
+
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class SPath extends UnresolvedPlan {
+  private UnresolvedPlan child;
+
+  private final String inField;
+
+  @Nullable private final String outField;
+
+  private final String path;
+
+  @Override
+  public UnresolvedPlan attach(UnresolvedPlan child) {
+    this.child = child;
+    return this;
+  }
+
+  @Override
+  public List<UnresolvedPlan> getChild() {
+    return this.child == null ? ImmutableList.of() : ImmutableList.of(this.child);
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitSpath(this, context);
+  }
+
+  public Eval rewriteAsEval() {
+    String outField = this.outField;
+    if (outField == null) {
+      outField = this.path;
+    }
+
+    return AstDSL.eval(
+        this.child,
+        AstDSL.let(
+            AstDSL.field(outField),
+            AstDSL.function(
+                "json_extract", AstDSL.field(inField), AstDSL.stringLiteral(this.path))));
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -100,6 +100,7 @@ import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.SPath;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
@@ -478,6 +479,11 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     visitChildren(node, context);
     buildParseRelNode(node, context);
     return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitSpath(SPath node, CalcitePlanContext context) {
+    return visitEval(node.rewriteAsEval(), context);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonExtractFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonExtractFunctionImpl.java
@@ -95,7 +95,9 @@ public class JsonExtractFunctionImpl extends ImplementorUDF {
   }
 
   private static String doJsonize(Object candidate) {
-    if (isScalarObject(candidate)) {
+    if (candidate == null) {
+      return "null"; // Matches isScalarObject, but not toString-able.
+    } else if (isScalarObject(candidate)) {
       return candidate.toString();
     } else {
       return JsonFunctions.jsonize(candidate);

--- a/docs/user/ppl/cmd/spath.rst
+++ b/docs/user/ppl/cmd/spath.rst
@@ -1,0 +1,80 @@
+=============
+spath
+=============
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Description
+============
+| The `spath` command allows extracting fields from structured text data. It currently allows selecting from JSON data with JSON paths.
+
+Version
+=======
+3.3.0
+
+Syntax
+============
+spath input=<field> [output=<field>] [path=]<path>
+
+
+* input: mandatory. The field to scan for JSON data.
+* output: optional. The destination field that the data will be loaded to. Defaults to the value of `path`.
+* path: mandatory. The path of the data to load for the object. For more information on path syntax, see `json_extract <../functions/json.rst#json_extract>`_.
+
+Note
+=====
+The `spath` command currently does not support pushdown behavior for extraction. It will be slow on large datasets. It's generally better to index fields needed for filtering directly instead of using `spath` to filter nested fields.
+
+Example 1: Simple Field Extraction
+==================================
+
+The simplest spath is to extract a single field. This extracts `n` from the `doc` field of type `text`.
+
+PPL query::
+
+    PPL> source=test_spath | spath input=doc n;
+    fetched rows / total rows = 3/3
+    +----------+---+
+    | doc      | n |
+    |----------+---|
+    | {"n": 1} | 1 |
+    | {"n": 2} | 2 |
+    | {"n": 3} | 3 |
+    +----------+---+
+
+Example 2: Lists & Nesting
+============================
+
+These queries demonstrate more JSON path uses, like traversing nested fields and extracting list elements.
+
+PPL query::
+
+    PPL> source=test_spath | spath input=doc output=first_element list{0} | spath input=doc output=all_elements list{} | spath input=doc output=nested nest_out.nest_in;
+    fetched rows / total rows = 3/3
+    +------------------------------------------------------+---------------+--------------+--------+
+    | doc                                                  | first_element | all_elements | nested |
+    |------------------------------------------------------+---------------+--------------+--------|
+    | {"list": [1, 2, 3, 4], "nest_out": {"nest_in": "a"}} | 1             | [1,2,3,4]    | a      |
+    | {"list": [], "nest_out": {"nest_in": "a"}}           | null          | []           | a      |
+    | {"list": [5, 6], "nest_out": {"nest_in": "a"}}       | 5             | [5,6]        | a      |
+    +------------------------------------------------------+---------------+--------------+--------+
+
+Example 3: Sum of inner elements
+============================
+
+The example shows extracting an inner field and doing statistics on it, using the docs from example 1. It also demonstrates that `spath` always returns strings for inner types.
+
+PPL query::
+
+    PPL> source=test_spath | spath input=doc n | eval n=cast(n as int) | stats sum(n);
+    fetched rows / total rows = 1/1
+    +--------+
+    | sum(n) |
+    |--------|
+    | 6      |
+    +--------+

--- a/docs/user/ppl/index.rst
+++ b/docs/user/ppl/index.rst
@@ -100,6 +100,8 @@ The query start with search command and then flowing a set of command delimited 
 
   - `sort command <cmd/sort.rst>`_
 
+  - `spath command <cmd/spath.rst>`_
+
   - `stats command <cmd/stats.rst>`_
 
   - `subquery (aka subsearch) command <cmd/subquery.rst>`_

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLSpathCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLSpathCommandIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+public class CalcitePPLSpathCommandIT extends PPLIntegTestCase {
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+
+    loadIndex(Index.BANK);
+
+    // Create test data for string concatenation
+    Request request1 = new Request("PUT", "/test_spath/_doc/1?refresh=true");
+    request1.setJsonEntity("{\"doc\": \"{\\\"n\\\": 1}\"}");
+    client().performRequest(request1);
+
+    Request request2 = new Request("PUT", "/test_spath/_doc/2?refresh=true");
+    request2.setJsonEntity("{\"doc\": \"{\\\"n\\\": 2}\"}");
+    client().performRequest(request2);
+
+    Request request3 = new Request("PUT", "/test_spath/_doc/3?refresh=true");
+    request3.setJsonEntity("{\"doc\": \"{\\\"n\\\": 3}\"}");
+    client().performRequest(request3);
+  }
+
+  @Test
+  public void testSimpleSpath() throws IOException {
+    JSONObject result =
+        executeQuery("source=test_spath | spath input=doc output=result path=n | fields result");
+    verifySchema(result, schema("result", "string"));
+    verifyDataRows(result, rows("1"), rows("2"), rows("3"));
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -28,6 +28,7 @@ HEAD:                               'HEAD';
 TOP:                                'TOP';
 RARE:                               'RARE';
 PARSE:                              'PARSE';
+SPATH:                              'SPATH';
 REGEX:                              'REGEX';
 PUNCT:                              'PUNCT';
 GROK:                               'GROK';
@@ -115,6 +116,9 @@ ANOMALY_SCORE_THRESHOLD:            'ANOMALY_SCORE_THRESHOLD';
 APPEND:                             'APPEND';
 COUNTFIELD:                         'COUNTFIELD';
 SHOWCOUNT:                          'SHOWCOUNT';
+INPUT:                              'INPUT';
+OUTPUT:                             'OUTPUT';
+PATH:                               'PATH';
 
 // COMPARISON FUNCTION KEYWORDS
 CASE:                               'CASE';
@@ -204,6 +208,8 @@ LT_PRTHS:                           '(';
 RT_PRTHS:                           ')';
 LT_SQR_PRTHS:                       '[';
 RT_SQR_PRTHS:                       ']';
+LT_CURLY:                           '{';
+RT_CURLY:                           '}';
 SINGLE_QUOTE:                       '\'';
 DOUBLE_QUOTE:                       '"';
 BACKTICK:                           '`';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -60,6 +60,7 @@ commands
    | rareCommand
    | grokCommand
    | parseCommand
+   | spathCommand
    | patternsCommand
    | lookupCommand
    | kmeansCommand
@@ -189,6 +190,28 @@ grokCommand
 
 parseCommand
    : PARSE (source_field = expression) (pattern = stringLiteral)
+   ;
+
+spathCommand
+   : SPATH spathParameter*
+   ;
+
+spathParameter
+   : (INPUT EQUAL input = expression)
+   | (OUTPUT EQUAL output = expression)
+   | ((PATH EQUAL)? path = indexablePath)
+   ;
+
+indexablePath
+   : pathElement (DOT pathElement)*
+   ;
+
+pathElement
+   : ident pathArrayAccess?
+   ;
+
+pathArrayAccess
+   : LT_CURLY (INTEGER_LITERAL)? RT_CURLY
    ;
 
 patternsMethod
@@ -1239,6 +1262,10 @@ keywordsCanBeId
    | ANOMALY_SCORE_THRESHOLD
    | COUNTFIELD
    | SHOWCOUNT
+   | PATH
+   | INPUT
+   | OUTPUT
+
    // AGGREGATIONS AND WINDOW
    | statsFunctionName
    | windowFunctionName

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -80,6 +80,7 @@ import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Reverse;
+import org.opensearch.sql.ast.tree.SPath;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
@@ -524,6 +525,34 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     Literal pattern = (Literal) internalVisitExpression(ctx.pattern);
 
     return new Parse(ParseMethod.REGEX, sourceField, pattern, ImmutableMap.of());
+  }
+
+  @Override
+  public UnresolvedPlan visitSpathCommand(OpenSearchPPLParser.SpathCommandContext ctx) {
+    String inField = null;
+    String outField = null;
+    String path = null;
+
+    for (OpenSearchPPLParser.SpathParameterContext param : ctx.spathParameter()) {
+      if (param.input != null) {
+        inField = param.input.getText();
+      }
+      if (param.output != null) {
+        outField = param.output.getText();
+      }
+      if (param.path != null) {
+        path = param.path.getText();
+      }
+    }
+
+    if (inField == null) {
+      throw new IllegalArgumentException("`input` parameter is required for `spath`");
+    }
+    if (path == null) {
+      throw new IllegalArgumentException("`path` parameter is required for `spath`");
+    }
+
+    return new SPath(inField, outField, path);
   }
 
   @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLSpathTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLSpathTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLSpathTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLSpathTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testSimpleEval() {
+    String ppl = "source=EMP | spath src.path input=ENAME";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], src.path=[JSON_EXTRACT($1, 'src.path':VARCHAR)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`,"
+            + " `JSON_EXTRACT`(`ENAME`, 'src.path') `src.path`\n"
+            + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testEvalWithOutput() {
+    String ppl = "source=EMP | spath src.path input=ENAME output=custom | fields custom";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(custom=[JSON_EXTRACT($1, 'src.path':VARCHAR)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `JSON_EXTRACT`(`ENAME`, 'src.path') `custom`\n" + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -42,6 +42,7 @@ import static org.opensearch.sql.ast.dsl.AstDSL.relation;
 import static org.opensearch.sql.ast.dsl.AstDSL.rename;
 import static org.opensearch.sql.ast.dsl.AstDSL.sort;
 import static org.opensearch.sql.ast.dsl.AstDSL.span;
+import static org.opensearch.sql.ast.dsl.AstDSL.spath;
 import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
 import static org.opensearch.sql.ast.dsl.AstDSL.tableFunction;
 import static org.opensearch.sql.ast.dsl.AstDSL.trendline;
@@ -679,6 +680,51 @@ public class AstBuilderTest {
             field("raw"),
             stringLiteral("pattern"),
             ImmutableMap.of()));
+  }
+
+  @Test
+  public void testBasicSpathCommand() {
+    assertEqual(
+        "source=t | spath input=f path=simple.nested",
+        spath(
+            relation("t"),
+            "f",
+            null, // no output field specified
+            "simple.nested"));
+  }
+
+  @Test
+  public void testSpathWithOutput() {
+    assertEqual(
+        "source=t | spath input=f output=o path=simple.nested",
+        spath(relation("t"), "f", "o", "simple.nested"));
+  }
+
+  @Test
+  public void testSpathWithArrayWildcard() {
+    assertEqual(
+        "source=t | spath input=f path=array{}.nested",
+        spath(relation("t"), "f", null, "array{}.nested"));
+  }
+
+  @Test
+  public void testSpathWithArrayIndex() {
+    assertEqual(
+        "source=t | spath input=f path=array{1}.nested",
+        spath(relation("t"), "f", null, "array{1}.nested"));
+  }
+
+  @Test
+  public void testSpathWithMultipleArrays() {
+    assertEqual(
+        "source=t | spath input=f path=outer{}.middle{2}.inner",
+        spath(relation("t"), "f", null, "outer{}.middle{2}.inner"));
+  }
+
+  @Test
+  public void testSpathWithNoPathKeyword() {
+    assertEqual(
+        "source=t | spath input=f simple.nested", spath(relation("t"), "f", null, "simple.nested"));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/SPathRewriteTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/SPathRewriteTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.ppl.utils;
 
 import static org.junit.Assert.assertEquals;

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/SPathRewriteTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/SPathRewriteTest.java
@@ -1,0 +1,62 @@
+package org.opensearch.sql.ppl.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.opensearch.sql.ast.dsl.AstDSL.eval;
+import static org.opensearch.sql.ast.dsl.AstDSL.field;
+import static org.opensearch.sql.ast.dsl.AstDSL.function;
+import static org.opensearch.sql.ast.dsl.AstDSL.let;
+import static org.opensearch.sql.ast.dsl.AstDSL.relation;
+import static org.opensearch.sql.ast.dsl.AstDSL.spath;
+import static org.opensearch.sql.ast.dsl.AstDSL.stringLiteral;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.tree.Eval;
+import org.opensearch.sql.ast.tree.SPath;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.ppl.antlr.PPLSyntaxParser;
+import org.opensearch.sql.ppl.parser.AstBuilder;
+
+public class SPathRewriteTest {
+  private final Settings settings = Mockito.mock(Settings.class);
+  private final PPLSyntaxParser parser = new PPLSyntaxParser();
+
+  private Node plan(String query) {
+    AstBuilder astBuilder = new AstBuilder(query, settings);
+    return astBuilder.visit(parser.parse(query));
+  }
+
+  // Control test to make sure something fundamental hasn't changed about the json_extract parsing
+  @Test
+  public void testEvalControl() {
+    assertEquals(
+        eval(
+            relation("t"),
+            let(field("o"), function("json_extract", field("f"), stringLiteral("simple.nested")))),
+        plan("source = t | eval o=json_extract(f, \"simple.nested\")"));
+  }
+
+  @Test
+  public void testSpathSimpleRewrite() {
+    SPath sp = spath(relation("t"), "f", "o", "simple.nested");
+    Eval ev = (Eval) plan("source = t | eval o=json_extract(f, \"simple.nested\")");
+
+    assertEquals(ev, sp.rewriteAsEval());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSpathMissingInputArgumentHandling() {
+    plan("source = t | spath path=a output=a");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSpathMissingPathArgumentHandling() {
+    plan("source = t | spath input=a output=a");
+  }
+
+  @Test
+  public void testSpathArgumentDeshuffle() {
+    assertEquals(plan("source = t | spath path=a input=a"), plan("source = t | spath input=a a"));
+  }
+}


### PR DESCRIPTION
Backport + license headers, will apply license headers in `main` with the followup PR.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
