### PR TITLE
Fix issue connecting with prometheus by wrapping with AccessController.doPrivilegedChecked

### DIFF
--- a/direct-query-core/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
+++ b/direct-query-core/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
@@ -92,7 +92,7 @@ public class PrometheusClientImpl implements PrometheusClient {
     Request request = new Request.Builder().url(queryUrl).build();
 
     logger.debug("Executing Prometheus request with headers: {}", request.headers().toString());
-    Response response = this.prometheusHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
 
     logger.debug("Received Prometheus response for query_range: code={}", response);
 
@@ -127,7 +127,7 @@ public class PrometheusClientImpl implements PrometheusClient {
     Request request = new Request.Builder().url(queryUrl).build();
 
     logger.info("Executing Prometheus request with headers: {}", request.headers().toString());
-    Response response = this.prometheusHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
 
     logger.info("Received Prometheus response for instant query: code={}", response);
     // Return the full response object, not just the data field
@@ -147,7 +147,7 @@ public class PrometheusClientImpl implements PrometheusClient {
             "%s/api/v1/labels%s", prometheusUri.toString().replaceAll("/$", ""), queryString);
     logger.debug("queryUrl: " + queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.prometheusHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
     return toListOfLabels(jsonObject.getJSONArray("data"));
   }
@@ -162,7 +162,7 @@ public class PrometheusClientImpl implements PrometheusClient {
             prometheusUri.toString().replaceAll("/$", ""), labelName, queryString);
     logger.debug("queryUrl: " + queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.prometheusHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
     return toListOfLabels(jsonObject.getJSONArray("data"));
   }
@@ -195,7 +195,7 @@ public class PrometheusClientImpl implements PrometheusClient {
             "%s/api/v1/series%s", prometheusUri.toString().replaceAll("/$", ""), queryString);
     logger.debug("queryUrl: " + queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.prometheusHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
     JSONArray dataArray = jsonObject.getJSONArray("data");
     return toListOfSeries(dataArray);
@@ -212,7 +212,7 @@ public class PrometheusClientImpl implements PrometheusClient {
             end);
     logger.debug("queryUrl: " + queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.prometheusHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
     return jsonObject.getJSONArray("data");
   }
@@ -223,7 +223,7 @@ public class PrometheusClientImpl implements PrometheusClient {
         String.format("%s/api/v1/alerts", prometheusUri.toString().replaceAll("/$", ""));
     logger.debug("Making Prometheus alerts request: {}", queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.prometheusHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
     return jsonObject.getJSONObject("data");
   }
@@ -236,7 +236,7 @@ public class PrometheusClientImpl implements PrometheusClient {
             "%s/api/v1/rules%s", prometheusUri.toString().replaceAll("/$", ""), queryString);
     logger.debug("Making Prometheus rules request: {}", queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.prometheusHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
     return jsonObject.getJSONObject("data");
   }
@@ -249,7 +249,7 @@ public class PrometheusClientImpl implements PrometheusClient {
 
     logger.debug("Making Alertmanager alerts request: {}", queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.alertmanagerHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.alertmanagerHttpClient.newCall(request).execute());
 
     return readAlertmanagerResponse(response);
   }
@@ -262,7 +262,7 @@ public class PrometheusClientImpl implements PrometheusClient {
 
     logger.debug("Making Alertmanager alert groups request: {}", queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.alertmanagerHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.alertmanagerHttpClient.newCall(request).execute());
 
     return readAlertmanagerResponse(response);
   }
@@ -274,7 +274,7 @@ public class PrometheusClientImpl implements PrometheusClient {
 
     logger.debug("Making Alertmanager receivers request: {}", queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.alertmanagerHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.alertmanagerHttpClient.newCall(request).execute());
 
     return readAlertmanagerResponse(response);
   }
@@ -286,7 +286,7 @@ public class PrometheusClientImpl implements PrometheusClient {
 
     logger.debug("Making Get Alertmanager silences request: {}", queryUrl);
     Request request = new Request.Builder().url(queryUrl).build();
-    Response response = this.alertmanagerHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.alertmanagerHttpClient.newCall(request).execute());
 
     return readAlertmanagerResponse(response);
   }
@@ -302,7 +302,7 @@ public class PrometheusClientImpl implements PrometheusClient {
             .header("Content-Type", "application/json")
             .post(RequestBody.create(silenceJson.getBytes(StandardCharsets.UTF_8)))
             .build();
-    Response response = this.alertmanagerHttpClient.newCall(request).execute();
+    Response response = AccessController.doPrivilegedChecked(() -> this.alertmanagerHttpClient.newCall(request).execute());
 
     if (response.isSuccessful()) {
       return Objects.requireNonNull(response.body()).string();


### PR DESCRIPTION
### Description

This PR fixes an issue connecting to a prometheus connector.

Before:

```
➜  curl -XPOST localhost:9200/_plugins/_query/_datasources -H 'Content-Type:application/json' --data-binary '{
  "name" : "my_prometheus",
    "connector": "prometheus",
    "properties" : {
      "prometheus.uri" : "http://localhost:9090"
    }
}'
"Created DataSource with name my_prometheus"%
➜  curl http://localhost:9200/_plugins/_directquery/_resources/my_prometheus/api/v1/metadata
{
  "status": 500,
  "error": {
    "type": "SecurityException",
    "reason": "There was internal problem at backend",
    "details": "Denied access to: localhost:9090, domain ProtectionDomain  (file:/usr/share/opensearch/plugins/opensearch-ubi/opensearch-ubi-3.5.0.0.jar \u003cno signer certificates\u003e)\n java.net.URLClassLoader@2a30b0cb\n \u003cno principals\u003e\n java.security.Permissions@420bdb83 (\n)\n\n"
  }
}
```

After: 

```
➜  curl -XPOST localhost:9200/_plugins/_query/_datasources -H 'Content-Type:application/json' --data-binary '{
  "name" : "my_prometheus",
    "connector": "prometheus",
    "properties" : {
      "prometheus.uri" : "http://localhost:9090"
    }
}'
"Created DataSource with name my_prometheus"%
➜  curl http://localhost:9200/_plugins/_directquery/_resources/my_prometheus/api/v1/metadata
{
  "status": 400,
  "error": {
    "type": "PrometheusClientException",
    "reason": "Invalid Request",
    "details": "Error while getting resources for METADATA: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:9090"
  }
}
```

Full Stack Trace

```
opensearch-node1-1       | java.lang.SecurityException: Denied access to: localhost:9090, domain ProtectionDomain  (file:/usr/share/opensearch/plugins/opensearch-ubi/opensearch-ubi-3.5.0.0.jar <no signer certificates>)
opensearch-node1-1       |  java.net.URLClassLoader@2a30b0cb
opensearch-node1-1       |  <no principals>
opensearch-node1-1       |  java.security.Permissions@420bdb83 (
opensearch-node1-1       | )
opensearch-node1-1       |
opensearch-node1-1       |
opensearch-node1-1       | 	at java.base/java.net.Socket.connect(Socket.java:640)
opensearch-node1-1       | 	at okhttp3.internal.platform.Platform.connectSocket(Platform.kt:128)
opensearch-node1-1       | 	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:295)
opensearch-node1-1       | 	at okhttp3.internal.connection.RealConnection.connect(RealConnection.kt:207)
opensearch-node1-1       | 	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.kt:226)
opensearch-node1-1       | 	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.kt:106)
opensearch-node1-1       | 	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.kt:74)
opensearch-node1-1       | 	at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:255)
opensearch-node1-1       | 	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
opensearch-node1-1       | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
opensearch-node1-1       | 	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
opensearch-node1-1       | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
opensearch-node1-1       | 	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
opensearch-node1-1       | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
opensearch-node1-1       | 	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
opensearch-node1-1       | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
opensearch-node1-1       | 	at org.opensearch.sql.common.interceptors.URIValidatorInterceptor.intercept(URIValidatorInterceptor.java:33)
opensearch-node1-1       | 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
opensearch-node1-1       | 	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
opensearch-node1-1       | 	at okhttp3.internal.connection.RealCall.execute(RealCall.kt:154)
opensearch-node1-1       | 	at org.opensearch.sql.prometheus.client.PrometheusClientImpl.getAllMetrics(PrometheusClientImpl.java:178)
opensearch-node1-1       | 	at org.opensearch.sql.prometheus.query.PrometheusQueryHandler.getResources(PrometheusQueryHandler.java:136)
opensearch-node1-1       | 	at org.opensearch.sql.prometheus.query.PrometheusQueryHandler.getResources(PrometheusQueryHandler.java:32)
opensearch-node1-1       | 	at org.opensearch.sql.directquery.DirectQueryExecutorServiceImpl.lambda$getDirectQueryResources$0(DirectQueryExecutorServiceImpl.java:81)
opensearch-node1-1       | 	at java.base/java.util.Optional.map(Optional.java:260)
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
