### PR TITLE
[Doc] Correct the comparision table for rex doc

### DIFF
--- a/docs/user/ppl/cmd/rex.rst
+++ b/docs/user/ppl/cmd/rex.rst
@@ -211,7 +211,8 @@ Feature                        rex          parse
 ============================= ============ ============
 Pattern Type                   Java Regex   Java Regex
 Named Groups Required          Yes          Yes
-Filtering by Match             No           Yes  
+Filtering by Match             No           No
+Multiple Named Groups          Yes          No
 Multiple Matches               Yes          No
 Text Substitution              Yes          No
 Offset Tracking                Yes          No

--- a/docs/user/ppl/cmd/rex.rst
+++ b/docs/user/ppl/cmd/rex.rst
@@ -211,7 +211,6 @@ Feature                        rex          parse
 ============================= ============ ============
 Pattern Type                   Java Regex   Java Regex
 Named Groups Required          Yes          Yes
-Filtering by Match             No           No
 Multiple Named Groups          Yes          No
 Multiple Matches               Yes          No
 Text Substitution              Yes          No


### PR DESCRIPTION
### Description
Correct the comparision table for rex doc
- Correct the wrong comparison result between `rex` and `parse` in `rex.rst`
  - Both `rex` and `parse` should only behave extraction instead of filtering.
- Add highlighted diff to mention `rex` supports multiple name group extractions

### Related Issues
* Relate #4109 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
