### PR TITLE
Support IP-typed fields as arguments of GEOIP function with Calcite

### DIFF
--- a/docs/user/ppl/functions/ip.rst
+++ b/docs/user/ppl/functions/ip.rst
@@ -45,7 +45,7 @@ Description
 
 Usage: `geoip(dataSourceName, ipAddress[, options])` to lookup location information from given IP addresses via OpenSearch GeoSpatial plugin API.
 
-Argument type: STRING, STRING, STRING
+Argument type: STRING, STRING/IP, STRING
 
 Return type: OBJECT
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteGeoIpFunctionsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteGeoIpFunctionsIT.java
@@ -5,12 +5,52 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WEBLOGS;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import java.util.Map;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.GeoIpFunctionsIT;
 
 public class CalciteGeoIpFunctionsIT extends GeoIpFunctionsIT {
   @Override
   public void init() throws Exception {
     super.init();
+    loadIndex(Index.WEBLOG);
     enableCalcite();
+
+    // Only limited IPs are loaded into geospatial data sources. Therefore, we insert IPs that match
+    // those known ones for test purpose
+    Request bulkRequest = new Request("POST", "/_bulk?refresh=true");
+    bulkRequest.setJsonEntity(
+        String.format(
+            "{\"index\":{\"_index\":\"%s\",\"_id\":6}}\n"
+                + "{\"host\":\"10.0.0.1\",\"method\":\"POST\"}\n"
+                + "{\"index\":{\"_index\":\"%s\",\"_id\":7}}\n"
+                + "{\"host\":\"fd12:2345:6789:1:a1b2:c3d4:e5f6:789a\",\"method\":\"POST\"}\n",
+            TEST_INDEX_WEBLOGS, TEST_INDEX_WEBLOGS));
+    client().performRequest(bulkRequest);
+  }
+
+  // In v2 it supports only string as IP inputs
+  @Test
+  public void testGeoIpEnrichmentWithIpFieldAsInput() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where method='POST' | eval ip_to_country = geoip('%s', host,"
+                    + " 'country') | fields host, ip_to_country",
+                TEST_INDEX_WEBLOGS, DATASOURCE_NAME));
+    verifySchema(result, schema("host", "ip"), schema("ip_to_country", "struct"));
+    verifyDataRows(
+        result,
+        rows("10.0.0.1", Map.of("country", "USA")),
+        rows("fd12:2345:6789:1:a1b2:c3d4:e5f6:789a", Map.of("country", "India")));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/GeoIpFunctionsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/GeoIpFunctionsIT.java
@@ -40,7 +40,7 @@ public class GeoIpFunctionsIT extends PPLIntegTestCase {
           "endpoint",
           "https://raw.githubusercontent.com/opensearch-project/geospatial/main/src/test/resources/ip2geo/server/city/manifest.json");
 
-  private static String DATASOURCE_NAME = "dummycityindex";
+  protected static String DATASOURCE_NAME = "dummycityindex";
 
   private static String PLUGIN_NAME = "opensearch-geospatial";
 
