### PR TITLE
Avoid unnecessary security plugin download in integ-test

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -83,9 +83,18 @@ ext {
         return repo + "opensearch-security-${securitySnapshotVersion}.zip"
     }
 
+    isSecurityTask = { ->
+        def taskName = gradle.startParameter.taskNames.join(' ')
+        return taskName.contains('Security') || System.getProperty('enableSecurity') == 'true'
+    }
+    
     var projectAbsPath = projectDir.getAbsolutePath()
     File downloadedSecurityPlugin = Paths.get(projectAbsPath, 'bin', 'opensearch-security-snapshot.zip').toFile()
+    
     configureSecurityPlugin = { OpenSearchCluster cluster ->
+        if (!isSecurityTask()) {
+            return
+        }
 
         cluster.getNodes().forEach { node ->
             var creds = node.getCredentials()
@@ -237,17 +246,17 @@ testClusters.all {
 
 def getJobSchedulerPlugin() {
     provider { (RegularFile) (() ->
-            configurations.zipArchive.asFileTree.matching {
-                include '**/opensearch-job-scheduler*'
-            }.singleFile )
+        configurations.zipArchive.asFileTree.matching {
+            include '**/opensearch-job-scheduler*'
+        }.singleFile )
     }
 }
 
 def getGeoSpatialPlugin() {
     provider { (RegularFile) (() ->
-            configurations.zipArchive.asFileTree.matching {
-                include '**/geospatia*'
-            }.singleFile )
+        configurations.zipArchive.asFileTree.matching {
+            include '**/geospatia*'
+        }.singleFile )
     }
 }
 


### PR DESCRIPTION
### Description
- Avoid unnecessary security plugin download in integ-test
- Remove confusing output in gradlew task executions.

Before: (it shows output from `project :integ-test` even though it is `:core:test`)
```
% ./gradlew :core:test                                      

> Configure project :integ-test
Security Plugin File Already Exists
Download https://raw.githubusercontent.com/opensearch-project/security/main/bwc-test/src/test/resources/security/esnode.pem
Download https://raw.githubusercontent.com/opensearch-project/security/main/bwc-test/src/test/resources/security/esnode-key.pem
Download https://raw.githubusercontent.com/opensearch-project/security/main/bwc-test/src/test/resources/security/root-ca.pem
Security Plugin File Already Exists
Download https://raw.githubusercontent.com/opensearch-project/security/main/bwc-test/src/test/resources/security/esnode.pem
Download https://raw.githubusercontent.com/opensearch-project/security/main/bwc-test/src/test/resources/security/esnode-key.pem
Download https://raw.githubusercontent.com/opensearch-project/security/main/bwc-test/src/test/resources/security/root-ca.pem
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.14
  OS Info               : Mac OS X 15.6.1 (aarch64)
  JDK Version           : 21 (Amazon Corretto JDK)
  JAVA_HOME             : /Users/moritato/.sdkman/candidates/java/21.0.8-amzn
  Random Testing Seed   : 617D105F7E5EFA0B
  Crypto Standard       : any-supported
=======================================

> Task :core:compileTestJava
Note: Some input files use or override a deprecated API.
...
```

After: (no output related to `project :integ-test`)
```
% ./gradlew :core:test
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.14
  OS Info               : Mac OS X 15.6.1 (aarch64)
  JDK Version           : 21 (Amazon Corretto JDK)
  JAVA_HOME             : /Users/moritato/.sdkman/candidates/java/21.0.8-amzn
  Random Testing Seed   : 9CDFA2D1386FFC7B
  Crypto Standard       : any-supported
=======================================

> Task :core:compileJava
/Volumes/workplace/sql/core/src/main/java/org/opensearch/sql/executor/QueryService.java:94: warning: [removal] AccessController in java.security has been deprecated and marked for removal
...
```


### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
