### PR TITLE
[Feature] Add efficient filtering (knn.filter) support for vectorSearch()

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
@@ -202,8 +202,33 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "WHERE v.state = 'TX' "
                 + "LIMIT 5");
 
-    // Efficient mode: knn rebuilt with filter inside, wrapped in WrapperQueryBuilder
+    // Efficient mode: knn rebuilt with filter inside, wrapped in WrapperQueryBuilder.
+    // The knn JSON (including the embedded filter) is base64-encoded inside the wrapper,
+    // so we verify structure by: (1) wrapper present, (2) no bool/must in plaintext
+    // (that would be post-filter shape), (3) decode the base64 payload to confirm
+    // the filter and predicate field are embedded inside the knn query.
     assertTrue("Explain should contain wrapper query:\n" + explain, explain.contains("wrapper"));
+    assertFalse(
+        "Efficient mode should not produce bool query (that is post-filter shape):\n" + explain,
+        explain.contains("\"bool\""));
+    assertFalse(
+        "Efficient mode should not contain must clause:\n" + explain, explain.contains("\"must\""));
+
+    // Extract and decode the base64 knn payload to verify filter embedding.
+    // The explain output escapes quotes as \", so match both \" and " forms.
+    java.util.regex.Matcher m =
+        java.util.regex.Pattern.compile("\\\\?\"query\\\\?\":\\\\?\"([A-Za-z0-9+/=]+)\\\\?\"")
+            .matcher(explain);
+    assertTrue("Explain should contain base64-encoded knn query:\n" + explain, m.find());
+    String knnJson =
+        new String(
+            java.util.Base64.getDecoder().decode(m.group(1)),
+            java.nio.charset.StandardCharsets.UTF_8);
+    assertTrue(
+        "Efficient mode knn JSON should contain filter:\n" + knnJson, knnJson.contains("filter"));
+    assertTrue(
+        "Efficient mode knn JSON should contain the WHERE predicate field:\n" + knnJson,
+        knnJson.contains("state"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
@@ -170,4 +170,57 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
 
     assertTrue("Explain should succeed with LIMIT <= k:\n" + explain, explain.contains("wrapper"));
   }
+
+  // ── filter_type explain ─────────────────────────────────────────────
+
+  @Test
+  public void testExplainFilterTypePostProducesBoolQuery() throws IOException {
+    String explain =
+        explainQuery(
+            "SELECT v._id, v._score "
+                + "FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', "
+                + "vector='[1.0, 2.0, 3.0]', option='k=10,filter_type=post') AS v "
+                + "WHERE v.state = 'TX' "
+                + "LIMIT 10");
+
+    assertTrue("Explain should contain bool query:\n" + explain, explain.contains("bool"));
+    assertTrue("Explain should contain must:\n" + explain, explain.contains("must"));
+    assertTrue("Explain should contain filter:\n" + explain, explain.contains("filter"));
+  }
+
+  @Test
+  public void testExplainFilterTypeEfficientProducesKnnWithFilter() throws IOException {
+    String explain =
+        explainQuery(
+            "SELECT v._id, v._score "
+                + "FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', "
+                + "vector='[1.0, 2.0]', option='k=5,filter_type=efficient') AS v "
+                + "WHERE v.state = 'TX' "
+                + "LIMIT 5");
+
+    // Efficient mode: knn rebuilt with filter inside, wrapped in WrapperQueryBuilder
+    assertTrue("Explain should contain wrapper query:\n" + explain, explain.contains("wrapper"));
+  }
+
+  @Test
+  public void testEfficientFilterWithOrderByScoreDescSucceeds() throws IOException {
+    String explain =
+        explainQuery(
+            "SELECT v._id, v._score "
+                + "FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', "
+                + "vector='[1.0, 2.0]', option='k=5,filter_type=efficient') AS v "
+                + "WHERE v.state = 'TX' "
+                + "ORDER BY v._score DESC "
+                + "LIMIT 5");
+
+    assertTrue(
+        "Explain should succeed with efficient + ORDER BY _score DESC:\n" + explain,
+        explain.contains("wrapper"));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -133,6 +133,21 @@ public class VectorSearchIT extends SQLIntegTestCase {
     assertThat(ex.getMessage(), containsString("Missing required option"));
   }
 
+  @Test
+  public void testRadialWithoutLimitRejects() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', "
+                        + "vector='[1.0, 2.0]', option='max_distance=10.5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("LIMIT is required for radial vector search"));
+  }
+
   // ── Sort restriction validation ─────────────────────────────────────────
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -168,4 +168,51 @@ public class VectorSearchIT extends SQLIntegTestCase {
 
     assertThat(ex.getMessage(), containsString("_score ASC is not supported"));
   }
+
+  // ── filter_type validation ────────────────────────────────────────────
+
+  @Test
+  public void testFilterTypeEfficientWithoutWhereRejects() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', "
+                        + "vector='[1.0, 2.0]', option='k=5,filter_type=efficient') AS v "
+                        + "LIMIT 5"));
+
+    assertThat(ex.getMessage(), containsString("filter_type requires a pushdownable WHERE clause"));
+  }
+
+  @Test
+  public void testFilterTypePostWithoutWhereRejects() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', "
+                        + "vector='[1.0, 2.0]', option='k=5,filter_type=post') AS v "
+                        + "LIMIT 5"));
+
+    assertThat(ex.getMessage(), containsString("filter_type requires a pushdownable WHERE clause"));
+  }
+
+  @Test
+  public void testInvalidFilterTypeRejects() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='t', field='f', "
+                        + "vector='[1.0]', option='k=5,filter_type=bogus') AS v"));
+
+    assertThat(ex.getMessage(), containsString("filter_type must be one of"));
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/FilterType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/FilterType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+
+/** Filter placement strategy for vectorSearch() WHERE clauses. */
+public enum FilterType {
+  /** WHERE placed in bool.filter outside the knn clause (post-filtering). */
+  POST("post"),
+
+  /** WHERE placed inside knn.filter for efficient pre-filtering. */
+  EFFICIENT("efficient");
+
+  private final String value;
+
+  FilterType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  private static final Set<String> VALID_VALUES =
+      Arrays.stream(values()).map(FilterType::getValue).collect(Collectors.toSet());
+
+  public static FilterType fromString(String str) {
+    for (FilterType ft : values()) {
+      if (ft.value.equals(str)) {
+        return ft;
+      }
+    }
+    throw new ExpressionEvaluationException(
+        String.format("filter_type must be one of %s, got '%s'", VALID_VALUES, str));
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -60,9 +60,18 @@ public class VectorSearchIndex extends OpenSearchIndex {
         getSettings().getSettingValue(Settings.Key.SQL_CURSOR_KEEP_ALIVE);
     var requestBuilder = createRequestBuilder();
 
-    // Use VectorSearchQueryBuilder to keep knn in must (scoring) context.
-    // WHERE filters will be placed in filter (non-scoring) context.
-    var queryBuilder = new VectorSearchQueryBuilder(requestBuilder, buildKnnQuery(), options);
+    // Callback for efficient filtering: serialize WHERE QueryBuilder to JSON,
+    // rebuild knn query with filter embedded. JSON handling stays in this class.
+    Function<QueryBuilder, QueryBuilder> rebuildWithFilter =
+        whereQuery -> new WrapperQueryBuilder(buildKnnQueryJson(whereQuery.toString()));
+
+    boolean filterTypeExplicit = filterType != null;
+    FilterType effectiveFilterType = filterType != null ? filterType : FilterType.POST;
+
+    var queryBuilder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, buildKnnQuery(), options,
+            effectiveFilterType, filterTypeExplicit, rebuildWithFilter);
     requestBuilder.pushDownTrackedScore(true);
 
     // Default size policy: LIMIT pushdown will further reduce if present.

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -70,8 +70,12 @@ public class VectorSearchIndex extends OpenSearchIndex {
 
     var queryBuilder =
         new VectorSearchQueryBuilder(
-            requestBuilder, buildKnnQuery(), options,
-            effectiveFilterType, filterTypeExplicit, rebuildWithFilter);
+            requestBuilder,
+            buildKnnQuery(),
+            options,
+            effectiveFilterType,
+            filterTypeExplicit,
+            rebuildWithFilter);
     requestBuilder.pushDownTrackedScore(true);
 
     // Default size policy: LIMIT pushdown will further reduce if present.

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -90,6 +90,15 @@ public class VectorSearchIndex extends OpenSearchIndex {
 
   // Package-private for testing
   String buildKnnQueryJson() {
+    return buildKnnQueryJson(null);
+  }
+
+  /**
+   * Builds knn query JSON, optionally embedding a filter clause for efficient filtering.
+   *
+   * @param filterJson serialized filter JSON to embed in knn.field.filter, or null for no filter
+   */
+  String buildKnnQueryJson(String filterJson) {
     StringBuilder vectorJson = new StringBuilder("[");
     for (int i = 0; i < vector.length; i++) {
       if (i > 0) vectorJson.append(",");
@@ -110,9 +119,14 @@ public class VectorSearchIndex extends OpenSearchIndex {
       }
     }
 
+    String filterClause = "";
+    if (filterJson != null) {
+      filterClause = String.format(",\"filter\":%s", filterJson);
+    }
+
     return String.format(
-        "{\"knn\":{\"%s\":{\"vector\":%s%s}}}",
-        field, vectorJson.toString(), optionsJson.toString());
+        "{\"knn\":{\"%s\":{\"vector\":%s%s%s}}}",
+        field, vectorJson.toString(), optionsJson.toString(), filterClause);
   }
 
   private static boolean isNumeric(String str) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -43,7 +43,7 @@ public class VectorSearchIndex extends OpenSearchIndex {
     this.filterType = filterType;
   }
 
-  /** Backward-compatible constructor — defaults to no explicit filter type. */
+  /** Default constructor — preserves existing call sites; uses no explicit filter type. */
   public VectorSearchIndex(
       OpenSearchClient client,
       Settings settings,

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -26,6 +26,7 @@ public class VectorSearchIndex extends OpenSearchIndex {
   private final String field;
   private final float[] vector;
   private final Map<String, String> options;
+  private final FilterType filterType; // null means default (POST)
 
   public VectorSearchIndex(
       OpenSearchClient client,
@@ -33,11 +34,24 @@ public class VectorSearchIndex extends OpenSearchIndex {
       String indexName,
       String field,
       float[] vector,
-      Map<String, String> options) {
+      Map<String, String> options,
+      FilterType filterType) {
     super(client, settings, indexName);
     this.field = field;
     this.vector = vector;
     this.options = options;
+    this.filterType = filterType;
+  }
+
+  /** Backward-compatible constructor — defaults to no explicit filter type. */
+  public VectorSearchIndex(
+      OpenSearchClient client,
+      Settings settings,
+      String indexName,
+      String field,
+      float[] vector,
+      Map<String, String> options) {
+    this(client, settings, indexName, field, vector, options, null);
   }
 
   @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -34,7 +34,8 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     implements TableFunctionImplementation {
 
   /** P0 allowed option keys. Rejects unknown/future keys to prevent unvalidated DSL injection. */
-  static final Set<String> ALLOWED_OPTION_KEYS = Set.of("k", "max_distance", "min_score");
+  static final Set<String> ALLOWED_OPTION_KEYS =
+      Set.of("k", "max_distance", "min_score", "filter_type");
 
   /**
    * Field names must be safe for JSON interpolation: alphanumeric, dots (nested), underscores,
@@ -189,6 +190,10 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
         throw new ExpressionEvaluationException(
             String.format("Unknown option key '%s'. Supported keys: %s", key, ALLOWED_OPTION_KEYS));
       }
+    }
+    if (options.containsKey("filter_type")) {
+      // Validate early — fromString throws if invalid
+      FilterType.fromString(options.get("filter_type"));
     }
     boolean hasK = options.containsKey("k");
     boolean hasMaxDistance = options.containsKey("max_distance");

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -100,7 +100,14 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     Map<String, String> options = parseOptions(optionStr);
     validateOptions(options);
 
-    return new VectorSearchIndex(client, settings, tableName, fieldName, vector, options);
+    // Strip filter_type — it's a SQL-layer directive, not a knn parameter
+    FilterType filterType = null;
+    if (options.containsKey("filter_type")) {
+      filterType = FilterType.fromString(options.remove("filter_type"));
+    }
+
+    return new VectorSearchIndex(
+        client, settings, tableName, fieldName, vector, options, filterType);
   }
 
   private float[] parseVector(String vectorLiteral) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -84,9 +84,8 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     } catch (ScriptQueryUnSupportedException e) {
       if (filterTypeExplicit) {
         throw new ExpressionEvaluationException(
-            "filter_type requires a pushdownable WHERE clause, but the given condition"
-                + " cannot be pushed down: "
-                + e.getMessage());
+            "filter_type only works when the WHERE clause can be translated to an"
+                + " OpenSearch filter. Rewrite the WHERE clause or omit filter_type.");
       }
       // Default mode: fall back to in-memory filtering (matches base class behavior)
       return false;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -44,6 +44,7 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
   private final boolean filterTypeExplicit;
   private final Function<QueryBuilder, QueryBuilder> rebuildKnnWithFilter;
   private boolean filterPushed = false;
+  private boolean limitPushed = false;
 
   /** Full constructor with filter type support. */
   public VectorSearchQueryBuilder(
@@ -89,6 +90,7 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
   @Override
   public boolean pushDownLimit(LogicalLimit limit) {
     validateLimitWithinK(limit.getLimit());
+    limitPushed = true;
     return super.pushDownLimit(limit);
   }
 
@@ -136,6 +138,12 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
   public OpenSearchRequestBuilder build() {
     if (filterTypeExplicit && !filterPushed) {
       throw new ExpressionEvaluationException("filter_type requires a pushdownable WHERE clause");
+    }
+    boolean isRadial = !options.containsKey("k");
+    if (isRadial && !limitPushed) {
+      throw new ExpressionEvaluationException(
+          "LIMIT is required for radial vector search (max_distance or min_score)."
+              + " Without LIMIT, the result set size is unbounded.");
     }
     return super.build();
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -19,6 +19,7 @@ import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.opensearch.storage.FilterType;
 import org.opensearch.sql.opensearch.storage.script.filter.FilterQueryBuilder;
+import org.opensearch.sql.opensearch.storage.script.filter.FilterQueryBuilder.ScriptQueryUnSupportedException;
 import org.opensearch.sql.opensearch.storage.serde.DefaultExpressionSerializer;
 import org.opensearch.sql.planner.logical.LogicalFilter;
 import org.opensearch.sql.planner.logical.LogicalLimit;
@@ -73,7 +74,19 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
   public boolean pushDownFilter(LogicalFilter filter) {
     FilterQueryBuilder queryBuilder = new FilterQueryBuilder(new DefaultExpressionSerializer());
     Expression queryCondition = filter.getCondition();
-    QueryBuilder whereQuery = queryBuilder.build(queryCondition);
+    QueryBuilder whereQuery;
+    try {
+      whereQuery = queryBuilder.build(queryCondition);
+    } catch (ScriptQueryUnSupportedException e) {
+      if (filterTypeExplicit) {
+        throw new ExpressionEvaluationException(
+            "filter_type requires a pushdownable WHERE clause, but the given condition"
+                + " cannot be pushed down: "
+                + e.getMessage());
+      }
+      // Default mode: fall back to in-memory filtering (matches base class behavior)
+      return false;
+    }
     filterPushed = true;
 
     if (filterType == FilterType.EFFICIENT) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -61,6 +61,10 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     this.options = options;
     this.filterType = filterType != null ? filterType : FilterType.POST;
     this.filterTypeExplicit = filterTypeExplicit;
+    if (this.filterType == FilterType.EFFICIENT && rebuildKnnWithFilter == null) {
+      throw new IllegalArgumentException(
+          "EFFICIENT filter mode requires a non-null rebuildKnnWithFilter callback");
+    }
     this.rebuildKnnWithFilter = rebuildKnnWithFilter;
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -64,9 +64,7 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
 
   /** Backward-compatible constructor — defaults to POST, not explicit. */
   public VectorSearchQueryBuilder(
-      OpenSearchRequestBuilder requestBuilder,
-      QueryBuilder knnQuery,
-      Map<String, String> options) {
+      OpenSearchRequestBuilder requestBuilder, QueryBuilder knnQuery, Map<String, String> options) {
     this(requestBuilder, knnQuery, options, FilterType.POST, false, null);
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -118,6 +118,7 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     // but PPL or future callers may set a non-zero count to combine sort+limit in one node.
     if (sort.getCount() != 0) {
       validateLimitWithinK(sort.getCount());
+      limitPushed = true;
       requestBuilder.pushDownLimit(sort.getCount(), 0);
     }
     return true;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.opensearch.storage.scan;
 
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -16,6 +17,7 @@ import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+import org.opensearch.sql.opensearch.storage.FilterType;
 import org.opensearch.sql.opensearch.storage.script.filter.FilterQueryBuilder;
 import org.opensearch.sql.opensearch.storage.serde.DefaultExpressionSerializer;
 import org.opensearch.sql.planner.logical.LogicalFilter;
@@ -27,20 +29,45 @@ import org.opensearch.sql.planner.logical.LogicalSort;
  * WHERE filters in a non-scoring (filter) context. This prevents the knn relevance scores from
  * being destroyed when a WHERE clause is pushed down.
  *
- * <p>Without this, the default pushDownFilter wraps both queries into bool.filter, which is a
- * non-scoring context.
+ * <p>Supports two filter placement strategies via {@link FilterType}:
+ *
+ * <ul>
+ *   <li>{@code POST} — WHERE in {@code bool.filter} outside knn (post-filtering, default)
+ *   <li>{@code EFFICIENT} — WHERE inside {@code knn.filter} for pre-filtering during ANN search
+ * </ul>
  */
 public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
 
   private final QueryBuilder knnQuery;
   private final Map<String, String> options;
+  private final FilterType filterType;
+  private final boolean filterTypeExplicit;
+  private final Function<QueryBuilder, QueryBuilder> rebuildKnnWithFilter;
+  private boolean filterPushed = false;
 
+  /** Full constructor with filter type support. */
   public VectorSearchQueryBuilder(
-      OpenSearchRequestBuilder requestBuilder, QueryBuilder knnQuery, Map<String, String> options) {
+      OpenSearchRequestBuilder requestBuilder,
+      QueryBuilder knnQuery,
+      Map<String, String> options,
+      FilterType filterType,
+      boolean filterTypeExplicit,
+      Function<QueryBuilder, QueryBuilder> rebuildKnnWithFilter) {
     super(requestBuilder);
     requestBuilder.getSourceBuilder().query(knnQuery);
     this.knnQuery = knnQuery;
     this.options = options;
+    this.filterType = filterType != null ? filterType : FilterType.POST;
+    this.filterTypeExplicit = filterTypeExplicit;
+    this.rebuildKnnWithFilter = rebuildKnnWithFilter;
+  }
+
+  /** Backward-compatible constructor — defaults to POST, not explicit. */
+  public VectorSearchQueryBuilder(
+      OpenSearchRequestBuilder requestBuilder,
+      QueryBuilder knnQuery,
+      Map<String, String> options) {
+    this(requestBuilder, knnQuery, options, FilterType.POST, false, null);
   }
 
   @Override
@@ -48,10 +75,16 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     FilterQueryBuilder queryBuilder = new FilterQueryBuilder(new DefaultExpressionSerializer());
     Expression queryCondition = filter.getCondition();
     QueryBuilder whereQuery = queryBuilder.build(queryCondition);
+    filterPushed = true;
 
-    // Combine: knn in must (scores), WHERE in filter (no scoring impact)
-    BoolQueryBuilder combined = QueryBuilders.boolQuery().must(knnQuery).filter(whereQuery);
-    requestBuilder.getSourceBuilder().query(combined);
+    if (filterType == FilterType.EFFICIENT) {
+      QueryBuilder rebuiltKnn = rebuildKnnWithFilter.apply(whereQuery);
+      requestBuilder.getSourceBuilder().query(rebuiltKnn);
+    } else {
+      // POST mode: knn in must (scores), WHERE in filter (no scoring impact)
+      BoolQueryBuilder combined = QueryBuilders.boolQuery().must(knnQuery).filter(whereQuery);
+      requestBuilder.getSourceBuilder().query(combined);
+    }
     return true;
   }
 
@@ -99,5 +132,13 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
             String.format("LIMIT %d exceeds k=%d in top-k vector search", limit, k));
       }
     }
+  }
+
+  @Override
+  public OpenSearchRequestBuilder build() {
+    if (filterTypeExplicit && !filterPushed) {
+      throw new ExpressionEvaluationException("filter_type requires a pushdownable WHERE clause");
+    }
+    return super.build();
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -68,7 +68,7 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     this.rebuildKnnWithFilter = rebuildKnnWithFilter;
   }
 
-  /** Backward-compatible constructor — defaults to POST, not explicit. */
+  /** Default constructor — preserves existing call sites; defaults to POST, not explicit. */
   public VectorSearchQueryBuilder(
       OpenSearchRequestBuilder requestBuilder, QueryBuilder knnQuery, Map<String, String> options) {
     this(requestBuilder, knnQuery, options, FilterType.POST, false, null);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchIndexTest.java
@@ -144,8 +144,13 @@ class VectorSearchIndexTest {
   void buildKnnQueryJsonWithFilterEmbeds() {
     VectorSearchIndex index =
         new VectorSearchIndex(
-            client, settings, "test-index", "embedding",
-            new float[] {1.0f, 2.0f}, Map.of("k", "5"), FilterType.EFFICIENT);
+            client,
+            settings,
+            "test-index",
+            "embedding",
+            new float[] {1.0f, 2.0f},
+            Map.of("k", "5"),
+            FilterType.EFFICIENT);
 
     String filterJson = "{\"term\":{\"city\":{\"value\":\"Miami\"}}}";
     String json = index.buildKnnQueryJson(filterJson);
@@ -160,8 +165,13 @@ class VectorSearchIndexTest {
   void buildKnnQueryJsonWithFilterRadial() {
     VectorSearchIndex index =
         new VectorSearchIndex(
-            client, settings, "test-index", "embedding",
-            new float[] {1.0f}, Map.of("max_distance", "10.5"), FilterType.EFFICIENT);
+            client,
+            settings,
+            "test-index",
+            "embedding",
+            new float[] {1.0f},
+            Map.of("max_distance", "10.5"),
+            FilterType.EFFICIENT);
 
     String filterJson = "{\"range\":{\"rating\":{\"gte\":4.0}}}";
     String json = index.buildKnnQueryJson(filterJson);
@@ -174,8 +184,13 @@ class VectorSearchIndexTest {
   void buildKnnQueryJsonNullFilterProducesBaseJson() {
     VectorSearchIndex index =
         new VectorSearchIndex(
-            client, settings, "test-index", "embedding",
-            new float[] {1.0f}, Map.of("k", "5"), null);
+            client,
+            settings,
+            "test-index",
+            "embedding",
+            new float[] {1.0f},
+            Map.of("k", "5"),
+            null);
 
     String json = index.buildKnnQueryJson(null);
     String baseJson = index.buildKnnQueryJson();
@@ -191,8 +206,13 @@ class VectorSearchIndexTest {
 
     VectorSearchIndex index =
         new VectorSearchIndex(
-            client, settings, "test-index", "embedding",
-            new float[] {1.0f}, options, FilterType.EFFICIENT);
+            client,
+            settings,
+            "test-index",
+            "embedding",
+            new float[] {1.0f},
+            options,
+            FilterType.EFFICIENT);
 
     String json = index.buildKnnQueryJson();
     assertFalse(json.contains("filter_type"), "filter_type should not appear in knn JSON");

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchIndexTest.java
@@ -141,6 +141,50 @@ class VectorSearchIndexTest {
   }
 
   @Test
+  void buildKnnQueryJsonWithFilterEmbeds() {
+    VectorSearchIndex index =
+        new VectorSearchIndex(
+            client, settings, "test-index", "embedding",
+            new float[] {1.0f, 2.0f}, Map.of("k", "5"), FilterType.EFFICIENT);
+
+    String filterJson = "{\"term\":{\"city\":{\"value\":\"Miami\"}}}";
+    String json = index.buildKnnQueryJson(filterJson);
+
+    assertTrue(json.contains("\"filter\""), "Should contain filter field");
+    assertTrue(json.contains("\"term\""), "Should contain the filter content");
+    assertTrue(json.contains("\"k\":5"), "Should still contain k");
+    assertTrue(json.contains("\"vector\":[1.0,2.0]"), "Should contain vector");
+  }
+
+  @Test
+  void buildKnnQueryJsonWithFilterRadial() {
+    VectorSearchIndex index =
+        new VectorSearchIndex(
+            client, settings, "test-index", "embedding",
+            new float[] {1.0f}, Map.of("max_distance", "10.5"), FilterType.EFFICIENT);
+
+    String filterJson = "{\"range\":{\"rating\":{\"gte\":4.0}}}";
+    String json = index.buildKnnQueryJson(filterJson);
+
+    assertTrue(json.contains("\"max_distance\":10.5"), "Should contain max_distance");
+    assertTrue(json.contains("\"filter\""), "Should contain filter");
+  }
+
+  @Test
+  void buildKnnQueryJsonNullFilterProducesBaseJson() {
+    VectorSearchIndex index =
+        new VectorSearchIndex(
+            client, settings, "test-index", "embedding",
+            new float[] {1.0f}, Map.of("k", "5"), null);
+
+    String json = index.buildKnnQueryJson(null);
+    String baseJson = index.buildKnnQueryJson();
+
+    assertEquals(baseJson, json, "null filter should produce same JSON as no-arg version");
+    assertFalse(json.contains("\"filter\""), "Should not contain filter field");
+  }
+
+  @Test
   void buildKnnQueryJsonExcludesFilterType() {
     LinkedHashMap<String, String> options = new LinkedHashMap<>();
     options.put("k", "5");

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchIndexTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchIndexTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.opensearch.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
@@ -137,6 +138,21 @@ class VectorSearchIndexTest {
     String json = index.buildKnnQueryJson();
     assertTrue(json.contains("\"method\":\"hnsw\""), "Non-numeric option should be quoted");
     assertTrue(json.contains("\"k\":5"), "Numeric option should be unquoted");
+  }
+
+  @Test
+  void buildKnnQueryJsonExcludesFilterType() {
+    LinkedHashMap<String, String> options = new LinkedHashMap<>();
+    options.put("k", "5");
+
+    VectorSearchIndex index =
+        new VectorSearchIndex(
+            client, settings, "test-index", "embedding",
+            new float[] {1.0f}, options, FilterType.EFFICIENT);
+
+    String json = index.buildKnnQueryJson();
+    assertFalse(json.contains("filter_type"), "filter_type should not appear in knn JSON");
+    assertTrue(json.contains("\"k\":5"), "k should still be present");
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -388,6 +388,45 @@ class VectorSearchTableFunctionImplementationTest {
     assertTrue(table instanceof VectorSearchIndex);
   }
 
+  @Test
+  void testInvalidFilterTypeRejects() {
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> args =
+        List.of(
+            DSL.namedArgument("table", DSL.literal("my-index")),
+            DSL.namedArgument("field", DSL.literal("embedding")),
+            DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")),
+            DSL.namedArgument("option", DSL.literal("k=5,filter_type=invalid")));
+    VectorSearchTableFunctionImplementation impl =
+        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, impl::applyArguments);
+    assertTrue(ex.getMessage().contains("filter_type must be one of"));
+  }
+
+  @Test
+  void testFilterTypePostAccepted() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "k=5,filter_type=post");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testFilterTypeEfficientAccepted() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "k=5,filter_type=efficient");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testParseOptionsPreservesFilterTypeValue() {
+    Map<String, String> options =
+        VectorSearchTableFunctionImplementation.parseOptions("k=5,filter_type=post");
+    assertEquals("post", options.get("filter_type"));
+  }
+
   private VectorSearchTableFunctionImplementation createImpl() {
     return createImplWithArgs("my-index", "embedding", "[1.0, 2.0, 3.0]", "k=5");
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.opensearch.storage.scan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -534,6 +535,48 @@ class VectorSearchQueryBuilderTest {
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownSort(sort));
     assertTrue(ex.getMessage().contains("unsupported sort expression"));
+  }
+
+  // ── Non-pushdownable filter handling ──────────────────────────────────
+
+  @Test
+  void pushDownFilterNonPushdownableWithExplicitFilterTypeThrows() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"), FilterType.POST, true, null);
+
+    // STRUCT = STRUCT triggers ScriptQueryUnSupportedException in FilterQueryBuilder
+    var condition =
+        DSL.equal(
+            new ReferenceExpression("nested_field", ExprCoreType.STRUCT),
+            new ReferenceExpression("other_field", ExprCoreType.STRUCT));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownFilter(filter));
+    assertTrue(ex.getMessage().contains("filter_type requires a pushdownable WHERE clause"));
+    assertTrue(ex.getMessage().contains("cannot be pushed down"));
+  }
+
+  @Test
+  void pushDownFilterNonPushdownableWithoutExplicitFilterTypeFallsBack() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    // STRUCT = STRUCT triggers ScriptQueryUnSupportedException in FilterQueryBuilder
+    var condition =
+        DSL.equal(
+            new ReferenceExpression("nested_field", ExprCoreType.STRUCT),
+            new ReferenceExpression("other_field", ExprCoreType.STRUCT));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    boolean pushed = builder.pushDownFilter(filter);
+    assertFalse(pushed, "Non-pushdownable filter should return false for in-memory fallback");
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -571,8 +571,9 @@ class VectorSearchQueryBuilderTest {
 
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownFilter(filter));
-    assertTrue(ex.getMessage().contains("filter_type requires a pushdownable WHERE clause"));
-    assertTrue(ex.getMessage().contains("cannot be pushed down"));
+    assertTrue(
+        ex.getMessage().contains("filter_type only works when the WHERE clause can be translated"));
+    assertTrue(ex.getMessage().contains("Rewrite the WHERE clause or omit filter_type"));
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -14,6 +14,7 @@ import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -25,6 +26,7 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+import org.opensearch.sql.opensearch.storage.FilterType;
 import org.opensearch.sql.planner.logical.LogicalFilter;
 import org.opensearch.sql.planner.logical.LogicalLimit;
 import org.opensearch.sql.planner.logical.LogicalValues;
@@ -287,6 +289,54 @@ class VectorSearchQueryBuilderTest {
     BoolQueryBuilder boolQuery = (BoolQueryBuilder) resultQuery;
     assertEquals(1, boolQuery.must().size(), "knn query should be in must (scoring context)");
     assertEquals(1, boolQuery.filter().size(), "compound WHERE should be in filter (non-scoring)");
+  }
+
+  @Test
+  void pushDownFilterEfficientPlacesInsideKnn() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    // Callback simulates VectorSearchIndex rebuilding knn with filter
+    Function<QueryBuilder, QueryBuilder> rebuildWithFilter =
+        whereQuery -> new WrapperQueryBuilder("{\"knn\":{\"filter\":\"embedded\"}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"),
+            FilterType.EFFICIENT, true, rebuildWithFilter);
+
+    var condition = DSL.equal(new ReferenceExpression("city", STRING), DSL.literal("Miami"));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    boolean pushed = builder.pushDownFilter(filter);
+
+    assertTrue(pushed, "pushDownFilter should succeed");
+    QueryBuilder resultQuery = requestBuilder.getSourceBuilder().query();
+    assertTrue(
+        resultQuery instanceof WrapperQueryBuilder,
+        "Efficient filter should produce a WrapperQueryBuilder (rebuilt knn), not BoolQuery");
+  }
+
+  @Test
+  void pushDownFilterExplicitPostProducesBool() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"),
+            FilterType.POST, true, null);
+
+    var condition = DSL.equal(new ReferenceExpression("name", STRING), DSL.literal("John"));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    boolean pushed = builder.pushDownFilter(filter);
+
+    assertTrue(pushed);
+    QueryBuilder resultQuery = requestBuilder.getSourceBuilder().query();
+    assertTrue(resultQuery instanceof BoolQueryBuilder);
+    BoolQueryBuilder boolQuery = (BoolQueryBuilder) resultQuery;
+    assertEquals(1, boolQuery.must().size());
+    assertEquals(1, boolQuery.filter().size());
   }
 
   private OpenSearchRequestBuilder createRequestBuilder() {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -301,8 +301,12 @@ class VectorSearchQueryBuilderTest {
         whereQuery -> new WrapperQueryBuilder("{\"knn\":{\"filter\":\"embedded\"}}");
     var builder =
         new VectorSearchQueryBuilder(
-            requestBuilder, knnQuery, Map.of("k", "5"),
-            FilterType.EFFICIENT, true, rebuildWithFilter);
+            requestBuilder,
+            knnQuery,
+            Map.of("k", "5"),
+            FilterType.EFFICIENT,
+            true,
+            rebuildWithFilter);
 
     var condition = DSL.equal(new ReferenceExpression("city", STRING), DSL.literal("Miami"));
     var dummyChild = new LogicalValues(Collections.emptyList());
@@ -323,8 +327,7 @@ class VectorSearchQueryBuilderTest {
     var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
     var builder =
         new VectorSearchQueryBuilder(
-            requestBuilder, knnQuery, Map.of("k", "5"),
-            FilterType.POST, true, null);
+            requestBuilder, knnQuery, Map.of("k", "5"), FilterType.POST, true, null);
 
     var condition = DSL.equal(new ReferenceExpression("name", STRING), DSL.literal("John"));
     var dummyChild = new LogicalValues(Collections.emptyList());
@@ -348,8 +351,7 @@ class VectorSearchQueryBuilderTest {
     var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
     var builder =
         new VectorSearchQueryBuilder(
-            requestBuilder, knnQuery, Map.of("k", "5"),
-            FilterType.POST, true, null);
+            requestBuilder, knnQuery, Map.of("k", "5"), FilterType.POST, true, null);
 
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, builder::build);
@@ -364,8 +366,12 @@ class VectorSearchQueryBuilderTest {
         whereQuery -> new WrapperQueryBuilder("{\"knn\":{\"filter\":\"embedded\"}}");
     var builder =
         new VectorSearchQueryBuilder(
-            requestBuilder, knnQuery, Map.of("k", "5"),
-            FilterType.EFFICIENT, true, rebuildWithFilter);
+            requestBuilder,
+            knnQuery,
+            Map.of("k", "5"),
+            FilterType.EFFICIENT,
+            true,
+            rebuildWithFilter);
 
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, builder::build);
@@ -388,8 +394,7 @@ class VectorSearchQueryBuilderTest {
     var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
     var builder =
         new VectorSearchQueryBuilder(
-            requestBuilder, knnQuery, Map.of("k", "5"),
-            FilterType.POST, true, null);
+            requestBuilder, knnQuery, Map.of("k", "5"), FilterType.POST, true, null);
 
     var condition = DSL.equal(new ReferenceExpression("name", STRING), DSL.literal("John"));
     var dummyChild = new LogicalValues(Collections.emptyList());
@@ -409,8 +414,12 @@ class VectorSearchQueryBuilderTest {
         whereQuery -> new WrapperQueryBuilder("{\"knn\":{}}");
     var builder =
         new VectorSearchQueryBuilder(
-            requestBuilder, knnQuery, Map.of("k", "5"),
-            FilterType.EFFICIENT, true, rebuildWithFilter);
+            requestBuilder,
+            knnQuery,
+            Map.of("k", "5"),
+            FilterType.EFFICIENT,
+            true,
+            rebuildWithFilter);
 
     var dummyChild = new LogicalValues(Collections.emptyList());
     var limit = new LogicalLimit(dummyChild, 10, 0);
@@ -428,8 +437,12 @@ class VectorSearchQueryBuilderTest {
         whereQuery -> new WrapperQueryBuilder("{\"knn\":{}}");
     var builder =
         new VectorSearchQueryBuilder(
-            requestBuilder, knnQuery, Map.of("k", "5"),
-            FilterType.EFFICIENT, true, rebuildWithFilter);
+            requestBuilder,
+            knnQuery,
+            Map.of("k", "5"),
+            FilterType.EFFICIENT,
+            true,
+            rebuildWithFilter);
 
     var dummyChild = new LogicalValues(Collections.emptyList());
     var sort =
@@ -452,8 +465,12 @@ class VectorSearchQueryBuilderTest {
         whereQuery -> new WrapperQueryBuilder("{\"knn\":{}}");
     var builder =
         new VectorSearchQueryBuilder(
-            requestBuilder, knnQuery, Map.of("k", "5"),
-            FilterType.EFFICIENT, true, rebuildWithFilter);
+            requestBuilder,
+            knnQuery,
+            Map.of("k", "5"),
+            FilterType.EFFICIENT,
+            true,
+            rebuildWithFilter);
 
     var dummyChild = new LogicalValues(Collections.emptyList());
     var sort =

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -404,6 +404,56 @@ class VectorSearchQueryBuilderTest {
     assertNotNull(result);
   }
 
+  // ── Radial without LIMIT rejection ─────────────────────────────────
+
+  @Test
+  void buildRejectsRadialMaxDistanceWithoutLimit() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("max_distance", "10.0"));
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, builder::build);
+    assertTrue(ex.getMessage().contains("LIMIT is required for radial vector search"));
+  }
+
+  @Test
+  void buildRejectsRadialMinScoreWithoutLimit() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("min_score", "0.5"));
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, builder::build);
+    assertTrue(ex.getMessage().contains("LIMIT is required for radial vector search"));
+  }
+
+  @Test
+  void buildSucceedsRadialWithLimit() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("max_distance", "10.0"));
+
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    builder.pushDownLimit(new LogicalLimit(dummyChild, 50, 0));
+
+    OpenSearchRequestBuilder result = builder.build();
+    assertNotNull(result);
+  }
+
+  @Test
+  void buildSucceedsTopKWithoutLimit() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    OpenSearchRequestBuilder result = builder.build();
+    assertNotNull(result);
+  }
+
   // ── Regression: LIMIT and sort invariants under efficient mode ──────
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -344,6 +344,20 @@ class VectorSearchQueryBuilderTest {
     assertEquals(1, boolQuery.filter().size());
   }
 
