### PR TITLE
Add merge_group trigger to test workflows

### DIFF
--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'integ-test/**'
       - '.github/workflows/integ-tests-with-security.yml'
+  merge_group:
 
 jobs:
   Get-CI-Image-Tag:

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -16,6 +16,7 @@ on:
       - '**/*.jar'
       - '**/*.pom'
       - '.github/workflows/sql-test-and-build-workflow.yml'
+  merge_group:
 
 jobs:
   Get-CI-Image-Tag:


### PR DESCRIPTION
### Description
Re: #4215, it seems prudent to actually act on #3606 now -- since automerge relies on branch protections to block on CI, but enabling branch protections globally means non-admins can never override them.

### Related Issues
#3606 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
