### PR TITLE
[Feature] Reject aggregations on vectorSearch() relations

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -230,4 +230,36 @@ public class VectorSearchIT extends SQLIntegTestCase {
 
     assertThat(ex.getMessage(), containsString("filter_type must be one of"));
   }
+
+  @Test
+  public void testGroupByRejects() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v.gender, COUNT(*) FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='f', vector='[1.0]', option='k=5') AS v GROUP BY v.gender"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString("Aggregations are not supported on vectorSearch() relations"));
+  }
+
+  @Test
+  public void testBareAggregateRejects() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT COUNT(*) FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='f', vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString("Aggregations are not supported on vectorSearch() relations"));
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -14,7 +14,7 @@ import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.opensearch.storage.scan.OpenSearchIndexScan;
-import org.opensearch.sql.opensearch.storage.scan.OpenSearchIndexScanBuilder;
+import org.opensearch.sql.opensearch.storage.scan.VectorSearchIndexScanBuilder;
 import org.opensearch.sql.opensearch.storage.scan.VectorSearchQueryBuilder;
 import org.opensearch.sql.storage.read.TableScanBuilder;
 
@@ -94,7 +94,7 @@ public class VectorSearchIndex extends OpenSearchIndex {
                 getClient(),
                 rb.getMaxResponseSize(),
                 rb.build(getIndexName(), cursorKeepAlive, getClient(), getFieldTypes().isEmpty()));
-    return new OpenSearchIndexScanBuilder(queryBuilder, createScanOperator);
+    return new VectorSearchIndexScanBuilder(queryBuilder, createScanOperator);
   }
 
   private QueryBuilder buildKnnQuery() {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
@@ -11,10 +11,10 @@ import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
 
 /**
- * Scan builder for vector search relations. Rejects aggregation pushdown because the semantics of
- * aggregations over knn-scored documents are ambiguous at the SQL surface (e.g., per-bucket _score
- * is undefined). Rejecting at push-down time keeps the MVP contract tight; support can be added
- * later without breaking existing users.
+ * Scan builder for vector search relations. Rejects aggregation pushdown as a SQL preview
+ * constraint: aggregations over vectorSearch() relations are not supported in the current preview.
+ * Native OpenSearch k-NN does support aggregations alongside similarity search; this restriction is
+ * specific to the SQL surface and may be lifted in a later release.
  */
 public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
 
@@ -27,7 +27,6 @@ public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
   @Override
   public boolean pushDownAggregation(LogicalAggregation aggregation) {
     throw new ExpressionEvaluationException(
-        "GROUP BY / aggregations are not supported on vectorSearch() relations. "
-            + "Wrap the vectorSearch() call in a subquery and aggregate over the subquery result.");
+        "Aggregations are not supported on vectorSearch() relations in the SQL preview.");
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.scan;
+
+import java.util.function.Function;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+import org.opensearch.sql.planner.logical.LogicalAggregation;
+
+/**
+ * Scan builder for vector search relations. Rejects aggregation pushdown because the semantics of
+ * aggregations over knn-scored documents are ambiguous at the SQL surface (e.g., per-bucket _score
+ * is undefined). Rejecting at push-down time keeps the MVP contract tight; support can be added
+ * later without breaking existing users.
+ */
+public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
+
+  public VectorSearchIndexScanBuilder(
+      PushDownQueryBuilder translator,
+      Function<OpenSearchRequestBuilder, OpenSearchIndexScan> scanFactory) {
+    super(translator, scanFactory);
+  }
+
+  @Override
+  public boolean pushDownAggregation(LogicalAggregation aggregation) {
+    throw new ExpressionEvaluationException(
+        "GROUP BY / aggregations are not supported on vectorSearch() relations. "
+            + "Wrap the vectorSearch() call in a subquery and aggregate over the subquery result.");
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
@@ -43,8 +43,8 @@ class VectorSearchIndexScanBuilderTest {
         assertThrows(
             ExpressionEvaluationException.class, () -> scanBuilder.pushDownAggregation(agg));
     assertTrue(
-        ex.getMessage().contains("GROUP BY"),
-        "Error should mention GROUP BY; actual: " + ex.getMessage());
+        ex.getMessage().contains("Aggregations are not supported"),
+        "Error should state aggregations are not supported; actual: " + ex.getMessage());
     assertTrue(
         ex.getMessage().contains("vectorSearch"),
         "Error should mention vectorSearch; actual: " + ex.getMessage());

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.scan;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.opensearch.index.query.WrapperQueryBuilder;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
+import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+import org.opensearch.sql.planner.logical.LogicalAggregation;
+import org.opensearch.sql.planner.logical.LogicalValues;
+
+class VectorSearchIndexScanBuilderTest {
+
+  @Test
+  void pushDownAggregationIsRejected() {
+    var requestBuilder =
+        new OpenSearchRequestBuilder(
+            mock(OpenSearchExprValueFactory.class), 10000, mock(Settings.class));
+    var queryBuilder =
+        new VectorSearchQueryBuilder(
+            requestBuilder, new WrapperQueryBuilder("{\"knn\":{}}"), java.util.Map.of("k", "5"));
+    var scanBuilder =
+        new VectorSearchIndexScanBuilder(queryBuilder, rb -> mock(OpenSearchIndexScan.class));
+
+    var agg =
+        new LogicalAggregation(
+            new LogicalValues(Collections.emptyList()),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            false);
+
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class, () -> scanBuilder.pushDownAggregation(agg));
+    assertTrue(
+        ex.getMessage().contains("GROUP BY"),
+        "Error should mention GROUP BY; actual: " + ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("vectorSearch"),
+        "Error should mention vectorSearch; actual: " + ex.getMessage());
+  }
+}


### PR DESCRIPTION
## Summary
Reject aggregations (including `GROUP BY` and bare aggregate functions like `COUNT(*)`) on `vectorSearch()` relations in the SQL preview. This is a SQL-surface constraint, not a native OpenSearch limitation — the k-NN plugin does support aggregations alongside similarity search. The restriction keeps the preview contract narrow and can be lifted in a later release.

## Changes
- New `VectorSearchIndexScanBuilder` overrides `pushDownAggregation` to throw `ExpressionEvaluationException`.
- `VectorSearchIndex.createScanBuilder` returns the new builder.
- Unit test covers the rejection path at the scan-builder level.
- Two new `VectorSearchIT` tests assert rejection end-to-end: `GROUP BY` and bare `COUNT(*)`.

## Test plan
- [x] `./gradlew :opensearch:test --tests '*VectorSearchIndexScanBuilderTest'` passes
- [x] `./gradlew :integ-test:compileTestJava` passes
- [x] `./gradlew :opensearch:spotlessCheck :integ-test:spotlessCheck` passes