### PR TITLE
Fix doctest requirements install

### DIFF
--- a/async-query/build.gradle
+++ b/async-query/build.gradle
@@ -62,6 +62,7 @@ test {
     }
 }
 task junit4(type: Test) {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform {
         includeEngines("junit-vintage")
     }

--- a/doctest/requirements.txt
+++ b/doctest/requirements.txt
@@ -1,2 +1,2 @@
 zc.customdoctests==1.0.1
-setuptools>=78.1.1
+click==7.1.2

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -58,7 +58,7 @@ spotless {
     java {
         target fileTree('.') {
             include '**/*.java'
-            exclude '**/build/**', '**/build-*/**'
+            exclude '**/build/**', '**/build-*/**', '**/gen/**'
         }
         importOrder()
 //        licenseHeader("/*\n" +


### PR DESCRIPTION
### Description
We already install setuptools as part of bootstrap, reinstalling a new version causes breakage with some python setups (particularly when the newer version is unavailable). On the other hand, doctest depends on click, which is unspecified.

Fixes some setups being unable to run doctest locally (I don't know how this has been passing in CI).

Also, async-query unit tests are independent. Enabling forking for it makes `./gradlew build --parallel -x doctest -x integTest` run 5x as fast locally. (Most of it is `IndexQuerySpecTest` and `IndexQuerySpecAlterTest`, we could split these classes into smaller chunks)

Also, don't run spotless on generated antlr output.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
