### PR TITLE
Add ahkcs as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @mengweieric @vamsimanohar @swiddis @penghuo @seankao-az @MaxKsyunz @Yury-Fridlyand @anirudha @forestmvey @acarbonetto @GumpacG @ykmr1224 @LantaoJin @noCharger @qianheng-aws @yuancu @RyanL1997
+*   @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @mengweieric @vamsimanohar @swiddis @penghuo @seankao-az @MaxKsyunz @Yury-Fridlyand @anirudha @forestmvey @acarbonetto @GumpacG @ykmr1224 @LantaoJin @noCharger @qianheng-aws @yuancu @RyanL1997 @ahkcs

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,6 +24,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Heng Qian         | [qianheng-aws](https://github.com/qianheng-aws)     | Amazon      |
 | Yuanchun Shen     | [yuancu](https://github.com/yuancu)                 | Amazon      |
 | Ryan Liang        | [RyanL1997](https://github.com/RyanL1997)           | Amazon      |
+| Kai Huang         | [ahkcs](https://github.com/ahkcs)                   | Amazon      |
 | Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)           | Improving   |
 | Yury Fridlyand    | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Improving   |
 | Andrew Carbonetto | [acarbonetto](https://github.com/acarbonetto)       | Improving   |


### PR DESCRIPTION
## Description

Welcoming new maintainer Kai Huang ([@ahkcs](https://github.com/ahkcs)).

Kai has been a consistently high-impact contributor to the SQL repo, with 144 closed PRs to date (and additional work in flight), spanning core PPL/Calcite features, bug fixes, and ongoing maintenance/backports. (https://github.com/opensearch-project/sql/pulls?q=is%3Apr+author%3Aahkcs+)

A few representative contributions include:

Support bin command with Calcite: https://github.com/opensearch-project/sql/pull/3878
Support multisearch command in Calcite: https://github.com/opensearch-project/sql/pull/4332
Support fetch_size API: https://github.com/opensearch-project/sql/pull/5109
Support mvmap: https://github.com/opensearch-project/sql/pull/4856
Support mvfind: https://github.com/opensearch-project/sql/pull/4839
Support mvdedup: https://github.com/opensearch-project/sql/pull/4828
Support split: https://github.com/opensearch-project/sql/pull/4814
Support mvzip: https://github.com/opensearch-project/sql/pull/4805
Support json_valid: https://github.com/opensearch-project/sql/pull/4803
These changes have directly expanded PPL functionality, improved correctness, and helped keep releases moving via backports and maintenance. I think adding Kai as a maintainer would strengthen our open-source posture and provide steady guidance for contributors across the PPL/Calcite surface area.

## Changes

- Added `Kai Huang | @ahkcs | Amazon` to `MAINTAINERS.md`
- Added `@ahkcs` to `.github/CODEOWNERS`