### PR TITLE
Add replace command with Calcite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -84,6 +84,7 @@ import org.opensearch.sql.ast.tree.Regex;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Replace;
 import org.opensearch.sql.ast.tree.Reverse;
 import org.opensearch.sql.ast.tree.Rex;
 import org.opensearch.sql.ast.tree.Search;
@@ -786,6 +787,11 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitCloseCursor(CloseCursor closeCursor, AnalysisContext context) {
     return new LogicalCloseCursor(closeCursor.getChild().get(0).accept(this, context));
+  }
+
+  @Override
+  public LogicalPlan visitReplace(Replace node, AnalysisContext context) {
+    throw getOnlyForCalciteException("Replace");
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -72,6 +72,7 @@ import org.opensearch.sql.ast.tree.Regex;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Replace;
 import org.opensearch.sql.ast.tree.Reverse;
 import org.opensearch.sql.ast.tree.Rex;
 import org.opensearch.sql.ast.tree.SPath;
@@ -241,6 +242,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitRename(Rename node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitReplace(Replace node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Replace.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Replace.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class Replace extends UnresolvedPlan {
+  private final UnresolvedExpression pattern;
+  private final UnresolvedExpression replacement;
+  private final List<Field> fieldList;
+  private UnresolvedPlan child;
+
+  public Replace(
+      UnresolvedExpression pattern, UnresolvedExpression replacement, List<Field> fieldList) {
+    this.pattern = pattern;
+    this.replacement = replacement;
+    this.fieldList = fieldList;
+    validate();
+  }
+
+  public void validate() {
+    if (pattern == null) {
+      throw new IllegalArgumentException("Pattern expression cannot be null in Replace command");
+    }
+    if (replacement == null) {
+      throw new IllegalArgumentException(
+          "Replacement expression cannot be null in Replace command");
+    }
+
+    // Validate pattern is a string literal
+    if (!(pattern instanceof Literal && ((Literal) pattern).getType() == DataType.STRING)) {
+      throw new IllegalArgumentException("Pattern must be a string literal in Replace command");
+    }
+
+    // Validate replacement is a string literal
+    if (!(replacement instanceof Literal && ((Literal) replacement).getType() == DataType.STRING)) {
+      throw new IllegalArgumentException("Replacement must be a string literal in Replace command");
+    }
+
+    if (fieldList == null || fieldList.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Field list cannot be empty in Replace command. Use IN clause to specify the field.");
+    }
+
+    Set<String> uniqueFields = new HashSet<>();
+    List<String> duplicates =
+        fieldList.stream()
+            .map(field -> field.getField().toString())
+            .filter(fieldName -> !uniqueFields.add(fieldName))
+            .collect(Collectors.toList());
+
+    if (!duplicates.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format("Duplicate fields [%s] in Replace command", String.join(", ", duplicates)));
+    }
+  }
+
+  @Override
+  public Replace attach(UnresolvedPlan child) {
+    if (null == this.child) {
+      this.child = child;
+    } else {
+      this.child.attach(child);
+    }
+    return this;
+  }
+
+  @Override
+  public List<UnresolvedPlan> getChild() {
+    return this.child == null ? ImmutableList.of() : ImmutableList.of(this.child);
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitReplace(this, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -112,6 +112,7 @@ import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Regex;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Replace;
 import org.opensearch.sql.ast.tree.Rex;
 import org.opensearch.sql.ast.tree.SPath;
 import org.opensearch.sql.ast.tree.Search;
@@ -144,6 +145,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
 
   private final CalciteRexNodeVisitor rexVisitor;
   private final CalciteAggCallVisitor aggVisitor;
+  private static final String NEW_FIELD_PREFIX = "new_";
 
   public CalciteRelNodeVisitor() {
     this.rexVisitor = new CalciteRexNodeVisitor(this);
@@ -2178,6 +2180,40 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     } else {
       throw new CalciteUnsupportedException("Explicit values node is unsupported in Calcite");
     }
+  }
+
+  @Override
+  public RelNode visitReplace(Replace node, CalcitePlanContext context) {
+    visitChildren(node, context);
+
+    List<String> fieldNames = context.relBuilder.peek().getRowType().getFieldNames();
+    RexNode patternNode = rexVisitor.analyze(node.getPattern(), context);
+    RexNode replacementNode = rexVisitor.analyze(node.getReplacement(), context);
+
+    List<RexNode> projectList = new ArrayList<>();
+    List<String> newFieldNames = new ArrayList<>();
+
+    // First add all original fields
+    for (String fieldName : fieldNames) {
+      RexNode fieldRef = context.relBuilder.field(fieldName);
+      projectList.add(fieldRef);
+      newFieldNames.add(fieldName);
+    }
+
+    // Then add new fields with replaced content using new_ prefix
+    for (Field field : node.getFieldList()) {
+      String fieldName = field.getField().toString();
+      RexNode fieldRef = context.relBuilder.field(fieldName);
+
+      RexNode replaceCall =
+          context.relBuilder.call(
+              SqlStdOperatorTable.REPLACE, fieldRef, patternNode, replacementNode);
+      projectList.add(replaceCall);
+      newFieldNames.add(NEW_FIELD_PREFIX + fieldName);
+    }
+
+    context.relBuilder.project(projectList, newFieldNames);
+    return context.relBuilder.peek();
   }
 
   private void buildParseRelNode(Parse node, CalcitePlanContext context) {

--- a/docs/category.json
+++ b/docs/category.json
@@ -63,6 +63,7 @@
     "user/ppl/cmd/rex.rst",
     "user/ppl/cmd/stats.rst",
     "user/ppl/cmd/timechart.rst",
-    "user/ppl/cmd/search.rst"
+    "user/ppl/cmd/search.rst",
+    "user/ppl/cmd/replace.rst"
   ]
 }

--- a/docs/user/ppl/cmd/replace.rst
+++ b/docs/user/ppl/cmd/replace.rst
@@ -1,0 +1,107 @@
+=============
+replace
+=============
+
+.. rubric:: Table of contents
+
+.. contents::
+ :local:
+ :depth: 2
+
+
+Description
+============
+| Using ``replace`` command to replace text in one or more fields in the search result.
+* The command creates new fields with *new_* prefix for replaced content (e.g., replacing text in 'country' creates 'new_country')
+* If a field with *new_* prefix already exists (e.g., 'new_country'), a number will be appended to create a unique field name (e.g., 'new_country0')
+
+
+Version
+=======
+3.3.0
+
+
+Syntax
+============
+replace '<pattern>' WITH '<replacement>' IN <field-name>[, <field-name>]...
+
+Note: This command is only available when Calcite engine is enabled.
+
+* pattern: mandatory. The text pattern you want to replace. Currently supports only plain text literals (no wildcards or regular expressions).
+* replacement: mandatory. The text you want to replace with.
+* field list: mandatory. One or more field names where the replacement should occur.
+
+
+Example 1: Replace text in one field
+====================================
+
+The example shows replacing text in one field.
+
+PPL query::
+
+ os> source=accounts | replace "IL" WITH "Illinois" IN state | fields state, new_state;
+ fetched rows / total rows = 4/4
+ +-------+-----------+
+ | state | new_state |
+ |-------+-----------|
+ | IL    | Illinois  |
+ | TN    | TN        |
+ | VA    | VA        |
+ | MD    | MD        |
+ +-------+-----------+
+
+
+Example 2: Replace text in multiple fields
+==========================================
+
+The example shows replacing text in multiple fields.
+
+PPL query::
+
+ os> source=accounts | replace "IL" WITH "Illinois" IN state, address | fields state, address, new_state, new_address;
+ fetched rows / total rows = 4/4
+ +-------+----------------------+-----------+----------------------+
+ | state | address              | new_state | new_address          |
+ |-------+----------------------+-----------+----------------------|
+ | IL    | 880 Holmes Lane      | Illinois  | 880 Holmes Lane      |
+ | TN    | 671 Bristol Street   | TN        | 671 Bristol Street   |
+ | VA    | 789 Madison Street   | VA        | 789 Madison Street   |
+ | MD    | 467 Hutchinson Court | MD        | 467 Hutchinson Court |
+ +-------+----------------------+-----------+----------------------+
+
+
+Example 3: Replace with IN clause and other commands
+====================================================
+
+The example shows using replace with other commands.
+
+PPL query::
+
+ os> source=accounts | replace "IL" WITH "Illinois" IN state | where age > 30 | fields state, age, new_state;
+ fetched rows / total rows = 3/3
+ +-------+-----+-----------+
+ | state | age | new_state |
+ |-------+-----+-----------|
+ | IL    | 32  | Illinois  |
+ | TN    | 36  | TN        |
+ | MD    | 33  | MD        |
+ +-------+-----+-----------+
+
+Example 4: Pattern matching with LIKE and replace
+=================================================
+
+Since replace command only supports plain string literals, you can use LIKE command with replace for pattern matching needs.
+
+PPL query::
+
+ os> source=accounts | where LIKE(address, '%Holmes%') | replace "Holmes" WITH "HOLMES" IN address | fields address, state, gender, age, city, new_address;
+ fetched rows / total rows = 1/1
+ +-----------------+-------+--------+-----+--------+-----------------+
+ | address         | state | gender | age | city   | new_address     |
+ |-----------------+-------+--------+-----+--------+-----------------|
+ | 880 Holmes Lane | IL    | M      | 32  | Brogan | 880 HOLMES Lane |
+ +-----------------+-------+--------+-----+--------+-----------------+
+
+Note
+====
+* For each field specified in the IN clause, a new field is created with prefix *new_* containing the replaced text. The original fields remain unchanged.

--- a/docs/user/ppl/index.rst
+++ b/docs/user/ppl/index.rst
@@ -124,6 +124,8 @@ The query start with search command and then flowing a set of command delimited 
 
   - `trendline command <cmd/trendline.rst>`_
 
+  - `replace command <cmd/replace.rst>`_
+
   - `where command <cmd/where.rst>`_
 
 * **Functions**

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteNoPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteNoPushdownIT.java
@@ -88,6 +88,7 @@ import org.opensearch.sql.ppl.PPLIntegTestCase;
   CalciteRegexCommandIT.class,
   CalciteRexCommandIT.class,
   CalciteRenameCommandIT.class,
+  CalciteReplaceCommandIT.class,
   CalciteResourceMonitorIT.class,
   CalciteSearchCommandIT.class,
   CalciteSettingsIT.class,

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -78,6 +78,7 @@ commands
    | regexCommand
    | timechartCommand
    | rexCommand
+   | replaceCommand
    ;
 
 commandName
@@ -115,6 +116,7 @@ commandName
    | REGEX
    | APPEND
    | REX
+   | REPLACE
    ;
 
 searchCommand
@@ -198,6 +200,10 @@ wcFieldList
 
 renameCommand
    : RENAME renameClasue (COMMA? renameClasue)*
+   ;
+
+replaceCommand
+   : REPLACE pattern=stringLiteral WITH replacement=stringLiteral IN fieldList
    ;
 
 statsCommand

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -94,6 +94,7 @@ import org.opensearch.sql.ast.tree.RareTopN.CommandType;
 import org.opensearch.sql.ast.tree.Regex;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Replace;
 import org.opensearch.sql.ast.tree.Reverse;
 import org.opensearch.sql.ast.tree.Rex;
 import org.opensearch.sql.ast.tree.SPath;
@@ -396,6 +397,25 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
                         internalVisitExpression(ct.orignalField),
                         internalVisitExpression(ct.renamedField)))
             .collect(Collectors.toList()));
