### PR TITLE
Update stalled action timeout

### DIFF
--- a/.github/workflows/stalled.yml
+++ b/.github/workflows/stalled.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           repo-token: ${{ steps.github_app_token.outputs.token }}
           stale-pr-label: 'stalled'
-          stale-pr-message: 'This PR is stalled because it has been open for 30 days with no activity.'
-          days-before-pr-stale: 30
+          stale-pr-message: 'This PR is stalled because it has been open for 2 weeks with no activity.'
+          days-before-pr-stale: 14
           days-before-issue-stale: -1
           days-before-pr-close: -1
           days-before-issue-close: -1
+          exempt-draft-pr: true


### PR DESCRIPTION
### Description
Reduces the stalled timer to 14 days (one triage interval) and also skips marking draft PRs as stalled

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
