### PR TITLE
Fix #5164: Detect integer/long overflow using Calcite's native checked arithmetic

### DIFF
--- a/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
+++ b/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
@@ -44,6 +44,7 @@ public abstract class Settings {
     CALCITE_PUSHDOWN_ROWCOUNT_ESTIMATION_FACTOR(
         "plugins.calcite.pushdown.rowcount.estimation.factor"),
     CALCITE_SUPPORT_ALL_JOIN_TYPES("plugins.calcite.all_join_types.allowed"),
+    CALCITE_CHECKED_ARITHMETIC("plugins.calcite.checked_arithmetic.enabled"),
 
     /** Query Settings. */
     FIELD_TYPE_TOLERANCE("plugins.query.field_type_tolerance"),

--- a/core/src/main/java/org/opensearch/sql/calcite/plan/rule/PPLAggregateConvertRule.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/plan/rule/PPLAggregateConvertRule.java
@@ -135,7 +135,9 @@ public class PPLAggregateConvertRule extends RelRule<PPLAggregateConvertRule.Con
         final Function<RelNode, Function<RexNode, RexNode>> literalConverterProvider;
         RexCall rexCall = (RexCall) project.getProjects().get(aggCall.getArgList().getFirst());
         if (rexCall.getOperator().kind == SqlKind.PLUS
-            || rexCall.getOperator().kind == SqlKind.MINUS) {
+            || rexCall.getOperator().kind == SqlKind.MINUS
+            || rexCall.getOperator().kind == SqlKind.CHECKED_PLUS
+            || rexCall.getOperator().kind == SqlKind.CHECKED_MINUS) {
           AggregateCall countCall =
               AggregateCall.create(
                   aggCall.getParserPosition(),
@@ -280,7 +282,12 @@ public class PPLAggregateConvertRule extends RelRule<PPLAggregateConvertRule.Con
 
     List<SqlKind> CONVERTABLE_FUNCTIONS =
         List.of(
-            SqlKind.PLUS, SqlKind.MINUS, SqlKind.TIMES
+            SqlKind.PLUS,
+            SqlKind.MINUS,
+            SqlKind.TIMES,
+            SqlKind.CHECKED_PLUS,
+            SqlKind.CHECKED_MINUS,
+            SqlKind.CHECKED_TIMES
             // Don't support division because of the issue of integer division
             // e.g. (2000 / 3) * 3 = 1998 while 2000 * 3 / 3 = 2000
             // SqlKind.DIVIDE

--- a/core/src/main/java/org/opensearch/sql/executor/QueryService.java
+++ b/core/src/main/java/org/opensearch/sql/executor/QueryService.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql2rel.ConvertToChecked;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Programs;
@@ -105,8 +106,14 @@ public class QueryService {
                     buildFrameworkConfig(), SysLimit.fromSettings(settings), queryType);
             RelNode relNode = analyze(plan, context);
             RelNode calcitePlan = convertToCalcitePlan(relNode, context);
+            if (isCheckedArithmeticEnabled()) {
+              calcitePlan = new ConvertToChecked(context.rexBuilder).visit(calcitePlan);
+            }
             analyzeMetric.set(System.nanoTime() - analyzeStart);
             executionEngine.execute(calcitePlan, context, listener);
+          } catch (ArithmeticException e) {
+            listener.onFailure(
+                new NonFallbackCalciteException("Arithmetic overflow: " + e.getMessage(), e));
           } catch (Throwable t) {
             if (isCalciteFallbackAllowed(t) && !(t instanceof NonFallbackCalciteException)) {
               log.warn("Fallback to V2 query engine since got exception", t);
@@ -146,6 +153,9 @@ public class QueryService {
                 () -> {
                   RelNode relNode = analyze(plan, context);
                   RelNode calcitePlan = convertToCalcitePlan(relNode, context);
+                  if (isCheckedArithmeticEnabled()) {
+                    calcitePlan = new ConvertToChecked(context.rexBuilder).visit(calcitePlan);
+                  }
                   executionEngine.explain(calcitePlan, mode, context, listener);
                 },
                 settings);
@@ -282,6 +292,14 @@ public class QueryService {
         return true;
       }
     }
+  }
+
+  private boolean isCheckedArithmeticEnabled() {
+    if (settings != null) {
+      Boolean enabled = settings.getSettingValue(Settings.Key.CALCITE_CHECKED_ARITHMETIC);
+      return enabled != null && enabled;
+    }
+    return true; // default: overflow checking enabled
   }
 
   private boolean isCalciteEnabled(Settings settings) {

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -960,3 +960,19 @@ Join types ``inner``, ``left``, ``outer`` (alias of ``left``), ``semi`` and ``an
 1. The default value is false since 3.3.0.
 2. This setting is node scope.
 3. This setting can be updated dynamically.
+
+plugins.calcite.checked_arithmetic.enabled
+==========================================
+
+Version
+-------
+3.3
+
+Description
+-----------
+
+When enabled, integer and long arithmetic operations (``+``, ``-``, ``*``, ``/``) detect overflow and return an error instead of silently wrapping. For example, ``2147483647 + 1`` returns an error rather than ``-2147483648``. Floating-point (``float``, ``double``) arithmetic is unaffected and follows IEEE 754 behavior.
+
+1. The default value is true since 3.3.0.
+2. This setting is node scope.
+3. This setting can be updated dynamically.

--- a/docs/user/ppl/functions/expressions.md
+++ b/docs/user/ppl/functions/expressions.md
@@ -18,8 +18,22 @@ Arithmetic expression is an expression formed by numeric literals and binary ari
    [plugins.ppl.syntax.legacy.preferred](../admin/settings.md) is `true` (default). When the
    setting is `false` the operands are promoted to floating point, preserving
    the fractional part. Division by zero still returns `NULL`.
-5. `%`: Modulo. This can be used with integers only with remainder of the division as result.  
-  
+5. `%`: Modulo. This can be used with integers only with remainder of the division as result.
+
+#### Overflow Behavior
+
+Integer and long arithmetic operations detect overflow and return an error
+instead of silently wrapping. For example, `2147483647 + 1` (integer max + 1)
+returns an error rather than `-2147483648`. This applies to `+`, `-`, and `*`
+on integer and long types.
+
+Floating-point arithmetic (`float`, `double`) follows IEEE 754 and does not
+produce overflow errors.
+
+This behavior is controlled by the `plugins.calcite.checked_arithmetic.enabled`
+setting (default: `true`). When disabled, arithmetic wraps silently as in
+standard Java.
+
 #### Precedence  
 
 Parentheses can be used to control the precedence of arithmetic operators. Otherwise, operators of higher precedence is performed first.

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5164.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5164.yml
@@ -1,0 +1,149 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+
+  - do:
+      indices.create:
+        index: test_overflow
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              int_field:
+                type: integer
+              long_field:
+                type: long
+              small_int:
+                type: integer
+
+  - do:
+      bulk:
+        index: test_overflow
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"int_field": 2147483647, "long_field": 9223372036854775807, "small_int": 10}'
+          - '{"index": {"_id": "2"}}'
+          - '{"int_field": 100, "long_field": 200, "small_int": 5}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+  - do:
+      indices.delete:
+        index: test_overflow
+        ignore_unavailable: true
+
+---
+"Normal integer addition does not error":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_overflow | where small_int = 5 | eval sum = int_field + small_int | fields int_field, small_int, sum
+  - match: { total: 1 }
+  - match: { datarows: [[100, 5, 105]] }
+  - match: { schema: [{ name: "int_field", type: "int" }, { name: "small_int", type: "int" }, { name: "sum", type: "int" }] }
+
+---
+"Integer addition overflow throws error":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_overflow | where int_field = 2147483647 | eval overflow = int_field + 1 | fields overflow
+  - match: { "$body": "/overflow/" }
+
+---
+"Long addition overflow throws error":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_overflow | where long_field = 9223372036854775807 | eval overflow = long_field + 1 | fields overflow
+  - match: { "$body": "/overflow/" }
+
+---
+"Integer multiplication overflow throws error":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_overflow | where int_field = 2147483647 | eval overflow = int_field * 2 | fields overflow
+  - match: { "$body": "/overflow/" }
+
+---
+"Long multiplication overflow throws error":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_overflow | where long_field = 9223372036854775807 | eval overflow = long_field * 2 | fields overflow
+  - match: { "$body": "/overflow/" }
+
+---
+"Integer subtraction overflow throws error":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_overflow | where int_field = 2147483647 | eval overflow = int_field - (-1) | fields overflow
+  - match: { "$body": "/overflow/" }
+
+---
+"Normal arithmetic with doubles does not error on large values":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=test_overflow | where small_int = 5 | eval result = small_int * 1.0 + 999999999999.0 | fields result
+  - match: { total: 1 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -186,6 +186,13 @@ public class OpenSearchSettings extends Settings {
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
 
+  public static final Setting<?> CALCITE_CHECKED_ARITHMETIC_SETTING =
+      Setting.boolSetting(
+          Key.CALCITE_CHECKED_ARITHMETIC.getKeyValue(),
+          true,
+          Setting.Property.NodeScope,
+          Setting.Property.Dynamic);
+
   public static final Setting<?> QUERY_MEMORY_LIMIT_SETTING =
       Setting.memorySizeSetting(
           Key.QUERY_MEMORY_LIMIT.getKeyValue(),
@@ -470,6 +477,12 @@ public class OpenSearchSettings extends Settings {
     register(
         settingBuilder,
         clusterSettings,
+        Key.CALCITE_CHECKED_ARITHMETIC,
+        CALCITE_CHECKED_ARITHMETIC_SETTING,
+        new Updater(Key.CALCITE_CHECKED_ARITHMETIC));
+    register(
+        settingBuilder,
+        clusterSettings,
         Key.QUERY_MEMORY_LIMIT,
         QUERY_MEMORY_LIMIT_SETTING,
         new Updater(Key.QUERY_MEMORY_LIMIT));
@@ -658,6 +671,7 @@ public class OpenSearchSettings extends Settings {
         .add(CALCITE_PUSHDOWN_ENABLED_SETTING)
         .add(CALCITE_PUSHDOWN_ROWCOUNT_ESTIMATION_FACTOR_SETTING)
         .add(CALCITE_SUPPORT_ALL_JOIN_TYPES_SETTING)
+        .add(CALCITE_CHECKED_ARITHMETIC_SETTING)
         .add(DEFAULT_PATTERN_METHOD_SETTING)
         .add(DEFAULT_PATTERN_MODE_SETTING)
         .add(DEFAULT_PATTERN_MAX_SAMPLE_COUNT_SETTING)

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/util/OpenSearchRelOptUtil.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/util/OpenSearchRelOptUtil.java
@@ -55,7 +55,7 @@ public class OpenSearchRelOptUtil {
       case MINUS_PREFIX:
         return getOrderEquivalentInputInfo(((RexCall) expr).getOperands().get(0))
             .map(inputInfo -> Pair.of(inputInfo.getLeft(), !inputInfo.getRight()));
-      case PLUS, MINUS:
+      case PLUS, MINUS, CHECKED_PLUS, CHECKED_MINUS:
         {
           RexNode operand0 = ((RexCall) expr).getOperands().get(0);
           RexNode operand1 = ((RexCall) expr).getOperands().get(1);
@@ -68,12 +68,14 @@ public class OpenSearchRelOptUtil {
           }
 
           RexNode variable = operand0Lit ? operand1 : operand0;
-          boolean flipped = (expr.getKind() == SqlKind.MINUS) && operand0Lit;
+          boolean flipped =
+              (expr.getKind() == SqlKind.MINUS || expr.getKind() == SqlKind.CHECKED_MINUS)
+                  && operand0Lit;
 
           return getOrderEquivalentInputInfo(variable)
               .map(inputInfo -> Pair.of(inputInfo.getLeft(), flipped != inputInfo.getRight()));
         }
-      case TIMES:
+      case TIMES, CHECKED_TIMES:
         {
           RexNode operand0 = ((RexCall) expr).getOperands().get(0);
           RexNode operand1 = ((RexCall) expr).getOperands().get(1);


### PR DESCRIPTION
### Description

Use Calcite's built-in `ConvertToChecked` visitor to rewrite arithmetic operators
(`PLUS`/`MINUS`/`TIMES`) to their overflow-safe `CHECKED` variants. These generate
`SqlFunctions.checkedPlus(int, int)` → `Math.addExact()` calls that throw
`ArithmeticException` on integer/long overflow instead of silently wrapping.

**Root cause:** Standard Calcite operators (`SqlStdOperatorTable.PLUS/MINUS/MULTIPLY`)
generate plain Java `+`/`-`/`*` in the Enumerable code path, which silently wrap
on overflow (e.g., `2147483647 + 1` returns `-2147483648`). This is also the default
behavior in Calcite itself — confirmed by testing with CsvTest.

**Approach:** Calcite 1.41.0 provides a native solution via `SqlConformance.checkedArithmetic()`
and the `ConvertToChecked` RelNode visitor. This PR applies that visitor in the
query execution pipeline, controlled by a new `plugins.calcite.checked_arithmetic.enabled`
setting (default: `true`).

**How it works:**
1. After plan optimization, `ConvertToChecked` rewrites `PLUS → CHECKED_PLUS`,
   `MINUS → CHECKED_MINUS`, `TIMES → CHECKED_MULTIPLY` in the RelNode tree
2. Calcite's code generator produces `SqlFunctions.checkedPlus(int, int)` calls
   that use `Math.addExact()` internally
3. `ArithmeticException` is caught at the `QueryService` level and wrapped in
   `NonFallbackCalciteException` to prevent silent fallback to the V2 engine
4. Float/double arithmetic is unaffected (IEEE 754 behavior)

**Comparison with custom UDF approach:** This replaces the initial approach of creating
custom UDF operators (AddFunction, SubtractFunction, MultiplyFunction). The native
Calcite approach is simpler (46 lines vs 484 lines), avoids boxing overhead, and
also covers division and unary minus overflow.

### Related Issues

#5164

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).