### PR TITLE
Revert partial of #4401

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/util/JdbcOpenSearchDataTypeConvertor.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/util/JdbcOpenSearchDataTypeConvertor.java
@@ -98,7 +98,6 @@ public class JdbcOpenSearchDataTypeConvertor {
           return ExprValueUtils.fromObjectValue(rs.getFloat(i));
 
         case Types.DECIMAL:
-          return ExprValueUtils.fromObjectValue(rs.getBigDecimal(i));
         case Types.NUMERIC:
         case Types.DOUBLE:
           return ExprValueUtils.fromObjectValue(rs.getDouble(i));


### PR DESCRIPTION
### Description
`./gradlew ':integ-test:integTest' --tests 'org.opensearch.sql.calcite.remote.CalciteStatsCommandIT.testStatsNestedDoubleValue'` failed with 
```
    Expected: iterable with items [[60.342]] in any order
         but: not matched: <[60.34199]>
```
due to https://github.com/opensearch-project/sql/pull/4401

Fixing: All numeric computation in runtime should use `Double` instead of `BigDecimal`. Revert partial of #4401

### Related Issues
Resolves #4502 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
