### PR TITLE
Fix alphanumeric search which starts with number

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -215,6 +215,37 @@ public class SearchCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testSearchWithAlphanumericLiteral() throws IOException {
+    // Test searching for alphanumeric strings starting with numbers (like trace IDs)
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "search source=%s b3cb01a03c846973fd496b973f49be85 | fields traceId, body",
+                TEST_INDEX_OTEL_LOGS));
+    verifyDataRows(
+        result,
+        rows(
+            "b3cb01a03c846973fd496b973f49be85",
+            "User e1ce63e6-8501-11f0-930d-c2fcbdc05f14 adding 4 of product HQTGWGPNH4 to cart"));
+
+    // Test another trace ID that starts with a number
+    JSONObject result2 =
+        executeQuery(
+            String.format(
+                "search source=%s 7475a30207dbef54d29e42c37f09a528 | fields traceId, severityText",
+                TEST_INDEX_OTEL_LOGS));
+    verifyDataRows(result2, rows("7475a30207dbef54d29e42c37f09a528", "ERROR"));
+
+    // Test alphanumeric string with mixed case
+    JSONObject result3 =
+        executeQuery(
+            String.format(
+                "search source=%s abc123def456ghi789 | fields traceId, severityText",
+                TEST_INDEX_OTEL_LOGS));
+    verifyDataRows(result3, rows("abc123def456ghi789", "TRACE"));
+  }
+
+  @Test
   public void testSearchWithComplexBooleanExpression() throws IOException {
     JSONObject result =
         executeQuery(

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -549,4 +549,6 @@ fragment ID_LITERAL:                ([@*A-Z_])+?[*A-Z_\-0-9]*;
 LINE_COMMENT:                       '//' ('\\\n' | ~[\r\n])* '\r'? '\n'? -> channel(HIDDEN);
 BLOCK_COMMENT:                      '/*' .*? '*/' -> channel(HIDDEN);
 
+EXTENDED_ALNUM_LITERAL:             [0-9][0-9A-Za-z_\-]*;
+
 ERROR_RECOGNITION:                  .    -> channel(ERRORCHANNEL);

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -140,6 +140,7 @@ searchLiteral
    : numericLiteral
    | booleanLiteral
    | ID
+   | EXTENDED_ALNUM_LITERAL
    | stringLiteral
    | searchableKeyWord
    ;
@@ -1234,6 +1235,7 @@ literalValue
    | floatLiteral
    | booleanLiteral
    | datetimeLiteral //#datetime
+   | EXTENDED_ALNUM_LITERAL
    ;
 
 intervalLiteral

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -52,6 +52,22 @@ public class PPLSyntaxParserTest {
   }
 
   @Test
+  public void testSearchCommandWithAlphanumericTraceIdShouldPass() {
+    ParseTree tree =
+        new PPLSyntaxParser().parse("source=demo-logs-otel-v1-* 5a57f0a17fc6f59fb2ad8ec6b52ea3fa");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
+  public void testSearchCommandWithAlphanumericLiteralsShouldPass() {
+    ParseTree tree = new PPLSyntaxParser().parse("source=logs 0123456789abcdef");
+    assertNotEquals(null, tree);
+
+    ParseTree tree2 = new PPLSyntaxParser().parse("source=logs 9abc_123-def");
+    assertNotEquals(null, tree2);
+  }
+
+  @Test
   public void testSearchCommandCrossClusterHiddenShouldPass() {
     ParseTree tree = new PPLSyntaxParser().parse("search source=c:.t a=1 b=2");
     assertNotEquals(null, tree);


### PR DESCRIPTION
### Description

unquoted search literals which starts  with numbers translate to wrong lucene query due to issue with ppl grammar.


### Example Query
POST _plugins/_ppl/
{
  "query": "source =demo-logs-otel-v1-* 5a57f0a17fc6f59fb2ad8ec6b52ea3fa "
}
```
{"from":0,"size":10000,"timeout":"1m","**query":{"query_string":{"query":"(5) AND (a57f0a17fc6f59fb2ad8ec6b52ea3fa)**","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"_source":{"includes":["severity","traceId","instrumentationScope","resource","flags","severityNumber","body","observedTime","schemaUrl","spanId","@timestamp","severityText","attributes","droppedAttributesCount","time","observedTimestamp"],"excludes":[]},"sort":[{"_doc":{"order":"asc"}}]}

```


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
