### PR TITLE
Update maven repo url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ buildscript {
         mavenLocal()
         mavenCentral()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/" }
+        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }
 
     dependencies {
@@ -92,7 +92,7 @@ repositories {
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     maven { url 'https://jitpack.io' }
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/" }
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }
 
 // Spotless checks will be added as PRs are applied to resolve each style issue is approved.
@@ -162,7 +162,7 @@ subprojects {
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/" }
         maven { url 'https://jitpack.io' }
-        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/" }
+        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }
 }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -53,8 +53,8 @@ boolean ignorePrometheus = ignorePrometheusProp != null && !ignorePrometheusProp
 
 repositories {
     mavenCentral()
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url 'https://jitpack.io' }
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/" }
 
     // Add extra repository for the JDBC driver if given by user
     if (System.getProperty("jdbcRepo") != null && new File(System.getProperty("jdbcRepo")).isDirectory()) {
@@ -68,7 +68,7 @@ ext {
     noticeFile = rootProject.file('NOTICE')
 
     getSecurityPluginDownloadLink = { ->
-        var repo = "https://ci.opensearch.org/ci/dbc/snapshots/org/opensearch/plugin/" +
+        var repo = "https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/plugin/" +
                    "opensearch-security/$opensearch_build_snapshot/"
         var metadataFile = Paths.get(projectDir.toString(), "build", "maven-metadata.xml").toAbsolutePath().toFile()
         download.run {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -82,7 +82,7 @@ publishing {
     repositories {
         maven {
             name = "Snapshots" //  optional target repository name
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/"
             credentials {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"


### PR DESCRIPTION
### Description
Update maven repo url to the latest

Revert the previous PR: https://github.com/opensearch-project/sql/pull/4558
The actual root cause is that the link for ci repo has changed, see related issue
### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/5360#issuecomment-3398576171

This URL for ci repo has changed
