### PR TITLE
[Feature] Add vector search execution pipeline for vectorSearch() table function

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
@@ -43,7 +43,8 @@ public class OpenSearchDataType implements ExprType, Serializable {
     ScaledFloat("scaled_float", ExprCoreType.DOUBLE),
     Double("double", ExprCoreType.DOUBLE),
     Boolean("boolean", ExprCoreType.BOOLEAN),
-    Alias("alias", ExprCoreType.UNKNOWN);
+    Alias("alias", ExprCoreType.UNKNOWN),
+    KnnVector("knn_vector", ExprCoreType.ARRAY);
     // TODO: ranges, geo shape, point, shape
 
     private final String name;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngine.java
@@ -7,10 +7,13 @@ package org.opensearch.sql.opensearch.storage;
 
 import static org.opensearch.sql.utils.SystemIndexUtils.isSystemIndex;
 
+import java.util.Collection;
+import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.expression.function.FunctionResolver;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.storage.system.OpenSearchSystemIndex;
 import org.opensearch.sql.storage.StorageEngine;
@@ -24,6 +27,11 @@ public class OpenSearchStorageEngine implements StorageEngine {
   @Getter private final OpenSearchClient client;
 
   @Getter private final Settings settings;
+
+  @Override
+  public Collection<FunctionResolver> getFunctions() {
+    return List.of(new VectorSearchTableFunctionResolver(client, settings));
+  }
 
   @Override
   public Table getTable(DataSourceSchemaName dataSourceSchemaName, String name) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -53,6 +53,13 @@ public class VectorSearchIndex extends OpenSearchIndex {
     var queryBuilder = new VectorSearchQueryBuilder(requestBuilder, buildKnnQuery());
     requestBuilder.pushDownTrackedScore(true);
 
+    // Top-k mode: default size to k so queries without LIMIT return k results
+    // instead of falling into the generic large-scan path.
+    // LIMIT pushdown will further reduce this if present.
+    if (options.containsKey("k")) {
+      requestBuilder.pushDownLimitToRequestTotal(Integer.parseInt(options.get("k")), 0);
+    }
+
     Function<OpenSearchRequestBuilder, OpenSearchIndexScan> createScanOperator =
         rb ->
             new OpenSearchIndexScan(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage;
+
+import java.util.Map;
+import java.util.function.Function;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WrapperQueryBuilder;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+import org.opensearch.sql.opensearch.storage.scan.OpenSearchIndexScan;
+import org.opensearch.sql.opensearch.storage.scan.OpenSearchIndexScanBuilder;
+import org.opensearch.sql.opensearch.storage.scan.VectorSearchQueryBuilder;
+import org.opensearch.sql.storage.read.TableScanBuilder;
+
+/**
+ * Vector-search-aware OpenSearch index. Seeds the scan with a knn query and enables score tracking.
+ */
+public class VectorSearchIndex extends OpenSearchIndex {
+
+  private static final String VECTOR_OPTION = "vector";
+
+  private final String field;
+  private final float[] vector;
+  private final Map<String, String> options;
+
+  public VectorSearchIndex(
+      OpenSearchClient client,
+      Settings settings,
+      String indexName,
+      String field,
+      float[] vector,
+      Map<String, String> options) {
+    super(client, settings, indexName);
+    this.field = field;
+    this.vector = vector;
+    this.options = options;
+  }
+
+  @Override
+  public TableScanBuilder createScanBuilder() {
+    final TimeValue cursorKeepAlive =
+        getSettings().getSettingValue(Settings.Key.SQL_CURSOR_KEEP_ALIVE);
+    var requestBuilder = createRequestBuilder();
+
+    // Use VectorSearchQueryBuilder to keep knn in must (scoring) context.
+    // WHERE filters will be placed in filter (non-scoring) context.
+    var queryBuilder = new VectorSearchQueryBuilder(requestBuilder, buildKnnQuery());
+    requestBuilder.pushDownTrackedScore(true);
+
+    Function<OpenSearchRequestBuilder, OpenSearchIndexScan> createScanOperator =
+        rb ->
+            new OpenSearchIndexScan(
+                getClient(),
+                rb.getMaxResponseSize(),
+                rb.build(getIndexName(), cursorKeepAlive, getClient(), getFieldTypes().isEmpty()));
+    return new OpenSearchIndexScanBuilder(queryBuilder, createScanOperator);
+  }
+
+  private QueryBuilder buildKnnQuery() {
+    StringBuilder vectorJson = new StringBuilder("[");
+    for (int i = 0; i < vector.length; i++) {
+      if (i > 0) vectorJson.append(",");
+      vectorJson.append(vector[i]);
+    }
+    vectorJson.append("]");
+
+    StringBuilder optionsJson = new StringBuilder();
+    for (Map.Entry<String, String> entry : options.entrySet()) {
+      optionsJson.append(",");
+      String value = entry.getValue();
+      // Numeric values go unquoted, everything else quoted
+      if (isNumeric(value)) {
+        optionsJson.append(String.format("\"%s\":%s", entry.getKey(), value));
+      } else {
+        optionsJson.append(String.format("\"%s\":\"%s\"", entry.getKey(), value));
+      }
+    }
+
+    String knnQueryJson =
+        String.format(
+            "{\"knn\":{\"%s\":{\"vector\":%s%s}}}",
+            field, vectorJson.toString(), optionsJson.toString());
+    return new WrapperQueryBuilder(knnQueryJson);
+  }
+
+  private static boolean isNumeric(String str) {
+    try {
+      Double.parseDouble(str);
+      return true;
+    } catch (NumberFormatException e) {
+      return false;
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -23,8 +23,6 @@ import org.opensearch.sql.storage.read.TableScanBuilder;
  */
 public class VectorSearchIndex extends OpenSearchIndex {
 
-  private static final String VECTOR_OPTION = "vector";
-
   private final String field;
   private final float[] vector;
   private final Map<String, String> options;
@@ -81,7 +79,8 @@ public class VectorSearchIndex extends OpenSearchIndex {
     for (Map.Entry<String, String> entry : options.entrySet()) {
       optionsJson.append(",");
       String value = entry.getValue();
-      // Numeric values go unquoted, everything else quoted
+      // All P0 option values are canonicalized to numeric strings by validateOptions().
+      // The quoted fallback is retained for forward compatibility with future non-numeric options.
       if (isNumeric(value)) {
         optionsJson.append(String.format("\"%s\":%s", entry.getKey(), value));
       } else {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -104,10 +104,23 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
 
   private float[] parseVector(String vectorLiteral) {
     String cleaned = vectorLiteral.replaceAll("[\\[\\]]", "").trim();
+    if (cleaned.isEmpty()) {
+      throw new ExpressionEvaluationException("Vector literal must not be empty");
+    }
     String[] parts = cleaned.split(",");
     float[] vector = new float[parts.length];
     for (int i = 0; i < parts.length; i++) {
-      vector[i] = Float.parseFloat(parts[i].trim());
+      try {
+        vector[i] = Float.parseFloat(parts[i].trim());
+      } catch (NumberFormatException e) {
+        throw new ExpressionEvaluationException(
+            String.format("Invalid vector component '%s': must be a number", parts[i].trim()));
+      }
+      if (!Float.isFinite(vector[i])) {
+        throw new ExpressionEvaluationException(
+            String.format(
+                "Invalid vector component '%s': must be a finite number", parts[i].trim()));
+      }
     }
     return vector;
   }
@@ -115,10 +128,20 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
   static Map<String, String> parseOptions(String optionStr) {
     Map<String, String> options = new LinkedHashMap<>();
     for (String pair : optionStr.split(",")) {
-      String[] kv = pair.trim().split("=", 2);
-      if (kv.length == 2) {
-        options.put(kv[0].trim(), kv[1].trim());
+      String trimmed = pair.trim();
+      if (trimmed.isEmpty()) {
+        continue;
       }
+      String[] kv = trimmed.split("=", 2);
+      if (kv.length != 2 || kv[0].trim().isEmpty() || kv[1].trim().isEmpty()) {
+        throw new ExpressionEvaluationException(
+            String.format("Malformed option segment '%s': expected key=value", trimmed));
+      }
+      String key = kv[0].trim();
+      if (options.containsKey(key)) {
+        throw new ExpressionEvaluationException(String.format("Duplicate option key '%s'", key));
+      }
+      options.put(key, kv[1].trim());
     }
     return options;
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -75,11 +75,13 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     List<String> args =
         arguments.stream()
             .map(
-                arg ->
-                    String.format(
-                        "%s=%s",
-                        ((NamedArgumentExpression) arg).getArgName(),
-                        ((NamedArgumentExpression) arg).getValue().toString()))
+                arg -> {
+                  if (arg instanceof NamedArgumentExpression) {
+                    NamedArgumentExpression named = (NamedArgumentExpression) arg;
+                    return String.format("%s=%s", named.getArgName(), named.getValue().toString());
+                  }
+                  return arg.toString();
+                })
             .collect(Collectors.toList());
     return String.format("%s(%s)", functionName, String.join(", ", args));
   }
@@ -147,6 +149,10 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     }
   }
 
+  /**
+   * Validates and canonicalizes option values. All P0 option values must be numeric. Parsing them
+   * here prevents non-numeric strings from reaching the raw JSON construction in buildKnnQuery().
+   */
   private void validateOptions(Map<String, String> options) {
     // Reject unknown option keys — only P0 keys are allowed
     for (String key : options.keySet()) {
@@ -161,6 +167,40 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     if (!hasK && !hasMaxDistance && !hasMinScore) {
       throw new ExpressionEvaluationException(
           "Missing required option: one of k, max_distance, or min_score");
+    }
+    // Parse and canonicalize numeric values — closes JSON injection via option values
+    if (hasK) {
+      parseIntOption(options, "k");
+    }
+    if (hasMaxDistance) {
+      parseDoubleOption(options, "max_distance");
+    }
+    if (hasMinScore) {
+      parseDoubleOption(options, "min_score");
+    }
+  }
+
+  private void parseIntOption(Map<String, String> options, String key) {
+    try {
+      int value = Integer.parseInt(options.get(key));
+      options.put(key, Integer.toString(value));
+    } catch (NumberFormatException e) {
+      throw new ExpressionEvaluationException(
+          String.format("Option '%s' must be an integer, got '%s'", key, options.get(key)));
+    }
+  }
+
+  private void parseDoubleOption(Map<String, String> options, String key) {
+    try {
+      double value = Double.parseDouble(options.get(key));
+      if (!Double.isFinite(value)) {
+        throw new ExpressionEvaluationException(
+            String.format("Option '%s' must be a finite number, got '%s'", key, options.get(key)));
+      }
+      options.put(key, Double.toString(value));
+    } catch (NumberFormatException e) {
+      throw new ExpressionEvaluationException(
+          String.format("Option '%s' must be a number, got '%s'", key, options.get(key)));
     }
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage;
+
+import static org.opensearch.sql.opensearch.storage.VectorSearchTableFunctionResolver.FIELD;
+import static org.opensearch.sql.opensearch.storage.VectorSearchTableFunctionResolver.OPTION;
+import static org.opensearch.sql.opensearch.storage.VectorSearchTableFunctionResolver.TABLE;
+import static org.opensearch.sql.opensearch.storage.VectorSearchTableFunctionResolver.VECTOR;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.data.model.ExprValue;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
+import org.opensearch.sql.expression.env.Environment;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.TableFunctionImplementation;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.storage.Table;
+
+public class VectorSearchTableFunctionImplementation extends FunctionExpression
+    implements TableFunctionImplementation {
+
+  private final FunctionName functionName;
+  private final List<Expression> arguments;
+  private final OpenSearchClient client;
+  private final Settings settings;
+
+  public VectorSearchTableFunctionImplementation(
+      FunctionName functionName,
+      List<Expression> arguments,
+      OpenSearchClient client,
+      Settings settings) {
+    super(functionName, arguments);
+    this.functionName = functionName;
+    this.arguments = arguments;
+    this.client = client;
+    this.settings = settings;
+  }
+
+  @Override
+  public ExprValue valueOf(Environment<Expression, ExprValue> valueEnv) {
+    throw new UnsupportedOperationException(
+        String.format("vectorSearch function [%s] is only supported in FROM clause", functionName));
+  }
+
+  @Override
+  public ExprType type() {
+    return ExprCoreType.STRUCT;
+  }
+
+  @Override
+  public String toString() {
+    List<String> args =
+        arguments.stream()
+            .map(
+                arg ->
+                    String.format(
+                        "%s=%s",
+                        ((NamedArgumentExpression) arg).getArgName(),
+                        ((NamedArgumentExpression) arg).getValue().toString()))
+            .collect(Collectors.toList());
+    return String.format("%s(%s)", functionName, String.join(", ", args));
+  }
+
+  @Override
+  public Table applyArguments() {
+    String tableName = getArgumentValue(TABLE);
+    String fieldName = getArgumentValue(FIELD);
+    String vectorLiteral = getArgumentValue(VECTOR);
+    String optionStr = getArgumentValue(OPTION);
+
+    float[] vector = parseVector(vectorLiteral);
+    Map<String, String> options = parseOptions(optionStr);
+    validateOptions(options);
+
+    return new VectorSearchIndex(client, settings, tableName, fieldName, vector, options);
+  }
+
+  private float[] parseVector(String vectorLiteral) {
+    String cleaned = vectorLiteral.replaceAll("[\\[\\]]", "").trim();
+    String[] parts = cleaned.split(",");
+    float[] vector = new float[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      vector[i] = Float.parseFloat(parts[i].trim());
+    }
+    return vector;
+  }
+
+  static Map<String, String> parseOptions(String optionStr) {
+    Map<String, String> options = new LinkedHashMap<>();
+    for (String pair : optionStr.split(",")) {
+      String[] kv = pair.trim().split("=", 2);
+      if (kv.length == 2) {
+        options.put(kv[0].trim(), kv[1].trim());
+      }
+    }
+    return options;
+  }
+
+  private void validateOptions(Map<String, String> options) {
+    boolean hasK = options.containsKey("k");
+    boolean hasMaxDistance = options.containsKey("max_distance");
+    boolean hasMinScore = options.containsKey("min_score");
+    if (!hasK && !hasMaxDistance && !hasMinScore) {
+      throw new ExpressionEvaluationException(
+          "Missing required option: one of k, max_distance, or min_score");
+    }
+  }
+
+  private String getArgumentValue(String name) {
+    return arguments.stream()
+        .filter(arg -> ((NamedArgumentExpression) arg).getArgName().equalsIgnoreCase(name))
+        .map(arg -> ((NamedArgumentExpression) arg).getValue().valueOf().stringValue())
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new ExpressionEvaluationException(
+                    String.format("Missing required argument: %s", name)));
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -13,6 +13,8 @@ import static org.opensearch.sql.opensearch.storage.VectorSearchTableFunctionRes
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.data.model.ExprValue;
@@ -30,6 +32,15 @@ import org.opensearch.sql.storage.Table;
 
 public class VectorSearchTableFunctionImplementation extends FunctionExpression
     implements TableFunctionImplementation {
+
+  /** P0 allowed option keys. Rejects unknown/future keys to prevent unvalidated DSL injection. */
+  static final Set<String> ALLOWED_OPTION_KEYS = Set.of("k", "max_distance", "min_score");
+
+  /**
+   * Field names must be safe for JSON interpolation: alphanumeric, dots (nested), underscores,
+   * hyphens. Rejects characters that could corrupt the WrapperQueryBuilder JSON.
+   */
+  private static final Pattern SAFE_FIELD_NAME = Pattern.compile("^[a-zA-Z0-9._\\-]+$");
 
   private final FunctionName functionName;
   private final List<Expression> arguments;
@@ -75,8 +86,10 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
 
   @Override
   public Table applyArguments() {
+    validateNamedArgs();
     String tableName = getArgumentValue(TABLE);
     String fieldName = getArgumentValue(FIELD);
+    validateFieldName(fieldName);
     String vectorLiteral = getArgumentValue(VECTOR);
     String optionStr = getArgumentValue(OPTION);
 
@@ -108,7 +121,40 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     return options;
   }
 
+  /** Reject non-named arguments early. vectorSearch() requires named args (key=value). */
+  private void validateNamedArgs() {
+    for (Expression arg : arguments) {
+      if (!(arg instanceof NamedArgumentExpression)) {
+        throw new ExpressionEvaluationException(
+            "vectorSearch() requires named arguments (e.g., table='index'), "
+                + "but received: "
+                + arg.getClass().getSimpleName());
+      }
+    }
+  }
+
+  /**
+   * Reject field names with characters that could corrupt the WrapperQueryBuilder JSON. Allows
+   * alphanumeric, dots (nested fields), underscores, and hyphens.
+   */
+  private void validateFieldName(String fieldName) {
+    if (!SAFE_FIELD_NAME.matcher(fieldName).matches()) {
+      throw new ExpressionEvaluationException(
+          String.format(
+              "Invalid field name '%s': must contain only alphanumeric characters,"
+                  + " dots, underscores, or hyphens",
+              fieldName));
+    }
+  }
+
   private void validateOptions(Map<String, String> options) {
+    // Reject unknown option keys — only P0 keys are allowed
+    for (String key : options.keySet()) {
+      if (!ALLOWED_OPTION_KEYS.contains(key)) {
+        throw new ExpressionEvaluationException(
+            String.format("Unknown option key '%s'. Supported keys: %s", key, ALLOWED_OPTION_KEYS));
+      }
+    }
     boolean hasK = options.containsKey("k");
     boolean hasMaxDistance = options.containsKey("max_distance");
     boolean hasMinScore = options.containsKey("min_score");

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -146,7 +146,7 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     return options;
   }
 
-  /** Reject non-named arguments early. vectorSearch() requires named args (key=value). */
+  /** Reject non-named arguments and null arg names early. */
   private void validateNamedArgs() {
     for (Expression arg : arguments) {
       if (!(arg instanceof NamedArgumentExpression)) {
@@ -154,6 +154,12 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
             "vectorSearch() requires named arguments (e.g., table='index'), "
                 + "but received: "
                 + arg.getClass().getSimpleName());
+      }
+      String name = ((NamedArgumentExpression) arg).getArgName();
+      if (name == null || name.isEmpty()) {
+        throw new ExpressionEvaluationException(
+            "vectorSearch() requires named arguments (e.g., table='index'), "
+                + "but received an argument with no name");
       }
     }
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolver.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage;
+
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionResolver;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+
+@RequiredArgsConstructor
+public class VectorSearchTableFunctionResolver implements FunctionResolver {
+
+  public static final String VECTOR_SEARCH = "vectorsearch";
+  public static final String TABLE = "table";
+  public static final String FIELD = "field";
+  public static final String VECTOR = "vector";
+  public static final String OPTION = "option";
+  public static final List<String> ARGUMENT_NAMES = List.of(TABLE, FIELD, VECTOR, OPTION);
+
+  private final OpenSearchClient client;
+  private final Settings settings;
+
+  @Override
+  public Pair<FunctionSignature, FunctionBuilder> resolve(FunctionSignature unresolvedSignature) {
+    FunctionName functionName = FunctionName.of(VECTOR_SEARCH);
+    FunctionSignature functionSignature =
+        new FunctionSignature(functionName, List.of(STRING, STRING, STRING, STRING));
+    FunctionBuilder functionBuilder =
+        (functionProperties, arguments) -> {
+          validateArguments(arguments);
+          return new VectorSearchTableFunctionImplementation(
+              functionName, arguments, client, settings);
+        };
+    return Pair.of(functionSignature, functionBuilder);
+  }
+
+  @Override
+  public FunctionName getFunctionName() {
+    return FunctionName.of(VECTOR_SEARCH);
+  }
+
+  private void validateArguments(List<Expression> arguments) {
+    if (arguments.size() != ARGUMENT_NAMES.size()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "vectorSearch requires %d arguments (%s), got %d",
+              ARGUMENT_NAMES.size(), String.join(", ", ARGUMENT_NAMES), arguments.size()));
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/OpenSearchIndexScanBuilder.java
@@ -45,8 +45,8 @@ public class OpenSearchIndexScanBuilder extends TableScanBuilder {
     this.scanFactory = scanFactory;
   }
 
-  /** Constructor used for unit tests. */
-  protected OpenSearchIndexScanBuilder(
+  /** Constructor that accepts a custom PushDownQueryBuilder delegate. */
+  public OpenSearchIndexScanBuilder(
       PushDownQueryBuilder translator,
       Function<OpenSearchRequestBuilder, OpenSearchIndexScan> scanFactory) {
     this.delegate = translator;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.scan;
+
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+import org.opensearch.sql.opensearch.storage.script.filter.FilterQueryBuilder;
+import org.opensearch.sql.opensearch.storage.serde.DefaultExpressionSerializer;
+import org.opensearch.sql.planner.logical.LogicalFilter;
+
+/**
+ * Query builder for vector search that keeps the knn query in a scoring (must) context and puts
+ * WHERE filters in a non-scoring (filter) context. This prevents the knn relevance scores from
+ * being destroyed when a WHERE clause is pushed down.
+ *
+ * <p>Without this, the default pushDownFilter wraps both queries into bool.filter, which is a
+ * non-scoring context.
+ */
+public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
+
+  private final QueryBuilder knnQuery;
+
+  public VectorSearchQueryBuilder(OpenSearchRequestBuilder requestBuilder, QueryBuilder knnQuery) {
+    super(requestBuilder);
+    // Set knn as the initial query (scoring context)
+    requestBuilder.getSourceBuilder().query(knnQuery);
+    this.knnQuery = knnQuery;
+  }
+
+  @Override
+  public boolean pushDownFilter(LogicalFilter filter) {
+    FilterQueryBuilder queryBuilder = new FilterQueryBuilder(new DefaultExpressionSerializer());
+    Expression queryCondition = filter.getCondition();
+    QueryBuilder whereQuery = queryBuilder.build(queryCondition);
+
+    // Combine: knn in must (scores), WHERE in filter (no scoring impact)
+    BoolQueryBuilder combined = QueryBuilders.boolQuery().must(knnQuery).filter(whereQuery);
+    requestBuilder.getSourceBuilder().query(combined);
+    return true;
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngineTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngineTest.java
@@ -6,17 +6,20 @@
 package org.opensearch.sql.opensearch.storage;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
 import static org.opensearch.sql.utils.SystemIndexUtils.TABLE_INFO;
 
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.DataSourceSchemaName;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.expression.function.FunctionResolver;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.storage.system.OpenSearchSystemIndex;
 import org.opensearch.sql.storage.Table;
@@ -34,6 +37,14 @@ class OpenSearchStorageEngineTest {
     Table table =
         engine.getTable(new DataSourceSchemaName(DEFAULT_DATASOURCE_NAME, "default"), "test");
     assertAll(() -> assertNotNull(table), () -> assertTrue(table instanceof OpenSearchIndex));
+  }
+
+  @Test
+  public void getFunctionsReturnsVectorSearchResolver() {
+    OpenSearchStorageEngine engine = new OpenSearchStorageEngine(client, settings);
+    Collection<FunctionResolver> functions = engine.getFunctions();
+    assertEquals(1, functions.size());
+    assertTrue(functions.iterator().next() instanceof VectorSearchTableFunctionResolver);
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngineTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/OpenSearchStorageEngineTest.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.opensearch.storage;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.sql.analysis.DataSourceSchemaIdentifierNameResolver.DEFAULT_DATASOURCE_NAME;
@@ -43,8 +42,9 @@ class OpenSearchStorageEngineTest {
   public void getFunctionsReturnsVectorSearchResolver() {
     OpenSearchStorageEngine engine = new OpenSearchStorageEngine(client, settings);
     Collection<FunctionResolver> functions = engine.getFunctions();
-    assertEquals(1, functions.size());
-    assertTrue(functions.iterator().next() instanceof VectorSearchTableFunctionResolver);
+    assertTrue(
+        functions.stream().anyMatch(f -> f instanceof VectorSearchTableFunctionResolver),
+        "getFunctions() should contain a VectorSearchTableFunctionResolver");
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -153,6 +153,33 @@ class VectorSearchTableFunctionImplementationTest {
   }
 
   @Test
+  void testNonNumericKThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "k=abc");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("must be an integer"));
+  }
+
+  @Test
+  void testNonNumericMaxDistanceThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "max_distance=notanumber");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("must be a number"));
+  }
+
+  @Test
+  void testInfiniteMinScoreThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "min_score=Infinity");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("must be a finite number"));
+  }
+
+  @Test
   void testNonNamedArgThrows() {
     FunctionName functionName = FunctionName.of("vectorsearch");
     List<Expression> args = List.of(DSL.literal("my-index"));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -139,6 +139,15 @@ class VectorSearchTableFunctionImplementationTest {
   }
 
   @Test
+  void testNoRequiredOptionThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Missing required option"));
+  }
+
+  @Test
   void testEmptyVectorThrows() {
     VectorSearchTableFunctionImplementation impl =
         createImplWithArgs("my-index", "embedding", "[]", "k=5");

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.storage.Table;
+
+@ExtendWith(MockitoExtension.class)
+class VectorSearchTableFunctionImplementationTest {
+
+  @Mock private OpenSearchClient client;
+
+  @Mock private Settings settings;
+
+  @Test
+  void testValueOfThrows() {
+    VectorSearchTableFunctionImplementation impl = createImpl();
+    UnsupportedOperationException ex =
+        assertThrows(UnsupportedOperationException.class, () -> impl.valueOf());
+    assertTrue(ex.getMessage().contains("only supported in FROM clause"));
+  }
+
+  @Test
+  void testType() {
+    VectorSearchTableFunctionImplementation impl = createImpl();
+    assertEquals(ExprCoreType.STRUCT, impl.type());
+  }
+
+  @Test
+  void testToString() {
+    VectorSearchTableFunctionImplementation impl = createImpl();
+    String str = impl.toString();
+    assertTrue(str.contains("vectorsearch"));
+    assertTrue(str.contains("table="));
+    assertTrue(str.contains("my-index"));
+  }
+
+  @Test
+  void testApplyArguments() {
+    VectorSearchTableFunctionImplementation impl = createImpl();
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testApplyArgumentsWithBracketedVector() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0, 3.0]", "k=5");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testApplyArgumentsWithUnbracketedVector() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "1.0, 2.0, 3.0", "k=5");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testApplyArgumentsWithComplexOptions() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "k=10,method.ef_search=100");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testApplyArgumentsWithMaxDistance() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "max_distance=10.0");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testApplyArgumentsWithMinScore() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "min_score=0.5");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testMissingSearchModeOptionThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "method.ef_search=100");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("one of k, max_distance, or min_score"));
+  }
+
+  @Test
+  void testParseOptionsMultiple() {
+    Map<String, String> opts =
+        VectorSearchTableFunctionImplementation.parseOptions("k=5,method.ef_search=100");
+    assertEquals("5", opts.get("k"));
+    assertEquals("100", opts.get("method.ef_search"));
+  }
+
+  @Test
+  void testMissingArgumentThrows() {
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> args =
+        List.of(
+            DSL.namedArgument("table", DSL.literal("my-index")),
+            DSL.namedArgument("field", DSL.literal("embedding")),
+            DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")));
+    VectorSearchTableFunctionImplementation impl =
+        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertEquals("Missing required argument: option", ex.getMessage());
+  }
+
+  private VectorSearchTableFunctionImplementation createImpl() {
+    return createImplWithArgs("my-index", "embedding", "[1.0, 2.0, 3.0]", "k=5");
+  }
+
+  private VectorSearchTableFunctionImplementation createImplWithArgs(
+      String table, String field, String vector, String option) {
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> args =
+        List.of(
+            DSL.namedArgument("table", DSL.literal(table)),
+            DSL.namedArgument("field", DSL.literal(field)),
+            DSL.namedArgument("vector", DSL.literal(vector)),
+            DSL.namedArgument("option", DSL.literal(option)));
+    return new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -121,6 +121,51 @@ class VectorSearchTableFunctionImplementationTest {
   }
 
   @Test
+  void testMalformedOptionSegmentThrows() {
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchTableFunctionImplementation.parseOptions("k=5,badoption"));
+    assertTrue(ex.getMessage().contains("Malformed option segment"));
+  }
+
+  @Test
+  void testDuplicateOptionKeyThrows() {
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchTableFunctionImplementation.parseOptions("k=5,k=10"));
+    assertTrue(ex.getMessage().contains("Duplicate option key"));
+  }
+
+  @Test
+  void testEmptyVectorThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("must not be empty"));
+  }
+
+  @Test
+  void testMalformedVectorComponentThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, abc, 3.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid vector component"));
+  }
+
+  @Test
+  void testNonFiniteVectorComponentThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, Infinity, 3.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("must be a finite number"));
+  }
+
+  @Test
   void testMissingArgumentThrows() {
     FunctionName functionName = FunctionName.of("vectorsearch");
     List<Expression> args =

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -78,11 +78,13 @@ class VectorSearchTableFunctionImplementationTest {
   }
 
   @Test
-  void testApplyArgumentsWithComplexOptions() {
+  void testUnknownOptionKeyThrows() {
     VectorSearchTableFunctionImplementation impl =
         createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "k=10,method.ef_search=100");
-    Table table = impl.applyArguments();
-    assertTrue(table instanceof VectorSearchIndex);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Unknown option key"));
+    assertTrue(ex.getMessage().contains("method.ef_search"));
   }
 
   @Test
@@ -104,18 +106,18 @@ class VectorSearchTableFunctionImplementationTest {
   @Test
   void testMissingSearchModeOptionThrows() {
     VectorSearchTableFunctionImplementation impl =
-        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "method.ef_search=100");
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "not_a_key=100");
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
-    assertTrue(ex.getMessage().contains("one of k, max_distance, or min_score"));
+    assertTrue(ex.getMessage().contains("Unknown option key"));
   }
 
   @Test
   void testParseOptionsMultiple() {
     Map<String, String> opts =
-        VectorSearchTableFunctionImplementation.parseOptions("k=5,method.ef_search=100");
+        VectorSearchTableFunctionImplementation.parseOptions("k=5,max_distance=10.0");
     assertEquals("5", opts.get("k"));
-    assertEquals("100", opts.get("method.ef_search"));
+    assertEquals("10.0", opts.get("max_distance"));
   }
 
   @Test
@@ -131,6 +133,34 @@ class VectorSearchTableFunctionImplementationTest {
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
     assertEquals("Missing required argument: option", ex.getMessage());
+  }
+
+  @Test
+  void testInvalidFieldNameThrows() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "field\"injection", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid field name"));
+  }
+
+  @Test
+  void testNestedFieldNameAllowed() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "doc.embedding", "[1.0, 2.0]", "k=5");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testNonNamedArgThrows() {
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> args = List.of(DSL.literal("my-index"));
+    VectorSearchTableFunctionImplementation impl =
+        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("requires named arguments"));
   }
 
   private VectorSearchTableFunctionImplementation createImpl() {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -235,6 +235,22 @@ class VectorSearchTableFunctionImplementationTest {
     assertTrue(ex.getMessage().contains("requires named arguments"));
   }
 
+  @Test
+  void testNullArgNameThrows() {
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> args =
+        List.of(
+            DSL.namedArgument(null, DSL.literal("my-index")),
+            DSL.namedArgument("field", DSL.literal("embedding")),
+            DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")),
+            DSL.namedArgument("option", DSL.literal("k=5")));
+    VectorSearchTableFunctionImplementation impl =
+        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("requires named arguments"));
+  }
+
   private VectorSearchTableFunctionImplementation createImpl() {
     return createImplWithArgs("my-index", "embedding", "[1.0, 2.0, 3.0]", "k=5");
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -104,7 +104,7 @@ class VectorSearchTableFunctionImplementationTest {
   }
 
   @Test
-  void testMissingSearchModeOptionThrows() {
+  void testUnknownOptionKeyOnlyThrows() {
     VectorSearchTableFunctionImplementation impl =
         createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "not_a_key=100");
     ExpressionEvaluationException ex =

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolverTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolverTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.function.FunctionBuilder;
+import org.opensearch.sql.expression.function.FunctionName;
+import org.opensearch.sql.expression.function.FunctionProperties;
+import org.opensearch.sql.expression.function.FunctionSignature;
+import org.opensearch.sql.expression.function.TableFunctionImplementation;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+
+@ExtendWith(MockitoExtension.class)
+class VectorSearchTableFunctionResolverTest {
+
+  @Mock private OpenSearchClient client;
+
+  @Mock private Settings settings;
+
+  @Mock private FunctionProperties functionProperties;
+
+  @Test
+  void testResolve() {
+    VectorSearchTableFunctionResolver resolver =
+        new VectorSearchTableFunctionResolver(client, settings);
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> expressions =
+        List.of(
+            DSL.namedArgument("table", DSL.literal("my-index")),
+            DSL.namedArgument("field", DSL.literal("embedding")),
+            DSL.namedArgument("vector", DSL.literal("[1.0, 2.0, 3.0]")),
+            DSL.namedArgument("option", DSL.literal("k=5")));
+    FunctionSignature functionSignature =
+        new FunctionSignature(
+            functionName, expressions.stream().map(Expression::type).collect(Collectors.toList()));
+
+    Pair<FunctionSignature, FunctionBuilder> resolution = resolver.resolve(functionSignature);
+
+    assertEquals(functionName, resolution.getKey().getFunctionName());
+    assertEquals(functionName, resolver.getFunctionName());
+    assertEquals(List.of(STRING, STRING, STRING, STRING), resolution.getKey().getParamTypeList());
+
+    TableFunctionImplementation impl =
+        (TableFunctionImplementation) resolution.getValue().apply(functionProperties, expressions);
+    assertTrue(impl instanceof VectorSearchTableFunctionImplementation);
+  }
+
+  @Test
+  void testWrongArgumentCount() {
+    VectorSearchTableFunctionResolver resolver =
+        new VectorSearchTableFunctionResolver(client, settings);
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> expressions =
+        List.of(
+            DSL.namedArgument("table", DSL.literal("my-index")),
+            DSL.namedArgument("field", DSL.literal("embedding")));
+    FunctionSignature functionSignature =
+        new FunctionSignature(
+            functionName, expressions.stream().map(Expression::type).collect(Collectors.toList()));
+
+    Pair<FunctionSignature, FunctionBuilder> resolution = resolver.resolve(functionSignature);
+    FunctionBuilder builder = resolution.getValue();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> builder.apply(functionProperties, expressions));
+    assertTrue(ex.getMessage().contains("requires 4 arguments"));
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.scan;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.WrapperQueryBuilder;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
+import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+
+class VectorSearchQueryBuilderTest {
+
+  @Test
+  void knnQuerySetAsScoringQuery() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("eyJrbm4iOnt9fQ==");
+
+    new VectorSearchQueryBuilder(requestBuilder, knnQuery);
+
+    QueryBuilder query = requestBuilder.getSourceBuilder().query();
+    assertTrue(
+        query instanceof WrapperQueryBuilder,
+        "knn query should be set directly as top-level query (scoring context)");
+  }
+
+  @Test
+  void knnQueryNotWrappedInFilterWhenNoWhere() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("eyJrbm4iOnt9fQ==");
+
+    new VectorSearchQueryBuilder(requestBuilder, knnQuery);
+
+    QueryBuilder query = requestBuilder.getSourceBuilder().query();
+    assertTrue(
+        query instanceof WrapperQueryBuilder,
+        "Without WHERE clause, knn query should NOT be wrapped in bool.filter");
+  }
+
+  private OpenSearchRequestBuilder createRequestBuilder() {
+    return new OpenSearchRequestBuilder(
+        mock(OpenSearchExprValueFactory.class), 10000, mock(Settings.class));
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -5,22 +5,30 @@
 
 package org.opensearch.sql.opensearch.storage.scan;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.WrapperQueryBuilder;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+import org.opensearch.sql.planner.logical.LogicalFilter;
+import org.opensearch.sql.planner.logical.LogicalValues;
 
 class VectorSearchQueryBuilderTest {
 
   @Test
   void knnQuerySetAsScoringQuery() {
     var requestBuilder = createRequestBuilder();
-    var knnQuery = new WrapperQueryBuilder("eyJrbm4iOnt9fQ==");
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
 
     new VectorSearchQueryBuilder(requestBuilder, knnQuery);
 
@@ -31,16 +39,27 @@ class VectorSearchQueryBuilderTest {
   }
 
   @Test
-  void knnQueryNotWrappedInFilterWhenNoWhere() {
+  void pushDownFilterKeepsKnnInScoringContext() {
     var requestBuilder = createRequestBuilder();
-    var knnQuery = new WrapperQueryBuilder("eyJrbm4iOnt9fQ==");
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery);
 
-    new VectorSearchQueryBuilder(requestBuilder, knnQuery);
+    // Simulate WHERE name = 'John'
+    var condition = DSL.equal(new ReferenceExpression("name", STRING), DSL.literal("John"));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
 
-    QueryBuilder query = requestBuilder.getSourceBuilder().query();
+    boolean pushed = builder.pushDownFilter(filter);
+
+    assertTrue(pushed, "pushDownFilter should succeed");
+    QueryBuilder resultQuery = requestBuilder.getSourceBuilder().query();
+    assertTrue(resultQuery instanceof BoolQueryBuilder, "Result should be a BoolQuery");
+    BoolQueryBuilder boolQuery = (BoolQueryBuilder) resultQuery;
+    assertEquals(1, boolQuery.must().size(), "knn query should be in must (scoring context)");
+    assertEquals(1, boolQuery.filter().size(), "WHERE predicate should be in filter (non-scoring)");
     assertTrue(
-        query instanceof WrapperQueryBuilder,
-        "Without WHERE clause, knn query should NOT be wrapped in bool.filter");
+        boolQuery.must().get(0) instanceof WrapperQueryBuilder,
+        "must clause should contain the original knn WrapperQueryBuilder");
   }
 
   private OpenSearchRequestBuilder createRequestBuilder() {


### PR DESCRIPTION
## Summary

Adds the current OpenSearch/V2 SQL execution pipeline for `vectorSearch()` table functions
on the `feature/vector-search-p0` branch. This is the execution companion to #5318, which
adds SQL relation syntax for table functions.

## What this PR adds

- **`VectorSearchTableFunctionResolver`**
  - Registers `vectorsearch` on the OpenSearch storage-engine table-function path
  - Defines the 4-argument surface: `table`, `field`, `vector`, `option`

- **`VectorSearchTableFunctionImplementation`**
  - Parses named arguments and rejects null/empty arg names defensively
  - Parses vector literals into `float[]`
  - Parses the comma-separated `option` string
  - Rejects malformed option segments
  - Rejects duplicate option keys
  - Rejects unknown option keys for P0
  - Canonicalizes P0 option values to numeric strings before DSL generation
  - Rejects empty, malformed, and non-finite vector components
  - Validates field names before interpolation into `WrapperQueryBuilder` JSON

- **`VectorSearchIndex`**
  - Seeds scans with a k-NN query via `WrapperQueryBuilder`
  - Enables score tracking so `_score` is available
  - Defaults top-k queries to `size = k` when `k` is present
  - Uses `VectorSearchQueryBuilder` for score-preserving filter pushdown

- **`VectorSearchQueryBuilder`**
  - Keeps the k-NN query in `bool.must` (scoring context)
  - Places SQL `WHERE` predicates in `bool.filter` (non-scoring context)

- **`OpenSearchDataType`**
  - Recognizes `knn_vector` and maps it to `ExprCoreType.ARRAY` as a P0 visibility shim

- **`OpenSearchStorageEngine`**
  - Registers the vectorsearch resolver in `getFunctions()`

## Scope note

This PR adds `vectorSearch()` on the current OpenSearch/V2 SQL execution path and
builds on #5318. It does not add ANSI SQL / Calcite / UnifiedQueryPlanner support.
Compatibility with the Analytics-engine unified query path is future work related
to #5248 / #5246.

The resolver is registered on the shared storage-engine table-function path via
`OpenSearchStorageEngine.getFunctions()`. PPL cannot currently reach this because
the PPL grammar's `tableSource` rule does not reference `tableFunction` — the rule
exists but is dead grammar (zero references from `fromClause`). A null-arg-name
guard is included defensively in case PPL wires up table functions in the future.

The `knn_vector` → `ARRAY` type shim is conceptually compatible with #5246's
API-contract direction of standard Calcite types without UDTs.

## Not in this PR (deferred to follow-up PRs in the feature stack)

- Mutual exclusivity validation for `k` / `max_distance` / `min_score`
- `k` range validation (1–10,000)
- Radial-query `LIMIT` enforcement
- `LIMIT > k` semantics
- Engine/method compatibility checks
- Field/type/dimension validation
- Migration from hand-built JSON to structured XContent builders
- Integration tests

## Next PRs

- **PR-3 (Validation Hardening):** Enforce exactly-one search mode (mutual exclusivity),
  k range [1, 10000], radial-without-LIMIT rejection, LIMIT > k rejection, unsupported
  shape rejection (ORDER BY non-score, GROUP BY, JOIN), integration tests
- **PR-4 (Efficient Filtering):** `filter_type=efficient|post` option, WHERE inside knn
  clause for efficient pre-filtering mode

## Test plan

- `./gradlew :opensearch:test --tests "*VectorSearchTableFunctionResolverTest"`
- `./gradlew :opensearch:test --tests "*VectorSearchTableFunctionImplementationTest"`
- `./gradlew :opensearch:test --tests "*VectorSearchQueryBuilderTest"`
- `./gradlew :opensearch:test --tests "*OpenSearchStorageEngineTest"`
- `./gradlew :opensearch:build`

## New unit coverage in this PR

- Unknown option key rejection
- Malformed option segment rejection
- Duplicate option key rejection
- Invalid field-name rejection
- Nested field-name acceptance
- Empty / malformed / non-finite vector rejection
- Non-numeric option value rejection
- Named-argument enforcement (non-named args and null arg names)
- `pushDownFilter()` preserving knn in scoring context
- Storage engine contains-check (not brittle exact-size assertion)