### PR TITLE
[Backport 2.19-dev] Specify timestamp field with `timefield` in timechart command (#4784)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/tree/Chart.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Chart.java
@@ -97,16 +97,14 @@ public class Chart extends UnresolvedPlan {
 
     PerFunction perFunc = perFuncOpt.get();
     // For chart, the rowSplit should contain the span information
-    UnresolvedExpression spanExpr = rowSplit;
-    if (rowSplit instanceof Alias) {
-      spanExpr = ((Alias) rowSplit).getDelegated();
-    }
+    UnresolvedExpression spanExpr =
+        rowSplit instanceof Alias ? ((Alias) rowSplit).getDelegated() : rowSplit;
     if (!(spanExpr instanceof Span)) {
       return this; // Cannot transform without span information
     }
 
     Span span = (Span) spanExpr;
-    Field spanStartTime = AstDSL.implicitTimestampField();
+    Field spanStartTime = (Field) span.getField();
     Function spanEndTime = timestampadd(span.getUnit(), span.getValue(), spanStartTime);
     Function spanMillis = timestampdiff(MILLISECOND, spanStartTime, spanEndTime);
     final int SECOND_IN_MILLISECOND = 1000;

--- a/docs/user/ppl/cmd/timechart.rst
+++ b/docs/user/ppl/cmd/timechart.rst
@@ -22,12 +22,14 @@ Syntax
 
 .. code-block:: text
 
-   timechart [span=<time_interval>] [limit=<number>] [useother=<boolean>] <aggregation_function> [by <field>]
+   timechart [timefield=<field_name>] [span=<time_interval>] [limit=<number>] [useother=<boolean>] <aggregation_function> [by <field>]
 
 **Parameters:**
 
+* **timefield**:  optional. Specifies the timestamp field to use for time interval grouping. **Default**: ``@timestamp``.
+
 * **span**: optional. Specifies the time interval for grouping data.
-  
+
   * Default: 1m (1 minute)
   * Available time units:
 
@@ -105,7 +107,7 @@ Return type: DOUBLE
 Notes
 =====
 
-* The ``timechart`` command requires a timestamp field named ``@timestamp`` in the data.
+* The ``timechart`` command requires a timestamp field in the data. By default, it uses the ``@timestamp`` field, but you can specify a different field using the ``timefield`` parameter.
 * Results are returned in an unpivoted format with separate rows for each time-field combination that has data.
 * Only combinations with actual data are included in the results - empty combinations are omitted rather than showing null or zero values.
 * The "top N" values for the ``limit`` parameter are selected based on the sum of values across all time intervals for each distinct field value.

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteTimechartCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteTimechartCommandIT.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.ResponseException;
+import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class CalciteTimechartCommandIT extends PPLIntegTestCase {
@@ -64,7 +65,7 @@ public class CalciteTimechartCommandIT extends PPLIntegTestCase {
   }
 
   @Test
-  public void testTimechartWithoutTimestampField() throws IOException {
+  public void testTimechartWithoutTimestampField() {
     Throwable exception =
         assertThrows(
             ResponseException.class,
@@ -72,6 +73,16 @@ public class CalciteTimechartCommandIT extends PPLIntegTestCase {
               executeQuery(String.format("source=%s | timechart count()", TEST_INDEX_BANK));
             });
     verifyErrorMessageContains(exception, "Field [@timestamp] not found.");
+  }
+
+  @Test
+  public void testTimechartWithCustomTimeField() throws IOException {
+    JSONObject result =
+        executeQuery(
+            StringUtils.format(
+                "source=%s | timechart timefield=birthdate span=1year count()", TEST_INDEX_BANK));
+    verifySchema(result, schema("birthdate", "timestamp"), schema("count()", "bigint"));
+    verifyDataRows(result, rows("2017-01-01 00:00:00", 2), rows("2018-01-01 00:00:00", 5));
   }
 
   @Test

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -146,6 +146,7 @@ LIMIT:                              'LIMIT';
 USEOTHER:                           'USEOTHER';
 OTHERSTR:                           'OTHERSTR';
 NULLSTR:                            'NULLSTR';
+TIMEFIELD:                          'TIMEFIELD';
 INPUT:                              'INPUT';
 OUTPUT:                             'OUTPUT';
 PATH:                               'PATH';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -332,6 +332,7 @@ timechartParameter
    : LIMIT EQUAL integerLiteral
    | SPAN EQUAL spanLiteral
    | USEOTHER EQUAL (booleanLiteral | ident)
+   | TIMEFIELD EQUAL (ident | stringLiteral)
    ;
 
 spanLiteral
@@ -1613,6 +1614,7 @@ searchableKeyWord
    | SED
    | MAX_MATCH
    | OFFSET_FIELD
+   | TIMEFIELD
    | patternMethod
    | patternMode
    // AGGREGATIONS AND WINDOW

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -749,7 +749,7 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     return new Argument("max", (Literal) this.visit(ctx.integerLiteral()));
   }
 
-  private QualifiedName visitIdentifiers(List<? extends ParserRuleContext> ctx) {
+  public QualifiedName visitIdentifiers(List<? extends ParserRuleContext> ctx) {
     return new QualifiedName(
         ctx.stream()
             .map(RuleContext::getText)
@@ -985,47 +985,6 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
       osDateMathExpression = DateTimeUtils.resolveTimeModifier(pplTimeModifier);
     }
     return AstDSL.stringLiteral(osDateMathExpression);
-  }
-
-  @Override
-  public UnresolvedExpression visitTimechartParameter(
-      OpenSearchPPLParser.TimechartParameterContext ctx) {
-    UnresolvedExpression timechartParameter;
-    if (ctx.SPAN() != null) {
-      // Convert span=1h to span(@timestamp, 1h)
-      Literal spanLiteral = (Literal) visit(ctx.spanLiteral());
-      timechartParameter =
-          AstDSL.spanFromSpanLengthLiteral(AstDSL.implicitTimestampField(), spanLiteral);
-    } else if (ctx.LIMIT() != null) {
-      Literal limit = (Literal) visit(ctx.integerLiteral());
-      if ((Integer) limit.getValue() < 0) {
-        throw new IllegalArgumentException("Limit must be a non-negative number");
-      }
-      timechartParameter = limit;
-    } else if (ctx.USEOTHER() != null) {
-      UnresolvedExpression useOther;
-      if (ctx.booleanLiteral() != null) {
-        useOther = visit(ctx.booleanLiteral());
-      } else if (ctx.ident() != null) {
-        QualifiedName ident = visitIdentifiers(List.of(ctx.ident()));
-        String useOtherValue = ident.toString();
-        if ("true".equalsIgnoreCase(useOtherValue) || "t".equalsIgnoreCase(useOtherValue)) {
-          useOther = AstDSL.booleanLiteral(true);
-        } else if ("false".equalsIgnoreCase(useOtherValue) || "f".equalsIgnoreCase(useOtherValue)) {
-          useOther = AstDSL.booleanLiteral(false);
-        } else {
-          throw new IllegalArgumentException(
-              "Invalid useOther value: " + ctx.ident().getText() + ". Expected true/false or t/f");
-        }
-      } else {
-        throw new IllegalArgumentException("value for useOther must be a boolean or identifier");
-      }
-      timechartParameter = useOther;
-    } else {
-      throw new IllegalArgumentException(
-          String.format("A parameter of timechart must be a span, limit or useOther, got %s", ctx));
-    }
-    return timechartParameter;
   }
 
   /**

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/ArgumentFactory.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/ArgumentFactory.java
@@ -33,6 +33,7 @@ import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.PrefixSortFieldCo
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SortFieldContext;
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.StreamstatsCommandContext;
 import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser.SuffixSortFieldContext;
+import org.opensearch.sql.ppl.parser.AstExpressionBuilder;
 
 /** Util class to get all arguments as a list from the PPL command. */
 public class ArgumentFactory {
@@ -244,6 +245,60 @@ public class ArgumentFactory {
         arguments.add(new Argument("usenull", getArgumentValue(optionCtx.booleanLiteral())));
       } else if (optionCtx.NULLSTR() != null) {
         arguments.add(new Argument("nullstr", getArgumentValue(optionCtx.stringLiteral())));
+      }
+    }
+    return arguments;
+  }
+
+  public static List<Argument> getArgumentList(
+      OpenSearchPPLParser.TimechartCommandContext timechartCtx,
+      AstExpressionBuilder expressionBuilder) {
+    List<Argument> arguments = new ArrayList<>();
+    for (OpenSearchPPLParser.TimechartParameterContext ctx : timechartCtx.timechartParameter()) {
+      if (ctx.SPAN() != null) {
+        arguments.add(
+            new Argument("spanliteral", (Literal) expressionBuilder.visit(ctx.spanLiteral())));
+      } else if (ctx.LIMIT() != null) {
+        Literal limit = getArgumentValue(ctx.integerLiteral());
+        if ((Integer) limit.getValue() < 0) {
+          throw new IllegalArgumentException("Limit must be a non-negative number");
+        }
+        arguments.add(new Argument("limit", limit));
+      } else if (ctx.USEOTHER() != null) {
+        Literal useOther;
+        if (ctx.booleanLiteral() != null) {
+          useOther = getArgumentValue(ctx.booleanLiteral());
+        } else if (ctx.ident() != null) {
+          String identLiteral = expressionBuilder.visitIdentifiers(List.of(ctx.ident())).toString();
+          if ("true".equalsIgnoreCase(identLiteral) || "t".equalsIgnoreCase(identLiteral)) {
+            useOther = AstDSL.booleanLiteral(true);
+          } else if ("false".equalsIgnoreCase(identLiteral) || "f".equalsIgnoreCase(identLiteral)) {
+            useOther = AstDSL.booleanLiteral(false);
+          } else {
+            throw new IllegalArgumentException(
+                "Invalid useOther value: "
+                    + ctx.ident().getText()
+                    + ". Expected true/false or t/f");
+          }
+        } else {
+          throw new IllegalArgumentException("value for useOther must be a boolean or identifier");
+        }
+        arguments.add(new Argument("useother", useOther));
+      } else if (ctx.TIMEFIELD() != null) {
+        Literal timeField;
+        if (ctx.ident() != null) {
+          timeField =
+              AstDSL.stringLiteral(
+                  expressionBuilder.visitIdentifiers(List.of(ctx.ident())).toString());
+        } else {
+          timeField = getArgumentValue(ctx.stringLiteral());
+        }
+        arguments.add(new Argument("timefield", timeField));
+      } else {
+        throw new IllegalArgumentException(
+            String.format(
+                "A parameter of timechart must be a span, limit, useother, or timefield, got %s",
+                ctx));
       }
     }
     return arguments;

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -1249,10 +1249,7 @@ public class AstBuilderTest {
                     alias("@timestamp", span(field("@timestamp"), intLiteral(1), SpanUnit.of("m"))))
                 .columnSplit(null)
                 .aggregationFunction(alias("per_second(a)", aggregate("sum", field("a"))))
-                .arguments(
-                    exprList(
-                        argument("limit", intLiteral(10)),
-                        argument("useother", booleanLiteral(true))))
+                .arguments(exprList())
                 .build(),
             let(
                 field("per_second(a)"),
@@ -1281,10 +1278,7 @@ public class AstBuilderTest {
                     alias("@timestamp", span(field("@timestamp"), intLiteral(1), SpanUnit.of("m"))))
                 .columnSplit(null)
                 .aggregationFunction(alias("per_minute(a)", aggregate("sum", field("a"))))
-                .arguments(
-                    exprList(
-                        argument("limit", intLiteral(10)),
-                        argument("useother", booleanLiteral(true))))
+                .arguments(exprList())
                 .build(),
             let(
                 field("per_minute(a)"),
@@ -1313,10 +1307,7 @@ public class AstBuilderTest {
                     alias("@timestamp", span(field("@timestamp"), intLiteral(1), SpanUnit.of("m"))))
                 .columnSplit(null)
                 .aggregationFunction(alias("per_hour(a)", aggregate("sum", field("a"))))
-                .arguments(
-                    exprList(
-                        argument("limit", intLiteral(10)),
-                        argument("useother", booleanLiteral(true))))
+                .arguments(exprList())
                 .build(),
             let(
                 field("per_hour(a)"),
@@ -1345,10 +1336,7 @@ public class AstBuilderTest {
                     alias("@timestamp", span(field("@timestamp"), intLiteral(1), SpanUnit.of("m"))))
                 .columnSplit(null)
                 .aggregationFunction(alias("per_day(a)", aggregate("sum", field("a"))))
-                .arguments(
-                    exprList(
-                        argument("limit", intLiteral(10)),
-                        argument("useother", booleanLiteral(true))))
+                .arguments(exprList())
                 .build(),
             let(
                 field("per_day(a)"),

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -1404,9 +1404,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(30),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(true))))
+            .arguments(exprList(argument("spanliteral", stringLiteral("30m"))))
             .build());
   }
 
@@ -1424,9 +1422,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(1),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(100)), argument("useother", booleanLiteral(true))))
+            .arguments(exprList(argument("limit", intLiteral(100))))
             .build());
   }
 