@@ -83,7 +83,7 @@ public class GeoIpFunctionsIT extends PPLIntegTestCase {
             String.format(
                 "search source=%s | eval enrichmentResult = geoip(\\\"%s\\\",%s) | fields name, ip,"
                     + " enrichmentResult",
-                TEST_INDEX_GEOIP, "dummycityindex", "ip"));
+                TEST_INDEX_GEOIP, DATASOURCE_NAME, "ip"));
 
     verifyColumn(resultGeoIp, columnName("name"), columnName("ip"), columnName("enrichmentResult"));
     verifyDataRows(
@@ -101,7 +101,7 @@ public class GeoIpFunctionsIT extends PPLIntegTestCase {
             String.format(
                 "search source=%s | eval enrichmentResult = geoip(\\\"%s\\\",%s,\\\"%s\\\") |"
                     + " fields name, ip, enrichmentResult",
-                TEST_INDEX_GEOIP, "dummycityindex", "ip", "city"));
+                TEST_INDEX_GEOIP, DATASOURCE_NAME, "ip", "city"));
 
     verifyColumn(resultGeoIp, columnName("name"), columnName("ip"), columnName("enrichmentResult"));
     verifyDataRows(
@@ -119,7 +119,7 @@ public class GeoIpFunctionsIT extends PPLIntegTestCase {
             String.format(
                 "search source=%s | eval enrichmentResult = geoip(\\\"%s\\\",%s,\\\"%s\\\") |"
                     + " fields name, ip, enrichmentResult",
-                TEST_INDEX_GEOIP, "dummycityindex", "ip", "city , country"));
+                TEST_INDEX_GEOIP, DATASOURCE_NAME, "ip", "city , country"));
 
     verifyColumn(resultGeoIp, columnName("name"), columnName("ip"), columnName("enrichmentResult"));
     verifyDataRows(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/functions/GeoIpFunction.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/functions/GeoIpFunction.java
@@ -16,16 +16,15 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.sql.type.CompositeOperandTypeChecker;
-import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
-import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.geospatial.action.IpEnrichmentActionClient;
 import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.data.model.ExprIpValue;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 import org.opensearch.transport.client.node.NodeClient;
@@ -38,8 +37,8 @@ import org.opensearch.transport.client.node.NodeClient;
  * <p>Signatures:
  *
  * <ul>
- *   <li>(STRING, STRING) -> MAP
- *   <li>(STRING, STRING, STRING) -> MAP
+ *   <li>(STRING, IP) -> MAP
+ *   <li>(STRING, IP, STRING) -> MAP
  * </ul>
  */
 public class GeoIpFunction extends ImplementorUDF {
@@ -59,11 +58,10 @@ public class GeoIpFunction extends ImplementorUDF {
 
   @Override
   public UDFOperandMetadata getOperandMetadata() {
-    return UDFOperandMetadata.wrap(
-        (CompositeOperandTypeChecker)
-            OperandTypes.CHARACTER_CHARACTER.or(
-                OperandTypes.family(
-                    SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)));
+    return UDFOperandMetadata.wrapUDT(
+        List.of(
+            List.of(ExprCoreType.STRING, ExprCoreType.IP),
+            List.of(ExprCoreType.STRING, ExprCoreType.IP, ExprCoreType.STRING)));
   }
 
   public static class GeoIPImplementor implements NotNullImplementor {
@@ -87,16 +85,20 @@ public class GeoIpFunction extends ImplementorUDF {
     }
 
     public static Map<String, ?> fetchIpEnrichment(
-        String dataSource, String ipAddress, NodeClient nodeClient) {
-      return fetchIpEnrichment(dataSource, ipAddress, Collections.emptySet(), nodeClient);
+        String dataSource, ExprIpValue ipAddress, NodeClient nodeClient) {
+      return fetchIpEnrichment(
+          dataSource, ipAddress.toString(), Collections.emptySet(), nodeClient);
     }
 
     public static Map<String, ?> fetchIpEnrichment(
-        String dataSource, String ipAddress, String commaSeparatedOptions, NodeClient nodeClient) {
+        String dataSource,
+        ExprIpValue ipAddress,
+        String commaSeparatedOptions,
+        NodeClient nodeClient) {
       String unquotedOptions = StringUtils.unquoteText(commaSeparatedOptions);
       final Set<String> options =
           Arrays.stream(unquotedOptions.split(",")).map(String::trim).collect(Collectors.toSet());
-      return fetchIpEnrichment(dataSource, ipAddress, options, nodeClient);
+      return fetchIpEnrichment(dataSource, ipAddress.toString(), options, nodeClient);
     }
 
     private static Map<String, ?> fetchIpEnrichment(


### PR DESCRIPTION
### Description

Previously, [`GEOIP` function](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/functions/ip.rst#geoip) supports only string as its input type for IPs. However, there exists IP type in PPL, and it's counter-intuitive to not supporting it as a valid input type.

This PR makes GEOIP function accept IP input types. Please note that this correction is only valid when Calcite is enabled. V2's behavior remains unchanged.

### Related Issues
Resolves #4468

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
