### PR TITLE
change Anonymizer to mask PPL

### DIFF
--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -831,7 +831,7 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
     @Override
     public String visitCase(Case node, String context) {
       StringBuilder builder = new StringBuilder();
-      builder.append("cast(");
+      builder.append("case(");
       for (When when : node.getWhenClauses()) {
         builder.append(analyze(when.getCondition(), context));
         builder.append(",");

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -562,13 +562,13 @@ public class PPLQueryDataAnonymizerTest {
   @Test
   public void testCaseWhen() {
     assertEquals(
-        "source=table | eval identifier=cast(identifier >= ***,***,identifier >= *** and identifier"
+        "source=table | eval identifier=case(identifier >= ***,***,identifier >= *** and identifier"
             + " < ***,*** else ***) | fields + identifier",
         anonymize(
             "source=t | eval level=CASE(score >= 90, 'A', score >= 80 AND score < 90, 'B' else 'C')"
                 + " | fields level"));
     assertEquals(
-        "source=table | eval identifier=cast(identifier >= ***,***,identifier >= *** and identifier"
+        "source=table | eval identifier=case(identifier >= ***,***,identifier >= *** and identifier"
             + " < ***,***) | fields + identifier",
         anonymize(
             "source=t | eval level=CASE(score >= 90, 'A', score >= 80 AND score < 90, 'B')"


### PR DESCRIPTION
### Description
The PR change Anonymizer to mask PPL as SQL.
Basically, we follow the rules:
1. Mask table name to `table`
2. Mask the column name to `identifier`
3. Mask customer input literal to `***` like regex
4. All the rename after as would be replaced to `identifier`
5. The new column create by eval will be masked to `identifier` like `eval identifer=....`

Some examples,
Example1
`source=my_table as alias_table_name |  rename my_column as alias_column | fields alias_column` -> `source=table as identifier | rename identifier as identifier | fields identifier` 
Exampl2
`source=table1 as t1 | right join max=0 on t1.id = t2.id table2 as t2 | fields t1.id` -> `source=table as identifier | right join max=*** left = identifier right = identifier on identifier = identifier table as identifier | fields + identifier`


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
#4125 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
