### PR TITLE
Fix rand() sort + head limit regression in PPL (issue #5114)

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5114.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5114.yml
@@ -1,0 +1,66 @@
+# Issue: https://github.com/opensearch-project/sql/issues/5114
+
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+  - do:
+      indices.create:
+        index: test_issue_5114
+        body:
+          mappings:
+            properties:
+              id:
+                type: integer
+              name:
+                type: keyword
+              reportsTo:
+                type: keyword
+  - do:
+      bulk:
+        index: test_issue_5114
+        refresh: true
+        body:
+          - '{"index":{"_id":"1"}}'
+          - '{"id":1,"name":"Dev","reportsTo":"Eliot"}'
+          - '{"index":{"_id":"2"}}'
+          - '{"id":2,"name":"Eliot","reportsTo":"Ron"}'
+          - '{"index":{"_id":"3"}}'
+          - '{"id":3,"name":"Ron","reportsTo":"Andrew"}'
+          - '{"index":{"_id":"4"}}'
+          - '{"id":4,"name":"Andrew","reportsTo":null}'
+          - '{"index":{"_id":"5"}}'
+          - '{"id":5,"name":"Asya","reportsTo":"Ron"}'
+          - '{"index":{"_id":"6"}}'
+          - '{"id":6,"name":"Dan","reportsTo":"Andrew"}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+  - do:
+      indices.delete:
+        index: test_issue_5114
+
+---
+"sort rand with head should cap result size to 5":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_issue_5114 | eval a = rand() | sort a | fields id | head 5
+
+  - match: { total: 5 }
+  - length: { datarows: 5 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/rules/SortExprIndexScanRule.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/planner/rules/SortExprIndexScanRule.java
@@ -105,7 +105,10 @@ public class SortExprIndexScanRule extends InterruptibleRelRule<SortExprIndexSca
     // EnumerableSort won't have limit or offset
     Integer limitValue = LimitIndexScanRule.extractLimitValue(sort.fetch);
     Integer offsetValue = LimitIndexScanRule.extractOffsetValue(sort.offset);
-    if (newScan instanceof CalciteLogicalIndexScan && limitValue != null && offsetValue != null) {
+    if (newScan instanceof CalciteLogicalIndexScan
+        && sort instanceof LogicalSort
+        && limitValue != null
+        && offsetValue != null) {
       newScan =
           (CalciteLogicalIndexScan)
               ((CalciteLogicalIndexScan) newScan)
@@ -219,6 +222,7 @@ public class SortExprIndexScanRule extends InterruptibleRelRule<SortExprIndexSca
       // Reject literals or constant expression - they don't provide meaningful sorting
       if (expr instanceof RexLiteral
           || RexUtil.isConstant(expr)
+          || !RexUtil.isDeterministic(expr)
           || !isSupportedSortScriptType(expr.getType().getSqlTypeName())) {
         return false;
       }


### PR DESCRIPTION
Superseded by #5128, which contains the same changes with DCO sign-off and spotless applied.