### PR TITLE
Use context.measure() for analytics engine profiling

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -25,9 +25,6 @@ import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.executor.ExecutionContext;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.pagination.Cursor;
-import org.opensearch.sql.monitor.profile.MetricName;
-import org.opensearch.sql.monitor.profile.ProfileMetric;
-import org.opensearch.sql.monitor.profile.QueryProfiling;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 
 /**
@@ -71,24 +68,23 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
   public void execute(
       RelNode plan, CalcitePlanContext context, ResponseListener<QueryResponse> listener) {
     try {
-      // Record EXECUTE metric before calling listener, because the listener's onResponse
-      // triggers SimpleJsonResponseFormatter which calls QueryProfiling.finish() to snapshot
-      // all metrics. The metric must be written before that snapshot.
-      ProfileMetric execMetric = QueryProfiling.current().getOrCreateMetric(MetricName.EXECUTE);
-      long execStart = System.nanoTime();
-
-      Iterable<Object[]> rows = planExecutor.execute(plan, null);
-
-      List<RelDataTypeField> fields = plan.getRowType().getFieldList();
-      List<ExprValue> results = convertRows(rows, fields);
-      Schema schema = buildSchema(fields);
-
-      execMetric.set(System.nanoTime() - execStart);
-
-      listener.onResponse(new QueryResponse(schema, results, Cursor.None));
+      listener.onResponse(executeQuery(plan));
     } catch (Exception e) {
       listener.onFailure(e);
     }
+  }
+
+  /**
+   * Execute a query plan and return the response directly. Separated from the listener-based {@link
+   * #execute(RelNode, CalcitePlanContext, ResponseListener)} so callers can wrap this with {@code
+   * context.measure(EXECUTE, ...)} for profiling.
+   */
+  public QueryResponse executeQuery(RelNode plan) {
+    Iterable<Object[]> rows = planExecutor.execute(plan, null);
+    List<RelDataTypeField> fields = plan.getRowType().getFieldList();
+    List<ExprValue> results = convertRows(rows, fields);
+    Schema schema = buildSchema(fields);
+    return new QueryResponse(schema, results, Cursor.None);
   }
 
   @Override

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.sql.monitor.profile.MetricName.EXECUTE;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -31,6 +32,9 @@ import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import org.opensearch.sql.monitor.profile.ProfileMetric;
+import org.opensearch.sql.monitor.profile.QueryProfile;
+import org.opensearch.sql.monitor.profile.QueryProfiling;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 
 class AnalyticsExecutionEngineTest {
@@ -247,6 +251,83 @@ class AnalyticsExecutionEngineTest {
             + errorRef.get().getClass().getSimpleName()
             + " - "
             + errorRef.get().getMessage());
+  }
+
+  // --- profiling tests ---
+
+  @Test
+  void executeQuery_returnsResponseDirectly() {
+    RelNode relNode = mockRelNode("name", SqlTypeName.VARCHAR);
+    when(mockExecutor.execute(relNode, null))
+        .thenReturn(Collections.singletonList(new Object[] {"Alice"}));
+
+    QueryResponse response = engine.executeQuery(relNode);
+
+    assertEquals(1, response.getSchema().getColumns().size());
+    assertEquals(1, response.getResults().size());
+    assertEquals("Alice", response.getResults().get(0).tupleValue().get("name").value());
+    System.out.println("executeQuery_returnsResponseDirectly: response returned directly, OK");
+  }
+
+  @Test
+  void executeQuery_executeMetricRecordedWithMeasure() throws Exception {
+    QueryProfiling.activate(true);
+    try {
+      RelNode relNode = mockRelNode("id", SqlTypeName.INTEGER);
+      when(mockExecutor.execute(relNode, null))
+          .thenReturn(Collections.singletonList(new Object[] {42}));
+
+      // Simulate what RestUnifiedQueryAction does: wrap executeQuery with measure
+      ProfileMetric metric = QueryProfiling.current().getOrCreateMetric(EXECUTE);
+      long start = System.nanoTime();
+      QueryResponse response = engine.executeQuery(relNode);
+      metric.set(System.nanoTime() - start);
+
+      // Verify response
+      assertEquals(1, response.getResults().size());
+
+      // Verify EXECUTE metric was recorded
+      QueryProfile profile = QueryProfiling.current().finish();
+      assertNotNull(profile, "Profile should be present when profiling is enabled");
+      double executeMs = profile.getPhases().get("execute").getTimeMillis();
+      assertTrue(executeMs >= 0, "EXECUTE metric should be recorded, got: " + executeMs);
+      System.out.println(
+          "executeQuery_executeMetricRecordedWithMeasure: EXECUTE=" + executeMs + "ms, OK");
+    } finally {
+      QueryProfiling.clear();
+    }
+  }
+
+  @Test
+  void executeQuery_metricCapturedBeforeFinish() throws Exception {
+    QueryProfiling.activate(true);
+    try {
+      RelNode relNode = mockRelNode("id", SqlTypeName.INTEGER);
+      // Simulate slow execution so the metric is measurably non-zero
+      when(mockExecutor.execute(relNode, null))
+          .thenAnswer(
+              inv -> {
+                Thread.sleep(10);
+                return Collections.singletonList(new Object[] {1});
+              });
+
+      // Step 1: measure EXECUTE — simulates context.measure(EXECUTE, ...)
+      ProfileMetric metric = QueryProfiling.current().getOrCreateMetric(EXECUTE);
+      long start = System.nanoTime();
+      QueryResponse response = engine.executeQuery(relNode);
+      metric.set(System.nanoTime() - start);
+
+      // Step 2: call finish() AFTER measure — simulates what the formatter does
+      QueryProfile profile = QueryProfiling.current().finish();
+
+      assertNotNull(profile, "Profile should not be null");
+      double executeMs = profile.getPhases().get("execute").getTimeMillis();
+      assertTrue(executeMs > 0, "EXECUTE metric should be > 0ms after measure, got: " + executeMs);
+      System.out.println(
+          "executeQuery_metricCapturedBeforeFinish: EXECUTE=" + executeMs + "ms (> 0), OK");
+    } finally {
+      QueryProfiling.clear();
+    }
   }
 
   // --- helpers ---

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/AnalyticsPPLIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/AnalyticsPPLIT.java
@@ -176,15 +176,21 @@ public class AnalyticsPPLIT extends PPLIntegTestCase {
     assertTrue("Profile should have 'phases' field", profile.has("phases"));
     JSONObject phases = profile.getJSONObject("phases");
 
+    assertTrue("Profile should have 'summary' field", profile.has("summary"));
+    double totalTime = profile.getJSONObject("summary").getDouble("total_time_ms");
+    assertTrue("Total time should be > 0, got " + totalTime + "ms", totalTime > 0);
+
     assertTrue("Phases should have 'analyze' field", phases.has("analyze"));
     double analyzeTime = phases.getJSONObject("analyze").getDouble("time_ms");
-    assertTrue(
-        "Analyze phase should have non-zero time, got " + analyzeTime + "ms", analyzeTime > 0);
+    assertTrue("Analyze phase should be > 0, got " + analyzeTime + "ms", analyzeTime > 0);
 
     assertTrue("Phases should have 'execute' field", phases.has("execute"));
     double executeTime = phases.getJSONObject("execute").getDouble("time_ms");
-    assertTrue(
-        "Execute phase should have non-zero time, got " + executeTime + "ms", executeTime > 0);
+    assertTrue("Execute phase should be > 0, got " + executeTime + "ms", executeTime > 0);
+
+    assertTrue("Phases should have 'format' field", phases.has("format"));
+    double formatTime = phases.getJSONObject("format").getDouble("time_ms");
+    assertTrue("Format phase should be > 0, got " + formatTime + "ms", formatTime > 0);
   }
 
   // --- Error handling tests ---

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -6,7 +6,9 @@
 package org.opensearch.sql.plugin.rest;
 
 import static org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
