### PR TITLE
[BugFix] Not between should use range query

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -2307,4 +2307,15 @@ public class CalciteExplainIT extends ExplainIT {
                         + " as avg_age by name"));
     verifyErrorMessageContains(e, "Cannot execute nested aggregation on");
   }
+
+  @Test
+  public void testNotBetweenPushDownExplain() throws Exception {
+    // test for issue https://github.com/opensearch-project/sql/issues/4903
+    enabledOnlyWhenPushdownIsEnabled();
+    String expected = loadExpectedPlan("explain_not_between_push.yaml");
+    assertYamlEqualsIgnoreId(
+        expected,
+        explainQueryYaml(
+            "source=opensearch-sql_test_index_bank | where age not between 30 and 39"));
+  }
 }

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_not_between_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_not_between_push.yaml
@@ -1,0 +1,8 @@
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(account_number=[$0], firstname=[$1], address=[$2], birthdate=[$3], gender=[$4], city=[$5], lastname=[$6], balance=[$7], employer=[$8], state=[$9], age=[$10], email=[$11], male=[$12])
+        LogicalFilter(condition=[SEARCH($10, Sarg[(-∞..30), (39..+∞)])])
+          CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]])
+  physical: |
+    CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_bank]], PushDownContext=[[PROJECT->[account_number, firstname, address, birthdate, gender, city, lastname, balance, employer, state, age, email, male], FILTER->SEARCH($10, Sarg[(-∞..30), (39..+∞)]), LIMIT->10000], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":10000,"timeout":"1m","query":{"bool":{"should":[{"range":{"age":{"from":null,"to":30.0,"include_lower":true,"include_upper":false,"boost":1.0}}},{"range":{"age":{"from":39.0,"to":null,"include_lower":false,"include_upper":true,"boost":1.0}}}],"adjust_pure_negative":true,"boost":1.0}},"_source":{"includes":["account_number","firstname","address","birthdate","gender","city","lastname","balance","employer","state","age","email","male"],"excludes":[]}}, requestedTotalSize=10000, pageSize=null, startFrom=0)])

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1424,14 +1424,18 @@ public class PredicateAnalyzer {
       Object upperBound =
           range.hasUpperBound() ? convertEndpointValue(range.upperEndpoint(), isTimeStamp) : null;
       RangeQueryBuilder rangeQueryBuilder = rangeQuery(getFieldReference());
-      rangeQueryBuilder =
-          range.lowerBoundType() == BoundType.CLOSED
-              ? rangeQueryBuilder.gte(lowerBound)
-              : rangeQueryBuilder.gt(lowerBound);
-      rangeQueryBuilder =
-          range.upperBoundType() == BoundType.CLOSED
-              ? rangeQueryBuilder.lte(upperBound)
-              : rangeQueryBuilder.lt(upperBound);
+      if (lowerBound != null) {
+        rangeQueryBuilder =
+            range.lowerBoundType() == BoundType.CLOSED
+                ? rangeQueryBuilder.gte(lowerBound)
+                : rangeQueryBuilder.gt(lowerBound);
+      }
+      if (upperBound != null) {
+        rangeQueryBuilder =
+            range.upperBoundType() == BoundType.CLOSED
+                ? rangeQueryBuilder.lte(upperBound)
+                : rangeQueryBuilder.lt(upperBound);
+      }
       if (isTimeStamp) rangeQueryBuilder.format("date_time");
       builder = rangeQueryBuilder;
       return this;


### PR DESCRIPTION
### Description
Not between should use range query instead of script query. It's caused by Range<?>::lowerBoundType/upperBoundType will throw NPE if its upper/lower Bound is null, therefore it falls back to script push down.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/4903
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
