### PR TITLE
`mvjoin` support in PPL Caclite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -62,6 +62,7 @@ public enum BuiltinFunctionName {
   /** Collection functions */
   ARRAY(FunctionName.of("array")),
   ARRAY_LENGTH(FunctionName.of("array_length")),
+  MVJOIN(FunctionName.of("mvjoin")),
   FORALL(FunctionName.of("forall")),
   EXISTS(FunctionName.of("exists")),
   FILTER(FunctionName.of("filter")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -818,14 +818,7 @@ public class PPLFuncImpTable {
 
       registerOperator(INTERNAL_PATTERN_PARSER, PPLBuiltinOperators.PATTERN_PARSER);
 
-      // Register MVJOIN with two different implementations
-      // For single string values - just return the string (register this first so it's checked
-      // first)
-      register(
-          MVJOIN,
-          (FunctionImp2) (builder, value, delimiter) -> value,
-          PPLTypeChecker.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER));
-      // For arrays - use Calcite's ARRAY_JOIN
+      // Register MVJOIN to use Calcite's ARRAY_JOIN
       register(
           MVJOIN,
           (FunctionImp2)

--- a/docs/user/ppl/functions/collection.rst
+++ b/docs/user/ppl/functions/collection.rst
@@ -223,22 +223,6 @@ Example::
     |----------------------------------|
     | a,b,c                            |
     +----------------------------------+
-
-    PPL> source=people | eval result = mvjoin(array('1', '2', '3'), ' | ') | fields result | head 1
-    fetched rows / total rows = 1/1
-    +----------------------------------+
-    | result                           |
-    |----------------------------------|
-    | 1 | 2 | 3                        |
-    +----------------------------------+
-
-    PPL> source=people | eval result = mvjoin(array('a', null, 'c'), ',') | fields result | head 1
-    fetched rows / total rows = 1/1
-    +----------------------------------+
-    | result                           |
-    |----------------------------------|
-    | a,c                              |
-    +----------------------------------+
     
     PPL> source=people | eval result = mvjoin('hello', ',') | fields result | head 1
     fetched rows / total rows = 1/1

--- a/docs/user/ppl/functions/collection.rst
+++ b/docs/user/ppl/functions/collection.rst
@@ -208,9 +208,9 @@ Description
 
 Version: 3.3.0
 
-Usage: mvjoin(array, delimiter) joins string array elements into a single string, separated by the specified delimiter. NULL elements are excluded from the output. Only string arrays are supported. When given a single string value instead of an array, the function returns it unchanged (the delimiter parameter is ignored).
+Usage: mvjoin(array, delimiter) joins string array elements into a single string, separated by the specified delimiter. NULL elements are excluded from the output. Only string arrays are supported. 
 
-Argument type: array: ARRAY of STRING or STRING, delimiter: STRING
+Argument type: array: ARRAY of STRING, delimiter: STRING
 
 Return type: STRING
 
@@ -218,16 +218,17 @@ Example::
 
     PPL> source=people | eval result = mvjoin(array('a', 'b', 'c'), ',') | fields result | head 1
     fetched rows / total rows = 1/1
-    +----------------------------------+
-    | result                           |
-    |----------------------------------|
-    | a,b,c                            |
-    +----------------------------------+
-    
-    PPL> source=people | eval result = mvjoin('hello', ',') | fields result | head 1
+    +------------------------------------+
+    | result                             |
+    |------------------------------------|
+    | "a,b,c"                            |
+    +------------------------------------+
+
+    PPL> source=accounts | eval names_array = array(firstname, lastname) | eval result = mvjoin(names_array, ', ') | fields result | head 1
     fetched rows / total rows = 1/1
-    +----------------------------------+
-    | result                           |
-    |----------------------------------|
-    | hello                            |
-    +----------------------------------+
+    +------------------------------------------+
+    | result                                   |
+    |------------------------------------------|
+    | "Amber, Duke"                            |
+    +------------------------------------------+
+    

--- a/docs/user/ppl/functions/collection.rst
+++ b/docs/user/ppl/functions/collection.rst
@@ -40,54 +40,6 @@ Example::
     | ["1", "demo"]                    |
     +----------------------------------+
 
-MVJOIN
-------
-
-Description
->>>>>>>>>>>
-
-Version: 3.2.0
-
-Usage: mvjoin(array, delimiter) joins string array elements into a single string, separated by the specified delimiter. NULL elements are excluded from the output. Only string arrays are supported. When given a single string value instead of an array, the function returns it unchanged (the delimiter parameter is ignored).
-
-Argument type: array: ARRAY of STRING or STRING, delimiter: STRING
-
-Return type: STRING
-
-Example::
-
-    PPL> source=people | eval result = mvjoin(array('a', 'b', 'c'), ',') | fields result | head 1
-    fetched rows / total rows = 1/1
-    +----------------------------------+
-    | result                           |
-    |----------------------------------|
-    | a,b,c                            |
-    +----------------------------------+
-
-    PPL> source=people | eval result = mvjoin(array('1', '2', '3'), ' | ') | fields result | head 1
-    fetched rows / total rows = 1/1
-    +----------------------------------+
-    | result                           |
-    |----------------------------------|
-    | 1 | 2 | 3                        |
-    +----------------------------------+
-
-    PPL> source=people | eval result = mvjoin(array('a', null, 'c'), ',') | fields result | head 1
-    fetched rows / total rows = 1/1
-    +----------------------------------+
-    | result                           |
-    |----------------------------------|
-    | a,c                              |
-    +----------------------------------+
-    
-    PPL> source=people | eval result = mvjoin('hello', ',') | fields result | head 1
-    fetched rows / total rows = 1/1
-    +----------------------------------+
-    | result                           |
-    |----------------------------------|
-    | hello                            |
-    +----------------------------------+
-
 ARRAY_LENGTH
 ------------
 
@@ -247,3 +199,51 @@ Example::
     |------------|
     | 80         |
     +------------+ 
+
+MVJOIN
+------
+
+Description
+>>>>>>>>>>>
+
+Version: 3.3.0
+
+Usage: mvjoin(array, delimiter) joins string array elements into a single string, separated by the specified delimiter. NULL elements are excluded from the output. Only string arrays are supported. When given a single string value instead of an array, the function returns it unchanged (the delimiter parameter is ignored).
+
+Argument type: array: ARRAY of STRING or STRING, delimiter: STRING
+
+Return type: STRING
+
+Example::
+
+    PPL> source=people | eval result = mvjoin(array('a', 'b', 'c'), ',') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | result                           |
+    |----------------------------------|
+    | a,b,c                            |
+    +----------------------------------+
+
+    PPL> source=people | eval result = mvjoin(array('1', '2', '3'), ' | ') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | result                           |
+    |----------------------------------|
+    | 1 | 2 | 3                        |
+    +----------------------------------+
+
+    PPL> source=people | eval result = mvjoin(array('a', null, 'c'), ',') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | result                           |
+    |----------------------------------|
+    | a,c                              |
+    +----------------------------------+
+    
+    PPL> source=people | eval result = mvjoin('hello', ',') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | result                           |
+    |----------------------------------|
+    | hello                            |
+    +----------------------------------+

--- a/docs/user/ppl/functions/collection.rst
+++ b/docs/user/ppl/functions/collection.rst
@@ -40,6 +40,54 @@ Example::
     | ["1", "demo"]                    |
     +----------------------------------+
 
+MVJOIN
+------
+
+Description
+>>>>>>>>>>>
+
+Version: 3.2.0
+
+Usage: mvjoin(array, delimiter) joins string array elements into a single string, separated by the specified delimiter. NULL elements are excluded from the output. Only string arrays are supported. When given a single string value instead of an array, the function returns it unchanged (the delimiter parameter is ignored).
+
+Argument type: array: ARRAY of STRING or STRING, delimiter: STRING
+
+Return type: STRING
+
+Example::
+
+    PPL> source=people | eval result = mvjoin(array('a', 'b', 'c'), ',') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | result                           |
+    |----------------------------------|
+    | a,b,c                            |
+    +----------------------------------+
+
+    PPL> source=people | eval result = mvjoin(array('1', '2', '3'), ' | ') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | result                           |
+    |----------------------------------|
+    | 1 | 2 | 3                        |
+    +----------------------------------+
+
+    PPL> source=people | eval result = mvjoin(array('a', null, 'c'), ',') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | result                           |
+    |----------------------------------|
+    | a,c                              |
+    +----------------------------------+
+    
+    PPL> source=people | eval result = mvjoin('hello', ',') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | result                           |
+    |----------------------------------|
+    | hello                            |
+    +----------------------------------+
+
 ARRAY_LENGTH
 ------------
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
@@ -10,6 +10,7 @@ import static org.opensearch.sql.util.MatcherUtils.*;
 
 import java.io.IOException;
 import java.util.List;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.ResponseException;
@@ -21,6 +22,7 @@ public class CalciteArrayFunctionIT extends PPLIntegTestCase {
     super.init();
     enableCalcite();
     loadIndex(Index.BANK);
+    loadIndex(Index.ARRAY);
   }
 
   @Test
@@ -332,5 +334,52 @@ public class CalciteArrayFunctionIT extends PPLIntegTestCase {
 
     verifySchema(actual, schema("result", "string"));
     verifyDataRows(actual, rows("apple AND banana AND cherry"));
+  }
+
+  @Test
+  public void testMvjoinWithArrayFromRealFields() throws IOException {
+    // Test mvjoin on arrays created from real fields using array() function
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval names_array = array(firstname, lastname) | eval result ="
+                    + " mvjoin(names_array, ',') | fields firstname, lastname, result | head 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(
+        actual,
+        schema("firstname", "string"),
+        schema("lastname", "string"),
+        schema("result", "string"));
+    // Verify that mvjoin correctly joins the firstname and lastname fields
+    JSONArray dataRows = actual.getJSONArray("datarows");
+    assertTrue(dataRows.length() > 0);
+    JSONArray firstRow = dataRows.getJSONArray(0);
+    assertEquals(firstRow.getString(0) + "," + firstRow.getString(1), firstRow.getString(2));
+  }
+
+  @Test
+  public void testMvjoinWithMultipleRealFields() throws IOException {
+    // Test mvjoin with arrays created from multiple real fields
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval info_array = array(city, state, employer) | eval result ="
+                    + " mvjoin(info_array, ' | ') | fields city, state, employer, result | head 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(
+        actual,
+        schema("city", "string"),
+        schema("state", "string"),
+        schema("employer", "string"),
+        schema("result", "string"));
+    // Verify that mvjoin correctly joins the city, state, and employer fields
+    JSONArray dataRows = actual.getJSONArray("datarows");
+    assertTrue(dataRows.length() > 0);
+    JSONArray firstRow = dataRows.getJSONArray(0);
+    assertEquals(
+        firstRow.getString(0) + " | " + firstRow.getString(1) + " | " + firstRow.getString(2),
+        firstRow.getString(3));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
@@ -298,18 +298,6 @@ public class CalciteArrayFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
-  public void testMvjoinWithSingleStringValue() throws IOException {
-    JSONObject actual =
-        executeQuery(
-            String.format(
-                "source=%s | eval result = mvjoin('hello', ',') | fields result | head 1",
-                TEST_INDEX_BANK));
-
-    verifySchema(actual, schema("result", "string"));
-    verifyDataRows(actual, rows("hello"));
-  }
-
-  @Test
   public void testMvjoinWithStringBooleans() throws IOException {
     // mvjoin only supports string arrays
     JSONObject actual =

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
@@ -241,4 +241,96 @@ public class CalciteArrayFunctionIT extends PPLIntegTestCase {
 
     verifyDataRows(actual, rows(60));
   }
+
+  @Test
+  public void testMvjoinWithStringArray() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = mvjoin(array('a', 'b', 'c'), ',') | fields result | head"
+                    + " 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "string"));
+    verifyDataRows(actual, rows("a,b,c"));
+  }
+
+  @Test
+  public void testMvjoinWithStringifiedNumbers() throws IOException {
+    // Note: mvjoin only supports string arrays
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = mvjoin(array('1', '2', '3'), ' | ') | fields result |"
+                    + " head 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "string"));
+    verifyDataRows(actual, rows("1 | 2 | 3"));
+  }
+
+  @Test
+  public void testMvjoinWithMixedStringValues() throws IOException {
+    // mvjoin only supports string arrays
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = mvjoin(array('1', 'text', '2.5'), ';') | fields result |"
+                    + " head 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "string"));
+    verifyDataRows(actual, rows("1;text;2.5"));
+  }
+
+  @Test
+  public void testMvjoinWithEmptyArray() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = mvjoin(array(), '-') | fields result | head 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "string"));
+    verifyDataRows(actual, rows(""));
+  }
+
+  @Test
+  public void testMvjoinWithSingleStringValue() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = mvjoin('hello', ',') | fields result | head 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "string"));
+    verifyDataRows(actual, rows("hello"));
+  }
+
+  @Test
+  public void testMvjoinWithStringBooleans() throws IOException {
+    // mvjoin only supports string arrays
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = mvjoin(array('true', 'false', 'true'), '|') | fields"
+                    + " result | head 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "string"));
+    verifyDataRows(actual, rows("true|false|true"));
+  }
+
+  @Test
+  public void testMvjoinWithSpecialDelimiters() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = mvjoin(array('apple', 'banana', 'cherry'), ' AND ') |"
+                    + " fields result | head 1",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "string"));
+    verifyDataRows(actual, rows("apple AND banana AND cherry"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -565,8 +565,8 @@ public class CalciteExplainIT extends ExplainIT {
         "source=opensearch-sql_test_index_account | eval result = mvjoin(array('a', 'b', 'c'), ',')"
             + " | fields result | head 1";
     var result = explainQueryToString(query);
-    assertTrue(result.contains("ARRAY_JOIN"));
-    assertTrue(result.contains("ARRAY"));
+    String expected = loadExpectedPlan("explain_mvjoin.json");
+    assertJsonEqualsIgnoreId(expected, result);
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.opensearch.sql.legacy.TestUtils.*;
+import static org.junit.Assert.assertTrue;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_LOGS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
@@ -556,6 +558,15 @@ public class CalciteExplainIT extends ExplainIT {
                     + " count() as cnt ]",
                 TEST_INDEX_BANK,
                 TEST_INDEX_BANK)));
+  }
+  @Test
+  public void testMvjoinExplain() throws IOException {
+    String query =
+        "source=opensearch-sql_test_index_account | eval result = mvjoin(array('a', 'b', 'c'), ',')"
+            + " | fields result | head 1";
+    var result = explainQueryToString(query);
+    assertTrue(result.contains("ARRAY_JOIN"));
+    assertTrue(result.contains("ARRAY"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -5,8 +5,8 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import static org.opensearch.sql.legacy.TestUtils.*;
 import static org.junit.Assert.assertTrue;
+import static org.opensearch.sql.legacy.TestUtils.*;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_LOGS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
@@ -559,6 +559,7 @@ public class CalciteExplainIT extends ExplainIT {
                 TEST_INDEX_BANK,
                 TEST_INDEX_BANK)));
   }
