### PR TITLE
Support absolute time range in search command 

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
@@ -20,6 +20,8 @@ public interface OpenSearchConstants {
 
   String METADATA_FIELD_ROUTING = "_routing";
 
+  String IMPLICIT_FIELD_TIMESTAMP = "@timestamp";
+
   java.util.Map<String, ExprType> METADATAFIELD_TYPE_MAP =
       Map.of(
           METADATA_FIELD_ID, ExprCoreType.STRING,

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -253,6 +253,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.calcite.plan.OpenSearchConstants;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
 import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
@@ -1061,7 +1062,10 @@ public class PPLFuncImpTable {
       if (argList.isEmpty()) {
         // Try to find @timestamp field
         var timestampField =
-            ctx.relBuilder.peek().getRowType().getField("@timestamp", false, false);
+            ctx.relBuilder
+                .peek()
+                .getRowType()
+                .getField(OpenSearchConstants.IMPLICIT_FIELD_TIMESTAMP, false, false);
         if (timestampField == null) {
           throw new IllegalArgumentException(
               "Default @timestamp field not found. Please specify a time field explicitly.");

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
@@ -56,8 +56,9 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithBinsParameter() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin value bins=5 | fields value | sort value | head 3");
+            String.format(
+                "source=%s | bin value bins=5 | fields value | sort value | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("value", null, "string"));
 
     verifyDataRows(result, rows("6000-7000"), rows("6000-7000"), rows("6000-7000"));
@@ -101,9 +102,8 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinValueFieldOnly() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin value span=2000"
-                + " | fields value | head 3");
+            String.format(
+                "source=%s | bin value span=2000 | fields value | head 3", TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("value", null, "string"));
 
     verifyDataRows(result, rows("8000-10000"), rows("6000-8000"), rows("8000-10000"));
@@ -151,9 +151,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithTimestampSpan() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=1h"
-                + " | fields `@timestamp`, value | sort `@timestamp` | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=1h | fields `@timestamp`, value | sort"
+                    + " `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
 
     // With 1-hour spans
@@ -168,9 +169,11 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithTimestampStats() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=4h"
-                + " | fields `@timestamp` | sort `@timestamp` | head 3");
+            String.format(
+                "source=%s"
+                    + " | bin @timestamp span=4h"
+                    + " | fields `@timestamp` | sort `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"));
 
     // With 4-hour spans and stats
@@ -186,9 +189,9 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
     // Test just the bin operation without aggregation
     JSONObject binOnlyResult =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=4h"
-                + " | fields `@timestamp` | head 3");
+            String.format(
+                "source=%s" + " | bin @timestamp span=4h" + " | fields `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
 
     // Verify schema and that binning works correctly
     verifySchema(binOnlyResult, schema("@timestamp", null, "timestamp"));
@@ -206,9 +209,11 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
     // Test bin operation with fields only - no aggregation
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=4h"
-                + " | fields `@timestamp` | sort `@timestamp` | head 3");
+            String.format(
+                "source=%s"
+                    + " | bin @timestamp span=4h"
+                    + " | fields `@timestamp` | sort `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
 
     // Verify schema
     verifySchema(result, schema("@timestamp", null, "timestamp"));
@@ -225,8 +230,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithMonthlySpan() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=4mon as cate | fields"
-                + " cate, @timestamp | head 5");
+            String.format(
+                "source=%s | bin @timestamp span=4mon as cate | fields"
+                    + " cate, @timestamp | head 5",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("cate", null, "string"), schema("@timestamp", null, "timestamp"));
 
     // With 4-month spans using 'mon' unit
@@ -388,8 +395,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampSpan30Seconds() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=30seconds | fields"
-                + " @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=30seconds | fields"
+                    + " @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -402,8 +411,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampSpan45Minutes() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=45minute | fields"
-                + " @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=45minute | fields"
+                    + " @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -416,8 +427,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampSpan7Days() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=7day | fields"
-                + " @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=7day | fields"
+                    + " @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -430,8 +443,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampSpan6Days() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=6day | fields"
-                + " @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=6day | fields"
+                    + " @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -444,8 +459,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampAligntimeHour() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=2h"
-                + " aligntime='@d+3h' | fields @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=2h"
+                    + " aligntime='@d+3h' | fields @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -458,8 +475,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampAligntimeEpoch() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=2h"
-                + " aligntime=1500000000 | fields @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=2h"
+                    + " aligntime=1500000000 | fields @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -567,8 +586,9 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithBinsParameterStatsCount() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin value bins=5 | stats count() by value | sort value | head 3");
+            String.format(
+                "source=%s" + " | bin value bins=5 | stats count() by value | sort value | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("count()", null, "bigint"), schema("value", null, "string"));
 
     verifyDataRows(result, rows(24L, "6000-7000"), rows(25L, "7000-8000"), rows(33L, "8000-9000"));
@@ -651,9 +671,11 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
     // Test bin operation with aggregation - this should now work correctly
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=4h"
-                + " | stats count() by `@timestamp` | sort `@timestamp` | head 3");
+            String.format(
+                "source=%s"
+                    + " | bin @timestamp span=4h"
+                    + " | stats count() by `@timestamp` | sort `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
 
     // Verify schema
     verifySchema(

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -46,6 +46,10 @@ public class TestsConstants {
   public static final String TEST_INDEX_WEBLOGS = TEST_INDEX + "_weblogs";
   public static final String TEST_INDEX_DATE = TEST_INDEX + "_date";
   public static final String TEST_INDEX_DATE_TIME = TEST_INDEX + "_datetime";
+
+  /** A test index with @timestamp field */
+  public static final String TEST_INDEX_TIME_DATA = TEST_INDEX + "_time_data";
+
   public static final String TEST_INDEX_DEEP_NESTED = TEST_INDEX + "_deep_nested";
   public static final String TEST_INDEX_STRINGS = TEST_INDEX + "_strings";
   public static final String TEST_INDEX_DATATYPE_NUMERIC = TEST_INDEX + "_datatypes_numeric";

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.ppl;
 import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_TIME_DATA;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WEBLOGS;
 import static org.opensearch.sql.util.MatcherUtils.assertJsonEqualsIgnoreId;
 
@@ -28,6 +29,7 @@ public class ExplainIT extends PPLIntegTestCase {
     loadIndex(Index.BANK);
     loadIndex(Index.DATE_FORMATS);
     loadIndex(Index.WEBLOG);
+    loadIndex(Index.TIME_TEST_DATA);
   }
 
   @Test
@@ -621,6 +623,18 @@ public class ExplainIT extends PPLIntegTestCase {
                 "source=%s | eval len = length(gender) | stats sum(balance + 100) as sum by len,"
                     + " gender ",
                 TEST_INDEX_BANK)));
+  }
+
+  @Test
+  public void testSearchCommandWithAbsoluteTimeRange() throws IOException {
+    Assume.assumeTrue("Generated script not stable in v2", isCalciteEnabled());
+    String expected = loadExpectedPlan("explain_search_with_absolute_time_range.json");
+    assertJsonEqualsIgnoreId(
+        expected,
+        explainQueryToString(
+            String.format(
+                "source=%s earliest='2022-12-10 13:11:04' latest='2025-09-03 15:10:00'",
+                TEST_INDEX_TIME_DATA)));
   }
 
   protected String loadExpectedPlan(String fileName) throws IOException {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -8,8 +8,11 @@ package org.opensearch.sql.ppl;
 import static org.opensearch.sql.legacy.TestsConstants.*;
 import static org.opensearch.sql.util.MatcherUtils.columnName;
 import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyNumOfRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
 import org.json.JSONObject;
@@ -24,6 +27,7 @@ public class SearchCommandIT extends PPLIntegTestCase {
     super.init();
     loadIndex(Index.BANK);
     loadIndex(Index.DOG);
+    loadIndex(Index.TIME_TEST_DATA);
   }
 
   @Test
@@ -66,5 +70,30 @@ public class SearchCommandIT extends PPLIntegTestCase {
       assertTrue(e.getMessage().contains("RuntimeException"));
       assertTrue(e.getMessage().contains(SYNTAX_EX_MSG_FRAGMENT));
     }
+  }
+
+  @Test
+  public void testSearchWithEarliest() throws IOException {
+    JSONObject result1 =
+        executeQuery(
+            String.format(
+                "search source=%s earliest='2025-08-01 03:47:41' | fields @timestamp",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result1, schema("@timestamp", "timestamp"));
+    verifyDataRows(result1, rows("2025-08-01 03:47:41"));
+
+    JSONObject result0 =
+        executeQuery(
+            String.format(
+                "search source=%s earliest='2025-08-01 03:47:42' | fields @timestamp",
+                TEST_INDEX_TIME_DATA));
+    verifyNumOfRows(result0, 0);
+
+    JSONObject result2 =
+        executeQuery(
+            String.format(
+                "search source=%s earliest='2025-08-01 02:00:55' | fields @timestamp",
+                TEST_INDEX_TIME_DATA));
+    verifyDataRows(result2, rows("2025-08-01 02:00:56"), rows("2025-08-01 03:47:41"));
   }
 }

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_search_with_absolute_time_range.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_search_with_absolute_time_range.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])\n    LogicalFilter(condition=[AND(>=($0, TIMESTAMP('2022-12-10 13:11:04':VARCHAR)), <=($0, TIMESTAMP('2025-09-03 15:10:00':VARCHAR)))])\n      CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])\n",
+    "physical": "CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[PROJECT->[@timestamp, category, value, timestamp], FILTER->SEARCH($0, Sarg[['2022-12-10 13:11:04':VARCHAR..'2025-09-03 15:10:00':VARCHAR]]:VARCHAR), LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"range\":{\"@timestamp\":{\"from\":\"2022-12-10T13:11:04.000Z\",\"to\":\"2025-09-03T15:10:00.000Z\",\"include_lower\":true,\"include_upper\":true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"@timestamp\",\"category\",\"value\",\"timestamp\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, requestedTotalSize=10000, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_search_with_absolute_time_range.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_search_with_absolute_time_range.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])\n    LogicalFilter(condition=[AND(>=($0, TIMESTAMP('2022-12-10 13:11:04':VARCHAR)), <=($0, TIMESTAMP('2025-09-03 15:10:00':VARCHAR)))])\n      CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])\n",
+    "physical": "EnumerableLimit(fetch=[10000])\n  EnumerableCalc(expr#0..9=[{inputs}], expr#10=[Sarg[['2022-12-10 13:11:04':VARCHAR..'2025-09-03 15:10:00':VARCHAR]]:VARCHAR], expr#11=[SEARCH($t0, $t10)], proj#0..3=[{exprs}], $condition=[$t11])\n    CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_search_with_absolute_time_range.json
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_search_with_absolute_time_range.json
@@ -1,0 +1,17 @@
+{
+  "root": {
+    "name": "ProjectOperator",
+    "description": {
+      "fields": "[@timestamp, category, value, timestamp]"
+    },
+    "children": [
+      {
+        "name": "OpenSearchIndexScan",
+        "description": {
+          "request": "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data, sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\":{\"@timestamp\":{\"from\":1670677864000,\"to\":null,\"include_lower\":true,\"include_upper\":true,\"boost\":1.0}}},{\"range\":{\"@timestamp\":{\"from\":null,\"to\":1756912200000,\"include_lower\":true,\"include_upper\":true,\"boost\":1.0}}}],\"adjust_pure_negative\":true,\"boost\":1.0}},\"_source\":{\"includes\":[\"@timestamp\",\"category\",\"value\",\"timestamp\"],\"excludes\":[]},\"sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false, pitId=*, cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+        },
+        "children": []
+      }
+    ]
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -113,7 +113,7 @@ commandName
    ;
 
 searchCommand
-   : (SEARCH)? (logicalExpression)* fromClause (logicalExpression)*     # searchFrom
+   : (SEARCH)? (timeRangeExpression | logicalExpression)* fromClause (timeRangeExpression | logicalExpression)*     # searchFrom
    ;
 
 describeCommand
@@ -624,6 +624,15 @@ singleFieldRelevanceFunction
 // Field is a list of columns
 multiFieldRelevanceFunction
    : multiFieldRelevanceFunctionName LT_PRTHS (LT_SQR_PRTHS field = relevanceFieldAndWeight (COMMA field = relevanceFieldAndWeight)* RT_SQR_PRTHS COMMA)? query = relevanceQuery (COMMA relevanceArg)* RT_PRTHS
+   ;
+
+timeRangeExpression
+   : (EARLIEST | LATEST) EQUAL timeRangeValue
+   ;
+
+timeRangeValue
+   : NOW
+   | stringLiteral
    ;
 
 // tables

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -39,6 +39,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -156,14 +157,15 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   /** Search command. */
   @Override
   public UnresolvedPlan visitSearchFrom(SearchFromContext ctx) {
-    if (ctx.logicalExpression().isEmpty()) {
+    if (ctx.logicalExpression().isEmpty() && ctx.timeRangeExpression().isEmpty()) {
       return visitFromClause(ctx.fromClause());
     } else {
+      Stream<UnresolvedExpression> logicalExpressions =
+          ctx.logicalExpression().stream().map(this::internalVisitExpression);
+      Stream<UnresolvedExpression> timeRangeExpressions =
+          ctx.timeRangeExpression().stream().map(this::internalVisitExpression);
       return new Filter(
-              ctx.logicalExpression().stream()
-                  .map(this::internalVisitExpression)
-                  .reduce(And::new)
-                  .get())
+              Stream.concat(logicalExpressions, timeRangeExpressions).reduce(And::new).get())
           .attach(visit(ctx.fromClause()));
     }
   }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.ppl.parser;
 
+import static org.opensearch.sql.ast.dsl.AstDSL.field;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.*;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BinaryArithmeticContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BooleanLiteralContext;
@@ -38,6 +39,8 @@ import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SpanClause
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StatsFunctionCallContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StringLiteralContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TableSourceContext;
+import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TimeRangeExpressionContext;
+import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.TimeRangeValueContext;
 import static org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.WcFieldExpressionContext;
 
 import com.google.common.collect.ImmutableList;
@@ -88,8 +91,10 @@ import org.opensearch.sql.ast.expression.subquery.ExistsSubquery;
 import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.expression.subquery.ScalarSubquery;
 import org.opensearch.sql.ast.tree.Trendline;
+import org.opensearch.sql.calcite.plan.OpenSearchConstants;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser;
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BinaryArithmeticContext;
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.BooleanLiteralContext;
@@ -811,5 +816,34 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitLogWithBaseSpan(OpenSearchPPLParser.LogWithBaseSpanContext ctx) {
     return org.opensearch.sql.ast.dsl.AstDSL.stringLiteral(ctx.getText());
+  }
+
+  /** Process time range value expressions (NOW or string literal) */
+  @Override
+  public UnresolvedExpression visitTimeRangeValue(TimeRangeValueContext ctx) {
+    if (ctx.NOW() != null) {
+      // Convert NOW keyword to function call NOW()
+      return buildFunction(BuiltinFunctionName.NOW.name(), List.of());
+    } else if (ctx.stringLiteral() != null) {
+      return visit(ctx.stringLiteral());
+    } else {
+      throw new IllegalArgumentException("Unknown time range value type");
+    }
+  }
+
+  /**
+   * Process time range expressions (EARLIEST='value' or LATEST='value') It creates a Comparison
+   * filter like @timestamp >= timeRangeValue
+   */
+  @Override
+  public UnresolvedExpression visitTimeRangeExpression(TimeRangeExpressionContext ctx) {
+    // EARLIEST != null --> @timestamp >= timeRangeValue
+    String operator =
+        ctx.EARLIEST() != null
+            ? BuiltinFunctionName.GTE.getName().toString()
+            : BuiltinFunctionName.LTE.getName().toString();
+    UnresolvedExpression timestampField = field(OpenSearchConstants.IMPLICIT_FIELD_TIMESTAMP);
+    UnresolvedExpression timeValue = visit(ctx.timeRangeValue());
+    return new Compare(operator, timestampField, timeValue);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAbstractTest.java
@@ -12,8 +12,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.opensearch.sql.executor.QueryType.PPL;
 
+import com.google.common.collect.ImmutableList;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
@@ -175,5 +177,61 @@ public class CalcitePPLAbstractTest {
   public void verifyErrorMessageContains(Throwable t, String msg) {
     String stackTrace = getStackTrace(t);
     assertThat(String.format("Actual stack trace was:\n%s", stackTrace), stackTrace.contains(msg));
+  }
+
+  /**
+   * Add a test table with @timestamp and created_at fields with name {@code LOGS}
+   *
+   * <p>Note: @timestamp and created_at have different orderings to test explicit field usage
+   */
+  protected Frameworks.ConfigBuilder configureTimestampLogSchema(
+      CalciteAssert.SchemaSpec... schemaSpecs) {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    final SchemaPlus schema = CalciteAssert.addSchema(rootSchema, schemaSpecs);
+
+    ImmutableList<Object[]> rows =
+        ImmutableList.of(
+            new Object[] {
+              "server1",
+              "ERROR",
+              "Database connection failed",
+              Date.valueOf("2023-01-01"),
+              Date.valueOf("2023-01-05")
+            },
+            new Object[] {
+              "server2",
+              "INFO",
+              "Service started",
+              Date.valueOf("2023-01-02"),
+              Date.valueOf("2023-01-04")
+            },
+            new Object[] {
+              "server1",
+              "WARN",
+              "High memory usage",
+              Date.valueOf("2023-01-03"),
+              Date.valueOf("2023-01-03")
+            },
+            new Object[] {
+              "server3",
+              "ERROR",
+              "Disk space low",
+              Date.valueOf("2023-01-04"),
+              Date.valueOf("2023-01-02")
+            },
+            new Object[] {
+              "server2",
+              "INFO",
+              "Backup completed",
+              Date.valueOf("2023-01-05"),
+              Date.valueOf("2023-01-01")
+            });
+    schema.add("LOGS", new CalcitePPLEarliestLatestTest.LogsTable(rows));
+
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(schema)
+        .traitDefs((List<RelTraitDef>) null)
+        .programs(Programs.heuristicJoinOrder(Programs.RULE_SET, true, 2));
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEarliestLatestTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEarliestLatestTest.java
@@ -6,14 +6,11 @@
 package org.opensearch.sql.ppl.calcite;
 
 import com.google.common.collect.ImmutableList;
-import java.sql.Date;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Linq4j;
-import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
@@ -21,16 +18,13 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.schema.Schema;
-import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.Statistics;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.test.CalciteAssert;
 import org.apache.calcite.tools.Frameworks;
-import org.apache.calcite.tools.Programs;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Test;
 
@@ -42,55 +36,7 @@ public class CalcitePPLEarliestLatestTest extends CalcitePPLAbstractTest {
 
   @Override
   protected Frameworks.ConfigBuilder config(CalciteAssert.SchemaSpec... schemaSpecs) {
-    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
-    final SchemaPlus schema = CalciteAssert.addSchema(rootSchema, schemaSpecs);
-
-    // Add a test table with @timestamp and created_at fields
-    // Note: @timestamp and created_at have different orderings to test explicit field usage
-    ImmutableList<Object[]> rows =
-        ImmutableList.of(
-            new Object[] {
-              "server1",
-              "ERROR",
-              "Database connection failed",
-              Date.valueOf("2023-01-01"),
-              Date.valueOf("2023-01-05")
-            },
-            new Object[] {
-              "server2",
-              "INFO",
-              "Service started",
-              Date.valueOf("2023-01-02"),
-              Date.valueOf("2023-01-04")
-            },
-            new Object[] {
-              "server1",
-              "WARN",
-              "High memory usage",
-              Date.valueOf("2023-01-03"),
-              Date.valueOf("2023-01-03")
-            },
-            new Object[] {
-              "server3",
-              "ERROR",
-              "Disk space low",
-              Date.valueOf("2023-01-04"),
-              Date.valueOf("2023-01-02")
-            },
-            new Object[] {
-              "server2",
-              "INFO",
-              "Backup completed",
-              Date.valueOf("2023-01-05"),
-              Date.valueOf("2023-01-01")
-            });
-    schema.add("LOGS", new LogsTable(rows));
-
-    return Frameworks.newConfigBuilder()
-        .parserConfig(SqlParser.Config.DEFAULT)
-        .defaultSchema(schema)
-        .traitDefs((List<RelTraitDef>) null)
-        .programs(Programs.heuristicJoinOrder(Programs.RULE_SET, true, 2));
+    return configureTimestampLogSchema(schemaSpecs);
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLSearchTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLSearchTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import static org.junit.Assert.assertThrows;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.Frameworks;
+import org.junit.Test;
+
+public class CalcitePPLSearchTest extends CalcitePPLAbstractTest {
+  public CalcitePPLSearchTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Override
+  protected Frameworks.ConfigBuilder config(CalciteAssert.SchemaSpec... schemaSpecs) {
+    return configureTimestampLogSchema(schemaSpecs);
+  }
+
+  @Test
+  public void testSearchWithFilter() {
+    String ppl = "search source=EMP DEPTNO=20";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalFilter(condition=[=($7, 20)])\n" + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql = "SELECT *\n" + "FROM `scott`.`EMP`\n" + "WHERE `DEPTNO` = 20";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testSearchWithoutTimestampShouldThrow() {
+    String ppl = "source=EMP earliest='2020-10-11'";
+    Throwable t = assertThrows(IllegalArgumentException.class, () -> getRelNode(ppl));
+    verifyErrorMessageContains(t, "field [@timestamp] not found");
+  }
+
+  @Test
+  public void testSearchWithAbsoluteTimeRange() {
+    String ppl = "source=LOGS earliest='2020-10-11' latest='2025-01-01'";
+    RelNode root = getRelNode(ppl);
+    // @timestamp is a field of type DATE here
+    String expectedLogical =
+        "LogicalFilter(condition=[AND(>=($3, DATE('2020-10-11':VARCHAR)), <=($3,"
+            + " DATE('2025-01-01':VARCHAR)))])\n"
+            + "  LogicalTableScan(table=[[scott, LOGS]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT *\n"
+            + "FROM `scott`.`LOGS`\n"
+            + "WHERE `@timestamp` >= `DATE`('2020-10-11') AND `@timestamp` <= `DATE`('2025-01-01')";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -546,4 +546,11 @@ public class PPLQueryDataAnonymizerTest {
     PPLQueryDataAnonymizer anonymize = new PPLQueryDataAnonymizer(settings);
     return anonymize.anonymizeStatement(statement);
   }
+
+  @Test
+  public void testSearchWithAbsoluteTimeRange() {
+    assertEquals(
+        "source=t | where @timestamp >= *** and @timestamp <= NOW()",
+        anonymize("search source=t earliest='2012-12-10 15:00:00' latest=now"));
+  }
 }


### PR DESCRIPTION
### Description
Support absolute time range modifier in search command. 


Examples:

```
source=any earliest='2020-12-10'
source=any earliest='2020-12-10' latest='2025-09-10 13:00:12'
source=any latest=now
```

Queries with earliest and latest time modifiers will be converted to scan followed by filters with the implicit timestamp field `@timestamp`. For example, `source=any earliest='2020-12-10'` is converted to `source=any | where @timestamp >= '2020-12-10'`

### Related Issues
Resolves #4135 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
