### PR TITLE
Revert "[Backport 2.19-dev] [AUTO] Increment version to 2.19.5-SNAPSHOT"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.19.5-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.19.4-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
Reverts opensearch-project/sql#5077 which cause CI failing, e.g. https://github.com/opensearch-project/sql/actions/runs/21615168490/job/62292227578?pr=5104

The root cause is that the artifacts of geospatial 2.15.0-SNAPSHOT is still not uploaded, ref https://github.com/opensearch-project/geospatial/pull/824#issuecomment-3833202839