### PR TITLE
Add version numbers for all settings in the docs

### DIFF
--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -19,6 +19,10 @@ When OpenSearch bootstraps, SQL plugin will register a few settings in OpenSearc
 plugins.sql.enabled
 ======================
 
+Version
+-------
+1.0
+
 Description
 -----------
 
@@ -81,6 +85,10 @@ Result set::
 plugins.sql.slowlog
 ============================
 
+Version
+-------
+1.0
+
 Description
 -----------
 
@@ -120,6 +128,10 @@ Result set::
 
 plugins.sql.cursor.keep_alive
 ================================
+
+Version
+-------
+1.0
 
 Description
 -----------
@@ -163,6 +175,10 @@ Result set::
 plugins.query.size_limit
 ========================
 
+Version
+-------
+1.0
+
 Description
 -----------
 
@@ -193,7 +209,7 @@ plugins.query.buckets
 
 Version
 -------
-3.4.0
+3.4
 
 Description
 -----------
@@ -228,6 +244,10 @@ The number of aggregation buckets is fixed to ``1000`` in v2. ``plugins.query.bu
 plugins.query.memory_limit
 ==========================
 
+Version
+-------
+1.0
+
 Description
 -----------
 
@@ -256,6 +276,10 @@ Result set::
 Thread Pool Settings
 ====================
 
+Version
+-------
+3.4
+
 The SQL plugin is integrated with the `OpenSearch Thread Pool Settings <https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/thread-pool-settings/>`_.
 There are two thread pools which can be configured on cluster setup via `settings.yml`::
 
@@ -276,6 +300,10 @@ A ``sql-worker`` thread may spawn multiple background threads.
 
 plugins.query.executionengine.spark.session.limit
 ==================================================
+
+Version
+-------
+2.12
 
 Description
 -----------
@@ -314,6 +342,10 @@ SQL query::
 plugins.query.executionengine.spark.refresh_job.limit
 =====================================================
 
+Version
+-------
+2.12
+
 Description
 -----------
 
@@ -351,6 +383,10 @@ SQL query::
 plugins.query.datasources.limit
 ===============================
 
+Version
+-------
+2.12
+
 Description
 -----------
 
@@ -383,6 +419,10 @@ SQL query::
 
 plugins.query.executionengine.spark.session_inactivity_timeout_millis
 =====================================================================
+
+Version
+-------
+2.12
 
 Description
 -----------
@@ -420,6 +460,10 @@ SQL query::
 plugins.query.executionengine.spark.auto_index_management.enabled
 =================================================================
 
+Version
+-------
+2.12
+
 Description
 -----------
 This setting controls the automatic management of request and result indices for each data source. When enabled, it
@@ -455,6 +499,10 @@ SQL query::
 
 plugins.query.executionengine.spark.session.index.ttl
 =====================================================
+
+Version
+-------
+2.12
 
 Description
 -----------
@@ -493,6 +541,10 @@ SQL query::
 plugins.query.executionengine.spark.result.index.ttl
 ====================================================
 
+Version
+-------
+2.12
+
 Description
 -----------
 This setting specifies the TTL for result indices when plugins.query.executionengine.spark.auto_index_management.enabled
@@ -529,6 +581,10 @@ SQL query::
 plugins.query.executionengine.async_query.enabled
 =================================================
 
+Version
+-------
+2.12
+
 Description
 -----------
 You can disable submit async query to reject all coming requests.
@@ -559,6 +615,10 @@ Request::
 
 plugins.query.executionengine.async_query.external_scheduler.enabled
 =====================================================================
+
+Version
+-------
+2.17
 
 Description
 -----------
@@ -595,6 +655,10 @@ Request ::
 plugins.query.executionengine.async_query.external_scheduler.interval
 =====================================================================
 
+Version
+-------
+2.17
+
 Description
 -----------
 This setting defines the interval at which the external scheduler applies for auto refresh queries. It optimizes Spark applications by allowing them to automatically decide whether to use the Spark scheduler or the external scheduler.
@@ -628,6 +692,10 @@ Request ::
 
 plugins.query.executionengine.spark.streamingjobs.housekeeper.interval
 ======================================================================
+
+Version
+-------
+2.13
 
 Description
 -----------
@@ -664,6 +732,10 @@ Request ::
 
 plugins.query.datasources.enabled
 =================================
+
+Version
+-------
+2.16
 
 Description
 -----------
@@ -745,6 +817,10 @@ To Re-enable Data Sources:::
 plugins.query.field_type_tolerance
 ==================================
 
+Version
+-------
+2.19
+
 Description
 -----------
 
@@ -804,6 +880,10 @@ first element of an array is returned, preserving the default behavior.
 plugins.calcite.enabled
 =======================
 
+Version
+-------
+3.0
+
 Description
 -----------
 
@@ -820,6 +900,10 @@ Check `join doc <../../ppl/cmd/join.rst>`_ for example.
 plugins.calcite.fallback.allowed
 ================================
 
