### PR TITLE
Add isnotempty PPL function

### DIFF
--- a/async-query-core/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/async-query-core/src/main/antlr/OpenSearchPPLLexer.g4
@@ -373,6 +373,7 @@ REPLACE:                            'REPLACE';
 REVERSE:                            'REVERSE';
 CAST:                               'CAST';
 ISEMPTY:                            'ISEMPTY';
+ISNOTEMPTY:                         'ISNOTEMPTY';
 ISBLANK:                            'ISBLANK';
 
 // JSON TEXT FUNCTIONS

--- a/async-query-core/src/main/antlr/OpenSearchPPLParser.g4
+++ b/async-query-core/src/main/antlr/OpenSearchPPLParser.g4
@@ -468,6 +468,7 @@ positionFunction
 booleanExpression
    : booleanFunctionCall                                                # booleanFunctionCallExpr
    | isEmptyExpression                                                  # isEmptyExpr
+   | isNotEmptyExpression                                               # isNotEmptyExpr
    | valueExpressionList NOT? IN LT_SQR_PRTHS subSearch RT_SQR_PRTHS    # inSubqueryExpr
    | EXISTS LT_SQR_PRTHS subSearch RT_SQR_PRTHS                         # existsSubqueryExpr
    | cidrMatchFunctionCall                                              # cidrFunctionCallExpr
@@ -475,6 +476,10 @@ booleanExpression
 
  isEmptyExpression
    : (ISEMPTY | ISBLANK) LT_PRTHS functionArg RT_PRTHS
+   ;
+
+ isNotEmptyExpression
+   : ISNOTEMPTY LT_PRTHS functionArg RT_PRTHS
    ;
 
  caseFunction
@@ -860,6 +865,7 @@ textFunctionName
    | REPLACE
    | REVERSE
    | ISEMPTY
