### PR TITLE
Implement validation for case statement in count(eval) expression

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -33,6 +33,7 @@ import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.ArraySqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
@@ -73,6 +74,7 @@ import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.CalciteUnsupportedException;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.PPLFuncImpTable;
@@ -538,7 +540,13 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   public RexNode visitCase(Case node, CalcitePlanContext context) {
     List<RexNode> caseOperands = new ArrayList<>();
     for (When when : node.getWhenClauses()) {
-      caseOperands.add(analyze(when.getCondition(), context));
+      RexNode condition = analyze(when.getCondition(), context);
+      if (!SqlTypeUtil.isBoolean(condition.getType())) {
+        throw new ExpressionEvaluationException(
+            StringUtils.format(
+                "Condition expected a boolean type, but got %s", condition.getType()));
+      }
+      caseOperands.add(condition);
       caseOperands.add(analyze(when.getResult(), context));
     }
     RexNode elseExpr =

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4272.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4272.yml
@@ -1,0 +1,42 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+
+---
+"Test validation error for count(eval) with non-boolean expression":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      bulk:
+        index: test_accounts
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"age": 25, "name": "John", "balance": 1000}'
+          - '{"index": {}}'
+          - '{"age": 30, "name": "Jane", "balance": 2000}'
+          - '{"index": {}}'
+          - '{"age": 35, "name": "Bob", "balance": 1500}'
+
+  # Test case: count(eval()) with non-boolean expression should throw validation error
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_accounts | stats count(eval(age)) as cnt
+  - match: {"$body": "/Condition\\s+expected\\s+a\\s+boolean\\s+type,\\s+but\\s+got\\s+BIGINT/"}


### PR DESCRIPTION
### Description

`count(eval( {condition} ))` is used to count rows that satisfies a certain criteria. It is translated to a CASE statement when visiting AST:
```java
 // AstExpressionBuilder.java
  @Override
  public UnresolvedExpression visitEvalExpression(EvalExpressionContext ctx) {
    /*
     * Rewrite "eval(p)" as "CASE WHEN p THEN 1 ELSE NULL END" so that COUNT or DISTINCT_COUNT
     * can correctly perform filtered counting.
     * Note: at present only eval(<predicate>) inside counting functions is supported.
     */
    UnresolvedExpression predicate = visit(ctx.logicalExpression());
    return AstDSL.caseWhen(null, AstDSL.when(predicate, AstDSL.intLiteral(1)));
  }
```

But the validation of its parameter is skipped since it is later directly converted to a CASE call:

```java
  // CalciteRexNodeVisitor.java
  @Override
  public RexNode visitCase(Case node, CalcitePlanContext context) {
    ...
    return context.rexBuilder.makeCall(SqlStdOperatorTable.CASE, caseOperands);
  }
```

This PR checks the type of the condition and throws an `ExpressionEvaluationException` exception when the condition of case are not of boolean types.

### Related Issues
Resolves #4272

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
