### PR TITLE
Add test alias for integTest

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -744,3 +744,10 @@ task integTestRemote(type: RestIntegTestTask) {
     exclude 'org/opensearch/sql/legacy/OrderIT.class'
     exclude 'org/opensearch/sql/jdbc/**'
 }
+
+// Add 'test' task as an alias for 'integTest' task
+test {
+    dependsOn integTest
+    group = 'verification'
+    description = 'Alias for integTest task - runs integration tests'
+}


### PR DESCRIPTION
### Description
- Add test alias for integTest
- This is to avoid Cline to be confused when running integ test. Cline tend to try using `:integ-test:test` target to run integ tests and fails then do back and force.

### Related Issues
- n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