@@ -1451,9 +1447,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(1),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(true))))
+            .arguments(exprList(argument("useother", booleanLiteral(true))))
             .build());
 
     assertEqual(
@@ -1468,9 +1462,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(1),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(false))))
+            .arguments(exprList(argument("useother", booleanLiteral(false))))
             .build());
   }
 
@@ -1488,9 +1480,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(1),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(true))))
+            .arguments(exprList(argument("useother", booleanLiteral(true))))
             .build());
 
     assertEqual(
@@ -1505,9 +1495,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(1),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(false))))
+            .arguments(exprList(argument("useother", booleanLiteral(false))))
             .build());
 
     assertEqual(
@@ -1522,9 +1510,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(1),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(true))))
+            .arguments(exprList(argument("useother", booleanLiteral(true))))
             .build());
 
     assertEqual(
@@ -1539,9 +1525,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(1),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(false))))
+            .arguments(exprList(argument("useother", booleanLiteral(false))))
             .build());
   }
 
@@ -1615,9 +1599,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(1),
                         SpanUnit.H)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(true))))
+            .arguments(exprList(argument("spanliteral", stringLiteral("1h"))))
             .build());
 
     // Test span literal with decimal value and minute unit
@@ -1633,9 +1615,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(2),
                         SpanUnit.m)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(true))))