+Version
+-------
+3.1
+
 Description
 -----------
 
@@ -831,6 +915,10 @@ If Calcite is enabled, you can use this setting to decide whether to allow fallb
 
 plugins.calcite.pushdown.enabled
 ================================
+
+Version
+-------
+3.1
 
 Description
 -----------
@@ -844,6 +932,10 @@ If Calcite is enabled, you can use this setting to decide whether to enable the 
 plugins.calcite.pushdown.rowcount.estimation.factor
 ===================================================
 
+Version
+-------
+3.1
+
 Description
 -----------
 
@@ -855,6 +947,10 @@ If Calcite pushdown optimization is enabled, this setting is used to estimate th
 
 plugins.calcite.all_join_types.allowed
 ======================================
+
+Version
+-------
+3.3
 
 Description
 -----------

--- a/docs/user/ppl/admin/settings.md
+++ b/docs/user/ppl/admin/settings.md
@@ -3,7 +3,11 @@
 ## Introduction  
 
 When OpenSearch bootstraps, PPL plugin will register a few settings in OpenSearch cluster settings. Most of the settings are able to change dynamically so you can control the behavior of PPL plugin without need to bounce your cluster.
-## plugins.ppl.enabled  
+## plugins.ppl.enabled
+
+### Version
+
+1.0
 
 ### Description  
 
@@ -65,7 +69,11 @@ Expected output:
 
 ```
   
-## plugins.ppl.query.timeout  
+## plugins.ppl.query.timeout
+
+### Version
+
+3.4
 
 ### Description  
 
@@ -102,7 +110,11 @@ Expected output:
 }
 ```
   
-## plugins.query.memory_limit  
+## plugins.query.memory_limit
+
+### Version
+
+1.0
 
 ### Description  
 
@@ -133,7 +145,11 @@ Expected output:
 ```
   
 Note: the legacy settings of `opendistro.ppl.query.memory_limit` is deprecated, it will fallback to the new settings if you request an update with the legacy name.
-## plugins.query.size_limit  
+## plugins.query.size_limit
+
+### Version
+
+1.0
 
 ### Description  
 
@@ -165,11 +181,12 @@ Expected output:
 ```
   
 Note: the legacy settings of `opendistro.query.size_limit` is deprecated, it will fallback to the new settings if you request an update with the legacy name.
-## plugins.query.buckets  
+## plugins.query.buckets
 
-### Version  
+### Version
 
-3.4.0
+3.4
+
 ### Description  
 
 This configuration indicates how many aggregation buckets will return in a single response. The default value equals to `plugins.query.size_limit`.
@@ -202,7 +219,11 @@ Expected output:
 ### Limitations  
 
 The number of aggregation buckets is fixed to `1000` in v2. `plugins.query.buckets` can only effect the number of aggregation buckets when calcite enabled.
-## plugins.calcite.all_join_types.allowed  
+## plugins.calcite.all_join_types.allowed
+
+### Version
+
+3.3
 
 ### Description  
 
@@ -233,7 +254,11 @@ Expected output:
 }
 ```
   
-## plugins.ppl.syntax.legacy.preferred  
+## plugins.ppl.syntax.legacy.preferred
+
+### Version
+
+3.3
 
 ### Description  
 
@@ -294,7 +319,11 @@ Expected output:
 }
 ```
   
-## plugins.ppl.values.max.limit  
+## plugins.ppl.values.max.limit
+
+### Version
+
+3.3
 
 ### Description  
 
@@ -367,14 +396,16 @@ Expected output:
 
 ```
   
-## plugins.ppl.subsearch.maxout  
+## plugins.ppl.subsearch.maxout
 
-### Description  
+### Version
+
+3.4
+
+### Description
 
 The size configures the maximum of rows to return from subsearch. The default value is: `10000`. A value of `0` indicates that the restriction is unlimited.
-### Version  
 
-3.4.0
 ### Example  
 
 Change the subsearch.maxout to unlimited
@@ -403,14 +434,16 @@ Expected output:
 }
 ```
   
-## plugins.ppl.join.subsearch_maxout  
+## plugins.ppl.join.subsearch_maxout
 
-### Description  
+### Version
+
+3.4
+
+### Description
 
 The size configures the maximum of rows from subsearch to join against. This configuration impacts `join` command. The default value is: `50000`. A value of `0` indicates that the restriction is unlimited.
-### Version  
 
-3.4.0
 ### Example  
 
 Change the join.subsearch_maxout to 5000


### PR DESCRIPTION
### Description
While debugging an oncall ticket, having the version number specified for [plugins.query.buckets](https://github.com/opensearch-project/sql/blob/b66dc12b21ce3f7311fc4412604192b497e1133a/docs/user/ppl/admin/settings.md?plain=1#L168-L172) was super useful. I was so inspired I wanted to do it with all the rest of our settings, too.

### Related Issues
Minor inconveniences with finding the version in which a config became available.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
