### PR TITLE
Add feedback reminder for CodeRabbit

### DIFF
--- a/.github/workflows/coderabbit-feedback.yml
+++ b/.github/workflows/coderabbit-feedback.yml
@@ -1,0 +1,28 @@
+name: CodeRabbit Feedback Reminder
+on:
+  pull_request_review_comment:
+    types: [created]
+permissions:
+  pull-requests: write
+jobs:
+  add-reaction-encouragement:
+    runs-on: ubuntu-latest
+    if: github.event.comment.user.login == 'coderabbitai[bot]'
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comment = context.payload.comment;
+            const originalBody = comment.body;
+            const feedbackMessage = "\n\n<sub>👋 Leave emoji reaction (👍/👎) to track effectiveness of CodeRabbit.</sub>";
+
+            // Only add the message if it's not already there
+            if (!originalBody.includes(feedbackMessage)) {
+              await github.rest.pulls.updateReviewComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+                body: originalBody + feedbackMessage
+              });
+            }


### PR DESCRIPTION
### Description
- Add feedback reminder for CodeRabbit
  - When CodeRabbit made review comment, it automatically adds reminder message to leave feedback. `👋 Leave emoji reaction (👍/👎) to track effectiveness of CodeRabbit.`
  - Later we can take stats on how many comments got positive/negative feedback via Github API, and make improvement based on the result.

### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
