### PR TITLE
Make analytics-engine an optional dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,12 @@ buildscript {
             // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT (opensearch_build)
             opensearch_build += "-SNAPSHOT"
         }
+        // Whether to build with analytics-engine support. Use -PhasAnalyticsEngine=true/false
+        // to override, otherwise auto-detect from file existence.
+        hasAnalyticsEngine = project.hasProperty('hasAnalyticsEngine')
+            ? Boolean.parseBoolean(project.property('hasAnalyticsEngine').toString())
+            : file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip").exists()
+        logger.lifecycle("Building with analytics-engine: ${hasAnalyticsEngine}")
         getArchType = {
             if (System.getProperty("os.arch").startsWith("x") || System.getProperty("os.arch").startsWith("amd")) {
                 return "amd64"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -63,7 +63,13 @@ dependencies {
     }
     api 'org.apache.calcite:calcite-linq4j:1.41.0'
     api project(':common')
-    compileOnly files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
+    // When analytics-engine is present, framework classes come from parent classloader (compileOnly).
+    // When absent, bundle the framework JAR so its classes are available at runtime.
+    if (file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip").exists()) {
+        compileOnly files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
+    } else {
+        api files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
+    }
     testImplementation files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
     implementation "com.github.seancfoley:ipaddress:5.4.2"
     implementation "com.jayway.jsonpath:json-path:2.9.0"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     api project(':common')
     // When analytics-engine is present, framework classes come from parent classloader (compileOnly).
     // When absent, bundle the framework JAR so its classes are available at runtime.
-    if (file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip").exists()) {
+    if (hasAnalyticsEngine) {
         compileOnly files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
     } else {
         api files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -195,7 +195,10 @@ testClusters {
         }))
         */
         plugin(getJobSchedulerPlugin(jsPlugin, bwcOpenSearchJSDownload))
-        plugin provider { (RegularFile) (() -> file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")) }
+        def analyticsZip = file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")
+        if (analyticsZip.exists()) {
+            plugin provider { (RegularFile) (() -> analyticsZip) }
+        }
         plugin ':opensearch-sql-plugin'
         testDistribution = 'archive'
     }

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -196,7 +196,7 @@ testClusters {
         */
         plugin(getJobSchedulerPlugin(jsPlugin, bwcOpenSearchJSDownload))
         def analyticsZip = file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")
-        if (analyticsZip.exists()) {
+        if (hasAnalyticsEngine) {
             plugin provider { (RegularFile) (() -> analyticsZip) }
         }
         plugin ':opensearch-sql-plugin'

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -270,7 +270,6 @@ def getGeoSpatialPlugin() {
     }
 }
 
-def analyticsEngineZip = file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")
 def getAnalyticsEnginePlugin() {
     provider { (RegularFile) (() -> file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")) }
 }
@@ -280,7 +279,7 @@ testClusters {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
         plugin(getGeoSpatialPlugin())
-        if (analyticsEngineZip.exists()) {
+        if (hasAnalyticsEngine) {
             plugin(getAnalyticsEnginePlugin())
         }
         plugin ":opensearch-sql-plugin"
@@ -290,7 +289,7 @@ testClusters {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
         plugin(getGeoSpatialPlugin())
-        if (analyticsEngineZip.exists()) {
+        if (hasAnalyticsEngine) {
             plugin(getAnalyticsEnginePlugin())
         }
         plugin ":opensearch-sql-plugin"
@@ -300,7 +299,7 @@ testClusters {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
         plugin(getGeoSpatialPlugin())
-        if (analyticsEngineZip.exists()) {
+        if (hasAnalyticsEngine) {
             plugin(getAnalyticsEnginePlugin())
         }
         plugin ":opensearch-sql-plugin"
@@ -308,7 +307,7 @@ testClusters {
     integTestWithSecurity {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
-        if (analyticsEngineZip.exists()) {
+        if (hasAnalyticsEngine) {
             plugin(getAnalyticsEnginePlugin())
         }
         plugin ":opensearch-sql-plugin"
@@ -316,7 +315,7 @@ testClusters {
     remoteIntegTestWithSecurity {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
-        if (analyticsEngineZip.exists()) {
+        if (hasAnalyticsEngine) {
             plugin(getAnalyticsEnginePlugin())
         }
         plugin ":opensearch-sql-plugin"
@@ -373,7 +372,7 @@ stopPrometheus.mustRunAfter startPrometheus
 
 task integJdbcTest(type: RestIntegTestTask) {
     testClusters.findAll {c -> c.clusterName == "integJdbcTest"}.first().with {
-        if (analyticsEngineZip.exists()) {
+        if (hasAnalyticsEngine) {
             plugin(getAnalyticsEnginePlugin())
         }
         plugin ":opensearch-sql-plugin"

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -270,6 +270,7 @@ def getGeoSpatialPlugin() {
     }
 }
 
+def analyticsEngineZip = file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")
 def getAnalyticsEnginePlugin() {
     provider { (RegularFile) (() -> file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")) }
 }
@@ -279,7 +280,9 @@ testClusters {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
         plugin(getGeoSpatialPlugin())
-        plugin(getAnalyticsEnginePlugin())
+        if (analyticsEngineZip.exists()) {
+            plugin(getAnalyticsEnginePlugin())
+        }
         plugin ":opensearch-sql-plugin"
         setting "plugins.query.datasources.encryption.masterkey", "1234567812345678"
     }
@@ -287,7 +290,9 @@ testClusters {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
         plugin(getGeoSpatialPlugin())
-        plugin(getAnalyticsEnginePlugin())
+        if (analyticsEngineZip.exists()) {
+            plugin(getAnalyticsEnginePlugin())
+        }
         plugin ":opensearch-sql-plugin"
         setting "plugins.query.datasources.encryption.masterkey", "1234567812345678"
     }
@@ -295,19 +300,25 @@ testClusters {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
         plugin(getGeoSpatialPlugin())
-        plugin(getAnalyticsEnginePlugin())
+        if (analyticsEngineZip.exists()) {
+            plugin(getAnalyticsEnginePlugin())
+        }
         plugin ":opensearch-sql-plugin"
     }
     integTestWithSecurity {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
-        plugin(getAnalyticsEnginePlugin())
+        if (analyticsEngineZip.exists()) {
+            plugin(getAnalyticsEnginePlugin())
+        }
         plugin ":opensearch-sql-plugin"
     }
     remoteIntegTestWithSecurity {
         testDistribution = 'archive'
         plugin(getJobSchedulerPlugin())
-        plugin(getAnalyticsEnginePlugin())
+        if (analyticsEngineZip.exists()) {
+            plugin(getAnalyticsEnginePlugin())
+        }
         plugin ":opensearch-sql-plugin"
     }
 }
@@ -362,7 +373,9 @@ stopPrometheus.mustRunAfter startPrometheus
 
 task integJdbcTest(type: RestIntegTestTask) {
     testClusters.findAll {c -> c.clusterName == "integJdbcTest"}.first().with {
-        plugin(getAnalyticsEnginePlugin())
+        if (analyticsEngineZip.exists()) {
+            plugin(getAnalyticsEnginePlugin())
+        }
         plugin ":opensearch-sql-plugin"
     }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -62,8 +62,7 @@ opensearchplugin {
 
 // When analytics-engine is present, exclude jars it provides via extendedPlugins classloader.
 // When analytics-engine is absent, keep all jars so the SQL plugin works standalone.
-def analyticsEngineZip = file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")
-if (analyticsEngineZip.exists()) {
+if (hasAnalyticsEngine) {
     bundlePlugin {
         exclude 'calcite-core-*.jar'
         exclude 'calcite-linq4j-*.jar'
@@ -206,7 +205,7 @@ dependencies {
     api project(':api')
     // analytics-framework: compileOnly when analytics-engine provides it via parent classloader,
     // runtimeOnly when standalone so it gets bundled in the plugin ZIP.
-    if (analyticsEngineZip.exists()) {
+    if (hasAnalyticsEngine) {
         compileOnly files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
     } else {
         // Bundle analytics-framework when analytics-engine is absent
@@ -358,7 +357,7 @@ def getJobSchedulerPlugin() {
 
 testClusters.integTest {
     plugin(getJobSchedulerPlugin())
-    if (analyticsEngineZip.exists()) {
+    if (hasAnalyticsEngine) {
         plugin provider { (RegularFile) (() -> file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")) }
     }
     plugin(project.tasks.bundlePlugin.archiveFile)

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -55,49 +55,52 @@ opensearchplugin {
     name 'opensearch-sql'
     description 'OpenSearch SQL'
     classname 'org.opensearch.sql.plugin.SQLPlugin'
-    extendedPlugins = ['opensearch-job-scheduler', 'analytics-engine']
+    extendedPlugins = ['opensearch-job-scheduler', 'analytics-engine;optional=true']
     licenseFile rootProject.file("LICENSE.txt")
     noticeFile rootProject.file("NOTICE")
 }
 
-// Exclude jars provided by analytics-engine plugin (shared via extendedPlugins classloader).
-// Must match exactly what's in the analytics-engine ZIP to avoid both jar hell and missing classes.
-bundlePlugin {
-    exclude 'calcite-core-*.jar'
-    exclude 'calcite-linq4j-*.jar'
-    exclude 'avatica-core-*.jar'
-    exclude 'avatica-metrics-*.jar'
-    exclude 'guava-*.jar'
-    exclude 'failureaccess-*.jar'
-    exclude 'slf4j-api-*.jar'
-    exclude 'commons-codec-*.jar'
-    exclude 'commons-compiler-*.jar'
-    exclude 'janino-*.jar'
-    exclude 'joou-java-6-*.jar'
-    exclude 'memory-0*.jar'
-    exclude 'sketches-core-*.jar'
-    exclude 'commons-lang3-*.jar'
-    exclude 'commons-text-*.jar'
-    exclude 'commons-math3-*.jar'
-    exclude 'commons-dbcp2-*.jar'
-    exclude 'commons-io-*.jar'
-    exclude 'commons-pool2-*.jar'
-    exclude 'uzaygezen-core-*.jar'
-    exclude 'icu4j-*.jar'
-    exclude 'error_prone_annotations-*.jar'
-    exclude 'jts-io-common-*.jar'
-    exclude 'proj4j-*.jar'
-    exclude 'json-path-*.jar'
-    exclude 'json-smart-*.jar'
-    exclude 'accessors-smart-*.jar'
-    exclude 'asm-9*.jar'
-    exclude 'httpclient5-*.jar'
-    exclude 'httpcore5-5*.jar'
-    exclude 'httpcore5-h2-*.jar'
-    exclude 'httpcore5-reactive-*.jar'
-    exclude 'antlr4-runtime-4.13.2.jar'
-    exclude 'jackson-annotations-*.jar'
-    exclude 'jackson-databind-*.jar'
+// When analytics-engine is present, exclude jars it provides via extendedPlugins classloader.
+// When analytics-engine is absent, keep all jars so the SQL plugin works standalone.
+def analyticsEngineZip = file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")
+if (analyticsEngineZip.exists()) {
+    bundlePlugin {
+        exclude 'calcite-core-*.jar'
+        exclude 'calcite-linq4j-*.jar'
+        exclude 'avatica-core-*.jar'
+        exclude 'avatica-metrics-*.jar'
+        exclude 'guava-*.jar'
+        exclude 'failureaccess-*.jar'
+        exclude 'slf4j-api-*.jar'
+        exclude 'commons-codec-*.jar'
+        exclude 'commons-compiler-*.jar'
+        exclude 'janino-*.jar'
+        exclude 'joou-java-6-*.jar'
+        exclude 'memory-0*.jar'
+        exclude 'sketches-core-*.jar'
+        exclude 'commons-lang3-*.jar'
+        exclude 'commons-text-*.jar'
+        exclude 'commons-math3-*.jar'
+        exclude 'commons-dbcp2-*.jar'
+        exclude 'commons-io-*.jar'
+        exclude 'commons-pool2-*.jar'
+        exclude 'uzaygezen-core-*.jar'
+        exclude 'icu4j-*.jar'
+        exclude 'error_prone_annotations-*.jar'
+        exclude 'jts-io-common-*.jar'
+        exclude 'proj4j-*.jar'
+        exclude 'json-path-*.jar'
+        exclude 'json-smart-*.jar'
+        exclude 'accessors-smart-*.jar'
+        exclude 'asm-9*.jar'
+        exclude 'httpclient5-*.jar'
+        exclude 'httpcore5-5*.jar'
+        exclude 'httpcore5-h2-*.jar'
+        exclude 'httpcore5-reactive-*.jar'
+        exclude 'antlr4-runtime-4.13.2.jar'
+        exclude 'jackson-annotations-*.jar'
+        exclude 'jackson-databind-*.jar'
+    }
 }
 
 publishing {
@@ -201,7 +204,14 @@ dependencies {
 
     api project(":ppl")
     api project(':api')
-    compileOnly files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
+    // analytics-framework: compileOnly when analytics-engine provides it via parent classloader,
+    // runtimeOnly when standalone so it gets bundled in the plugin ZIP.
+    if (analyticsEngineZip.exists()) {
+        compileOnly files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
+    } else {
+        // Bundle analytics-framework when analytics-engine is absent
+        api files("${rootDir}/libs/analytics-framework-3.6.0-SNAPSHOT.jar")
+    }
     compileOnly files("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.jar")
     api project(':legacy')
     api project(':opensearch')
@@ -348,7 +358,9 @@ def getJobSchedulerPlugin() {
 
 testClusters.integTest {
     plugin(getJobSchedulerPlugin())
-    plugin provider { (RegularFile) (() -> file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")) }
+    if (analyticsEngineZip.exists()) {
+        plugin provider { (RegularFile) (() -> file("${rootDir}/libs/analytics-engine-3.6.0-SNAPSHOT.zip")) }
+    }
     plugin(project.tasks.bundlePlugin.archiveFile)
     testDistribution = "ARCHIVE"
 


### PR DESCRIPTION
## Summary
- Change `extendedPlugins` to `analytics-engine;optional=true` so the SQL plugin starts without analytics-engine installed
- Conditionally exclude Calcite JARs from `bundlePlugin` based on whether analytics-engine ZIP exists at build time
- Conditionally load analytics-engine in all test clusters (integTest, yamlRestTest, security, JDBC, doctest)
- Conditionally set analytics-framework dependency scope (`compileOnly` when parent provides it, `api` when standalone)

## Behavior
- **With analytics-engine**: Calcite and analytics-framework excluded from SQL plugin (provided by parent classloader), analytics path works as before
- **Without analytics-engine**: Calcite and analytics-framework bundled in SQL plugin, analytics path skipped, regular SQL/PPL queries work normally

## Verification

### With analytics-engine present
```
$ ./gradlew :opensearch-sql-plugin:bundlePlugin
BUILD SUCCESSFUL

$ unzip -l opensearch-sql-*.zip | grep calcite-core
(not found — excluded, provided by parent)

$ unzip -l opensearch-sql-*.zip | grep analytics-framework
(not found — excluded, provided by parent)

$ ./gradlew :integ-test:integTest -Dtests.class="*AnalyticsPPLIT" -Dtests.class="*AnalyticsSQLIT"
BUILD SUCCESSFUL

$ ./gradlew :doctest:doctest -PignorePrometheus
Ran 75 tests — BUILD SUCCESSFUL
```

### Without analytics-engine (ZIP removed)
```
$ mv libs/analytics-engine-*.zip libs/analytics-engine-*.zip.bak

$ ./gradlew :opensearch-sql-plugin:bundlePlugin
BUILD SUCCESSFUL

$ unzip -l opensearch-sql-*.zip | grep calcite-core
  8811320  calcite-core-1.41.0.jar (bundled)

$ unzip -l opensearch-sql-*.zip | grep analytics-framework
    11979  analytics-framework-3.6.0-SNAPSHOT.jar (bundled)

$ ./gradlew :integ-test:integTest -Dtests.class="org.opensearch.sql.calcite.CalcitePPLBasicIT"
BUILD SUCCESSFUL

$ ./gradlew :doctest:doctest -PignorePrometheus
Ran 75 tests — BUILD SUCCESSFUL
```

## Context
Per discussion with @mch2 — analytics-engine should be an optional dependency so the SQL plugin can work standalone. OpenSearch supports `optional=true` syntax for `extendedPlugins` (parses `;optional=true` suffix in `PluginInfo`).

Ref: https://github.com/opensearch-project/sql/issues/5246#issuecomment-4210068441
