### PR TITLE
Add whitelist to block non-query statements in unified SQL path

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -14,6 +14,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
@@ -60,8 +61,7 @@ public class UnifiedQueryPlanner {
   public RelNode plan(String query) {
     try {
       return context.measure(ANALYZE, () -> strategy.plan(query));
-    } catch (SyntaxCheckException e) {
-      // Re-throw syntax error without wrapping
+    } catch (SyntaxCheckException | UnsupportedOperationException e) {
       throw e;
     } catch (Exception e) {
       throw new IllegalStateException("Failed to plan query", e);
@@ -82,6 +82,11 @@ public class UnifiedQueryPlanner {
     public RelNode plan(String query) throws Exception {
       try (Planner planner = Frameworks.getPlanner(context.getPlanContext().config)) {
         SqlNode parsed = planner.parse(query);
+        if (!parsed.isA(SqlKind.QUERY)) {
+          throw new UnsupportedOperationException(
+              "Only query statements are supported. Got: " + parsed.getKind());
+        }
+
         SqlNode rewritten = parsed.accept(NamedArgRewriter.INSTANCE);
         SqlNode validated = planner.validate(rewritten);
         RelRoot relRoot = planner.rel(validated);

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.api;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.impl.AbstractSchema;
@@ -210,5 +211,51 @@ public class UnifiedQueryPlannerSqlTest extends UnifiedQueryTestBase {
   @Test
   public void testInvalidSqlThrowsException() {
     assertThrows(IllegalStateException.class, () -> planner.plan("SELECT FROM"));
+  }
+
+  @Test
+  public void testNonQueryStatementsBlockedByWhitelist() {
+    List.of(
+            """
+            INSERT INTO catalog.employees (id, name, age, department)
+            VALUES (99, 'injected', 0, 'hacked')\
+            """,
+            """
+            DELETE FROM catalog.employees
+            WHERE age > 30\
+            """,
+            """
+            UPDATE catalog.employees
+            SET department = 'Fired'
+            WHERE age > 50\
+            """,
+            """
+            EXPLAIN PLAN FOR
+            SELECT * FROM catalog.employees\
+            """,
+            """
+            MERGE INTO catalog.employees AS t
+            USING (SELECT 99 AS id) AS s ON t.id = s.id
+            WHEN MATCHED THEN UPDATE SET name = 'hacked'\
+            """)
+        .forEach(
+            sql ->
+                givenInvalidQuery(sql).assertErrorMessage("Only query statements are supported"));
+  }
+
+  @Test
+  public void testNonQueryStatementsBlockedByParser() {
+    List.of(
+            """
+            CREATE MATERIALIZED VIEW mv AS
+            SELECT department, count(*)
+            FROM catalog.employees
+            GROUP BY department\
+            """,
+            """
+            SHOW TABLES\
+            """)
+        .forEach(
+            sql -> givenInvalidQuery(sql).assertErrorMessage("Incorrect syntax near the keyword"));
   }
 }

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
@@ -106,7 +106,7 @@ public class UnifiedQueryPlannerTest extends UnifiedQueryTestBase {
     assertNotNull("Plan should be created with multiple catalogs", plan);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test(expected = UnsupportedOperationException.class)
   public void testUnsupportedStatementType() {
     planner.plan("explain source = catalog.employees"); // explain statement
   }


### PR DESCRIPTION
### Description

The unified SQL path uses Calcite's `SqlParser.parseQuery()` which, despite its name, accepts any SQL statement type including DML and DDL. The SQL V2 grammar restricts input to `SELECT`/`SHOW`/`DESCRIBE` at the parser level, but the unified path had no equivalent protection.

## Changes

Validate the parsed `SqlNode` against `SqlKind.QUERY` in `CalciteNativeStrategy.plan()` before proceeding to planning. Non-query statements are rejected with `UnsupportedOperationException`.

| Statement type | SQL V2/Legacy | Unified SQL | Blocked by |
|---|---|---|---|
| SELECT (with JOIN, subquery, etc.) | ✅ | ✅ Allowed | — |
| UNION, EXCEPT, INTERSECT | ✅ UNION/EXCEPT | ✅ Allowed | — |
| CTE (WITH), VALUES | ❌ | ✅ Allowed | — |
| DDL (CREATE MV, etc.) | ❌ | ❌ Blocked | Calcite parser |
| SHOW / DESCRIBE | ✅ | ❌ Blocked | Calcite parser |
| EXPLAIN | Separate `/_explain` path | ❌ Blocked | Whitelist |
| INSERT, DELETE, UPDATE, MERGE | ❌ | ❌ Blocked | Whitelist |

> Note: EXPLAIN, SHOW, and DESCRIBE have separate execution paths in the current SQL plugin and are out of scope for the unified query API — they should be handled by the API caller for now.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
