### PR TITLE
Fix eval on grouped fields after timechart

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/plan/LogicalSystemLimit.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/LogicalSystemLimit.java
@@ -65,16 +65,15 @@ public class LogicalSystemLimit extends Sort {
   }
 
   public static LogicalSystemLimit create(SystemLimitType type, RelNode input, RexNode fetch) {
-    return create(type, input, input.getTraitSet().getCollation(), null, fetch);
+    return create(type, input, null, fetch);
   }
 
   public static LogicalSystemLimit create(
-      SystemLimitType type,
-      RelNode input,
-      RelCollation collation,
-      @Nullable RexNode offset,
-      @Nullable RexNode fetch) {
+      SystemLimitType type, RelNode input, @Nullable RexNode offset, @Nullable RexNode fetch) {
     RelOptCluster cluster = input.getCluster();
+    List<RelCollation> collations = input.getTraitSet().getTraits(RelCollationTraitDef.INSTANCE);
+    // When there exists multiple sets of equivalent collations, we randomly select one
+    RelCollation collation = collations == null ? null : collations.get(0);
     collation = RelCollationTraitDef.INSTANCE.canonize(collation);
     RelTraitSet traitSet = input.getTraitSet().replace(Convention.NONE).replace(collation);
     return new LogicalSystemLimit(type, cluster, traitSet, input, collation, offset, fetch);

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4644.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4644.yml
@@ -1,0 +1,88 @@
+setup:
+  - do:
+      indices.create:
+        index: timechart-eval-bug
+        body:
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              "user":
+                type: keyword
+  - do:
+      bulk:
+        index: timechart-eval-bug
+        refresh: true
+        body:
+          - '{"index":{}}'
+          - '{"@timestamp":"2024-05-01T00:15:00Z","user":"alice"}'
+          - '{"index":{}}'
+          - '{"@timestamp":"2024-05-01T00:30:00Z","user":"bob"}'
+          - '{"index":{}}'
+          - '{"@timestamp":"2024-05-02T00:45:00Z","user":"alice"}'
+          - '{"index":{}}'
+          - '{"@timestamp":"2024-05-03T00:20:00Z","user":"bob"}'
+
+---
+"timechart with eval on @timestamp field":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=timechart-eval-bug | where HOUR(@timestamp) = 0 | timechart span=1d COUNT() by user | eval copyTimestamp = @timestamp
+
+  - match: { total: 4 }
+  - match: { "schema": [ { "name": "@timestamp", "type": "timestamp" }, { "name": "user", "type": "string" }, { "name": "COUNT()", "type": "bigint" }, { "name": "copyTimestamp", "type": "timestamp" }] }
+  - match: {"datarows": [["2024-05-01 00:00:00", "alice", 1, "2024-05-01 00:00:00"], ["2024-05-01 00:00:00", "bob", 1, "2024-05-01 00:00:00"], ["2024-05-02 00:00:00", "alice", 1, "2024-05-02 00:00:00"], ["2024-05-03 00:00:00", "bob", 1, "2024-05-03 00:00:00"]]}
+
+---
+"timechart with eval on by field":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=timechart-eval-bug | where HOUR(@timestamp) = 0 | timechart span=1d COUNT() by user | eval copyUser = user
+
+  - match: { total: 4 }
+  - match: { "schema": [ { "name": "@timestamp", "type": "timestamp" }, { "name": "user", "type": "string" }, { "name": "COUNT()", "type": "bigint" }, { "name": "copyUser", "type": "string" }] }
+  - match: {"datarows": [["2024-05-01 00:00:00", "alice", 1, "alice"], ["2024-05-01 00:00:00", "bob", 1, "bob"], ["2024-05-02 00:00:00", "alice", 1, "alice"], ["2024-05-03 00:00:00", "bob", 1, "bob"]]}
+
+---
+"timechart with eval on aggregated field":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=timechart-eval-bug | where HOUR(@timestamp) = 0 | timechart span=1d COUNT() by user | eval doubleCount = `COUNT()` * 2
+
+  - match: { total: 4 }
+  - match: { "schema": [ { "name": "@timestamp", "type": "timestamp" }, { "name": "user", "type": "string" }, { "name": "COUNT()", "type": "bigint" }, { "name": "doubleCount", "type": "bigint" }] }
+  - match: {"datarows": [["2024-05-01 00:00:00", "alice", 1, 2], ["2024-05-01 00:00:00", "bob", 1, 2], ["2024-05-02 00:00:00", "alice", 1, 2], ["2024-05-03 00:00:00", "bob", 1, 2]]}
+
+---
+"timechart with DATE_FORMAT on @timestamp":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=timechart-eval-bug | where HOUR(@timestamp) = 0 | timechart span=1d COUNT() by user | eval formatted_date = DATE_FORMAT(@timestamp, 'yyyy-MM-dd')
+
+  - match: { total: 4 }
+  - match: { "schema": [ { "name": "@timestamp", "type": "timestamp" }, { "name": "user", "type": "string" }, { "name": "COUNT()", "type": "bigint" }, { "name": "formatted_date", "type": "string" }] }
+  - match: {"datarows": [["2024-05-01 00:00:00", "alice", 1, "2024-05-01"], ["2024-05-01 00:00:00", "bob", 1, "2024-05-01"], ["2024-05-02 00:00:00", "alice", 1, "2024-05-02"], ["2024-05-03 00:00:00", "bob", 1, "2024-05-03"]]}


### PR DESCRIPTION
### Description
Reduce RelCompositeTrait of RelCollation to a single collation when creating LogicalSystemLimit

### Related Issues
Resolves #4644

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
