### PR TITLE
Add support for `median(<value>)`

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -198,6 +198,7 @@ public enum BuiltinFunctionName {
   TAKE(FunctionName.of("take")),
   // t-digest percentile which is used in OpenSearch core by default.
   PERCENTILE_APPROX(FunctionName.of("percentile_approx")),
+  MEDIAN(FunctionName.of("median")),
   EARLIEST(FunctionName.of("earliest")),
   LATEST(FunctionName.of("latest")),
   DISTINCT_COUNT_APPROX(FunctionName.of("distinct_count_approx")),
@@ -344,6 +345,7 @@ public enum BuiltinFunctionName {
           .put("take", BuiltinFunctionName.TAKE)
           .put("percentile", BuiltinFunctionName.PERCENTILE_APPROX)
           .put("percentile_approx", BuiltinFunctionName.PERCENTILE_APPROX)
+          .put("median", BuiltinFunctionName.MEDIAN)
           .put("earliest", BuiltinFunctionName.EARLIEST)
           .put("latest", BuiltinFunctionName.LATEST)
           .put("distinct_count_approx", BuiltinFunctionName.DISTINCT_COUNT_APPROX)

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -419,6 +419,26 @@ Example::
     | 32      |
     +---------+
 
+MEDIAN
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: MEDIAN(expr). Returns the median (50th percentile) value of `expr`. This is equivalent to ``PERCENTILE(expr, 50)``.
+
+Note: This function is only available when Calcite is enabled.
+
+Example::
+
+    ppl> source=accounts | stats median(age);
+    fetched rows / total rows = 1/1
+    +-------------+
+    | median(age) |
+    |-------------|
+    | 32          |
+    +-------------+
+
 HAVING Clause
 =============
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -969,4 +969,12 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
         rows(1, "VA"),
         rows(1, "WA"));
   }
+
+  @Test
+  public void testMedian() throws IOException {
+    JSONObject actual =
+        executeQuery(String.format("source=%s | stats median(balance)", TEST_INDEX_BANK));
+    verifySchema(actual, schema("median(balance)", "bigint"));
+    verifyDataRows(actual, rows(32838));
+  }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -512,6 +512,7 @@ statsFunctionName
    | STDDEV_POP
    | PERCENTILE
    | PERCENTILE_APPROX
+   | MEDIAN
    ;
 
 earliestLatestFunction

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAggregationTest.java
@@ -696,4 +696,19 @@ public class CalcitePPLAggregationTest extends CalcitePPLAbstractTest {
     String ppl = "source=EMP | stats perc100.1(SAL)";
     getRelNode(ppl);
   }
+
+  @Test
+  public void testMedian() {
+    String ppl = "source=EMP | stats median(SAL)";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalAggregate(group=[{}], median(SAL)=[percentile_approx($0, $1, $2)])\n"
+            + "  LogicalProject(SAL=[$5], $f1=[50.0:DECIMAL(3, 1)], $f2=[FLAG(DECIMAL)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `percentile_approx`(`SAL`, 50.0, DECIMAL) `median(SAL)`\n" + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -1298,4 +1298,16 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
         SyntaxCheckException.class,
         () -> assertEqual("source=t | stats perc100.1(a)", (Node) null));
   }
+
+  @Test
+  public void testMedianAggFuncExpr() {
+    assertEqual(
+        "source=t | stats median(a)",
+        agg(
+            relation("t"),
+            exprList(alias("median(a)", aggregate("median", field("a")))),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()));
+  }
 }


### PR DESCRIPTION
### Description
PPL lacks `median` function `median(<field>)` in stats aggregation functions.

This PR implements the support of the `median` shortcut and rewrite it to `perc50(<value>)`, which is already supported with pushdown optimization.

`median(<field>)` and `percentile50(<field>)` are functionally equivalent - they both return the 50th percentile value of the specified field.

However, there are some subtle differences:

- `median()` is specifically designed for finding the middle value and may have slight performance optimizations for this exact use case.
- percentile50() is part of the more general percentile function family, which can calculate any percentile (1-99)

In practice, both will give you the same result for the 50th percentile calculation. The choice between them is often a matter of code readability and intent - median() makes it immediately clear you want the median value, while percentile50() shows you're working with percentile calculations.

### Related Issues
Resolves #[4200]<https://github.com/opensearch-project/sql/issues/4200>

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [x] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).