### PR TITLE
Fix #5166: Handle standard JSONPath prefix in json_extract

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonUtils.java
@@ -23,6 +23,14 @@ public class JsonUtils {
   public static String convertToJsonPath(String input) {
     if (input == null || input.isEmpty()) return "$";
 
+    // If the input already starts with "$.", it's already in JSONPath notation.
+    // Strip the "$." prefix and normalize the rest.
+    if (input.startsWith("$.")) {
+      input = input.substring(2);
+    } else if (input.equals("$")) {
+      return "$";
+    }
+
     StringBuilder sb = new StringBuilder("$.");
     int i = 0;
     while (i < input.length()) {

--- a/core/src/test/java/org/opensearch/sql/expression/function/jsonUDF/JsonExtractFunctionImplTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/jsonUDF/JsonExtractFunctionImplTest.java
@@ -75,4 +75,26 @@ public class JsonExtractFunctionImplTest {
     Object result = JsonExtractFunctionImpl.eval("{}", "name", "age");
     assertEquals("[null,null]", result);
   }
+
+  @Test
+  public void testExtractWithDollarPrefixPath() {
+    // Issue #5166: paths starting with "$." should work correctly
+    String json = "{\"name\":\"alice\",\"scores\":[90,85,92]}";
+    Object result = JsonExtractFunctionImpl.eval(json, "$.name");
+    assertEquals("alice", result);
+  }
+
+  @Test
+  public void testExtractNestedWithDollarPrefixPath() {
+    String json = "{\"user\":{\"name\":\"alice\"}}";
+    Object result = JsonExtractFunctionImpl.eval(json, "$.user.name");
+    assertEquals("alice", result);
+  }
+
+  @Test
+  public void testExtractArrayWithDollarPrefixPath() {
+    String json = "{\"name\":\"alice\",\"scores\":[90,85,92]}";
+    Object result = JsonExtractFunctionImpl.eval(json, "$.scores");
+    assertEquals("[90,85,92]", result);
+  }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -66,6 +66,15 @@ public class JsonFunctionsTest {
   }
 
   @Test
+  void test_convertToJsonPathWithDollarPrefix() {
+    // Issue #5166: paths starting with "$." should not get double-prefixed
+    assertEquals("$.name", convertToJsonPath("$.name"));
+    assertEquals("$.user.name", convertToJsonPath("$.user.name"));
+    assertEquals("$.scores", convertToJsonPath("$.scores"));
+    assertEquals("$", convertToJsonPath("$"));
+  }
+
+  @Test
   void test_convertToJsonPathWithWrongPath() {
     IllegalArgumentException e =
         assertThrows(IllegalArgumentException.class, () -> convertToJsonPath("a.{"));

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5166.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5166.yml
@@ -1,0 +1,87 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+
+  - do:
+      indices.create:
+        index: issue5166
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              int_field:
+                type: integer
+              json_data:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue5166", "_id": "1"}}'
+          - '{"int_field": 42, "json_data": "{\"name\":\"alice\",\"scores\":[90,85,92]}"}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue5166
+        ignore_unavailable: true
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"Issue 5166: json_extract with dollar-prefix path extracts value from field":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=issue5166 | eval name = json_extract(json_data, '$.name') | fields name"
+
+  - match: { total: 1 }
+  - match: { schema: [ { name: name, type: string } ] }
+  - match: { datarows: [ [ "alice" ] ] }
+
+---
+"Issue 5166: json_extract with dollar-prefix path extracts array from field":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=issue5166 | eval scores = json_extract(json_data, '$.scores') | fields scores"
+
+  - match: { total: 1 }
+  - match: { schema: [ { name: scores, type: string } ] }
+  - match: { datarows: [ [ "[90,85,92]" ] ] }
+
+---
+"Issue 5166: json_extract without dollar-prefix still works":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=issue5166 | eval name = json_extract(json_data, 'name') | fields name"
+
+  - match: { total: 1 }
+  - match: { schema: [ { name: name, type: string } ] }
+  - match: { datarows: [ [ "alice" ] ] }


### PR DESCRIPTION
### Description

`json_extract` always returned string `"null"` instead of the actual extracted value when using standard JSONPath notation (e.g., `$.name`).

**Root cause:** `JsonUtils.convertToJsonPath()` unconditionally prepends `$.` to all input paths. When users pass standard JSONPath like `$.name`, it becomes `$.$.name` — an invalid path that matches nothing, causing Calcite's `JsonFunctions` to return null.

**Fix:** Strip any existing `$.` prefix before normalization in `convertToJsonPath()`, so paths already in standard JSONPath form are handled correctly. Also handles bare `$` input. The fix benefits all 5 JSON UDFs that share this code path (json_extract, json_delete, json_set, json_append, json_extend).

### Related Issues

#5166

### Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).