### PR TITLE
[BugFix] Fix SQL CLI integration test flaky failure

### DIFF
--- a/.github/workflows/sql-cli-integration-test.yml
+++ b/.github/workflows/sql-cli-integration-test.yml
@@ -69,6 +69,7 @@ jobs:
           echo "Building SQL modules from current branch..."
           ./gradlew publishToMavenLocal -x test -x integTest
           echo "SQL modules published to Maven Local"
+          ./gradlew clean
 
       - name: Run SQL CLI tests with local SQL modules
         working-directory: sql-cli


### PR DESCRIPTION
## Summary

- Fixes intermittent `NoSuchFileException` in the SQL CLI integration test workflow caused by a Gradle incremental compilation race condition
- Adds `./gradlew clean` after `publishToMavenLocal` so sql-cli resolves dependencies from Maven Local jars instead of stale build output

* Resolves #5335

## Test plan

- [x] Verify the `sql-cli-integration-test` workflow passes consistently (no more flaky `NoSuchFileException` failures)
