### PR TITLE
Define unified SQL language spec with composable extensions

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -13,6 +13,7 @@ plugins {
 
 dependencies {
     api project(':ppl')
+    api group: 'org.apache.calcite', name: 'calcite-babel', version: '1.41.0'
 
     testImplementation testFixtures(project(':api'))
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'

--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
@@ -29,6 +29,7 @@ import org.opensearch.sql.api.parser.CalciteSqlQueryParser;
 import org.opensearch.sql.api.parser.PPLQueryParser;
 import org.opensearch.sql.api.parser.UnifiedQueryParser;
 import org.opensearch.sql.api.spec.LanguageSpec;
+import org.opensearch.sql.api.spec.UnifiedPplSpec;
 import org.opensearch.sql.api.spec.UnifiedSqlSpec;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.SysLimit;
@@ -57,7 +58,7 @@ public class UnifiedQueryContext implements AutoCloseable {
   /** Query parser created eagerly from this context's configuration. */
   private final UnifiedQueryParser<?> parser;
 
-  /** Language spec for SQL, or null for PPL (TODO: converge PPL onto LanguageSpec). */
+  /** Language spec for the query's frontend (SQL or PPL). */
   private final LanguageSpec langSpec;
 
   /**
@@ -208,7 +209,11 @@ public class UnifiedQueryContext implements AutoCloseable {
     public UnifiedQueryContext build() {
       Objects.requireNonNull(queryType, "Must specify language before build");
 
-      LanguageSpec langSpec = (queryType == QueryType.SQL) ? UnifiedSqlSpec.extended() : null;
+      LanguageSpec langSpec =
+          switch (queryType) {
+            case SQL -> UnifiedSqlSpec.extended();
+            case PPL -> UnifiedPplSpec.create();
+          };
       Settings settings = buildSettings();
       CalcitePlanContext planContext =
           CalcitePlanContext.create(
@@ -252,13 +257,11 @@ public class UnifiedQueryContext implements AutoCloseable {
               .traitDefs((List<RelTraitDef>) null)
               .programs(Programs.calc(DefaultRelMetadataProvider.INSTANCE));
 
-      if (langSpec != null) {
-        builder
-            .parserConfig(langSpec.parserConfig())
-            .sqlValidatorConfig(langSpec.validatorConfig())
-            .operatorTable(langSpec.operatorTable());
-      }
-      return builder.build();
+      return builder
+          .parserConfig(langSpec.parserConfig())
+          .sqlValidatorConfig(langSpec.validatorConfig())
+          .operatorTable(langSpec.operatorTable())
+          .build();
     }
 
     private SchemaPlus findSchemaByPath(SchemaPlus rootSchema, String defaultPath) {

--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
@@ -17,22 +17,19 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.parser.SqlParser;
-import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Programs;
 import org.opensearch.sql.api.parser.CalciteSqlQueryParser;
 import org.opensearch.sql.api.parser.PPLQueryParser;
 import org.opensearch.sql.api.parser.UnifiedQueryParser;
-import org.opensearch.sql.api.spec.UnifiedFunctionSpec;
+import org.opensearch.sql.api.spec.LanguageSpec;
+import org.opensearch.sql.api.spec.UnifiedSqlSpec;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.SysLimit;
 import org.opensearch.sql.common.setting.Settings;
@@ -59,6 +56,9 @@ public class UnifiedQueryContext implements AutoCloseable {
 
   /** Query parser created eagerly from this context's configuration. */
   private final UnifiedQueryParser<?> parser;
+
+  /** Language spec for SQL, or null for PPL (TODO: converge PPL onto LanguageSpec). */
+  private final LanguageSpec langSpec;
 
   /**
    * Returns the profiling result. Call after query execution to retrieve collected metrics. Returns
@@ -208,12 +208,14 @@ public class UnifiedQueryContext implements AutoCloseable {
     public UnifiedQueryContext build() {
       Objects.requireNonNull(queryType, "Must specify language before build");
 
+      LanguageSpec langSpec = (queryType == QueryType.SQL) ? UnifiedSqlSpec.extended() : null;
       Settings settings = buildSettings();
       CalcitePlanContext planContext =
           CalcitePlanContext.create(
-              buildFrameworkConfig(), SysLimit.fromSettings(settings), queryType);
+              buildFrameworkConfig(langSpec), SysLimit.fromSettings(settings), queryType);
       QueryProfiling.activate(profiling);
-      return new UnifiedQueryContext(planContext, settings, createParser(planContext, settings));
+      return new UnifiedQueryContext(
+          planContext, settings, createParser(planContext, settings), langSpec);
     }
 
     private UnifiedQueryParser<?> createParser(CalcitePlanContext planContext, Settings settings) {
@@ -239,25 +241,24 @@ public class UnifiedQueryContext implements AutoCloseable {
     }
 
     @SuppressWarnings({"rawtypes"})
-    private FrameworkConfig buildFrameworkConfig() {
+    private FrameworkConfig buildFrameworkConfig(LanguageSpec langSpec) {
       SchemaPlus rootSchema = CalciteSchema.createRootSchema(true, cacheMetadata).plus();
       catalogs.forEach(rootSchema::add);
 
       SchemaPlus defaultSchema = findSchemaByPath(rootSchema, defaultNamespace);
-      return Frameworks.newConfigBuilder()
-          .parserConfig(buildParserConfig())
-          .operatorTable(
-              SqlOperatorTables.chain(
-                  SqlStdOperatorTable.instance(), UnifiedFunctionSpec.RELEVANCE.operatorTable()))
-          .defaultSchema(defaultSchema)
-          .traitDefs((List<RelTraitDef>) null)
-          .programs(Programs.calc(DefaultRelMetadataProvider.INSTANCE))
-          .build();
-    }
+      Frameworks.ConfigBuilder builder =
+          Frameworks.newConfigBuilder()
+              .defaultSchema(defaultSchema)
+              .traitDefs((List<RelTraitDef>) null)
+              .programs(Programs.calc(DefaultRelMetadataProvider.INSTANCE));
 
-    private SqlParser.Config buildParserConfig() {
-      // Preserve identifier case for lowercase OpenSearch index names
-      return SqlParser.Config.DEFAULT.withUnquotedCasing(Casing.UNCHANGED);
+      if (langSpec != null) {
+        builder
+            .parserConfig(langSpec.parserConfig())
+            .sqlValidatorConfig(langSpec.validatorConfig())
+            .operatorTable(langSpec.operatorTable());
+      }
+      return builder.build();
     }
 
     private SchemaPlus findSchemaByPath(SchemaPlus rootSchema, String defaultPath) {

--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -16,9 +16,9 @@ import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.util.SqlVisitor;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
-import org.opensearch.sql.api.parser.NamedArgRewriter;
 import org.opensearch.sql.api.parser.UnifiedQueryParser;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
@@ -87,7 +87,12 @@ public class UnifiedQueryPlanner {
               "Only query statements are supported. Got: " + parsed.getKind());
         }
 
-        SqlNode rewritten = parsed.accept(NamedArgRewriter.INSTANCE);
+        // TODO: move post-parse rewriting into CalciteSqlQueryParser
+        SqlNode rewritten = parsed;
+        for (SqlVisitor<SqlNode> visitor : context.getLangSpec().postParseRules()) {
+          rewritten = rewritten.accept(visitor);
+        }
+
         SqlNode validated = planner.validate(rewritten);
         RelRoot relRoot = planner.rel(validated);
         return relRoot.project();

--- a/api/src/main/java/org/opensearch/sql/api/spec/LanguageSpec.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/LanguageSpec.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.util.SqlOperatorTables;
+import org.apache.calcite.sql.util.SqlVisitor;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+/**
+ * Language specification defining the dialect the engine accepts. Provides parser configuration,
+ * validator configuration, and composable {@link LanguageExtension}s that contribute operators and
+ * post-parse rewrite rules.
+ *
+ * <p>Implementations define a complete language surface — for example, {@link UnifiedSqlSpec}
+ * provides ANSI and extended SQL modes. A future PPL spec would implement this same interface once
+ * PPL converges on the Calcite pipeline.
+ */
+public interface LanguageSpec {
+
+  /**
+   * A composable language extension that contributes operators and post-parse rewrite rules. All
+   * methods have defaults so extensions only override what they need.
+   */
+  interface LanguageExtension {
+
+    /**
+     * Operators (functions, aggregates) this extension adds. Chained with the standard operator
+     * table during validation.
+     */
+    default SqlOperatorTable operators() {
+      return SqlOperatorTables.of();
+    }
+
+    /**
+     * AST rewrite rules applied after parsing and before validation. Each visitor transforms the
+     * parse tree (e.g., rewriting named arguments into MAP literals).
+     */
+    default List<SqlVisitor<SqlNode>> postParseRules() {
+      return List.of();
+    }
+  }
+
+  /**
+   * Parser configuration controlling how SQL text is tokenized and parsed into a parse tree,
+   * including parser factory, lexical rules, and conformance.
+   */
+  SqlParser.Config parserConfig();
+
+  /**
+   * Validator configuration controlling what SQL semantics the validator accepts, such as GROUP BY
+   * behavior, LIMIT syntax, and type coercion.
+   */
+  SqlValidator.Config validatorConfig();
+
+  /**
+   * Language extensions registered with this spec. Each extension contributes operators and
+   * post-parse rewrite rules that are composed by {@link #operatorTable()} and {@link
+   * #postParseRules()}.
+   */
+  List<LanguageExtension> extensions();
+
+  /**
+   * Chained operator table combining the standard Calcite operators with all operators contributed
+   * by registered extensions.
+   */
+  default SqlOperatorTable operatorTable() {
+    List<SqlOperatorTable> tables = new ArrayList<>();
+    tables.add(SqlStdOperatorTable.instance());
+    extensions().forEach(ext -> tables.add(ext.operators()));
+    return SqlOperatorTables.chain(tables);
+  }
+
+  /**
+   * All post-parse rewrite rules from registered extensions, flattened in registration order.
+   * Applied to the parse tree after parsing and before validation.
+   */
+  default List<SqlVisitor<SqlNode>> postParseRules() {
+    return extensions().stream().flatMap(ext -> ext.postParseRules().stream()).toList();
+  }
+}

--- a/api/src/main/java/org/opensearch/sql/api/spec/UnifiedPplSpec.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/UnifiedPplSpec.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+/**
+ * PPL language specification.
+ *
+ * <p>Note: PPL currently has its own parsing and analyzing pipeline, so only configuration and
+ * extensions applied after RelNode construction are in use. The parser and validator configs
+ * returned here are inert for the PPL path.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UnifiedPplSpec implements LanguageSpec {
+
+  public static UnifiedPplSpec create() {
+    return new UnifiedPplSpec();
+  }
+
+  @Override
+  public SqlParser.Config parserConfig() {
+    return SqlParser.config();
+  }
+
+  @Override
+  public SqlValidator.Config validatorConfig() {
+    return SqlValidator.Config.DEFAULT;
+  }
+
+  @Override
+  public List<LanguageExtension> extensions() {
+    return List.of();
+  }
+}

--- a/api/src/main/java/org/opensearch/sql/api/spec/UnifiedSqlSpec.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/UnifiedSqlSpec.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParserImplFactory;
+import org.apache.calcite.sql.parser.babel.SqlBabelParserImpl;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.opensearch.sql.api.spec.search.SearchExtension;
+
+/**
+ * SQL language specification. Configures Calcite's parser, validator, and composable extensions for
+ * OpenSearch SQL compatibility.
+ *
+ * <p>Use {@link #extended()} for the default configuration with lenient syntax, hyphenated
+ * identifiers, and search functions.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Accessors(fluent = true)
+public class UnifiedSqlSpec implements LanguageSpec {
+
+  /** Lexical rules: identifier quoting, character escaping, and special identifier support. */
+  private final Lex lex;
+
+  /** Parser implementation: controls keyword reservation and grammar extensions. */
+  private final SqlParserImplFactory parserFactory;
+
+  /** Validation rules: what SQL semantics the validator accepts (GROUP BY, LIMIT, coercion). */
+  private final SqlConformanceEnum conformance;
+
+  /** Composable extensions contributing operators and post-parse rewrite rules. */
+  @Getter private final List<LanguageExtension> extensions;
+
+  /**
+   * Extended SQL spec: Babel parser, BIG_QUERY lex (hyphenated identifiers, backtick quoting),
+   * BABEL conformance (lenient GROUP BY, LIMIT, optional FROM), and search functions.
+   */
+  public static UnifiedSqlSpec extended() {
+    return new UnifiedSqlSpec(
+        Lex.BIG_QUERY,
+        SqlBabelParserImpl.FACTORY,
+        SqlConformanceEnum.BABEL,
+        List.of(new SearchExtension()));
+  }
+
+  @Override
+  public SqlParser.Config parserConfig() {
+    return SqlParser.config()
+        .withParserFactory(parserFactory)
+        .withLex(lex)
+        .withConformance(conformance);
+  }
+
+  @Override
+  public SqlValidator.Config validatorConfig() {
+    return SqlValidator.Config.DEFAULT.withConformance(conformance);
+  }
+}

--- a/api/src/main/java/org/opensearch/sql/api/spec/search/NamedArgRewriter.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/search/NamedArgRewriter.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.sql.api.parser;
+package org.opensearch.sql.api.spec.search;
 
 import java.util.List;
 import lombok.AccessLevel;

--- a/api/src/main/java/org/opensearch/sql/api/spec/search/SearchExtension.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/search/SearchExtension.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec.search;
+
+import java.util.List;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.util.SqlVisitor;
+import org.opensearch.sql.api.spec.LanguageSpec;
+import org.opensearch.sql.api.spec.UnifiedFunctionSpec;
+
+/** Search Extension: relevance functions and named argument rewriting. */
+public class SearchExtension implements LanguageSpec.LanguageExtension {
+
+  @Override
+  public SqlOperatorTable operators() {
+    return UnifiedFunctionSpec.RELEVANCE.operatorTable();
+  }
+
+  @Override
+  public List<SqlVisitor<SqlNode>> postParseRules() {
+    return List.of(NamedArgRewriter.INSTANCE);
+  }
+}

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
@@ -237,6 +237,9 @@ public class UnifiedQueryPlannerSqlTest extends UnifiedQueryTestBase {
             MERGE INTO catalog.employees AS t
             USING (SELECT 99 AS id) AS s ON t.id = s.id
             WHEN MATCHED THEN UPDATE SET name = 'hacked'\
+            """,
+            """
+            SHOW TABLES\
             """)
         .forEach(
             sql ->
@@ -245,7 +248,6 @@ public class UnifiedQueryPlannerSqlTest extends UnifiedQueryTestBase {
 
   @Test
   public void testNonQueryStatementsBlockedByParser() {
-    // Babel parser rejects CREATE MATERIALIZED VIEW
     givenInvalidQuery(
             """
             CREATE MATERIALIZED VIEW mv AS
@@ -254,12 +256,5 @@ public class UnifiedQueryPlannerSqlTest extends UnifiedQueryTestBase {
             GROUP BY department\
             """)
         .assertErrorMessage("Encountered");
-
-    // Babel parser accepts SHOW TABLES but it's blocked by query-type whitelist
-    givenInvalidQuery(
-            """
-            SHOW TABLES\
-            """)
-        .assertErrorMessage("Only query statements are supported");
   }
 }

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
@@ -245,17 +245,21 @@ public class UnifiedQueryPlannerSqlTest extends UnifiedQueryTestBase {
 
   @Test
   public void testNonQueryStatementsBlockedByParser() {
-    List.of(
+    // Babel parser rejects CREATE MATERIALIZED VIEW
+    givenInvalidQuery(
             """
             CREATE MATERIALIZED VIEW mv AS
             SELECT department, count(*)
             FROM catalog.employees
             GROUP BY department\
-            """,
+            """)
+        .assertErrorMessage("Encountered");
+
+    // Babel parser accepts SHOW TABLES but it's blocked by query-type whitelist
+    givenInvalidQuery(
             """
             SHOW TABLES\
             """)
-        .forEach(
-            sql -> givenInvalidQuery(sql).assertErrorMessage("Incorrect syntax near the keyword"));
+        .assertErrorMessage("Only query statements are supported");
   }
 }

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedRelevanceSearchSqlTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedRelevanceSearchSqlTest.java
@@ -25,7 +25,7 @@ public class UnifiedRelevanceSearchSqlTest extends UnifiedQueryTestBase {
     givenQuery(
             """
             SELECT * FROM catalog.employees
-            WHERE "match"(name, 'John')\
+            WHERE match(name, 'John')\
             """)
         .assertPlan(
             """
@@ -100,7 +100,7 @@ public class UnifiedRelevanceSearchSqlTest extends UnifiedQueryTestBase {
     givenQuery(
             """
             SELECT * FROM catalog.employees
-            WHERE "match"(name, 'John', operator='AND', boost=2.0)\
+            WHERE match(name, 'John', operator='AND', boost=2.0)\
             """)
         .assertPlanContains(
             "match(MAP('field', $1), MAP('query', 'John'),"
@@ -112,7 +112,7 @@ public class UnifiedRelevanceSearchSqlTest extends UnifiedQueryTestBase {
     givenInvalidQuery(
             """
             SELECT * FROM catalog.employees
-            WHERE "match"('John')\
+            WHERE match('John')\
             """)
         .assertErrorMessage(
             "No match found for function signature match(<(CHAR(5), CHAR(4)) MAP>)");

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedSqlSpecTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedSqlSpecTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api;
+
+import java.util.Map;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.junit.Test;
+import org.opensearch.sql.executor.QueryType;
+
+public class UnifiedSqlSpecTest extends UnifiedQueryTestBase {
+
+  @Override
+  protected QueryType queryType() {
+    return QueryType.SQL;
+  }
+
+  @Override
+  protected UnifiedQueryContext.Builder contextBuilder() {
+    AbstractSchema schema =
+        new AbstractSchema() {
+          @Override
+          protected Map<String, Table> getTableMap() {
+            return Map.of(
+                "employees", createEmployeesTable(),
+                "logs-2024-01", createEmployeesTable());
+          }
+        };
+    return UnifiedQueryContext.builder()
+        .language(queryType())
+        .catalog(DEFAULT_CATALOG, schema)
+        .defaultNamespace(DEFAULT_CATALOG);
+  }
+
+  @Test
+  public void hyphenatedTableIdentifier() {
+    givenQuery("SELECT * FROM logs-2024-01")
+        .assertPlanContains("LogicalTableScan(table=[[catalog, logs-2024-01]])");
+  }
+
+  @Test
+  public void backtickQuotedIdentifiers() {
+    givenQuery("SELECT `name` FROM employees").assertPlanContains("LogicalProject(name=[$1])");
+  }
+
+  @Test
+  public void doubleQuotedStringLiteral() {
+    givenQuery("SELECT \"Hello\" FROM employees").assertPlanContains("LogicalProject");
+  }
+
+  @Test
+  public void matchNotReserved() {
+    givenQuery("SELECT * FROM employees WHERE match(name, 'Hattie')")
+        .assertPlanContains("LogicalFilter");
+  }
+
+  @Test
+  public void reservedWordAsAlias() {
+    givenQuery("SELECT age AS year FROM employees").assertPlanContains("LogicalProject(year=[$2])");
+  }
+
+  @Test
+  public void limitSyntax() {
+    givenQuery("SELECT * FROM employees LIMIT 10").assertPlanContains("LogicalSort(fetch=[10])");
+  }
+
+  @Test
+  public void selectWithoutFrom() {
+    givenQuery("SELECT 1").assertPlanContains("LogicalValues(tuples=[[{ 1 }]])");
+  }
+
+  @Test
+  public void groupByAlias() {
+    givenQuery("SELECT department AS dept, COUNT(*) AS cnt FROM employees GROUP BY dept")
+        .assertPlanContains("LogicalAggregate(group=[{0}]");
+  }
+
+  @Test
+  public void groupByOrdinal() {
+    givenQuery("SELECT name, COUNT(*) FROM employees GROUP BY 1")
+        .assertPlanContains("LogicalAggregate");
+  }
+
+  @Test
+  public void castBooleanToInteger() {
+    givenQuery("SELECT CAST(true AS INTEGER) FROM employees").assertPlanContains("LogicalProject");
+  }
+
+  @Test
+  public void integerComparedToString() {
+    givenQuery("SELECT * FROM employees WHERE age > '30'").assertPlanContains("LogicalFilter");
+  }
+
+  @Test
+  public void matchFunction() {
+    givenQuery("SELECT * FROM employees WHERE match(name, 'John')")
+        .assertPlanContains("match(MAP('field', $1), MAP('query', 'John'))");
+  }
+
+  @Test
+  public void matchPhraseFunction() {
+    givenQuery("SELECT * FROM employees WHERE match_phrase(name, 'quick fox')")
+        .assertPlanContains("match_phrase(MAP('field', $1), MAP('query', 'quick fox'))");
+  }
+
+  @Test
+  public void namedParametersSyntax() {
+    givenQuery("SELECT * FROM employees WHERE match_phrase(name, 'quick fox', slop=2)")
+        .assertPlanContains("match_phrase(MAP('field', $1), MAP('query', 'quick fox')");
+  }
+}

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedSqlSpecTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedSqlSpecTest.java
@@ -48,13 +48,14 @@ public class UnifiedSqlSpecTest extends UnifiedQueryTestBase {
 
   @Test
   public void doubleQuotedStringLiteral() {
-    givenQuery("SELECT \"Hello\" FROM employees").assertPlanContains("LogicalProject");
+    givenQuery("SELECT \"Hello\" AS greeting FROM employees")
+        .assertPlanContains("LogicalProject(greeting=['Hello'])");
   }
 
   @Test
   public void matchNotReserved() {
     givenQuery("SELECT * FROM employees WHERE match(name, 'Hattie')")
-        .assertPlanContains("LogicalFilter");
+        .assertPlanContains("match(MAP('field', $1), MAP('query', 'Hattie'))");
   }
 
   @Test
@@ -80,18 +81,21 @@ public class UnifiedSqlSpecTest extends UnifiedQueryTestBase {
 
   @Test
   public void groupByOrdinal() {
-    givenQuery("SELECT name, COUNT(*) FROM employees GROUP BY 1")
-        .assertPlanContains("LogicalAggregate");
+    givenQuery("SELECT name, COUNT(*) AS cnt FROM employees GROUP BY 1")
+        .assertPlanContains("LogicalAggregate(group=[{0}], cnt=[COUNT()])")
+        .assertPlanContains("LogicalProject(name=[$1])");
   }
 
   @Test
   public void castBooleanToInteger() {
-    givenQuery("SELECT CAST(true AS INTEGER) FROM employees").assertPlanContains("LogicalProject");
+    givenQuery("SELECT CAST(true AS INTEGER) AS val FROM employees")
+        .assertPlanContains("LogicalProject(val=[1])");
   }
 
   @Test
   public void integerComparedToString() {
-    givenQuery("SELECT * FROM employees WHERE age > '30'").assertPlanContains("LogicalFilter");
+    givenQuery("SELECT * FROM employees WHERE age > '30'")
+        .assertPlanContains("condition=[>($2, CAST('30'):INTEGER NOT NULL)]");
   }
 
   @Test

--- a/api/src/test/java/org/opensearch/sql/api/spec/search/NamedArgRewriterTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/spec/search/NamedArgRewriterTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.sql.api.parser;
+package org.opensearch.sql.api.spec.search;
 
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
### Description

This PR introduces a new abstraction `LanguageSpec`. Its SQL implementation `UnifiedSqlSpec` defines the unified SQL language specification as Phase 1 of unifying the fragmented OpenSearch SQL surface described in #5346.

- Each language spec defines the **global parsing and validation behavior** of the language through lex, parser, and conformance configuration.
- Each language spec can be enriched with **composable extensions** that contribute additional syntax, operators, or rewrite rules.

<img width="1113" height="1071" alt="Screenshot 2026-04-16 at 3 51 37 PM" src="https://github.com/user-attachments/assets/20ff9cb9-e122-4d09-82ef-390298e4dbf0" />

### SQL Compatibiilty

`UnifiedSqlSpec`'s extended mode addresses the following breaking change categories from the [gap analysis report](https://github.com/opensearch-project/sql/issues/5346#issuecomment-4247257399):

#### Parsing & Syntax

| Category | Count | Status | Details |
|----------|------:|:---:|---------|
| **Identifier: Hyphenated** | ~750 | ✅ | `FROM logs-2024-01` — Lex BIG_QUERY BQHID |
| **Identifier: Dot-prefixed** | 4 | ❌ | `FROM test.one` — dot is schema separator |
| **Identifier: @-prefixed** | 1 | ❌ | `@timestamp` — `@` not in identifier chars |
| **Identifier: Slash** | 1 | N/A | `account/wrongType` — deprecated ES syntax |
| **Quoting: Backtick** | 0 | ✅ | `` `name` `` — Lex BIG_QUERY |
| **Quoting: Double-quote** | 2 | ⚠️ | `"Hello"` is string literal (trade-off for hyphenated IDs) |
| **Quoting: Backslash escape** | 0 | ✅ | `'it\'s'` — Lex BIG_QUERY BQ_SINGLE |
| **Keyword: match() reserved** | 0 | ✅ | Babel de-reserves MATCH |
| **Keyword: Reserved as alias** | 0 | ✅ | `SELECT age AS year` — Babel |
| **Square bracket syntax** | 33 | ❌ | `multi_match([f1, f2], 'text')` — needs custom grammar |
| **Trailing semicolons** | 11 | ❌ | `SELECT * FROM t;` — parseSqlStmtEof rejects |
| **MySQL `#` comments** | 0* | ❌ | `# comment` — Calcite only supports `--` and `/* */` |
| **SHOW/DESCRIBE** | 13 | N/A | `SHOW TABLES LIKE ...` — parser/whitelist limitation |
| **JSON body as query** | 1 | N/A | `{"query": "SELECT ..."}` — not SQL |

#### Validation & Conformance

| Category | Count | Status | Details |
|----------|------:|:---:|---------|
| **GROUP BY alias** | - | ✅ | `GROUP BY dept` — BABEL conformance |
| **GROUP BY ordinal** | - | ✅ | `GROUP BY 1` — BABEL conformance |
| **GROUP BY strict** | 9 | ⚠️ | `SELECT * ... GROUP BY age` — BABEL allows non-strict, but qualified column refs still fail |
| **LIMIT syntax** | - | ✅ | `LIMIT 10` — BABEL conformance |
| **Optional FROM** | - | ✅ | `SELECT 1` — BABEL conformance |
| **CAST BOOLEAN→INT** | - | ✅ | `CAST(true AS INTEGER)` — BABEL lenient coercion |

### Next Steps

- [ ] Explore solutions for the remaining gaps and update the user documentation
- [ ] Confirm and document the additional behaviors enabled by extended mode compared with SQL V2 / Legacy
- [ ] Define and implement ANSI mode (`UnifiedSqlSpec.ansi()`) aligned with Spark SQL ANSI compliance

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5346

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
