### PR TITLE
Mitigate the CI failure caused by 500 Internal Server Error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,6 @@ repositories {
     maven {
         url 'https://jitpack.io'
         content { includeGroup "com.github.babbel" }
-        maxRetries = 3
-        retryDelay = 1000
     }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
 }
@@ -164,8 +162,6 @@ subprojects {
         maven {
             url 'https://jitpack.io'
             content { includeGroup "com.github.babbel" }
-            maxRetries = 3
-            retryDelay = 1000
         }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@
 version=1.13.0
 org.gradle.jvmargs=-Duser.language=en -Duser.country=US
 org.gradle.parallel=true
+org.gradle.caching=true

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -62,8 +62,6 @@ repositories {
     maven {
         url 'https://jitpack.io'
         content { includeGroup "com.github.babbel" }
-        maxRetries = 3
-        retryDelay = 1000
     }
 
     // Add extra repository for the JDBC driver if given by user

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -49,8 +49,6 @@ repositories {
     maven {
         url 'https://jitpack.io'
         content { includeGroup "com.github.babbel" }
-        maxRetries = 3
-        retryDelay = 1000
     }
 }
 


### PR DESCRIPTION
### Description
Today, the CI always fails with
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':opensearch-sql-plugin:shadowJar'.
> Could not resolve all dependencies for configuration ':opensearch-sql-plugin:runtimeClasspath'.
   > Could not resolve com.github.babbel:okhttp-aws-signer:1.0.2.
     Required by:
         project :opensearch-sql-plugin > project :ppl > project :common
      > Could not resolve com.github.babbel:okhttp-aws-signer:1.0.2.
         > Could not get resource 'https://ci.opensearch.org/ci/dbc/snapshots/maven/com/github/babbel/okhttp-aws-signer/1.0.2/okhttp-aws-signer-1.0.2.pom'.
            > Could not GET 'https://ci.opensearch.org/ci/dbc/snapshots/maven/com/github/babbel/okhttp-aws-signer/1.0.2/okhttp-aws-signer-1.0.2.pom'. Received status code 403 from server: Forbidden

      > Could not resolve com.github.babbel:okhttp-aws-signer:1.0.2.
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
         > Could not get resource 'https://ci.opensearch.org/ci/dbc/snapshots/lucene/com/github/babbel/okhttp-aws-signer/1.0.2/okhttp-aws-signer-1.0.2.pom'.

            > Could not GET 'https://ci.opensearch.org/ci/dbc/snapshots/lucene/com/github/babbel/okhttp-aws-signer/1.0.2/okhttp-aws-signer-1.0.2.pom'. Received status code 403 from server: Forbidden
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
      > Could not resolve com.github.babbel:okhttp-aws-signer:1.0.2.

         > Could not get resource 'https://jitpack.io/com/github/babbel/okhttp-aws-signer/1.0.2/okhttp-aws-signer-1.0.2.pom'.
For more on this, please refer to https://docs.gradle.org/8.14/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
            > Could not GET 'https://jitpack.io/com/github/babbel/okhttp-aws-signer/1.0.2/okhttp-aws-signer-1.0.2.pom'. Received status code 500 from server: Internal Server Error
3 actionable tasks: 3 executed
```

Add build cache to mitigate the failures when download `'https://jitpack.io'`

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
