### PR TITLE
[Maintenance] Fix CVE-2025-48924

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,9 @@ allprojects {
         resolutionStrategy.force 'org.apache.commons:commons-text:1.11.0'
         resolutionStrategy.force 'commons-io:commons-io:2.15.0'
         resolutionStrategy.force 'org.yaml:snakeyaml:2.2'
+        resolutionStrategy.dependencySubstitution {
+            substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0') because 'CVE-2025-48924: commons-lang 2.x vulnerable to StackOverflowError'
+        }
     }
 }
 


### PR DESCRIPTION
### Description
Fix CVE-2025-48924

The problematic dependency happens to be in a diamond dependency situation:

```bash
  ├── commons-lang3:3.18.0  <- correct version already
  └── calcite-core:1.38.0
      └── aggdesigner-algorithm:6.0
          └── commons-lang:2.4  <- reported version
```

### Related Issues
* Resolve https://advisories.opensearch.org/advisory/CVE-2025-48924

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
