### PR TITLE
Add profiling and explain mode support for SQL analytics path

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/AnalyticsSQLIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/AnalyticsSQLIT.java
@@ -121,6 +121,29 @@ public class AnalyticsSQLIT extends SQLIntegTestCase {
     assertTrue("Format phase should be > 0, got " + formatTime + "ms", formatTime > 0);
   }
 
+  @Test
+  public void testProfileDisabledByDefault() throws IOException {
+    JSONObject result = executeQuery("SELECT * FROM parquet_logs");
+    assertFalse("Response should NOT have 'profile' field by default", result.has("profile"));
+  }
+
+  @Test
+  public void testProfileExplicitlyDisabled() throws IOException {
+    Request request = new Request("POST", QUERY_API_ENDPOINT);
+    request.setJsonEntity(
+        String.format(
+            Locale.ROOT,
+            "{\n  \"query\": \"%s\",\n  \"profile\": false\n}",
+            "SELECT * FROM parquet_logs"));
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    Response response = client().performRequest(request);
+    JSONObject result = new JSONObject(getResponseBody(response, true));
+
+    assertFalse("Response should NOT have 'profile' when profile=false", result.has("profile"));
+  }
+
   @Test(expected = ResponseException.class)
   public void testSyntaxError() throws IOException {
     executeQuery("SELEC * FROM parquet_logs");

--- a/integ-test/src/test/java/org/opensearch/sql/sql/AnalyticsSQLIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/AnalyticsSQLIT.java
@@ -5,16 +5,21 @@
 
 package org.opensearch.sql.sql;
 
+import static org.opensearch.sql.legacy.TestUtils.getResponseBody;
 import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
+import java.util.Locale;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
@@ -81,6 +86,39 @@ public class AnalyticsSQLIT extends SQLIntegTestCase {
         rows("2024-01-15 10:30:00", 200),
         rows("2024-01-15 10:31:00", 200),
         rows("2024-01-15 10:32:00", 500));
+  }
+
+  @Test
+  public void testProfileResponseIncludesProfilingData() throws IOException {
+    Request request = new Request("POST", QUERY_API_ENDPOINT);
+    request.setJsonEntity(
+        String.format(
+            Locale.ROOT,
+            "{\n  \"query\": \"%s\",\n  \"profile\": true\n}",
+            "SELECT * FROM parquet_logs"));
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    Response response = client().performRequest(request);
+    JSONObject result = new JSONObject(getResponseBody(response, true));
+
+    assertTrue("Response should have 'profile' field when profile=true", result.has("profile"));
+    JSONObject profile = result.getJSONObject("profile");
+
+    assertTrue("Profile should have 'summary' field", profile.has("summary"));
+    double totalTime = profile.getJSONObject("summary").getDouble("total_time_ms");
+    assertTrue("Total time should be > 0, got " + totalTime + "ms", totalTime > 0);
+
+    JSONObject phases = profile.getJSONObject("phases");
+
+    double analyzeTime = phases.getJSONObject("analyze").getDouble("time_ms");
+    assertTrue("Analyze phase should be > 0, got " + analyzeTime + "ms", analyzeTime > 0);
+
+    double executeTime = phases.getJSONObject("execute").getDouble("time_ms");
+    assertTrue("Execute phase should be > 0, got " + executeTime + "ms", executeTime > 0);
+
+    double formatTime = phases.getJSONObject("format").getDouble("time_ms");
+    assertTrue("Format phase should be > 0, got " + formatTime + "ms", formatTime > 0);
   }
 
   @Test(expected = ResponseException.class)

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -60,7 +60,6 @@ import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptEngine;
 import org.opensearch.script.ScriptService;
-import org.opensearch.sql.ast.statement.ExplainMode;
 import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelper;
