### PR TITLE
Introduce forced compilation deps for consistent CLI builds

### DIFF
--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -85,6 +85,13 @@ pitest {
     junit5PluginVersion = '1.0.0'
 }
 
+// Ensure compileJava waits for all dependency modules to finish building classes
+// This prevents race conditions in parallel builds and composite builds
+tasks.named('compileJava') {
+    dependsOn ':core:classes'
+    dependsOn ':common:classes'
+}
+
 test {
     maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -85,6 +85,14 @@ spotless {
     }
 }
 
+// Ensure compileJava waits for all dependency modules to finish building classes
+// This prevents race conditions in parallel builds and composite builds
+tasks.named('compileJava') {
+    dependsOn ':core:classes'
+    dependsOn ':common:classes'
+    dependsOn ':protocol:classes'
+}
+
 test {
     maxParallelForks = Runtime.runtime.availableProcessors()
     testLogging {

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -49,6 +49,13 @@ configurations.all {
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 }
 
+// Ensure compileJava waits for all dependency modules to finish building classes
+// This prevents race conditions in parallel builds and composite builds
+tasks.named('compileJava') {
+    dependsOn ':core:classes'
+    dependsOn ':opensearch:classes'
+}
+
 test {
     maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -78,6 +78,14 @@ spotless {
     }
 }
 
+// Ensure compileJava waits for all dependency modules to finish building classes
+// This prevents race conditions in parallel builds and composite builds
+tasks.named('compileJava') {
+    dependsOn ':core:classes'
+    dependsOn ':common:classes'
+    dependsOn ':protocol:classes'
+}
+
 test {
     maxParallelForks = Runtime.runtime.availableProcessors()
     useJUnitPlatform()


### PR DESCRIPTION
### Description
It looks like sometimes the CLI fails to build in CI because of a compilation race condition -- this adds some explicit dependencies to hopefully fix the flakiness.

Will rerun a few times to see if CLI failures continue.

### Related Issues
Flaky CI coming up in #5129 and #5080 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
