### PR TITLE
Fix the flaky yamlRestTest caused by order of sample_logs

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4866.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4866.yml
@@ -5,6 +5,13 @@ setup:
           transient:
             plugins.calcite.enabled: true
   - do:
+      indices.create:
+        index: hdfs_logs
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+  - do:
       bulk:
         index: hdfs_logs
         refresh: true


### PR DESCRIPTION
### Description
`Patterns with specified max_sample_count should return correct result` is flaky

### Related Issues
Resolves #5118 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
