### PR TITLE
Version bump 2.19-dev to 2.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.19.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.19.4-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -45,7 +45,7 @@ apply plugin: 'java'
 apply plugin: 'io.freefair.lombok'
 apply plugin: 'com.wiredforcode.spawn'
 
-String baseVersion = "2.19.0"
+String baseVersion = "2.19.4"
 String bwcFilePath = "src/test/resources/bwc/"
 String calciteCodegen = "$projectDir/src/test/java/codegen/"
 String ignorePrometheusProp = System.getProperty("ignorePrometheus")


### PR DESCRIPTION
### Description
Updates our 2.19 build artifact and the version of OS we're building against. Some weird bugs are coming from relying on OS 2.19.0's Netty version.

### Related Issues
Any request with `Accept-Encoding: zstd` hangs with the 2.19.0 artifact.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
