### PR TITLE
[CVE-2026-24400] Bump assertj-core from 3.9.1 to 3.27.7

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation "com.github.seancfoley:ipaddress:5.4.2"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.9.1'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.27.7'
     testImplementation group: 'com.google.guava', name: 'guava', version: "${guava_version}"
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')


### PR DESCRIPTION
### Description

### Summary

Bumps `org.assertj:assertj-core` from 3.9.1 to 3.27.7 in the common module to resolve [CVE-2026-24400](https://nvd.nist.gov/vuln/detail/CVE-2026-24400). The original fix was merged to main in [#5100](https://github.com/opensearch-project/sql/pull/5100), but the automated backport to 2.19-dev failed.

### Testing

Verified assertj-core only appears in :common module across the entire project:

```
for module in $(./gradlew projects 2>/dev/null | grep "Project '" | sed "s/.*Project '\\(.*\\)'/\\1/"); do
  echo "=== $module ==="
  ./gradlew ${module}:dependencies 2>/dev/null | grep -i assertj
done

=== :async-query ===
=== :async-query-core ===
=== :benchmarks ===
=== :common ===
+--- org.assertj:assertj-core:3.27.7
+--- org.assertj:assertj-core:3.27.7 (n)
+--- org.assertj:assertj-core:3.27.7
=== :core ===
=== :datasources ===
=== :doctest ===
=== :integ-test ===
=== :legacy ===
=== :opensearch ===
=== :opensearch-sql-plugin ===
=== :ppl ===
=== :prometheus ===
=== :protocol ===
=== :spark ===
=== :sql ===
```

### Related Issues
Resolves CVE-2026-24400

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
