### PR TITLE
Support access to nested field of struct after fields command

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -177,11 +177,10 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
           return TYPE_FACTORY.createArrayType(
               TYPE_FACTORY.createSqlType(SqlTypeName.ANY, nullable), -1);
         case STRUCT:
-          // TODO: should use RelRecordType instead of MapSqlType here
-          // https://github.com/opensearch-project/sql/issues/3459
           final RelDataType relKey = TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
+          // TODO: should we provide more precise type here?
           return TYPE_FACTORY.createMapType(
-              relKey, TYPE_FACTORY.createSqlType(SqlTypeName.BINARY), nullable);
+              relKey, TYPE_FACTORY.createSqlType(SqlTypeName.ANY), nullable);
         case UNKNOWN:
         default:
           throw new IllegalArgumentException(

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3459.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3459.yml
@@ -1,0 +1,59 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              parent_field:
+                properties:
+                  child_field:
+                    type: integer
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{ "parent_field": { "child_field": 4 } }'
+          - '{"index": {}}'
+          - '{ "parent_field": { "child_field": 3 } }'
+          - '{"index": {}}'
+          - '{ "parent_field": { "child_field": 2 } }'
+          - '{"index": {}}'
+          - '{ "parent_field": { "child_field": 1 } }'
+          - '{"index": {}}'
+          - '{ "parent_field": { "child_field": 5 } }'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+
+---
+"Access to nested field after field command":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test | fields parent_field | sort parent_field.child_field | head 3
+
+  - match: { total: 3 }
+  - match: { schema: [ { "name": "parent_field", "type": "struct" } ] }
+  - match: { datarows: [ [ {"child_field": 1} ], [ {"child_field": 2} ], [ {"child_field": 3} ] ] }


### PR DESCRIPTION
### Description
Support access to nested field of struct after fields command

### Related Issues
Resolves #3459

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
