### PR TITLE
[Backport 2.19-dev] adding capability in SQLQueryUtils to identify if SQL query is for creating a table or not

### DIFF
--- a/async-query-core/src/main/java/org/opensearch/sql/spark/utils/SQLQueryUtils.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/utils/SQLQueryUtils.java
@@ -43,14 +43,24 @@ public class SQLQueryUtils {
   private static final Logger logger = LogManager.getLogger(SQLQueryUtils.class);
 
   public static List<FullyQualifiedTableName> extractFullyQualifiedTableNames(String sqlQuery) {
-    SqlBaseParser sqlBaseParser =
-        new SqlBaseParser(
-            new CommonTokenStream(new SqlBaseLexer(new CaseInsensitiveCharStream(sqlQuery))));
-    sqlBaseParser.addErrorListener(new SyntaxAnalysisErrorListener());
+    return extractFullyQualifiedTableNamesWithMetadata(sqlQuery).getFullyQualifiedTableNames();
+  }
+
+  public static TableExtractionResult extractFullyQualifiedTableNamesWithMetadata(String sqlQuery) {
+    SqlBaseParser sqlBaseParser = getBaseParser(sqlQuery);
     StatementContext statement = sqlBaseParser.statement();
-    SparkSqlTableNameVisitor sparkSqlTableNameVisitor = new SparkSqlTableNameVisitor();
-    statement.accept(sparkSqlTableNameVisitor);
-    return sparkSqlTableNameVisitor.getFullyQualifiedTableNames();
+    SparkSqlTableNameVisitor visitor = new SparkSqlTableNameVisitor();
+    statement.accept(visitor);
+
+    // Remove duplicate table names
+    List<FullyQualifiedTableName> uniqueFullyQualifiedTableNames = new LinkedList<>();
+    for (FullyQualifiedTableName fullyQualifiedTableName : visitor.getFullyQualifiedTableNames()) {
+      if (!uniqueFullyQualifiedTableNames.contains(fullyQualifiedTableName)) {
+        uniqueFullyQualifiedTableNames.add(fullyQualifiedTableName);
+      }
+    }
+
+    return new TableExtractionResult(uniqueFullyQualifiedTableNames, visitor.isCreateTable());
   }
 
   public static IndexQueryDetails extractIndexDetails(String sqlQuery) {
@@ -92,6 +102,8 @@ public class SQLQueryUtils {
 
     @Getter private List<FullyQualifiedTableName> fullyQualifiedTableNames = new LinkedList<>();
 
+    @Getter private boolean isCreateTable = false;
+
     public SparkSqlTableNameVisitor() {}
 
     @Override
@@ -129,6 +141,12 @@ public class SQLQueryUtils {
         }
       }
       return super.visitCreateTableHeader(ctx);
+    }
+
+    @Override
+    public Void visitCreateTable(SqlBaseParser.CreateTableContext ctx) {
+      isCreateTable = true;
+      return super.visitCreateTable(ctx);
     }
   }
 
@@ -378,6 +396,17 @@ public class SQLQueryUtils {
     // https://github.com/apache/spark/blob/v3.5.0/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkParserUtils.scala#L35
     public String removeUnwantedQuotes(String input) {
       return input.replaceAll("^\"|\"$", "");
+    }
+  }
+
+  public static class TableExtractionResult {
+    @Getter private final List<FullyQualifiedTableName> fullyQualifiedTableNames;
+    @Getter private final boolean isCreateTableQuery;
+
+    public TableExtractionResult(
+        List<FullyQualifiedTableName> fullyQualifiedTableNames, boolean isCreateTableQuery) {
+      this.fullyQualifiedTableNames = fullyQualifiedTableNames;
+      this.isCreateTableQuery = isCreateTableQuery;
     }
   }
 }

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/utils/SQLQueryUtilsTest.java
@@ -25,6 +25,7 @@ import org.opensearch.sql.spark.dispatcher.model.FullyQualifiedTableName;
 import org.opensearch.sql.spark.dispatcher.model.IndexQueryActionType;
 import org.opensearch.sql.spark.dispatcher.model.IndexQueryDetails;
 import org.opensearch.sql.spark.flint.FlintIndexType;
