### PR TITLE
Add gradle.properties file to build sql with -Pcrypto.standard=FIPS=140-3 by default

### DIFF
--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import org.opensearch.gradle.info.FipsBuildParams
+
 plugins {
     id 'java-library'
     id "io.freefair.lombok"
@@ -27,8 +29,12 @@ dependencies {
         exclude group: 'org.bouncycastle', module: 'bcprov-ext-jdk18on'
     }
 
-    // bc-fips is provided by OpenSearch core at runtime since opensearch 3.6.0
-    compileOnly "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
+    // When building with -Pcrypto.standard=FIPS-140-3, bcFips jars are provided by OpenSearch
+    if (FipsBuildParams.isInFipsMode()) {
+        compileOnly "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
+    } else {
+        implementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
+    }
     testImplementation "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ version=1.13.0
 org.gradle.jvmargs=-Duser.language=en -Duser.country=US
 org.gradle.parallel=true
 org.gradle.caching=true
+crypto.standard=FIPS-140-3

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -68,7 +68,7 @@ fi
 
 mkdir -p $OUTPUT
 
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
 zipPath=$(find . -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
@@ -77,7 +77,7 @@ echo "COPY ${distributions}/*.zip"
 mkdir -p $OUTPUT/plugins
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
-./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
-./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
+./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 mkdir -p $OUTPUT/maven/org/opensearch
 cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch


### PR DESCRIPTION
### Description

Inspired by https://github.com/opensearch-project/ml-commons/pull/4719, this PR adds a gradle.properties file so that we only need to declare `-Pcrypto.standard=FIPS-140-3` in a single place. Now its not necessary to pass the build param in commands like `./gradlew assemble -Pcrypto.standard=FIPS-140-3` as it passes the arg by default.

In order to build without the flag, you would need to override like so: `./gradlew assemble -Pcrypto.standard=any-supported
`
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Refactoring

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
