### PR TITLE
Grouping key field type can only be overwritten when the `ExprCoreType`s are different

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4845.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4845.yml
@@ -1,0 +1,49 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              "EventDate":
+                type: date
+                format: yyyy-MM-dd HH:mm:ss||strict_date_optional_time||epoch_millis
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"EventDate": "2013-07-15 10:47:34"}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+
+---
+"handle custom format field with pushdown":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test | stats count() by EventDate
+
+  - match: { total: 1 }
+  - match: {"schema": [{"name": "count()", "type": "bigint"},{"name": "EventDate", "type": "timestamp"}]}
+  - match: {"datarows": [[1, "2013-07-15 10:47:34"]]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -79,13 +79,20 @@ public class OpenSearchExprValueFactory {
   private final boolean fieldTypeTolerance;
 
   /**
-   * Extend existing mapping by new data without overwrite. Called from aggregation only {@see
-   * AggregationQueryBuilder#buildTypeMapping}.
+   * Extend existing mapping by new data. Overwrite only when the ExprCoreType of them are
+   * different. Called from aggregation only {@see AggregationQueryBuilder#buildTypeMapping}.
    *
    * @param typeMapping A data type mapping produced by aggregation.
    */
   public void extendTypeMapping(Map<String, OpenSearchDataType> typeMapping) {
-    this.typeMapping.putAll(typeMapping);
+    typeMapping.forEach(
+        (groupKey, extendedType) -> {
+          OpenSearchDataType existedType = this.typeMapping.get(groupKey);
+          if (existedType == null
+              || !existedType.getExprCoreType().equals(extendedType.getExprCoreType())) {
+            this.typeMapping.put(groupKey, extendedType);
+          }
+        });
   }
 
   @Getter @Setter private OpenSearchAggregationResponseParser parser;


### PR DESCRIPTION
### Description
This bug introduced by https://github.com/opensearch-project/sql/pull/4500 by overwriting a new OpenSearchDateType which the custom formats are missing.
How to fix:
We only overwrite the group field' type when their `ExprCoreType`s are different.

### Related Issues
Resolves #4845

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
