### PR TITLE
Doctest: Use 1.0 branch of CLI instead of main

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -26,8 +26,8 @@ task cloneSqlCli(type: Exec) {
     
     if (repoDir.exists()) {
         // Repository already exists, fetch and checkout latest
-        commandLine 'git', '-C', repoDir.absolutePath, 'fetch', 'origin', 'main'
-        commandLine 'git', '-C', repoDir.absolutePath, 'checkout', 'origin/main'
+        commandLine 'git', '-C', repoDir.absolutePath, 'fetch', 'origin', '1.0-legacy'
+        commandLine 'git', '-C', repoDir.absolutePath, 'checkout', 'origin/1.0-legacy'
     } else {
         // Repository doesn't exist, clone it
         commandLine 'git', 'clone', 'https://github.com/opensearch-project/sql-cli.git', repoDir.absolutePath


### PR DESCRIPTION
### Description
We're releasing SQL CLI 2.0 soon. This changes the output format of commands, which will cause disruption for the current doctest action. I've created a new `1.0-legacy` branch that contains the contents of the current `main` branch, so doctest won't be affected by these updates.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
