### PR TITLE
[DOC] Show backticks in testing-doctest.md

### DIFF
--- a/docs/dev/testing-doctest.md
+++ b/docs/dev/testing-doctest.md
@@ -75,12 +75,15 @@ For PPL documentation, Markdown format is now supported with the following guide
 
 3. **Code Block Format**: Use **paired** fenced code blocks - each input block must be followed by its expected output block:
 
+````text
 ```ppl
 search source=accounts | where age > 25 | fields firstname, lastname
 ```
+````
 
 Expected output:
 
+````text
 ```text
 +-------------+------------+
 | firstname   | lastname   |
@@ -89,6 +92,7 @@ Expected output:
 | Hattie      | Bond       |
 +-------------+------------+
 ```
+````
 
 **Input/Output Pairs**: Each input code fence must be immediately followed by an "Expected output:" section with an output code fence
 - **Supported Input Languages**: `sql`, `ppl`, `bash`, `sh`, `bash ppl`
@@ -96,15 +100,11 @@ Expected output:
 
 4. **Ignoring Tests**: To skip specific code blocks from testing, add `ignore` attribute:
 
+````text
 ```ppl ignore
 search source=accounts | head 5
 ```
-
-Expected output:
-
-```text
-This output won't be tested
-```
+````
 
 5. **Validation**: Markdown categories only accept `.md` files - mixing with `.rst` files will cause validation errors
 6. **Testing**: Run `./gradlew doctest` to validate your markdown documentation


### PR DESCRIPTION
### Description
Show backticks in testing-doctest.md

Before:
<img width="733" height="123" alt="Screenshot 2025-12-11 at 1 14 09 PM" src="https://github.com/user-attachments/assets/418c25cf-89ba-492b-ad3f-a4c97cd1e6f5" />

After:
<img width="652" height="126" alt="Screenshot 2025-12-11 at 1 14 56 PM" src="https://github.com/user-attachments/assets/a40f10a8-3d7a-427c-91b8-d8a9a108a798" />


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
