### PR TITLE
[Backport 2.19] Support profile option for PPL - Part II Implement operator level metrics

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/profile/PlanProfileBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/profile/PlanProfileBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.profile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.calcite.adapter.enumerable.EnumerableRel;
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.sql.calcite.plan.Scannable;
+import org.opensearch.sql.monitor.profile.ProfilePlanNode;
+
+/** Builds a profiled EnumerableRel plan tree and matching plan node structure. */
+public final class PlanProfileBuilder {
+
+  private PlanProfileBuilder() {}
+
+  public static ProfilePlan profile(RelNode root) {
+    Objects.requireNonNull(root, "root");
+    return profileRel(root);
+  }
+
+  private static ProfilePlan profileRel(RelNode rel) {
+    List<ProfilePlan> childPlans = new ArrayList<>();
+    for (RelNode input : rel.getInputs()) {
+      childPlans.add(profileRel(input));
+    }
+
+    List<RelNode> newInputs =
+        childPlans.stream().map(ProfilePlan::rel).collect(Collectors.toList());
+    List<ProfilePlanNode> childNodes =
+        childPlans.stream().map(ProfilePlan::planRoot).collect(Collectors.toList());
+
+    ProfilePlanNode planNode = new ProfilePlanNode(nodeName(rel), childNodes);
+    RelNode wrappedRel = wrap(rel, newInputs, planNode);
+    return new ProfilePlan(wrappedRel, planNode);
+  }
+
+  private static RelNode wrap(RelNode rel, List<RelNode> inputs, ProfilePlanNode planNode) {
+    if (!(rel instanceof EnumerableRel)) {
+      try {
+        return rel.copy(rel.getTraitSet(), inputs);
+      } catch (UnsupportedOperationException e) {
+        return rel;
+      }
+    }
+    if (rel instanceof Scannable) {
+      return new ProfileScannableRel((EnumerableRel) rel, inputs, planNode);
+    }
+    return new ProfileEnumerableRel((EnumerableRel) rel, inputs, planNode);
+  }
+
+  private static String nodeName(RelNode rel) {
+    return rel.getRelTypeName();
+  }
+
+  /** Pair of the profiled RelNode tree and its root plan node. */
+  public static final class ProfilePlan {
+    private final RelNode rel;
+    private final ProfilePlanNode planRoot;
+
+    public ProfilePlan(RelNode rel, ProfilePlanNode planRoot) {
+      this.rel = rel;
+      this.planRoot = planRoot;
+    }
+
+    public RelNode rel() {
+      return rel;
+    }
+
+    public ProfilePlanNode planRoot() {
+      return planRoot;
+    }
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/profile/ProfileEnumerableRel.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/profile/ProfileEnumerableRel.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.profile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.apache.calcite.adapter.enumerable.EnumerableRel;
+import org.apache.calcite.adapter.enumerable.EnumerableRelImplementor;
+import org.apache.calcite.linq4j.AbstractEnumerable;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.tree.BlockBuilder;
+import org.apache.calcite.linq4j.tree.BlockStatement;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.linq4j.tree.GotoExpressionKind;
+import org.apache.calcite.linq4j.tree.GotoStatement;
+import org.apache.calcite.linq4j.tree.Statement;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.type.RelDataType;
+import org.opensearch.sql.monitor.profile.ProfilePlanNode;
+import org.opensearch.sql.monitor.profile.ProfilePlanNodeMetrics;
+
+/** EnumerableRel wrapper that records inclusive time and row counts. */
+public class ProfileEnumerableRel extends AbstractRelNode implements EnumerableRel {
+
+  private final EnumerableRel delegate;
+  private final List<RelNode> inputs;
+  protected final ProfilePlanNode planNode;
+
+  public ProfileEnumerableRel(
+      EnumerableRel delegate, List<RelNode> inputs, ProfilePlanNode planNode) {
+    super(
+        Objects.requireNonNull(delegate, "delegate").getCluster(),
+        Objects.requireNonNull(delegate, "delegate").getTraitSet());
+    this.delegate = delegate;
+    this.inputs = new ArrayList<>(Objects.requireNonNull(inputs, "inputs"));
+    this.planNode = Objects.requireNonNull(planNode, "planNode");
+  }
+
+  @Override
+  public List<RelNode> getInputs() {
+    return inputs;
+  }
+
+  @Override
+  public void replaceInput(int ordinalInParent, RelNode p) {
+    inputs.set(ordinalInParent, p);
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    return new ProfileEnumerableRel(delegate, inputs, planNode);
+  }
+
+  @Override
+  protected RelDataType deriveRowType() {
+    return delegate.getRowType();
+  }
+
+  @Override
+  public String getRelTypeName() {
+    return delegate.getRelTypeName();
+  }
+
+  @Override
+  public RelWriter explainTerms(RelWriter pw) {
+    RelWriter writer = pw;
+    for (RelNode input : inputs) {
+      writer = writer.input("input", input);
+    }
+    return writer;
+  }
+
+  @Override
+  public Result implement(EnumerableRelImplementor implementor, Prefer pref) {
+    EnumerableRel rewritten = (EnumerableRel) delegate.copy(delegate.getTraitSet(), inputs);
+    Result result = rewritten.implement(implementor, pref);
+    return new Result(
+        wrapBlock(
+            result.block, implementor.stash(planNode.metrics(), ProfilePlanNodeMetrics.class)),
+        result.physType,
+        result.format);
+  }
+
+  /**
+   * Rewrite the generated block by wrapping the returned Enumerable with profiling.
+   *
+   * <p>Example (simplified):
+   *
+   * <pre>
+   * // Before:
+   * {
+   *   final Enumerable<Object[]> input = ...;
+   *   return input;
+   * }
+   *
+   * // After:
+   * {
+   *   final Enumerable<Object[]> input = ...;
+   *   return ProfileEnumerableRel.profile(input, metrics);
+   * }
+   * </pre>
+   */
+  private static BlockStatement wrapBlock(BlockStatement block, Expression metricsExpression) {
+    List<Statement> statements = block.statements;
+    if (statements.isEmpty()) {
+      return block;
+    }
+    Statement last = statements.get(statements.size() - 1);
+    // Expect Calcite to end blocks with a return GotoStatement; skip profiling if it doesn't.
+    if (!(last instanceof GotoStatement)) {
+      return block;
+    }
+    GotoStatement gotoStatement = (GotoStatement) last;
+    // Only rewrite blocks that return an expression; otherwise keep the original block.
+    if (gotoStatement.kind != GotoExpressionKind.Return || gotoStatement.expression == null) {
+      return block;
+    }
+    Expression profiled =
+        Expressions.call(
+            ProfileEnumerableRel.class, "profile", gotoStatement.expression, metricsExpression);
+    BlockBuilder builder = new BlockBuilder();
+    for (int i = 0; i < statements.size() - 1; i++) {
+      builder.add(statements.get(i));
+    }
+    builder.add(Expressions.return_(gotoStatement.labelTarget, profiled));
+    return builder.toBlock();
+  }
+
+  public static <T> Enumerable<T> profile(
+      Enumerable<T> enumerable, ProfilePlanNodeMetrics metrics) {
+    if (metrics == null) {
+      return enumerable;
+    }
+    return new AbstractEnumerable<>() {
+      @Override
+      public Enumerator<T> enumerator() {
+        long start = System.nanoTime();
+        Enumerator<T> delegate = enumerable.enumerator();
+        metrics.addTimeNanos(System.nanoTime() - start);
+        return new ProfileEnumerator<>(delegate, metrics);
+      }
+    };
+  }
+
+  private static final class ProfileEnumerator<T> implements Enumerator<T> {
+    private final Enumerator<T> delegate;
+    private final ProfilePlanNodeMetrics metrics;
+
+    private ProfileEnumerator(Enumerator<T> delegate, ProfilePlanNodeMetrics metrics) {
+      this.delegate = delegate;
+      this.metrics = metrics;
+    }
+
+    @Override
+    public T current() {
+      return delegate.current();
+    }
+
+    @Override
+    public boolean moveNext() {
+      long start = System.nanoTime();
+      try {
+        boolean hasNext = delegate.moveNext();
+        if (hasNext) {
+          metrics.incrementRows();
+        }
+        return hasNext;
+      } finally {
+        metrics.addTimeNanos(System.nanoTime() - start);
+      }
+    }
+
+    @Override
+    public void reset() {
+      delegate.reset();
+    }
+
+    @Override
+    public void close() {
+      long start = System.nanoTime();
+      try {
+        delegate.close();
+      } finally {
+        metrics.addTimeNanos(System.nanoTime() - start);
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/calcite/profile/ProfileScannableRel.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/profile/ProfileScannableRel.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.profile;
+
+import java.util.List;
+import org.apache.calcite.adapter.enumerable.EnumerableRel;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.rel.RelNode;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.opensearch.sql.calcite.plan.Scannable;
+import org.opensearch.sql.monitor.profile.ProfilePlanNode;
+
+/** EnumerableRel wrapper that also supports Scannable plans. */
+public final class ProfileScannableRel extends ProfileEnumerableRel implements Scannable {
+
+  private final Scannable scannable;
+
+  public ProfileScannableRel(
+      EnumerableRel delegate, List<RelNode> inputs, ProfilePlanNode planNode) {
+    super(delegate, inputs, planNode);
+    this.scannable = (Scannable) delegate;
+  }
+
+  @Override
+  public Enumerable<@Nullable Object> scan() {
+    return profile(scannable.scan(), planNode.metrics());
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/NoopProfileContext.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/NoopProfileContext.java
@@ -14,12 +14,20 @@ public final class NoopProfileContext implements ProfileContext {
 
   private NoopProfileContext() {}
 
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+
   /** {@inheritDoc} */
   @Override
   public ProfileMetric getOrCreateMetric(MetricName name) {
     Objects.requireNonNull(name, "name");
     return NoopProfileMetric.INSTANCE;
   }
+
+  @Override
+  public void setPlanRoot(ProfilePlanNode planRoot) {}
 
   /** {@inheritDoc} */
   @Override

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/ProfileContext.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/ProfileContext.java
@@ -8,12 +8,24 @@ package org.opensearch.sql.monitor.profile;
 /** Context for collecting profiling metrics during query execution. */
 public interface ProfileContext {
   /**
+   * @return whether profiling is enabled for this context.
+   */
+  boolean isEnabled();
+
+  /**
    * Obtain or create a metric with the provided name.
    *
    * @param name fully qualified metric name
    * @return metric instance
    */
   ProfileMetric getOrCreateMetric(MetricName name);
+
+  /**
+   * Register the root plan node for profiling.
+   *
+   * @param planRoot root plan node
+   */
+  void setPlanRoot(ProfilePlanNode planRoot);
 
   /**
    * Finalize profiling and return a snapshot.

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/ProfilePlanNode.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/ProfilePlanNode.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.monitor.profile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Mutable plan node used while profiling a query. */
+public final class ProfilePlanNode {
+
+  private final String nodeName;
+  private final List<ProfilePlanNode> children;
+  private final ProfilePlanNodeMetrics metrics = new ProfilePlanNodeMetrics();
+
+  public ProfilePlanNode(String nodeName, List<ProfilePlanNode> children) {
+    this.nodeName = Objects.requireNonNull(nodeName, "nodeName");
+    this.children = List.copyOf(Objects.requireNonNull(children, "children"));
+  }
+
+  public ProfilePlanNodeMetrics metrics() {
+    return metrics;
+  }
+
+  public QueryProfile.PlanNode snapshot() {
+    List<QueryProfile.PlanNode> snapshotChildren = new ArrayList<>();
+    for (ProfilePlanNode child : children) {
+      snapshotChildren.add(child.snapshot());
+    }
+    List<QueryProfile.PlanNode> outputChildren =
+        snapshotChildren.isEmpty() ? null : List.copyOf(snapshotChildren);
+    return new QueryProfile.PlanNode(
+        nodeName, ProfileUtils.roundToMillis(metrics.timeNanos()), metrics.rows(), outputChildren);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/ProfilePlanNodeMetrics.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/ProfilePlanNodeMetrics.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.monitor.profile;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/** Metrics captured for a single plan node. */
+public final class ProfilePlanNodeMetrics {
+
+  private final LongAdder timeNanos = new LongAdder();
+  private final LongAdder rows = new LongAdder();
+
+  public ProfilePlanNodeMetrics() {}
+
+  public void addTimeNanos(long nanos) {
+    if (nanos > 0) {
+      timeNanos.add(nanos);
+    }
+  }
+
+  public void incrementRows() {
+    rows.increment();
+  }
+
+  public long timeNanos() {
+    return timeNanos.sum();
+  }
+
+  public long rows() {
+    return rows.sum();
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/ProfileUtils.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/ProfileUtils.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.monitor.profile;
+
+/** Utility helpers for profiling metrics. */
+public final class ProfileUtils {
+
+  private ProfileUtils() {}
+
+  /**
+   * Convert nanoseconds to milliseconds, rounded to two decimals.
+   *
+   * @param nanos duration in nanoseconds
+   * @return rounded milliseconds
+   */
+  public static double roundToMillis(long nanos) {
+    return Math.round((nanos / 1_000_000.0d) * 100.0d) / 100.0d;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/QueryProfile.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/QueryProfile.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.monitor.profile;
 
 import com.google.gson.annotations.SerializedName;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -20,6 +21,8 @@ public final class QueryProfile {
 
   private final Map<String, Phase> phases;
 
+  private final PlanNode plan;
+
   /**
    * Create a new query profile snapshot.
    *
@@ -27,8 +30,20 @@ public final class QueryProfile {
    * @param phases metric values keyed by {@link MetricName}
    */
   public QueryProfile(double totalTimeMillis, Map<MetricName, Double> phases) {
+    this(totalTimeMillis, phases, null);
+  }
+
+  /**
+   * Create a new query profile snapshot.
+   *
+   * @param totalTimeMillis total elapsed milliseconds for the query (rounded to two decimals)
+   * @param phases metric values keyed by {@link MetricName}
+   * @param plan plan tree profiling output
+   */
+  public QueryProfile(double totalTimeMillis, Map<MetricName, Double> phases, PlanNode plan) {
     this.summary = new Summary(totalTimeMillis);
     this.phases = buildPhases(phases);
+    this.plan = plan;
   }
 
   private Map<String, Phase> buildPhases(Map<MetricName, Double> phases) {
@@ -60,6 +75,26 @@ public final class QueryProfile {
 
     private Phase(double timeMillis) {
       this.timeMillis = timeMillis;
+    }
+  }
+
+  @Getter
+  public static final class PlanNode {
+
+    private final String node;
+
+    @SerializedName("time_ms")
+    private final double timeMillis;
+
+    private final long rows;
+
+    private final List<PlanNode> children;
+
+    public PlanNode(String node, double timeMillis, long rows, List<PlanNode> children) {
+      this.node = node;
+      this.timeMillis = timeMillis;
+      this.rows = rows;
+      this.children = children;
     }
   }
 }

--- a/core/src/test/java/org/opensearch/sql/calcite/profile/PlanProfileBuilderTest.java
+++ b/core/src/test/java/org/opensearch/sql/calcite/profile/PlanProfileBuilderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.profile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.calcite.adapter.enumerable.EnumerableRel;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.calcite.plan.Scannable;
+
+@ExtendWith(MockitoExtension.class)
+class PlanProfileBuilderTest {
+
+  @Mock private RelOptCluster cluster;
+  private RelTraitSet traitSet;
+
+  @BeforeEach
+  void setUp() {
+    traitSet = RelTraitSet.createEmpty();
+  }
+
+  @Test
+  void wrapsEnumerableRel() {
+    EnumerableRel rel = mockEnumerableRel("EnumerableCalc", List.of());
+
+    PlanProfileBuilder.ProfilePlan plan = PlanProfileBuilder.profile((RelNode) rel);
+
+    assertInstanceOf(ProfileEnumerableRel.class, plan.rel());
+    assertEquals("EnumerableCalc", plan.planRoot().snapshot().getNode());
+  }
+
+  @Test
+  void wrapsScannableRel() {
+    EnumerableRel rel = mockScannableRel("CalciteEnumerableIndexScan", List.of());
+
+    PlanProfileBuilder.ProfilePlan plan = PlanProfileBuilder.profile((RelNode) rel);
+
+    assertInstanceOf(ProfileScannableRel.class, plan.rel());
+    assertEquals("CalciteEnumerableIndexScan", plan.planRoot().snapshot().getNode());
+  }
+
+  @Test
+  void rebuildsInputsForNonEnumerableRel() {
+    EnumerableRel child = mockEnumerableRel("EnumerableCalc", List.of());
+    RelNode parent = mock(RelNode.class);
+    when(parent.getInputs()).thenReturn(List.of(child));
+    when(parent.getRelTypeName()).thenReturn("Parent");
+    when(parent.getTraitSet()).thenReturn(traitSet);
+    when(parent.copy(any(), anyList())).thenReturn(parent);
+
+    PlanProfileBuilder.ProfilePlan plan = PlanProfileBuilder.profile(parent);
+
+    ArgumentCaptor<List<RelNode>> inputsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(parent).copy(any(), inputsCaptor.capture());
+    List<RelNode> copiedInputs = inputsCaptor.getValue();
+    assertNotNull(copiedInputs);
+    assertInstanceOf(ProfileEnumerableRel.class, copiedInputs.get(0));
+    assertEquals("Parent", plan.planRoot().snapshot().getNode());
+  }
+
+  private EnumerableRel mockEnumerableRel(String name, List<RelNode> inputs) {
+    EnumerableRel rel = mock(EnumerableRel.class);
+    when(rel.getRelTypeName()).thenReturn(name);
+    when(rel.getInputs()).thenReturn(inputs);
+    when(rel.getCluster()).thenReturn(cluster);
+    when(rel.getTraitSet()).thenReturn(traitSet);
+    return rel;
+  }
+
+  private EnumerableRel mockScannableRel(String name, List<RelNode> inputs) {
+    EnumerableRel rel =
+        mock(
+            EnumerableRel.class,
+            org.mockito.Mockito.withSettings().extraInterfaces(Scannable.class));
+    when(rel.getRelTypeName()).thenReturn(name);
+    when(rel.getInputs()).thenReturn(inputs);
+    when(rel.getCluster()).thenReturn(cluster);
+    when(rel.getTraitSet()).thenReturn(traitSet);
+    return rel;
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/calcite/profile/ProfileEnumerableRelTest.java
+++ b/core/src/test/java/org/opensearch/sql/calcite/profile/ProfileEnumerableRelTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.profile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.calcite.linq4j.AbstractEnumerable;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.monitor.profile.ProfilePlanNodeMetrics;
+
+class ProfileEnumerableRelTest {
+
+  @Test
+  void profileReturnsSameEnumerableWhenMetricsMissing() {
+    Enumerable<Integer> enumerable = new TestEnumerable(2);
+
+    Enumerable<Integer> result = ProfileEnumerableRel.profile(enumerable, null);
+
+    assertSame(enumerable, result);
+  }
+
+  @Test
+  void profileTracksRowsAndTime() {
+    ProfilePlanNodeMetrics metrics = new ProfilePlanNodeMetrics();
+    Enumerable<Integer> enumerable = new TestEnumerable(2);
+
+    Enumerator<Integer> enumerator = ProfileEnumerableRel.profile(enumerable, metrics).enumerator();
+    while (enumerator.moveNext()) {
+      enumerator.current();
+    }
+    enumerator.close();
+
+    assertEquals(2, metrics.rows());
+    assertTrue(metrics.timeNanos() > 0);
+  }
+
+  private static final class TestEnumerable extends AbstractEnumerable<Integer> {
+    private final int size;
+
+    private TestEnumerable(int size) {
+      this.size = size;
+    }
+
+    @Override
+    public Enumerator<Integer> enumerator() {
+      return new Enumerator<>() {
+        private int index = -1;
+
+        @Override
+        public Integer current() {
+          return index;
+        }
+
+        @Override
+        public boolean moveNext() {
+          sleepMillis(1);
+          index++;
+          return index < size;
+        }
+
+        @Override
+        public void reset() {
+          index = -1;
+        }
+
+        @Override
+        public void close() {
+          sleepMillis(1);
+        }
+      };
+    }
+  }
+
+  private static void sleepMillis(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/docs/user/ppl/interfaces/endpoint.md
+++ b/docs/user/ppl/interfaces/endpoint.md
@@ -181,6 +181,14 @@ Expected output (trimmed):
          "optimize": { "time_ms": 18.2 },
          "execute": { "time_ms": 4.87 },
          "format": { "time_ms": 0.05 }
+      },
+      "plan": {
+         "node": "EnumerableCalc",
+         "time_ms": 4.82,
+         "rows": 2,
+         "children": [
+            { "node": "CalciteEnumerableIndexScan", "time_ms": 4.12, "rows": 2 }
+         ]
       }
    }
 }
@@ -190,3 +198,6 @@ Expected output (trimmed):
 
 - Profile output is only returned when the query finishes successfully.
 - Profiling runs only when Calcite is enabled.
+- Plan node names use Calcite physical operator names (for example, `EnumerableCalc` or `CalciteEnumerableIndexScan`).
+- Plan `time_ms` is inclusive of child operators and represents wall-clock time; overlapping work can make summed plan times exceed `summary.total_time_ms`.
+- Scan nodes reflect operator wall-clock time; background prefetch can make scan time smaller than total request latency.

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/api/ppl.profile.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/api/ppl.profile.yml
@@ -54,6 +54,8 @@ teardown:
   - gt: {profile.phases.optimize.time_ms: 0.0}
   - gt: {profile.phases.execute.time_ms: 0.0}
   - gt: {profile.phases.format.time_ms: 0.0}
+  - gt: {profile.plan.time_ms: 0.0}
+  - match: {profile.plan.rows: 2}
 
 ---
 "Profile ignored for explain api":


### PR DESCRIPTION
## Description
Backport of #5044 to `2.19-dev`.

Note: `OpenSearchQueryRequest` was intentionally left as the upstream `2.19-dev` version for manual merge in this backport. Please resolve that file in a follow-up commit.

## Changes
- cherry-pick `07629d430` (Support profile option for PPL - Part II Implement operator level metrics)
- resolve conflicts for `CalciteToolsHelper` and `OpenSearchExecutionEngine`
- Java 11 lambda capture fix in `CalciteToolsHelper`

## Testing
- `./gradlew compileJava`
