### PR TITLE
[Backport 2.19-dev] Support time modifiers in search command  (#4224)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/OpenSearchConstants.java
@@ -20,6 +20,8 @@ public interface OpenSearchConstants {
 
   String METADATA_FIELD_ROUTING = "_routing";
 
+  String IMPLICIT_FIELD_TIMESTAMP = "@timestamp";
+
   java.util.Map<String, ExprType> METADATAFIELD_TYPE_MAP =
       Map.of(
           METADATA_FIELD_ID, ExprCoreType.STRING,

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/condition/EarliestFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/condition/EarliestFunction.java
@@ -68,6 +68,6 @@ public class EarliestFunction extends ImplementorUDF {
     ZonedDateTime earliest =
         getRelativeZonedDateTime(
             expression, ZonedDateTime.ofInstant(clock.instant(), clock.getZone()));
-    return earliest.isBefore(candidateDatetime);
+    return !earliest.isAfter(candidateDatetime);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/condition/LatestFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/condition/LatestFunction.java
@@ -68,6 +68,6 @@ public class LatestFunction extends ImplementorUDF {
     ZonedDateTime latest =
         getRelativeZonedDateTime(
             expression, ZonedDateTime.ofInstant(clock.instant(), clock.getZone()));
-    return latest.isAfter(candidateDatetime);
+    return !latest.isBefore(candidateDatetime);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/utils/DateTimeUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/DateTimeUtils.java
@@ -15,7 +15,9 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
-import java.util.regex.Pattern;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import lombok.experimental.UtilityClass;
 import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprValue;
@@ -24,9 +26,13 @@ import org.opensearch.sql.expression.function.FunctionProperties;
 @UtilityClass
 public class DateTimeUtils {
 
-  private static final Pattern OFFSET_PATTERN = Pattern.compile("([+-])(\\d+)([smhdwMy]?)");
   private static final DateTimeFormatter DIRECT_FORMATTER =
       DateTimeFormatter.ofPattern("MM/dd/yyyy:HH:mm:ss");
+  public static final Set<DateTimeFormatter> SUPPORTED_FORMATTERS =
+      Set.of(
+          DIRECT_FORMATTER,
+          DateTimeFormatters.DATE_TIMESTAMP_FORMATTER,
+          DateTimeFormatter.ISO_DATE_TIME);
 
   /**
    * Util method to round the date/time with given unit.
@@ -182,10 +188,9 @@ public class DateTimeUtils {
   public static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
 
   public static ZonedDateTime getRelativeZonedDateTime(String input, ZonedDateTime baseTime) {
-    try {
-      Instant parsed = LocalDateTime.parse(input, DIRECT_FORMATTER).toInstant(ZoneOffset.UTC);
-      return parsed.atZone(baseTime.getZone());
-    } catch (DateTimeParseException ignored) {
+    Optional<ZonedDateTime> parsed = tryParseAbsoluteTime(input);
+    if (parsed.isPresent()) {
+      return parsed.get().withZoneSameInstant(baseTime.getZone());
     }
 
     if ("now".equalsIgnoreCase(input) || "now()".equalsIgnoreCase(input)) {
@@ -224,7 +229,6 @@ public class DateTimeUtils {
             "Unexpected character '" + c + "' at position " + i + " in input: " + input);
       }
     }
-
     return result;
   }
 
@@ -236,34 +240,7 @@ public class DateTimeUtils {
       return sign.equals("-") ? base.minusMonths(months) : base.plusMonths(months);
     }
 
-    ChronoUnit chronoUnit;
-    switch (unit) {
-      case "s":
-        chronoUnit = ChronoUnit.SECONDS;
-        break;
-      case "m":
-        chronoUnit = ChronoUnit.MINUTES;
-        break;
-      case "h":
-        chronoUnit = ChronoUnit.HOURS;
-        break;
-      case "d":
-        chronoUnit = ChronoUnit.DAYS;
-        break;
-      case "w":
-        chronoUnit = ChronoUnit.WEEKS;
-        break;
-      case "M":
-        chronoUnit = ChronoUnit.MONTHS;
-        break;
-      case "y":
-        chronoUnit = ChronoUnit.YEARS;
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported offset unit: " + rawUnit);
-    }
-
-
+    ChronoUnit chronoUnit = mapChronoUnit(unit, "Unsupported offset unit: " + rawUnit);
     return sign.equals("-") ? base.minus(value, chronoUnit) : base.plus(value, chronoUnit);
   }
 
@@ -362,6 +339,426 @@ public class DateTimeUtils {
       default:
         if (lower.matches("w[0-7]")) return lower;
         throw new IllegalArgumentException("Unsupported unit alias: " + rawUnit);
+    }
+  }
+
+  /**
+   * Translate a PPL time modifier expression to a <a
+   * href="https://docs.opensearch.org/latest/field-types/supported-field-types/date/#date-math"
+   * >OpenSearch date math expression</a>.
+   *
+   * <p>Examples:
+   *
+   * <ul>
+   *   <li>2020-12-10 12:00:00.123 -> 2020-12-10T12:00:00.123Z
+   *   <li>now, now() -> now
+   *   <li>-30seconds, -30s -> now-30s
+   *   <li>-1h@d -> now-1h/d
+   *   <li>2020-12-10 12:00:00.123@month -> 2020-12-10T12:00:00.123Z/M
+   * </ul>
+   *
+   * @param timeModifier The time modifier string in PPL format
+   * @return The time string in OpenSearch date math format
+   */
+  public static String resolveTimeModifier(String timeModifier) {
+    return resolveTimeModifier(timeModifier, ZonedDateTime.now(ZoneOffset.UTC));
+  }
+
+  /**
+   * Convert time modifier with a reference for now. This is mainly useful for quarter conversion,
+   * which is time-sensitive.
+   *
+   * <p>Background: PPL time modifier supports alignment to quarter, while OpenSearch does not
+   * support so in time math. We implement a workaround by first aligning the date to the current
+   * month then subtracting 0 to 2 months from it. In order to know how many months to subtract, it
+   * is useful to know when is it now.
+   */
+  static String resolveTimeModifier(String input, ZonedDateTime nowReference) {
+    if (input == null || input.isEmpty()) {
+      return null;
+    }
+
+    if ("now".equalsIgnoreCase(input) || "now()".equalsIgnoreCase(input)) {
+      return "now";
+    }
+
+    String absoluteTime = tryParseAbsoluteTimeAndFormat(input);
+    if (absoluteTime != null) {
+      return absoluteTime;
+    }
+
+    return parseRelativeTimeExpression(input, nowReference);
+  }
+
+  /**
+   * Try to parse the input as an absolute datetime.
+   *
+   * @param input The time string
+   * @return ISO formatted datetime string or null if parsing fails
+   */
+  private static String tryParseAbsoluteTimeAndFormat(String input) {
+    Optional<ZonedDateTime> parsed = tryParseAbsoluteTime(input);
+    return parsed
+        .map(zonedDateTime -> zonedDateTime.format(DateTimeFormatter.ISO_INSTANT))
+        .orElse(null);
+  }
+
+  private static Optional<ZonedDateTime> tryParseAbsoluteTime(String input) {
+    for (DateTimeFormatter formatter : SUPPORTED_FORMATTERS) {
+      try {
+        ZonedDateTime parsed;
+        if (formatter == DateTimeFormatter.ISO_DATE_TIME) {
+          // ISO_DATE_TIME can handle zone information
+          parsed = ZonedDateTime.parse(input, formatter);
+        } else {
+          // Treat LocalDateTime formatters as UTC
+          LocalDateTime localDateTime = LocalDateTime.parse(input, formatter);
+          parsed = localDateTime.atZone(ZoneOffset.UTC);
+        }
+        return Optional.of(parsed);
+      } catch (DateTimeParseException ignored) {
+        // Try next formatter
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Parse a PPL relative time expression and convert it to OpenSearch date math format. This
+   * overload accepts a reference time for date calculations, particularly useful for quarters.
+   */
+  private static String parseRelativeTimeExpression(String input, ZonedDateTime nowReference) {
+    if (!containsRelativeTimeOperators(input)) {
+      return input;
+    }
+
+    StringBuilder result = new StringBuilder("now");
+    int position = 0;
+    ZonedDateTime currentReference =
+        nowReference; // Track current reference time as operations are applied
+
+    while (position < input.length()) {
+      char currentChar = input.charAt(position);
+
+      if (currentChar == '@') {
+        // Handle snap operation (@unit -> /unit)
+        position = processSnap(input, position, result, currentReference);
+      } else if (currentChar == '+' || currentChar == '-') {
+        // Handle offset operation (+/-value[unit]) and update reference time
+        OffsetResult offsetResult = processOffset(input, position, result, currentReference);
+        position = offsetResult.newPosition;
+        currentReference = offsetResult.updatedReference; // Update the reference time
+      } else {
+        throw new IllegalArgumentException(
+            "Unexpected character '"
+                + currentChar
+                + "' at position "
+                + position
+                + " in input: "
+                + input);
+      }
+    }
+    return result.toString();
+  }
+
+    /**
+     * Helper class to return multiple values from processOffset
+     */
+    private static final class OffsetResult {
+        private final int newPosition;
+        private final ZonedDateTime updatedReference;
+
+        /**
+         *
+         */
+        private OffsetResult(int newPosition, ZonedDateTime updatedReference) {
+            this.newPosition = newPosition;
+            this.updatedReference = updatedReference;
+        }
+
+        public int newPosition() {
+            return newPosition;
+        }
+
+        public ZonedDateTime updatedReference() {
+            return updatedReference;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (OffsetResult) obj;
+            return this.newPosition == that.newPosition &&
+                    Objects.equals(this.updatedReference, that.updatedReference);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(newPosition, updatedReference);
+        }
+
+        @Override
+        public String toString() {
+            return "OffsetResult[" +
+                    "newPosition=" + newPosition + ", " +
+                    "updatedReference=" + updatedReference + ']';
+        }
+    }
+
+  /** Check if the input contains relative time operators (+ - @). */
+  private static boolean containsRelativeTimeOperators(String input) {
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      if (c == '+' || c == '-' || c == '@') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Process a snap operation in the input string. Returns the new position after processing. */
+  private static int processSnap(
+      String input, int position, StringBuilder result, ZonedDateTime nowReference) {
+    // Skip the '@' character
+    int nextPosition = position + 1;
+
+    // Extract the unit
+    int endOfUnit = nextPosition;
+    while (endOfUnit < input.length() && Character.isLetterOrDigit(input.charAt(endOfUnit))) {
+      endOfUnit++;
+    }
+
+    String rawUnit = input.substring(nextPosition, endOfUnit);
+    String normalizedUnit = normalizeUnit(rawUnit);
+
+    // Special handling for quarter
+    if ("q".equals(normalizedUnit)) {
+      return processQuarterSnap(result, nowReference, endOfUnit);
+    }
+
+    // Special handling for week and week days
+    // In PPL, plain @w is equivalent to @w0 (Sunday)
+    if ("w".equals(normalizedUnit)) {
+      return processWeekDaySnap(result, "w0", nowReference, endOfUnit);
+    }
+    // Special handling for week days (w0-w7)
+    else if (normalizedUnit.matches("w[0-7]")) {
+      return processWeekDaySnap(result, normalizedUnit, nowReference, endOfUnit);
+    }
+
+    String osUnit = convertToOsUnit(rawUnit);
+
+    // Append the OpenSearch format (/unit)
+    result.append('/').append(osUnit);
+
+    return endOfUnit;
+  }
+
+  /**
+   * Process a week day snap operation, mapping a normalized week day unit (w0-w7) to the OpenSearch
+   * date math format.
+   *
+   * <p>PPL and OpenSearch have different week start conventions:
+   *
+   * <ul>
+   *   <li>PPL: Week starts on Sunday (@w0 or @w7), @w1 is Monday, ..., @w6 is Saturday
+   *   <li>OpenSearch: Week starts on Monday (/w)
+   * </ul>
+   *
+   * <p>Additionally, PPL always aligns to the most recent occurrence of the specified day in the
+   * past. This means the result will depend on the current reference day (nowReference).
+   *
+   * <p>Examples with different reference days:
+   *
+   * <ul>
+   *   <li>Reference=Wednesday, Target=Tuesday: now/w+1d (Tuesday in current week)
+   *   <li>Reference=Wednesday, Target=Thursday: now/w-4d (Thursday from previous week)
+   *   <li>Reference=Sunday, Target=Monday: now/w (Align to last Monday)
+   *   <li>Reference=Sunday, Target=Sunday: now/w+6d (PPL expects to align to today, so we align to
+   *       Monday then plus 6 days)
+   * </ul>
+   */
+  private static int processWeekDaySnap(
+      StringBuilder result, String weekDay, ZonedDateTime nowReference, int endOfUnit) {
+    int dayNumber;
+    try {
+      dayNumber = Integer.parseInt(weekDay.substring(1));
+      if (dayNumber < 0 || dayNumber > 7) {
+        throw new IllegalArgumentException("Invalid week day: " + weekDay);
+      }
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid week day format: " + weekDay);
+    }
+
+    result.append("/w");
+
+    int dayAdjust = 0;
+    int dayNumberReference = nowReference.getDayOfWeek().getValue();
+    if (dayNumber == 0 || dayNumber == 7) {
+      dayNumber = 7; // normalize to 7
+      if (dayNumber == dayNumberReference) {
+        // If aligning to Sunday on Sunday, align to Monday then plus 6 days
+        dayAdjust = 6;
+      } else {
+        // Otherwise, align to Monday then subtract 1 day
+        dayAdjust = -1;
+      }
+    } else if (dayNumber > 1) {
+      // Other days are (dayNumber-1) days after Monday
+      dayAdjust = dayNumber - 1;
+      // If the expected day is greater than today, then align to this day in the last week.
+      if (dayNumber > dayNumberReference) {
+        dayAdjust -= 7; // Move to the previous week
+      }
+    }
+
+    if (dayAdjust > 0) {
+      result.append("+").append(dayAdjust).append("d");
+    } else if (dayAdjust < 0) {
+      result.append(dayAdjust).append("d");
+    }
+
+    return endOfUnit;
+  }
+
+  /** Process a quarter snap operation, aligning to the start of the current quarter. */
+  private static int processQuarterSnap(
+      StringBuilder result, ZonedDateTime nowReference, int endOfUnit) {
+    // Calculate which month to snap to based on the current month
+    int month = nowReference.getMonthValue();
+    int quarterStartMonth = ((month - 1) / 3) * 3 + 1; // 1->1, 2->1, 3->1, 4->4, etc.
+    int monthsToSubtract = month - quarterStartMonth;
+
+    // Format for OpenSearch: now/M-NM where N is the number of months to subtract
+    result.append("/M");
+    if (monthsToSubtract > 0) {
+      result.append("-").append(monthsToSubtract).append("M");
+    }
+
+    return endOfUnit;
+  }
+
+  /**
+   * Process an offset operation in the input string. It returns an OffsetResult containing new
+   * position and updated reference time
+   */
+  private static OffsetResult processOffset(
+      String input, int position, StringBuilder result, ZonedDateTime nowReference) {
+    // Get the sign (+ or -)
+    char sign = input.charAt(position);
+    result.append(sign);
+    int nextPosition = position + 1;
+
+    // Extract the value
+    int endOfValue = nextPosition;
+    while (endOfValue < input.length() && Character.isDigit(input.charAt(endOfValue))) {
+      endOfValue++;
+    }
+    String valueStr = input.substring(nextPosition, endOfValue);
+    int value = valueStr.isEmpty() ? 1 : Integer.parseInt(valueStr);
+    result.append(value);
+
+    // Extract the unit
+    int endOfUnit = endOfValue;
+    while (endOfUnit < input.length() && Character.isLetter(input.charAt(endOfUnit))) {
+      endOfUnit++;
+    }
+    String rawUnit = input.substring(endOfValue, endOfUnit);
+    String normalizedUnit = normalizeUnit(rawUnit);
+
+    // Calculate the updated reference time based on the offset
+    ZonedDateTime updatedReference =
+        applyOffsetToReference(nowReference, sign, value, normalizedUnit);
+
+    // Special handling for quarter
+    if ("q".equals(normalizedUnit)) {
+      int newPosition = processQuarterOffset(value, result, endOfUnit);
+      return new OffsetResult(newPosition, updatedReference);
+    }
+    String osUnit = convertToOsUnit(rawUnit);
+    result.append(osUnit);
+
+    return new OffsetResult(endOfUnit, updatedReference);
+  }
+
+  /** Apply an offset with normalized unit to the reference time */
+  private static ZonedDateTime applyOffsetToReference(
+      ZonedDateTime reference, char sign, int value, String unit) {
+    if ("q".equals(unit)) {
+      // Convert quarters to months
+      int months = value * 3;
+      return sign == '+' ? reference.plusMonths(months) : reference.minusMonths(months);
+    }
+
+    ChronoUnit chronoUnit = mapChronoUnit(unit, "Unsupported offset unit: " + unit);
+
+    return sign == '+' ? reference.plus(value, chronoUnit) : reference.minus(value, chronoUnit);
+  }
+
+  private static ChronoUnit mapChronoUnit(String unit, String errorMessage) {
+      ChronoUnit chronoUnit;
+      switch (unit) {
+          case "s":
+              chronoUnit = ChronoUnit.SECONDS;
+              break;
+          case "m":
+              chronoUnit = ChronoUnit.MINUTES;
+              break;
+          case "h":
+              chronoUnit = ChronoUnit.HOURS;
+              break;
+          case "d":
+              chronoUnit = ChronoUnit.DAYS;
+              break;
+          case "w":
+              chronoUnit = ChronoUnit.WEEKS;
+              break;
+          case "M":
+              chronoUnit = ChronoUnit.MONTHS;
+              break;
+          case "y":
+              chronoUnit = ChronoUnit.YEARS;
+              break;
+          default:
+              throw new IllegalArgumentException(errorMessage);
+      }
+      return chronoUnit;
+  }
+
+  /**
+   * Process a quarter offset operation, converting it to months for OpenSearch. Returns the new
+   * position after processing
+   */
+  private static int processQuarterOffset(int value, StringBuilder result, int endOfUnit) {
+    // Convert quarters to months (1 quarter = 3 months)
+    int months = value * 3;
+
+    // We already added the sign and value to the result string in the calling method,
+    // so we need to remove what was added before adding the correct value
+    result.delete(result.length() - String.valueOf(value).length(), result.length());
+
+    // Now append the correct value in months with the M unit
+    result.append(months).append("M");
+
+    return endOfUnit;
+  }
+
+  /** Convert PPL time unit to OpenSearch time unit. */
+  private static String convertToOsUnit(String PPLUnit) {
+    String normalizedUnit = normalizeUnit(PPLUnit);
+
+    // Special handling for quarter
+    if ("q".equals(normalizedUnit)) {
+      // OpenSearch doesn't have native quarter support, use month (M) instead
+      return "M";
+    } else if ("M".equals(normalizedUnit)) {
+      // Month is already correctly represented as 'M' in OpenSearch
+      return normalizedUnit;
+    } else {
+      // For other units, use the normalized unit directly
+      // Note: week day specifications (w0-w7) are handled separately in processWeekDaySnap
+      return normalizedUnit;
     }
   }
 }

--- a/core/src/test/java/org/opensearch/sql/utils/DateTimeUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/utils/DateTimeUtilsTest.java
@@ -6,19 +6,28 @@
 package org.opensearch.sql.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.sql.utils.DateTimeUtils.getRelativeZonedDateTime;
+import static org.opensearch.sql.utils.DateTimeUtils.resolveTimeModifier;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.planner.physical.collector.Rounding.DateTimeUnit;
 
 public class DateTimeUtilsTest {
+  private final ZonedDateTime monday = ZonedDateTime.of(2025, 9, 15, 2, 0, 0, 0, ZoneOffset.UTC);
+  private final ZonedDateTime tuesday =
+      ZonedDateTime.of(2014, 11, 18, 14, 27, 32, 0, ZoneOffset.UTC);
+  private final ZonedDateTime wednesday =
+      ZonedDateTime.of(2025, 10, 22, 10, 32, 12, 0, ZoneOffset.UTC);
+  private final ZonedDateTime thursday = ZonedDateTime.of(2025, 9, 11, 10, 0, 0, 0, ZoneOffset.UTC);
+  private final ZonedDateTime sunday = ZonedDateTime.of(2025, 9, 14, 2, 0, 0, 0, ZoneOffset.UTC);
+
   @Test
   void round() {
     long actual =
@@ -44,67 +53,42 @@ public class DateTimeUtilsTest {
 
   @Test
   void testRelativeZonedDateTimeWithSnap() {
-    String dateTimeString = "2025-10-22 10:32:12";
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-    LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
-    ZonedDateTime snap1 = getRelativeZonedDateTime("-1d@d", zonedDateTime);
-    ZonedDateTime snap2 = getRelativeZonedDateTime("-3d-2h@h", zonedDateTime);
-    assertEquals(snap1.toLocalDateTime().toString(), "2025-10-21T00:00");
-    assertEquals(snap2.toLocalDateTime().toString(), "2025-10-19T08:00");
+    ZonedDateTime snap1 = getRelativeZonedDateTime("-1d@d", wednesday);
+    ZonedDateTime snap2 = getRelativeZonedDateTime("-3d-2h@h", wednesday);
+    assertEquals("2025-10-21T00:00", snap1.toLocalDateTime().toString());
+    assertEquals("2025-10-19T08:00", snap2.toLocalDateTime().toString());
   }
 
   @Test
   void testRelativeZonedDateTimeWithOffset() {
-    String dateTimeString = "2025-10-22 10:32:12";
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-    LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
-    ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@mon", zonedDateTime);
-    ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2h+10m@h", zonedDateTime);
-    assertEquals(snap1.toLocalDateTime().toString(), "2026-10-01T00:00");
-    assertEquals(snap2.toLocalDateTime().toString(), "2025-10-18T22:00");
+    ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@mon", wednesday);
+    ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2h+10m@h", wednesday);
+    assertEquals("2026-10-01T00:00", snap1.toLocalDateTime().toString());
+    assertEquals("2025-10-18T22:00", snap2.toLocalDateTime().toString());
   }
 
   @Test
   void testRelativeZonedDateTimeWithAlias() {
-    String dateTimeString = "2025-10-22 10:32:12";
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-    LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
-    ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@Month", zonedDateTime);
-    ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2h+10m@hours", zonedDateTime);
-    assertEquals(snap1.toLocalDateTime().toString(), "2026-10-01T00:00");
-    assertEquals(snap2.toLocalDateTime().toString(), "2025-10-18T22:00");
+    ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@Month", wednesday);
+    ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2h+10m@hours", wednesday);
+    assertEquals("2026-10-01T00:00", snap1.toLocalDateTime().toString());
+    assertEquals("2025-10-18T22:00", snap2.toLocalDateTime().toString());
   }
 
   @Test
   void testRelativeZonedDateTimeWithWeekDayAndQuarter() {
-    String dateTimeString = "2025-10-22 10:32:12";
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-    LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
-    ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@W5", zonedDateTime);
-    ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2q+10m@quarter", zonedDateTime);
-    assertEquals(snap1.toLocalDateTime().toString(), "2026-10-16T00:00");
-    assertEquals(snap2.toLocalDateTime().toString(), "2025-04-01T00:00");
+    ZonedDateTime snap1 = getRelativeZonedDateTime("-1d+1y@W5", wednesday);
+    ZonedDateTime snap2 = getRelativeZonedDateTime("-3d@d-2q+10m@quarter", wednesday);
+    assertEquals("2026-10-16T00:00", snap1.toLocalDateTime().toString());
+    assertEquals("2025-04-01T00:00", snap2.toLocalDateTime().toString());
   }
 
   @Test
   void testRelativeZonedDateTimeWithWrongInput() {
-    String dateTimeString = "2025-10-22 10:32:12";
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-    LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneOffset.UTC);
     IllegalArgumentException e =
         assertThrows(
-            IllegalArgumentException.class, () -> getRelativeZonedDateTime("1d+1y", zonedDateTime));
-    assertEquals(e.getMessage(), "Unexpected character '1' at position 0 in input: 1d+1y");
+            IllegalArgumentException.class, () -> getRelativeZonedDateTime("1d+1y", wednesday));
+    assertEquals("Unexpected character '1' at position 0 in input: 1d+1y", e.getMessage());
   }
 
   @Test
@@ -177,5 +161,263 @@ public class DateTimeUtilsTest {
             .toInstant()
             .toEpochMilli(),
         Instant.ofEpochMilli(rounded).toEpochMilli());
+  }
+
+  @Test
+  void testResolveTimeModifierNull() {
+    assertNull(DateTimeUtils.resolveTimeModifier(null));
+    assertNull(DateTimeUtils.resolveTimeModifier(""));
+  }
+
+  @Test
+  void testResolveTimeModifierWithDatetimeString() {
+    assertEquals("2025-10-22T00:00:00Z", DateTimeUtils.resolveTimeModifier("2025-10-22"));
+    assertEquals("2025-10-22T10:32:12Z", DateTimeUtils.resolveTimeModifier("2025-10-22 10:32:12"));
+    // Test "direct" format
+    assertEquals("2025-10-22T10:32:12Z", DateTimeUtils.resolveTimeModifier("10/22/2025:10:32:12"));
+    // Test ISO 8601 format
+    assertEquals("2025-10-22T10:32:12Z", DateTimeUtils.resolveTimeModifier("2025-10-22T10:32:12Z"));
+  }
+
+  @Test
+  void testResolveTimeModifierWithOffsets() {
+    assertEquals("now-30s", DateTimeUtils.resolveTimeModifier("-30s"));
+    assertEquals("now-1h", DateTimeUtils.resolveTimeModifier("-1h"));
+    assertEquals("now+1d", DateTimeUtils.resolveTimeModifier("+1d"));
+    assertEquals("now-3M", DateTimeUtils.resolveTimeModifier("-3month"));
+    assertEquals("now-1y", DateTimeUtils.resolveTimeModifier("-1year"));
+  }
+
+  @Test
+  void testTimeUnitVariants() {
+    // Test all variants of seconds
+    assertEquals("now-5s", DateTimeUtils.resolveTimeModifier("-5s"));
+    assertEquals("now-5s", DateTimeUtils.resolveTimeModifier("-5sec"));
+    assertEquals("now-5s", DateTimeUtils.resolveTimeModifier("-5secs"));
+    assertEquals("now-5s", DateTimeUtils.resolveTimeModifier("-5second"));
+    assertEquals("now-5s", DateTimeUtils.resolveTimeModifier("-5seconds"));
+
+    // Test all variants of minutes
+    assertEquals("now-5m", DateTimeUtils.resolveTimeModifier("-5m"));
+    assertEquals("now-5m", DateTimeUtils.resolveTimeModifier("-5min"));
+    assertEquals("now-5m", DateTimeUtils.resolveTimeModifier("-5mins"));
+    assertEquals("now-5m", DateTimeUtils.resolveTimeModifier("-5minute"));
+    assertEquals("now-5m", DateTimeUtils.resolveTimeModifier("-5minutes"));
+
+    // Test all variants of hours
+    assertEquals("now-5h", DateTimeUtils.resolveTimeModifier("-5h"));
+    assertEquals("now-5h", DateTimeUtils.resolveTimeModifier("-5hr"));
+    assertEquals("now-5h", DateTimeUtils.resolveTimeModifier("-5hrs"));
+    assertEquals("now-5h", DateTimeUtils.resolveTimeModifier("-5hour"));
+    assertEquals("now-5h", DateTimeUtils.resolveTimeModifier("-5hours"));
+
+    // Test all variants of days
+    assertEquals("now-5d", DateTimeUtils.resolveTimeModifier("-5d"));
+    assertEquals("now-5d", DateTimeUtils.resolveTimeModifier("-5day"));
+    assertEquals("now-5d", DateTimeUtils.resolveTimeModifier("-5days"));
+
+    // Test all variants of weeks
+    assertEquals("now-5w", DateTimeUtils.resolveTimeModifier("-5w"));
+    assertEquals("now-5w", DateTimeUtils.resolveTimeModifier("-5wk"));
+    assertEquals("now-5w", DateTimeUtils.resolveTimeModifier("-5wks"));
+    assertEquals("now-5w", DateTimeUtils.resolveTimeModifier("-5week"));
+    assertEquals("now-5w", DateTimeUtils.resolveTimeModifier("-5weeks"));
+
+    // Test all variants of months
+    assertEquals("now-5M", DateTimeUtils.resolveTimeModifier("-5mon"));
+    assertEquals("now-5M", DateTimeUtils.resolveTimeModifier("-5month"));
+    assertEquals("now-5M", DateTimeUtils.resolveTimeModifier("-5months"));
+
+    // Test all variants of years
+    assertEquals("now-5y", DateTimeUtils.resolveTimeModifier("-5y"));
+    assertEquals("now-5y", DateTimeUtils.resolveTimeModifier("-5yr"));
+    assertEquals("now-5y", DateTimeUtils.resolveTimeModifier("-5yrs"));
+    assertEquals("now-5y", DateTimeUtils.resolveTimeModifier("-5year"));
+    assertEquals("now-5y", DateTimeUtils.resolveTimeModifier("-5years"));
+
+    // Test case sensitivity handling
+    assertEquals("now-5s", DateTimeUtils.resolveTimeModifier("-5S"));
+    assertEquals("now-5m", DateTimeUtils.resolveTimeModifier("-5MIN"));
+    assertEquals("now-5h", DateTimeUtils.resolveTimeModifier("-5HOUR"));
+    assertEquals("now-5d", DateTimeUtils.resolveTimeModifier("-5DAY"));
+    assertEquals("now-5w", DateTimeUtils.resolveTimeModifier("-5WEEK"));
+    assertEquals("now-5M", DateTimeUtils.resolveTimeModifier("-5MONTH"));
+    assertEquals("now-5y", DateTimeUtils.resolveTimeModifier("-5YEAR"));
+  }
+
+  @Test
+  void testResolveTimeModifierWithSnap() {
+    // Test basic snapping
+    assertEquals("now/d", DateTimeUtils.resolveTimeModifier("@d"));
+    assertEquals("now/h", DateTimeUtils.resolveTimeModifier("@h"));
+    assertEquals("now/w-1d", resolveTimeModifier("@w", wednesday));
+    assertEquals("now/M", DateTimeUtils.resolveTimeModifier("@month"));
+    assertEquals("now/y", DateTimeUtils.resolveTimeModifier("@y"));
+
+    // Test snapping with all time unit variants
+    // Seconds variants
+    assertEquals("now/s", DateTimeUtils.resolveTimeModifier("@s"));
+    assertEquals("now/s", DateTimeUtils.resolveTimeModifier("@sec"));
+    assertEquals("now/s", DateTimeUtils.resolveTimeModifier("@secs"));
+    assertEquals("now/s", DateTimeUtils.resolveTimeModifier("@second"));
+    assertEquals("now/s", DateTimeUtils.resolveTimeModifier("@seconds"));
+
+    // Minutes variants
+    assertEquals("now/m", DateTimeUtils.resolveTimeModifier("@m"));
+    assertEquals("now/m", DateTimeUtils.resolveTimeModifier("@min"));
+    assertEquals("now/m", DateTimeUtils.resolveTimeModifier("@mins"));
+    assertEquals("now/m", DateTimeUtils.resolveTimeModifier("@minute"));
+    assertEquals("now/m", DateTimeUtils.resolveTimeModifier("@minutes"));
+
+    // Hours variants
+    assertEquals("now/h", DateTimeUtils.resolveTimeModifier("@h"));
+    assertEquals("now/h", DateTimeUtils.resolveTimeModifier("@hr"));
+    assertEquals("now/h", DateTimeUtils.resolveTimeModifier("@hrs"));
+    assertEquals("now/h", DateTimeUtils.resolveTimeModifier("@hour"));
+    assertEquals("now/h", DateTimeUtils.resolveTimeModifier("@hours"));
+
+    // Days variants
+    assertEquals("now/d", DateTimeUtils.resolveTimeModifier("@d"));
+    assertEquals("now/d", DateTimeUtils.resolveTimeModifier("@day"));
+    assertEquals("now/d", DateTimeUtils.resolveTimeModifier("@days"));
+
+    // Weeks variants
+    assertEquals("now/w-1d", resolveTimeModifier("@w", wednesday));
+    assertEquals("now/w-1d", resolveTimeModifier("@wk", thursday));
+    assertEquals("now/w-1d", resolveTimeModifier("@wks", wednesday));
+    assertEquals("now/w-1d", resolveTimeModifier("@week", wednesday));
+    assertEquals("now/w-1d", resolveTimeModifier("@weeks", wednesday));
+
+    // Month variants
+    assertEquals("now/M", DateTimeUtils.resolveTimeModifier("@mon"));
+    assertEquals("now/M", DateTimeUtils.resolveTimeModifier("@month"));
+    assertEquals("now/M", DateTimeUtils.resolveTimeModifier("@months"));
+
+    // Year variants
+    assertEquals("now/y", DateTimeUtils.resolveTimeModifier("@y"));
+    assertEquals("now/y", DateTimeUtils.resolveTimeModifier("@yr"));
+    assertEquals("now/y", DateTimeUtils.resolveTimeModifier("@yrs"));
+    assertEquals("now/y", DateTimeUtils.resolveTimeModifier("@year"));
+    assertEquals("now/y", DateTimeUtils.resolveTimeModifier("@years"));
+  }
+
+  @Test
+  void testResolveTimeModifierWithCombined() {
+    ZonedDateTime thursday = ZonedDateTime.of(2025, 9, 11, 10, 0, 0, 0, ZoneOffset.UTC);
+    assertEquals("now-1d/d", DateTimeUtils.resolveTimeModifier("-1d@d"));
+    assertEquals("now-3h/h", DateTimeUtils.resolveTimeModifier("-3h@h"));
+    assertEquals("now-1M/M", DateTimeUtils.resolveTimeModifier("-1month@month"));
+    assertEquals("now+1y/M", DateTimeUtils.resolveTimeModifier("+1y@mon"));
+    assertEquals("now-2d-3h/h", DateTimeUtils.resolveTimeModifier("-2d-3h@h"));
+    assertEquals("now-1d/w-3d", resolveTimeModifier("-1d@w5", thursday));
+
+    // Test combined formats with different time unit variants
+    assertEquals("now-10s/m", DateTimeUtils.resolveTimeModifier("-10seconds@minute"));
+    assertEquals("now-1h/d", DateTimeUtils.resolveTimeModifier("-1hour@day"));
+    assertEquals("now+2d/w-1d", resolveTimeModifier("+2days@week", thursday));
+    assertEquals("now-3w/M", DateTimeUtils.resolveTimeModifier("-3weeks@month"));
+    assertEquals("now+1y/y", DateTimeUtils.resolveTimeModifier("+1year@year"));
+
+    // Test multiple offsets with different time unit variants
+    assertEquals("now-1d-6h/h", DateTimeUtils.resolveTimeModifier("-1day-6hours@hour"));
+    assertEquals("now-2w+3d/d", DateTimeUtils.resolveTimeModifier("-2weeks+3days@day"));
+    assertEquals("now-1y+2M-5d/d", DateTimeUtils.resolveTimeModifier("-1year+2months-5days@d"));
+
+    // Test with case variations
+    assertEquals("now-1h/d", DateTimeUtils.resolveTimeModifier("-1HOUR@DAY"));
+    assertEquals("now+5d/M", DateTimeUtils.resolveTimeModifier("+5Day@Month"));
+  }
+
+  @Test
+  void testResolveTimeModifierWithInvalidInput() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> DateTimeUtils.resolveTimeModifier("1d+1y"));
+    assertEquals("Unexpected character '1' at position 0 in input: 1d+1y", e.getMessage());
+    assertThrows(IllegalArgumentException.class, () -> DateTimeUtils.resolveTimeModifier("-1x"));
+    assertThrows(
+        IllegalArgumentException.class, () -> DateTimeUtils.resolveTimeModifier("@fortnight"));
+    assertThrows(
+        IllegalArgumentException.class, () -> DateTimeUtils.resolveTimeModifier("-5decades"));
+    assertThrows(IllegalArgumentException.class, () -> DateTimeUtils.resolveTimeModifier("@+d"));
+  }
+
+  @Test
+  void testParseTimeWithReferenceTimeModifier() {
+    // Test with different reference dates in different quarters
+
+    ZonedDateTime jan = ZonedDateTime.of(2023, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    assertEquals("now/M", resolveTimeModifier("@q", jan)); // Jan is already start of Q1
+
+    ZonedDateTime feb = ZonedDateTime.of(2023, 2, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    assertEquals("now/M-1M", resolveTimeModifier("@q", feb)); // Feb needs to go back 1 month to Jan
+
+    ZonedDateTime mar = ZonedDateTime.of(2023, 3, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    assertEquals(
+        "now/M-2M", resolveTimeModifier("@q", mar)); // Mar needs to go back 2 months to Jan
+
+    ZonedDateTime apr = ZonedDateTime.of(2023, 4, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    assertEquals("now/M", resolveTimeModifier("@q", apr)); // Apr is already start of Q2
+
+    ZonedDateTime may = ZonedDateTime.of(2023, 5, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    assertEquals("now/M-1M", resolveTimeModifier("@q", may)); // May needs to go back 1 month to Apr
+
+    ZonedDateTime sep = ZonedDateTime.of(2023, 9, 11, 10, 0, 0, 0, ZoneOffset.UTC);
+    assertEquals(
+        "now/M-2M", resolveTimeModifier("@q", sep)); // Sep needs to go back 2 months to Jul
+  }
+
+  @Test
+  void testParseTimeWithReferenceTimeModifierAndOffset() {
+    // Test with quarter snap combined with other operations, using fixed reference times
+
+    // March 15, 2023 (Q1)
+    ZonedDateTime refTime = ZonedDateTime.of(2023, 3, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+
+    // Quarter snapping with offsets
+    assertEquals(
+        "now-1d/M-2M", resolveTimeModifier("-1d@q", refTime)); // -1 day, then snap to Q1 (Jan)
+    assertEquals(
+        "now+5h/M-2M", resolveTimeModifier("+5h@q", refTime)); // +5 hours, then snap to Q1 (Jan)
+    assertEquals(
+        "now-2M/M", resolveTimeModifier("-2month@q", refTime)); // -2 months, then snap to Q1 (Jan)
+    assertEquals(
+        "now+1M/M", resolveTimeModifier("+1month@q", refTime)); // +1 month, then snap to Q2 (April)
+
+    // Quarter offsets
+    assertEquals("now-3M", resolveTimeModifier("-1q", refTime)); // -1 quarter = -3 months
+    assertEquals("now-6M", resolveTimeModifier("-2q", refTime)); // -2 quarters = -6 months
+    assertEquals("now+3M", resolveTimeModifier("+1q", refTime)); // +1 quarter = +3 months
+
+    // Multiple operations with quarters
+    assertEquals("now-3M+1d", resolveTimeModifier("-1q+1d", refTime)); // -1 quarter then +1 day
+    assertEquals(
+        "now-3M/M-2M", resolveTimeModifier("-1q@q", refTime)); // -1 quarter then snap to quarter
+  }
+
+  @Test
+  void testWeekDaySnapping() {
+    // Test all week day snap variants
+    assertEquals("now/w-1d", resolveTimeModifier("@w", thursday));
+    assertEquals("now/w-1d", resolveTimeModifier("@week", thursday));
+    assertEquals("now/w", resolveTimeModifier("@w1", thursday)); // Monday (OpenSearch default)
+    assertEquals("now/w-1d", resolveTimeModifier("@w0", thursday)); // Sunday
+    assertEquals("now/w-1d", resolveTimeModifier("@w7", thursday)); // Sunday (alternative)
+    assertEquals("now/w+1d", resolveTimeModifier("@w2", thursday)); // Tuesday
+    assertEquals("now/w+2d", resolveTimeModifier("@w3", thursday)); // Wednesday
+    assertEquals("now/w+3d", resolveTimeModifier("@w4", thursday)); // Thursday
+    assertEquals("now/w-3d", resolveTimeModifier("@w5", thursday)); // Friday
+    assertEquals("now/w-2d", resolveTimeModifier("@w6", thursday)); // Saturday
+
+    // Test with offsets
+    assertEquals("now-1d/w", resolveTimeModifier("-1d@w1", thursday)); // Monday with offset
+    assertEquals("now+2h/w-1d", resolveTimeModifier("+2h@w0", thursday)); // Sunday with offset
+    assertEquals("now-3h/w+2d", resolveTimeModifier("-3h@w3", thursday)); // Wednesday with offset
+
+    // Both reference and target are Sunday
+    assertEquals("now/w+6d", resolveTimeModifier("@w", sunday));
+
+    // Both reference and target are monday
+    assertEquals("now/w", resolveTimeModifier("@w1", monday));
   }
 }

--- a/docs/dev/opensearch-nested-field-subquery.md
+++ b/docs/dev/opensearch-nested-field-subquery.md
@@ -9,7 +9,7 @@ Let’s go though the use cases find out how to translate the SQL to DSL.
 
 ### **1.  EXISTS**
 
-If the SQL doesn’t have condition in the subquery, the [OpenSearch exists](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/query-dsl-exists-query.html) could be used to translate the SQL to DSL.
+If the SQL doesn’t have condition in the subquery, the [OpenSearch exists](https://docs.opensearch.org/latest/query-dsl/term/exists) could be used to translate the SQL to DSL.
 
 ```
 SELECT e.name AS employeeName

--- a/docs/user/ppl/functions/condition.rst
+++ b/docs/user/ppl/functions/condition.rst
@@ -423,7 +423,7 @@ The relative string can be one of the following formats:
 1. `"now"` or `"now()"`:  
    Uses the current system time.
 
-2. Absolute format (`MM/dd/yyyy:HH:mm:ss`):  
+2. Absolute format (`MM/dd/yyyy:HH:mm:ss` or `yyyy-MM-dd HH:mm:ss`):
    Converts the string to a timestamp and compares it with the data.
 
 3. Relative format: `(+|-)<time_integer><time_unit>[+<...>]@<snap_unit>`  
@@ -460,7 +460,7 @@ Example::
     +-----+
     | cnt |
     |-----|
-    | 971 |
+    | 972 |
     +-----+
 
 LATEST
@@ -492,7 +492,7 @@ Example::
     +-----+
     | cnt |
     |-----|
-    | 968 |
+    | 969 |
     +-----+
 
 REGEX_MATCH

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
@@ -57,8 +57,9 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithBinsParameter() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin value bins=5 | fields value | sort value | head 3");
+            String.format(
+                "source=%s | bin value bins=5 | fields value | sort value | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("value", null, "string"));
 
     verifyDataRows(result, rows("6000-7000"), rows("6000-7000"), rows("6000-7000"));
@@ -102,9 +103,8 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinValueFieldOnly() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin value span=2000"
-                + " | fields value | head 3");
+            String.format(
+                "source=%s | bin value span=2000 | fields value | head 3", TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("value", null, "string"));
 
     verifyDataRows(result, rows("8000-10000"), rows("6000-8000"), rows("8000-10000"));
@@ -152,9 +152,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithTimestampSpan() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=1h"
-                + " | fields `@timestamp`, value | sort `@timestamp` | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=1h | fields `@timestamp`, value | sort"
+                    + " `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
 
     // With 1-hour spans
@@ -169,9 +170,11 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithTimestampStats() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=4h"
-                + " | fields `@timestamp` | sort `@timestamp` | head 3");
+            String.format(
+                "source=%s"
+                    + " | bin @timestamp span=4h"
+                    + " | fields `@timestamp` | sort `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"));
 
     // With 4-hour spans and stats
@@ -187,9 +190,9 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
     // Test just the bin operation without aggregation
     JSONObject binOnlyResult =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=4h"
-                + " | fields `@timestamp` | head 3");
+            String.format(
+                "source=%s" + " | bin @timestamp span=4h" + " | fields `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
 
     // Verify schema and that binning works correctly
     verifySchema(binOnlyResult, schema("@timestamp", null, "timestamp"));
@@ -207,9 +210,11 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
     // Test bin operation with fields only - no aggregation
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=4h"
-                + " | fields `@timestamp` | sort `@timestamp` | head 3");
+            String.format(
+                "source=%s"
+                    + " | bin @timestamp span=4h"
+                    + " | fields `@timestamp` | sort `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
 
     // Verify schema
     verifySchema(result, schema("@timestamp", null, "timestamp"));
@@ -226,8 +231,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithMonthlySpan() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=4mon as cate | fields"
-                + " cate, @timestamp | head 5");
+            String.format(
+                "source=%s | bin @timestamp span=4mon as cate | fields"
+                    + " cate, @timestamp | head 5",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("cate", null, "string"), schema("@timestamp", null, "timestamp"));
 
     // With 4-month spans using 'mon' unit
@@ -389,8 +396,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampSpan30Seconds() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=30seconds | fields"
-                + " @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=30seconds | fields"
+                    + " @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -403,8 +412,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampSpan45Minutes() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=45minute | fields"
-                + " @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=45minute | fields"
+                    + " @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -417,8 +428,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampSpan7Days() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=7day | fields"
-                + " @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=7day | fields"
+                    + " @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -431,8 +444,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampSpan6Days() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=6day | fields"
-                + " @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=6day | fields"
+                    + " @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -445,8 +460,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampAligntimeHour() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=2h"
-                + " aligntime='@d+3h' | fields @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=2h"
+                    + " aligntime='@d+3h' | fields @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -459,8 +476,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinTimestampAligntimeEpoch() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data | bin @timestamp span=2h"
-                + " aligntime=1500000000 | fields @timestamp, value | sort @timestamp | head 3");
+            String.format(
+                "source=%s | bin @timestamp span=2h"
+                    + " aligntime=1500000000 | fields @timestamp, value | sort @timestamp | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("@timestamp", null, "timestamp"), schema("value", null, "int"));
     verifyDataRows(
         result,
@@ -541,8 +560,9 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinWithBinsParameterStatsCount() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin value bins=5 | stats count() by value | sort value | head 3");
+            String.format(
+                "source=%s" + " | bin value bins=5 | stats count() by value | sort value | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("count()", null, "bigint"), schema("value", null, "string"));
 
     verifyDataRows(result, rows(24L, "6000-7000"), rows(25L, "7000-8000"), rows(33L, "8000-9000"));
@@ -625,9 +645,11 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
     // Test bin operation with aggregation - this should now work correctly
     JSONObject result =
         executeQuery(
-            "source=opensearch-sql_test_index_time_data"
-                + " | bin @timestamp span=4h"
-                + " | stats count() by `@timestamp` | sort `@timestamp` | head 3");
+            String.format(
+                "source=%s"
+                    + " | bin @timestamp span=4h"
+                    + " | stats count() by `@timestamp` | sort `@timestamp` | head 3",
+                TEST_INDEX_TIME_DATA));
 
     // Verify schema
     verifySchema(

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -48,6 +48,10 @@ public class TestsConstants {
   public static final String TEST_INDEX_WEBLOGS = TEST_INDEX + "_weblogs";
   public static final String TEST_INDEX_DATE = TEST_INDEX + "_date";
   public static final String TEST_INDEX_DATE_TIME = TEST_INDEX + "_datetime";
+
+  /** A test index with @timestamp field */
+  public static final String TEST_INDEX_TIME_DATA = TEST_INDEX + "_time_data";
+
   public static final String TEST_INDEX_DEEP_NESTED = TEST_INDEX + "_deep_nested";
   public static final String TEST_INDEX_TELEMETRY = TEST_INDEX + "_telemetry";
   public static final String TEST_INDEX_STRINGS = TEST_INDEX + "_strings";

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/ExplainIT.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_OTEL_LOGS;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_TIME_DATA;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WEBLOGS;
 import static org.opensearch.sql.util.MatcherUtils.assertJsonEqualsIgnoreId;
 import static org.opensearch.sql.util.MatcherUtils.assertYamlEqualsJsonIgnoreId;
@@ -34,6 +35,7 @@ public class ExplainIT extends PPLIntegTestCase {
     loadIndex(Index.DATE_FORMATS);
     loadIndex(Index.WEBLOG);
     loadIndex(Index.OTELLOGS);
+    loadIndex(Index.TIME_TEST_DATA);
   }
 
   @Test
@@ -675,18 +677,47 @@ public class ExplainIT extends PPLIntegTestCase {
                 TEST_INDEX_BANK)));
   }
 
-  protected String loadExpectedPlan(String fileName) throws IOException {
-    String prefix;
-    if (isCalciteEnabled()) {
-      if (isPushdownDisabled()) {
-        prefix = "expectedOutput/calcite_no_pushdown/";
-      } else {
-        prefix = "expectedOutput/calcite/";
-      }
-    } else {
-      prefix = "expectedOutput/ppl/";
-    }
-    return loadFromFile(prefix + fileName);
+  @Test
+  public void testSearchCommandWithAbsoluteTimeRange() throws IOException {
+    String expected = loadExpectedPlan("search_with_absolute_time_range.yaml");
+    assertYamlEqualsJsonIgnoreId(
+        expected,
+        explainQueryToString(
+            String.format(
+                "source=%s earliest='2022-12-10 13:11:04' latest='2025-09-03 15:10:00'",
+                TEST_INDEX_TIME_DATA)));
+  }
+
+  @Test
+  public void testSearchCommandWithRelativeTimeRange() throws IOException {
+    assertYamlEqualsJsonIgnoreId(
+        loadExpectedPlan("search_with_relative_time_range.yaml"),
+        //            "",
+        explainQueryToString(
+            String.format("source=%s earliest=-1q latest=+30d", TEST_INDEX_TIME_DATA)));
+
+    assertYamlEqualsJsonIgnoreId(
+        loadExpectedPlan("search_with_relative_time_snap.yaml"),
+        explainQueryToString(
+            String.format("source=%s earliest='-1q@year' latest=now", TEST_INDEX_TIME_DATA)));
+  }
+
+  @Test
+  public void testSearchCommandWithNumericTimeRange() throws IOException {
+    String expected = loadExpectedPlan("search_with_numeric_time_range.yaml");
+    assertYamlEqualsJsonIgnoreId(
+        expected,
+        explainQueryToString(
+            String.format("source=%s earliest=1 latest=1754020061.123456", TEST_INDEX_TIME_DATA)));
+  }
+
+  @Test
+  public void testSearchCommandWithChainedTimeModifier() throws IOException {
+    assertYamlEqualsJsonIgnoreId(
+        loadExpectedPlan("search_with_chained_time_modifier.yaml"),
+        explainQueryToString(
+            String.format(
+                "source=%s earliest='-3d@d-2h+10m' latest='-1d+1y@mon'", TEST_INDEX_TIME_DATA)));
   }
 
   // Search command explain examples - 3 core use cases
@@ -718,5 +749,19 @@ public class ExplainIT extends PPLIntegTestCase {
         expected,
         explainQueryToString(
             String.format("search source=%s severityText=ERR* | fields severityText ", TEST_INDEX_OTEL_LOGS)));
+  }
+
+  protected String loadExpectedPlan(String fileName) throws IOException {
+    String prefix;
+    if (isCalciteEnabled()) {
+      if (isPushdownDisabled()) {
+        prefix = "expectedOutput/calcite_no_pushdown/";
+      } else {
+        prefix = "expectedOutput/calcite/";
+      }
+    } else {
+      prefix = "expectedOutput/ppl/";
+    }
+    return loadFromFile(prefix + fileName);
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -8,17 +8,27 @@ package org.opensearch.sql.ppl;
 import static org.opensearch.sql.legacy.TestsConstants.*;
 import static org.opensearch.sql.util.MatcherUtils.columnName;
 import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyNumOfRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.ResponseException;
+import org.opensearch.sql.common.utils.StringUtils;
 
 public class SearchCommandIT extends PPLIntegTestCase {
+  private static final DateTimeFormatter PPL_TIMESTAMP_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
   @Override
   public void init() throws Exception {
@@ -26,6 +36,7 @@ public class SearchCommandIT extends PPLIntegTestCase {
     loadIndex(Index.BANK);
     loadIndex(Index.DOG);
     loadIndex(Index.OTELLOGS);
+    loadIndex(Index.TIME_TEST_DATA);
   }
 
   @Test
@@ -991,5 +1002,313 @@ public class SearchCommandIT extends PPLIntegTestCase {
                 "search source=%s `attributes.transaction.id`=1s | fields body",
                 TEST_INDEX_OTEL_LOGS));
     verifyDataRows(spanLengthSearchResult); // Should return no results
+  }
+
+  @Test
+  public void testSearchWithAbsoluteEarliestAndNow() throws IOException {
+    JSONObject result1 =
+        executeQuery(
+            String.format(
+                "search source=%s earliest='2025-08-01 03:47:41' latest=now | fields @timestamp",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result1, schema("@timestamp", "timestamp"));
+    verifyDataRows(result1, rows("2025-08-01 03:47:41"));
+
+    JSONObject result0 =
+        executeQuery(
+            String.format(
+                "search source=%s earliest='2025-08-01 03:47:42' latest=now() | fields @timestamp",
+                TEST_INDEX_TIME_DATA));
+    verifyNumOfRows(result0, 0);
+
+    JSONObject result2 =
+        executeQuery(
+            String.format(
+                "search source=%s earliest='2025-08-01 02:00:55' | fields @timestamp",
+                TEST_INDEX_TIME_DATA));
+    verifyDataRows(result2, rows("2025-08-01 02:00:56"), rows("2025-08-01 03:47:41"));
+  }
+
+  @Test
+  public void testSearchWithChainedRelativeTimeRange() throws IOException {
+    JSONObject result1 =
+        executeQuery(
+            String.format(
+                "search source=%s earliest='2025-08-01 03:47:41' latest=+1months@year | fields"
+                    + " @timestamp",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result1, schema("@timestamp", "timestamp"));
+    verifyDataRows(result1, rows("2025-08-01 03:47:41"));
+  }
+
+  @Test
+  public void testSearchWithNumericTimeRange() throws IOException {
+    JSONObject result1 =
+        executeQuery(
+            String.format(
+                "search source=%s earliest=1754020060.123 latest=1754020061 | fields @timestamp",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result1, schema("@timestamp", "timestamp"));
+    verifyDataRows(result1, rows("2025-08-01 03:47:41"));
+  }
+
+  @Test
+  public void testSearchTimeModifierWithSnappedWeek() throws IOException {
+    // Test whether alignment to weekday works
+
+    final int docId = 101;
+    Request insertRequest =
+        new Request("PUT", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+
+    // Get the current weekday
+    LocalDateTime base = LocalDateTime.now(ZoneOffset.UTC);
+    // Truncate to last sunday
+    LocalDateTime lastSunday =
+        base.minusDays((base.getDayOfWeek().getValue() % 7)).truncatedTo(ChronoUnit.DAYS);
+    LocalDateTime lastMonday =
+        base.minusDays((base.getDayOfWeek().getValue() + 6) % 7).truncatedTo(ChronoUnit.DAYS);
+    LocalDateTime lastFriday =
+        base.minusDays((base.getDayOfWeek().getValue() + 2) % 7).truncatedTo(ChronoUnit.DAYS);
+
+    // Insert data
+    LocalDateTime insertedSunday = lastSunday.plusMinutes(10);
+    insertRequest.setJsonEntity(
+        StringUtils.format(
+            "{\"value\":100090,\"category\":\"A\",\"@timestamp\":\"%s\"}\n",
+            insertedSunday.format(DateTimeFormatter.ISO_DATE_TIME)));
+    client().performRequest(insertRequest);
+
+    JSONObject result1 =
+        executeQuery(String.format("source=%s earliest=@w0 latest='@w+1h'", TEST_INDEX_TIME_DATA));
+    verifySchema(
+        result1,
+        schema("timestamp", "timestamp"),
+        schema("value", "int"),
+        schema("category", "string"),
+        schema("@timestamp", "timestamp"));
+    verifyDataRows(
+        result1, rows(insertedSunday.format(PPL_TIMESTAMP_FORMATTER), "A", 100090, null));
+
+    // Test last Monday
+    LocalDateTime insertedMonday = lastMonday.plusHours(2).plusMinutes(10);
+    Request insertRequest2 =
+        new Request("PUT", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    insertRequest2.setJsonEntity(
+        StringUtils.format(
+            "{\"value\":100091,\"category\":\"B\",\"@timestamp\":\"%s\"}\n",
+            insertedMonday.format(DateTimeFormatter.ISO_DATE_TIME)));
+    client().performRequest(insertRequest2);
+
+    JSONObject result2 =
+        executeQuery(
+            String.format(
+                "source=%s earliest='@w1+2h' latest='@w1+2h+30min'", TEST_INDEX_TIME_DATA));
+    verifySchema(
+        result2,
+        schema("timestamp", "timestamp"),
+        schema("value", "int"),
+        schema("category", "string"),
+        schema("@timestamp", "timestamp"));
+    verifyDataRows(
+        result2, rows(insertedMonday.format(PPL_TIMESTAMP_FORMATTER), "B", 100091, null));
+
+    // Test last Friday
+    LocalDateTime insertedFriday = lastFriday.plusMinutes(10);
+    Request insertRequest3 =
+        new Request("PUT", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    insertRequest3.setJsonEntity(
+        StringUtils.format(
+            "{\"value\":100092,\"category\":\"C\",\"@timestamp\":\"%s\"}\n",
+            insertedFriday.format(DateTimeFormatter.ISO_DATE_TIME)));
+    client().performRequest(insertRequest3);
+
+    JSONObject result3 =
+        executeQuery(
+            String.format("source=%s earliest=@w5 latest='@w5+30minutes'", TEST_INDEX_TIME_DATA));
+    verifySchema(
+        result3,
+        schema("timestamp", "timestamp"),
+        schema("value", "int"),
+        schema("category", "string"),
+        schema("@timestamp", "timestamp"));
+    verifyDataRows(
+        result3, rows(insertedFriday.format(PPL_TIMESTAMP_FORMATTER), "C", 100092, null));
+
+    Request deleteRequest =
+        new Request(
+            "DELETE", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    client().performRequest(deleteRequest);
+  }
+
+  @Test
+  public void testSearchWithRelativeTimeModifiers() throws IOException {
+    final int docId = 101;
+
+    LocalDateTime currentTime = LocalDateTime.now(ZoneOffset.UTC);
+    LocalDateTime testTime = currentTime.minusMinutes(30).truncatedTo(ChronoUnit.MINUTES);
+
+    Request insertRequest =
+        new Request("PUT", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    insertRequest.setJsonEntity(
+        StringUtils.format(
+            "{\"value\":200001,\"category\":\"RELATIVE\",\"@timestamp\":\"%s\"}\n",
+            testTime.format(DateTimeFormatter.ISO_DATE_TIME)));
+    client().performRequest(insertRequest);
+
+    // Test -1h (1 hour ago) since it's only 30 minutes old
+    JSONObject result1 =
+        executeQuery(
+            String.format(
+                "source=%s earliest=-1h | fields @timestamp, value | head 5",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result1, schema("@timestamp", "timestamp"), schema("value", "int"));
+    verifyDataRows(result1, rows(testTime.format(PPL_TIMESTAMP_FORMATTER), 200001));
+
+    // Test -30m (30 minutes ago)
+    JSONObject result2 =
+        executeQuery(
+            String.format(
+                "source=%s earliest=-50m latest=now | fields @timestamp, value | head 5",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result2, schema("@timestamp", "timestamp"), schema("value", "int"));
+    verifyDataRows(result2, rows(testTime.format(PPL_TIMESTAMP_FORMATTER), 200001));
+
+    // Test -7d (7 days ago) - should return no results since our data is recent
+    JSONObject result3 =
+        executeQuery(
+            String.format(
+                "source=%s earliest=-7d latest=-6d | fields @timestamp | head 1",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result3, schema("@timestamp", "timestamp"));
+    verifyNumOfRows(result3, 0);
+
+    Request deleteRequest =
+        new Request(
+            "DELETE", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    client().performRequest(deleteRequest);
+  }
+
+  @Test
+  public void testSearchWithTimeUnitSnapping() throws IOException {
+    final int docId = 101;
+
+    LocalDateTime currentHour = LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
+    LocalDateTime testTime = currentHour.plusMinutes(15).truncatedTo(ChronoUnit.MINUTES);
+
+    Request insertRequest =
+        new Request("PUT", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    insertRequest.setJsonEntity(
+        StringUtils.format(
+            "{\"value\":200002,\"category\":\"SNAP\",\"@timestamp\":\"%s\"}\n",
+            testTime.format(DateTimeFormatter.ISO_DATE_TIME)));
+    client().performRequest(insertRequest);
+
+    // Test @h (snap to hour)
+    JSONObject result1 =
+        executeQuery(
+            String.format(
+                "source=%s earliest=@h latest='@h+1h' | fields @timestamp, value",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result1, schema("@timestamp", "timestamp"), schema("value", "int"));
+    verifyDataRows(result1, rows(testTime.format(PPL_TIMESTAMP_FORMATTER), 200002));
+
+    // Test @d (snap to day)
+    JSONObject result2 =
+        executeQuery(
+            String.format(
+                "source=%s earliest=@d latest='@d+1d' | fields @timestamp | head 5",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result2, schema("@timestamp", "timestamp"));
+    verifyDataRows(result2, rows(testTime.format(PPL_TIMESTAMP_FORMATTER)));
+
+    // Test @M (snap to month)
+    JSONObject result3 =
+        executeQuery(
+            String.format(
+                "source=%s earliest=@mon latest='@mon+1mon' | fields @timestamp | head 5",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result3, schema("@timestamp", "timestamp"));
+    verifyDataRows(result3, rows(testTime.format(PPL_TIMESTAMP_FORMATTER)));
+
+    Request deleteRequest =
+        new Request(
+            "DELETE", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    client().performRequest(deleteRequest);
+  }
+
+  @Test
+  public void testSearchWithQuarterlyModifiers() throws IOException {
+    final int docId = 101;
+
+    LocalDateTime currentQuarter =
+        LocalDateTime.now(ZoneOffset.UTC)
+            .plusYears(1)
+            .withMonth(((LocalDateTime.now(ZoneOffset.UTC).getMonthValue() - 1) / 3) * 3 + 1)
+            .withDayOfMonth(1)
+            .truncatedTo(ChronoUnit.DAYS);
+    LocalDateTime testTime = currentQuarter.plusDays(15);
+
+    Request insertRequest =
+        new Request("PUT", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    insertRequest.setJsonEntity(
+        StringUtils.format(
+            "{\"value\":200003,\"category\":\"QUARTER\",\"@timestamp\":\"%s\"}\n",
+            testTime.format(DateTimeFormatter.ISO_DATE_TIME)));
+    client().performRequest(insertRequest);
+
+    // Test @q (snap to quarter)
+    JSONObject result1 =
+        executeQuery(
+            String.format(
+                "source=%s earliest=+1year@q latest='+1year@q+3M' | fields @timestamp, value",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result1, schema("@timestamp", "timestamp"), schema("value", "int"));
+    verifyDataRows(result1, rows(testTime.format(PPL_TIMESTAMP_FORMATTER), 200003));
+
+    // Test -2q (2 quarters ago, equivalent to -6M), should return no data
+    JSONObject result2 =
+        executeQuery(
+            String.format(
+                "source=%s earliest='+1year-2q' latest='+1year-1q' | fields @timestamp | head 1",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result2, schema("@timestamp", "timestamp"));
+    verifyNumOfRows(result2, 0);
+
+    Request deleteRequest =
+        new Request(
+            "DELETE", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    client().performRequest(deleteRequest);
+  }
+
+  @Test
+  public void testSearchWithComplexChainedExpressions() throws IOException {
+    final int docId = 101;
+
+    LocalDateTime lastDay =
+        LocalDateTime.now(ZoneOffset.UTC).minusDays(1).truncatedTo(ChronoUnit.DAYS);
+    LocalDateTime testTime = lastDay.minusHours(2).plusMinutes(10);
+
+    Request insertRequest =
+        new Request("PUT", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    insertRequest.setJsonEntity(
+        StringUtils.format(
+            "{\"value\":200004,\"category\":\"COMPLEX\",\"@timestamp\":\"%s\"}\n",
+            testTime.format(DateTimeFormatter.ISO_DATE_TIME)));
+    client().performRequest(insertRequest);
+
+    // Test -1d@d-2h+10m (1 day ago at day start, minus 2 hours, plus 10 minutes)
+    JSONObject result1 =
+        executeQuery(
+            String.format(
+                "source=%s earliest='-1d@d-2h' latest='-1d@d-2h+20m' | fields @timestamp,"
+                    + " value",
+                TEST_INDEX_TIME_DATA));
+    verifySchema(result1, schema("@timestamp", "timestamp"), schema("value", "int"));
+    verifyDataRows(result1, rows(testTime.format(PPL_TIMESTAMP_FORMATTER), 200004));
+
+    Request deleteRequest =
+        new Request(
+            "DELETE", String.format("/%s/_doc/%d?refresh=true", TEST_INDEX_TIME_DATA, docId));
+    client().performRequest(deleteRequest);
   }
 }

--- a/integ-test/src/test/resources/expectedOutput/calcite/search_with_absolute_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/search_with_absolute_time_range.yaml
@@ -1,0 +1,8 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=2022\-12\-10T13\:11\:04Z) AND (@timestamp:<=2025\-09\-03T15\:10\:00Z)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[PROJECT->[@timestamp, category, value, timestamp], FILTER->query_string(MAP('query', '(@timestamp:>=2022\-12\-10T13\:11\:04Z) AND (@timestamp:<=2025\-09\-03T15\:10\:00Z)':VARCHAR)), LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":10000,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=2022\\-12\\-10T13\\:11\\:04Z) AND (@timestamp:<=2025\\-09\\-03T15\\:10\\:00Z)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"_source":{"includes":["@timestamp","category","value","timestamp"],"excludes":[]},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=10000, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite/search_with_chained_time_modifier.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/search_with_chained_time_modifier.yaml
@@ -1,0 +1,8 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=now\-3d\/d\-2h\+10m) AND (@timestamp:<=now\-1d\+1y\/M)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[PROJECT->[@timestamp, category, value, timestamp], FILTER->query_string(MAP('query', '(@timestamp:>=now\-3d\/d\-2h\+10m) AND (@timestamp:<=now\-1d\+1y\/M)':VARCHAR)), LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":10000,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=now\\-3d\\/d\\-2h\\+10m) AND (@timestamp:<=now\\-1d\\+1y\\/M)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"_source":{"includes":["@timestamp","category","value","timestamp"],"excludes":[]},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=10000, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite/search_with_numeric_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/search_with_numeric_time_range.yaml
@@ -1,0 +1,8 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=1000) AND (@timestamp:<=1754020061123.456)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[PROJECT->[@timestamp, category, value, timestamp], FILTER->query_string(MAP('query', '(@timestamp:>=1000) AND (@timestamp:<=1754020061123.456)':VARCHAR)), LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":10000,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=1000) AND (@timestamp:<=1754020061123.456)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"_source":{"includes":["@timestamp","category","value","timestamp"],"excludes":[]},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=10000, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite/search_with_relative_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/search_with_relative_time_range.yaml
@@ -1,0 +1,8 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=now\-3M) AND (@timestamp:<=now\+30d)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[PROJECT->[@timestamp, category, value, timestamp], FILTER->query_string(MAP('query', '(@timestamp:>=now\-3M) AND (@timestamp:<=now\+30d)':VARCHAR)), LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":10000,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=now\\-3M) AND (@timestamp:<=now\\+30d)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"_source":{"includes":["@timestamp","category","value","timestamp"],"excludes":[]},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=10000, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite/search_with_relative_time_snap.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/search_with_relative_time_snap.yaml
@@ -1,0 +1,8 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=now\-3M\/y) AND (@timestamp:<=now)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[PROJECT->[@timestamp, category, value, timestamp], FILTER->query_string(MAP('query', '(@timestamp:>=now\-3M\/y) AND (@timestamp:<=now)':VARCHAR)), LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":10000,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=now\\-3M\\/y) AND (@timestamp:<=now)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"_source":{"includes":["@timestamp","category","value","timestamp"],"excludes":[]},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=10000, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_absolute_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_absolute_time_range.yaml
@@ -1,0 +1,10 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=2022\-12\-10T13\:11\:04Z) AND (@timestamp:<=2025\-09\-03T15\:10\:00Z)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    EnumerableLimit(fetch=[10000])
+      EnumerableCalc(expr#0..9=[{inputs}], proj#0..3=[{exprs}])
+        CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[FILTER->query_string(MAP('query', '(@timestamp:>=2022\-12\-10T13\:11\:04Z) AND (@timestamp:<=2025\-09\-03T15\:10\:00Z)':VARCHAR))], OpenSearchRequestBuilder(sourceBuilder={"from":0,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=2022\\-12\\-10T13\\:11\\:04Z) AND (@timestamp:<=2025\\-09\\-03T15\\:10\\:00Z)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_chained_time_modifier.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_chained_time_modifier.yaml
@@ -1,0 +1,10 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=now\-3d\/d\-2h\+10m) AND (@timestamp:<=now\-1d\+1y\/M)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    EnumerableLimit(fetch=[10000])
+      EnumerableCalc(expr#0..9=[{inputs}], proj#0..3=[{exprs}])
+        CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[FILTER->query_string(MAP('query', '(@timestamp:>=now\-3d\/d\-2h\+10m) AND (@timestamp:<=now\-1d\+1y\/M)':VARCHAR))], OpenSearchRequestBuilder(sourceBuilder={"from":0,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=now\\-3d\\/d\\-2h\\+10m) AND (@timestamp:<=now\\-1d\\+1y\\/M)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_numeric_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_numeric_time_range.yaml
@@ -1,0 +1,10 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=1000) AND (@timestamp:<=1754020061123.456)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    EnumerableLimit(fetch=[10000])
+      EnumerableCalc(expr#0..9=[{inputs}], proj#0..3=[{exprs}])
+        CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[FILTER->query_string(MAP('query', '(@timestamp:>=1000) AND (@timestamp:<=1754020061123.456)':VARCHAR))], OpenSearchRequestBuilder(sourceBuilder={"from":0,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=1000) AND (@timestamp:<=1754020061123.456)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_relative_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_relative_time_range.yaml
@@ -1,0 +1,10 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=now\-3M) AND (@timestamp:<=now\+30d)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    EnumerableLimit(fetch=[10000])
+      EnumerableCalc(expr#0..9=[{inputs}], proj#0..3=[{exprs}])
+        CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[FILTER->query_string(MAP('query', '(@timestamp:>=now\-3M) AND (@timestamp:<=now\+30d)':VARCHAR))], OpenSearchRequestBuilder(sourceBuilder={"from":0,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=now\\-3M) AND (@timestamp:<=now\\+30d)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_relative_time_snap.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/search_with_relative_time_snap.yaml
@@ -1,0 +1,10 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(@timestamp=[$0], category=[$1], value=[$2], timestamp=[$3])
+        LogicalFilter(condition=[query_string(MAP('query', '(@timestamp:>=now\-3M\/y) AND (@timestamp:<=now)':VARCHAR))])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]])
+  physical: |
+    EnumerableLimit(fetch=[10000])
+      EnumerableCalc(expr#0..9=[{inputs}], proj#0..3=[{exprs}])
+        CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_time_data]], PushDownContext=[[FILTER->query_string(MAP('query', '(@timestamp:>=now\-3M\/y) AND (@timestamp:<=now)':VARCHAR))], OpenSearchRequestBuilder(sourceBuilder={"from":0,"timeout":"1m","query":{"query_string":{"query":"(@timestamp:>=now\\-3M\\/y) AND (@timestamp:<=now)","fields":[],"type":"best_fields","default_operator":"or","max_determinized_states":10000,"enable_position_increments":true,"fuzziness":"AUTO","fuzzy_prefix_length":0,"fuzzy_max_expansions":50,"phrase_slop":0,"escape":false,"auto_generate_synonyms_phrase_query":true,"fuzzy_transpositions":true,"boost":1.0}},"sort":[{"_doc":{"order":"asc"}}]}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_absolute_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_absolute_time_range.yaml
@@ -1,0 +1,20 @@
+root:
+  name: ProjectOperator
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  children:
+    - name: OpenSearchIndexScan
+      description:
+        request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
+          \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
+          :{\"query_string\":{\"query\":\"(@timestamp:>=2022\\\\-12\\\\-10T13\\\\\
+          :11\\\\:04Z) AND (@timestamp:<=2025\\\\-09\\\\-03T15\\\\:10\\\\:00Z)\",\"\
+          fields\":[],\"type\":\"best_fields\",\"default_operator\":\"or\",\"max_determinized_states\"\
+          :10000,\"enable_position_increments\":true,\"fuzziness\":\"AUTO\",\"fuzzy_prefix_length\"\
+          :0,\"fuzzy_max_expansions\":50,\"phrase_slop\":0,\"escape\":false,\"auto_generate_synonyms_phrase_query\"\
+          :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
+          :[\"@timestamp\",\"category\",\"value\",\"timestamp\"],\"excludes\":[]},\"\
+          sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false,\
+          \ pitId=*,\
+          \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+      children: []

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_chained_time_modifier.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_chained_time_modifier.yaml
@@ -1,0 +1,20 @@
+root:
+  name: ProjectOperator
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  children:
+    - name: OpenSearchIndexScan
+      description:
+        request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
+          \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
+          :{\"query_string\":{\"query\":\"(@timestamp:>=now\\\\-3d\\\\/d\\\\-2h\\\\\
+          +10m) AND (@timestamp:<=now\\\\-1d\\\\+1y\\\\/M)\",\"fields\":[],\"type\"\
+          :\"best_fields\",\"default_operator\":\"or\",\"max_determinized_states\"\
+          :10000,\"enable_position_increments\":true,\"fuzziness\":\"AUTO\",\"fuzzy_prefix_length\"\
+          :0,\"fuzzy_max_expansions\":50,\"phrase_slop\":0,\"escape\":false,\"auto_generate_synonyms_phrase_query\"\
+          :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
+          :[\"@timestamp\",\"category\",\"value\",\"timestamp\"],\"excludes\":[]},\"\
+          sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false,\
+          \ pitId=*,\
+          \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+      children: []

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_numeric_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_numeric_time_range.yaml
@@ -1,0 +1,19 @@
+root:
+  name: ProjectOperator
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  children:
+    - name: OpenSearchIndexScan
+      description:
+        request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
+          \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
+          :{\"query_string\":{\"query\":\"(@timestamp:>=1000) AND (@timestamp:<=1754020061123.456)\"\
+          ,\"fields\":[],\"type\":\"best_fields\",\"default_operator\":\"or\",\"max_determinized_states\"\
+          :10000,\"enable_position_increments\":true,\"fuzziness\":\"AUTO\",\"fuzzy_prefix_length\"\
+          :0,\"fuzzy_max_expansions\":50,\"phrase_slop\":0,\"escape\":false,\"auto_generate_synonyms_phrase_query\"\
+          :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
+          :[\"@timestamp\",\"category\",\"value\",\"timestamp\"],\"excludes\":[]},\"\
+          sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false,\
+          \ pitId=*,\
+          \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+      children: []

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_relative_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_relative_time_range.yaml
@@ -1,0 +1,20 @@
+root:
+  name: ProjectOperator
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  children:
+    - name: OpenSearchIndexScan
+      description:
+        request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
+          \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
+          :{\"query_string\":{\"query\":\"(@timestamp:>=now\\\\-3M) AND (@timestamp:<=now\\\
+          \\+30d)\",\"fields\":[],\"type\":\"best_fields\",\"default_operator\":\"\
+          or\",\"max_determinized_states\":10000,\"enable_position_increments\":true,\"\
+          fuzziness\":\"AUTO\",\"fuzzy_prefix_length\":0,\"fuzzy_max_expansions\"\
+          :50,\"phrase_slop\":0,\"escape\":false,\"auto_generate_synonyms_phrase_query\"\
+          :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
+          :[\"@timestamp\",\"category\",\"value\",\"timestamp\"],\"excludes\":[]},\"\
+          sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false,\
+          \ pitId=*,\
+          \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+      children: []

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_relative_time_snap.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_relative_time_snap.yaml
@@ -1,0 +1,19 @@
+root:
+  name: ProjectOperator
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  children:
+    - name: OpenSearchIndexScan
+      description:
+        request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
+          \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
+          :{\"query_string\":{\"query\":\"(@timestamp:>=now\\\\-3M\\\\/y) AND (@timestamp:<=now)\"\
+          ,\"fields\":[],\"type\":\"best_fields\",\"default_operator\":\"or\",\"max_determinized_states\"\
+          :10000,\"enable_position_increments\":true,\"fuzziness\":\"AUTO\",\"fuzzy_prefix_length\"\
+          :0,\"fuzzy_max_expansions\":50,\"phrase_slop\":0,\"escape\":false,\"auto_generate_synonyms_phrase_query\"\
+          :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
+          :[\"@timestamp\",\"category\",\"value\",\"timestamp\"],\"excludes\":[]},\"\
+          sort\":[{\"_doc\":{\"order\":\"asc\"}}]}, needClean=true, searchDone=false,\
+          \ pitId=*,\
+          \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+      children: []

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4224.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4224.yml
@@ -1,0 +1,64 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+
+---
+"Time modifiers in Search command":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      bulk:
+        index: test_time_modifiers
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2024-01-15T10:30:00.123456789Z", "earliest": "first", "latest": "last", "severityText": "INFO", "message": "Test message 1"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2024-01-15T10:30:05.678901234Z", "earliest": "second", "latest": "end", "severityText": "ERROR", "message": "Test message 2"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2024-01-15T10:30:10.123456789Z", "earliest": "third", "latest": "final", "severityText": "WARN", "message": "Test message 3"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2024-01-15T10:30:15.987654321Z", "earliest": "fourth", "latest": "complete", "severityText": "DEBUG", "message": "Test message 4"}'
+
+  # Test 1: Time modifier using implicit @timestamp field
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: search earliest='2024-01-15 10:30:05' latest='2024-01-15 10:30:10' source=test_time_modifiers | fields @timestamp, severityText, message | sort @timestamp
+  - match: {"total": 2}
+  - match: {"datarows.0.0": "2024-01-15 10:30:05.678901234"}
+  - match: {"datarows.0.1": "ERROR"}
+  - match: {"datarows.1.0": "2024-01-15 10:30:10.123456789"}
+  - match: {"datarows.1.1": "WARN"}
+
+  # Test 2: Access explicit 'earliest' and 'latest' columns using backticks
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: search `earliest`="second" AND `latest`="end" source=test_time_modifiers | fields @timestamp, `earliest`, `latest`, severityText
+  - match: {"total": 1}
+  - match: {"datarows.0.0": "2024-01-15 10:30:05.678901234"}
+  - match: {"datarows.0.1": "second"}
+  - match: {"datarows.0.2": "end"}
+  - match: {"datarows.0.3": "ERROR"}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -231,6 +231,7 @@ SINGLE_QUOTE:                       '\'';
 DOUBLE_QUOTE:                       '"';
 BACKTICK:                           '`';
 ARROW:                              '->';
+fragment AT:                        '@';
 
 // Operators. Bit
 
@@ -523,6 +524,16 @@ NUMERIC_ID : DEC_DIGIT+ ID_LITERAL;
 
 // LITERALS AND VALUES
 //STRING_LITERAL:                     DQUOTA_STRING | SQUOTA_STRING | BQUOTA_STRING;
+fragment WEEK_SNAP_UNIT:            'W' [0-7];
+fragment TIME_SNAP_UNIT:              'S' | 'SEC' | 'SECOND'
+                                    | 'M' | 'MIN' | 'MINUTE'
+                                    | 'H' | 'HR' | 'HOUR' | 'HOURS'
+                                    | 'D' | 'DAY'
+                                    | 'W' | 'WEEK' | WEEK_SNAP_UNIT
+                                    | 'MON' | 'MONTH'
+                                    | 'Q' | 'QTR' | 'QUARTER'
+                                    | 'Y' | 'YR' | 'YEAR';
+TIME_SNAP:                          AT TIME_SNAP_UNIT;
 ID:                                 ID_LITERAL;
 CLUSTER:                            CLUSTER_PREFIX_LITERAL;
 INTEGER_LITERAL:                    DEC_DIGIT+;

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -128,7 +128,8 @@ searchCommand
    ;
 
 searchExpression
- : LT_PRTHS searchExpression RT_PRTHS                 # groupedExpression
+ : timeModifier                                       # timeModifierExpression
+ | LT_PRTHS searchExpression RT_PRTHS                 # groupedExpression
  | NOT searchExpression                               # notExpression
  | searchExpression OR searchExpression               # orExpression
  | searchExpression AND searchExpression              # andExpression
@@ -783,6 +784,20 @@ singleFieldRelevanceFunction
 // Field is a list of columns
 multiFieldRelevanceFunction
    : multiFieldRelevanceFunctionName LT_PRTHS (LT_SQR_PRTHS field = relevanceFieldAndWeight (COMMA field = relevanceFieldAndWeight)* RT_SQR_PRTHS COMMA)? query = relevanceQuery (COMMA relevanceArg)* RT_PRTHS
+   ;
+
+timeModifier
+   : (EARLIEST | LATEST) EQUAL timeModifierValue
+   ;
+
+timeModifierValue
+   : NOW
+   | NOW LT_PRTHS RT_PRTHS
+   | DECIMAL_LITERAL
+   | INTEGER_LITERAL
+   | stringLiteral
+   | TIME_SNAP
+   | (PLUS | MINUS) SPANLENGTH (TIME_SNAP)?
    ;
 
 // tables

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLSearchTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLSearchTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import static org.junit.Assert.assertThrows;
+
+import java.util.List;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Programs;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class CalcitePPLSearchTest extends CalcitePPLAbstractTest {
+  public CalcitePPLSearchTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Override
+  protected Frameworks.ConfigBuilder config(CalciteAssert.SchemaSpec... schemaSpecs) {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    final SchemaPlus schema = CalciteAssert.addSchema(rootSchema, schemaSpecs);
+
+    schema.add(
+        "LOGS",
+        new CalcitePPLEarliestLatestTestUtils.LogsTable(
+            CalcitePPLEarliestLatestTestUtils.createLogsTestData()));
+
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(schema)
+        .traitDefs((List<RelTraitDef>) null)
+        .programs(Programs.heuristicJoinOrder(Programs.RULE_SET, true, 2));
+  }
+
+  @Test
+  public void testSearchWithFilter() {
+    String ppl = "search source=EMP DEPTNO=20";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalFilter(condition=[query_string(MAP('query', 'DEPTNO:20':VARCHAR))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT *\nFROM `scott`.`EMP`\nWHERE `query_string`(MAP ('query', 'DEPTNO:20'))";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Ignore("Fields used in search commands are not validated. Enable after fixing it.")
+  @Test
+  public void testSearchWithoutTimestampShouldThrow() {
+    String ppl = "source=EMP earliest='2020-10-11'";
+    Throwable t = assertThrows(IllegalArgumentException.class, () -> getRelNode(ppl));
+    verifyErrorMessageContains(t, "field [@timestamp] not found");
+  }
+
+  @Test
+  public void testSearchWithAbsoluteTimeRange() {
+    String ppl = "source=LOGS earliest='2020-10-11' latest='2025-01-01'";
+    RelNode root = getRelNode(ppl);
+    // @timestamp is a field of type DATE here
+
+    String expectedLogical =
+        "LogicalFilter(condition=[query_string(MAP('query',"
+            + " '(@timestamp:>=2020\\-10\\-11T00\\:00\\:00Z) AND"
+            + " (@timestamp:<=2025\\-01\\-01T00\\:00\\:00Z)':VARCHAR))])\n"
+            + "  LogicalTableScan(table=[[scott, LOGS]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT *\n"
+            + "FROM `scott`.`LOGS`\n"
+            + "WHERE `query_string`(MAP ('query', '(@timestamp:>=2020\\-10\\-11T00\\:00\\:00Z) AND"
+            + " (@timestamp:<=2025\\-01\\-01T00\\:00\\:00Z)'))";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testSearchWithTimeSnap() {
+    String ppl = "search source=LOGS earliest=@year";
+    getRelNode(ppl);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -1360,4 +1360,27 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
             emptyList(),
             defaultStatsArgs()));
   }
+
+  @Test
+  public void testTimeModifierEarliestWithNumericValue() {
+    assertEqual("source=t earliest=1", search(relation("t"), "@timestamp:>=1000"));
+
+    assertEqual(
+        "source=t earliest=1754020061.123456",
+        search(relation("t"), "@timestamp:>=1754020061123.456"));
+  }
+
+  @Test
+  public void testTimeModifierLatestWithNowValue() {
+    assertEqual(
+        "source=t earliest=now latest=now()",
+        search(relation("t"), "(@timestamp:>=now) AND (@timestamp:<=now)"));
+  }
+
+  @Test
+  public void testTimeModifierEarliestWithStringValue() {
+    assertEqual(
+        "source=t earliest='2025-12-10 14:00:00'",
+        search(relation("t"), "@timestamp:>=2025\\-12\\-10T14\\:00\\:00Z"));
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -691,4 +691,11 @@ public class PPLQueryDataAnonymizerTest {
     PPLQueryDataAnonymizer anonymize = new PPLQueryDataAnonymizer(settings);
     return anonymize.anonymizeStatement(statement);
   }
+
+  @Test
+  public void testSearchWithAbsoluteTimeRange() {
+    assertEquals(
+        "source=table (@timestamp:*** AND (@timestamp:***",
+        anonymize("search source=table earliest='2012-12-10 15:00:00' latest=now"));
+  }
 }


### PR DESCRIPTION
## Description

Backport #4224 to 2.19-dev

## Commit Messages

* Implement absolute time range in search command



Unit test search with absolute time range



Rephrase timeRange and timeModifier



Switch to earliest and latest udf



Add a convert util



Verify time correctness during coversion



Fix quarter parsing bugs



Fix week snap parsing



Remove old implementation that translates time modifier to time filter



* Fix anomalyzed test & add a todo for an ignored test



* Support now() in time range



* Fix time modifier explain ITs



* Support unixtimestamp (second) as a time modifier value



* Update docs for search command with time modifiers



* Test accessing fields with name earliest and latest in search command



* Update doctest in condition.rst due to the update in the implementation of earliest and latest conditions



* Update PPLQueryDataAnonymizerTest.java



* Update explain ITs to use yaml plan files



* Update a link to OpenSearch exists



* Support using timesnaps without quotes



* Add a unit test for direct format

- additionally rename parseRelativeTime to resolveTimeModifier



* Add support to ISO 8601 date format to time modifier, as it is now widely supported in PPL



* Update syntax by reusing SPANLENGTH definition



* Update explain IT for search with time modifier



* Add integration tests for time modifiers



* Parse timestamp string with multiple parsers in a loop



* Remove opensearch test dependency from core module



* Fix unit tests



* Minor updates to explain limitations in search doc



---------


(cherry picked from commit e4685137de681a5f513a88c681b406ad5a786c27)

### Related Issues

#4135

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
