### PR TITLE
Mod function should return decimal instead of float when handle the operands are decimal literal

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/math/ModFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/math/ModFunction.java
@@ -94,6 +94,9 @@ public class ModFunction extends ImplementorUDF {
       BigDecimal b0 = new BigDecimal(dividend.toString());
       BigDecimal b1 = new BigDecimal(divisor.toString());
       BigDecimal result = b0.remainder(b1);
+      if (dividend instanceof BigDecimal || divisor instanceof BigDecimal) {
+        return result;
+      }
       return MathUtils.coerceToWidestFloatingType(dividend, divisor, result.doubleValue());
     }
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMathFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMathFunctionTest.java
@@ -238,6 +238,17 @@ public class CalcitePPLMathFunctionTest extends CalcitePPLAbstractTest {
   }
 
   @Test
+  public void testModDecimal() {
+    RelNode root = getRelNode("source=EMP | eval MOD = mod(3.1, 2) | fields MOD");
+    String expectedLogical =
+        "LogicalProject(MOD=[MOD(3.1:DECIMAL(2, 1), 2)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+    String expectedSparkSql = "SELECT MOD(3.1, 2) `MOD`\nFROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
   public void testPi() {
     RelNode root = getRelNode("source=EMP | eval PI = pi() | fields PI");
     String expectedLogical = "LogicalProject(PI=[PI])\n  LogicalTableScan(table=[[scott, EMP]])\n";


### PR DESCRIPTION
### Description
Mod function should return decimal instead of float when handle the operands are decimal literal

### Related Issues
Resolves #4406

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
