### PR TITLE
added isnotnull condition support

### DIFF
--- a/docs/user/ppl/functions/condition.md
+++ b/docs/user/ppl/functions/condition.md
@@ -7,6 +7,8 @@ PPL conditional functions enable global filtering of query results based on spec
 
 Returns `TRUE` if the field is `NULL`, `FALSE` otherwise.
 
+The `field IS NULL` predicate syntax is also supported as a synonym.
+
 The `isnull()` function is commonly used:
 - In `eval` expressions to create conditional fields.
 - With the `if()` function to provide default values.
@@ -69,6 +71,14 @@ source=accounts
 | where isnull(employer)
 | fields account_number, firstname, employer
 ```
+
+The `IS NULL` predicate syntax can be used as an equivalent alternative:
+
+```ppl
+source=accounts
+| where employer IS NULL
+| fields account_number, firstname, employer
+```
   
 The query returns the following results:
   
@@ -86,6 +96,8 @@ fetched rows / total rows = 1/1
 **Usage**: `isnotnull(field)`
 
 Returns `TRUE` if the field is NOT `NULL`, `FALSE` otherwise.
+
+The `field IS NOT NULL` predicate syntax is also supported as a synonym.
 
 The `isnotnull()` function is commonly used:
 - In `eval` expressions to create Boolean flags.
@@ -128,6 +140,14 @@ The following example shows how to filter records using `isnotnull` in a `where`
 ```ppl
 source=accounts
 | where not isnotnull(employer)
+| fields account_number, employer
+```
+
+The `IS NOT NULL` predicate syntax can be used as an equivalent alternative:
+
+```ppl
+source=accounts
+| where employer IS NOT NULL
 | fields account_number, employer
 ```
   

--- a/docs/user/ppl/functions/condition.md
+++ b/docs/user/ppl/functions/condition.md
@@ -142,8 +142,19 @@ source=accounts
 | where not isnotnull(employer)
 | fields account_number, employer
 ```
+  
+The query returns the following results:
+  
+```text
+fetched rows / total rows = 1/1
++----------------+----------+
+| account_number | employer |
+|----------------+----------|
+| 18             | null     |
++----------------+----------+
+```
 
-The `IS NOT NULL` predicate syntax can be used as an equivalent alternative:
+The `IS NOT NULL` predicate syntax is equivalent to `isnotnull()`:
 
 ```ppl
 source=accounts
@@ -154,11 +165,13 @@ source=accounts
 The query returns the following results:
   
 ```text
-fetched rows / total rows = 1/1
+fetched rows / total rows = 3/3
 +----------------+----------+
 | account_number | employer |
 |----------------+----------|
-| 18             | null     |
+| 1              | Pyrami   |
+| 6              | Netagy   |
+| 13             | Quility  |
 +----------------+----------+
 ```
   

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -194,6 +194,27 @@ public class WhereCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testIsNullPredicate() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where age IS NULL | fields firstname",
+                TEST_INDEX_BANK_WITH_NULL_VALUES));
+    verifyDataRows(result, rows("Virginia"));
+  }
+
+  @Test
+  public void testIsNotNullPredicate() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where age IS NOT NULL and like(firstname, 'Ambe_%%') | fields"
+                    + " firstname",
+                TEST_INDEX_BANK_WITH_NULL_VALUES));
+    verifyDataRows(result, rows("Amber JOHnny"));
+  }
+
+  @Test
   public void testWhereWithMetadataFields() throws IOException {
     JSONObject result =
         executeQuery(

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -187,7 +187,9 @@ PATH:                               'PATH';
 CASE:                               'CASE';
 ELSE:                               'ELSE';
 IN:                                 'IN';
+IS:                                 'IS';
 EXISTS:                             'EXISTS';
+NULL:                               'NULL';
 
 // Geo IP eval function
 GEOIP:                              'GEOIP';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -911,6 +911,11 @@ expression
    | left = expression comparisonOperator right = expression    # compareExpr
    | expression NOT? IN LT_PRTHS valueList RT_PRTHS             # inExpr
    | expression NOT? BETWEEN expression AND expression          # between
+   | expression IS nullNotnull                                  # isNullPredicate
+   ;
+
+nullNotnull
+   : NOT? NULL
    ;
 
 
@@ -1594,6 +1599,8 @@ wildcard
 keywordsCanBeId
    : searchableKeyWord
    | IN
+   | IS
+   | NULL
    ;
 
 searchableKeyWord

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -250,8 +250,7 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
   }
 
   @Override
-  public UnresolvedExpression visitIsNullPredicate(
-      OpenSearchPPLParser.IsNullPredicateContext ctx) {
+  public UnresolvedExpression visitIsNullPredicate(OpenSearchPPLParser.IsNullPredicateContext ctx) {
     return new Function(
         ctx.nullNotnull().NOT() == null
             ? IS_NULL.getName().getFunctionName()

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -249,6 +249,16 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     return ctx.NOT() != null ? new Not(expr) : expr;
   }
 
+  @Override
+  public UnresolvedExpression visitIsNullPredicate(
+      OpenSearchPPLParser.IsNullPredicateContext ctx) {
+    return new Function(
+        ctx.nullNotnull().NOT() == null
+            ? IS_NULL.getName().getFunctionName()
+            : IS_NOT_NULL.getName().getFunctionName(),
+        Arrays.asList(visit(ctx.expression())));
+  }
+
   /** Value Expression. */
   @Override
   public UnresolvedExpression visitBinaryArithmetic(BinaryArithmeticContext ctx) {

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -299,6 +299,24 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
         filter(relation("t"), function("is not null", field("a"))));
   }
 
+  @Test
+  public void testIsNullPredicate() {
+    assertEqual(
+        "source=t | where a is null", filter(relation("t"), function("is null", field("a"))));
+    assertEqual(
+        "source=t | where a IS NULL", filter(relation("t"), function("is null", field("a"))));
+  }
+
+  @Test
+  public void testIsNotNullPredicate() {
+    assertEqual(
+        "source=t | where a is not null",
+        filter(relation("t"), function("is not null", field("a"))));
+    assertEqual(
+        "source=t | where a IS NOT NULL",
+        filter(relation("t"), function("is not null", field("a"))));
+  }
+
   /** Todo. search operator should not include functionCall, need to change antlr. */
   @Ignore("search operator should not include functionCall, need to change antlr")
   public void testEvalExpr() {


### PR DESCRIPTION
### Description
Adds support for field IS [NOT] NULL as a predicate syntax in PPL, as a synonym for the existing `isnull(field)` / `isnotnull(field)` functions. 
Previously, users coming from a SQL background would naturally write where field is not null in PPL, only to receive a parse error with no guidance.

### Related Issues
Resolves #5262 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
