### PR TITLE
[2.19-dev] Fix CalcitePPLAppendCommandIT failure via new join config

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAppendCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAppendCommandIT.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class CalcitePPLAppendCommandIT extends PPLIntegTestCase {
@@ -90,71 +91,86 @@ public class CalcitePPLAppendCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testAppendEmptySearchWithJoin() throws IOException {
-    List<String> emptySourceWithJoinPPLs =
-        Arrays.asList(
-            String.format(
-                Locale.ROOT,
-                "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | "
-                    + " join left=L right=R on L.gender = R.gender %s ]",
-                TEST_INDEX_ACCOUNT,
-                TEST_INDEX_ACCOUNT),
-            String.format(
-                Locale.ROOT,
-                "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | "
-                    + " cross join left=L right=R on L.gender = R.gender %s ]",
-                TEST_INDEX_ACCOUNT,
-                TEST_INDEX_ACCOUNT),
-            String.format(
-                Locale.ROOT,
-                "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | "
-                    + " left join left=L right=R on L.gender = R.gender %s ]",
-                TEST_INDEX_ACCOUNT,
-                TEST_INDEX_ACCOUNT),
-            String.format(
-                Locale.ROOT,
-                "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | "
-                    + " semi join left=L right=R on L.gender = R.gender %s ]",
-                TEST_INDEX_ACCOUNT,
-                TEST_INDEX_ACCOUNT));
+    withSettings(
+        Settings.Key.CALCITE_SUPPORT_ALL_JOIN_TYPES,
+        "true",
+        () -> {
+          List<String> emptySourceWithJoinPPLs =
+              Arrays.asList(
+                  String.format(
+                      Locale.ROOT,
+                      "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | "
+                          + " join left=L right=R on L.gender = R.gender %s ]",
+                      TEST_INDEX_ACCOUNT,
+                      TEST_INDEX_ACCOUNT),
+                  String.format(
+                      Locale.ROOT,
+                      "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | "
+                          + " cross join left=L right=R on L.gender = R.gender %s ]",
+                      TEST_INDEX_ACCOUNT,
+                      TEST_INDEX_ACCOUNT),
+                  String.format(
+                      Locale.ROOT,
+                      "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | "
+                          + " left join left=L right=R on L.gender = R.gender %s ]",
+                      TEST_INDEX_ACCOUNT,
+                      TEST_INDEX_ACCOUNT),
+                  String.format(
+                      Locale.ROOT,
+                      "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | "
+                          + " semi join left=L right=R on L.gender = R.gender %s ]",
+                      TEST_INDEX_ACCOUNT,
+                      TEST_INDEX_ACCOUNT));
 
-    for (String ppl : emptySourceWithJoinPPLs) {
-      JSONObject actual = executeQuery(ppl);
-      verifySchemaInOrder(
-          actual, schema("sum_age_by_gender", "bigint"), schema("gender", "string"));
-      verifyDataRows(actual, rows(14947, "F"), rows(15224, "M"));
-    }
+          for (String ppl : emptySourceWithJoinPPLs) {
+            JSONObject actual = null;
+            try {
+              actual = executeQuery(ppl);
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+            verifySchemaInOrder(
+                actual, schema("sum_age_by_gender", "bigint"), schema("gender", "string"));
+            verifyDataRows(actual, rows(14947, "F"), rows(15224, "M"));
+          }
 
-    List<String> emptySourceWithRightOrFullJoinPPLs =
-        Arrays.asList(
-            String.format(
-                Locale.ROOT,
-                "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | where"
-                    + " gender = 'F' |  right join on gender = gender [source=%s | stats count() as"
-                    + " cnt by gender ] ]",
-                TEST_INDEX_ACCOUNT,
-                TEST_INDEX_ACCOUNT),
-            String.format(
-                Locale.ROOT,
-                "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | where"
-                    + " gender = 'F' |  full join on gender = gender [source=%s | stats count() as"
-                    + " cnt by gender ] ]",
-                TEST_INDEX_ACCOUNT,
-                TEST_INDEX_ACCOUNT));
+          List<String> emptySourceWithRightOrFullJoinPPLs =
+              Arrays.asList(
+                  String.format(
+                      Locale.ROOT,
+                      "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | where"
+                          + " gender = 'F' |  right join on gender = gender [source=%s | stats count() as"
+                          + " cnt by gender ] ]",
+                      TEST_INDEX_ACCOUNT,
+                      TEST_INDEX_ACCOUNT),
+                  String.format(
+                      Locale.ROOT,
+                      "source=%s | stats sum(age) as sum_age_by_gender by gender | append [ | where"
+                          + " gender = 'F' |  full join on gender = gender [source=%s | stats count() as"
+                          + " cnt by gender ] ]",
+                      TEST_INDEX_ACCOUNT,
+                      TEST_INDEX_ACCOUNT));
 
-    for (String ppl : emptySourceWithRightOrFullJoinPPLs) {
-      JSONObject actual = executeQuery(ppl);
-      verifySchemaInOrder(
-          actual,
-          schema("sum_age_by_gender", "bigint"),
-          schema("gender", "string"),
-          schema("cnt", "bigint"));
-      verifyDataRows(
-          actual,
-          rows(14947, "F", null),
-          rows(15224, "M", null),
-          rows(null, "F", 493),
-          rows(null, "M", 507));
-    }
+          for (String ppl : emptySourceWithRightOrFullJoinPPLs) {
+            JSONObject actual = null;
+            try {
+              actual = executeQuery(ppl);
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+            verifySchemaInOrder(
+                actual,
+                schema("sum_age_by_gender", "bigint"),
+                schema("gender", "string"),
+                schema("cnt", "bigint"));
+            verifyDataRows(
+                actual,
+                rows(14947, "F", null),
+                rows(15224, "M", null),
+                rows(null, "F", 493),
+                rows(null, "M", 507));
+          }
+        });
   }
 
   @Test


### PR DESCRIPTION
### Description
Backporting #4244 missing configs after backporting #4267 merged. This PR is to fix the IT failure is the new config introduced in #4267 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
