### PR TITLE
Fix MAP field overwrite in eval with dotted-path assignments

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -981,10 +981,11 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
 
   private void projectPlusOverriding(
       List<RexNode> newFields, List<String> newNames, CalcitePlanContext context) {
-    List<String> originalFieldNames = context.relBuilder.peek().getRowType().getFieldNames();
+    RelDataType rowType = context.relBuilder.peek().getRowType();
+    List<String> originalFieldNames = rowType.getFieldNames();
     List<RexNode> toOverrideList =
         originalFieldNames.stream()
-            .filter(originalName -> shouldOverrideField(originalName, newNames))
+            .filter(originalName -> shouldOverrideField(originalName, newNames, rowType))
             .map(a -> (RexNode) context.relBuilder.field(a))
             .toList();
     // 1. add the new fields, For example "age0, country0"
@@ -1004,15 +1005,19 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     context.relBuilder.rename(expectedRenameFields);
   }
 
-  private boolean shouldOverrideField(String originalName, List<String> newNames) {
+  private boolean shouldOverrideField(
+      String originalName, List<String> newNames, RelDataType rowType) {
+    RelDataTypeField field = rowType.getField(originalName, true, false);
+    boolean isMapType = field != null && field.getType().getSqlTypeName() == SqlTypeName.MAP;
     return newNames.stream()
         .anyMatch(
             newName ->
                 // Match exact field names (e.g., "age" == "age") for flat fields
                 newName.equals(originalName)
                     // OR match nested paths (e.g., "resource.attributes..." starts with
-                    // "resource.")
-                    || newName.startsWith(originalName + "."));
+                    // "resource."), but not for MAP fields where dotted names are flat
+                    // columns rather than real sub-fields (e.g. spath-produced MAP columns)
+                    || (!isMapType && newName.startsWith(originalName + ".")));
   }
 
   private List<List<RexInputRef>> extractInputRefList(List<RelBuilder.AggCall> aggCalls) {

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLSpathTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLSpathTest.java
@@ -144,4 +144,33 @@ public class CalcitePPLSpathTest extends CalcitePPLAbstractTest {
                 + "FROM `scott`.`EMP`\n"
                 + "ORDER BY 10) `t0`");
   }
+
+  @Test
+  public void testSpathAutoExtractModeWithMultipleDottedEval() {
+    // Regression test: eval with multiple dotted-path assignments from the same MAP root
+    // must not drop the MAP column after the first assignment (#5185)
+    withPPLQuery(
+            "source=EMP | spath input=ENAME output=result"
+                + " | eval result.user.name=result.user.name, result.user.age=result.user.age"
+                + " | fields result.user.name, result.user.age")
+        .expectLogical(
+            "LogicalProject(result.user.name=[ITEM(JSON_EXTRACT_ALL($1), 'user.name')],"
+                + " result.user.age=[ITEM(JSON_EXTRACT_ALL($1), 'user.age')])\n"
+                + "  LogicalTableScan(table=[[scott, EMP]])\n");
+  }
+
+  @Test
+  public void testSpathAutoExtractModeWithConsecutiveDottedEval() {
+    // Regression test: chained eval commands with dotted-path assignments from the same MAP root
+    // must not drop the MAP column between evals (#5185)
+    withPPLQuery(
+            "source=EMP | spath input=ENAME output=result"
+                + " | eval result.user.name=result.user.name"
+                + " | eval result.user.age=result.user.age"
+                + " | fields result.user.name, result.user.age")
+        .expectLogical(
+            "LogicalProject(result.user.name=[ITEM(JSON_EXTRACT_ALL($1), 'user.name')],"
+                + " result.user.age=[ITEM(JSON_EXTRACT_ALL($1), 'user.age')])\n"
+                + "  LogicalTableScan(table=[[scott, EMP]])\n");
+  }
 }


### PR DESCRIPTION
eval was overwriting MAP fields when multiple dotted-path names were assigned. The issue was assuming any dotted path starting with a field name meant it was a nested access, but MAP columns have flat names with dots in them. Now we check the field type before deciding to override.

Fixes #5185