### PR TITLE
Coerce any to specific types for dynamic fields

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -247,7 +247,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     RexNode fieldRex = rexVisitor.analyze(node.getField(), context);
     RexNode patternRex = rexVisitor.analyze(node.getPattern(), context);
 
-    if (!SqlTypeFamily.CHARACTER.contains(fieldRex.getType())) {
+    if (!SqlTypeFamily.CHARACTER.contains(fieldRex.getType())
+        && !SqlTypeName.ANY.equals(fieldRex.getType().getSqlTypeName())) {
       throw new IllegalArgumentException(
           String.format(
               "Regex command requires field of string type, but got %s for field '%s'",
@@ -255,8 +256,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     }
 
     RexNode regexCondition =
-        context.rexBuilder.makeCall(
-            org.apache.calcite.sql.fun.SqlLibraryOperators.REGEXP_CONTAINS, fieldRex, patternRex);
+        PPLFuncImpTable.INSTANCE.resolve(
+            context.rexBuilder, BuiltinFunctionName.REGEX_MATCH, fieldRex, patternRex);
 
     if (node.isNegated()) {
       regexCondition = context.rexBuilder.makeCall(SqlStdOperatorTable.NOT, regexCondition);


### PR DESCRIPTION
### Description
- Coerce any to specific types
- This is for dynamic fields to work without explicit cast.

### Related Issues
Permissive mode RFC: https://github.com/opensearch-project/sql/issues/4349
Dynamic fields RFC: https://github.com/opensearch-project/sql/issues/4433

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