+
   @Test
   public void testMvjoinExplain() throws IOException {
     String query =

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_mvjoin.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_mvjoin.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalSort(fetch=[1])\n    LogicalProject(result=[ARRAY_JOIN(array('a', 'b', 'c'), ',')])\n      CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableCalc(expr#0..16=[{inputs}], expr#17=['a'], expr#18=['b'], expr#19=['c'], expr#20=[array($t17, $t18, $t19)], expr#21=[','], expr#22=[ARRAY_JOIN($t20, $t21)], result=[$t22])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[LIMIT->1, LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"size\":1,\"timeout\":\"1m\"}, requestedTotalSize=1, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_mvjoin.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_mvjoin.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalSort(fetch=[1])\n    LogicalProject(result=[ARRAY_JOIN(array('a', 'b', 'c'), ',')])\n      CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableLimit(fetch=[10000])\n  EnumerableCalc(expr#0..16=[{inputs}], expr#17=['a'], expr#18=['b'], expr#19=['c'], expr#20=[array($t17, $t18, $t19)], expr#21=[','], expr#22=[ARRAY_JOIN($t20, $t21)], result=[$t22])\n    EnumerableLimit(fetch=[1])\n      CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n"
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -421,6 +421,7 @@ ISBLANK:                            'ISBLANK';
 // COLLECTION FUNCTIONS
 ARRAY:                              'ARRAY';
 ARRAY_LENGTH:                       'ARRAY_LENGTH';
+MVJOIN:                             'MVJOIN';
 FORALL:                             'FORALL';
 FILTER:                             'FILTER';
 TRANSFORM:                          'TRANSFORM';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -930,6 +930,7 @@ geoipFunctionName
 collectionFunctionName
     : ARRAY
     | ARRAY_LENGTH
+    | MVJOIN
     | FORALL
     | EXISTS
     | FILTER

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
@@ -40,26 +40,6 @@ public class CalcitePPLArrayFunctionTest extends CalcitePPLAbstractTest {
   }
 
   @Test
-  public void testMvjoinWithSingleStringValue() {
-    String ppl = "source=EMP | eval joined = mvjoin('hello', ',') | head 1 | fields joined";
-    RelNode root = getRelNode(ppl);
-
-    String expectedLogical =
-        "LogicalProject(joined=[$8])\n"
-            + "  LogicalSort(fetch=[1])\n"
-            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
-            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=['hello':VARCHAR])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n";
-    verifyLogical(root, expectedLogical);
-
-    String expectedResult = "joined=hello\n";
-    verifyResult(root, expectedResult);
-
-    String expectedSparkSql = "SELECT 'hello' `joined`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 1";
-    verifyPPLToSparkSQL(root, expectedSparkSql);
-  }
-
-  @Test
   public void testMvjoinWithDifferentDelimiter() {
     String ppl =
         "source=EMP | eval joined = mvjoin(array('apple', 'banana', 'cherry'), ' | ') | head 1 |"

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLArrayFunctionTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLArrayFunctionTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testMvjoinWithStringArray() {
+    String ppl =
+        "source=EMP | eval joined = mvjoin(array('a', 'b', 'c'), ',') | head 1 | fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=[ARRAY_JOIN(array('a', 'b', 'c'), ',')])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "joined=a,b,c\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT ARRAY_JOIN(`array`('a', 'b', 'c'), ',') `joined`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMvjoinWithSingleStringValue() {
+    String ppl = "source=EMP | eval joined = mvjoin('hello', ',') | head 1 | fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=['hello':VARCHAR])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "joined=hello\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql = "SELECT 'hello' `joined`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMvjoinWithDifferentDelimiter() {
+    String ppl =
+        "source=EMP | eval joined = mvjoin(array('apple', 'banana', 'cherry'), ' | ') | head 1 |"
+            + " fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=[ARRAY_JOIN(array('apple':VARCHAR,"
+            + " 'banana':VARCHAR, 'cherry':VARCHAR), ' | ':VARCHAR)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "joined=apple | banana | cherry\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT ARRAY_JOIN(`array`('apple', 'banana', 'cherry'), ' | ') `joined`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMvjoinWithEmptyArray() {
+    String ppl = "source=EMP | eval joined = mvjoin(array(), ',') | head 1 | fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=[ARRAY_JOIN(array(), ',')])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "joined=\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT ARRAY_JOIN(`array`(), ',') `joined`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMvjoinWithFieldReference() {
+    String ppl =
+        "source=EMP | eval joined = mvjoin(array(ENAME, JOB), '-') | head 1 | fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=[ARRAY_JOIN(array($1, $2), '-')])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT ARRAY_JOIN(`array`(`ENAME`, `JOB`), '-') `joined`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
@@ -176,16 +176,12 @@ public class CalcitePPLFunctionTypeTest extends CalcitePPLAbstractTest {
         "LOG2 function expects {[INTEGER]|[DOUBLE]}, but got [STRING,STRING]");
   }
 
+  // mvjoin should reject non-string single values
   @Test
   public void testMvjoinRejectsNonStringValues() {
-    // mvjoin should reject non-string single values
-    Exception e =
-        Assert.assertThrows(
-            ExpressionEvaluationException.class,
-            () ->
-                getRelNode("source=EMP | eval result = mvjoin(42, ',') | fields result | head 1"));
-
-    verifyErrorMessageContains(
-        e, "MVJOIN function expects {[STRING,STRING],[ARRAY,STRING]}, but got [INTEGER,STRING]");
+    verifyQueryThrowsException(
+      "source=EMP | eval result = mvjoin(42, ',') | fields result | head 1",
+      "MVJOIN function expects {[STRING,STRING],[ARRAY,STRING]}, but got [INTEGER,STRING]"
+    );
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
@@ -180,8 +180,7 @@ public class CalcitePPLFunctionTypeTest extends CalcitePPLAbstractTest {
   @Test
   public void testMvjoinRejectsNonStringValues() {
     verifyQueryThrowsException(
-      "source=EMP | eval result = mvjoin(42, ',') | fields result | head 1",
-      "MVJOIN function expects {[STRING,STRING],[ARRAY,STRING]}, but got [INTEGER,STRING]"
-    );
+        "source=EMP | eval result = mvjoin(42, ',') | fields result | head 1",
+        "MVJOIN function expects {[STRING,STRING],[ARRAY,STRING]}, but got [INTEGER,STRING]");
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
@@ -181,6 +181,6 @@ public class CalcitePPLFunctionTypeTest extends CalcitePPLAbstractTest {
   public void testMvjoinRejectsNonStringValues() {
     verifyQueryThrowsException(
         "source=EMP | eval result = mvjoin(42, ',') | fields result | head 1",
-        "MVJOIN function expects {[STRING,STRING],[ARRAY,STRING]}, but got [INTEGER,STRING]");
+        "MVJOIN function expects {[ARRAY,STRING]}, but got [INTEGER,STRING]");
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
@@ -188,20 +188,4 @@ public class CalcitePPLFunctionTypeTest extends CalcitePPLAbstractTest {
     verifyErrorMessageContains(
         e, "MVJOIN function expects {[STRING,STRING],[ARRAY,STRING]}, but got [INTEGER,STRING]");
   }
-
-  @Test
-  public void testMvjoinRejectsNumericArrays() {
-    // mvjoin should reject non-string arrays at runtime
-    // Note: Type checking doesn't happen at PPL level for array element types
-    Exception e =
-        Assert.assertThrows(
-            RuntimeException.class,
-            () ->
-                getRelNode(
-                    "source=EMP | eval result = mvjoin(array(1, 2, 3), ',') | fields result | head"
-                        + " 1"));
-
-    // The actual error comes from Calcite's ARRAY_JOIN operator
-    verifyErrorMessageContains(e, "arrayToString supports only String or ByteString");
-  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -616,11 +616,6 @@ public class PPLQueryDataAnonymizerTest {
     assertEquals(
         "source=t | eval result=mvjoin(array(***,***,***),***) | fields + result",
         anonymize("source=t | eval result=mvjoin(array('a', 'b', 'c'), ',') | fields result"));
-
-    // Test mvjoin with single string value
-    assertEquals(
-        "source=t | eval result=mvjoin(***,***) | fields + result",
-        anonymize("source=t | eval result=mvjoin('hello', ',') | fields result"));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -582,20 +582,16 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
-  public void testRexCommand() {
-    when(settings.getSettingValue(Key.PPL_REX_MAX_MATCH_LIMIT)).thenReturn(10);
+  public void testMvjoin() {
+    // Test mvjoin with array of strings
+    assertEquals(
+        "source=t | eval result=mvjoin(array(***,***,***),***) | fields + result",
+        anonymize("source=t | eval result=mvjoin(array('a', 'b', 'c'), ',') | fields result"));
 
+    // Test mvjoin with single string value
     assertEquals(
-        "source=t | rex field=message mode=extract \"(?<user>[A-Z]+)\" max_match=1",
-        anonymize("source=t | rex field=message \"(?<user>[A-Z]+)\""));
-    assertEquals(
-        "source=t | rex field=lastname mode=extract \"(?<initial>^[A-Z])\" max_match=1 | fields +"
-            + " lastname,initial",
-        anonymize(
-            "source=t | rex field=lastname \"(?<initial>^[A-Z])\" | fields lastname, initial"));
-    assertEquals(
-        "source=t | rex field=name mode=extract \"(?<first>[A-Z])\" max_match=3",
-        anonymize("source=t | rex field=name \"(?<first>[A-Z])\" max_match=3"));
+        "source=t | eval result=mvjoin(***,***) | fields + result",
+        anonymize("source=t | eval result=mvjoin('hello', ',') | fields result"));
   }
 
   @Test


### PR DESCRIPTION
### Description
This PR adds support for the mvjoin function in PPL with Apache Calcite integration. The mvjoin function concatenates the elements of a multi-value field into a single string using a specified delimiter.  This is useful for converting multi-value fields into a readable string format.

Syntax: `mvjoin(multivalue_field, delimiter)`

Example:
```
source=logs | eval joined_values = mvjoin(array('apple', 'banana', 'cherry'), ', ')
// Result: "apple, banana, cherry"
```

### Related Issues
Resolves #4146 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [x] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
