### PR TITLE
Add hashCode() and equals() to the value class of ExprJavaType

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/type/ExprJavaType.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/type/ExprJavaType.java
@@ -14,7 +14,9 @@ import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 
 /**
  * The JavaType for ExprUDT. The UDT which needs to use self-implemented java class should extend
- * this.
+ * this. Its javaClazz should override equals() and hashCode() methods. For example, {@link
+ * org.opensearch.sql.data.model.ExprIpValue} (javaClazz of {@link ExprIPType}) overrides the
+ * equals() and hashCode().
  */
 public class ExprJavaType extends AbstractExprRelDataType<JavaType> {
   public ExprJavaType(OpenSearchTypeFactory typeFactory, ExprUDT exprUDT, Class<?> javaClazz) {

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprIpValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprIpValue.java
@@ -6,11 +6,13 @@
 package org.opensearch.sql.data.model;
 
 import inet.ipaddr.IPAddress;
+import lombok.EqualsAndHashCode;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.utils.IPUtils;
 
 /** Expression IP Address Value. */
+@EqualsAndHashCode(callSuper = false)
 public class ExprIpValue extends AbstractExprValue {
   private final IPAddress value;
 

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4726.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4726.yml
@@ -1,0 +1,83 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+  - do:
+      indices.create:
+        index: test1
+        body:
+          mappings:
+            properties:
+              "timestamp":
+                type: date
+              "status":
+                type: integer
+              "client_ip":
+                type: ip
+  - do:
+      indices.create:
+        index: test2
+        body:
+          mappings:
+            properties:
+              "client_ip":
+                type: ip
+              "city":
+                type: keyword
+              "country":
+                type: keyword
+  - do:
+      bulk:
+        index: test1
+        refresh: true
+        body:
+          - '{"index":{}}'
+          - '{"datetime":"2025-01-15T00:30:00Z","status":200,"client_ip":"10.0.0.1"}'
+          - '{"index":{}}'
+          - '{"datetime":"2025-01-15T02:15:00Z","status":200,"client_ip":"10.0.0.2"}'
+          - '{"index":{}}'
+          - '{"datetime":"2025-01-15T10:50:00Z","status":200,"client_ip":"10.0.0.11"}'
+          - '{"index":{}}'
+          - '{"datetime":"2025-01-15T23:45:00Z","status":200,"client_ip":"10.0.0.24"}'
+  - do:
+      bulk:
+        index: test2
+        refresh: true
+        body:
+          - '{"index":{}}'
+          - '{"client_ip": "10.0.0.1","country": "Canada","city": "Toronto"}'
+          - '{"index":{}}'
+          - '{"client_ip": "10.0.0.24","country": "UK","city": "London"}'
+          - '{"index":{}}'
+          - '{"client_ip": "10.0.1.1","country": "USA","city": "New York"}'
+          - '{"index":{}}'
+          - '{"client_ip": "10.0.1.2","country": "USA","city": "Seattle"}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+
+---
+"hash join on IP type should work":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test1 | stats count() as cnt by client_ip | join type=inner client_ip test2 | fields client_ip, cnt
+
+
+  - match: { total: 2 }
+  - match: {"datarows": [["10.0.0.1", 1], ["10.0.0.24", 1]]}


### PR DESCRIPTION
### Description
```
source=web_logs
| stats count() as request_count by client_ip
| join type=inner client_ip ip_geodata
```
The query above is optimized to `HashJoin` since the left output comes from an aggregation. Unlike `MergeJoin`, the `HashJoin` uses `hashCode()` to get the equivalence key from a HashMap. The value object `ExprIpValue` of `ExprIPType` should override the hashCode() and equals() methods. (If the join is `MergeJoin`, there is no issue since `ExprIpValue` has already implemented `Comparable`.

### Related Issues
Resolves #4726 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced IP value type handling to ensure proper equality and comparison operations

* **Tests**
  * Added integration test validating IP type operations in hash join queries across multiple indices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->