### PR TITLE
Check server status before starting Prometheus

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -43,7 +43,7 @@ task bootstrap(type: Exec, dependsOn: ['cloneSqlCli']) {
 
 }
 
-def isPrometheusRunning() {
+def isPrometheusRunning = { ->
     try {
         def process = "pgrep -f prometheus".execute()
         def output = process.text

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -332,7 +332,6 @@ task startPrometheus(type: SpawnProcessTask) {
     }
     command "$projectDir/bin/prometheus/prometheus --storage.tsdb.path=$projectDir/bin/prometheus/data --config.file=$projectDir/bin/prometheus/prometheus.yml"
     ready 'TSDB started'
-    println "Prometheus started"
     onlyIf { !ignorePrometheus && !isPrometheusRunning() }
 }
 


### PR DESCRIPTION
### Description
Check server status before starting Prometheus:
Integ-test and doc-test are all need to start a OpenSearch cluster which depends on a running prometheus server. Sometimes we need to run integration tests in IDE, but face failed to start OpenSearch cluster due to prometheus server is running.

### Related Issues
Resolves #4536

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
