### PR TITLE
Prevent limit pushdown before action building instead of in action executing

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -579,6 +579,17 @@ public class CalciteExplainIT extends ExplainIT {
   }
 
   @Test
+  public void testPreventLimitPushdown() throws IOException {
+    enabledOnlyWhenPushdownIsEnabled();
+    setMaxResultWindow("opensearch-sql_test_index_account", 1);
+    String query = "source=opensearch-sql_test_index_account | head 1 from 1";
+    var result = explainQueryToString(query);
+    String expected = loadExpectedPlan("explain_prevent_limit_push.yaml");
+    assertYamlEqualsJsonIgnoreId(expected, result);
+    resetMaxResultWindow("opensearch-sql_test_index_account");
+  }
+
+  @Test
   public void testPushdownLimitIntoAggregation() throws IOException {
     enabledOnlyWhenPushdownIsEnabled();
     String expected = loadExpectedPlan("explain_limit_agg_pushdown.json");

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_prevent_limit_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_prevent_limit_push.yaml
@@ -1,0 +1,10 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(account_number=[$0], firstname=[$1], address=[$2], balance=[$3], gender=[$4], city=[$5], employer=[$6], state=[$7], age=[$8], email=[$9], lastname=[$10])
+        LogicalSort(offset=[1], fetch=[1])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])
+  physical: |
+    EnumerableLimit(fetch=[10000])
+      EnumerableLimit(offset=[1], fetch=[1])
+        CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[PROJECT->[account_number, firstname, address, balance, gender, city, employer, state, age, email, lastname]], OpenSearchRequestBuilder(sourceBuilder={"from":0,"timeout":"1m","_source":{"includes":["account_number","firstname","address","balance","gender","city","employer","state","age","email","lastname"],"excludes":[]}}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3102.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3102.yml
@@ -4,6 +4,11 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+  - do:
       indices.create:
         index: test
         body:
@@ -20,6 +25,14 @@ setup:
           - '{"id": 2}'
           - '{"index": {}}'
           - '{"id": 3}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
 
 ---
 "Prevent push down limit if the offset reach max_result_window":

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/AbstractCalciteIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/AbstractCalciteIndexScan.java
@@ -170,6 +170,7 @@ public abstract class AbstractCalciteIndexScan extends TableScan {
     @Getter private AggPushDownAction aggPushDownAction;
     @Getter private boolean isLimitPushed = false;
     @Getter private boolean isProjectPushed = false;
+    @Getter private int startFrom = 0;
 
     @Override
     public PushDownContext clone() {
@@ -184,6 +185,7 @@ public abstract class AbstractCalciteIndexScan extends TableScan {
       }
       if (pushDownAction.type == PushDownType.LIMIT) {
         isLimitPushed = true;
+        startFrom += ((LimitDigest) pushDownAction.digest).offset();
       }
       if (pushDownAction.type == PushDownType.PROJECT) {
         isProjectPushed = true;


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/sql/pull/3713 tried to prevent push down limit with offset reach maxResultWindow in action being executing (applying) which didn't work in v3.

Fixing: Prevent limit pushdown before action building instead of in action executing

### Related Issues
Resolves #4376 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
