### PR TITLE
Split integ tests into calcite & non-calcite

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [21, 25]
-        test-type: ['unit', 'integration', 'doc']
+        test-type: ['unit', 'integration-calcite', 'integration-non-calcite', 'doc']
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
@@ -53,8 +53,10 @@ jobs:
           chown -R 1000:1000 `pwd`
           if [ "${{ matrix.test-type }}" = "unit" ]; then
             su `id -un 1000` -c "./gradlew --continue build -x integTest -x yamlRestTest -x doctest"
-          elif [ "${{ matrix.test-type }}" = "integration" ]; then
-            su `id -un 1000` -c "./gradlew --continue integTest yamlRestTest"
+          elif [ "${{ matrix.test-type }}" = "integration-calcite" ]; then
+            su `id -un 1000` -c "./gradlew --continue integTestCalcite yamlRestTest"
+          elif [ "${{ matrix.test-type }}" = "integration-non-calcite" ]; then
+            su `id -un 1000` -c "./gradlew --continue integTestNonCalcite"
           else
             su `id -un 1000` -c "./gradlew --continue doctest"
           fi
@@ -109,7 +111,7 @@ jobs:
           - { os: windows-latest, java: 25, os_build_args: -PbuildPlatform=windows }
           - { os: macos-14, java: 21, os_build_args: '' }
           - { os: macos-14, java: 25, os_build_args: '' }
-        test-type: ['unit', 'integration', 'doc']
+        test-type: ['unit', 'integration-calcite', 'integration-non-calcite', 'doc']
         exclude:
           # Exclude doctest for Windows
           - test-type: doc
@@ -131,8 +133,10 @@ jobs:
         run: |
           if [ "${{ matrix.test-type }}" = "unit" ]; then
             ./gradlew --continue build -x integTest -x yamlRestTest -x doctest ${{ matrix.entry.os_build_args }}
-          elif [ "${{ matrix.test-type }}" = "integration" ]; then
-            ./gradlew --continue integTest yamlRestTest ${{ matrix.entry.os_build_args }}
+          elif [ "${{ matrix.test-type }}" = "integration-calcite" ]; then
+            ./gradlew --continue integTestCalcite yamlRestTest ${{ matrix.entry.os_build_args }}
+          elif [ "${{ matrix.test-type }}" = "integration-non-calcite" ]; then
+            ./gradlew --continue integTestNonCalcite ${{ matrix.entry.os_build_args }}
           else
             ./gradlew --continue doctest ${{ matrix.entry.os_build_args }}
           fi

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -278,6 +278,32 @@ testClusters {
         plugin ":opensearch-sql-plugin"
         setting "plugins.query.datasources.encryption.masterkey", "1234567812345678"
     }