+  }
+
+  /** Replace command. */
+  @Override
+  public UnresolvedPlan visitReplaceCommand(OpenSearchPPLParser.ReplaceCommandContext ctx) {
+    UnresolvedExpression pattern = internalVisitExpression(ctx.pattern);
+    UnresolvedExpression replacement = internalVisitExpression(ctx.replacement);
+
+    List<Field> fieldList =
+        ctx.fieldList().fieldExpression().stream()
+            .map(field -> (Field) internalVisitExpression(field))
+            .collect(Collectors.toList());
+
+    return new Replace(pattern, replacement, fieldList);
+  }
+
+  private String removeQuotes(String text) {
+    // Remove both single and double quotes
+    return text.replaceAll("^[\"']|[\"']$", "");
   }
 
   /** Stats command. */

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -77,6 +77,7 @@ import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Regex;
 import org.opensearch.sql.ast.tree.Relation;
 import org.opensearch.sql.ast.tree.Rename;
+import org.opensearch.sql.ast.tree.Replace;
 import org.opensearch.sql.ast.tree.Reverse;
 import org.opensearch.sql.ast.tree.Rex;
 import org.opensearch.sql.ast.tree.Search;
@@ -274,6 +275,25 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
             .map(entry -> StringUtils.format("%s as %s", entry.getKey(), entry.getValue()))
             .collect(Collectors.joining(","));
     return StringUtils.format("%s | rename %s", child, renames);