+import static org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
 import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
+import static org.opensearch.sql.monitor.profile.MetricName.EXECUTE;
 import static org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.SQL_WORKER_THREAD_POOL_NAME;
 import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
@@ -36,7 +38,6 @@ import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit;
 import org.opensearch.sql.common.response.ResponseListener;
-import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.sql.executor.analytics.AnalyticsExecutionEngine;
 import org.opensearch.sql.lang.LangSpec;
@@ -109,11 +110,11 @@ public class RestUnifiedQueryAction {
                 () -> {
                   try (UnifiedQueryContext context = buildContext(queryType, profiling)) {
                     UnifiedQueryPlanner planner = new UnifiedQueryPlanner(context);
-                    RelNode plan = planner.plan(query);
                     CalcitePlanContext planContext = context.getPlanContext();
-                    plan = addQuerySizeLimit(plan, planContext);
-                    analyticsEngine.execute(
-                        plan, planContext, createQueryListener(queryType, listener));
+                    RelNode plan = addQuerySizeLimit(planner.plan(query), planContext);
+                    QueryResponse response =
+                        context.measure(EXECUTE, () -> analyticsEngine.executeQuery(plan));
+                    createQueryListener(queryType, listener).onResponse(response);
                   } catch (Exception e) {
                     listener.onFailure(e);
                   }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -9,6 +9,7 @@ import static org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import static org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
 import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
 import static org.opensearch.sql.monitor.profile.MetricName.EXECUTE;
+import static org.opensearch.sql.monitor.profile.MetricName.FORMAT;
 import static org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.SQL_WORKER_THREAD_POOL_NAME;
 import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
@@ -114,7 +115,9 @@ public class RestUnifiedQueryAction {
                     RelNode plan = addQuerySizeLimit(planner.plan(query), planContext);
                     QueryResponse response =
                         context.measure(EXECUTE, () -> analyticsEngine.executeQuery(plan));
-                    createQueryListener(queryType, listener).onResponse(response);
+                    String result =
+                        context.measure(FORMAT, () -> formatResponse(response, queryType));
+                    listener.onResponse(new TransportPPLQueryResponse(result));
                   } catch (Exception e) {
                     listener.onFailure(e);
                   }
@@ -220,25 +223,16 @@ public class RestUnifiedQueryAction {
         context.relBuilder.literal(context.sysLimit.querySizeLimit()));
   }
 
-  private ResponseListener<QueryResponse> createQueryListener(
-      QueryType queryType, ActionListener<TransportPPLQueryResponse> transportListener) {
+  /**
+   * Format the query response as a JSON string without triggering profiling finish(). This allows
+   * the caller to wrap formatting with context.measure(FORMAT, ...) and call finish() afterwards.
+   */
+  private static String formatResponse(QueryResponse response, QueryType queryType) {
+    LangSpec langSpec = queryType == QueryType.PPL ? PPL_SPEC : LangSpec.SQL_SPEC;
     ResponseFormatter<QueryResult> formatter = new SimpleJsonResponseFormatter(PRETTY);
-    return new ResponseListener<QueryResponse>() {
-      @Override
-      public void onResponse(QueryResponse response) {
-        LangSpec langSpec = queryType == QueryType.PPL ? PPL_SPEC : LangSpec.SQL_SPEC;
-        String result =
-            formatter.format(
-                new QueryResult(
-                    response.getSchema(), response.getResults(), response.getCursor(), langSpec));
-        transportListener.onResponse(new TransportPPLQueryResponse(result));
-      }
-
-      @Override
-      public void onFailure(Exception e) {
-        transportListener.onFailure(e);
-      }
-    };
+    return formatter.format(
+        new QueryResult(
+            response.getSchema(), response.getResults(), response.getCursor(), langSpec));
   }
 
   private static Runnable withCurrentContext(final Runnable task) {


### PR DESCRIPTION
## Summary
- Use `context.measure()` for all three profiling phases (ANALYZE, EXECUTE, FORMAT) in the analytics engine path, replacing manual metric recording
- Extract `executeQuery()` from `AnalyticsExecutionEngine` that returns `QueryResponse` directly, separating execution work from the listener callback
- Extract `formatResponse()` in `RestUnifiedQueryAction`, separating formatting from the callback
- This ensures each metric is recorded before the next phase starts, so `finish()` snapshots all metrics correctly

## Context
The old approach manually recorded EXECUTE and FORMAT metrics using `ProfileMetric.set()`. This was necessary because `context.measure()` writes the metric in its `finally` block — after the action completes. But `SimpleJsonResponseFormatter` calls `finish()` inside the action (to embed the profile in the JSON response), which snapshots all metrics before the `finally` block runs, resulting in 0ms.

The fix: extract the execution and formatting work into separate methods that **return results** instead of calling callbacks. This way, `context.measure()` wraps only the work — its `finally` block writes the metric before the next phase starts. The listener callback (which triggers `finish()`) is called last, after all three metrics are already recorded:

```java
// ANALYZE — already wrapped inside UnifiedQueryPlanner.plan()
RelNode plan = planner.plan(query);

// EXECUTE — wraps extracted executeQuery() that returns QueryResponse
QueryResponse response = context.measure(EXECUTE, () -> analyticsEngine.executeQuery(plan));

// FORMAT — wraps extracted formatResponse() that returns String
String result = context.measure(FORMAT, () -> formatResponse(response, queryType));

// Callback fires AFTER all metrics are written — finish() snapshots correct values
listener.onResponse(new TransportPPLQueryResponse(result));
```