### PR TITLE
[BugFix] Fix json_set crash and json_delete no-op with $.key paths (#5167)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonUtils.java
@@ -23,6 +23,15 @@ public class JsonUtils {
   public static String convertToJsonPath(String input) {
     if (input == null || input.isEmpty()) return "$";
 
+    // Strip leading "$." or "$" to avoid double-prefixing (issue #5167)
+    if (input.startsWith("$.")) {
+      input = input.substring(2);
+    } else if (input.startsWith("$")) {
+      input = input.substring(1);
+    }
+
+    if (input.isEmpty()) return "$";
+
     StringBuilder sb = new StringBuilder("$.");
     int i = 0;
     while (i < input.length()) {

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -19,6 +19,8 @@ import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.LiteralExpression;
+import org.opensearch.sql.expression.function.jsonUDF.JsonDeleteFunctionImpl;
+import org.opensearch.sql.expression.function.jsonUDF.JsonSetFunctionImpl;
 import org.opensearch.sql.expression.function.jsonUDF.JsonUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -66,6 +68,18 @@ public class JsonFunctionsTest {
   }
 
   @Test
+  void test_convertToJsonPathWithDollarPrefix() {
+    // Issue #5167: paths already starting with $ or $. should not be double-prefixed
+    assertEquals("$.name", convertToJsonPath("$.name"));
+    assertEquals("$.a.b.c", convertToJsonPath("$.a.b.c"));
+    assertEquals("$.[*]", convertToJsonPath("$.[*]"));
+    assertEquals("$.a[2].c", convertToJsonPath("$.a[2].c"));
+    assertEquals("$.[3].bc[*].d[1]", convertToJsonPath("$.[3].bc[*].d[1]"));
+    // Bare $ should return $
+    assertEquals("$", convertToJsonPath("$"));
+  }
+
+  @Test
   void test_convertToJsonPathWithWrongPath() {
     IllegalArgumentException e =
         assertThrows(IllegalArgumentException.class, () -> convertToJsonPath("a.{"));
@@ -98,6 +112,23 @@ public class JsonFunctionsTest {
     String candidate4 = "$.a2[*].b2[1].c2";
     List<String> target4 = List.of("$.a2[0].b2[1].c2", "$.a2[1].b2[1].c2", "$.a2[2].b2[1]");
     assertEquals(expandJsonPath(node, candidate4), target4);
+  }
+
+  @Test
+  void test_jsonSetWithDollarPrefixedPath() {
+    // Issue #5167: json_set with $.key path should work correctly
+    Object result =
+        JsonSetFunctionImpl.eval(
+            "{\"name\":\"alice\",\"scores\":[90,85,92]}", "$.name", "modified_alice");
+    assertEquals("{\"name\":\"modified_alice\",\"scores\":[90,85,92]}", result);
+  }
+
+  @Test
+  void test_jsonDeleteWithDollarPrefixedPath() throws Exception {
+    // Issue #5167: json_delete with $.key path should remove the key
+    Object result =
+        JsonDeleteFunctionImpl.eval("{\"name\":\"alice\",\"scores\":[90,85,92]}", "$.name");
+    assertEquals("{\"scores\":[90,85,92]}", result);
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJsonBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJsonBuiltinFunctionIT.java
@@ -297,6 +297,38 @@ public class CalcitePPLJsonBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testJsonSetWithDollarPrefixedPath() throws IOException {
+    // Issue #5167: json_set with $.key path should not double-prefix
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval a"
+                    + " =json_set('{\\\"name\\\":\\\"alice\\\",\\\"scores\\\":[90,85,92]}',"
+                    + " '$.name', 'modified_alice')| fields a | head 1",
+                TEST_INDEX_PEOPLE2));
+
+    verifySchema(actual, schema("a", "string"));
+
+    verifyDataRows(actual, rows("{\"name\":\"modified_alice\",\"scores\":[90,85,92]}"));
+  }
+
+  @Test
+  public void testJsonDeleteWithDollarPrefixedPath() throws IOException {
+    // Issue #5167: json_delete with $.key path should remove the key
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval a"
+                    + " =json_delete('{\\\"name\\\":\\\"alice\\\",\\\"scores\\\":[90,85,92]}',"
+                    + " '$.name')| fields a | head 1",
+                TEST_INDEX_PEOPLE2));
+
+    verifySchema(actual, schema("a", "string"));
+
+    verifyDataRows(actual, rows("{\"scores\":[90,85,92]}"));
+  }
+
+  @Test
   public void testJsonDelete() throws IOException {
     JSONObject actual =
         executeQuery(

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5167.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5167.yml
@@ -1,0 +1,84 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+
+  - do:
+      indices.create:
+        index: issue5167
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              int_field:
+                type: integer
+              json_data:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue5167", "_id": "1"}}'
+          - '{"int_field": 42, "json_data": "{\"name\":\"alice\",\"scores\":[90,85,92]}"}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue5167
+        ignore_unavailable: true
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"Issue 5167: json_set with $.key path should update the value":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=issue5167 | where int_field = 42 | eval modified = json_set(json_data, '$.name', 'modified_alice') | fields modified"
+
+  - match: { total: 1 }
+  - match: { datarows: [ [ "{\"name\":\"modified_alice\",\"scores\":[90,85,92]}" ] ] }
+
+---
+"Issue 5167: json_delete with $.key path should remove the key":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=issue5167 | where int_field = 42 | eval deleted = json_delete(json_data, '$.name') | fields deleted"
+
+  - match: { total: 1 }
+  - match: { datarows: [ [ "{\"scores\":[90,85,92]}" ] ] }
+
+---
+"Issue 5167: json_set with unprefixed path still works":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=issue5167 | where int_field = 42 | eval modified = json_set(json_data, 'name', 'bob') | fields modified"
+
+  - match: { total: 1 }
+  - match: { datarows: [ [ "{\"name\":\"bob\",\"scores\":[90,85,92]}" ] ] }


### PR DESCRIPTION
### Description
`json_set` crashes (HTTP 500) and `json_delete` silently returns unchanged JSON when using standard JSONPath `$.key` syntax. The root cause is `convertToJsonPath()` in `JsonUtils.java`, which unconditionally prepends `$.` to the input — turning `$.name` into `$.$.name` (double-prefixed).

The fix strips any existing `$.` or `$` prefix from the input before processing, preventing double-prefixing while preserving the existing curly-brace-to-bracket conversion logic.

### Related Issues
Resolves #5167, #5170

### Check List
- [x] New functionality includes testing
- [x] Commits signed per DCO (`-s`)
- [x] `spotlessCheck` passed
- [x] Unit tests passed
- [x] Integration tests passed