### PR TITLE
Adds parenthesis support at the PPL parser -> AST stage

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -98,4 +98,44 @@ public class WhereCommandIT extends PPLIntegTestCase {
                 TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifyDataRows(result, rows("Amber JOHnny"));
   }
+
+  @Test
+  public void testWhereWithParentheses() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where (firstname='Amber') | fields firstname",
+                TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Amber"));
+  }
+
+  @Test
+  public void testWhereWithParenthesesAndLogicalOperators() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where (firstname='Amber' and lastname='Duke') or age=36 | fields firstname, lastname, age",
+                TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Amber", "Duke", 32), rows("Hattie", "Bond", 36));
+  }
+
+  @Test
+  public void testWhereWithNestedParentheses() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where ((firstname='Amber' and lastname='Duke') or (firstname='Hattie' and lastname='Bond')) | fields firstname, lastname",
+                TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Amber", "Duke"), rows("Hattie", "Bond"));
+  }
+
+  @Test
+  public void testWhereWithParenthesesAndNot() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where not (age < 30) and firstname='Amber' | fields firstname, age",
+                TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Amber", 32));
+  }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -257,8 +257,9 @@ expression
 
 // predicates
 logicalExpression
-   : comparisonExpression                                       # comparsion
-   | NOT logicalExpression                                      # logicalNot
+   : NOT logicalExpression                                      # logicalNot
+   | LT_PRTHS logicalExpression RT_PRTHS                        # parentheticLogicalExpr
+   | comparisonExpression                                       # comparsion
    | left = logicalExpression OR right = logicalExpression      # logicalOr
    | left = logicalExpression (AND)? right = logicalExpression  # logicalAnd
    | left = logicalExpression XOR right = logicalExpression     # logicalXor

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -96,6 +96,12 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     return new Xor(visit(ctx.left), visit(ctx.right));
   }
 
+  @Override
+  public UnresolvedExpression visitParentheticLogicalExpr(
+      OpenSearchPPLParser.ParentheticLogicalExprContext ctx) {
+    return visit(ctx.logicalExpression()); // Discard parenthesis around
+  }
+
   /** Comparison expression. */
   @Override
   public UnresolvedExpression visitCompareExpr(CompareExprContext ctx) {

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -98,6 +98,55 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
   }
 
   @Test
+  public void testParentheticLogicalExpr() {
+    assertEqual(
+        "source=t | where (a=1)",
+        filter(relation("t"), compare("=", field("a"), intLiteral(1))));
+  }
+
+  @Test
+  public void testParentheticLogicalExprWithAnd() {
+    assertEqual(
+        "source=t | where (a=1 and b=2) or c=3",
+        filter(
+            relation("t"),
+            or(
+                and(compare("=", field("a"), intLiteral(1)), compare("=", field("b"), intLiteral(2))),
+                compare("=", field("c"), intLiteral(3)))));
+  }
+
+  @Test
+  public void testParentheticLogicalExprWithOr() {
+    assertEqual(
+        "source=t | where a=1 and (b=2 or c=3)",
+        filter(
+            relation("t"),
+            and(
+                compare("=", field("a"), intLiteral(1)),
+                or(compare("=", field("b"), intLiteral(2)), compare("=", field("c"), intLiteral(3))))));
+  }
+
+  @Test
+  public void testNestedParentheticLogicalExpr() {
+    assertEqual(
+        "source=t | where ((a=1 and b=2) or (c=3 and d=4))",
+        filter(
+            relation("t"),
+            or(
+                and(compare("=", field("a"), intLiteral(1)), compare("=", field("b"), intLiteral(2))),
+                and(compare("=", field("c"), intLiteral(3)), compare("=", field("d"), intLiteral(4))))));
+  }
+
+  @Test
+  public void testParentheticLogicalExprWithNot() {
+    assertEqual(
+        "source=t | where not (a=1 and b=2)",
+        filter(
+            relation("t"),
+            not(and(compare("=", field("a"), intLiteral(1)), compare("=", field("b"), intLiteral(2))))));
+  }
+
+  @Test
   public void testLogicalLikeExpr() {
     assertEqual(
         "source=t like(a, '_a%b%c_d_')",


### PR DESCRIPTION
### Description
Add parentheses support to the where command in the PPL V2.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
