### PR TITLE
Fix the bug of explicit makeNullLiteral for UDT fields

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
@@ -126,6 +126,9 @@ public class ExtendedRexBuilder extends RexBuilder {
         //            ImmutableList.of(exp, makeZeroLiteral(sourceType)));
       }
     } else if (OpenSearchTypeFactory.isUserDefinedType(type)) {
+      if (RexLiteral.isNullLiteral(exp)) {
+        return super.makeCast(pos, type, exp, matchNullability, safe, format);
+      }
       var udt = ((AbstractExprRelDataType<?>) type).getUdt();
       var argExprType = OpenSearchTypeFactory.convertRelDataTypeToExprType(sourceType);
       return switch (udt) {

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4383.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4383.yml
@@ -1,0 +1,62 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+
+---
+"Append UDT fields should merge schema successfully":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      indices.create:
+        index: log-test1
+        body:
+          mappings:
+            properties:
+              "timestamp":
+                type: date
+  - do:
+      indices.create:
+        index: log-test2
+        body:
+          mappings:
+            properties:
+              "host":
+                type: ip
+
+  - do:
+      bulk:
+        index: log-test1
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{ "timestamp" : "2025-09-04T16:15:00.000Z" }'
+  - do:
+      bulk:
+        index: log-test2
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{ "host" : "0.0.0.2" }'
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=log-test1 | append [ source=log-test2 ]
+
+  - match: { total: 2 }
+  - match: { datarows: [["2025-09-04 16:15:00", null], [null, "0.0.0.2"]] }


### PR DESCRIPTION
### Description
Fix the bug that Calcite will error out when CalciteRelBuilder explicitly calling `makeNullLiteral` for UDT type fields. 

UDT type cast is handled by UDF. It's totally fine for `CAST` function, regardless whether the field value is NULL or non NULL. But for some cases in building RelNode, it has the problem of explicitly casting NULL to UDT type by `RexBuilder.makeNullLiteral` method. UDT cast is a RexCall of calling UDF, but `makeNullLiteral` internally expects the returned node to be RexLiteral of NULL. Thus, Calcite throws a hard error due to Java class casting failure.

This PR fixes this issue by adding a simple check and calling super method in case the RexNode to be cast is literally NULL.

### Related Issues
Resolves #4383 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
