### PR TITLE
Bump ANTLR Version to 4.13.2

### DIFF
--- a/async-query-core/build.gradle
+++ b/async-query-core/build.gradle
@@ -43,7 +43,7 @@ configurations {
 }
 
 dependencies {
-    antlr "org.antlr:antlr4:4.7.1"
+    antlr "org.antlr:antlr4:4.13.2"
 
     implementation project(':core')
     implementation 'org.json:json:20231013'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    api "org.antlr:antlr4-runtime:4.7.1"
+    api "org.antlr:antlr4-runtime:4.13.2"
     api group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     api group: 'org.apache.logging.log4j', name: 'log4j-core', version:"${versions.log4j}"
     api group: 'org.apache.commons', name: 'commons-lang3', version: "${commons_lang3_version}"

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -120,8 +120,8 @@ dependencies {
     api project(':opensearch')
 
     // ANTLR gradle plugin and runtime dependency
-    antlr "org.antlr:antlr4:4.7.1"
-    implementation "org.antlr:antlr4-runtime:4.7.1"
+    antlr "org.antlr:antlr4:4.13.2"
+    implementation "org.antlr:antlr4-runtime:4.13.2"
     compileOnly group: 'javax.servlet', name: 'servlet-api', version:'2.5'
 
     testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version:'2.2'

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -48,11 +48,11 @@ configurations {
 }
 
 dependencies {
-    antlr "org.antlr:antlr4:4.7.1"
+    antlr "org.antlr:antlr4:4.13.2"
 
     runtimeOnly group: 'org.reflections', name: 'reflections', version: '0.9.12'
 
-    implementation "org.antlr:antlr4-runtime:4.7.1"
+    implementation "org.antlr:antlr4-runtime:4.13.2"
     implementation group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     api group: 'org.json', name: 'json', version: '20231013'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:"${versions.log4j}"

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -43,9 +43,9 @@ configurations {
 }
 
 dependencies {
-    antlr "org.antlr:antlr4:4.7.1"
+    antlr "org.antlr:antlr4:4.13.2"
 
-    implementation "org.antlr:antlr4-runtime:4.7.1"
+    implementation "org.antlr:antlr4-runtime:4.13.2"
     implementation group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     implementation group: 'org.json', name: 'json', version:'20231013'
     implementation project(':common')


### PR DESCRIPTION
### Description
Bump ANTLR4 from 4.7.1 to 4.13.2 across all modules that directly declare it.                                                                                                                                                                                
                                                                                                                                                                                                                                                               
#### Changes                                                                                                                                                                                                                                                  
Version updated in 5 modules:                                                                                                                                                                                                                                
  - `common` – `antlr4-runtime` (api dependency)                                                                                                                                                                                                               
  - `ppl` – `antlr4` (codegen tool) + `antlr4-runtime`                                                                                                                                                                                                         
  - `sql` – `antlr4` (codegen tool) + `antlr4-runtime`                                                                                                                                                                                                         
  - `legacy` – `antlr4` (codegen tool) + `antlr4-runtime`
  - `async-query-core` – `antlr4` (codegen tool)

#### Why 4.13.2
- antlr4ng (frontend runtime) requires ATN serialization v4 when reconstructing lexer/parser from serialized ATN data.
- ANTLR 4.7.1 uses ATN serialization v3; ANTLR ≥ 4.10 produces/consumes ATN v4.
- 4.13.2 is the latest stable ANTLR4 release, so we target it to minimize future upgrades and pick up bug fixes.

### Backwards Compatibility
- The .g4 grammar sources are expected to remain compatible with ANTLR 4.13.2; this change primarily updates the generated lexer/parser code by regenerating it under the newer ANTLR toolchain.
- ANTLR minor-version upgrades may introduce differences in parsing behavior at the margins (especially error recovery paths, error messages, and reported line/column positions). CI coverage (unit + integration tests) is used to validate that existing SQL/PPL functionality remains correct and that no regressions are introduced.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
