### PR TITLE
Fix pitest dependency resolution with stable runtime version

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -38,11 +38,11 @@ repositories {
 
 pitest {
     targetClasses = ['org.opensearch.sql.*']
-    pitestVersion = '1.19.0-rc.2'
+    pitestVersion = '1.22.1'
     threads = 4
     outputFormats = ['HTML', 'XML']
     timestampedReports = false
-    junit5PluginVersion = '1.0.0'
+    junit5PluginVersion = '1.2.1'
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- The pitest Gradle plugin `1.19.0-rc.2` is needed for Gradle 9 compatibility, but its matching RC runtime artifacts (`org.pitest:pitest-command-line:1.19.0-rc.2`) are not published to Maven Central, causing `Could not find org.pitest:pitest-command-line:1.19.0-rc.2` errors when running `./gradlew :core:pitest`.
- This PR decouples the plugin version from the runtime version by setting `pitestVersion = '1.22.1'` (latest stable release available on Maven Central) and updating `junit5PluginVersion` to `1.2.1`.
- Verified locally: pitest resolves all dependencies from `mavenCentral()` and completes mutation testing successfully (8279 mutations generated, 3750 killed, 74% test strength).

### Related GitHub issues
- [szpak/gradle-pitest-plugin#380](https://github.com/szpak/gradle-pitest-plugin/issues/380) — stable 1.19.0 not yet released
- [szpak/gradle-pitest-plugin#386](https://github.com/szpak/gradle-pitest-plugin/issues/386) — rc.2 task configuration problem
- [szpak/gradle-pitest-plugin#385](https://github.com/szpak/gradle-pitest-plugin/issues/385) — NoClassDefFoundError with rc.2

## Test plan
- [x] `./gradlew :core:pitest` completes successfully (BUILD SUCCESSFUL in 5m 17s)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)