### PR TITLE
[BugFix] Add regression tests for disabled object field queries (#4904)

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4904.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/4904.yml
@@ -1,0 +1,95 @@
+# Issue: https://github.com/opensearch-project/sql/issues/4904
+# PPL query failed if field mapping has enabled:false
+# Regression tests to ensure disabled object fields work with Calcite engine.
+
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+  - do:
+      indices.create:
+        index: test_issue_4904
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              log:
+                type: object
+                enabled: false
+  - do:
+      bulk:
+        index: test_issue_4904
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"log": {"a": 3, "b": "hello"}}'
+          - '{"index": {}}'
+          - '{"log": {"a": 1, "b": "world"}}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+  - do:
+      indices.delete:
+        index: test_issue_4904
+
+---
+"PPL source query on index with disabled object field":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=test_issue_4904"
+  - match: { total: 2 }
+  - length: { datarows: 2 }
+
+---
+"PPL where clause filtering on disabled object sub-field":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=test_issue_4904 | where log.a = 3"
+  - match: { total: 1 }
+  - length: { datarows: 1 }
+
+---
+"PPL fields and sort on disabled object sub-field returns correct values":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=test_issue_4904 | fields log.a | sort log.a"
+  - match: { total: 2 }
+  - length: { datarows: 2 }
+  - match: { datarows.0.0: 1 }
+  - match: { datarows.1.0: 3 }


### PR DESCRIPTION
### Description
Issue #4904 reported that PPL queries failed when a field mapping has `enabled:false`. The bug manifested as a `RuntimeException: cannot translate call AS($t2, $t3)` when the Calcite engine tried to push down a filter on a disabled object's sub-field as a script.

Investigation shows this issue has been resolved on `main` by the cumulative effect of several improvements:
- MAP path resolution improvements (#5198, #5206)
- Script pushdown standardization (#4914)
- Error handling for dot-containing field names (#4907)

The Calcite engine now correctly resolves sub-field access on disabled objects (typed as MAP) using `ITEM(field, key)` expressions, and the filter pushdown handles these expressions without error.

This PR adds YAML REST regression tests to prevent the issue from recurring:
1. Basic source query on an index with a disabled object field
2. `where` clause filtering on a disabled object sub-field
3. `fields` and `sort` commands on disabled object sub-fields with value verification

### Related Issues
Resolves #4904

### Check List
- [x] New functionality includes testing
- [x] Commits signed per DCO (`-s`)
- [x] `spotlessCheck` passed
- [x] YAML REST tests passed