### PR TITLE
Update version to 3.3 with fallback

### DIFF
--- a/async-query/build.gradle
+++ b/async-query/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 
 dependencies {
-    implementation "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
+    implementation "org.opensearch:opensearch-job-scheduler-spi:${createVersionRange(opensearch_build)}"
 
     api project(':core')
     api project(':async-query-core')
@@ -24,7 +24,7 @@ dependencies {
     implementation project(':datasources')
     implementation project(':legacy')
 
-    implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
+    implementation group: 'org.opensearch', name: 'opensearch', version: "${createVersionRange(opensearch_version)}"
     implementation group: 'org.json', name: 'json', version: '20231013'
     api group: 'com.amazonaws', name: 'aws-java-sdk-emr', version: "${aws_java_sdk_version}"
     api group: 'com.amazonaws', name: 'aws-java-sdk-emrserverless', version: "${aws_java_sdk_version}"
@@ -48,7 +48,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
         because 'allows tests to run from IDEs that bundle older version of launcher'
     }
-    testImplementation("org.opensearch.test:framework:${opensearch_version}")
+    testImplementation("org.opensearch.test:framework:${createVersionRange(opensearch_version)}")
     testImplementation project(':opensearch')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.2.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.3.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')
@@ -16,6 +16,28 @@ buildscript {
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
         }
+
+        // Turn a
+        createVersionRange = { String version ->
+            def components = version.tokenize('.')
+            if (components.size() < 2) {
+                return version
+            }
+            def major = components[0]
+            def minor = components[1].toInteger()
+
+            def prevMinor = minor - 1
+            if (prevMinor < 0) {
+                return version
+            }
+
+            if (components.size() < 3) {
+                return "[${major}.${prevMinor}, ${major}.${minor}]"
+            }
+            def tail = String.join(".", components.subList(2, components.size()))
+            return "[${major}.${prevMinor}.${tail}, ${major}.${minor}.${tail}]"
+        }
+
         //this variable for always downloading snapshot version of security plugin.
         //need to figure out more elegant solution for integ tests with security.
         opensearch_build_snapshot = opensearch_build + '-SNAPSHOT'
@@ -72,7 +94,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
+        classpath "org.opensearch.gradle:build-tools:${createVersionRange(opensearch_version)}"
     }
 }
 

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -18,9 +18,9 @@ dependencies {
     implementation project(':protocol')
     implementation project(':opensearch')
     implementation project(':legacy')
-    implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
-    implementation group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
-    implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
+    implementation group: 'org.opensearch', name: 'opensearch', version: "${createVersionRange(opensearch_version)}"
+    implementation group: 'org.opensearch', name: 'opensearch-x-content', version: "${createVersionRange(opensearch_version)}"
+    implementation group: 'org.opensearch', name: 'common-utils', version: "${createVersionRange(opensearch_build)}"
     implementation group: 'commons-io', name: 'commons-io', version: "${commons_io_version}"
     // FIXME. upgrade aws-encryption-sdk-java once the bouncycastle dependency update to 1.78.
     implementation ('com.amazonaws:aws-encryption-sdk-java:2.4.1') {

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -185,9 +185,9 @@ configurations {
 }
 
 dependencies {
-    testImplementation group: 'org.opensearch.test', name: 'framework', version: "${opensearch_version}"
-    testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
-    testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${opensearch_version}"
+    testImplementation group: 'org.opensearch.test', name: 'framework', version: "${createVersionRange(opensearch_version)}"
+    testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${createVersionRange(opensearch_version)}"
+    testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-client', version: "${createVersionRange(opensearch_version)}"
     testImplementation group: 'org.opensearch.driver', name: 'opensearch-sql-jdbc', version: System.getProperty("jdbcDriverVersion", '1.2.0.0')
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: "${hamcrest_version}"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:"${versions.log4j}"
@@ -203,11 +203,11 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
 
     // Needed for BWC tests
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${createVersionRange(opensearch_build)}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-sql-plugin', version: "${bwcVersion}-SNAPSHOT"
 
     // For GeoIP PPL functions
-    zipArchive group: 'org.opensearch.plugin', name:'geospatial', version: "${opensearch_build}"
+    zipArchive group: 'org.opensearch.plugin', name:'geospatial', version: "${createVersionRange(opensearch_build)}"
 }
 
 java {

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -101,8 +101,8 @@ test {
 dependencies {
     implementation group: 'com.alibaba', name: 'druid', version:'1.0.15'
     implementation group: 'org.locationtech.spatial4j', name: 'spatial4j', version:'0.7'
-    implementation group: "org.opensearch.plugin", name: 'parent-join-client', version: "${opensearch_version}"
-    implementation group: "org.opensearch.plugin", name: 'reindex-client', version: "${opensearch_version}"
+    implementation group: "org.opensearch.plugin", name: 'parent-join-client', version: "${createVersionRange(opensearch_version)}"
+    implementation group: "org.opensearch.plugin", name: 'reindex-client', version: "${createVersionRange(opensearch_version)}"
     constraints {
         implementation("commons-codec:commons-codec:${commons_codec_version}") {
             because 'https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379'
@@ -112,9 +112,9 @@ dependencies {
     implementation group: 'org.json', name: 'json', version:'20231013'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${commons_lang3_version}"
     implementation group: 'org.apache.commons', name: 'commons-text', version: "${commons_text_version}"
-    implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
+    implementation group: 'org.opensearch', name: 'opensearch', version: "${createVersionRange(opensearch_version)}"
     // add geo module as dependency. https://github.com/opensearch-project/OpenSearch/pull/4180/.
-    implementation group: 'org.opensearch.plugin', name: 'geo', version: "${opensearch_version}"
+    implementation group: 'org.opensearch.plugin', name: 'geo', version: "${createVersionRange(opensearch_version)}"
     api project(':sql')
     api project(':common')
     api project(':opensearch')

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -32,15 +32,16 @@ plugins {
 
 dependencies {
     api project(':core')
-    api group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
+    api group: 'org.opensearch', name: 'opensearch', version: "${createVersionRange(opensearch_version)}"
     implementation "io.github.resilience4j:resilience4j-retry:${resilience4j_version}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
     implementation group: 'org.json', name: 'json', version:'20231013'
-    compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
-    implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
-    implementation group: 'org.opensearch', name:'geospatial-client', version: "${opensearch_build}"
+    compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${createVersionRange(opensearch_version)}"
+    implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${createVersionRange(opensearch_build)}"
+    implementation group: 'org.opensearch', name:'geospatial-client', version: "${createVersionRange(opensearch_build)}"
+
 
     annotationProcessor 'org.immutables:value:2.8.8'
     compileOnly 'org.immutables:value-annotations:2.8.8'
@@ -53,8 +54,8 @@ dependencies {
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
     testImplementation group: 'org.mockito', name: 'mockito-core', version: "${mockito_version}"
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${mockito_version}"
-    testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
-    testImplementation group: 'org.opensearch.test', name: 'framework', version: "${opensearch_version}"
+    testImplementation group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${createVersionRange(opensearch_version)}"
+    testImplementation group: 'org.opensearch.test', name: 'framework', version: "${createVersionRange(opensearch_version)}"
 }
 
 spotless {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -110,7 +110,7 @@ public class OpenSearchSettings extends Settings {
   public static final Setting<?> CALCITE_ENGINE_ENABLED_SETTING =
       Setting.boolSetting(
           Key.CALCITE_ENGINE_ENABLED.getKeyValue(),
-          false,
+          true,
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -149,7 +149,7 @@ spotless {
 }
 
 dependencies {
-    compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
+    compileOnly "org.opensearch:opensearch-job-scheduler-spi:${createVersionRange(opensearch_build)}"
 
     api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
@@ -168,7 +168,7 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: "${versions.mockito}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${createVersionRange(opensearch_build)}"
 }
 
 test {

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api project(':core')
     implementation project(':datasources')
 
-    implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
+    implementation group: 'org.opensearch', name: 'opensearch', version: "${createVersionRange(opensearch_version)}"
     implementation "io.github.resilience4j:resilience4j-retry:${resilience4j_version}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"


### PR DESCRIPTION
### Description
To allow ourselves to update versions whenever without needing to wait for all our dependencies to do their version updates, what if we implemented a version fallback? This implements a wrapper that configures a gradle range with this version and the last minor version (`[3.2.0-SNAPSHOT, 3.3.0-SNAPSHOT]`, etc). Then it loads the most recent dependency that exists.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
