### PR TITLE
[Maintenance] Fix bc-fips jar hell by marking dependency as compileOnly

### DIFF
--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     // bc-fips is provided by OpenSearch core at runtime since opensearch 3.6.0
     compileOnly "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
+    testImplementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')


### PR DESCRIPTION
### Description
Fix bc-fips jar hell by marking dependency as compileOnly

- #5155 addressed the `bc-fips` jar hell by conditionally using `compileOnly` only when the `-Pcrypto.standard=FIPS-140-3` build flag is set. However, since [OpenSearch#20625](https://github.com/opensearch-project/OpenSearch/pull/20625), OpenSearch 3.6.0 ships `bc-fips-2.1.2.jar` in core `lib/` **by default** — not just in FIPS mode. This means the jar hell still occurs in normal (non-FIPS) builds, which is what CI is hitting.
- Fix: always use `compileOnly` for `bc-fips`, since OpenSearch core now provides it regardless of FIPS mode.

### Example failures from https://github.com/opensearch-project/sql/actions/runs/22168363820/job/64100552932?pr=5141#step:6:283
```bash
| Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-sql due to jar hell
| 	at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:779)
| 	at org.opensearch.plugins.PluginsService.checkJarHellForPlugin(PluginsService.java:404)
| 	at org.opensearch.tools.cli.plugin.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:834)
| 	at org.opensearch.tools.cli.plugin.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:811)
| 	at org.opensearch.tools.cli.plugin.InstallPluginCommand.installPlugin(InstallPluginCommand.java:846)
| 	at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:277)
| 	at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:251)
| 	at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110)
| 	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
| 	at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
| 	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
| 	at org.opensearch.cli.Command.main(Command.java:101)
| 	at org.opensearch.tools.cli.plugin.PluginCli.main(PluginCli.java:66)
| Caused by: java.lang.IllegalStateException: jar hell!
| class: META-INF.versions.11.org.bouncycastle.crypto.fips.FipsSecureRandom$Random11Spi
| jar1: /__w/sql/sql/integ-test/build/testclusters/integTest-0/distro/3.6.0-ARCHIVE/plugins/.installing-15693190113652499017/bc-fips-2.1.2.jar
| jar2: /__w/sql/sql/integ-test/build/testclusters/integTest-0/distro/3.6.0-ARCHIVE/lib/bc-fips-2.1.2.jar
| 	at org.opensearch.common.bootstrap.JarHell.checkClass(JarHell.java:316)
| 	at org.opensearch.common.bootstrap.JarHell.checkJarHell(JarHell.java:215)
| 	at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:777)
| 	... 12 more

> Task :integ-test:stopPrometheus
```
 
### Related Issues
* Relate https://github.com/opensearch-project/sql/pull/5155

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