+  // ── Constructor validation ──────────────────────────────────────────
+
+  @Test
+  void constructorRejectsEfficientModeWithNullCallback() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new VectorSearchQueryBuilder(
+                requestBuilder, knnQuery, Map.of("k", "5"), FilterType.EFFICIENT, true, null));
+  }
+
   // ── Build-time validation ────────────────────────────────────────────
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.opensearch.storage.scan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -337,6 +338,135 @@ class VectorSearchQueryBuilderTest {
     BoolQueryBuilder boolQuery = (BoolQueryBuilder) resultQuery;
     assertEquals(1, boolQuery.must().size());
     assertEquals(1, boolQuery.filter().size());
+  }
+
+  // ── Build-time validation ────────────────────────────────────────────
+
+  @Test
+  void buildRejectsExplicitFilterTypePostWithoutWhere() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"),
+            FilterType.POST, true, null);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, builder::build);
+    assertTrue(ex.getMessage().contains("filter_type requires a pushdownable WHERE clause"));
+  }
+
+  @Test
+  void buildRejectsExplicitFilterTypeEfficientWithoutWhere() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    Function<QueryBuilder, QueryBuilder> rebuildWithFilter =
+        whereQuery -> new WrapperQueryBuilder("{\"knn\":{\"filter\":\"embedded\"}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"),
+            FilterType.EFFICIENT, true, rebuildWithFilter);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, builder::build);
+    assertTrue(ex.getMessage().contains("filter_type requires a pushdownable WHERE clause"));
+  }
+
+  @Test
+  void buildSucceedsWithNoFilterTypeAndNoWhere() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    OpenSearchRequestBuilder result = builder.build();
+    assertNotNull(result);
+  }
+
+  @Test
+  void buildSucceedsWithFilterTypeAndPushedWhere() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"),
+            FilterType.POST, true, null);
+
+    var condition = DSL.equal(new ReferenceExpression("name", STRING), DSL.literal("John"));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    builder.pushDownFilter(new LogicalFilter(dummyChild, condition));
+
+    OpenSearchRequestBuilder result = builder.build();
+    assertNotNull(result);
+  }
+
+  // ── Regression: LIMIT and sort invariants under efficient mode ──────
+
+  @Test
+  void pushDownLimitExceedingKThrowsUnderEfficientMode() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    Function<QueryBuilder, QueryBuilder> rebuildWithFilter =
+        whereQuery -> new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"),
+            FilterType.EFFICIENT, true, rebuildWithFilter);
+
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var limit = new LogicalLimit(dummyChild, 10, 0);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownLimit(limit));
+    assertTrue(ex.getMessage().contains("LIMIT 10 exceeds k=5"));
+  }
+
+  @Test
+  void pushDownSortScoreDescAcceptedUnderEfficientMode() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    Function<QueryBuilder, QueryBuilder> rebuildWithFilter =
+        whereQuery -> new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"),
+            FilterType.EFFICIENT, true, rebuildWithFilter);
+
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var sort =
+        new org.opensearch.sql.planner.logical.LogicalSort(
+            dummyChild,
+            List.of(
+                org.apache.commons.lang3.tuple.ImmutablePair.of(
+                    org.opensearch.sql.ast.tree.Sort.SortOption.DEFAULT_DESC,
+                    new ReferenceExpression("_score", ExprCoreType.FLOAT))));
+
+    boolean pushed = builder.pushDownSort(sort);
+    assertTrue(pushed, "ORDER BY _score DESC should be accepted under efficient mode");
+  }
+
+  @Test
+  void pushDownSortNonScoreRejectedUnderEfficientMode() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    Function<QueryBuilder, QueryBuilder> rebuildWithFilter =
+        whereQuery -> new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, knnQuery, Map.of("k", "5"),
+            FilterType.EFFICIENT, true, rebuildWithFilter);
+
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var sort =
+        new org.opensearch.sql.planner.logical.LogicalSort(
+            dummyChild,
+            List.of(
+                org.apache.commons.lang3.tuple.ImmutablePair.of(
+                    org.opensearch.sql.ast.tree.Sort.SortOption.DEFAULT_ASC,
+                    new ReferenceExpression("name", STRING))));
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownSort(sort));
+    assertTrue(ex.getMessage().contains("unsupported sort expression"));
   }
 
   private OpenSearchRequestBuilder createRequestBuilder() {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -536,6 +536,31 @@ class VectorSearchQueryBuilderTest {
     assertTrue(ex.getMessage().contains("unsupported sort expression"));
   }
 
+  @Test
+  void buildSucceedsRadialWithSortEmbeddedLimit() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder =
+        new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("max_distance", "10.0"));
+
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    // LogicalSort with count=50 simulates PPL sort-with-limit path
+    var sort =
+        new org.opensearch.sql.planner.logical.LogicalSort(
+            dummyChild,
+            50,
+            List.of(
+                org.apache.commons.lang3.tuple.ImmutablePair.of(
+                    org.opensearch.sql.ast.tree.Sort.SortOption.DEFAULT_DESC,
+                    new ReferenceExpression("_score", ExprCoreType.FLOAT))));
+
+    builder.pushDownSort(sort);
+
+    // build() should not reject — limitPushed must be true via pushDownSort's count path
+    OpenSearchRequestBuilder result = builder.build();
+    assertNotNull(result);
+  }
+
   private OpenSearchRequestBuilder createRequestBuilder() {
     return new OpenSearchRequestBuilder(
         mock(OpenSearchExprValueFactory.class), 10000, mock(Settings.class));


### PR DESCRIPTION
## Summary

Adds `filter_type=post|efficient` option to `vectorSearch()` so WHERE clauses can be placed inside the knn clause (`knn.filter`) for efficient pre-filtering during ANN search, or outside as `bool.filter` for post-filtering (default). Also adds mandatory LIMIT enforcement for radial search.

### What this PR adds

**FilterType enum and option parsing**
- New `FilterType` enum (`POST`, `EFFICIENT`) with `fromString()` validation
- `filter_type` added to allowed option keys in `VectorSearchTableFunctionImplementation`
- `filter_type` is stripped from options before knn JSON generation — it's a SQL-layer directive, not a knn parameter

**Efficient filter pushdown**
- `VectorSearchQueryBuilder.pushDownFilter()` branches on filter type:
  - `POST` (default): knn in `bool.must` + WHERE in `bool.filter` (post-filtering)
  - `EFFICIENT`: rebuilds knn query with WHERE embedded in `knn.filter` via callback
- `Function<QueryBuilder, QueryBuilder>` callback keeps JSON serialization in `VectorSearchIndex`
- `buildKnnQueryJson()` collapsed to accept optional filter JSON parameter — no duplication

**Build-time validation**
- `build()` override rejects explicit `filter_type` when no filter is pushed down (either no WHERE clause at all, or the WHERE clause was not pushdownable)
- `pushDownFilter()` catches `ScriptQueryUnSupportedException` for non-pushdownable conditions:
  - With explicit `filter_type`: throws a clear error explaining the condition cannot be pushed down
  - Without explicit `filter_type`: returns `false` to fall back to in-memory filtering, matching base class behavior

**Radial search LIMIT requirement**
- Radial search (`max_distance` or `min_score`) without an explicit `LIMIT` clause is rejected at build time with a clear error message
- Prevents unbounded result sets from radial queries that could silently return up to `maxResultWindow` rows

**Engine support**
- `knn.filter` is supported for lucene and faiss engines (HNSW, IVF). Engine compatibility is not validated by the SQL plugin — unsupported engines reject at execution time.

### SQL syntax

```sql
-- Post-filtering (default, same as omitting filter_type)
SELECT v._id, v._score
FROM vectorSearch(table='my-index', field='embedding',
     vector='[1.0, 2.0, 3.0]', option='k=10,filter_type=post') AS v
WHERE v.city = 'Seattle'
LIMIT 10

-- Efficient pre-filtering (WHERE inside knn.filter)
SELECT v._id, v._score
FROM vectorSearch(table='my-index', field='embedding',
     vector='[1.0, 2.0, 3.0]', option='k=10,filter_type=efficient') AS v
WHERE v.city = 'Seattle'
LIMIT 10

-- Radial search requires LIMIT
SELECT v._id, v._score
FROM vectorSearch(table='my-index', field='embedding',
     vector='[1.0, 2.0, 3.0]', option='max_distance=10.5') AS v
LIMIT 100
```

## Test plan
- [x] `./gradlew spotlessCheck` — PASS
- [x] `./gradlew :opensearch:test` — PASS
- [x] `./gradlew :integ-test:integTest -Dtests.class="*VectorSearchIT"` — PASS
- [x] `./gradlew :integ-test:integTest -Dtests.class="*VectorSearchExplainIT"` — PASS
- [x] `./gradlew build -x integTest` — PASS (full build excluding integration tests)