### PR TITLE
[Backport 2.19-dev] Support millisecond span (#4672)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/expression/IntervalUnit.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/IntervalUnit.java
@@ -14,8 +14,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum IntervalUnit {
   UNKNOWN,
-
   MICROSECOND,
+  MILLISECOND,
   SECOND,
   MINUTE,
   HOUR,

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SpanUnit.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 public enum SpanUnit {
   UNKNOWN("unknown"),
   NONE(""),
+  MICROSECOND("us"),
+  US("us"),
   MILLISECOND("ms"),
   MS("ms"),
   SECONDS("s"),

--- a/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ExtendedRexBuilder.java
@@ -56,38 +56,59 @@ public class ExtendedRexBuilder extends RexBuilder {
   public SqlIntervalQualifier createIntervalUntil(SpanUnit unit) {
     TimeUnit timeUnit;
     switch (unit) {
+      case MICROSECOND:
+      case US:
+        timeUnit = TimeUnit.MICROSECOND;
+        break;
       case MILLISECOND:
       case MS:
         timeUnit = TimeUnit.MILLISECOND;
         break;
+      case SECONDS:
       case SECOND:
+      case SECS:
+      case SEC:
       case S:
         timeUnit = TimeUnit.SECOND;
         break;
+      case MINUTES:
       case MINUTE:
+      case MINS:
+      case MIN:
       case m:
         timeUnit = TimeUnit.MINUTE;
         break;
+      case HOURS:
       case HOUR:
+      case HRS:
+      case HR:
       case H:
         timeUnit = TimeUnit.HOUR;
         break;
+      case DAYS:
       case DAY:
       case D:
         timeUnit = TimeUnit.DAY;
         break;
+      case WEEKS:
       case WEEK:
       case W:
         timeUnit = TimeUnit.WEEK;
         break;
+      case MONTHS:
       case MONTH:
+      case MON:
       case M:
         timeUnit = TimeUnit.MONTH;
         break;
+      case QUARTERS:
       case QUARTER:
+      case QTRS:
+      case QTR:
       case Q:
         timeUnit = TimeUnit.QUARTER;
         break;
+      case YEARS:
       case YEAR:
       case Y:
         timeUnit = TimeUnit.YEAR;

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/PlanUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/PlanUtils.java
@@ -70,8 +70,10 @@ public interface PlanUtils {
     SpanUnit result;
     switch (unit) {
       case MICROSECOND:
-        result = SpanUnit.MILLISECOND;
+        result = SpanUnit.MICROSECOND;
         break;
+        case MILLISECOND:
+            result = SpanUnit.MILLISECOND;
       case SECOND:
         result = SpanUnit.SECOND;
         break;
@@ -108,9 +110,12 @@ public interface PlanUtils {
 
   static IntervalUnit spanUnitToIntervalUnit(SpanUnit unit) {
     switch (unit) {
+      case MICROSECOND:
+      case US:
+        return IntervalUnit.MICROSECOND;
       case MILLISECOND:
       case MS:
-        return IntervalUnit.MICROSECOND;
+        return IntervalUnit.MILLISECOND;
       case SECOND:
       case SECONDS:
       case SEC:

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.expression.datetime;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MICROS;
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -2152,6 +2153,9 @@ DATETIME,
       case "MICROSECOND":
         temporalUnit = MICROS;
         break;
+      case "MILLISECOND":
+        temporalUnit = MILLIS;
+        break;
       case "SECOND":
         temporalUnit = SECONDS;
         break;
@@ -2191,9 +2195,12 @@ DATETIME,
 
   private ExprValue getTimeDifference(String part, LocalDateTime startTime, LocalDateTime endTime) {
     long returnVal;
-    switch (part) {
+    switch (part.toUpperCase(Locale.ROOT)) {
       case "MICROSECOND":
         returnVal = MICROS.between(startTime, endTime);
+        break;
+      case "MILLISECOND":
+        returnVal = MILLIS.between(startTime, endTime);
         break;
       case "SECOND":
         returnVal = SECONDS.between(startTime, endTime);

--- a/core/src/test/java/org/opensearch/sql/ast/tree/TimechartTest.java
+++ b/core/src/test/java/org/opensearch/sql/ast/tree/TimechartTest.java
@@ -54,9 +54,9 @@ class TimechartTest {
                 let(
                     "per_second(bytes)",
                     divide(
-                        multiply("per_second(bytes)", 1.0),
+                        multiply("per_second(bytes)", 1000.0),
                         timestampdiff(
-                            "SECOND",
+                            "MILLISECOND",
                             "@timestamp",
                             timestampadd(expectedIntervalUnit, spanValue, "@timestamp")))),
                 timechart(span(spanValue, spanUnit), alias("per_second(bytes)", sum("bytes")))));
@@ -73,9 +73,9 @@ class TimechartTest {
                 let(
                     "per_minute(bytes)",
                     divide(
-                        multiply("per_minute(bytes)", 60.0),
+                        multiply("per_minute(bytes)", 60000.0),
                         timestampdiff(
-                            "SECOND",
+                            "MILLISECOND",
                             "@timestamp",
                             timestampadd(expectedIntervalUnit, spanValue, "@timestamp")))),
                 timechart(span(spanValue, spanUnit), alias("per_minute(bytes)", sum("bytes")))));
@@ -92,9 +92,9 @@ class TimechartTest {
                 let(
                     "per_hour(bytes)",
                     divide(
-                        multiply("per_hour(bytes)", 3600.0),
+                        multiply("per_hour(bytes)", 3600000.0),
                         timestampdiff(
-                            "SECOND",
+                            "MILLISECOND",
                             "@timestamp",
                             timestampadd(expectedIntervalUnit, spanValue, "@timestamp")))),
                 timechart(span(spanValue, spanUnit), alias("per_hour(bytes)", sum("bytes")))));
@@ -111,9 +111,9 @@ class TimechartTest {
                 let(
                     "per_day(bytes)",
                     divide(
-                        multiply("per_day(bytes)", 86400.0),
+                        multiply("per_day(bytes)", 8.64E7),
                         timestampdiff(
-                            "SECOND",
+                            "MILLISECOND",
                             "@timestamp",
                             timestampadd(expectedIntervalUnit, spanValue, "@timestamp")))),
                 timechart(span(spanValue, spanUnit), alias("per_day(bytes)", sum("bytes")))));
@@ -149,9 +149,9 @@ class TimechartTest {
                 let(
                     "per_second(bytes)",
                     divide(
-                        multiply("per_second(bytes)", 1.0),
+                        multiply("per_second(bytes)", 1000.0),
                         timestampdiff(
-                            "SECOND", "@timestamp", timestampadd("MINUTE", 5, "@timestamp")))),
+                            "MILLISECOND", "@timestamp", timestampadd("MINUTE", 5, "@timestamp")))),
                 expected));
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -444,8 +444,8 @@ public class CalciteExplainIT extends ExplainIT {
     var result = explainQueryToString("source=events | timechart span=2m per_second(cpu_usage)");
     assertTrue(
         result.contains(
-            "per_second(cpu_usage)=[DIVIDE(*($1, 1.0E0), "
-                + "TIMESTAMPDIFF('SECOND':VARCHAR, $0, TIMESTAMPADD('MINUTE':VARCHAR, 2, $0)))]"));
+            "per_second(cpu_usage)=[DIVIDE(*($1, 1000.0E0), TIMESTAMPDIFF('MILLISECOND':VARCHAR,"
+                + " $0, TIMESTAMPADD('MINUTE':VARCHAR, 2, $0)))]"));
     assertTrue(result.contains("per_second(cpu_usage)=[SUM($0)]"));
   }
 
@@ -454,8 +454,8 @@ public class CalciteExplainIT extends ExplainIT {
     var result = explainQueryToString("source=events | timechart span=2m per_minute(cpu_usage)");
     assertTrue(
         result.contains(
-            "per_minute(cpu_usage)=[DIVIDE(*($1, 60.0E0), "
-                + "TIMESTAMPDIFF('SECOND':VARCHAR, $0, TIMESTAMPADD('MINUTE':VARCHAR, 2, $0)))]"));
+            "per_minute(cpu_usage)=[DIVIDE(*($1, 60000.0E0), TIMESTAMPDIFF('MILLISECOND':VARCHAR,"
+                + " $0, TIMESTAMPADD('MINUTE':VARCHAR, 2, $0)))]"));
     assertTrue(result.contains("per_minute(cpu_usage)=[SUM($0)]"));
   }
 
@@ -464,8 +464,8 @@ public class CalciteExplainIT extends ExplainIT {
     var result = explainQueryToString("source=events | timechart span=2m per_hour(cpu_usage)");
     assertTrue(
         result.contains(
-            "per_hour(cpu_usage)=[DIVIDE(*($1, 3600.0E0), "
-                + "TIMESTAMPDIFF('SECOND':VARCHAR, $0, TIMESTAMPADD('MINUTE':VARCHAR, 2, $0)))]"));
+            "per_hour(cpu_usage)=[DIVIDE(*($1, 3600000.0E0), TIMESTAMPDIFF('MILLISECOND':VARCHAR,"
+                + " $0, TIMESTAMPADD('MINUTE':VARCHAR, 2, $0)))]"));
     assertTrue(result.contains("per_hour(cpu_usage)=[SUM($0)]"));
   }
 
