### PR TITLE
Remove Java11 review guidance

### DIFF
--- a/.rules/REVIEW_GUIDELINES.md
+++ b/.rules/REVIEW_GUIDELINES.md
@@ -90,7 +90,6 @@ This document provides general code review principles and standards for the Open
 
 ### OpenSearch SQL
 - **JDK 21**: Required for development
-- **Java 11 Compatibility**: Maintain when possible for OpenSearch 2.x
 - **Module Structure**: Respect existing module boundaries (core, ppl, sql, opensearch, integ-test)
 - **Test Naming**: `*IT.java` for integration tests, `*Test.java` for unit tests
 


### PR DESCRIPTION
### Description
- Remove Java11 review guidance as we no longer backport to 2.x

### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