+            .arguments(exprList(argument("spanliteral", stringLiteral("2m"))))
             .build());
 
     // Test span literal without unit (should use NONE unit)
@@ -1651,9 +1631,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                         intLiteral(10),
                         SpanUnit.NONE)))
             .aggregationFunction(alias("count()", aggregate("count", allFields())))
-            .arguments(
-                exprList(
-                    argument("limit", intLiteral(10)), argument("useother", booleanLiteral(true))))
+            .arguments(exprList(argument("spanliteral", intLiteral(10))))
             .build());
 
     // Test span literal with decimal value

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -255,9 +255,12 @@ public class PPLQueryDataAnonymizerTest {
   @Test
   public void testTimechartCommand() {
     assertEquals(
-        "source=table | timechart limit=*** useother=*** count() by span(time_identifier, ***"
-            + " m) identifier",
+        "source=table | timechart count() by identifier",
         anonymize("source=t | timechart count() by host"));
+
+    assertEquals(
+        "source=table | timechart timefield=time_identifier max(identifier)",
+        anonymize("source=t | timechart timefield=month max(revenue)"));
   }
 
   @Test


### PR DESCRIPTION
### Description

Backport #4784 to 2.19-dev

### Commit Messages

* Support param timefield to specify span field in timechart



* Update doc to introduce timefield parameter



* Update ASTBuilderTest for chart: default args are handled in rel node visitor



* Fix ast expression builder test



* Fix anomanyzer test



* Support using specified timefield in per functions



* Omit by-timestamp clause in timechart command



* Mask timefield argument in anonymizer



* Anonymize argument span



---------


(cherry picked from commit afc98dd6757288b8b269b78d8e2e5f323f78cae6)



### Related Issues
Resolves #4576

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
