### PR TITLE
Update sql docs for querying multiple indices

### DIFF
--- a/docs/user/general/identifiers.rst
+++ b/docs/user/general/identifiers.rst
@@ -150,7 +150,7 @@ Description
 To query multiple indices, you could
 
 1. Include ``*`` in index name, this is an index pattern for wildcard match.
-2. Delimited multiple indices and seperated them by ``,``. Note: no space allowed between each index.
+2. Use multiple indices by separating them with ``,`` and enclosing the entire comma-separated list in backticks. Note: no space allowed between each index.
 
 
 Examples

--- a/docs/user/general/identifiers.rst
+++ b/docs/user/general/identifiers.rst
@@ -150,7 +150,7 @@ Description
 To query multiple indices, you could
 
 1. Include ``*`` in index name, this is an index pattern for wildcard match.
-2. Use multiple indices by separating them with ``,`` and enclosing the entire comma-separated list in backticks. Note: no space allowed between each index.
+2. Delimit multiple indices with ``,`` and enclose the entire comma-separated list in backticks. Note: no space allowed between each index.
 
 
 Examples


### PR DESCRIPTION
### Description
- Updates SQL docs to clarify that when querying mulitple indices, the list needs to be enclosed in backticks

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
