### PR TITLE
handle double negation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.2.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.3.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')

--- a/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/ExpressionAnalyzer.java
@@ -153,6 +153,13 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
 
   @Override
   public Expression visitNot(Not node, AnalysisContext context) {
+    // Handle double negation: NOT(NOT(X)) -> X
+    if (node.getExpression() instanceof Not) {
+      Not innerNot = (Not) node.getExpression();
+      // Double negation detected: return the inner expression directly
+      return innerNot.getExpression().accept(this, context);
+    }
+
     return DSL.not(node.getExpression().accept(this, context));
   }
 


### PR DESCRIPTION
### Description
Try to resolve the CI failure in #4036 

Adding double negation handling logic to resolve the following issue:

Issue: The query not firstname not in ('Amber', 'Dale') should return 2 rows but returns 998 rows in 3.3.
 I ran explain queries to it, and here is the result:
  - Working (direct IN): {"bool": {"should": [{"term": "Amber"}, {"term": "Dale"}]}}
  - Broken (double negation): {"bool": {"must_not": [{"bool": {"must_not": [{"bool": {"should": [{"term": "Amber"}, {"term": "Dale"}]}}]}}]}}
It seems like the double negation was not handled properly in version 3.3