+import org.opensearch.sql.spark.utils.SQLQueryUtils.TableExtractionResult;
 
 @ExtendWith(MockitoExtension.class)
 public class SQLQueryUtilsTest {
@@ -442,6 +443,69 @@ public class SQLQueryUtilsTest {
     assertTrue(SQLQueryUtils.isFlintExtensionQuery(refreshSkippingIndex));
     IndexQueryDetails indexDetails = SQLQueryUtils.extractIndexDetails(refreshSkippingIndex);
     assertEquals(IndexQueryActionType.RECOVER, indexDetails.getIndexQueryActionType());
+  }
+
+  @Test
+  void testExtractFullyQualifiedTableNamesWithMetadata() {
+    // Test CREATE TABLE queries
+    String createTableQuery =
+        "CREATE EXTERNAL TABLE\n"
+            + "myS3.default.alb_logs\n"
+            + "[ PARTITIONED BY (col_name [, … ] ) ]\n"
+            + "[ ROW FORMAT DELIMITED row_format ]\n"
+            + "STORED AS file_format\n"
+            + "LOCATION { 's3://bucket/folder/' }";
+
+    TableExtractionResult result =
+        SQLQueryUtils.extractFullyQualifiedTableNamesWithMetadata(createTableQuery);
+    assertTrue(result.isCreateTableQuery());
+    assertEquals(1, result.getFullyQualifiedTableNames().size());
+    assertFullyQualifiedTableName(
+        "myS3", "default", "alb_logs", result.getFullyQualifiedTableNames().get(0));
+
+    String createTableQuery2 =
+        "CREATE TABLE myS3.default.new_table (id INT, name STRING) USING PARQUET";
+    result = SQLQueryUtils.extractFullyQualifiedTableNamesWithMetadata(createTableQuery2);
+    assertTrue(result.isCreateTableQuery());
+    assertEquals(1, result.getFullyQualifiedTableNames().size());
+    assertFullyQualifiedTableName(
+        "myS3", "default", "new_table", result.getFullyQualifiedTableNames().get(0));
+
+    // Test SELECT queries
+    String selectQuery = "SELECT * FROM myS3.default.alb_logs";
+    result = SQLQueryUtils.extractFullyQualifiedTableNamesWithMetadata(selectQuery);
+    assertFalse(result.isCreateTableQuery());
+    assertEquals(1, result.getFullyQualifiedTableNames().size());
+    assertFullyQualifiedTableName(
+        "myS3", "default", "alb_logs", result.getFullyQualifiedTableNames().get(0));
+
+    // Test DROP TABLE queries
+    String dropTableQuery = "DROP TABLE myS3.default.alb_logs";
+    result = SQLQueryUtils.extractFullyQualifiedTableNamesWithMetadata(dropTableQuery);
+    assertFalse(result.isCreateTableQuery());
+    assertEquals(1, result.getFullyQualifiedTableNames().size());
+    assertFullyQualifiedTableName(
+        "myS3", "default", "alb_logs", result.getFullyQualifiedTableNames().get(0));
+
+    // Test DESCRIBE TABLE queries
+    String describeTableQuery = "DESCRIBE TABLE myS3.default.alb_logs";
+    result = SQLQueryUtils.extractFullyQualifiedTableNamesWithMetadata(describeTableQuery);
+    assertFalse(result.isCreateTableQuery());
+    assertEquals(1, result.getFullyQualifiedTableNames().size());
+    assertFullyQualifiedTableName(
+        "myS3", "default", "alb_logs", result.getFullyQualifiedTableNames().get(0));
+
+    // Test JOIN queries
+    String joinQuery =
+        "SELECT * FROM myS3.default.alb_logs JOIN myS3.default.http_logs ON alb_logs.id ="
+            + " http_logs.id";
+    result = SQLQueryUtils.extractFullyQualifiedTableNamesWithMetadata(joinQuery);
+    assertFalse(result.isCreateTableQuery());
+    assertEquals(2, result.getFullyQualifiedTableNames().size());
+    assertFullyQualifiedTableName(
+        "myS3", "default", "alb_logs", result.getFullyQualifiedTableNames().get(0));
+    assertFullyQualifiedTableName(
+        "myS3", "default", "http_logs", result.getFullyQualifiedTableNames().get(1));
   }
 
   @Getter


### PR DESCRIPTION
BackPorting Already Merged PR (https://github.com/opensearch-project/sql/pull/4029) - https://github.com/opensearch-project/sql/commit/5cb51814ed1bb527c47a5e827c773a1899c081e9
from main to 2.19-dev
### Description
Adding capability in SQLQueryUtils to identify if SQL query is for creating a table or not.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [x] New functionality includes testing.
- [NA] New functionality has been documented.
 - [NA] New functionality has javadoc added.
 - [NA] New functionality has a user manual doc added.
- [NA] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
