### PR TITLE
Run unit test suites in parallel

### DIFF
--- a/async-query-core/build.gradle
+++ b/async-query-core/build.gradle
@@ -85,6 +85,7 @@ spotless {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()
     testLogging {
         events "skipped", "failed"

--- a/async-query/build.gradle
+++ b/async-query/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform {
         includeEngines("junit-jupiter")
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -94,6 +94,7 @@ spotless {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()
     testLogging {
         events "skipped", "failed"

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()
     testLogging {
         events "skipped", "failed"

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -84,6 +84,7 @@ compileTestJava {
 
 // TODO: Need to update integration test to use OpenSearch test framework
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     include '**/*Test.class'
     exclude 'org/opensearch/sql/intgtest/**'
     // Gradle runs unit test using a working directory other and project root

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -85,6 +85,7 @@ pitest {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()
     testLogging {
         events "skipped", "failed"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -172,6 +172,7 @@ dependencies {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     include '**/*Test.class'
     testLogging {
         events "passed", "skipped", "failed"

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -86,6 +86,7 @@ spotless {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     testLogging {
         events "passed", "skipped", "failed"
         exceptionFormat "full"

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -49,6 +49,7 @@ configurations.all {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -78,6 +78,7 @@ spotless {
 }
 
 test {
+    maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"


### PR DESCRIPTION
### Description
Our unit tests don't have any cross-dependency, so we can freely turn on parallelization for them. Makes builds a bit faster locally. (At least the parts where most of the feedback is -- async is still slow but now it runs at the end instead of the start.)

### Related Issues
Slow local builds. I want `./gradlew -x doctest -x integTest` to be fast.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
