### PR TITLE
Fix typo: rename renameClasue to renameClause

### DIFF
--- a/async-query-core/src/main/antlr/OpenSearchPPLParser.g4
+++ b/async-query-core/src/main/antlr/OpenSearchPPLParser.g4
@@ -156,7 +156,7 @@ fieldsCommand
    ;
 
 renameCommand
-   : RENAME renameClasue (COMMA renameClasue)*
+   : RENAME renameClause (COMMA renameClause)*
    ;
 
 statsCommand
@@ -362,7 +362,7 @@ hintPair
    | rightHintKey = RIGHT_HINT DOT ID EQUAL rightHintValue = ident          #rightHint
    ;
 
-renameClasue
+renameClause
    : orignalField = wcFieldExpression AS renamedField = wcFieldExpression
    ;
 

--- a/language-grammar/src/main/antlr4/OpenSearchPPLParser.g4
+++ b/language-grammar/src/main/antlr4/OpenSearchPPLParser.g4
@@ -160,7 +160,7 @@ fieldsCommand
    ;
 
 renameCommand
-   : RENAME renameClasue (COMMA renameClasue)*
+   : RENAME renameClause (COMMA renameClause)*
    ;
 
 statsCommand
@@ -365,7 +365,7 @@ hintPair
    | rightHintKey = RIGHT_HINT DOT ID EQUAL rightHintValue = ident          #rightHint
    ;
 
-renameClasue
+renameClause
    : orignalField = wcFieldExpression AS renamedField = wcFieldExpression
    ;
 

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -229,7 +229,7 @@ wcFieldList
    ;
 
 renameCommand
-   : RENAME renameClasue (COMMA? renameClasue)*
+   : RENAME renameClause (COMMA? renameClause)*
    ;
 
 replaceCommand
@@ -758,7 +758,7 @@ joinOption
    | MAX EQUAL integerLiteral                           # maxOption
    ;
 
-renameClasue
+renameClause
    : orignalField = renameFieldExpression AS renamedField = renameFieldExpression
    ;
 

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -429,7 +429,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitRenameCommand(RenameCommandContext ctx) {
     return new Rename(
-        ctx.renameClasue().stream()
+        ctx.renameClause().stream()
             .map(
                 ct ->
                     new Map(


### PR DESCRIPTION
## Summary
- Fix typo `renameClasue` → `renameClause` across all three ANTLR grammar files and the `AstBuilder` parser reference
- No functional change — just a naming correction in the grammar rule

## Test plan
- [x] `./gradlew generateGrammarSource compileJava` — builds successfully
- [x] `./gradlew test` — all 140 tasks pass, zero failures