@@ -474,8 +474,8 @@ public class CalciteExplainIT extends ExplainIT {
     var result = explainQueryToString("source=events | timechart span=2m per_day(cpu_usage)");
     assertTrue(
         result.contains(
-            "per_day(cpu_usage)=[DIVIDE(*($1, 86400.0E0), "
-                + "TIMESTAMPDIFF('SECOND':VARCHAR, $0, TIMESTAMPADD('MINUTE':VARCHAR, 2, $0)))]"));
+            "per_day(cpu_usage)=[DIVIDE(*($1, 8.64E7), TIMESTAMPDIFF('MILLISECOND':VARCHAR, $0,"
+                + " TIMESTAMPADD('MINUTE':VARCHAR, 2, $0)))]"));
     assertTrue(result.contains("per_day(cpu_usage)=[SUM($0)]"));
   }
 

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4550.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4550.yml
@@ -1,0 +1,93 @@
+setup:
+  - do:
+      indices.create:
+        index: test_data_2023
+        body:
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              "packets":
+                type: integer
+  - do:
+      bulk:
+        index: test_data_2023
+        refresh: true
+        body:
+          - '{"index":{}}'
+          - '{"@timestamp":"2023-10-08T10:00:00.000Z","packets":10}'
+          - '{"index":{}}'
+          - '{"@timestamp":"2023-10-08T10:00:00.500Z","packets":15}'
+          - '{"index":{}}'
+          - '{"@timestamp":"2023-10-08T10:00:01.000Z","packets":20}'
+          - '{"index":{}}'
+          - '{"@timestamp":"2023-10-08T10:00:01.500Z","packets":25}'
+          - '{"index":{}}'
+          - '{"@timestamp":"2023-10-08T10:00:02.000Z","packets":30}'
+
+---
+"timechart with millisecond span":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_data_2023 | timechart span=500ms count()
+
+  - match: { total: 5 }
+  - match: { "schema": [ { "name": "@timestamp", "type": "timestamp" }, { "name": "count", "type": "bigint" }] }
+  - match: {"datarows": [["2023-10-08 10:00:00", 1], ["2023-10-08 10:00:00.5", 1], ["2023-10-08 10:00:01", 1], ["2023-10-08 10:00:01.5", 1], ["2023-10-08 10:00:02", 1]]}
+
+---
+"timechart with millisecond span and per_second function":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_data_2023 | timechart span=1000ms per_second(packets)
+
+  - match: { total: 3 }
+  - match: { "schema": [ { "name": "@timestamp", "type": "timestamp" }, { "name": "per_second(packets)", "type": "double" }] }
+  - match: {"datarows": [["2023-10-08 10:00:00", 25.0], ["2023-10-08 10:00:01", 45.0], ["2023-10-08 10:00:02", 30.0]]}
+
+---
+"timechart with milliseconds":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_data_2023 | timechart span=250milliseconds count()
+
+  - match: { total: 5 }
+  - match: { "schema": [ { "name": "@timestamp", "type": "timestamp" }, { "name": "count", "type": "bigint" }] }
+
+---
+"timechart with second span for comparison":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_data_2023 | timechart span=1s count()
+
+  - match: { total: 3 }
+  - match: { "schema": [ { "name": "@timestamp", "type": "timestamp" }, { "name": "count", "type": "bigint" }] }
+  - match: {"datarows": [["2023-10-08 10:00:00", 2], ["2023-10-08 10:00:01", 2], ["2023-10-08 10:00:02", 1]]}

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -170,6 +170,7 @@ HOUR_MINUTE:                        'HOUR_MINUTE';
 HOUR_OF_DAY:                        'HOUR_OF_DAY';
 HOUR_SECOND:                        'HOUR_SECOND';
 INTERVAL:                           'INTERVAL';
