### PR TITLE
Run settings doctests last and remove per-doc “rollback” sections

### DIFF
--- a/docs/category.json
+++ b/docs/category.json
@@ -2,7 +2,6 @@
   "bash": [
     "user/ppl/interfaces/endpoint.rst",
     "user/ppl/interfaces/protocol.rst",
-    "user/ppl/admin/settings.rst",
     "user/optimization/optimization.rst",
     "user/admin/settings.rst"
   ],
@@ -64,5 +63,8 @@
     "user/ppl/functions/string.rst",
     "user/ppl/general/datatypes.rst",
     "user/ppl/general/identifiers.rst"
+  ],
+  "bash_settings": [
+    "user/ppl/admin/settings.rst"
   ]
 }

--- a/docs/user/ppl/admin/settings.rst
+++ b/docs/user/ppl/admin/settings.rst
@@ -73,22 +73,6 @@ PPL query::
       "status": 400
     }
 
-Example 3
----------
-
-You can reset the setting to default value like this.
-
-PPL query::
-
-    sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X PUT localhost:9200/_plugins/_query/settings \
-    ... -d '{"transient" : {"plugins.ppl.enabled" : null}}'
-    {
-      "acknowledged": true,
-      "persistent": {},
-      "transient": {}
-    }
-
 plugins.query.memory_limit
 ==========================
 
@@ -144,17 +128,6 @@ Change the size_limit to 1000::
           }
         }
       },
-      "transient": {}
-    }
-
-Rollback to default value::
-
-    sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X PUT localhost:9200/_plugins/_query/settings \
-    ... -d '{"persistent" : {"plugins.query.size_limit" : null}}'
-    {
-      "acknowledged": true,
-      "persistent": {},
       "transient": {}
     }
 
@@ -268,22 +241,6 @@ PPL query::
     }
 
 Example 2
----------
-
-Reset to default (unlimited) by setting to null:
-
-PPL query::
-
-    sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X PUT localhost:9200/_plugins/_query/settings \
-    ... -d '{"transient" : {"plugins.ppl.values.max.limit" : null}}'
-    {
-      "acknowledged": true,
-      "persistent": {},
-      "transient": {}
-    }
-
-Example 3
 ---------
 
 Set to 0 explicitly for unlimited values:

--- a/doctest/test_docs.py
+++ b/doctest/test_docs.py
@@ -365,6 +365,7 @@ def create_cli_suite(filepaths, parser, setup_func):
 # Entry point for unittest discovery
 def load_tests(loader, suite, ignore):
     tests = []
+    settings_tests = []
     category_manager = CategoryManager()
     
     for category_name in category_manager.get_all_categories():
@@ -372,9 +373,16 @@ def load_tests(loader, suite, ignore):
         if not docs:
             continue
 
-        tests.append(get_test_suite(category_manager, category_name, get_doc_filepaths(docs)))
+        suite = get_test_suite(category_manager, category_name, get_doc_filepaths(docs))
+        if 'settings' in category_name:
+            settings_tests.append(suite)
+        else:
+            tests.append(suite)
 
     random.shuffle(tests)
+    if settings_tests:
+        random.shuffle(settings_tests)
+        tests.extend(settings_tests)
     return DocTests(tests)
 
 def get_test_suite(category_manager: CategoryManager, category_name, filepaths):


### PR DESCRIPTION
### Description
1. remove rollback-to-default examples from docs/user/ppl/admin/settings.rst to match current guidance
2. move user/ppl/admin/settings.rst into a dedicated bash_settings category for doctest selection
3. keep random ordering for other suites while ensuring the settings suite runs last in doctest/test_docs.py

### Related Issues
https://github.com/opensearch-project/sql/issues/4441

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
