### PR TITLE
Fix bug of missed analyzed node when pushdown filter for Search call

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -239,6 +239,19 @@ public class CalciteExplainIT extends ExplainIT {
   }
 
   @Test
+  public void testFilterWithSearchCall() throws IOException {
+    enabledOnlyWhenPushdownIsEnabled();
+    String expected = loadExpectedPlan("explain_filter_with_search.yaml");
+    assertYamlEqualsJsonIgnoreId(
+        expected,
+        explainQueryToString(
+            String.format(
+                "source=%s | where birthdate >= '2023-01-01 00:00:00' and birthdate < '2023-01-03"
+                    + " 00:00:00' | stats count() by span(birthdate, 1d)",
+                TEST_INDEX_BANK)));
+  }
+
+  @Test
   public void testExplainWithReverse() throws IOException {
     String result =
         executeWithReplace(

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_filter_with_search.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_filter_with_search.yaml
@@ -1,0 +1,11 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(count()=[$1], span(birthdate,1d)=[$0])
+        LogicalAggregate(group=[{0}], count()=[COUNT()])
+          LogicalProject(span(birthdate,1d)=[SPAN($3, 1, 'd')])
+            LogicalFilter(condition=[IS NOT NULL($3)])
+              LogicalFilter(condition=[AND(>=($3, TIMESTAMP('2023-01-01 00:00:00':VARCHAR)), <($3, TIMESTAMP('2023-01-03 00:00:00':VARCHAR)))])
+                CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]])
+  physical: |
+    CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]], PushDownContext=[[PROJECT->[birthdate], FILTER->SEARCH($0, Sarg[['2023-01-01 00:00:00':VARCHAR..'2023-01-03 00:00:00':VARCHAR); NULL AS FALSE]:VARCHAR), AGGREGATION->rel#:LogicalAggregate.NONE.[](input=RelSubset#,group={0},count()=COUNT()), PROJECT->[count(), span(birthdate,1d)], LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":0,"timeout":"1m","query":{"bool":{"must":[{"range":{"birthdate":{"from":"2023-01-01T00:00:00.000Z","to":"2023-01-03T00:00:00.000Z","include_lower":true,"include_upper":false,"boost":1.0}}},{"exists":{"field":"birthdate","boost":1.0}}],"adjust_pure_negative":true,"boost":1.0}},"_source":{"includes":["birthdate"],"excludes":[]},"sort":[],"aggregations":{"composite_buckets":{"composite":{"size":1000,"sources":[{"span(birthdate,1d)":{"date_histogram":{"field":"birthdate","missing_bucket":false,"order":"asc","fixed_interval":"1d"}}}]}}}}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -656,17 +656,20 @@ public class PredicateAnalyzer {
         case SEARCH:
           QueryExpression expression = constructQueryExpressionForSearch(call, pair);
           RexUnknownAs nullAs = getNullAsForSearch(call);
-          return switch (nullAs) {
-              // e.g. where isNotNull(a) and (a = 1 or a = 2)
-              // TODO: For this case, seems return `expression` should be equivalent
-            case FALSE -> CompoundQueryExpression.and(
-                false, expression, QueryExpression.create(pair.getKey()).exists());
-              // e.g. where isNull(a) or a = 1 or a = 2
-            case TRUE -> CompoundQueryExpression.or(
-                expression, QueryExpression.create(pair.getKey()).notExists());
-              // e.g. where a = 1 or a = 2
-            case UNKNOWN -> expression;
-          };
+          QueryExpression finalExpression =
+              switch (nullAs) {
+                  // e.g. where isNotNull(a) and (a = 1 or a = 2)
+                  // TODO: For this case, seems return `expression` should be equivalent
+                case FALSE -> CompoundQueryExpression.and(
+                    false, expression, QueryExpression.create(pair.getKey()).exists());
+                  // e.g. where isNull(a) or a = 1 or a = 2
+                case TRUE -> CompoundQueryExpression.or(
+                    expression, QueryExpression.create(pair.getKey()).notExists());
+                  // e.g. where a = 1 or a = 2
+                case UNKNOWN -> expression;
+              };
+          finalExpression.updateAnalyzedNodes(call);
+          return finalExpression;
         default:
           break;
       }
@@ -1220,7 +1223,7 @@ public class PredicateAnalyzer {
 
     @Override
     public List<RexNode> getAnalyzedNodes() {
-      return List.of(analyzedRexNode);
+      return analyzedRexNode == null ? List.of() : List.of(analyzedRexNode);
     }
 
     @Override
@@ -1499,7 +1502,7 @@ public class PredicateAnalyzer {
 
     @Override
     public List<RexNode> getAnalyzedNodes() {
-      return List.of(analyzedNode);
+      return analyzedNode == null ? List.of() : List.of(analyzedNode);
     }
 
     @Override


### PR DESCRIPTION
### Description
Fix bug of missed analyzed node when pushdown filter for Search call

### Related Issues
Resolves #4387 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