+MILLISECOND:                        'MILLISECOND';
 MICROSECOND:                        'MICROSECOND';
 MINUTE:                             'MINUTE';
 MINUTE_MICROSECOND:                 'MINUTE_MICROSECOND';
@@ -505,7 +506,8 @@ ALIGNTIME:                          'ALIGNTIME';
 PERCENTILE_SHORTCUT:                PERC(INTEGER_LITERAL | DECIMAL_LITERAL) | 'P'(INTEGER_LITERAL | DECIMAL_LITERAL);
 
 SPANLENGTH: [0-9]+ (
-    'US'|'MS'|'CS'|'DS'
+    'US' |'CS'|'DS'
+    |'MS'|'MILLISECOND'|'MILLISECONDS'
     |'S'|'SEC'|'SECS'|'SECOND'|'SECONDS'
     |'MIN'|'MINS'|'MINUTE'|'MINUTES'
     |'H'|'HR'|'HRS'|'HOUR'|'HOURS'

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -1157,6 +1157,7 @@ extractFunctionCall
 
 simpleDateTimePart
    : MICROSECOND
+   | MILLISECOND
    | SECOND
    | MINUTE
    | HOUR
@@ -1335,6 +1336,7 @@ timestampLiteral
 
 intervalUnit
    : MICROSECOND
+   | MILLISECOND
    | SECOND
    | MINUTE
    | HOUR

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLTimechartTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLTimechartTest.java
@@ -86,9 +86,9 @@ public class CalcitePPLTimechartTest extends CalcitePPLAbstractTest {
   public void testTimechartPerSecond() {
     withPPLQuery("source=events | timechart per_second(cpu_usage)")
         .expectSparkSQL(
-            "SELECT `@timestamp`, `DIVIDE`(`per_second(cpu_usage)` * 1.0E0, TIMESTAMPDIFF('SECOND',"
-                + " `@timestamp`, TIMESTAMPADD('MINUTE', 1, `@timestamp`)))"
-                + " `per_second(cpu_usage)`\n"
+            "SELECT `@timestamp`, `DIVIDE`(`per_second(cpu_usage)` * 1.0000E3,"
+                + " TIMESTAMPDIFF('MILLISECOND', `@timestamp`, TIMESTAMPADD('MINUTE', 1,"
+                + " `@timestamp`))) `per_second(cpu_usage)`\n"
                 + "FROM (SELECT `SPAN`(`@timestamp`, 1, 'm') `@timestamp`, SUM(`cpu_usage`)"
                 + " `per_second(cpu_usage)`\n"
                 + "FROM `scott`.`events`\n"
@@ -100,9 +100,9 @@ public class CalcitePPLTimechartTest extends CalcitePPLAbstractTest {
   public void testTimechartPerMinute() {
     withPPLQuery("source=events | timechart per_minute(cpu_usage)")
         .expectSparkSQL(
-            "SELECT `@timestamp`, `DIVIDE`(`per_minute(cpu_usage)` * 6.00E1,"
-                + " TIMESTAMPDIFF('SECOND', `@timestamp`, TIMESTAMPADD('MINUTE', 1, `@timestamp`)))"
-                + " `per_minute(cpu_usage)`\n"
+            "SELECT `@timestamp`, `DIVIDE`(`per_minute(cpu_usage)` * 6.00000E4,"
+                + " TIMESTAMPDIFF('MILLISECOND', `@timestamp`, TIMESTAMPADD('MINUTE', 1,"
+                + " `@timestamp`))) `per_minute(cpu_usage)`\n"
                 + "FROM (SELECT `SPAN`(`@timestamp`, 1, 'm') `@timestamp`, SUM(`cpu_usage`)"
                 + " `per_minute(cpu_usage)`\n"
                 + "FROM `scott`.`events`\n"
@@ -114,9 +114,9 @@ public class CalcitePPLTimechartTest extends CalcitePPLAbstractTest {
   public void testTimechartPerHour() {
     withPPLQuery("source=events | timechart per_hour(cpu_usage)")
         .expectSparkSQL(
-            "SELECT `@timestamp`, `DIVIDE`(`per_hour(cpu_usage)` * 3.6000E3,"
-                + " TIMESTAMPDIFF('SECOND', `@timestamp`, TIMESTAMPADD('MINUTE', 1, `@timestamp`)))"
-                + " `per_hour(cpu_usage)`\n"
+            "SELECT `@timestamp`, `DIVIDE`(`per_hour(cpu_usage)` * 3.6000000E6,"
+                + " TIMESTAMPDIFF('MILLISECOND', `@timestamp`, TIMESTAMPADD('MINUTE', 1,"
+                + " `@timestamp`))) `per_hour(cpu_usage)`\n"
                 + "FROM (SELECT `SPAN`(`@timestamp`, 1, 'm') `@timestamp`, SUM(`cpu_usage`)"
                 + " `per_hour(cpu_usage)`\n"
                 + "FROM `scott`.`events`\n"
@@ -128,9 +128,9 @@ public class CalcitePPLTimechartTest extends CalcitePPLAbstractTest {
   public void testTimechartPerDay() {
     withPPLQuery("source=events | timechart per_day(cpu_usage)")
         .expectSparkSQL(
-            "SELECT `@timestamp`, `DIVIDE`(`per_day(cpu_usage)` * 8.64000E4,"
-                + " TIMESTAMPDIFF('SECOND', `@timestamp`, TIMESTAMPADD('MINUTE', 1, `@timestamp`)))"
-                + " `per_day(cpu_usage)`\n"
+            "SELECT `@timestamp`, `DIVIDE`(`per_day(cpu_usage)` * 8.64E7,"
+                + " TIMESTAMPDIFF('MILLISECOND', `@timestamp`, TIMESTAMPADD('MINUTE', 1,"
+                + " `@timestamp`))) `per_day(cpu_usage)`\n"
                 + "FROM (SELECT `SPAN`(`@timestamp`, 1, 'm') `@timestamp`, SUM(`cpu_usage`)"
                 + " `per_day(cpu_usage)`\n"
                 + "FROM `scott`.`events`\n"

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -1195,10 +1195,10 @@ public class AstBuilderTest {
                 field("per_second(a)"),
                 function(
                     "/",
-                    function("*", field("per_second(a)"), doubleLiteral(1.0)),
+                    function("*", field("per_second(a)"), doubleLiteral(1000.0)),
                     function(
                         "timestampdiff",
-                        stringLiteral("SECOND"),
+                        stringLiteral("MILLISECOND"),
                         field("@timestamp"),
                         function(
                             "timestampadd",
@@ -1220,10 +1220,10 @@ public class AstBuilderTest {
                 field("per_minute(a)"),
                 function(
                     "/",
-                    function("*", field("per_minute(a)"), doubleLiteral(60.0)),
+                    function("*", field("per_minute(a)"), doubleLiteral(60000.0)),
                     function(
                         "timestampdiff",
-                        stringLiteral("SECOND"),
+                        stringLiteral("MILLISECOND"),
                         field("@timestamp"),
                         function(
                             "timestampadd",
@@ -1245,10 +1245,10 @@ public class AstBuilderTest {
                 field("per_hour(a)"),
                 function(
                     "/",
-                    function("*", field("per_hour(a)"), doubleLiteral(3600.0)),
+                    function("*", field("per_hour(a)"), doubleLiteral(3600000.0)),
                     function(
                         "timestampdiff",
-                        stringLiteral("SECOND"),
+                        stringLiteral("MILLISECOND"),
                         field("@timestamp"),
                         function(
                             "timestampadd",
@@ -1270,10 +1270,10 @@ public class AstBuilderTest {
                 field("per_day(a)"),
                 function(
                     "/",
-                    function("*", field("per_day(a)"), doubleLiteral(86400.0)),
+                    function("*", field("per_day(a)"), doubleLiteral(8.64E7)),
                     function(
                         "timestampdiff",
-                        stringLiteral("SECOND"),
+                        stringLiteral("MILLISECOND"),
                         field("@timestamp"),
                         function(
                             "timestampadd",


### PR DESCRIPTION
### Description
Backport #4672 to 2.19-dev


### Commit Message

* Support millisecond span



* Update per funciton tests



---------


(cherry picked from commit b224750d9bb865aa6695055c6ec4246485f597c2)



### Related Issues
Resolves #4550 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