+    integTestCalcite {
+        testDistribution = 'archive'
+        plugin(getJobSchedulerPlugin())
+        plugin(getGeoSpatialPlugin())
+        plugin ":opensearch-sql-plugin"
+        setting "plugins.query.datasources.encryption.masterkey", "1234567812345678"
+    }
+    integTestNonCalcite {
+        testDistribution = 'archive'
+        plugin(getJobSchedulerPlugin())
+        plugin(getGeoSpatialPlugin())
+        plugin ":opensearch-sql-plugin"
+        setting "plugins.query.datasources.encryption.masterkey", "1234567812345678"
+    }
+    remoteClusterCalcite {
+        testDistribution = 'archive'
+        plugin(getJobSchedulerPlugin())
+        plugin(getGeoSpatialPlugin())
+        plugin ":opensearch-sql-plugin"
+    }
+    remoteClusterNonCalcite {
+        testDistribution = 'archive'
+        plugin(getJobSchedulerPlugin())
+        plugin(getGeoSpatialPlugin())
+        plugin ":opensearch-sql-plugin"
+    }
     yamlRestTest {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
@@ -455,9 +481,18 @@ yamlRestTest {
     systemProperty 'tests.security.manager', 'false'
 }
 
-// Run PPL ITs and new, legacy and comparison SQL ITs with new SQL engine enabled
-integTest {
-    useCluster testClusters.remoteCluster
+task printIntegTestPaths {
+    doLast {
+        println "Test report available at: file://${project.buildDir}/reports/tests/integTest/index.html"
+        println "integTest cluster logs available at: file://${project.buildDir}/testclusters/integTest-0/logs/integTest.log"
+        println "remoteCluster cluster logs available at: file://${project.buildDir}/testclusters/remoteCluster-0/logs/remoteCluster.log"
+    }
+}
+
+// Run Calcite integration tests
+task integTestCalcite(type: RestIntegTestTask) {
+    useCluster testClusters.integTestCalcite
+    useCluster testClusters.remoteClusterCalcite
 
     // Set properties for connection to clusters and between clusters
     doFirst {
@@ -477,12 +512,9 @@ integTest {
     testLogging {
         events "failed"
     }
-    
+
     dependsOn ':opensearch-sql-plugin:bundlePlugin'
-    if(!ignorePrometheus && getOSFamilyType() != "windows") {
-        dependsOn startPrometheus
-        finalizedBy stopPrometheus
-    }
+    // Prometheus is managed by the main integTest task to avoid conflicts
 
     // enable calcite codegen in IT
     systemProperty 'calcite.debug', 'false'
@@ -508,6 +540,74 @@ integTest {
         systemProperty 'cluster.debug', getDebug()
     }
 
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5006'
+    }
+
+    if (System.getProperty("tests.rest.bwcsuite") == null) {
+        filter {
+            excludeTestsMatching "org.opensearch.sql.bwc.*IT"
+        }
+    }
+
+    // Include only Calcite tests
+    include 'org/opensearch/sql/calcite/**/*IT.class'
+
+    // Exclude doctest and correctness
+    exclude 'org/opensearch/sql/doctest/**/*IT.class'
+    exclude 'org/opensearch/sql/correctness/**'
+}
+
+// Run non-Calcite integration tests
+task integTestNonCalcite(type: RestIntegTestTask) {
+    useCluster testClusters.integTestNonCalcite
+    useCluster testClusters.remoteClusterNonCalcite
+
+    // Set properties for connection to clusters and between clusters
+    doFirst {
+        getClusters().forEach { cluster ->
+            String allTransportSocketURI = cluster.nodes.stream().flatMap { node ->
+                node.getAllTransportPortURI().stream()
+            }.collect(Collectors.joining(","))
+            String allHttpSocketURI = cluster.nodes.stream().flatMap { node ->
+                node.getAllHttpSocketURI().stream()
+            }.collect(Collectors.joining(","))
+
+            systemProperty "tests.rest.${cluster.name}.http_hosts", "${-> allHttpSocketURI}"
+            systemProperty "tests.rest.${cluster.name}.transport_hosts", "${-> allTransportSocketURI}"
+        }
+    }
+
+    testLogging {
+        events "failed"
+    }
+
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
+    // Prometheus is managed by the main integTest task to avoid conflicts
+
+    // enable calcite codegen in IT
+    systemProperty 'calcite.debug', 'false'
+    systemProperty 'org.codehaus.janino.source_debugging.enable', 'false'
+    systemProperty 'org.codehaus.janino.source_debugging.dir', calciteCodegen
+
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty('project.root', project.projectDir.absolutePath)
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    // Set default query size limit
+    systemProperty 'defaultQuerySizeLimit', '10000'
+
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst {
+        if (System.getProperty("debug-jvm") != null) {
+            setDebug(true);
+        }
+        systemProperty 'cluster.debug', getDebug()
+    }
 
     if (System.getProperty("test.debug") != null) {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5006'
@@ -524,6 +624,9 @@ integTest {
         exclude 'org/opensearch/sql/ppl/ShowDataSourcesCommandIT.class'
         exclude 'org/opensearch/sql/ppl/InformationSchemaCommandIT.class'
     }
+
+    // Exclude Calcite tests
+    exclude 'org/opensearch/sql/calcite/**'
 
     exclude 'org/opensearch/sql/doctest/**/*IT.class'
     exclude 'org/opensearch/sql/correctness/**'
@@ -545,16 +648,17 @@ integTest {
 
     // Exclude this IT, because they executed in another task (:integTestWithSecurity)
     exclude 'org/opensearch/sql/security/**'
-
-    finalizedBy 'printIntegTestPaths'
 }
 
-task printIntegTestPaths {
-    doLast {
-        println "Test report available at: file://${project.buildDir}/reports/tests/integTest/index.html"
-        println "integTest cluster logs available at: file://${project.buildDir}/testclusters/integTest-0/logs/integTest.log"
-        println "remoteCluster cluster logs available at: file://${project.buildDir}/testclusters/remoteCluster-0/logs/remoteCluster.log"
+// Run PPL ITs and new, legacy and comparison SQL ITs with new SQL engine enabled
+// This task now orchestrates both Calcite and non-Calcite integration tests
+integTest {
+    dependsOn integTestCalcite, integTestNonCalcite
+    if(!ignorePrometheus && getOSFamilyType() != "windows") {
+        dependsOn startPrometheus
+        finalizedBy stopPrometheus
     }
+    finalizedBy 'printIntegTestPaths'
 }
 
 task comparisonTest(type: RestIntegTestTask) {


### PR DESCRIPTION
### Description
CI enhancement: Split the tests into two major groups and add both to the CI matrix. Each group gets its own cluster. This split roughly divides our tests in half, so it's convenient and should shorten test cycles.

If I'm bored some weekend, I might try to turn these into properly templated tasks that let us spin up a few different IT actions with minimal boilerplate, but this is a lazy implementation that just copies everything and doesn't try to simplify e.g. configuration management.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
