### PR TITLE
[Backport 2.19-dev] `mvjoin` support in PPL Caclite

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -62,6 +62,7 @@ public enum BuiltinFunctionName {
   /** Collection functions */
   ARRAY(FunctionName.of("array")),
   ARRAY_LENGTH(FunctionName.of("array_length")),
+  MVJOIN(FunctionName.of("mvjoin")),
   FORALL(FunctionName.of("forall")),
   EXISTS(FunctionName.of("exists")),
   FILTER(FunctionName.of("filter")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -144,6 +144,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.MONTH_O
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.MULTIPLY;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.MULTIPLYFUNCTION;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.MULTI_MATCH;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.MVJOIN;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.NOT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.NOTEQUAL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.NOW;
@@ -800,6 +801,15 @@ public class PPLFuncImpTable {
       registerOperator(WEEKOFYEAR, PPLBuiltinOperators.WEEK);
 
       registerOperator(INTERNAL_PATTERN_PARSER, PPLBuiltinOperators.PATTERN_PARSER);
+
+      // Register MVJOIN to use Calcite's ARRAY_JOIN
+      register(
+          MVJOIN,
+          (FunctionImp2)
+              (builder, array, delimiter) ->
+                  builder.makeCall(SqlLibraryOperators.ARRAY_JOIN, array, delimiter),
+          PPLTypeChecker.family(SqlTypeFamily.ARRAY, SqlTypeFamily.CHARACTER));
+
       registerOperator(ARRAY, PPLBuiltinOperators.ARRAY);
       registerOperator(ARRAY_LENGTH, SqlLibraryOperators.ARRAY_LENGTH);
       registerOperator(FORALL, PPLBuiltinOperators.FORALL);

--- a/docs/user/ppl/functions/collection.rst
+++ b/docs/user/ppl/functions/collection.rst
@@ -199,3 +199,36 @@ Example::
     |------------|
     | 80         |
     +------------+ 
+
+MVJOIN
+------
+
+Description
+>>>>>>>>>>>
+
+Version: 3.3.0
+
+Usage: mvjoin(array, delimiter) joins string array elements into a single string, separated by the specified delimiter. NULL elements are excluded from the output. Only string arrays are supported. 
+
+Argument type: array: ARRAY of STRING, delimiter: STRING
+
+Return type: STRING
+
+Example::
+
+    PPL> source=people | eval result = mvjoin(array('a', 'b', 'c'), ',') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +------------------------------------+
+    | result                             |
+    |------------------------------------|
+    | "a,b,c"                            |
+    +------------------------------------+
+
+    PPL> source=accounts | eval names_array = array(firstname, lastname) | eval result = mvjoin(names_array, ', ') | fields result | head 1
+    fetched rows / total rows = 1/1
+    +------------------------------------------+
+    | result                                   |
+    |------------------------------------------|
+    | "Amber, Duke"                            |
+    +------------------------------------------+
+    

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -5,10 +5,7 @@
 
 package org.opensearch.sql.calcite.remote;
 
-<<<<<<< HEAD
-=======
 import static org.junit.Assert.assertTrue;
->>>>>>> cb51d8e00 (`mvjoin` support in PPL Caclite (#4217))
 import static org.opensearch.sql.legacy.TestUtils.*;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_LOGS;
@@ -508,7 +505,6 @@ public class CalciteExplainIT extends ExplainIT {
   }
 
   @Test
-<<<<<<< HEAD
   public void testSimpleSortExpressionPushDownExplain() throws Exception {
     String query =
         "source=opensearch-sql_test_index_bank| eval age2 = age + 2 | sort age2 | fields age, age2";
@@ -523,14 +519,16 @@ public class CalciteExplainIT extends ExplainIT {
         "source=opensearch-sql_test_index_bank| eval b = balance + 1 | sort b | fields b";
     var result = explainQueryToString(query);
     String expected = loadExpectedPlan("explain_simple_sort_expr_single_expr_output_push.json");
-=======
+    assertJsonEqualsIgnoreId(expected, result);
+  }
+
+  @Test
   public void testMvjoinExplain() throws IOException {
     String query =
         "source=opensearch-sql_test_index_account | eval result = mvjoin(array('a', 'b', 'c'), ',')"
             + " | fields result | head 1";
     var result = explainQueryToString(query);
     String expected = loadExpectedPlan("explain_mvjoin.json");
->>>>>>> cb51d8e00 (`mvjoin` support in PPL Caclite (#4217))
     assertJsonEqualsIgnoreId(expected, result);
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -5,6 +5,10 @@
 
 package org.opensearch.sql.calcite.remote;
 
+<<<<<<< HEAD
+=======
+import static org.junit.Assert.assertTrue;
+>>>>>>> cb51d8e00 (`mvjoin` support in PPL Caclite (#4217))
 import static org.opensearch.sql.legacy.TestUtils.*;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_LOGS;
@@ -504,6 +508,7 @@ public class CalciteExplainIT extends ExplainIT {
   }
 
   @Test
+<<<<<<< HEAD
   public void testSimpleSortExpressionPushDownExplain() throws Exception {
     String query =
         "source=opensearch-sql_test_index_bank| eval age2 = age + 2 | sort age2 | fields age, age2";
@@ -518,6 +523,14 @@ public class CalciteExplainIT extends ExplainIT {
         "source=opensearch-sql_test_index_bank| eval b = balance + 1 | sort b | fields b";
     var result = explainQueryToString(query);
     String expected = loadExpectedPlan("explain_simple_sort_expr_single_expr_output_push.json");
+=======
+  public void testMvjoinExplain() throws IOException {
+    String query =
+        "source=opensearch-sql_test_index_account | eval result = mvjoin(array('a', 'b', 'c'), ',')"
+            + " | fields result | head 1";
+    var result = explainQueryToString(query);
+    String expected = loadExpectedPlan("explain_mvjoin.json");
+>>>>>>> cb51d8e00 (`mvjoin` support in PPL Caclite (#4217))
     assertJsonEqualsIgnoreId(expected, result);
   }
 

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_mvjoin.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_mvjoin.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalSort(fetch=[1])\n    LogicalProject(result=[ARRAY_JOIN(array('a', 'b', 'c'), ',')])\n      CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableCalc(expr#0..16=[{inputs}], expr#17=['a'], expr#18=['b'], expr#19=['c'], expr#20=[array($t17, $t18, $t19)], expr#21=[','], expr#22=[ARRAY_JOIN($t20, $t21)], result=[$t22])\n  CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[LIMIT->1, LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={\"from\":0,\"size\":1,\"timeout\":\"1m\"}, requestedTotalSize=1, pageSize=null, startFrom=0)])\n"
+  }
+}

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_mvjoin.json
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_mvjoin.json
@@ -1,0 +1,6 @@
+{
+  "calcite": {
+    "logical": "LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])\n  LogicalSort(fetch=[1])\n    LogicalProject(result=[ARRAY_JOIN(array('a', 'b', 'c'), ',')])\n      CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n",
+    "physical": "EnumerableLimit(fetch=[10000])\n  EnumerableCalc(expr#0..16=[{inputs}], expr#17=['a'], expr#18=['b'], expr#19=['c'], expr#20=[array($t17, $t18, $t19)], expr#21=[','], expr#22=[ARRAY_JOIN($t20, $t21)], result=[$t22])\n    EnumerableLimit(fetch=[1])\n      CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])\n"
+  }
+}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -421,6 +421,7 @@ ISBLANK:                            'ISBLANK';
 // COLLECTION FUNCTIONS
 ARRAY:                              'ARRAY';
 ARRAY_LENGTH:                       'ARRAY_LENGTH';
+MVJOIN:                             'MVJOIN';
 FORALL:                             'FORALL';
 FILTER:                             'FILTER';
 TRANSFORM:                          'TRANSFORM';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -913,6 +913,7 @@ mathematicalFunctionName
 collectionFunctionName
     : ARRAY
     | ARRAY_LENGTH
+    | MVJOIN
     | FORALL
     | EXISTS
     | FILTER

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLArrayFunctionTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLArrayFunctionTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testMvjoinWithStringArray() {
+    String ppl =
+        "source=EMP | eval joined = mvjoin(array('a', 'b', 'c'), ',') | head 1 | fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=[ARRAY_JOIN(array('a', 'b', 'c'), ',')])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "joined=a,b,c\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT ARRAY_JOIN(`array`('a', 'b', 'c'), ',') `joined`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMvjoinWithDifferentDelimiter() {
+    String ppl =
+        "source=EMP | eval joined = mvjoin(array('apple', 'banana', 'cherry'), ' | ') | head 1 |"
+            + " fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=[ARRAY_JOIN(array('apple':VARCHAR,"
+            + " 'banana':VARCHAR, 'cherry':VARCHAR), ' | ':VARCHAR)])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "joined=apple | banana | cherry\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT ARRAY_JOIN(`array`('apple', 'banana', 'cherry'), ' | ') `joined`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMvjoinWithEmptyArray() {
+    String ppl = "source=EMP | eval joined = mvjoin(array(), ',') | head 1 | fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=[ARRAY_JOIN(array(), ',')])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "joined=\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT ARRAY_JOIN(`array`(), ',') `joined`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testMvjoinWithFieldReference() {
+    String ppl =
+        "source=EMP | eval joined = mvjoin(array(ENAME, JOB), '-') | head 1 | fields joined";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(joined=[$8])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], joined=[ARRAY_JOIN(array($1, $2), '-')])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT ARRAY_JOIN(`array`(`ENAME`, `JOB`), '-') `joined`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
@@ -308,4 +308,12 @@ public class CalcitePPLFunctionTypeTest extends CalcitePPLAbstractTest {
             + " {[BYTE],[SHORT],[INTEGER],[LONG],[FLOAT],[DOUBLE],[STRING],[BOOLEAN],[DATE],[TIME],[TIMESTAMP],[IP],[BINARY]},"
             + " but got [ARRAY]");
   }
+
+  // mvjoin should reject non-string single values
+  @Test
+  public void testMvjoinRejectsNonStringValues() {
+    verifyQueryThrowsException(
+        "source=EMP | eval result = mvjoin(42, ',') | fields result | head 1",
+        "MVJOIN function expects {[ARRAY,STRING]}, but got [INTEGER,STRING]");
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLFunctionTypeTest.java
@@ -312,8 +312,12 @@ public class CalcitePPLFunctionTypeTest extends CalcitePPLAbstractTest {
   // mvjoin should reject non-string single values
   @Test
   public void testMvjoinRejectsNonStringValues() {
-    verifyQueryThrowsException(
-        "source=EMP | eval result = mvjoin(42, ',') | fields result | head 1",
-        "MVJOIN function expects {[ARRAY,STRING]}, but got [INTEGER,STRING]");
+    Exception e =
+        Assert.assertThrows(
+            ExpressionEvaluationException.class,
+            () ->
+                getRelNode("source=EMP | eval result = mvjoin(42, ',') | fields result | head 1"));
+    verifyErrorMessageContains(
+        e, "MVJOIN function expects {[ARRAY,STRING]}, but got [INTEGER,STRING]");
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -606,6 +606,14 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testMvjoin() {
+    // Test mvjoin with array of strings
+    assertEquals(
+        "source=t | eval result=mvjoin(array(***,***,***),***) | fields + result",
+        anonymize("source=t | eval result=mvjoin(array('a', 'b', 'c'), ',') | fields result"));
+  }
+
+  @Test
   public void testRexWithOffsetField() {
     when(settings.getSettingValue(Key.PPL_REX_MAX_MATCH_LIMIT)).thenReturn(10);
 


### PR DESCRIPTION
### Description
This PR adds support for the mvjoin function in PPL with Apache Calcite integration. The mvjoin function concatenates the elements of a multi-value field into a single string using a specified delimiter.  This is useful for converting multi-value fields into a readable string format.

Syntax: `mvjoin(multivalue_field, delimiter)`

Example:
```
source=logs | eval joined_values = mvjoin(array('apple', 'banana', 'cherry'), ', ')
// Result: "apple, banana, cherry"
```

Original PR to main: https://github.com/opensearch-project/sql/pull/4217


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
