### PR TITLE
`Bin` command big5 queries

### DIFF
--- a/integ-test/src/test/resources/big5/queries/bin_aligntime.ppl
+++ b/integ-test/src/test/resources/big5/queries/bin_aligntime.ppl
@@ -1,0 +1,3 @@
+source = big5
+| bin `@timestamp` span=12h aligntime="@d+3h"
+| head 10

--- a/integ-test/src/test/resources/big5/queries/bin_bins.ppl
+++ b/integ-test/src/test/resources/big5/queries/bin_bins.ppl
@@ -1,0 +1,3 @@
+source = big5
+| bin `metrics.size` bins=5
+| head 10

--- a/integ-test/src/test/resources/big5/queries/bin_default.ppl
+++ b/integ-test/src/test/resources/big5/queries/bin_default.ppl
@@ -1,0 +1,3 @@
+source = big5
+| bin `metrics.size`
+| head 10

--- a/integ-test/src/test/resources/big5/queries/bin_minspan.ppl
+++ b/integ-test/src/test/resources/big5/queries/bin_minspan.ppl
@@ -1,0 +1,3 @@
+source = big5
+| bin `metrics.size` minspan=100
+| head 10

--- a/integ-test/src/test/resources/big5/queries/bin_span_log.ppl
+++ b/integ-test/src/test/resources/big5/queries/bin_span_log.ppl
@@ -1,0 +1,3 @@
+source = big5
+| bin `metrics.size` span=log10
+| head 10

--- a/integ-test/src/test/resources/big5/queries/bin_span_numeric.ppl
+++ b/integ-test/src/test/resources/big5/queries/bin_span_numeric.ppl
@@ -1,0 +1,3 @@
+source = big5
+| bin `metrics.size` span=1000
+| head 10

--- a/integ-test/src/test/resources/big5/queries/bin_span_time.ppl
+++ b/integ-test/src/test/resources/big5/queries/bin_span_time.ppl
@@ -1,0 +1,3 @@
+source = big5
+| bin `@timestamp` span=1h
+| head 10

--- a/integ-test/src/test/resources/big5/queries/bin_start_end.ppl
+++ b/integ-test/src/test/resources/big5/queries/bin_start_end.ppl
@@ -1,0 +1,3 @@
+source = big5
+| bin `metrics.size` bins=5 start=0 end=10000
+| head 10


### PR DESCRIPTION
### Description
Adding big5 queries used for performance testing in the new features implemented for the `bin` command.

### Related Issues
#3878 

