### PR TITLE
Add `allowed_warnings` in yaml restful tests

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3459.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3459.yml
@@ -48,6 +48,8 @@ teardown:
         - allowed_warnings
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3655.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3655.yml
@@ -44,6 +44,8 @@ teardown:
             plugins.calcite.enabled : true
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -54,6 +56,8 @@ teardown:
   - match: {"datarows": [["This is a match_only_text field 1"]]}
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -66,6 +70,8 @@ teardown:
 ---
 "Support match_only_text field type with Calcite disabled":
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3946.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/3946.yml
@@ -39,7 +39,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
-      allowed_warnings: []
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4201.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4201.yml
@@ -88,6 +88,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4339.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4339.yml
@@ -46,6 +46,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -72,6 +73,8 @@ teardown:
           - '{"index": {}}'
           - '{"log": {"url": {"time": 2} } }'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4342.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4342.yml
@@ -37,6 +37,8 @@ teardown:
           - '{ "@timestamp" : "2025-09-04T16:15:00.000Z" }'
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4356.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4356.yml
@@ -74,7 +74,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -84,6 +87,8 @@ teardown:
   - match: {"datarows": [[10.0, 0.1], [15.0, 0.15], [null, null], [null, null]]}
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -93,6 +98,8 @@ teardown:
   - match: { "datarows": [ [ "11", 1.0 ], [ "1.51.5", 2.25 ], [ "truetrue", null ], [ "abcdeabcde", null ] ] }
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -106,7 +113,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -116,6 +126,8 @@ teardown:
   - match: {"datarows": [[true,true,null], [false,true,null], [null, null, true], [null, null, null]]}
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -129,7 +141,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -144,7 +159,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -158,7 +176,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -168,6 +189,8 @@ teardown:
   - match: {"datarows": [[4, 2.5, 1.25]]}
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -181,7 +204,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4383.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4383.yml
@@ -52,6 +52,8 @@ teardown:
           - '{ "host" : "0.0.0.2" }'
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4391.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4391.yml
@@ -27,6 +27,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4407.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4407.yml
@@ -27,6 +27,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4415.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4415.yml
@@ -31,6 +31,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4469.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4469.yml
@@ -46,6 +46,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4481.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4481.yml
@@ -49,6 +49,8 @@
           - '{"as": {"field": {"on": {"limit": {"datamodel": {"overwrite": {"sed": {"label": {"aggregation": {"brain": {"simple_pattern": {"max_match": {"offset_field": {"to": {"millisecond": 1 } } } } } } } } } } } } } } }'
 
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4490.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4490.yml
@@ -25,6 +25,8 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -42,6 +44,8 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4513.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4513.yml
@@ -17,6 +17,8 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -34,6 +36,8 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4527.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4527.yml
@@ -41,6 +41,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       catch: bad_request
       headers:
         Content-Type: 'application/json'

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4529.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4529.yml
@@ -37,6 +37,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4547.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4547.yml
@@ -170,6 +170,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -184,6 +186,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4550.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4550.yml
@@ -32,6 +32,8 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -49,6 +51,8 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -66,6 +70,8 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -82,6 +88,8 @@ setup:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4559.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4559.yml
@@ -41,6 +41,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -58,6 +59,8 @@ teardown:
                }
              }'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4563_4664.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4563_4664.yml
@@ -35,7 +35,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -51,7 +54,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4575.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4575.yml
@@ -42,7 +42,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       bulk:
         index: test
         refresh: true
@@ -50,6 +53,8 @@ teardown:
           - '{"index": {}}'
           - '{"a": {"b": {"c": "/a/b/c"} }, "d": {"e": {"f": "/d/e/f"} }, "num": 10 }'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4580.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4580.yml
@@ -36,6 +36,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -53,6 +55,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -70,6 +74,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -87,6 +93,8 @@ teardown:
         - headers
         - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4619.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4619.yml
@@ -46,6 +46,7 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
       bulk:
         index: test
@@ -72,6 +73,8 @@ teardown:
           - '{"index": {}}'
           - '{"log": {"url": {"time": 2} } }'
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4705.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4705.yml
@@ -38,7 +38,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -53,7 +56,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -68,7 +74,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -83,7 +92,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -98,7 +110,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -113,7 +128,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:
@@ -128,7 +146,10 @@ teardown:
   - skip:
       features:
         - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
       headers:
         Content-Type: 'application/json'
       ppl:


### PR DESCRIPTION
### Description
Even we've merged #4569, we'd better still to add  `allowed_warnings` in all yaml restful tests due to the PRs are always needed to backport to 2.19-dev branch which is no `_shard_doc` can be used.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
