### PR TITLE
Print links to test logs after integTest

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -449,12 +449,6 @@ integTest {
         events "failed"
     }
     
-    doLast {
-        println "Test report available at: file://${project.buildDir}/reports/tests/integTest/index.html"
-        println "integTest cluster logs available at: file://${project.buildDir}/testclusters/integTest-0/logs/integTest.log"
-        println "remoteCluster cluster logs available at: file://${project.buildDir}/testclusters/remoteCluster-0/logs/remoteCluster.log"
-    }
-    
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
     if(getOSFamilyType() != "windows") {
         dependsOn startPrometheus
@@ -522,8 +516,17 @@ integTest {
 
     // Exclude this IT, because they executed in another task (:integTestWithSecurity)
     exclude 'org/opensearch/sql/security/**'
+
+    finalizedBy 'printIntegTestPaths'
 }
 
+task printIntegTestPaths {
+    doLast {
+        println "Test report available at: file://${project.buildDir}/reports/tests/integTest/index.html"
+        println "integTest cluster logs available at: file://${project.buildDir}/testclusters/integTest-0/logs/integTest.log"
+        println "remoteCluster cluster logs available at: file://${project.buildDir}/testclusters/remoteCluster-0/logs/remoteCluster.log"
+    }
+}
 
 task comparisonTest(type: RestIntegTestTask) {
     testLogging {


### PR DESCRIPTION
### Description
- Print links to test logs after integTest
 - It helps coding agent to identify the server side logs

Sample output
```
% ./gradlew :integ-test:integTest
...
> Task :integ-test:integTest
Test report available at: file:///Volumes/workplace/sql/integ-test/build/reports/tests/integTest/index.html
integTest cluster logs available at: file:///Volumes/workplace/sql/integ-test/build/testclusters/integTest-0/logs/integTest.log
remoteCluster cluster logs available at: file:///Volumes/workplace/sql/integ-test/build/testclusters/remoteCluster-0/logs/remoteCluster.log
...
```

### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