@@ -204,7 +203,7 @@ public class SQLPlugin extends Plugin
         unifiedQueryHandler.explain(
             sqlRequest.getQuery(),
             QueryType.SQL,
-            ExplainMode.STANDARD,
+            sqlRequest.mode(),
             new ResponseListener<>() {
               @Override
               public void onResponse(ExplainResponse response) {
@@ -232,7 +231,7 @@ public class SQLPlugin extends Plugin
         unifiedQueryHandler.execute(
             sqlRequest.getQuery(),
             QueryType.SQL,
-            false,
+            sqlRequest.profile(),
             new ActionListener<>() {
               @Override
               public void onResponse(TransportPPLQueryResponse response) {

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -76,7 +76,11 @@ public class SQLQueryRequest {
     this.format = getFormat(params);
     this.sanitize = shouldSanitize(params);
     this.pretty = shouldPretty(params);
-    this.profile = jsonContent != null && jsonContent.optBoolean("profile", false);
+    this.profile =
+        jsonContent != null
+            && jsonContent.optBoolean("profile", false)
+            && !isExplainRequest()
+            && "jdbc".equalsIgnoreCase(format);
     this.cursor = cursor;
   }
 

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.json.JSONObject;
+import org.opensearch.sql.ast.statement.ExplainMode;
 import org.opensearch.sql.protocol.response.format.Format;
 
 /** SQL query request. */
@@ -27,7 +28,7 @@ import org.opensearch.sql.protocol.response.format.Format;
 public class SQLQueryRequest {
   private static final String QUERY_FIELD_CURSOR = "cursor";
   private static final Set<String> SUPPORTED_FIELDS =
-      Set.of("query", "fetch_size", "parameters", QUERY_FIELD_CURSOR);
+      Set.of("query", "fetch_size", "parameters", QUERY_FIELD_CURSOR, "profile");
   private static final String QUERY_PARAMS_FORMAT = "format";
   private static final String QUERY_PARAMS_SANITIZE = "sanitize";
   private static final String QUERY_PARAMS_PRETTY = "pretty";
@@ -55,6 +56,10 @@ public class SQLQueryRequest {
   @Accessors(fluent = true)
   private boolean pretty = false;
 
+  @Getter
+  @Accessors(fluent = true)
+  private boolean profile = false;
+
   private String cursor;
 
   /** Constructor of SQLQueryRequest that passes request params. */
@@ -71,6 +76,7 @@ public class SQLQueryRequest {
     this.format = getFormat(params);
     this.sanitize = shouldSanitize(params);
     this.pretty = shouldPretty(params);
+    this.profile = jsonContent != null && jsonContent.optBoolean("profile", false);
     this.cursor = cursor;
   }
 
@@ -120,6 +126,11 @@ public class SQLQueryRequest {
 
   public boolean isCursorCloseRequest() {
     return path.endsWith("/close");
+  }
+
+  /** Get the explain mode from the format parameter. */
+  public ExplainMode mode() {
+    return isExplainRequest() ? ExplainMode.of(format) : ExplainMode.STANDARD;
   }
 
   /** Decide on the formatter by the requested format. */

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -320,6 +320,27 @@ public class SQLQueryRequestTest {
     assertTrue(request.isSupported());
   }
 
+  @Test
+  public void should_disable_profile_for_explain_request() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .jsonContent("{\"query\": \"SELECT 1\", \"profile\": true}")
+            .path("_plugins/_sql/_explain")
+            .format("standard")
+            .build();
+    assertFalse(request.profile());
+  }
+
+  @Test
+  public void should_disable_profile_for_non_jdbc_format() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .jsonContent("{\"query\": \"SELECT 1\", \"profile\": true}")
+            .format("csv")
+            .build();
+    assertFalse(request.profile());
+  }
+
   // --- ExplainMode tests ---
 
   @Test

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -18,6 +18,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ast.statement.ExplainMode;
 import org.opensearch.sql.protocol.response.format.Format;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -282,6 +283,75 @@ public class SQLQueryRequestTest {
   public void should_support_raw_format() {
     SQLQueryRequest csvRequest = SQLQueryRequestBuilder.request("SELECT 1").format("raw").build();
     assertTrue(csvRequest.isSupported());
+  }
+
+  // --- Profile tests ---
+
+  @Test
+  public void should_default_profile_to_false() {
+    SQLQueryRequest request = SQLQueryRequestBuilder.request("SELECT 1").build();
+    assertFalse(request.profile());
+  }
+
+  @Test
+  public void should_enable_profile_when_set_true() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .jsonContent("{\"query\": \"SELECT 1\", \"profile\": true}")
+            .build();
+    assertTrue(request.profile());
+  }
+
+  @Test
+  public void should_disable_profile_when_set_false() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .jsonContent("{\"query\": \"SELECT 1\", \"profile\": false}")
+            .build();
+    assertFalse(request.profile());
+  }
+
+  @Test
+  public void should_support_request_with_profile_field() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .jsonContent("{\"query\": \"SELECT 1\", \"profile\": true}")
+            .build();
+    assertTrue(request.isSupported());
+  }
+
+  // --- ExplainMode tests ---
+
+  @Test
+  public void should_default_mode_to_standard() {
+    SQLQueryRequest request = SQLQueryRequestBuilder.request("SELECT 1").build();
+    assertEquals(ExplainMode.STANDARD, request.mode());
+  }
+
+  @Test
+  public void should_use_format_as_explain_mode() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .format("extended")
+            .path("_plugins/_sql/_explain")
+            .build();
+    assertEquals(ExplainMode.EXTENDED, request.mode());
+  }
+
+  @Test
+  public void should_use_standard_mode_for_non_explain_request() {
+    SQLQueryRequest request = SQLQueryRequestBuilder.request("SELECT 1").format("csv").build();
+    assertEquals(ExplainMode.STANDARD, request.mode());
+  }
+
+  @Test
+  public void should_support_cost_explain_mode() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .format("cost")
+            .path("_plugins/_sql/_explain")
+            .build();
+    assertEquals(ExplainMode.COST, request.mode());
   }
 
   /** SQL query request build helper to improve test data setup readability. */


### PR DESCRIPTION
## Summary
- Add `profile` field and `mode()` method to `SQLQueryRequest`, matching PPL's existing `PPLQueryRequest.profile()` and `PPLQueryRequest.mode()` support
- Replace hardcoded `false` and `ExplainMode.STANDARD` in `SQLPlugin.createSqlAnalyticsRouter()` with `sqlRequest.profile()` and `sqlRequest.mode()`
- Add `"profile"` to `SUPPORTED_FIELDS` so SQL requests with `"profile": true` are not rejected

## Changes
| File | Change |
|------|--------|
| `SQLQueryRequest.java` | Added `profile` field (parsed from JSON body), `mode()` method (derives `ExplainMode` from format param) |
| `SQLPlugin.java` | Use `sqlRequest.profile()` and `sqlRequest.mode()` instead of hardcoded values |
| `AnalyticsSQLIT.java` | Added `testProfileResponseIncludesProfilingData` — verifies summary, analyze, execute, format are all > 0ms |

## Test plan
- [x] Existing `SQLQueryRequestTest` passes
- [x] Existing `AnalyticsSQLIT` tests pass
- [x] `testProfileResponseIncludesProfilingData` — sends `{"query": "SELECT * FROM parquet_logs", "profile": true}` and verifies all profiling metrics are > 0ms