### PR TITLE
[Backport 2.19-dev] Support pushdown sort by simple expressions (#4071)

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -413,6 +413,24 @@ public class CalciteExplainIT extends ExplainIT {
             "source=opensearch-sql_test_index_account | stats list(age) as age_list"));
   }
 
+  @Test
+  public void testSimpleSortExpressionPushDownExplain() throws Exception {
+    String query =
+        "source=opensearch-sql_test_index_bank| eval age2 = age + 2 | sort age2 | fields age, age2";
+    var result = explainQueryToString(query);
+    String expected = loadExpectedPlan("explain_simple_sort_expr_push.json");
+    assertJsonEqualsIgnoreId(expected, result);
+  }
+
+  @Test
+  public void testSimpleSortExpressionPushDownWithOnlyExprProjected() throws Exception {
+    String query =
+        "source=opensearch-sql_test_index_bank| eval b = balance + 1 | sort b | fields b";
+    var result = explainQueryToString(query);
+    String expected = loadExpectedPlan("explain_simple_sort_expr_single_expr_output_push.json");
+    assertJsonEqualsIgnoreId(expected, result);
+  }
+
   /**
    * Executes the PPL query and returns the result as a string with windows-style line breaks
    * replaced with Unix-style ones.

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSortCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSortCommandIT.java
@@ -7,9 +7,12 @@ package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyOrder;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
+import java.util.Locale;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.ppl.SortCommandIT;
@@ -27,5 +30,149 @@ public class CalciteSortCommandIT extends SortCommandIT {
     JSONObject result =
         executeQuery(String.format("source=%s | head 2 | sort age | fields age", TEST_INDEX_BANK));
     verifyOrder(result, rows(32), rows(36));
+  }
+
+  @Test
+  public void testPushdownSortPlusExpression() throws IOException {
+    String ppl =
+        String.format(
+            Locale.ROOT,
+            "source=%s | eval age2 = age + 2 | sort age2 | fields age | head 2",
+            TEST_INDEX_BANK);
+    String explained = explainQueryToString(ppl);
+    if (isPushdownEnabled()) {
+      assertTrue(
+          explained.contains(
+              "[SORT->[{\\n"
+                  + "  \\\"age\\\" : {\\n"
+                  + "    \\\"order\\\" : \\\"asc\\\",\\n"
+                  + "    \\\"missing\\\" : \\\"_first\\\"\\n"
+                  + "  }\\n"
+                  + "}]"));
+    }
+
+    JSONObject result = executeQuery(ppl);
+    verifyOrder(result, rows(28), rows(32));
+  }
+
+  @Test
+  public void testPushdownSortMinusExpression() throws IOException {
+    String ppl =
+        String.format(
+            Locale.ROOT,
+            "source=%s | eval age2 = 1 - age | sort age2 | fields age | head 2",
+            TEST_INDEX_BANK);
+    String explained = explainQueryToString(ppl);
+    if (isPushdownEnabled()) {
+      assertTrue(
+          explained.contains(
+              "[SORT->[{\\n"
+                  + "  \\\"age\\\" : {\\n"
+                  + "    \\\"order\\\" : \\\"desc\\\",\\n"
+                  + "    \\\"missing\\\" : \\\"_first\\\"\\n"
+                  + "  }\\n"
+                  + "}]"));
+    }
+
+    JSONObject result = executeQuery(ppl);
+    verifyOrder(result, rows(39), rows(36));
+  }
+
+  @Test
+  public void testPushdownSortTimesExpression() throws IOException {
+    String ppl =
+        String.format(
+            Locale.ROOT,
+            "source=%s | eval age2 = 5 * age | sort age2 | fields age | head 2",
+            TEST_INDEX_BANK);
+    String explained = explainQueryToString(ppl);
+    if (isPushdownEnabled()) {
+      assertTrue(
+          explained.contains(
+              "[SORT->[{\\n"
+                  + "  \\\"age\\\" : {\\n"
+                  + "    \\\"order\\\" : \\\"asc\\\",\\n"
+                  + "    \\\"missing\\\" : \\\"_first\\\"\\n"
+                  + "  }\\n"
+                  + "}]"));
+    }
+
+    JSONObject result = executeQuery(ppl);
+    verifyOrder(result, rows(28), rows(32));
+  }
+
+  @Test
+  public void testPushdownSortByMultiExpressions() throws IOException {
+    String ppl =
+        String.format(
+            Locale.ROOT,
+            "source=%s | eval age2 = 5 * age | sort gender, age2 | fields gender, age | head 2",
+            TEST_INDEX_BANK);
+    String explained = explainQueryToString(ppl);
+    if (isPushdownEnabled()) {
+      assertTrue(
+          explained.contains(
+              "[SORT->[{\\n"
+                  + "  \\\"gender.keyword\\\" : {\\n"
+                  + "    \\\"order\\\" : \\\"asc\\\",\\n"
+                  + "    \\\"missing\\\" : \\\"_first\\\"\\n"
+                  + "  }\\n"
+                  + "}, {\\n"
+                  + "  \\\"age\\\" : {\\n"
+                  + "    \\\"order\\\" : \\\"asc\\\",\\n"
+                  + "    \\\"missing\\\" : \\\"_first\\\"\\n"
+                  + "  }\\n"
+                  + "}]"));
+    }
+
+    JSONObject result = executeQuery(ppl);
+    verifyOrder(result, rows("F", 28), rows("F", 34));
+  }
+
+  @Test
+  public void testPushdownSortCastExpression() throws IOException {
+    String ppl =
+        String.format(
+            Locale.ROOT,
+            "source=%s | eval age2 = cast(age * 5 as long) | sort age2 | fields age | head 2",
+            TEST_INDEX_BANK);
+    String explained = explainQueryToString(ppl);
+    if (isPushdownEnabled()) {
+      assertTrue(
+          explained.contains(
+              "[SORT->[{\\n"
+                  + "  \\\"age\\\" : {\\n"
+                  + "    \\\"order\\\" : \\\"asc\\\",\\n"
+                  + "    \\\"missing\\\" : \\\"_first\\\"\\n"
+                  + "  }\\n"
+                  + "}]"));
+    }
+
+    JSONObject result = executeQuery(ppl);
+    verifyOrder(result, rows(28), rows(32));
+  }
+
+  @Test
+  public void testPushdownSortCastToDoubleExpression() throws IOException {
+    // Similar to query: 'source=%s | sort num(age)'. But left query doesn't output casted column.
+    String ppl =
+        String.format(
+            "source=%s | eval age2 = cast(age as double) | sort age2 | fields age, age2 | head 2",
+            TEST_INDEX_BANK);
+    String explained = explainQueryToString(ppl);
+    if (isPushdownEnabled()) {
+      assertTrue(
+          explained.contains(
+              "SORT->[{\\n"
+                  + "  \\\"age\\\" : {\\n"
+                  + "    \\\"order\\\" : \\\"asc\\\",\\n"
+                  + "    \\\"missing\\\" : \\\"_first\\\"\\n"
+                  + "  }\\n"
+                  + "}]"));
+    }
+
+    JSONObject result = executeQuery(ppl);
+    verifySchema(result, schema("age", "int"), schema("age2", "double"));
+    verifyOrder(result, rows(28, 28d), rows(32, 32d));
   }
 }

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_simple_sort_expr_push.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_simple_sort_expr_push.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalProject(age=[$10], age2=[$19])\n    LogicalSort(sort0=[$19], dir0=[ASC-nulls-first])\n      LogicalProject(account_number=[$0], firstname=[$1], address=[$2], birthdate=[$3], gender=[$4], city=[$5], lastname=[$6], balance=[$7], employer=[$8], state=[$9], age=[$10], email=[$11], male=[$12], _id=[$13], _index=[$14], _score=[$15], _maxscore=[$16], _sort=[$17], _routing=[$18], age2=[+($10, 2)])\n        CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]])\n",
+    "physical": "EnumerableCalc(expr#0=[{inputs}], expr#1=[2], expr#2=[+($t0, $t1)], age=[$t0], $f1=[$t2])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]], PushDownContext=[[SORT->[{\n  \"age\" : {\n    \"order\" : \"asc\",\n    \"missing\" : \"_first\"\n  }\n}], LIMIT->10000, PROJECT->[age]], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"age\"],\"excludes\":[]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, requestedTotalSize=10000, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_simple_sort_expr_single_expr_output_push.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_simple_sort_expr_single_expr_output_push.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(sort0=[$0], dir0=[ASC-nulls-first], fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalProject(b=[$19])\n    LogicalSort(sort0=[$19], dir0=[ASC-nulls-first])\n      LogicalProject(account_number=[$0], firstname=[$1], address=[$2], birthdate=[$3], gender=[$4], city=[$5], lastname=[$6], balance=[$7], employer=[$8], state=[$9], age=[$10], email=[$11], male=[$12], _id=[$13], _index=[$14], _score=[$15], _maxscore=[$16], _sort=[$17], _routing=[$18], b=[+($7, 1)])\n        CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]])\n",
+    "physical": "EnumerableCalc(expr#0=[{inputs}], expr#1=[1], expr#2=[+($t0, $t1)], $f0=[$t2])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]], PushDownContext=[[SORT->[{\n  \"balance\" : {\n    \"order\" : \"asc\",\n    \"missing\" : \"_first\"\n  }\n}], LIMIT->10000, PROJECT->[balance]], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"balance\"],\"excludes\":[]},\"sort\":[{\"balance\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, requestedTotalSize=10000, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_simple_sort_expr_push.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_simple_sort_expr_push.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalProject(age=[$10], age2=[$19])\n    LogicalSort(sort0=[$19], dir0=[ASC-nulls-first])\n      LogicalProject(account_number=[$0], firstname=[$1], address=[$2], birthdate=[$3], gender=[$4], city=[$5], lastname=[$6], balance=[$7], employer=[$8], state=[$9], age=[$10], email=[$11], male=[$12], _id=[$13], _index=[$14], _score=[$15], _maxscore=[$16], _sort=[$17], _routing=[$18], age2=[+($10, 2)])\n        CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]])\n",
+    "physical": "EnumerableLimit(fetch=[10000])\n  EnumerableSort(sort0=[$1], dir0=[ASC-nulls-first])\n    EnumerableCalc(expr#0..18=[{inputs}], expr#19=[2], expr#20=[+($t10, $t19)], age=[$t10], age2=[$t20])\n      CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_simple_sort_expr_single_expr_output_push.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_simple_sort_expr_single_expr_output_push.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(sort0=[$0], dir0=[ASC-nulls-first], fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalProject(b=[$19])\n    LogicalSort(sort0=[$19], dir0=[ASC-nulls-first])\n      LogicalProject(account_number=[$0], firstname=[$1], address=[$2], birthdate=[$3], gender=[$4], city=[$5], lastname=[$6], balance=[$7], employer=[$8], state=[$9], age=[$10], email=[$11], male=[$12], _id=[$13], _index=[$14], _score=[$15], _maxscore=[$16], _sort=[$17], _routing=[$18], b=[+($7, 1)])\n        CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]])\n",
+    "physical": "EnumerableLimit(fetch=[10000])\n  EnumerableSort(sort0=[$0], dir0=[ASC-nulls-first])\n    EnumerableCalc(expr#0..18=[{inputs}], expr#19=[1], expr#20=[+($t7, $t19)], b=[$t20])\n      CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]])\n"
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/ExpandCollationOnProjectExprRule.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/ExpandCollationOnProjectExprRule.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.planner.physical;
+
+import java.util.Optional;
+import org.apache.calcite.adapter.enumerable.EnumerableProject;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.AbstractConverter;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
+import org.apache.calcite.rel.core.Project;
+import org.apache.commons.lang3.tuple.Pair;
+import org.immutables.value.Value;
+import org.opensearch.sql.opensearch.util.OpenSearchRelOptUtil;
+
+/**
+ * When ENUMERABLE convention physical node is converted from logical node, each enumerable node's
+ * collation is recalculated based on input collations. However, if SortProjectExprTransposeRule
+ * takes effect, the input collation is changed to a sort over field instead of original sort over
+ * expression. It changes the collation requirement of the whole query.
+ *
+ * <p>AbstractConverter physical node is supposed to resolve the problem of inconsistent collation
+ * requirement between physical node input and output. This optimization rule finds equivalent
+ * output expression collations and input field collations. If their collation traits are satisfied,
+ * generate a new RelSubset without top sort
+ */
+@Value.Enclosing
+public class ExpandCollationOnProjectExprRule
+    extends RelRule<ExpandCollationOnProjectExprRule.Config> {
+
+  protected ExpandCollationOnProjectExprRule(Config config) {
+    super(config);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    final AbstractConverter converter = call.rel(0);
+    final Project project = call.rel(1);
+    final RelTraitSet toTraits = converter.getTraitSet();
+    final RelCollation toCollation = toTraits.getTrait(RelCollationTraitDef.INSTANCE);
+    final RelTrait fromTrait =
+        project.getInput().getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
+    // In case of fromTrait is an instance of RelCompositeTrait, it most likely finds equivalence by
+    // default.
+    // Let it go through default ExpandConversionRule to determine trait satisfaction.
+    if (fromTrait != null && fromTrait instanceof RelCollation) {
+      RelCollation fromCollation = (RelCollation) fromTrait;
+      // TODO: Handle the case where multi expr collations are mapped to the same source field
+      if (toCollation == null
+          || toCollation.getFieldCollations().isEmpty()
+          || fromCollation == null
+          || fromCollation.getFieldCollations().size() < toCollation.getFieldCollations().size()) {
+        return;
+      }
+
+      for (int i = 0; i < toCollation.getFieldCollations().size(); i++) {
+        RelFieldCollation targetFieldCollation = toCollation.getFieldCollations().get(i);
+        Optional<Pair<Integer, Boolean>> equivalentCollationInputInfo =
+            OpenSearchRelOptUtil.getOrderEquivalentInputInfo(
+                project.getProjects().get(targetFieldCollation.getFieldIndex()));
+
+        if (equivalentCollationInputInfo.isEmpty()) {
+          return;
+        }
+
+        RelFieldCollation sourceFieldCollation = fromCollation.getFieldCollations().get(i);
+        int equivalentSourceIndex = equivalentCollationInputInfo.get().getLeft();
+        Direction equivalentSourceDirection =
+            equivalentCollationInputInfo.get().getRight()
+                ? targetFieldCollation.getDirection().reverse()
+                : targetFieldCollation.getDirection();
+        if (!(equivalentSourceIndex == sourceFieldCollation.getFieldIndex()
+            && equivalentSourceDirection == sourceFieldCollation.getDirection())) {
+          return;
+        }
+      }
+
+      // After collation equivalence analysis, fromTrait satisfies toTrait. Copy the target trait
+      // set
+      // to new EnumerableProject.
+      Project newProject =
+          project.copy(toTraits, project.getInput(), project.getProjects(), project.getRowType());
+      call.transformTo(newProject);
+    }
+  }
+
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+
+    /**
+     * Only match ENUMERABLE convention RelNode combination like below to narrow the optimization
+     * searching space: - AbstractConverter - EnumerableProject
+     */
+    ExpandCollationOnProjectExprRule.Config DEFAULT =
+        ImmutableExpandCollationOnProjectExprRule.Config.builder()
+            .build()
+            .withOperandSupplier(
+                b0 ->
+                    b0.operand(AbstractConverter.class)
+                        .oneInput(
+                            b1 ->
+                                b1.operand(EnumerableProject.class)
+                                    .predicate(OpenSearchIndexScanRule::projectContainsExpr)
+                                    .predicate(p -> !p.containsOver())
+                                    .anyInputs()));
+
+    @Override
+    default ExpandCollationOnProjectExprRule toRule() {
+      return new ExpandCollationOnProjectExprRule(this);
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/OpenSearchIndexRules.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/OpenSearchIndexRules.java
@@ -24,6 +24,10 @@ public class OpenSearchIndexRules {
       OpenSearchSortIndexScanRule.Config.DEFAULT.toRule();
   private static final OpenSearchDedupPushdownRule DEDUP_PUSH_DOWN =
       OpenSearchDedupPushdownRule.Config.DEFAULT.toRule();
+  private static final SortProjectExprTransposeRule SORT_PROJECT_EXPR_TRANSPOSE =
+      SortProjectExprTransposeRule.Config.DEFAULT.toRule();
+  private static final ExpandCollationOnProjectExprRule EXPAND_COLLATION_ON_PROJECT_EXPR =
+      ExpandCollationOnProjectExprRule.Config.DEFAULT.toRule();
 
   public static final List<RelOptRule> OPEN_SEARCH_INDEX_SCAN_RULES =
       ImmutableList.of(
@@ -33,7 +37,9 @@ public class OpenSearchIndexRules {
           COUNT_STAR_INDEX_SCAN,
           LIMIT_INDEX_SCAN,
           SORT_INDEX_SCAN,
-          DEDUP_PUSH_DOWN);
+          DEDUP_PUSH_DOWN,
+          SORT_PROJECT_EXPR_TRANSPOSE,
+          EXPAND_COLLATION_ON_PROJECT_EXPR);
 
   // prevent instantiation
   private OpenSearchIndexRules() {}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/OpenSearchIndexScanRule.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/OpenSearchIndexScanRule.java
@@ -8,9 +8,11 @@ package org.opensearch.sql.opensearch.planner.physical;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexOver;
 import org.opensearch.sql.opensearch.storage.OpenSearchIndex;
@@ -57,6 +59,10 @@ public interface OpenSearchIndexScanRule {
    */
   static boolean isLogicalSortLimit(LogicalSort sort) {
     return sort.fetch != null;
+  }
+
+  static boolean projectContainsExpr(Project project) {
+    return project.getProjects().stream().anyMatch(p -> p instanceof RexCall);
   }
 
   static boolean sortByFieldsOnly(Sort sort) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/SortProjectExprTransposeRule.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/physical/SortProjectExprTransposeRule.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.planner.physical;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rex.RexNode;
+import org.apache.commons.lang3.tuple.Pair;
+import org.immutables.value.Value;
+import org.opensearch.sql.opensearch.util.OpenSearchRelOptUtil;
+
+/**
+ * An optimization rule to support translating a project expression collation to its input
+ * collation. Limited expressions are supported like +, -, *, CAST. With this translation, we can
+ * transpose Sort - Project pattern to allow pushing down equivalent field sort into scan as if we
+ * push down sort expression script into scan.
+ */
+@Value.Enclosing
+public class SortProjectExprTransposeRule extends RelRule<SortProjectExprTransposeRule.Config> {
+
+  protected SortProjectExprTransposeRule(Config config) {
+    super(config);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    final Sort sort = call.rel(0);
+    final Project project = call.rel(1);
+
+    List<RelFieldCollation> pushable = new ArrayList<>();
+    boolean allPushable = true;
+    for (RelFieldCollation fieldCollation : sort.getCollation().getFieldCollations()) {
+      RexNode expr = project.getProjects().get(fieldCollation.getFieldIndex());
+
+      Optional<Pair<Integer, Boolean>> pushableExprInputInfo =
+          OpenSearchRelOptUtil.getOrderEquivalentInputInfo(expr);
+      if (pushableExprInputInfo.isEmpty()) {
+        allPushable = false;
+        break;
+      }
+
+      int inputIndex = pushableExprInputInfo.get().getLeft();
+      boolean flipped = pushableExprInputInfo.get().getRight();
+      // TODO: need to determine whether we want to reverse null direction
+      Direction dir =
+          flipped ? fieldCollation.getDirection().reverse() : fieldCollation.getDirection();
+
+      pushable.add(new RelFieldCollation(inputIndex, dir, fieldCollation.nullDirection));
+    }
+    // Not support partial collations pushdown because output needs resorting anyway
+    if (!allPushable || pushable.isEmpty()) {
+      return;
+    }
+
+    // Build transposed sort
+    RelCollation inputCollation = RelCollations.of(pushable);
+    Sort lowerSort =
+        sort.copy(
+            sort.getTraitSet().replace(inputCollation),
+            project.getInput(),
+            inputCollation,
+            null,
+            null);
+    RelNode result;
+    if (sort.fetch == null && sort.offset == null) {
+      result =
+          project.copy(sort.getTraitSet(), lowerSort, project.getProjects(), project.getRowType());
+    } else {
+      // Handle sort with limit case. We need to split the original sort into two logical sorts.
+      // The higher sort is a logical limit and the lower sort ensures equivalent collations.
+      Sort limitSort =
+          sort.copy(
+              sort.getTraitSet().replace(RelCollations.EMPTY),
+              lowerSort,
+              RelCollations.EMPTY,
+              sort.offset,
+              sort.fetch);
+      result =
+          project.copy(sort.getTraitSet(), limitSort, project.getProjects(), project.getRowType());
+    }
+
+    Map<RelNode, RelNode> equiv;
+    if (sort.offset == null
+        && sort.fetch == null
+        && project
+            .getCluster()
+            .getPlanner()
+            .getRelTraitDefs()
+            .contains(RelCollationTraitDef.INSTANCE)) {
+      equiv = ImmutableMap.of(lowerSort, project.getInput());
+    } else {
+      equiv = ImmutableMap.of();
+    }
+
+    call.transformTo(result, equiv);
+  }
+
+  /**
+   * Only match logical sort and project to reduce RelSubset searching space. To support limit
+   * transpose, we can only match LogicalSort because limit operator is different between logical
+   * and physical conventions, aka LogicalSort with fetch vs EnumerableLimit.
+   */
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+    SortProjectExprTransposeRule.Config DEFAULT =
+        ImmutableSortProjectExprTransposeRule.Config.builder()
+            .build()
+            .withOperandSupplier(
+                b0 ->
+                    b0.operand(LogicalSort.class)
+                        .oneInput(
+                            b1 ->
+                                b1.operand(LogicalProject.class)
+                                    .predicate(OpenSearchIndexScanRule::projectContainsExpr)
+                                    .predicate(p -> !p.containsOver())
+                                    .anyInputs()));
+
+    @Override
+    default SortProjectExprTransposeRule toRule() {
+      return new SortProjectExprTransposeRule(this);
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/util/OpenSearchRelOptUtil.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/util/OpenSearchRelOptUtil.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.util;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import lombok.experimental.UtilityClass;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.commons.lang3.tuple.Pair;
+
+@UtilityClass
+public class OpenSearchRelOptUtil {
+
+  /**
+   * Given an input Calcite RexNode, find the single input field with equivalent collation
+   * information. The function returns the pair of input field index and a flag to indicate whether
+   * the ordering is flipped.
+   *
+   * @param expr Calcite expression node
+   * @return Optional pair of input field index and flipped flag
+   */
+  public static Optional<Pair<Integer, Boolean>> getOrderEquivalentInputInfo(RexNode expr) {
+    switch (expr.getKind()) {
+      case INPUT_REF:
+        RexInputRef inputRef = (RexInputRef) expr;
+        return Optional.of(Pair.of(inputRef.getIndex(), false));
+      case PLUS_PREFIX:
+        return getOrderEquivalentInputInfo(((RexCall) expr).getOperands().get(0));
+      case MINUS_PREFIX:
+        return getOrderEquivalentInputInfo(((RexCall) expr).getOperands().get(0))
+            .map(inputInfo -> Pair.of(inputInfo.getLeft(), !inputInfo.getRight()));
+      case PLUS, MINUS:
+        {
+          RexNode operand0 = ((RexCall) expr).getOperands().get(0);
+          RexNode operand1 = ((RexCall) expr).getOperands().get(1);
+
+          boolean operand0Lit = operand0.isA(SqlKind.LITERAL);
+          boolean operand1Lit = operand1.isA(SqlKind.LITERAL);
+
+          if (operand0Lit == operand1Lit) {
+            return Optional.empty();
+          }
+
+          RexNode variable = operand0Lit ? operand1 : operand0;
+          boolean flipped = (expr.getKind() == SqlKind.MINUS) && operand0Lit;
+
+          return getOrderEquivalentInputInfo(variable)
+              .map(inputInfo -> Pair.of(inputInfo.getLeft(), flipped != inputInfo.getRight()));
+        }
+      case TIMES:
+        {
+          RexNode operand0 = ((RexCall) expr).getOperands().get(0);
+          RexNode operand1 = ((RexCall) expr).getOperands().get(1);
+
+          RexNode lit =
+              operand0.isA(SqlKind.LITERAL)
+                  ? operand0
+                  : (operand1.isA(SqlKind.LITERAL) ? operand1 : null);
+          RexNode variable = (lit == operand0) ? operand1 : operand0;
+
+          if (lit == null) {
+            return Optional.empty();
+          }
+
+          BigDecimal k = ((RexLiteral) lit).getValueAs(BigDecimal.class);
+          if (k == null || k.signum() == 0) {
+            return Optional.empty();
+          }
+          boolean flipped = k.signum() < 0;
+
+          return getOrderEquivalentInputInfo(variable)
+              .map(inputInfo -> Pair.of(inputInfo.getLeft(), flipped != inputInfo.getRight()));
+        }
+        // Ignore DIVIDE operator for now because it has too many precision issues
+      case CAST, SAFE_CAST:
+        {
+          RexNode child = ((RexCall) expr).getOperands().get(0);
+          if (!isOrderPreservingCast(child.getType(), expr.getType())) {
+            return Optional.empty();
+          }
+          return getOrderEquivalentInputInfo(child);
+        }
+      default:
+        return Optional.empty();
+    }
+  }
+
+  private static boolean isOrderPreservingCast(RelDataType src, RelDataType dst) {
+    final SqlTypeName srcType = src.getSqlTypeName();
+    final SqlTypeName dstType = dst.getSqlTypeName();
+
+    if (SqlTypeUtil.isIntType(src) && SqlTypeUtil.isApproximateNumeric(dst)) {
+      int intBits =
+          switch (srcType) {
+            case TINYINT -> 8;
+            case SMALLINT -> 16;
+            case INTEGER -> 32;
+            case BIGINT -> 64;
+            default -> 0;
+          };
+      // Float and double can only handle exact number based on its significand precision
+      int floatBits =
+          switch (dstType) {
+            case FLOAT -> 24;
+            case DOUBLE -> 53;
+            default -> 0;
+          };
+      return intBits > 0 && floatBits > 0 && intBits <= floatBits;
+    }
+
+    if (SqlTypeUtil.isExactNumeric(src) && SqlTypeUtil.isExactNumeric(dst)) {
+      int srcPrec = src.getPrecision();
+      int dstPrec = dst.getPrecision();
+      return dstPrec >= srcPrec;
+    }
+
+    if (SqlTypeUtil.isCharacter(src) && SqlTypeUtil.isCharacter(dst)) {
+      int srcLength = src.getPrecision();
+      int dstLength = dst.getPrecision();
+      return dstLength >= srcLength || dstLength == RelDataType.PRECISION_NOT_SPECIFIED;
+    }
+
+    if (srcType == SqlTypeName.DATE
+        && (dstType == SqlTypeName.TIMESTAMP
+            || dstType == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+      return true;
+    }
+
+    if (srcType == SqlTypeName.TIME
+        && (dstType == SqlTypeName.TIMESTAMP
+            || dstType == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+      return true;
+    }
+
+    if (srcType == dstType) {
+      return dst.getPrecision() >= src.getPrecision() && dst.getScale() >= src.getScale();
+    }
+
+    return false;
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/util/OpenSearchRelOptUtilTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/util/OpenSearchRelOptUtilTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class OpenSearchRelOptUtilTest {
+  private final RexBuilder rexBuilder;
+  private final RelDataTypeFactory typeFactory;
+  private RexInputRef inputRef1;
+  private RexInputRef inputRef2;
+  private RelDataType inputType;
+
+  public OpenSearchRelOptUtilTest() {
+    this.typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    this.rexBuilder = new RexBuilder(typeFactory);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    inputType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    inputRef1 = rexBuilder.makeInputRef(inputType, 5);
+    inputRef2 = rexBuilder.makeInputRef(inputType, 1);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_InputRef() {
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(inputRef1);
+    assertExpectedInputInfo(result, 5, false);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_PlusPrefix() {
+    RexNode plusPrefix = rexBuilder.makeCall(SqlStdOperatorTable.UNARY_PLUS, inputRef1);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(plusPrefix);
+    assertExpectedInputInfo(result, 5, false);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_MinusPrefix() {
+    RexNode minusPrefix = rexBuilder.makeCall(SqlStdOperatorTable.UNARY_MINUS, inputRef1);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(minusPrefix);
+    assertExpectedInputInfo(result, 5, true);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_MinusPrefixWithAlreadyFlippedInput() {
+    RexNode innerMinusPrefix = rexBuilder.makeCall(SqlStdOperatorTable.UNARY_MINUS, inputRef1);
+    RexNode outerMinusPrefix =
+        rexBuilder.makeCall(SqlStdOperatorTable.UNARY_MINUS, innerMinusPrefix);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(outerMinusPrefix);
+    assertExpectedInputInfo(result, 5, false);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_PlusOrMinusWithLiteralSecond() {
+    RexNode plus =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS, inputRef1, rexBuilder.makeLiteral(1, inputType));
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(plus);
+    assertExpectedInputInfo(result, 5, false);
+
+    RexNode minus =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.MINUS, inputRef1, rexBuilder.makeLiteral(1, inputType));
+    result = OpenSearchRelOptUtil.getOrderEquivalentInputInfo(minus);
+    assertExpectedInputInfo(result, 5, false);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_PlusTwoInputs() {
+    RexNode plus = rexBuilder.makeCall(SqlStdOperatorTable.PLUS, inputRef1, inputRef2);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(plus);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_PlusTwoLiterals() {
+    RexNode plus =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            rexBuilder.makeLiteral(1, inputType),
+            rexBuilder.makeLiteral(2, inputType));
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(plus);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_PlusWithLiteralFirst() {
+    RexNode plus =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS, rexBuilder.makeLiteral(1, inputType), inputRef1);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(plus);
+    assertExpectedInputInfo(result, 5, false);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_MinusWithLiteralFirst() {
+    RexNode minus =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.MINUS, rexBuilder.makeLiteral(1, inputType), inputRef1);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(minus);
+    assertExpectedInputInfo(result, 5, true);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_TimesWithPositiveLiteral() {
+    RexNode times =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.MULTIPLY, inputRef1, rexBuilder.makeLiteral(1, inputType));
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(times);
+    assertExpectedInputInfo(result, 5, false);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_TimesWithNegativeLiteral() {
+    RexNode times =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.MULTIPLY, inputRef1, rexBuilder.makeLiteral(-1, inputType));
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(times);
+    assertExpectedInputInfo(result, 5, true);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_TimesWithZeroOrNullLiteral() {
+    RexNode times =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.MULTIPLY, inputRef1, rexBuilder.makeLiteral(0, inputType));
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(times);
+    assertFalse(result.isPresent());
+
+    times =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.MULTIPLY, inputRef1, rexBuilder.makeNullLiteral(inputType));
+    result = OpenSearchRelOptUtil.getOrderEquivalentInputInfo(times);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_TimesTwoInputs() {
+    RexNode times = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY, inputRef1, inputRef2);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(times);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_CastOrderPreserving() {
+    // Cast from integer to long
+    RelDataType srcType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    RexNode srcInput = rexBuilder.makeInputRef(srcType, 1);
+    RelDataType dstType = typeFactory.createSqlType(SqlTypeName.BIGINT);
+    RexNode cast = rexBuilder.makeCast(dstType, srcInput);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(cast);
+    assertExpectedInputInfo(result, 1, false);
+
+    // Safe cast from integer to long
+    RexNode safeCast = rexBuilder.makeCast(dstType, srcInput, false, true);
+    result = OpenSearchRelOptUtil.getOrderEquivalentInputInfo(safeCast);
+    assertExpectedInputInfo(result, 1, false);
+
+    // Cast from date to timestamp
+    srcType = typeFactory.createSqlType(SqlTypeName.DATE);
+    srcInput = rexBuilder.makeInputRef(srcType, 1);
+    dstType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+    cast = rexBuilder.makeCast(dstType, srcInput);
+    result = OpenSearchRelOptUtil.getOrderEquivalentInputInfo(cast);
+    assertExpectedInputInfo(result, 1, false);
+
+    // Cast from integer to double
+    srcType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    srcInput = rexBuilder.makeInputRef(srcType, 1);
+    dstType = typeFactory.createSqlType(SqlTypeName.DOUBLE);
+    cast = rexBuilder.makeCast(dstType, srcInput);
+    result = OpenSearchRelOptUtil.getOrderEquivalentInputInfo(cast);
+    assertExpectedInputInfo(result, 1, false);
+
+    // Cast from integer to float
+    srcType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    srcInput = rexBuilder.makeInputRef(srcType, 1);
+    dstType = typeFactory.createSqlType(SqlTypeName.FLOAT);
+    cast = rexBuilder.makeCast(dstType, srcInput);
+    result = OpenSearchRelOptUtil.getOrderEquivalentInputInfo(cast);
+    assertFalse(result.isPresent());
+
+    // Cast from low precision to high precision
+    srcType = typeFactory.createSqlType(SqlTypeName.DECIMAL);
+    srcInput = rexBuilder.makeInputRef(srcType, 1);
+    dstType =
+        typeFactory.createSqlType(
+            SqlTypeName.DECIMAL, srcType.getPrecision() + 4, srcType.getScale() + 4);
+    cast = rexBuilder.makeCast(dstType, srcInput);
+    result = OpenSearchRelOptUtil.getOrderEquivalentInputInfo(cast);
+    assertExpectedInputInfo(result, 1, false);
+  }
+
+  @Test
+  public void testGetOrderEquivalentInputInfo_UnsupportedOperation() {
+    RexNode times = rexBuilder.makeCall(SqlStdOperatorTable.DIVIDE, inputRef1, inputRef2);
+    Optional<Pair<Integer, Boolean>> result =
+        OpenSearchRelOptUtil.getOrderEquivalentInputInfo(times);
+    assertFalse(result.isPresent());
+  }
+
+  private void assertExpectedInputInfo(
+      Optional<Pair<Integer, Boolean>> result, int index, boolean flipped) {
+    assertTrue(result.isPresent());
+    assertEquals(index, result.get().getLeft().intValue());
+    assertEquals(flipped, result.get().getRight());
+  }
+}


### PR DESCRIPTION
* Support pushdown sort by simple expressions



* Fix IT for no pushdown case



* Add minor case to allow sort pushdown for casted floating number



* Fix the issue of using wrong fromCollation



* Add some unit tests for OpenSearchRelOptUtil



* Fix checkstyle



---------

### Description
Manual backpot #4071 into 2.19-dev

### Related Issues


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