+  }
+
+  @Override
+  public String visitReplace(Replace node, String context) {
+    // Get the child query string
+    String child = node.getChild().get(0).accept(this, context);
+
+    // Get pattern and replacement expressions
+    String pattern = visitExpression(node.getPattern());
+    String replacement = visitExpression(node.getReplacement());
+
+    // Get field list
+    String fieldListStr =
+        " IN "
+            + node.getFieldList().stream().map(Field::toString).collect(Collectors.joining(", "));
+
+    // Build the replace command string
+    return StringUtils.format(
+        "%s | replace %s WITH %s%s", child, pattern, replacement, fieldListStr);
   }
 
   /** Build {@link LogicalAggregation}. */

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLReplaceTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLReplaceTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import java.util.Collections;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.tree.Replace;
+
+public class CalcitePPLReplaceTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLReplaceTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testBasicReplace() {
+    String ppl = "source=EMP | replace \"CLERK\" WITH \"EMPLOYEE\" IN JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], new_JOB=[REPLACE($2, 'CLERK':VARCHAR,"
+            + " 'EMPLOYEE':VARCHAR)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`, "
+            + "REPLACE(`JOB`, 'CLERK', 'EMPLOYEE') `new_JOB`\n"
+            + "FROM `scott`.`EMP`";
+
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+
+    String expectedResult =
+        "EMPNO=7369; ENAME=SMITH; JOB=CLERK; MGR=7902; HIREDATE=1980-12-17; SAL=800.00; COMM=null;"
+            + " DEPTNO=20; new_JOB=EMPLOYEE\n"
+            + "EMPNO=7499; ENAME=ALLEN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-20; SAL=1600.00;"
+            + " COMM=300.00; DEPTNO=30; new_JOB=SALESMAN\n"
+            + "EMPNO=7521; ENAME=WARD; JOB=SALESMAN; MGR=7698; HIREDATE=1981-02-22; SAL=1250.00;"
+            + " COMM=500.00; DEPTNO=30; new_JOB=SALESMAN\n"
+            + "EMPNO=7566; ENAME=JONES; JOB=MANAGER; MGR=7839; HIREDATE=1981-02-04; SAL=2975.00;"
+            + " COMM=null; DEPTNO=20; new_JOB=MANAGER\n"
+            + "EMPNO=7654; ENAME=MARTIN; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-28; SAL=1250.00;"
+            + " COMM=1400.00; DEPTNO=30; new_JOB=SALESMAN\n"
+            + "EMPNO=7698; ENAME=BLAKE; JOB=MANAGER; MGR=7839; HIREDATE=1981-01-05; SAL=2850.00;"
+            + " COMM=null; DEPTNO=30; new_JOB=MANAGER\n"
+            + "EMPNO=7782; ENAME=CLARK; JOB=MANAGER; MGR=7839; HIREDATE=1981-06-09; SAL=2450.00;"
+            + " COMM=null; DEPTNO=10; new_JOB=MANAGER\n"
+            + "EMPNO=7788; ENAME=SCOTT; JOB=ANALYST; MGR=7566; HIREDATE=1987-04-19; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20; new_JOB=ANALYST\n"
+            + "EMPNO=7839; ENAME=KING; JOB=PRESIDENT; MGR=null; HIREDATE=1981-11-17; SAL=5000.00;"
+            + " COMM=null; DEPTNO=10; new_JOB=PRESIDENT\n"
+            + "EMPNO=7844; ENAME=TURNER; JOB=SALESMAN; MGR=7698; HIREDATE=1981-09-08; SAL=1500.00;"
+            + " COMM=0.00; DEPTNO=30; new_JOB=SALESMAN\n"
+            + "EMPNO=7876; ENAME=ADAMS; JOB=CLERK; MGR=7788; HIREDATE=1987-05-23; SAL=1100.00;"
+            + " COMM=null; DEPTNO=20; new_JOB=EMPLOYEE\n"
+            + "EMPNO=7900; ENAME=JAMES; JOB=CLERK; MGR=7698; HIREDATE=1981-12-03; SAL=950.00;"
+            + " COMM=null; DEPTNO=30; new_JOB=EMPLOYEE\n"
+            + "EMPNO=7902; ENAME=FORD; JOB=ANALYST; MGR=7566; HIREDATE=1981-12-03; SAL=3000.00;"
+            + " COMM=null; DEPTNO=20; new_JOB=ANALYST\n"
+            + "EMPNO=7934; ENAME=MILLER; JOB=CLERK; MGR=7782; HIREDATE=1982-01-23; SAL=1300.00;"
+            + " COMM=null; DEPTNO=10; new_JOB=EMPLOYEE\n";
+
+    verifyResult(root, expectedResult);
+  }
+
+  @Test
+  public void testMultipleFieldsReplace() {
+    String ppl =
+        "source=EMP | replace \"CLERK\" WITH \"EMPLOYEE\" IN JOB | replace \"20\" WITH \"RESEARCH\""
+            + " IN DEPTNO";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], new_JOB=[REPLACE($2, 'CLERK':VARCHAR, 'EMPLOYEE':VARCHAR)],"
+            + " new_DEPTNO=[REPLACE($7, '20':VARCHAR, 'RESEARCH':VARCHAR)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`, "
+            + "REPLACE(`JOB`, 'CLERK', 'EMPLOYEE') `new_JOB`, "
+            + "REPLACE(`DEPTNO`, '20', 'RESEARCH') `new_DEPTNO`\n"
+            + "FROM `scott`.`EMP`";
+
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testReplaceSameValueInMultipleFields() {
+    // In EMP table, both JOB and MGR fields contain numeric values
+    String ppl = "source=EMP | replace \"7839\" WITH \"CEO\" IN MGR, EMPNO";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], new_MGR=[REPLACE($3, '7839':VARCHAR, 'CEO':VARCHAR)],"
+            + " new_EMPNO=[REPLACE($0, '7839':VARCHAR, 'CEO':VARCHAR)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`, "
+            + "REPLACE(`MGR`, '7839', 'CEO') `new_MGR`, "
+            + "REPLACE(`EMPNO`, '7839', 'CEO') `new_EMPNO`\n"
+            + "FROM `scott`.`EMP`";
+
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testReplaceWithPipeline() {
+    String ppl =
+        "source=EMP | where JOB = 'CLERK' | replace \"CLERK\" WITH \"EMPLOYEE\" IN JOB | sort SAL";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalSort(sort0=[$5], dir0=[ASC-nulls-first])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], new_JOB=[REPLACE($2, 'CLERK':VARCHAR,"
+            + " 'EMPLOYEE':VARCHAR)])\n"
+            + "    LogicalFilter(condition=[=($2, 'CLERK':VARCHAR)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`, "
+            + "REPLACE(`JOB`, 'CLERK', 'EMPLOYEE') `new_JOB`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE `JOB` = 'CLERK'\n"
+            + "ORDER BY `SAL`";
+
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test(expected = Exception.class)
+  public void testReplaceWithoutWithKeywordShouldFail() {
+    String ppl = "source=EMP | replace \"CLERK\" \"EMPLOYEE\" IN JOB";
+    getRelNode(ppl);
+  }
+
+  @Test(expected = Exception.class)
+  public void testReplaceWithoutInKeywordShouldFail() {
+    String ppl = "source=EMP | replace \"CLERK\" WITH \"EMPLOYEE\" JOB";
+    getRelNode(ppl);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testReplaceWithExpressionShouldFail() {
+    String ppl = "source=EMP | replace EMPNO + 1 WITH \"EMPLOYEE\" IN JOB";
+    getRelNode(ppl);
+  }
+
+  @Test(expected = Exception.class)
+  public void testReplaceWithInvalidFieldShouldFail() {
+    String ppl = "source=EMP | replace \"CLERK\" WITH \"EMPLOYEE\" IN INVALID_FIELD";
+    getRelNode(ppl);
+  }
+
+  @Test(expected = Exception.class)
+  public void testReplaceWithMultipleInKeywordsShouldFail() {
+    String ppl = "source=EMP | replace \"CLERK\" WITH \"EMPLOYEE\" IN JOB IN ENAME";
+    getRelNode(ppl);
+  }
+
+  @Test(expected = Exception.class)
+  public void testReplaceWithMissingQuotesShouldFail() {
+    String ppl = "source=EMP | replace CLERK WITH EMPLOYEE IN JOB";
+    getRelNode(ppl);
+  }
+
+  @Test(expected = Exception.class)
+  public void testReplaceWithMissingReplacementValueShouldFail() {
+    String ppl = "source=EMP | replace \"CLERK\" WITH IN JOB";
+    getRelNode(ppl);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReplaceWithNullPatternShouldFail() {
+    Replace replace =
+        new Replace(null, new Literal("EMPLOYEE", DataType.STRING), Collections.emptyList());
+    replace.validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReplaceWithNullReplacementShouldFail() {
+    Replace replace =
+        new Replace(new Literal("CLERK", DataType.STRING), null, Collections.emptyList());
+    replace.validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReplaceWithNonStringPatternShouldFail() {
+    Replace replace =
+        new Replace(
+            new Literal(123, DataType.INTEGER),
+            new Literal("EMPLOYEE", DataType.STRING),
+            Collections.emptyList());
+    replace.validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReplaceWithNonStringReplacementShouldFail() {
+    Replace replace =
+        new Replace(
+            new Literal("CLERK", DataType.STRING),
+            new Literal(456, DataType.INTEGER),
+            Collections.emptyList());
+    replace.validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReplaceWithNullFieldListShouldFail() {
+    Replace replace =
+        new Replace(
+            new Literal("CLERK", DataType.STRING), new Literal("EMPLOYEE", DataType.STRING), null);
+    replace.validate();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testReplaceWithEmptyFieldListShouldFail() {
+    Replace replace =
+        new Replace(
+            new Literal("CLERK", DataType.STRING),
+            new Literal("EMPLOYEE", DataType.STRING),
+            Collections.emptyList());
+    replace.validate();
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -555,6 +555,49 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testReplaceCommandSingleField() {
+    assertEquals(
+        "source=EMP | replace *** WITH *** IN Field(field=fieldname, fieldArgs=[])",
+        anonymize("source=EMP | replace \"value\" WITH \"newvalue\" IN fieldname"));
+  }
+
+  @Test
+  public void testReplaceCommandMultipleFields() {
+    assertEquals(
+        "source=EMP | replace *** WITH *** IN Field(field=fieldname1, fieldArgs=[]),"
+            + " Field(field=fieldname2, fieldArgs=[])",
+        anonymize("source=EMP | replace \"value\" WITH \"newvalue\" IN fieldname1, fieldname2"));
+  }
+
+  @Test(expected = Exception.class)
+  public void testReplaceCommandWithoutInShouldFail() {
+    anonymize("source=EMP | replace \"value\" WITH \"newvalue\"");
+  }
+
+  @Test
+  public void testReplaceCommandSpecialCharactersInFields() {
+    assertEquals(
+        "source=EMP | replace *** WITH *** IN Field(field=user.name, fieldArgs=[]),"
+            + " Field(field=user.email, fieldArgs=[])",
+        anonymize("source=EMP | replace \"value\" WITH \"newvalue\" IN user.name, user.email"));
+  }
+
+  @Test
+  public void testReplaceCommandWithWildcards() {
+    assertEquals(
+        "source=EMP | replace *** WITH *** IN Field(field=fieldname, fieldArgs=[])",
+        anonymize("source=EMP | replace \"CLERK*\" WITH \"EMPLOYEE*\" IN fieldname"));
+  }
+
+  @Test
+  public void testReplaceCommandWithMultipleWildcards() {
+    assertEquals(
+        "source=EMP | replace *** WITH *** IN Field(field=fieldname1, fieldArgs=[]),"
+            + " Field(field=fieldname2, fieldArgs=[])",
+        anonymize("source=EMP | replace \"*TEST*\" WITH \"*NEW*\" IN fieldname1, fieldname2"));
+  }
+
+  @Test
   public void testPatterns() {
     when(settings.getSettingValue(Key.PATTERN_METHOD)).thenReturn("SIMPLE_PATTERN");
     when(settings.getSettingValue(Key.PATTERN_MODE)).thenReturn("LABEL");


### PR DESCRIPTION
### Description
Implement the replace command in PPL to replace text patterns in specified fields. This PR includes the grammar implementation and basic replacement functionality. This implementation reuses the existing replace functionality. Missing/new features for regex support is added in a separate PR.

### Syntax
`<source> | replace '<pattern>' WITH '<replacement>' IN field_list`

pattern: The text pattern to search for (case-sensitive)
replacement: The text to replace matches with
field_list: Comma-separated list of fields to perform replacement in
Replace creates new fields with prefix 'new_' containing the replaced text, while preserving original fields.

### Semantics
#### Expected Behavior:

- Action: Creates new fields with replaced text values
- Scope: Operates only on specified fields
- Data Preservation: Original fields remain unchanged
- Case Sensitivity: Text literal matching is case-sensitive
- Pattern Type: Only supports literal string patterns (wildcards or regex will be added in a separate PR)

#### Implementation Approach:

- Creates new fields with 'new_' prefix for each specified field
- Performs literal string replacement in the specified fields
- Maintains original field values
- Validates field existence and pattern/replacement values

### Example Queries

```
-- Replace in single field
source=logs | replace 'error' WITH 'ERROR' IN message

-- Replace in multiple fields 
source=logs | replace 'USA' WITH 'United States' IN country, state

-- Replace with other commands
source=logs | where level='error' | replace 'error' WITH 'ERROR' IN message | sort @timestamp

-- Replace and select specific fields
source=logs | replace 'error' WITH 'ERROR' IN message | fields message, new_message
```

#### Output Schema
For each field specified in IN clause, a new field is created:

- Original field: remains unchanged
- New field: prefixed with 'new_' containing replaced text

#### Example:

Input fields: message="error occurred", level="error"
After replace 'error' WITH 'ERROR' IN message, level:
- message: "error occurred"
- new_message: "ERROR occurred"
- level: "error"
- new_level: "ERROR"

### Related Issues

https://github.com/opensearch-project/sql/issues/3975

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [x] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
