### PR TITLE
Escape underscore character in documentation for LIKE

### DIFF
--- a/docs/user/ppl/cmd/where.md
+++ b/docs/user/ppl/cmd/where.md
@@ -54,8 +54,8 @@ fetched rows / total rows = 2/2
   
 ## Example 3: Pattern Matching with LIKE  
 
-Pattern Matching with Underscore (_)
-The example demonstrates using LIKE with underscore (_) to match a single character.
+Pattern Matching with Underscore (\_)
+The example demonstrates using LIKE with underscore (\_) to match a single character.
   
 ```ppl
 source=accounts


### PR DESCRIPTION
### Description
Properly escape underscore character in documentation for LIKE so it doesn't render as italicised text.

### Related Issues
NA

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
