### PR TITLE
Do not remove nested fields in resolving AllFieldsExcludeMeta

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/expression/AllFields.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/AllFields.java
@@ -18,7 +18,7 @@ import org.opensearch.sql.ast.Node;
 public class AllFields extends UnresolvedExpression {
   public static final AllFields INSTANCE = new AllFields();
 
-  public AllFields() {}
+  protected AllFields() {}
 
   public static AllFields of() {
     return INSTANCE;

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -380,7 +380,10 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
           "Invalid field exclusion: operation would exclude all fields from the result set");
     }
     AllFields allFields = (AllFields) node.getProjectList().getFirst();
-    tryToRemoveNestedFields(context);
+    if (!(allFields instanceof AllFieldsExcludeMeta)) {
+      // Should not remove nested fields for AllFieldsExcludeMeta.
+      tryToRemoveNestedFields(context);
+    }
     tryToRemoveMetaFields(context, allFields instanceof AllFieldsExcludeMeta);
     return context.relBuilder.peek();
   }

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4575.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4575.yml
@@ -1,0 +1,60 @@
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              a:
+                properties:
+                  b:
+                    properties:
+                      c:
+                        type: keyword
+              d:
+                properties:
+                  e:
+                    properties:
+                      f:
+                        type: keyword
+              num:
+                type: integer
+
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+
+---
+"Access struct fields after join":
+  - skip:
+      features:
+        - headers
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"a": {"b": {"c": "/a/b/c"} }, "d": {"e": {"f": "/d/e/f"} }, "num": 10 }'
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=test | eval N=d.e.f | join type=inner left=l, right=r ON l.N = r.F [ source=test | rename d.e.f as F | fields F ] | fields num, N, a.b.c, d.e.f'
+  - match: {"total": 1}
+  - match: { schema: [ { "name": "num", "type": "int" }, { "name": "N", "type": "string" }, { "name": "a.b.c", "type": "string" }, { "name": "d.e.f", "type": "string" } ] }
+  - match: { datarows: [ [ 10, "/d/e/f",  "/a/b/c",  "/d/e/f"] ] }


### PR DESCRIPTION
### Description
Fix the issue that struct/nested field cannot be accessed after join (or other bi-operator):
```
{
  "mappings": {
    "properties": {
      "time": { "type": "date" },
      "a": {
        "properties": {
          "b": {
            "properties": {
              "c": { "type": "keyword" }
            }
          }
        }
      },
      "d": {
        "properties": {
          "e": {
            "properties": {
              "f": { "type": "keyword" }
            }
          }
        }
      }
    }
  }
}
```
For query
```
source=test | join type=inner left=l, right=r ON l.time = r.time test
| fields a.b.c
```
its AST tree is
```
plan=Project(projectList=[AllFields()]
	child=[Join(
		left=SubqueryAlias(alias=l, 
			child=[Project(projectList=[AllFieldsExcludeMeta()]
				child=[Relation(tableNames=[test])])])]),
		right=SubqueryAlias(alias=r, 
			child=[Project(projectList=[AllFieldsExcludeMeta()]
				child=[Relation(tableNames=[test])])])])])
```

Current `visitProject()` **mistakenly removes nested fields** in handling `AllFieldsExcludeMeta`, which cause no `a.b.c` fields in join's children. So `a.b.c` cannot be accessed after join.

### Related Issues
Resolves #4575 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
