### PR TITLE
Add AnalyticsExecutionEngine and query routing for Parquet-backed indices

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.executor.analytics;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlExplainLevel;
+import org.opensearch.sql.ast.statement.ExplainMode;
+import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.data.model.ExprTupleValue;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.executor.ExecutionContext;
+import org.opensearch.sql.executor.ExecutionEngine;
+import org.opensearch.sql.executor.pagination.Cursor;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+
+/**
+ * Execution engine adapter for the analytics engine (Project Mustang).
+ *
+ * <p>Bridges the analytics engine's {@link QueryPlanExecutor} with the SQL plugin's {@link
+ * ExecutionEngine} response pipeline. Takes a Calcite {@link RelNode}, delegates execution to the
+ * analytics engine, and converts the raw results into {@link QueryResponse}.
+ */
+public class AnalyticsExecutionEngine implements ExecutionEngine {
+
+  private final QueryPlanExecutor planExecutor;
+
+  public AnalyticsExecutionEngine(QueryPlanExecutor planExecutor) {
+    this.planExecutor = planExecutor;
+  }
+
+  /** Not supported. Analytics queries use the RelNode path exclusively. */
+  @Override
+  public void execute(PhysicalPlan plan, ResponseListener<QueryResponse> listener) {
+    listener.onFailure(
+        new UnsupportedOperationException("Analytics engine only supports RelNode execution"));
+  }
+
+  /** Not supported. Analytics queries use the RelNode path exclusively. */
+  @Override
+  public void execute(
+      PhysicalPlan plan, ExecutionContext context, ResponseListener<QueryResponse> listener) {
+    listener.onFailure(
+        new UnsupportedOperationException("Analytics engine only supports RelNode execution"));
+  }
+
+  /** Not supported. Analytics queries use the RelNode path exclusively. */
+  @Override
+  public void explain(PhysicalPlan plan, ResponseListener<ExplainResponse> listener) {
+    listener.onFailure(
+        new UnsupportedOperationException("Analytics engine only supports RelNode execution"));
+  }
+
+  @Override
+  public void execute(
+      RelNode plan, CalcitePlanContext context, ResponseListener<QueryResponse> listener) {
+    try {
+      Integer querySizeLimit = context.sysLimit.querySizeLimit();
+      Iterable<Object[]> rows = planExecutor.execute(plan, null);
+
+      List<RelDataTypeField> fields = plan.getRowType().getFieldList();
+      List<ExprValue> results = convertRows(rows, fields, querySizeLimit);
+      Schema schema = buildSchema(fields);
+
+      listener.onResponse(new QueryResponse(schema, results, Cursor.None));
+    } catch (Exception e) {
+      listener.onFailure(e);
+    }
+  }
+
+  @Override
+  public void explain(
+      RelNode plan,
+      ExplainMode mode,
+      CalcitePlanContext context,
+      ResponseListener<ExplainResponse> listener) {
+    try {
+      SqlExplainLevel level =
+          mode == ExplainMode.SIMPLE
+              ? SqlExplainLevel.NO_ATTRIBUTES
+              : mode == ExplainMode.COST
+                  ? SqlExplainLevel.ALL_ATTRIBUTES
+                  : SqlExplainLevel.EXPPLAN_ATTRIBUTES;
+      String logical = RelOptUtil.toString(plan, level);
+      ExplainResponseNodeV2 nodeV2 = new ExplainResponseNodeV2(logical, null, null);
+      listener.onResponse(new ExplainResponse(nodeV2));
+    } catch (Exception e) {
+      listener.onFailure(e);
+    }
+  }
+
+  private List<ExprValue> convertRows(
+      Iterable<Object[]> rows, List<RelDataTypeField> fields, Integer querySizeLimit) {
+    List<ExprValue> results = new ArrayList<>();
+    for (Object[] row : rows) {
+      if (querySizeLimit != null && results.size() >= querySizeLimit) {
+        break;
+      }
+      Map<String, ExprValue> valueMap = new LinkedHashMap<>();
+      for (int i = 0; i < fields.size(); i++) {
+        String columnName = fields.get(i).getName();
+        Object value = (i < row.length) ? row[i] : null;
+        valueMap.put(columnName, ExprValueUtils.fromObjectValue(value));
+      }
+      results.add(ExprTupleValue.fromExprValueMap(valueMap));
+    }
+    return results;
+  }
+
+  private Schema buildSchema(List<RelDataTypeField> fields) {
+    List<Schema.Column> columns = new ArrayList<>();
+    for (RelDataTypeField field : fields) {
+      ExprType exprType = convertType(field.getType());
+      columns.add(new Schema.Column(field.getName(), null, exprType));
+    }
+    return new Schema(columns);
+  }
+
+  private ExprType convertType(RelDataType type) {
+    try {
+      return OpenSearchTypeFactory.convertRelDataTypeToExprType(type);
+    } catch (IllegalArgumentException e) {
+      return org.opensearch.sql.data.type.ExprCoreType.UNKNOWN;
+    }
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/QueryPlanExecutor.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/QueryPlanExecutor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.executor.analytics;
+
+import org.apache.calcite.rel.RelNode;
+
+/**
+ * Executes a Calcite {@link RelNode} logical plan against the analytics engine.
+ *
+ * <p>This is a local equivalent of {@code org.opensearch.analytics.exec.QueryPlanExecutor} from the
+ * analytics-framework library. It will be replaced by the upstream interface once the
+ * analytics-framework JAR is published.
+ *
+ * @see <a
+ *     href="https://github.com/opensearch-project/OpenSearch/blob/9142d0e789c6a6c4708f1bc015745ed55202eefe/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/exec/QueryPlanExecutor.java">Upstream
+ *     QueryPlanExecutor</a>
+ */
+@FunctionalInterface
+public interface QueryPlanExecutor {
+
+  /**
+   * Executes the given logical plan and returns result rows.
+   *
+   * @param plan the Calcite RelNode subtree to execute
+   * @param context execution context (opaque to avoid server dependency)
+   * @return rows produced by the engine
+   */
+  Iterable<Object[]> execute(RelNode plan, Object context);
+}

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.executor.analytics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ast.statement.ExplainMode;
+import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.calcite.SysLimit;
+import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
+import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import org.opensearch.sql.executor.ExecutionEngine.Schema;
+import org.opensearch.sql.planner.physical.PhysicalPlan;
+
+class AnalyticsExecutionEngineTest {
+
+  private AnalyticsExecutionEngine engine;
+  private QueryPlanExecutor mockExecutor;
+  private CalcitePlanContext mockContext;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mockExecutor = mock(QueryPlanExecutor.class);
+    engine = new AnalyticsExecutionEngine(mockExecutor);
+    mockContext = mock(CalcitePlanContext.class);
+    setSysLimit(mockContext, SysLimit.DEFAULT);
+  }
+
+  /** Sets the public final sysLimit field on a mocked CalcitePlanContext. */
+  private static void setSysLimit(CalcitePlanContext context, SysLimit sysLimit) throws Exception {
+    Field field = CalcitePlanContext.class.getDeclaredField("sysLimit");
+    field.setAccessible(true);
+    field.set(context, sysLimit);
+  }
+
+  @Test
+  void executeRelNode_basicTypesAndRows() {
+    RelNode relNode = mockRelNode("name", SqlTypeName.VARCHAR, "age", SqlTypeName.INTEGER);
+    Iterable<Object[]> rows = Arrays.asList(new Object[] {"Alice", 30}, new Object[] {"Bob", 25});
+    when(mockExecutor.execute(relNode, null)).thenReturn(rows);
+    // sysLimit is set to SysLimit.DEFAULT (querySizeLimit=10000) in setUp()
+
+    AtomicReference<QueryResponse> responseRef = new AtomicReference<>();
+    engine.execute(relNode, mockContext, captureListener(responseRef));
+
+    QueryResponse response = responseRef.get();
+    assertNotNull(response);
+
+    // Verify schema
+    Schema schema = response.getSchema();
+    assertEquals(2, schema.getColumns().size());
+    assertEquals("name", schema.getColumns().get(0).getName());
+    assertEquals(ExprCoreType.STRING, schema.getColumns().get(0).getExprType());
+    assertEquals("age", schema.getColumns().get(1).getName());
+    assertEquals(ExprCoreType.INTEGER, schema.getColumns().get(1).getExprType());
+
+    // Verify rows
+    assertEquals(2, response.getResults().size());
+    assertEquals("Alice", response.getResults().get(0).tupleValue().get("name").value());
+    assertEquals(30, response.getResults().get(0).tupleValue().get("age").value());
+    assertEquals("Bob", response.getResults().get(1).tupleValue().get("name").value());
+    assertEquals(25, response.getResults().get(1).tupleValue().get("age").value());
+
+    // Verify no pagination cursor
+    assertEquals(org.opensearch.sql.executor.pagination.Cursor.None, response.getCursor());
+  }
+
+  @Test
+  void executeRelNode_numericTypes() {
+    RelNode relNode =
+        mockRelNode(
+            "b", SqlTypeName.TINYINT,
+            "s", SqlTypeName.SMALLINT,
+            "i", SqlTypeName.INTEGER,
+            "l", SqlTypeName.BIGINT,
+            "f", SqlTypeName.FLOAT,
+            "d", SqlTypeName.DOUBLE);
+    Iterable<Object[]> rows =
+        Collections.singletonList(new Object[] {(byte) 1, (short) 2, 3, 4L, 5.0f, 6.0});
+    when(mockExecutor.execute(relNode, null)).thenReturn(rows);
+    // sysLimit is set to SysLimit.DEFAULT (querySizeLimit=10000) in setUp()
+
+    AtomicReference<QueryResponse> responseRef = new AtomicReference<>();
+    engine.execute(relNode, mockContext, captureListener(responseRef));
+
+    Schema schema = responseRef.get().getSchema();
+    assertEquals(ExprCoreType.BYTE, schema.getColumns().get(0).getExprType());
+    assertEquals(ExprCoreType.SHORT, schema.getColumns().get(1).getExprType());
+    assertEquals(ExprCoreType.INTEGER, schema.getColumns().get(2).getExprType());
+    assertEquals(ExprCoreType.LONG, schema.getColumns().get(3).getExprType());
+    assertEquals(ExprCoreType.FLOAT, schema.getColumns().get(4).getExprType());
+    assertEquals(ExprCoreType.DOUBLE, schema.getColumns().get(5).getExprType());
+  }
+
+  @Test
+  void executeRelNode_temporalTypes() {
+    RelNode relNode =
+        mockRelNode(
+            "dt", SqlTypeName.DATE,
+            "tm", SqlTypeName.TIME,
+            "ts", SqlTypeName.TIMESTAMP);
+    Iterable<Object[]> emptyRows = Collections.emptyList();
+    when(mockExecutor.execute(relNode, null)).thenReturn(emptyRows);
+    // sysLimit is set to SysLimit.DEFAULT (querySizeLimit=10000) in setUp()
+
+    AtomicReference<QueryResponse> responseRef = new AtomicReference<>();
+    engine.execute(relNode, mockContext, captureListener(responseRef));
+
+    Schema schema = responseRef.get().getSchema();
+    assertEquals(ExprCoreType.DATE, schema.getColumns().get(0).getExprType());
+    assertEquals(ExprCoreType.TIME, schema.getColumns().get(1).getExprType());
+    assertEquals(ExprCoreType.TIMESTAMP, schema.getColumns().get(2).getExprType());
+  }
+
+  @Test
+  void executeRelNode_querySizeLimit() throws Exception {
+    RelNode relNode = mockRelNode("id", SqlTypeName.INTEGER);
+    List<Object[]> manyRows = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      manyRows.add(new Object[] {i});
+    }
+    when(mockExecutor.execute(relNode, null)).thenReturn(manyRows);
+    setSysLimit(mockContext, new SysLimit(10, 10000, 50000));
+
+    AtomicReference<QueryResponse> responseRef = new AtomicReference<>();
+    engine.execute(relNode, mockContext, captureListener(responseRef));
+
+    assertEquals(10, responseRef.get().getResults().size());
+  }
+
+  @Test
+  void executeRelNode_emptyResults() {
+    RelNode relNode = mockRelNode("name", SqlTypeName.VARCHAR);
+    Iterable<Object[]> emptyRows = Collections.emptyList();
+    when(mockExecutor.execute(relNode, null)).thenReturn(emptyRows);
+    // sysLimit is set to SysLimit.DEFAULT (querySizeLimit=10000) in setUp()
+
+    AtomicReference<QueryResponse> responseRef = new AtomicReference<>();
+    engine.execute(relNode, mockContext, captureListener(responseRef));
+
+    QueryResponse response = responseRef.get();
+    assertNotNull(response);
+    assertEquals(1, response.getSchema().getColumns().size());
+    assertTrue(response.getResults().isEmpty());
+  }
+
+  @Test
+  void executeRelNode_nullValues() {
+    RelNode relNode = mockRelNode("name", SqlTypeName.VARCHAR, "age", SqlTypeName.INTEGER);
+    Iterable<Object[]> rows = Collections.singletonList(new Object[] {null, null});
+    when(mockExecutor.execute(relNode, null)).thenReturn(rows);
+    // sysLimit is set to SysLimit.DEFAULT (querySizeLimit=10000) in setUp()
+
+    AtomicReference<QueryResponse> responseRef = new AtomicReference<>();
+    engine.execute(relNode, mockContext, captureListener(responseRef));
+
+    QueryResponse response = responseRef.get();
+    assertEquals(1, response.getResults().size());
+    assertTrue(response.getResults().get(0).tupleValue().get("name").isNull());
+    assertTrue(response.getResults().get(0).tupleValue().get("age").isNull());
+  }
+
+  @Test
+  void executeRelNode_errorPropagation() {
+    RelNode relNode = mockRelNode("id", SqlTypeName.INTEGER);
+    when(mockExecutor.execute(relNode, null)).thenThrow(new RuntimeException("Engine failure"));
+    // sysLimit is set to SysLimit.DEFAULT (querySizeLimit=10000) in setUp()
+
+    AtomicReference<Exception> errorRef = new AtomicReference<>();
+    engine.execute(
+        relNode,
+        mockContext,
+        new ResponseListener<QueryResponse>() {
+          @Override
+          public void onResponse(QueryResponse response) {}
+
+          @Override
+          public void onFailure(Exception e) {
+            errorRef.set(e);
+          }
+        });
+
+    assertNotNull(errorRef.get());
+    assertEquals("Engine failure", errorRef.get().getMessage());
+  }
+
+  @Test
+  void explainRelNode() {
+    // Use a real Calcite LogicalValues node so RelOptUtil.toString works
+    SqlTypeFactoryImpl typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataType rowType = typeFactory.builder().add("name", SqlTypeName.VARCHAR).build();
+    RelNode relNode = mock(RelNode.class);
+    when(relNode.getRowType()).thenReturn(rowType);
+    // RelOptUtil.toString calls rel.explain(RelWriterImpl), so we need a real node
+    // For simplicity, test that explain doesn't throw and returns non-null
+    // A full explain test would require building a real RelNode tree
+
+    AtomicReference<ExplainResponse> responseRef = new AtomicReference<>();
+    AtomicReference<Exception> errorRef = new AtomicReference<>();
+    engine.explain(
+        relNode,
+        ExplainMode.STANDARD,
+        mockContext,
+        new ResponseListener<ExplainResponse>() {
+          @Override
+          public void onResponse(ExplainResponse response) {
+            responseRef.set(response);
+          }
+
+          @Override
+          public void onFailure(Exception e) {
+            errorRef.set(e);
+          }
+        });
+
+    // RelOptUtil.toString on a mock may throw or produce output depending on mock setup.
+    // We accept either a successful response or a caught failure (not an uncaught exception).
+    assertTrue(responseRef.get() != null || errorRef.get() != null);
+  }
+
+  @Test
+  void explainRelNode_errorPropagation() {
+    // Mock a RelNode whose explain triggers an error
+    RelNode relNode = mock(RelNode.class);
+    org.mockito.Mockito.doThrow(new RuntimeException("Explain failure"))
+        .when(relNode)
+        .explain(org.mockito.ArgumentMatchers.any());
+
+    AtomicReference<Exception> errorRef = new AtomicReference<>();
+    engine.explain(
+        relNode,
+        ExplainMode.STANDARD,
+        mockContext,
+        new ResponseListener<ExplainResponse>() {
+          @Override
+          public void onResponse(ExplainResponse response) {}
+
+          @Override
+          public void onFailure(Exception e) {
+            errorRef.set(e);
+          }
+        });
+
+    assertNotNull(errorRef.get());
+  }
+
+  @Test
+  void physicalPlanExecute_callsOnFailure() {
+    PhysicalPlan physicalPlan = mock(PhysicalPlan.class);
+    AtomicReference<Exception> errorRef = new AtomicReference<>();
+    engine.execute(
+        physicalPlan,
+        new ResponseListener<QueryResponse>() {
+          @Override
+          public void onResponse(QueryResponse response) {}
+
+          @Override
+          public void onFailure(Exception e) {
+            errorRef.set(e);
+          }
+        });
+    assertNotNull(errorRef.get());
+    assertTrue(errorRef.get() instanceof UnsupportedOperationException);
+  }
+
+  @Test
+  void physicalPlanExecuteWithContext_callsOnFailure() {
+    PhysicalPlan physicalPlan = mock(PhysicalPlan.class);
+    AtomicReference<Exception> errorRef = new AtomicReference<>();
+    engine.execute(
+        physicalPlan,
+        org.opensearch.sql.executor.ExecutionContext.emptyExecutionContext(),
+        new ResponseListener<QueryResponse>() {
+          @Override
+          public void onResponse(QueryResponse response) {}
+
+          @Override
+          public void onFailure(Exception e) {
+            errorRef.set(e);
+          }
+        });
+    assertNotNull(errorRef.get());
+    assertTrue(errorRef.get() instanceof UnsupportedOperationException);
+  }
+
+  @Test
+  void physicalPlanExplain_callsOnFailure() {
+    PhysicalPlan physicalPlan = mock(PhysicalPlan.class);
+    AtomicReference<Exception> errorRef = new AtomicReference<>();
+    engine.explain(
+        physicalPlan,
+        new ResponseListener<ExplainResponse>() {
+          @Override
+          public void onResponse(ExplainResponse response) {}
+
+          @Override
+          public void onFailure(Exception e) {
+            errorRef.set(e);
+          }
+        });
+    assertNotNull(errorRef.get());
+    assertTrue(errorRef.get() instanceof UnsupportedOperationException);
+  }
+
+  // --- helpers ---
+
+  private RelNode mockRelNode(Object... nameTypePairs) {
+    SqlTypeFactoryImpl typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataTypeFactory.Builder builder = typeFactory.builder();
+    for (int i = 0; i < nameTypePairs.length; i += 2) {
+      String name = (String) nameTypePairs[i];
+      SqlTypeName typeName = (SqlTypeName) nameTypePairs[i + 1];
+      builder.add(name, typeName);
+    }
+    RelDataType rowType = builder.build();
+
+    RelNode relNode = mock(RelNode.class);
+    when(relNode.getRowType()).thenReturn(rowType);
+    return relNode;
+  }
+
+  private ResponseListener<QueryResponse> captureListener(AtomicReference<QueryResponse> ref) {
+    return new ResponseListener<QueryResponse>() {
+      @Override
+      public void onResponse(QueryResponse response) {
+        ref.set(response);
+      }
+
+      @Override
+      public void onFailure(Exception e) {
+        throw new AssertionError("Unexpected failure", e);
+      }
+    };
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/AnalyticsPPLIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/AnalyticsPPLIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyNumOfRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+/**
+ * Integration tests for PPL queries routed through the analytics engine path (Project Mustang).
+ * Queries targeting "parquet_*" indices are routed to {@code RestUnifiedQueryAction} which uses
+ * {@code AnalyticsExecutionEngine} with a stub {@code QueryPlanExecutor}.
+ *
+ * <p>These tests validate the full pipeline: REST request → routing → planning via
+ * UnifiedQueryPlanner → execution via AnalyticsExecutionEngine → response formatting.
+ *
+ * <p>Note: The stub executor ignores the logical plan and always returns all rows for the matched
+ * table. Tests that use projection (| fields) or filter (| where) will still get all rows back with
+ * the projected schema, but the data values may not match the projected columns since the stub does
+ * not actually evaluate the plan.
+ */
+public class AnalyticsPPLIT extends PPLIntegTestCase {
+
+  @Override
+  protected void init() throws Exception {
+    // No index loading needed — stub schema and data are hardcoded
+    // in RestUnifiedQueryAction and StubQueryPlanExecutor
+  }
+
+  @Test
+  public void testBasicQueryReturnsResults() throws IOException {
+    JSONObject result = executeQuery("source = opensearch.parquet_logs");
+    verifySchema(
+        result,
+        schema("ts", "timestamp"),
+        schema("status", "integer"),
+        schema("message", "keyword"),
+        schema("ip_addr", "keyword"));
+    verifyNumOfRows(result, 3);
+  }
+
+  @Test
+  public void testParquetMetricsTable() throws IOException {
+    JSONObject result = executeQuery("source = opensearch.parquet_metrics");
+    verifySchema(
+        result,
+        schema("ts", "timestamp"),
+        schema("cpu", "double"),
+        schema("memory", "double"),
+        schema("host", "keyword"));
+    verifyNumOfRows(result, 2);
+  }
+
+  @Test
+  public void testResponseFormatHasRequiredFields() throws IOException {
+    JSONObject result = executeQuery("source = opensearch.parquet_logs");
+    assertTrue(result.has("schema"));
+    assertTrue(result.has("datarows"));
+    assertTrue(result.has("total"));
+    assertTrue(result.has("size"));
+    assertTrue(result.has("status"));
+    assertEquals(200, result.getInt("status"));
+  }
+
+  @Test
+  public void testExplainQuery() throws IOException {
+    String explainResult =
+        explainQueryToString("source = opensearch.parquet_logs | fields ts, message");
+    assertTrue(explainResult.contains("LogicalProject"));
+    assertTrue(explainResult.contains("LogicalTableScan"));
+  }
+
+  @Test
+  public void testFieldsProjectionChangesSchema() throws IOException {
+    JSONObject result = executeQuery("source = opensearch.parquet_logs | fields ts, message");
+    // Schema should only have the projected columns
+    verifySchema(result, schema("ts", "timestamp"), schema("message", "keyword"));
+    // Stub returns all rows (it ignores the plan), but the row data is projected
+    // by column position, so row count should still be 3
+    verifyNumOfRows(result, 3);
+  }
+
+  @Test
+  public void testNonParquetQueryStillWorks() throws IOException {
+    loadIndex(Index.ACCOUNT);
+    JSONObject result =
+        executeQuery(String.format("source=%s | head 1 | fields firstname", TEST_INDEX_ACCOUNT));
+    assertNotNull(result);
+    assertTrue(result.has("datarows"));
+  }
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -160,6 +160,7 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
 
     api project(":ppl")
+    api project(':api')
     api project(':legacy')
     api project(':opensearch')
     api project(':prometheus')

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -163,7 +163,7 @@ public class SQLPlugin extends Plugin
     Metrics.getInstance().registerDefaultMetrics();
 
     return Arrays.asList(
-        new RestPPLQueryAction(),
+        new RestPPLQueryAction(clusterService, this.client),
         new RestPPLGrammarAction(),
         new RestSqlAction(settings, injector),
         new RestSqlStatsAction(settings, restController),

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLQueryAction.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.IndexNotFoundException;
@@ -29,6 +30,7 @@ import org.opensearch.sql.datasources.exceptions.DataSourceClientException;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.QueryEngineException;
 import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.executor.QueryType;
 import org.opensearch.sql.legacy.metrics.MetricName;
 import org.opensearch.sql.legacy.metrics.Metrics;
 import org.opensearch.sql.opensearch.response.error.ErrorMessageFactory;
@@ -44,9 +46,13 @@ public class RestPPLQueryAction extends BaseRestHandler {
 
   private static final Logger LOG = LogManager.getLogger();
 
+  /** Unified query handler for Parquet-backed indices (Analytics engine path). */
+  private final RestUnifiedQueryAction unifiedQueryHandler;
+
   /** Constructor of RestPPLQueryAction. */
-  public RestPPLQueryAction() {
+  public RestPPLQueryAction(ClusterService clusterService, NodeClient client) {
     super();
+    this.unifiedQueryHandler = new RestUnifiedQueryAction(client, new StubQueryPlanExecutor());
   }
 
   private static boolean isClientError(Exception e) {
@@ -85,6 +91,13 @@ public class RestPPLQueryAction extends BaseRestHandler {
   protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient nodeClient) {
     TransportPPLQueryRequest transportPPLQueryRequest =
         new TransportPPLQueryRequest(PPLQueryRequestFactory.getPPLRequest(request));
+
+    // Route to unified query pipeline for Parquet-backed indices
+    String pplQuery = transportPPLQueryRequest.toPPLQueryRequest().getRequest();
+    if (RestUnifiedQueryAction.isUnifiedQueryPath(pplQuery)) {
+      boolean isExplain = request.path().endsWith("/_explain");
+      return channel -> unifiedQueryHandler.execute(pplQuery, QueryType.PPL, channel, isExplain);
+    }
 
     return channel ->
         nodeClient.execute(

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.plugin.rest;
+
+import static org.opensearch.core.rest.RestStatus.OK;
+import static org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
+import static org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
+import static org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.SQL_WORKER_THREAD_POOL_NAME;
+import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.sql.api.UnifiedQueryContext;
+import org.opensearch.sql.api.UnifiedQueryPlanner;
+import org.opensearch.sql.ast.statement.ExplainMode;
+import org.opensearch.sql.calcite.CalcitePlanContext;
+import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.executor.QueryType;
+import org.opensearch.sql.executor.analytics.AnalyticsExecutionEngine;
+import org.opensearch.sql.executor.analytics.QueryPlanExecutor;
+import org.opensearch.sql.legacy.metrics.MetricName;
+import org.opensearch.sql.legacy.metrics.Metrics;
+import org.opensearch.sql.protocol.response.QueryResult;
+import org.opensearch.sql.protocol.response.format.JdbcResponseFormatter;
+import org.opensearch.sql.protocol.response.format.JsonResponseFormatter;
+import org.opensearch.sql.protocol.response.format.ResponseFormatter;
+import org.opensearch.transport.client.node.NodeClient;
+
+/**
+ * Handles queries routed to the Analytics engine via the unified query pipeline. Parses PPL queries
+ * using {@link UnifiedQueryPlanner} to generate a Calcite {@link RelNode}, then delegates to {@link
+ * AnalyticsExecutionEngine} for execution.
+ */
+public class RestUnifiedQueryAction {
+
+  private static final Logger LOG = LogManager.getLogger(RestUnifiedQueryAction.class);
+  private static final String SCHEMA_NAME = "opensearch";
+
+  /**
+   * Pattern to extract index name from PPL source clause. Matches: source = index, source=index,
+   * source = `index`, source = catalog.index
+   */
+  private static final Pattern SOURCE_PATTERN =
+      Pattern.compile(
+          "source\\s*=\\s*`?([a-zA-Z0-9_.*]+(?:\\.[a-zA-Z0-9_.*]+)*)`?", Pattern.CASE_INSENSITIVE);
+
+  private final AnalyticsExecutionEngine analyticsEngine;
+  private final NodeClient client;
+
+  public RestUnifiedQueryAction(NodeClient client, QueryPlanExecutor planExecutor) {
+    this.client = client;
+    this.analyticsEngine = new AnalyticsExecutionEngine(planExecutor);
+  }
+
+  /**
+   * Check if the query targets a non-Lucene (Parquet-backed) index. Currently uses a prefix
+   * convention ("parquet_"). In production, this will check index settings.
+   */
+  public static boolean isUnifiedQueryPath(String query) {
+    if (query == null) {
+      return false;
+    }
+    String indexName = extractIndexName(query);
+    if (indexName == null) {
+      return false;
+    }
+    // Handle qualified names like "catalog.parquet_logs" — check the last segment
+    int lastDot = indexName.lastIndexOf('.');
+    String tableName = lastDot >= 0 ? indexName.substring(lastDot + 1) : indexName;
+    return tableName.startsWith("parquet_");
+  }
+
+  /**
+   * Extract the source index name from a PPL query string.
+   *
+   * @param query the PPL query string
+   * @return the index name, or null if not found
+   */
+  static String extractIndexName(String query) {
+    Matcher matcher = SOURCE_PATTERN.matcher(query);
+    if (matcher.find()) {
+      return matcher.group(1);
+    }
+    return null;
+  }
+
+  /**
+   * Execute a query through the unified query pipeline on the sql-worker thread pool.
+   *
+   * @param query the PPL query string
+   * @param queryType SQL or PPL
+   * @param channel the REST channel for sending the response
+   * @param isExplain whether this is an explain request
+   */
+  public void execute(String query, QueryType queryType, RestChannel channel, boolean isExplain) {
+    client
+        .threadPool()
+        .schedule(
+            () -> doExecute(query, queryType, channel, isExplain),
+            new TimeValue(0),
+            SQL_WORKER_THREAD_POOL_NAME);
+  }
+
+  private void doExecute(
+      String query, QueryType queryType, RestChannel channel, boolean isExplain) {
+    try {
+      long startTime = System.nanoTime();
+
+      // TODO: Replace stub schema with EngineContext.getSchema() when analytics engine is ready
+      AbstractSchema schema = buildStubSchema();
+
+      try (UnifiedQueryContext context =
+          UnifiedQueryContext.builder()
+              .language(queryType)
+              .catalog(SCHEMA_NAME, schema)
+              .defaultNamespace(SCHEMA_NAME)
+              .build()) {
+
+        UnifiedQueryPlanner planner = new UnifiedQueryPlanner(context);
+        RelNode plan = planner.plan(query);
+        long planTime = System.nanoTime();
+        LOG.info(
+            "[unified] Planning completed in {}ms for {} query",
+            (planTime - startTime) / 1_000_000,
+            queryType);
+
+        CalcitePlanContext planContext = context.getPlanContext();
+
+        if (isExplain) {
+          analyticsEngine.explain(
+              plan, ExplainMode.STANDARD, planContext, createExplainListener(channel));
+        } else {
+          analyticsEngine.execute(plan, planContext, createQueryListener(channel, planTime));
+        }
+      }
+    } catch (Exception e) {
+      recordFailureMetric(e);
+      reportError(channel, e);
+    }
+  }
+
+  private ResponseListener<QueryResponse> createQueryListener(
+      RestChannel channel, long planEndTime) {
+    ResponseFormatter<QueryResult> formatter = new JdbcResponseFormatter(PRETTY);
+    return new ResponseListener<QueryResponse>() {
+      @Override
+      public void onResponse(QueryResponse response) {
+        long execTime = System.nanoTime();
+        LOG.info(
+            "[unified] Execution completed in {}ms, {} rows returned",
+            (execTime - planEndTime) / 1_000_000,
+            response.getResults().size());
+        Metrics.getInstance().getNumericalMetric(MetricName.PPL_REQ_TOTAL).increment();
+        Metrics.getInstance().getNumericalMetric(MetricName.PPL_REQ_COUNT_TOTAL).increment();
+        String result =
+            formatter.format(
+                new QueryResult(
+                    response.getSchema(), response.getResults(), response.getCursor(), PPL_SPEC));
+        channel.sendResponse(new BytesRestResponse(OK, formatter.contentType(), result));
+      }
+
+      @Override
+      public void onFailure(Exception e) {
+        recordFailureMetric(e);
+        reportError(channel, e);
+      }
+    };
+  }
+
+  private ResponseListener<ExplainResponse> createExplainListener(RestChannel channel) {
+    return new ResponseListener<ExplainResponse>() {
+      @Override
+      public void onResponse(ExplainResponse response) {
+        Metrics.getInstance().getNumericalMetric(MetricName.PPL_REQ_TOTAL).increment();
+        Metrics.getInstance().getNumericalMetric(MetricName.PPL_REQ_COUNT_TOTAL).increment();
+        JsonResponseFormatter<ExplainResponse> formatter =
+            new JsonResponseFormatter<ExplainResponse>(PRETTY) {
+              @Override
+              protected Object buildJsonObject(ExplainResponse resp) {
+                return resp;
+              }
+            };
+        channel.sendResponse(
+            new BytesRestResponse(OK, formatter.contentType(), formatter.format(response)));
+      }
+
+      @Override
+      public void onFailure(Exception e) {
+        recordFailureMetric(e);
+        reportError(channel, e);
+      }
+    };
+  }
+
+  /**
+   * Stub schema for development and testing. Returns a hardcoded table definition for any
+   * "parquet_*" table. Will be replaced by EngineContext.getSchema() when the analytics engine is
+   * ready.
+   */
+  private static AbstractSchema buildStubSchema() {
+    return new AbstractSchema() {
+      @Override
+      protected Map<String, Table> getTableMap() {
+        return Map.of(
+            "parquet_logs", buildStubTable(),
+            "parquet_metrics", buildStubMetricsTable());
+      }
+    };
+  }
+
+  private static Table buildStubTable() {
+    return new AbstractTable() {
+      @Override
+      public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        return typeFactory
+            .builder()
+            .add("ts", SqlTypeName.TIMESTAMP)
+            .add("status", SqlTypeName.INTEGER)
+            .add("message", SqlTypeName.VARCHAR)
+            .add("ip_addr", SqlTypeName.VARCHAR)
+            .build();
+      }
+    };
+  }
+
+  private static Table buildStubMetricsTable() {
+    return new AbstractTable() {
+      @Override
+      public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        return typeFactory
+            .builder()
+            .add("ts", SqlTypeName.TIMESTAMP)
+            .add("cpu", SqlTypeName.DOUBLE)
+            .add("memory", SqlTypeName.DOUBLE)
+            .add("host", SqlTypeName.VARCHAR)
+            .build();
+      }
+    };
+  }
+
+  private static void recordFailureMetric(Exception e) {
+    LOG.error("[unified] Query execution failed", e);
+    Metrics.getInstance().getNumericalMetric(MetricName.PPL_FAILED_REQ_COUNT_SYS).increment();
+  }
+
+  private static void reportError(RestChannel channel, Exception e) {
+    channel.sendResponse(
+        new BytesRestResponse(
+            org.opensearch.core.rest.RestStatus.INTERNAL_SERVER_ERROR,
+            "application/json; charset=UTF-8",
+            "{\"error\":{\"type\":\""
+                + e.getClass().getSimpleName()
+                + "\",\"reason\":\""
+                + (e.getMessage() != null ? e.getMessage().replace("\"", "\\\"") : "Unknown error")
+                + "\"},\"status\":500}"));
+  }
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/StubQueryPlanExecutor.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/StubQueryPlanExecutor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.plugin.rest;
+
+import java.sql.Timestamp;
+import java.util.List;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.sql.executor.analytics.QueryPlanExecutor;
+
+/**
+ * Stub implementation of {@link QueryPlanExecutor} for development and testing. Returns canned data
+ * so the full pipeline (routing → planning → execution → response formatting) can be validated
+ * without the analytics engine.
+ *
+ * <p>Will be replaced by the real analytics engine implementation when available.
+ */
+public class StubQueryPlanExecutor implements QueryPlanExecutor {
+
+  @Override
+  public Iterable<Object[]> execute(RelNode plan, Object context) {
+    // Return canned rows matching the stub schema defined in RestUnifiedQueryAction.
+    // The column order must match the schema: ts, status, message, ip_addr
+    // (for parquet_logs table). For other tables, return empty results.
+    String tableName = extractTableName(plan);
+    if (tableName != null && tableName.contains("parquet_logs")) {
+      return List.of(
+          new Object[] {
+            Timestamp.valueOf("2024-01-15 10:30:00"), 200, "Request completed", "192.168.1.1"
+          },
+          new Object[] {
+            Timestamp.valueOf("2024-01-15 10:31:00"), 200, "Health check OK", "192.168.1.2"
+          },
+          new Object[] {
+            Timestamp.valueOf("2024-01-15 10:32:00"), 500, "Internal server error", "192.168.1.3"
+          });
+    }
+    if (tableName != null && tableName.contains("parquet_metrics")) {
+      return List.of(
+          new Object[] {Timestamp.valueOf("2024-01-15 10:30:00"), 75.5, 8192.0, "host-1"},
+          new Object[] {Timestamp.valueOf("2024-01-15 10:31:00"), 82.3, 7680.0, "host-2"});
+    }
+    return List.of();
+  }
+
+  private String extractTableName(RelNode plan) {
+    // Use RelOptUtil.toString to get the full plan tree including child nodes
+    String planStr = RelOptUtil.toString(plan);
+    if (planStr.contains("parquet_logs")) {
+      return "parquet_logs";
+    }
+    if (planStr.contains("parquet_metrics")) {
+      return "parquet_metrics";
+    }
+    return null;
+  }
+}

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.plugin.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RestUnifiedQueryActionTest {
+
+  // --- isUnifiedQueryPath ---
+
+  @Test
+  public void isUnifiedQueryPath_parquetPrefix() {
+    assertTrue(RestUnifiedQueryAction.isUnifiedQueryPath("source = parquet_logs | fields ts"));
+  }
+
+  @Test
+  public void isUnifiedQueryPath_parquetPrefixNoSpaces() {
+    assertTrue(RestUnifiedQueryAction.isUnifiedQueryPath("source=parquet_logs | fields ts"));
+  }
+
+  @Test
+  public void isUnifiedQueryPath_parquetPrefixWithCatalog() {
+    assertTrue(
+        RestUnifiedQueryAction.isUnifiedQueryPath("source = opensearch.parquet_logs | fields ts"));
+  }
+
+  @Test
+  public void isUnifiedQueryPath_nonParquetIndex() {
+    assertFalse(RestUnifiedQueryAction.isUnifiedQueryPath("source = my_logs | fields ts"));
+  }
+
+  @Test
+  public void isUnifiedQueryPath_nullQuery() {
+    assertFalse(RestUnifiedQueryAction.isUnifiedQueryPath(null));
+  }
+
+  @Test
+  public void isUnifiedQueryPath_emptyQuery() {
+    assertFalse(RestUnifiedQueryAction.isUnifiedQueryPath(""));
+  }
+
+  // --- extractIndexName ---
+
+  @Test
+  public void extractIndexName_simpleSource() {
+    assertEquals("my_logs", RestUnifiedQueryAction.extractIndexName("source = my_logs"));
+  }
+
+  @Test
+  public void extractIndexName_noSpaces() {
+    assertEquals("my_logs", RestUnifiedQueryAction.extractIndexName("source=my_logs"));
+  }
+
+  @Test
+  public void extractIndexName_withPipe() {
+    assertEquals(
+        "my_logs",
+        RestUnifiedQueryAction.extractIndexName("source = my_logs | where status = 200"));
+  }
+
+  @Test
+  public void extractIndexName_backticks() {
+    assertEquals(
+        "my_logs", RestUnifiedQueryAction.extractIndexName("source = `my_logs` | fields ts"));
+  }
+
+  @Test
+  public void extractIndexName_qualifiedName() {
+    assertEquals(
+        "opensearch.my_logs",
+        RestUnifiedQueryAction.extractIndexName("source = opensearch.my_logs | fields ts"));
+  }
+
+  @Test
+  public void extractIndexName_caseInsensitive() {
+    assertEquals("my_logs", RestUnifiedQueryAction.extractIndexName("SOURCE = my_logs"));
+  }
+
+  @Test
+  public void extractIndexName_noSourceClause() {
+    assertNull(RestUnifiedQueryAction.extractIndexName("describe my_logs"));
+  }
+
+  @Test
+  public void extractIndexName_wildcardIndex() {
+    assertEquals("parquet_*", RestUnifiedQueryAction.extractIndexName("source = parquet_*"));
+  }
+}


### PR DESCRIPTION
## Summary
Implements the execution engine adapter and query routing infrastructure for Project Mustang's unified query pipeline ([#5247](https://github.com/opensearch-project/sql/issues/5247)).

- **`QueryPlanExecutor`** — `@FunctionalInterface` contract for analytics engine plan execution. Local equivalent of upstream `org.opensearch.analytics.exec.QueryPlanExecutor`; will be swapped when analytics-framework JAR is published.
- **`AnalyticsExecutionEngine`** — Implements `ExecutionEngine`. Bridges `QueryPlanExecutor` output (`Iterable<Object[]>`) to the SQL plugin's `QueryResponse` pipeline with type mapping via `OpenSearchTypeFactory` and row conversion via `ExprValueUtils`.
- **`RestUnifiedQueryAction`** — Orchestrates the full analytics query path: index detection, schema building, PPL planning via `UnifiedQueryPlanner`, execution via `AnalyticsExecutionEngine`, response formatting via `JdbcResponseFormatter`. Runs on `sql-worker` thread pool.
- **`RestPPLQueryAction`** — Added routing branch: queries targeting `parquet_` prefixed indices are routed to the analytics path; all other queries go through the existing Lucene path unchanged.
- **`StubQueryPlanExecutor`** — Returns canned data for `parquet_logs` and `parquet_metrics` stub tables, enabling full pipeline testing without the analytics engine.

## Test plan
- [x] 12 unit tests for `AnalyticsExecutionEngine` (type mapping, row conversion, query size limit, null handling, error propagation, explain, PhysicalPlan rejection)
- [x] 10 unit tests for `RestUnifiedQueryAction` (index name extraction, routing detection for various PPL patterns)
- [ ] Integration tests (Step 5 — requires test cluster with stub plugin)
- [ ] Existing PPL integration test suite regression check