### PR TITLE
Remove shared mutable optimizer field that caused race condition

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/SelectExpressionAnalyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/SelectExpressionAnalyzer.java
@@ -34,7 +34,8 @@ import org.opensearch.sql.expression.ReferenceExpression;
  */
 @RequiredArgsConstructor
 public class SelectExpressionAnalyzer
-    extends AbstractNodeVisitor<List<NamedExpression>, SelectExpressionAnalyzer.AnalysisContextWithOptimizer> {
+    extends AbstractNodeVisitor<
+        List<NamedExpression>, SelectExpressionAnalyzer.AnalysisContextWithOptimizer> {
   private final ExpressionAnalyzer expressionAnalyzer;
 
   /** Analyze Select fields. */
@@ -43,7 +44,8 @@ public class SelectExpressionAnalyzer
       AnalysisContext analysisContext,
       ExpressionReferenceOptimizer optimizer) {
     // Create per-request context wrapper to avoid shared mutable state
-    AnalysisContextWithOptimizer contextWithOptimizer = new AnalysisContextWithOptimizer(analysisContext, optimizer);
+    AnalysisContextWithOptimizer contextWithOptimizer =
+        new AnalysisContextWithOptimizer(analysisContext, optimizer);
     ImmutableList.Builder<NamedExpression> builder = new ImmutableList.Builder<>();
     for (UnresolvedExpression unresolvedExpression : selectList) {
       builder.addAll(unresolvedExpression.accept(this, contextWithOptimizer));
@@ -55,8 +57,9 @@ public class SelectExpressionAnalyzer
   static class AnalysisContextWithOptimizer {
     final AnalysisContext analysisContext;
     final ExpressionReferenceOptimizer optimizer;
-    
-    AnalysisContextWithOptimizer(AnalysisContext analysisContext, ExpressionReferenceOptimizer optimizer) {
+
+    AnalysisContextWithOptimizer(
+        AnalysisContext analysisContext, ExpressionReferenceOptimizer optimizer) {
       this.analysisContext = analysisContext;
       this.optimizer = optimizer;
     }
@@ -64,7 +67,8 @@ public class SelectExpressionAnalyzer
 
   @Override
   public List<NamedExpression> visitField(Field node, AnalysisContextWithOptimizer context) {
-    return Collections.singletonList(DSL.named(node.accept(expressionAnalyzer, context.analysisContext)));
+    return Collections.singletonList(
+        DSL.named(node.accept(expressionAnalyzer, context.analysisContext)));
   }
 
   @Override
@@ -99,12 +103,15 @@ public class SelectExpressionAnalyzer
     // (OVER clause) and thus depends on name in alias to be replaced correctly
     return context.optimizer.optimize(
         DSL.named(
-            expr.getName(), delegatedExpr.accept(expressionAnalyzer, context.analysisContext), expr.getAlias()),
+            expr.getName(),
+            delegatedExpr.accept(expressionAnalyzer, context.analysisContext),
+            expr.getAlias()),
         context.analysisContext);
   }
 
   @Override
-  public List<NamedExpression> visitAllFields(AllFields node, AnalysisContextWithOptimizer context) {
+  public List<NamedExpression> visitAllFields(
+      AllFields node, AnalysisContextWithOptimizer context) {
     TypeEnvironment environment = context.analysisContext.peek();
     Map<String, ExprType> lookupAllFields = environment.lookupAllFields(Namespace.FIELD_NAME);
     return lookupAllFields.entrySet().stream()
@@ -119,7 +126,8 @@ public class SelectExpressionAnalyzer
   public List<NamedExpression> visitNestedAllTupleFields(
       NestedAllTupleFields node, AnalysisContextWithOptimizer context) {
     TypeEnvironment environment = context.analysisContext.peek();
-    Map<String, ExprType> lookupAllTupleFields = environment.lookupAllTupleFields(Namespace.FIELD_NAME);
+    Map<String, ExprType> lookupAllTupleFields =
+        environment.lookupAllTupleFields(Namespace.FIELD_NAME);
     environment.resolve(new Symbol(Namespace.FIELD_NAME, node.getPath()));
 
     // Match all fields with same path as used in nested function.

--- a/core/src/test/java/org/opensearch/sql/analysis/ExpressionReferenceOptimizerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/ExpressionReferenceOptimizerTest.java
@@ -142,12 +142,15 @@ class ExpressionReferenceOptimizerTest extends AnalyzerTestBase {
   void visitAggregator_with_missing_mapping_returns_original() {
     BuiltinFunctionRepository repository = BuiltinFunctionRepository.getInstance();
     LogicalPlan emptyPlan = LogicalPlanDSL.relation("test", table);
-    ExpressionReferenceOptimizer optimizer = new ExpressionReferenceOptimizer(repository, emptyPlan);
-    
+    ExpressionReferenceOptimizer optimizer =
+        new ExpressionReferenceOptimizer(repository, emptyPlan);
+
     Expression unmappedAggregator = DSL.count(DSL.ref("age", INTEGER));
     AnalysisContext context = new AnalysisContext();
-    
-    Expression result = optimizer.visitAggregator((org.opensearch.sql.expression.aggregation.Aggregator<?>) unmappedAggregator, context);
+
+    Expression result =
+        optimizer.visitAggregator(
+            (org.opensearch.sql.expression.aggregation.Aggregator<?>) unmappedAggregator, context);
     assertEquals(unmappedAggregator, result);
   }
 

--- a/core/src/test/java/org/opensearch/sql/analysis/SelectExpressionAnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/SelectExpressionAnalyzerTest.java
@@ -88,16 +88,17 @@ public class SelectExpressionAnalyzerTest extends AnalyzerTestBase {
 
   @Test
   public void testContextWrapperIsolation() {
-    // Test that context wrapper properly isolates optimizer instances, each wrapper should have its own optimizer
+    // Test that context wrapper properly isolates optimizer instances, each wrapper should have its
+    // own optimizer
     ExpressionReferenceOptimizer optimizer1 = mock(ExpressionReferenceOptimizer.class);
     ExpressionReferenceOptimizer optimizer2 = mock(ExpressionReferenceOptimizer.class);
-    
+
     AnalysisContext baseContext = new AnalysisContext();
-    SelectExpressionAnalyzer.AnalysisContextWithOptimizer wrapper1 = 
+    SelectExpressionAnalyzer.AnalysisContextWithOptimizer wrapper1 =
         new SelectExpressionAnalyzer.AnalysisContextWithOptimizer(baseContext, optimizer1);
-    SelectExpressionAnalyzer.AnalysisContextWithOptimizer wrapper2 = 
+    SelectExpressionAnalyzer.AnalysisContextWithOptimizer wrapper2 =
         new SelectExpressionAnalyzer.AnalysisContextWithOptimizer(baseContext, optimizer2);
-    
+
     assertEquals(baseContext, wrapper1.analysisContext);
     assertEquals(baseContext, wrapper2.analysisContext);
     assertEquals(optimizer1, wrapper1.optimizer);


### PR DESCRIPTION
### Description

Remove shared mutable `optimizer` field that caused race condition. This field was shared across all concurrent queries that using same Analyzer singleton. For example,

```
    this.optimizer = optimizer;
```

Query A sets to optimizerA and Query B overwrite it, causing Query A to use Query B's optimizer with wrong LogicalPlan mappings. 

This resulted in "can't evaluate on aggregator" exception https://github.com/opensearch-project/sql/blob/773066fdde249a6d9e6457e22ed74c42e01aceaf/core/src/main/java/org/opensearch/sql/expression/aggregation/Aggregator.java#L81-L83


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.  N/A
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added. N/A
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed. N/A
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). N/A
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose). N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
