### PR TITLE
Support ISO8601-formatted string in PPL

### DIFF
--- a/core/src/main/java/org/opensearch/sql/data/model/ExprTimestampValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprTimestampValue.java
@@ -13,6 +13,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
@@ -31,17 +33,24 @@ public class ExprTimestampValue extends AbstractExprValue {
   /**
    * Constructor with timestamp string.
    *
-   * @param timestamp a date or timestamp string (does not accept time string)
+   * @param timestamp a date or timestamp string (does not accept time string). It accepts both ISO
+   *     8601 format and {@code yyyy-MM-dd HH:mm:ss[.SSSSSSSSS]} format
    */
   public ExprTimestampValue(String timestamp) {
     try {
-      this.timestamp =
-          LocalDateTime.parse(timestamp, DateTimeFormatters.DATE_TIMESTAMP_FORMATTER)
-              .toInstant(ZoneOffset.UTC);
+      LocalDateTime ldt;
+      try {
+        ldt = LocalDateTime.parse(timestamp, DateTimeFormatters.DATE_TIMESTAMP_FORMATTER);
+      } catch (DateTimeParseException ignored) {
+        ZonedDateTime zdt = ZonedDateTime.parse(timestamp, DateTimeFormatter.ISO_DATE_TIME);
+        ldt = zdt.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+      }
+      this.timestamp = ldt.toInstant(ZoneOffset.UTC);
     } catch (DateTimeParseException e) {
       throw new ExpressionEvaluationException(
           String.format(
-              "timestamp:%s in unsupported format, please use 'yyyy-MM-dd HH:mm:ss[.SSSSSSSSS]'",
+              "timestamp:%s in unsupported format, please use 'yyyy-MM-dd HH:mm:ss[.SSSSSSSSS]' or"
+                  + " ISO 8601 format",
               timestamp));
     }
   }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimestampTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimestampTest.java
@@ -64,7 +64,8 @@ public class TimestampTest extends ExpressionTestBase {
             () -> DSL.timestamp(functionProperties, DSL.literal(value)).valueOf());
     assertEquals(
         String.format(
-            "timestamp:%s in unsupported format, please " + "use 'yyyy-MM-dd HH:mm:ss[.SSSSSSSSS]'",
+            "timestamp:%s in unsupported format, please "
+                + "use 'yyyy-MM-dd HH:mm:ss[.SSSSSSSSS]' or ISO 8601 format",
             value),
         exception.getMessage());
   }


### PR DESCRIPTION
### Description

PPL has been adopting `YYYY-MM-DD HH:mm:ss[.SSSSSSSSS]` as its default format for timestamp. However, OpenSearch's default timestamp format is ISO 8601. This may cause confusion for PPL customers as shown in #4188 .

With this PR, we extent the support of timestamp format to ISO 8601. An example of such format is `2025-09-08T06:34:00Z`. It also brings additional benefit in that users can specify a timestamp with zone offset like `2025-09-07T18:34:00-12:00`. This allows users to input the data in a format that is easier to interpret.

### Related Issues
Resolves #4188

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
