### PR TITLE
Add issue template for doc issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-issue.md
+++ b/.github/ISSUE_TEMPLATE/docs-issue.md
@@ -1,0 +1,20 @@
+---
+name: 📃 Documentation issue
+about: Need docs? Create an issue to request or add new documentation.
+title: '[DOC]'
+labels: 'untriaged, documentation'
+assignees: ''
+---
+
+**What do you want to do?**
+
+- [ ] Request a change to existing documentation
+- [ ] Add new documentation
+- [ ] Report a technical problem with the documentation
+- [ ] Other
+  
+  **Tell us about your request.** Provide a summary of the request.
+  
+  **Version:** List the OpenSearch version to which this issue applies, e.g. 2.14, 2.12--2.14, or all.
+  
+  **What other resources are available?** Provide links to related issues, POCs, steps for testing, etc.


### PR DESCRIPTION
### Description
We have [a growing number of documentation issues](https://github.com/opensearch-project/sql/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20label%3Adocumentation), these are currently under feature requests but that's not quite right, and non-maintainers can't change the labels after issue creation. This copies the documentation issue template from `documentation-website`, so external contributors can create requests for doc fixes.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
