### PR TITLE
Add scalar min/max to BuiltinFunctionName

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -2905,7 +2905,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
    */
   private AggCall buildAggCall(RelBuilder relBuilder, String aggFunctionName, RexNode node) {
     BuiltinFunctionName aggFunction =
-        BuiltinFunctionName.of(aggFunctionName)
+        BuiltinFunctionName.ofAggregation(aggFunctionName)
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -58,6 +58,8 @@ public enum BuiltinFunctionName {
   SIN(FunctionName.of("sin")),
   TAN(FunctionName.of("tan")),
   SPAN(FunctionName.of("span")),
+  SCALAR_MAX(FunctionName.of("scalar_max")),
+  SCALAR_MIN(FunctionName.of("scalar_min")),
 
   /** Binning Functions. */
   SPAN_BUCKET(FunctionName.of("span_bucket")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -186,6 +186,8 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.RIGHT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.RINT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.ROUND;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.RTRIM;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.SCALAR_MAX;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.SCALAR_MIN;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.SECOND;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.SECOND_OF_MINUTE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.SEC_TO_TIME;
@@ -868,9 +870,9 @@ public class PPLFuncImpTable {
       registerOperator(INTERNAL_REGEXP_REPLACE_5, SqlLibraryOperators.REGEXP_REPLACE_5);
       registerOperator(INTERNAL_TRANSLATE3, SqlLibraryOperators.TRANSLATE3);
 
-      // Register eval functions for PPL max() and min() calls
-      registerOperator(MAX, PPLBuiltinOperators.SCALAR_MAX);
-      registerOperator(MIN, PPLBuiltinOperators.SCALAR_MIN);
+      // Register eval functions for PPL scalar max() and min() calls
+      registerOperator(SCALAR_MAX, PPLBuiltinOperators.SCALAR_MAX);
+      registerOperator(SCALAR_MIN, PPLBuiltinOperators.SCALAR_MIN);
 
       // Register PPL UDF operator
       registerOperator(COSH, PPLBuiltinOperators.COSH);

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -82,13 +82,15 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
 
   private static final int DEFAULT_TAKE_FUNCTION_SIZE_VALUE = 10;
 
-  /** The function name mapping between fronted and core engine. */
-  private static final Map<String, String> FUNCTION_NAME_MAPPING =
+  /** The eval function name mapping between fronted and core engine. */
+  private static final Map<String, String> EVAL_FUNCTION_NAME_MAPPING =
       new ImmutableMap.Builder<String, String>()
           .put("isnull", IS_NULL.getName().getFunctionName())
           .put("isnotnull", IS_NOT_NULL.getName().getFunctionName())
           .put("regex_match", REGEXP_MATCH.getName().getFunctionName()) // compatible with old one
           .put("regexp_replace", REPLACE.getName().getFunctionName())
+          .put("max", SCALAR_MAX.getName().getFunctionName()) // this is scalar max
+          .put("min", SCALAR_MIN.getName().getFunctionName()) // this is scalar min
           .build();
 
   private final AstBuilder astBuilder;
@@ -439,7 +441,8 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   public UnresolvedExpression visitEvalFunctionCall(EvalFunctionCallContext ctx) {
     final String functionName = ctx.evalFunctionName().getText();
     final String mappedName =
-        FUNCTION_NAME_MAPPING.getOrDefault(functionName.toLowerCase(Locale.ROOT), functionName);
+        EVAL_FUNCTION_NAME_MAPPING.getOrDefault(
+            functionName.toLowerCase(Locale.ROOT), functionName);
 
     // Rewrite sum and avg functions to arithmetic expressions
     if (SUM.getName().getFunctionName().equalsIgnoreCase(mappedName)


### PR DESCRIPTION
### Description
Add scalar min/max to BuiltinFunctionName.

Since parsing min/max aggregation function and scalar function (eval function) in AST parser are separated, we can use different names in `BuiltinFunctionName` with no changes in PPL interface/syntax.

`eval a = max(b)` -> SCALAR_MAX
`stats max(b)/eventstats max(b)/streamstats max(b)` -> (AGG) MAX

### Related Issues
Resolves #4774 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
