### PR TITLE
[Backport 3.5][CVE-2026-24400] Upgrade assertj-core to 3.27.7

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.4.2"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.9.1'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.27.7'
     testImplementation group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: "${hamcrest_version}"
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')

--- a/release-notes/opensearch-sql.release-notes-3.5.0.0.md
+++ b/release-notes/opensearch-sql.release-notes-3.5.0.0.md
@@ -74,3 +74,4 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.5.0
 * Remove shadow jar task from build file ([#4955](https://github.com/opensearch-project/sql/pull/4955))
 * Add Frequently Used Big5 PPL Queries ([#4976](https://github.com/opensearch-project/sql/pull/4976))
 * Increment version to 3.5.0 ([#5040](https://github.com/opensearch-project/sql/pull/5040))
+* Upgrade assertj-core to 3.27.7 ([#5100](https://github.com/opensearch-project/sql/pull/5100))


### PR DESCRIPTION
### Description
Direct backport of #5100 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
