### PR TITLE
Update github workflows to move from macos-13 to 14

### DIFF
--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, macos-13 ]
+        os: [ windows-latest, macos-14 ]
         java: [21, 24]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -107,8 +107,8 @@ jobs:
         entry:
           - { os: windows-latest, java: 21, os_build_args: -PbuildPlatform=windows }
           - { os: windows-latest, java: 24, os_build_args: -PbuildPlatform=windows }
-          - { os: macos-13, java: 21, os_build_args: '' }
-          - { os: macos-13, java: 24, os_build_args: '' }
+          - { os: macos-14, java: 21, os_build_args: '' }
+          - { os: macos-14, java: 24, os_build_args: '' }
         test-type: ['unit', 'integration', 'doc']
         exclude:
           # Exclude doctest for Windows


### PR DESCRIPTION
### Description
- Update github workflows to move from macos-13 to 14
- Reference: https://github.com/actions/runner-images/issues/13046

### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