+   | ISNOTEMPTY
    | ISBLANK
    ;
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -289,6 +289,7 @@ public enum BuiltinFunctionName {
 
   IS_PRESENT(FunctionName.of("ispresent")),
   IS_EMPTY(FunctionName.of("isempty")),
+  IS_NOT_EMPTY(FunctionName.of("isnotempty")),
   IS_BLANK(FunctionName.of("isblank")),
 
   ROW_NUMBER(FunctionName.of("row_number")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -91,6 +91,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.INTERNA
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.INTERNAL_TRANSLATE3;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_BLANK;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_EMPTY;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NOT_EMPTY;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NOT_NULL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_NULL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.IS_PRESENT;
@@ -1251,6 +1252,17 @@ public class PPLFuncImpTable {
                       SqlStdOperatorTable.OR,
                       builder.makeCall(SqlStdOperatorTable.IS_NULL, arg),
                       builder.makeCall(SqlStdOperatorTable.IS_EMPTY, arg)),
+          PPLTypeChecker.family(SqlTypeFamily.ANY));
+      register(
+          IS_NOT_EMPTY,
+          (FunctionImp1)
+              (builder, arg) ->
+                  builder.makeCall(
+                      SqlStdOperatorTable.NOT,
+                      builder.makeCall(
+                          SqlStdOperatorTable.OR,
+                          builder.makeCall(SqlStdOperatorTable.IS_NULL, arg),
+                          builder.makeCall(SqlStdOperatorTable.IS_EMPTY, arg))),
           PPLTypeChecker.family(SqlTypeFamily.ANY));
       register(
           IS_BLANK,

--- a/docs/user/ppl/functions/condition.md
+++ b/docs/user/ppl/functions/condition.md
@@ -642,8 +642,40 @@ fetched rows / total rows = 4/4
 | False         |         | True              | null     |
 +---------------+---------+-------------------+----------+
 ```
-  
-## EARLIEST  
+
+## ISNOTEMPTY
+
+### Description
+
+Usage: `isnotempty(field)` returns true if the field is not null and is not an empty string.
+
+**Argument type:** All supported data types.
+**Return type:** `BOOLEAN`
+
+### Example
+
+```ppl
+source=accounts
+| eval temp = ifnull(employer, '   ')
+| eval `isnotempty(employer)` = isnotempty(employer), `isnotempty(temp)` = isnotempty(temp)
+| fields `isnotempty(temp)`, temp, `isnotempty(employer)`, employer
+```
+
+Expected output:
+
+```text
+fetched rows / total rows = 4/4
++------------------+---------+----------------------+----------+
+| isnotempty(temp) | temp    | isnotempty(employer) | employer |
+|------------------+---------+----------------------+----------|
+| True             | Pyrami  | True                 | Pyrami   |
+| True             | Netagy  | True                 | Netagy   |
+| True             | Quility | True                 | Quility  |
+| True             |         | False                | null     |
++------------------+---------+----------------------+----------+
+```
+
+## EARLIEST
 
 ### Description  
 

--- a/docs/user/ppl/functions/index.md
+++ b/docs/user/ppl/functions/index.md
@@ -54,6 +54,7 @@ PPL supports a wide range of built-in functions for data processing and analysis
   - [ISPRESENT](condition.md/#ispresent)
   - [ISBLANK](condition.md/#isblank)
   - [ISEMPTY](condition.md/#isempty)
+  - [ISNOTEMPTY](condition.md/#isnotempty)
   - [EARLIEST](condition.md/#earliest)
   - [LATEST](condition.md/#latest)
   - [REGEXP_MATCH](condition.md/#regexp_match)

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLConditionBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLConditionBuiltinFunctionIT.java
@@ -283,6 +283,28 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testIsNotEmpty() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where isnotempty(name) | fields name, age",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+
+    verifySchema(actual, schema("name", "string"), schema("age", "int"));
+
+    // isnotempty = NOT isempty. isempty returns (null,10) and ("",57).
+    // So isnotempty returns everything else: Jake, Hello, John, Jane, Kevin, whitespace.
+    verifyDataRows(
+        actual,
+        rows("Jake", 70),
+        rows("Hello", 30),
+        rows("John", 25),
+        rows("Jane", 20),
+        rows("Kevin", null),
+        rows("    ", 27));
+  }
+
+  @Test
   public void testIsBlank() throws IOException {
     JSONObject actual =
         executeQuery(

--- a/language-grammar/src/main/antlr4/OpenSearchPPLLexer.g4
+++ b/language-grammar/src/main/antlr4/OpenSearchPPLLexer.g4
@@ -419,6 +419,7 @@ BETWEEN:                            'BETWEEN';
 CIDRMATCH:                          'CIDRMATCH';
 ISPRESENT:                          'ISPRESENT';
 ISEMPTY:                            'ISEMPTY';
+ISNOTEMPTY:                         'ISNOTEMPTY';
 ISBLANK:                            'ISBLANK';
 
 // FLOWCONTROL FUNCTIONS

--- a/language-grammar/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/language-grammar/src/main/antlr4/OpenSearchPPLParser.g4
@@ -851,6 +851,7 @@ conditionFunctionBase
    | EARLIEST
    | LATEST
    | ISEMPTY
+   | ISNOTEMPTY
    | ISBLANK
    ;
 
@@ -877,6 +878,7 @@ textFunctionName
    | REPLACE
    | REVERSE
    | ISEMPTY
+   | ISNOTEMPTY
    | ISBLANK
    ;
 

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -463,6 +463,7 @@ CIDRMATCH:                          'CIDRMATCH';
 BETWEEN:                            'BETWEEN';
 ISPRESENT:                          'ISPRESENT';
 ISEMPTY:                            'ISEMPTY';
+ISNOTEMPTY:                         'ISNOTEMPTY';
 ISBLANK:                            'ISBLANK';
 
 // COLLECTION FUNCTIONS

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -1378,6 +1378,7 @@ conditionFunctionName
    | JSON_VALID
    | ISPRESENT
    | ISEMPTY
+   | ISNOTEMPTY
    | ISBLANK
    | EARLIEST
    | LATEST


### PR DESCRIPTION
## Description

Adds `isnotempty(field)` to PPL. Returns `true` when a field is not null and not empty string — logical negation of `isempty(field)`.

Resolves #5182

## Changes

- Added `ISNOTEMPTY` token and parser rules in ppl, language-grammar, and async-query-core grammars
- Added `IS_NOT_EMPTY` enum constant to `BuiltinFunctionName`
- Registered Calcite implementation as `NOT(IS_NULL(arg) OR IS_EMPTY(arg))` in `PPLFuncImpTable`
- Added `testIsNotEmpty` integration test
- Added docs