### PR TITLE
Fix gitignore to ignore symbolic link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ http-client.env.json
 /doctest/opensearch-job-scheduler/
 .factorypath
 
-# Coding agent files
-.claude/
-.clinerules/
-memory-bank/
+# Coding agent files (could be symlinks)
+.claude
+.clinerules
+memory-bank


### PR DESCRIPTION
### Description
- Previous commit was working for directory, but not working for symbolic link to directory.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
