### PR TITLE
Fix timezone dependent test failures

### DIFF
--- a/core/src/test/java/org/opensearch/sql/data/model/ExprValueCompareTest.java
+++ b/core/src/test/java/org/opensearch/sql/data/model/ExprValueCompareTest.java
@@ -13,8 +13,9 @@ import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_MISSING;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_NULL;
 import static org.opensearch.sql.utils.DateTimeUtils.extractTimestamp;
 
-import java.time.LocalDate;
+import java.time.Instant;
 import java.time.Period;
+import java.time.ZoneOffset;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,8 +23,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.ExpressionTestBase;
+import org.opensearch.sql.expression.function.FunctionProperties;
 
 public class ExprValueCompareTest extends ExpressionTestBase {
+
+  // Use a fixed timestamp for consistent test results across timezones
+  private static final FunctionProperties FIXED_FUNCTION_PROPERTIES =
+      new FunctionProperties(Instant.parse("2023-05-15T00:00:00Z"), ZoneOffset.UTC);
 
   @Test
   public void timeValueCompare() {
@@ -60,13 +66,11 @@ public class ExprValueCompareTest extends ExpressionTestBase {
         Arguments.of(
             new ExprTimestampValue("1984-11-22 00:00:00"), new ExprDateValue("1984-11-22")),
         Arguments.of(
-            new ExprTimestampValue(LocalDate.now() + " 00:00:00"),
-            new ExprDateValue(LocalDate.now())),
-        Arguments.of(new ExprDateValue(LocalDate.now()), new ExprTimeValue("00:00:00")),
+            new ExprTimestampValue("2023-05-15 00:00:00"), new ExprDateValue("2023-05-15")),
+        Arguments.of(new ExprDateValue("2023-05-15"), new ExprTimeValue("00:00:00")),
         Arguments.of(
             new ExprTimestampValue("1984-11-22 00:00:00"), new ExprDateValue("1984-11-22")),
-        Arguments.of(
-            new ExprTimeValue("17:42:15"), new ExprTimestampValue(LocalDate.now() + " 17:42:15")));
+        Arguments.of(new ExprTimeValue("17:42:15"), new ExprTimestampValue("2023-05-15 17:42:15")));
   }
 
   /**
@@ -78,8 +82,8 @@ public class ExprValueCompareTest extends ExpressionTestBase {
   public void compareEqDifferentDateTimeValueTypes(ExprValue left, ExprValue right) {
     assertEquals(
         0,
-        extractTimestamp(left, functionProperties)
-            .compareTo(extractTimestamp(right, functionProperties)));
+        extractTimestamp(left, FIXED_FUNCTION_PROPERTIES)
+            .compareTo(extractTimestamp(right, FIXED_FUNCTION_PROPERTIES)));
   }
 
   private static Stream<Arguments> getNotEqualDatetimeValuesOfDifferentTypes() {
@@ -87,11 +91,10 @@ public class ExprValueCompareTest extends ExpressionTestBase {
         Arguments.of(
             new ExprDateValue("1984-11-22"), new ExprTimestampValue("2020-09-16 17:30:00")),
         Arguments.of(new ExprDateValue("1984-11-22"), new ExprTimeValue("19:14:38")),
-        Arguments.of(new ExprTimeValue("19:14:38"), new ExprDateValue(LocalDate.now())),
+        Arguments.of(new ExprTimeValue("19:14:38"), new ExprDateValue("2023-05-15")),
         Arguments.of(new ExprTimeValue("19:14:38"), new ExprTimestampValue("1984-02-03 04:05:07")),
         Arguments.of(new ExprTimestampValue("2012-08-07 19:14:38"), new ExprTimeValue("09:07:00")),
-        Arguments.of(
-            new ExprTimestampValue(LocalDate.now() + " 19:14:38"), new ExprTimeValue("09:07:00")),
+        Arguments.of(new ExprTimestampValue("2023-05-15 19:14:38"), new ExprTimeValue("09:07:00")),
         Arguments.of(
             new ExprTimestampValue("2012-08-07 00:00:00"), new ExprDateValue("1961-04-12")),
         Arguments.of(

--- a/core/src/test/java/org/opensearch/sql/expression/ExpressionTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/ExpressionTestBase.java
@@ -26,6 +26,8 @@ import static org.opensearch.sql.data.model.ExprValueUtils.tupleValue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.function.Function;
 import org.opensearch.sql.data.model.ExprValue;
@@ -36,7 +38,9 @@ import org.opensearch.sql.expression.function.FunctionProperties;
 
 public class ExpressionTestBase {
 
-  protected final FunctionProperties functionProperties = new FunctionProperties();
+  // Use fixed timestamp to ensure timezone-independent tests
+  protected final FunctionProperties functionProperties =
+      new FunctionProperties(Instant.parse("2023-05-15T00:00:00Z"), ZoneOffset.UTC);
 
   protected Environment<Expression, ExprType> typeEnv;
 

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateDiffTest.java
@@ -12,9 +12,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.temporal.Temporal;
-import java.util.TimeZone;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -28,9 +26,14 @@ public class DateDiffTest extends DateTimeTestBase {
   private static final LocalDate dateSample2 = LocalDate.of(1961, 4, 12);
   private static final LocalDate dateSample3 = LocalDate.of(1993, 3, 4);
   private static final LocalDate epochStart = LocalDate.of(1970, 1, 1);
-  private static final LocalDate dateNow = LocalDate.now();
+  // Use fixed date instead of LocalDate.now() to avoid timezone issues
+  private static final LocalDate dateNow = LocalDate.of(2023, 5, 15);
   private static final LocalDateTime dateTimeSample1 = LocalDateTime.of(1961, 4, 12, 9, 7);
   private static final LocalDateTime dateTimeSample2 = LocalDateTime.of(1993, 3, 4, 5, 6);
+  // Use fixed datetime instead of LocalDateTime.now()
+  private static final LocalDateTime fixedNow = LocalDateTime.of(2023, 5, 15, 12, 0, 0);
+  // Use fixed instant instead of Instant.now()
+  private static final Instant fixedInstantNow = Instant.parse("2023-05-15T12:00:00Z");
 
   // Function signature is:
   // (DATE/TIMESTAMP/TIME, DATE/TIMESTAMP/TIME) -> LONG
@@ -39,15 +42,14 @@ public class DateDiffTest extends DateTimeTestBase {
     return Stream.of(
         Arguments.of(timeSample1, timeSample2, 0L),
         Arguments.of(timeSample1, dateNow, 0L),
-        Arguments.of(timeSample1, LocalDateTime.now(), 0L),
-        Arguments.of(
-            timeSample1, Instant.now().plusMillis(TimeZone.getDefault().getRawOffset()), 0L),
+        Arguments.of(timeSample1, fixedNow, 0L),
+        Arguments.of(timeSample1, fixedInstantNow, 0L),
         Arguments.of(dateSample1, timeSample1, -DAYS.between(dateSample1, dateNow)),
         Arguments.of(dateSample1, dateSample3, -DAYS.between(dateSample1, dateSample3)),
         Arguments.of(dateSample1, dateTimeSample1, -DAYS.between(dateSample1, dateSample2)),
         Arguments.of(
             dateSample1, Instant.ofEpochSecond(42), -DAYS.between(dateSample1, epochStart)),
-        Arguments.of(dateTimeSample1, LocalTime.now(), -DAYS.between(dateSample2, dateNow)),
+        Arguments.of(dateTimeSample1, LocalTime.of(12, 0), -DAYS.between(dateSample2, dateNow)),
         Arguments.of(dateTimeSample1, dateSample3, -DAYS.between(dateSample2, dateSample3)),
         Arguments.of(dateTimeSample1, dateTimeSample2, -DAYS.between(dateSample2, dateSample3)),
         Arguments.of(
@@ -58,8 +60,8 @@ public class DateDiffTest extends DateTimeTestBase {
             Instant.ofEpochSecond(0), dateTimeSample2, -DAYS.between(epochStart, dateSample3)),
         Arguments.of(
             Instant.ofEpochSecond(0),
-            Instant.now(),
-            -DAYS.between(epochStart, LocalDateTime.now(ZoneId.of("UTC")))));
+            fixedInstantNow,
+            -DAYS.between(epochStart, fixedNow.toLocalDate())));
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/DateTimeTestBase.java
@@ -24,11 +24,16 @@ import org.opensearch.sql.expression.ExpressionTestBase;
 import org.opensearch.sql.expression.FunctionExpression;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.BuiltinFunctionRepository;
+import org.opensearch.sql.expression.function.FunctionProperties;
 
 public class DateTimeTestBase extends ExpressionTestBase {
 
   protected final BuiltinFunctionRepository functionRepository =
       BuiltinFunctionRepository.getInstance();
+
+  // Override functionProperties with fixed values to ensure timezone-independent tests
+  protected final FunctionProperties functionProperties =
+      new FunctionProperties(Instant.parse("2023-05-15T00:00:00Z"), ZoneOffset.UTC);
 
   protected ExprValue eval(Expression expression) {
     return expression.valueOf();

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/StrToDateTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/StrToDateTest.java
@@ -29,6 +29,7 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ExpressionTestBase;
 import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.function.FunctionProperties;
 
 class StrToDateTest extends ExpressionTestBase {
 
@@ -89,10 +90,12 @@ class StrToDateTest extends ExpressionTestBase {
   }
 
   private static LocalDateTime getExpectedTimeResult(int hour, int minute, int seconds) {
+    // Use a fixed date to avoid timezone-dependent test failures
+    LocalDate fixedDate = LocalDate.of(2023, 5, 15);
     return LocalDateTime.of(
-        LocalDate.now().getYear(),
-        LocalDate.now().getMonthValue(),
-        LocalDate.now().getDayOfMonth(),
+        fixedDate.getYear(),
+        fixedDate.getMonthValue(),
+        fixedDate.getDayOfMonth(),
         hour,
         minute,
         seconds);
@@ -108,10 +111,13 @@ class StrToDateTest extends ExpressionTestBase {
   @ParameterizedTest(name = "{1}")
   @MethodSource("getTestDataForStrToDateWithTime")
   public void test_str_to_date_with_time_type(String parsed, String format) {
+    // Use fixed function properties to ensure consistent test results across timezones
+    FunctionProperties fixedFunctionProperties =
+        new FunctionProperties(Instant.parse("2023-05-15T00:00:00Z"), ZoneOffset.UTC);
 
     FunctionExpression expression =
         DSL.str_to_date(
-            functionProperties,
+            fixedFunctionProperties,
             DSL.literal(new ExprStringValue(parsed)),
             DSL.literal(new ExprStringValue(format)));
 
@@ -152,19 +158,23 @@ class StrToDateTest extends ExpressionTestBase {
     final int MINUTES = 11;
     final int SECONDS = 12;
 
+    // Use fixed function properties to ensure consistent test results across timezones
+    FunctionProperties fixedFunctionProperties =
+        new FunctionProperties(Instant.parse("2023-05-15T00:00:00Z"), ZoneOffset.UTC);
+
     LocalTime arg = LocalTime.of(HOURS, MINUTES, SECONDS);
     String format = "%h,%i,%s";
 
     FunctionExpression dateFormatExpr =
         DSL.time_format(
-            functionProperties,
+            fixedFunctionProperties,
             DSL.literal(new ExprTimeValue(arg)),
             DSL.literal(new ExprStringValue(format)));
     String timeFormatResult = eval(dateFormatExpr).stringValue();
 
     FunctionExpression strToDateExpr =
         DSL.str_to_date(
-            functionProperties,
+            fixedFunctionProperties,
             DSL.literal(new ExprStringValue(timeFormatResult)),
             DSL.literal(new ExprStringValue(format)));
     LocalDateTime strToDateResult =

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampAddTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampAddTest.java
@@ -122,27 +122,29 @@ class TimeStampAddTest extends ExpressionTestBase {
   }
 
   private static Stream<Arguments> getTestDataForTestAddingDatePartToTime() {
+    // Use fixed date to avoid timezone-dependent test failures
+    LocalDate fixedDate = LocalDate.of(2023, 5, 15);
     return Stream.of(
-        Arguments.of("DAY", 1, "10:11:12", LocalDate.now().plusDays(1)),
-        Arguments.of("DAY", 5, "10:11:12", LocalDate.now().plusDays(5)),
-        Arguments.of("DAY", 10, "10:11:12", LocalDate.now().plusDays(10)),
-        Arguments.of("DAY", -10, "10:11:12", LocalDate.now().plusDays(-10)),
-        Arguments.of("WEEK", 1, "10:11:12", LocalDate.now().plusWeeks(1)),
-        Arguments.of("WEEK", 5, "10:11:12", LocalDate.now().plusWeeks(5)),
-        Arguments.of("WEEK", 10, "10:11:12", LocalDate.now().plusWeeks(10)),
-        Arguments.of("WEEK", -10, "10:11:12", LocalDate.now().plusWeeks(-10)),
-        Arguments.of("MONTH", 1, "10:11:12", LocalDate.now().plusMonths(1)),
-        Arguments.of("MONTH", 5, "10:11:12", LocalDate.now().plusMonths(5)),
-        Arguments.of("MONTH", 10, "10:11:12", LocalDate.now().plusMonths(10)),
-        Arguments.of("MONTH", -10, "10:11:12", LocalDate.now().plusMonths(-10)),
-        Arguments.of("QUARTER", 1, "10:11:12", LocalDate.now().plusMonths(3 * 1)),
-        Arguments.of("QUARTER", 3, "10:11:12", LocalDate.now().plusMonths(3 * 3)),
-        Arguments.of("QUARTER", 5, "10:11:12", LocalDate.now().plusMonths(3 * 5)),
-        Arguments.of("QUARTER", -5, "10:11:12", LocalDate.now().plusMonths(3 * -5)),
-        Arguments.of("YEAR", 1, "10:11:12", LocalDate.now().plusYears(1)),
-        Arguments.of("YEAR", 5, "10:11:12", LocalDate.now().plusYears(5)),
-        Arguments.of("YEAR", 10, "10:11:12", LocalDate.now().plusYears(10)),
-        Arguments.of("YEAR", -10, "10:11:12", LocalDate.now().plusYears(-10)));
+        Arguments.of("DAY", 1, "10:11:12", fixedDate.plusDays(1)),
+        Arguments.of("DAY", 5, "10:11:12", fixedDate.plusDays(5)),
+        Arguments.of("DAY", 10, "10:11:12", fixedDate.plusDays(10)),
+        Arguments.of("DAY", -10, "10:11:12", fixedDate.plusDays(-10)),
+        Arguments.of("WEEK", 1, "10:11:12", fixedDate.plusWeeks(1)),
+        Arguments.of("WEEK", 5, "10:11:12", fixedDate.plusWeeks(5)),
+        Arguments.of("WEEK", 10, "10:11:12", fixedDate.plusWeeks(10)),
+        Arguments.of("WEEK", -10, "10:11:12", fixedDate.plusWeeks(-10)),
+        Arguments.of("MONTH", 1, "10:11:12", fixedDate.plusMonths(1)),
+        Arguments.of("MONTH", 5, "10:11:12", fixedDate.plusMonths(5)),
+        Arguments.of("MONTH", 10, "10:11:12", fixedDate.plusMonths(10)),
+        Arguments.of("MONTH", -10, "10:11:12", fixedDate.plusMonths(-10)),
+        Arguments.of("QUARTER", 1, "10:11:12", fixedDate.plusMonths(3 * 1)),
+        Arguments.of("QUARTER", 3, "10:11:12", fixedDate.plusMonths(3 * 3)),
+        Arguments.of("QUARTER", 5, "10:11:12", fixedDate.plusMonths(3 * 5)),
+        Arguments.of("QUARTER", -5, "10:11:12", fixedDate.plusMonths(3 * -5)),
+        Arguments.of("YEAR", 1, "10:11:12", fixedDate.plusYears(1)),
+        Arguments.of("YEAR", 5, "10:11:12", fixedDate.plusYears(5)),
+        Arguments.of("YEAR", 10, "10:11:12", fixedDate.plusYears(10)),
+        Arguments.of("YEAR", -10, "10:11:12", fixedDate.plusYears(-10)));
   }
 
   @ParameterizedTest
@@ -174,8 +176,10 @@ class TimeStampAddTest extends ExpressionTestBase {
             DSL.literal(new ExprIntegerValue(addedInterval)),
             DSL.literal(new ExprTimeValue(timeArg)));
 
+    // Use fixed date to avoid timezone-dependent test failures
     LocalDateTime expected =
-        LocalDateTime.of(LocalDate.now(), LocalTime.parse(timeArg).plusMinutes(addedInterval));
+        LocalDateTime.of(
+            LocalDate.of(2023, 5, 15), LocalTime.parse(timeArg).plusMinutes(addedInterval));
 
     assertEquals(new ExprTimestampValue(expected), eval(expr));
   }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimeStampDiffTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -222,7 +223,12 @@ class TimeStampDiffTest extends ExpressionTestBase {
   @ParameterizedTest
   @MethodSource("getUnits")
   public void testTimestampDiffWithTimeType(String unit) {
-    LocalDateTime base = LocalDateTime.of(LocalDate.now(), LocalTime.of(10, 11, 12));
+    // Use fixed date to avoid timezone-dependent test failures
+    LocalDateTime base = LocalDateTime.of(LocalDate.of(2023, 5, 15), LocalTime.of(10, 11, 12));
+
+    // Use fixed function properties to ensure consistent test results across timezones
+    FunctionProperties fixedFunctionProperties =
+        new FunctionProperties(Instant.parse("2023-05-15T00:00:00Z"), ZoneOffset.UTC);
 
     ExprValue timeExpr = generateArg(unit, "TIME", base, 0);
     ExprValue timestampExpr = generateArg(unit, "TIMESTAMP", base, 0);
@@ -234,7 +240,7 @@ class TimeStampDiffTest extends ExpressionTestBase {
 
     for (ExprValue arg1 : expressions) {
       for (ExprValue arg2 : expressions) {
-        FunctionExpression funcExpr = timestampdiffQuery(functionProperties, unit, arg1, arg2);
+        FunctionExpression funcExpr = timestampdiffQuery(fixedFunctionProperties, unit, arg1, arg2);
 
         assertEquals(0L, eval(funcExpr).longValue());
       }

--- a/core/src/test/java/org/opensearch/sql/expression/datetime/TimestampTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/datetime/TimestampTest.java
@@ -74,8 +74,12 @@ public class TimestampTest extends ExpressionTestBase {
   public void timestamp_one_arg_time() {
     var expr = DSL.timestamp(functionProperties, DSL.time(DSL.literal("22:33:44")));
     assertEquals(TIMESTAMP, expr.type());
+    // Use fixed date to avoid timezone-dependent test failures
     var refValue =
-        LocalDate.now().atTime(LocalTime.of(22, 33, 44)).atZone(ZoneOffset.UTC).toInstant();
+        LocalDate.of(2023, 5, 15)
+            .atTime(LocalTime.of(22, 33, 44))
+            .atZone(ZoneOffset.UTC)
+            .toInstant();
     assertEquals(new ExprTimestampValue(refValue), expr.valueOf());
   }
 
@@ -105,7 +109,8 @@ public class TimestampTest extends ExpressionTestBase {
   }
 
   private static Stream<Arguments> getTestData() {
-    var today = LocalDate.now();
+    // Use fixed date to avoid timezone-dependent test failures
+    var today = LocalDate.of(2023, 5, 15);
     // First argument of `TIMESTAMP` function, second argument and expected result value
     return Stream.of(
         // STRING and STRING/DATE/TIME/DATETIME/TIMESTAMP


### PR DESCRIPTION
### Description
- Fix timezone dependent test failures.
- Those tests were failing while local date is different between UTC and local timezone. 

### Related Issues
n/a

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
