### PR TITLE
Don't recreate indices on every doctest

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -66,6 +66,8 @@ task startPrometheus(type: SpawnProcessTask) {
 
 //evaluationDependsOn(':')
 task startOpenSearch(type: SpawnProcessTask) {
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
+
     if( getOSFamilyType() == "windows") {
         command "${path}\\gradlew.bat -p ${plugin_path} runRestTestCluster"
     }

--- a/doctest/test_docs.py
+++ b/doctest/test_docs.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import sys
 import unittest
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import partial
 
 import click
@@ -205,6 +206,7 @@ class TestDataManager:
     
     def __init__(self):
         self.client = OpenSearch([ENDPOINT], verify_certs=True)
+        self.is_loaded = False
     
     def load_file(self, filename, index_name):
         mapping_file_path = './test_mapping/' + filename
@@ -218,18 +220,33 @@ class TestDataManager:
                 for line in f:
                     yield json.loads(line)
 
-        helpers.bulk(self.client, load_json(), stats_only=True, index=index_name, refresh='wait_for')
+        helpers.bulk(self.client, load_json(), stats_only=True, index=index_name, refresh="wait_for")
 
     def load_all_test_data(self):
-        for index_name, filename in TEST_DATA.items():
+        if self.is_loaded:
+            return
+
+        def load_index(index_name, filename):
             if filename is not None:
                 self.load_file(filename, index_name)
             else:
                 debug(f"Skipping index '{index_name}' - filename is None")
 
-    def cleanup_indices(self):
-        indices_to_delete = list(TEST_DATA.keys())
-        self.client.indices.delete(index=indices_to_delete, ignore_unavailable=True)
+        with ThreadPoolExecutor() as executor:
+            futures = {
+                executor.submit(load_index, index_name, filename): index_name
+                for index_name, filename in TEST_DATA.items()
+            }
+
+            for future in as_completed(futures):
+                index_name = futures[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    debug(f"Error loading index '{index_name}': {str(e)}")
+                    raise
+
+        self.is_loaded = True
 
 
 def sql_cli_transform(s):
@@ -282,7 +299,7 @@ def set_up_test_indices_without_calcite(test):
 
 
 def tear_down(test):
-    get_test_data_manager().cleanup_indices()
+    pass
 
 
 docsuite = partial(doctest.DocFileSuite,


### PR DESCRIPTION
### Description
Since I've been working on build timing lately: the vast majority of our time in doctest is spent repeatedly creating and destroying test indices with `refresh=wait_for`.

Originally I just wanted to rewrite this to run all the indexing in parallel, but it turns out: our doctests don't do any index modifications. There's no real reason to be repeatedly destroying and reindexing all this data. Disabling this behavior (in addition to parallel index creation) makes doctest run in ~13 seconds locally:

```
/workplace/sawiddis/sql/doctest/../docs/user/dql/expressions.rst
Doctest: expressions.rst ... ok
/workplace/sawiddis/sql/doctest/../docs/user/general/comments.rst
Doctest: comments.rst ... ok
...
/workplace/sawiddis/sql/doctest/../docs/user/ppl/cmd/stats.rst
Doctest: stats.rst ... ok

----------------------------------------------------------------------
Ran 54 tests in 12.838s
```

(Also, I found a missing task dependency that was causing `./gradlew -x integTest --parallel` to fail to run doctest)

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
