### PR TITLE
Fix missing keywordsCanBeId

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4481.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4481.yml
@@ -11,7 +11,7 @@
             properties:
               "as":
                 properties:
-                  "by":
+                  "field":
                     properties:
                       "on":
                         properties:
@@ -46,14 +46,14 @@
         refresh: true
         body:
           - '{"index": {}}'
-          - '{"as": {"by": {"on": {"limit": {"datamodel": {"overwrite": {"sed": {"label": {"aggregation": {"brain": {"simple_pattern": {"max_match": {"offset_field": {"to": {"millisecond": 1 } } } } } } } } } } } } } } }'
+          - '{"as": {"field": {"on": {"limit": {"datamodel": {"overwrite": {"sed": {"label": {"aggregation": {"brain": {"simple_pattern": {"max_match": {"offset_field": {"to": {"millisecond": 1 } } } } } } } } } } } } } } }'
 
   - do:
       headers:
         Content-Type: 'application/json'
       ppl:
         body:
-          query: source=log-test | fields as.by.on.limit.datamodel.overwrite.sed.label.aggregation.brain.simple_pattern.max_match.offset_field.to.millisecond
+          query: source=log-test | fields as.field.on.limit.datamodel.overwrite.sed.label.aggregation.brain.simple_pattern.max_match.offset_field.to.millisecond
 
   - match: { total: 1 }
   - length: { datarows: 1 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -17,6 +17,7 @@ EXPLAIN:                            'EXPLAIN';
 FROM:                               'FROM';
 WHERE:                              'WHERE';
 FIELDS:                             'FIELDS';
+FIELD:                              'FIELD';
 TABLE:                              'TABLE';  // Alias for FIELDS command
 RENAME:                             'RENAME';
 STATS:                              'STATS';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -1468,10 +1468,10 @@ searchableKeyWord
    | INPUT
    | OUTPUT
    | AS
-   | BY
    | ON
    | LIMIT
    | OVERWRITE
+   | FIELD
    | SED
    | MAX_MATCH
    | OFFSET_FIELD


### PR DESCRIPTION
### Description
Follow keywords was not added to `keywordsCanBeId`:
```
as
on
limit
overwrite
field
sed
label
aggregation
brain
simple_pattern
max_match
offset_field
savedsearch (deleted, never used)
datamodel (deleted, never used)
to (deleted, never used)
millisecond (deleted, never used)
```

### Related Issues
Resolves #4481 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
