### PR TITLE
[Feature] Strengthen VectorSearchExplainIT with structural DSL assertions

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
@@ -27,6 +27,10 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
   // quotes as \", so the regex tolerates both \" and " forms around the query key/value.
   private static final Pattern WRAPPER_PAYLOAD =
       Pattern.compile("\\\\?\"query\\\\?\":\\\\?\"([A-Za-z0-9+/=]+)\\\\?\"");
+  // Anchored on the surrounding `sourceBuilder=...`, `pitId=` tokens in OpenSearchRequest's
+  // toString() output. Test-only coupling: if that request-string format changes (token renamed,
+  // pitId removed), this helper breaks even when the DSL shape is still correct. Update the regex
+  // anchors if that happens.
   private static final Pattern SOURCE_BUILDER_JSON =
       Pattern.compile("sourceBuilder=(\\{.*?\\}), pitId=", Pattern.DOTALL);
 
@@ -79,6 +83,12 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
     assertTrue(
         "Explain should contain track_scores:\n" + explain, explain.contains("track_scores"));
 
+    // Top-k without WHERE should have the knn at the root, not wrapped in an outer bool.
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
+    assertFalse(
+        "Top-k without WHERE should not wrap knn in an outer bool:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
+
     String knnJson = decodeSoleKnnJson(explain);
     assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
     assertTrue(
@@ -102,6 +112,12 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "', field='embedding', "
                 + "vector='[1.0, 2.0]', option='max_distance=10.5') AS v "
                 + "LIMIT 100");
+
+    // Radial without WHERE should have the knn at the root, not wrapped in an outer bool.
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
+    assertFalse(
+        "Radial without WHERE should not wrap knn in an outer bool:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
 
     String knnJson = decodeSoleKnnJson(explain);
     assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
@@ -127,6 +143,12 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "', field='embedding', "
                 + "vector='[1.0, 2.0]', option='min_score=0.8') AS v "
                 + "LIMIT 100");
+
+    // Radial without WHERE should have the knn at the root, not wrapped in an outer bool.
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
+    assertFalse(
+        "Radial without WHERE should not wrap knn in an outer bool:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
 
     String knnJson = decodeSoleKnnJson(explain);
     assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
@@ -406,8 +428,23 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "ORDER BY v._score DESC "
                 + "LIMIT 5");
 
+    // Same efficient-mode shape guarantee as testExplainFilterTypeEfficientProducesKnnWithFilter,
+    // with an added ORDER BY _score DESC: no outer bool/must, and the WHERE predicate must be
+    // embedded inside the knn payload (efficient filtering, not post-filter).
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
+    assertFalse(
+        "Efficient mode should not produce bool query (that is post-filter shape):\n"
+            + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
+    assertFalse(
+        "Efficient mode should not contain must clause:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"must\""));
+
+    String knnJson = decodeSoleKnnJson(explain);
     assertTrue(
-        "Explain should succeed with efficient + ORDER BY _score DESC:\n" + explain,
-        explain.contains("wrapper"));
+        "Efficient mode knn JSON should contain filter:\n" + knnJson, knnJson.contains("filter"));
+    assertTrue(
+        "Efficient mode knn JSON should contain the WHERE predicate field:\n" + knnJson,
+        knnJson.contains("state"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
@@ -6,6 +6,12 @@
 package org.opensearch.sql.sql;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.Test;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.legacy.TestsConstants;
@@ -16,6 +22,38 @@ import org.opensearch.sql.legacy.TestsConstants;
  * plans the query without executing it against a knn index.
  */
 public class VectorSearchExplainIT extends SQLIntegTestCase {
+
+  // Matches WrapperQueryBuilder's base64 payload in explain JSON. The explain output escapes
+  // quotes as \", so the regex tolerates both \" and " forms around the query key/value.
+  private static final Pattern WRAPPER_PAYLOAD =
+      Pattern.compile("\\\\?\"query\\\\?\":\\\\?\"([A-Za-z0-9+/=]+)\\\\?\"");
+  private static final Pattern SOURCE_BUILDER_JSON =
+      Pattern.compile("sourceBuilder=(\\{.*?\\}), pitId=", Pattern.DOTALL);
+
+  /** Decodes every base64-encoded wrapper payload in the explain output into its knn JSON. */
+  private static List<String> decodeWrapperKnnJsons(String explain) {
+    List<String> payloads = new ArrayList<>();
+    Matcher m = WRAPPER_PAYLOAD.matcher(explain);
+    while (m.find()) {
+      payloads.add(new String(Base64.getDecoder().decode(m.group(1)), StandardCharsets.UTF_8));
+    }
+    return payloads;
+  }
+
+  /** Returns the single wrapper knn JSON, asserting exactly one is present. */
+  private static String decodeSoleKnnJson(String explain) {
+    List<String> payloads = decodeWrapperKnnJsons(explain);
+    assertEquals(
+        "Expected exactly one wrapper query payload in explain:\n" + explain, 1, payloads.size());
+    return payloads.get(0);
+  }
+
+  /** Extracts and unescapes the sourceBuilder JSON embedded in the explain request string. */
+  private static String extractSourceBuilderJson(String explain) {
+    Matcher m = SOURCE_BUILDER_JSON.matcher(explain);
+    assertTrue("Explain should contain sourceBuilder JSON:\n" + explain, m.find());
+    return m.group(1).replace("\\\"", "\"");
+  }
 
   @Override
   protected void init() throws Exception {
@@ -38,11 +76,20 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "vector='[1.0, 2.0, 3.0]', option='k=5') AS v "
                 + "LIMIT 5");
 
-    // WrapperQueryBuilder wraps the knn JSON — verify the wrapper is present
-    // and track_scores is enabled for score preservation.
-    assertTrue("Explain should contain wrapper query:\n" + explain, explain.contains("wrapper"));
     assertTrue(
         "Explain should contain track_scores:\n" + explain, explain.contains("track_scores"));
+
+    String knnJson = decodeSoleKnnJson(explain);
+    assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
+    assertTrue(
+        "knn JSON should target the embedding field:\n" + knnJson,
+        knnJson.contains("\"embedding\""));
+    assertTrue(
+        "knn JSON should contain the vector values:\n" + knnJson,
+        knnJson.contains("[1.0,2.0,3.0]"));
+    assertTrue("knn JSON should contain k=5:\n" + knnJson, knnJson.contains("\"k\":5"));
+    assertFalse(
+        "Top-k without WHERE should not embed a filter:\n" + knnJson, knnJson.contains("filter"));
   }
 
   @Test
@@ -56,7 +103,18 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "vector='[1.0, 2.0]', option='max_distance=10.5') AS v "
                 + "LIMIT 100");
 
-    assertTrue("Explain should contain wrapper query:\n" + explain, explain.contains("wrapper"));
+    String knnJson = decodeSoleKnnJson(explain);
+    assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
+    assertTrue(
+        "knn JSON should target the embedding field:\n" + knnJson,
+        knnJson.contains("\"embedding\""));
+    assertTrue(
+        "knn JSON should contain the vector values:\n" + knnJson, knnJson.contains("[1.0,2.0]"));
+    assertTrue(
+        "knn JSON should contain max_distance=10.5:\n" + knnJson,
+        knnJson.contains("\"max_distance\":10.5"));
+    assertFalse(
+        "Radial without WHERE should not embed a filter:\n" + knnJson, knnJson.contains("filter"));
   }
 
   @Test
@@ -70,7 +128,18 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "vector='[1.0, 2.0]', option='min_score=0.8') AS v "
                 + "LIMIT 100");
 
-    assertTrue("Explain should contain wrapper query:\n" + explain, explain.contains("wrapper"));
+    String knnJson = decodeSoleKnnJson(explain);
+    assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
+    assertTrue(
+        "knn JSON should target the embedding field:\n" + knnJson,
+        knnJson.contains("\"embedding\""));
+    assertTrue(
+        "knn JSON should contain the vector values:\n" + knnJson, knnJson.contains("[1.0,2.0]"));
+    assertTrue(
+        "knn JSON should contain min_score=0.8:\n" + knnJson,
+        knnJson.contains("\"min_score\":0.8"));
+    assertFalse(
+        "Radial without WHERE should not embed a filter:\n" + knnJson, knnJson.contains("filter"));
   }
 
   // ── Post-filter DSL shape ────────────────────────────────────────────
@@ -87,13 +156,35 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "WHERE v.state = 'TX' "
                 + "LIMIT 10");
 
-    assertTrue("Explain should contain bool query:\n" + explain, explain.contains("bool"));
+    // Post-filter shape: outer bool.must=[knn], bool.filter=[term] — WHERE lives OUTSIDE the knn
+    // payload. Verify by decoding the wrapper and asserting the predicate field is NOT embedded.
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
     assertTrue(
-        "Explain should contain must clause (knn in scoring context):\n" + explain,
-        explain.contains("must"));
+        "Explain should contain bool query:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
     assertTrue(
-        "Explain should contain filter clause (WHERE in non-scoring context):\n" + explain,
-        explain.contains("filter"));
+        "Explain should contain must clause (knn in scoring context):\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"must\""));
+    assertTrue(
+        "Explain should contain filter clause (WHERE in non-scoring context):\n"
+            + sourceBuilderJson,
+        sourceBuilderJson.contains("\"filter\""));
+    assertTrue(
+        "Explain should contain the outer state predicate:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"state.keyword\""));
+
+    String knnJson = decodeSoleKnnJson(explain);
+    assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
+    assertTrue(
+        "knn JSON should target the embedding field:\n" + knnJson,
+        knnJson.contains("\"embedding\""));
+    assertTrue("knn JSON should contain k=10:\n" + knnJson, knnJson.contains("\"k\":10"));
+    assertFalse(
+        "Post-filter mode must not embed the WHERE predicate inside knn:\n" + knnJson,
+        knnJson.contains("state"));
+    assertFalse(
+        "Post-filter mode must not embed a filter inside knn:\n" + knnJson,
+        knnJson.contains("filter"));
   }
 
   @Test
@@ -108,13 +199,41 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "WHERE v.state = 'TX' AND v.age > 30 "
                 + "LIMIT 10");
 
-    assertTrue("Explain should contain bool query:\n" + explain, explain.contains("bool"));
+    // Compound post-filter still uses outer bool.must=[knn]/bool.filter=[predicates]. Both WHERE
+    // predicates must stay outside the knn payload; otherwise efficient mode could false-positive.
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
     assertTrue(
-        "Explain should contain must clause (knn in scoring context):\n" + explain,
-        explain.contains("must"));
+        "Explain should contain bool query:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
     assertTrue(
-        "Explain should contain filter clause (compound WHERE in non-scoring context):\n" + explain,
-        explain.contains("filter"));
+        "Explain should contain must clause (knn in scoring context):\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"must\""));
+    assertTrue(
+        "Explain should contain filter clause (compound WHERE in non-scoring context):\n"
+            + sourceBuilderJson,
+        sourceBuilderJson.contains("\"filter\""));
+    assertTrue(
+        "Explain should contain the outer state predicate:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"state.keyword\""));
+    assertTrue(
+        "Explain should contain the outer age predicate:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"age\""));
+
+    String knnJson = decodeSoleKnnJson(explain);
+    assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
+    assertTrue(
+        "knn JSON should target the embedding field:\n" + knnJson,
+        knnJson.contains("\"embedding\""));
+    assertTrue("knn JSON should contain k=10:\n" + knnJson, knnJson.contains("\"k\":10"));
+    assertFalse(
+        "Compound post-filter must not embed the state predicate inside knn:\n" + knnJson,
+        knnJson.contains("state"));
+    assertFalse(
+        "Compound post-filter must not embed the age predicate inside knn:\n" + knnJson,
+        knnJson.contains("age"));
+    assertFalse(
+        "Compound post-filter must not embed a filter inside knn:\n" + knnJson,
+        knnJson.contains("filter"));
   }
 
   @Test
@@ -129,13 +248,37 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "WHERE v.state = 'TX' "
                 + "LIMIT 100");
 
-    assertTrue("Explain should contain bool query:\n" + explain, explain.contains("bool"));
+    // Radial + WHERE should also keep the WHERE predicate in the outer bool.filter rather than
+    // embedding it into the radial knn payload.
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
     assertTrue(
-        "Explain should contain must clause (knn in scoring context):\n" + explain,
-        explain.contains("must"));
+        "Explain should contain bool query:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
     assertTrue(
-        "Explain should contain filter clause (WHERE in non-scoring context):\n" + explain,
-        explain.contains("filter"));
+        "Explain should contain must clause (knn in scoring context):\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"must\""));
+    assertTrue(
+        "Explain should contain filter clause (WHERE in non-scoring context):\n"
+            + sourceBuilderJson,
+        sourceBuilderJson.contains("\"filter\""));
+    assertTrue(
+        "Explain should contain the outer state predicate:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"state.keyword\""));
+
+    String knnJson = decodeSoleKnnJson(explain);
+    assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
+    assertTrue(
+        "knn JSON should target the embedding field:\n" + knnJson,
+        knnJson.contains("\"embedding\""));
+    assertTrue(
+        "knn JSON should contain max_distance=10.5:\n" + knnJson,
+        knnJson.contains("\"max_distance\":10.5"));
+    assertFalse(
+        "Radial post-filter must not embed the WHERE predicate inside knn:\n" + knnJson,
+        knnJson.contains("state"));
+    assertFalse(
+        "Radial post-filter must not embed a filter inside knn:\n" + knnJson,
+        knnJson.contains("filter"));
   }
 
   // ── Sort + LIMIT explain ─────────────────────────────────────────────
@@ -185,9 +328,35 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "WHERE v.state = 'TX' "
                 + "LIMIT 10");
 
-    assertTrue("Explain should contain bool query:\n" + explain, explain.contains("bool"));
-    assertTrue("Explain should contain must:\n" + explain, explain.contains("must"));
-    assertTrue("Explain should contain filter:\n" + explain, explain.contains("filter"));
+    // Explicit filter_type=post must produce the same bool.must=[knn]/bool.filter=[term] shape as
+    // the default, and the WHERE predicate must NOT leak into the knn payload (that would be
+    // efficient mode). This is the key false-positive guard: substring-only checks would pass for
+    // efficient mode too.
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
+    assertTrue(
+        "Explain should contain bool query:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
+    assertTrue(
+        "Explain should contain must:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"must\""));
+    assertTrue(
+        "Explain should contain filter:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"filter\""));
+    assertTrue(
+        "Explain should contain the outer state predicate:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"state.keyword\""));
+
+    String knnJson = decodeSoleKnnJson(explain);
+    assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
+    assertTrue(
+        "knn JSON should target the embedding field:\n" + knnJson,
+        knnJson.contains("\"embedding\""));
+    assertFalse(
+        "filter_type=post must not embed the WHERE predicate inside knn:\n" + knnJson,
+        knnJson.contains("state"));
+    assertFalse(
+        "filter_type=post must not embed a filter inside knn:\n" + knnJson,
+        knnJson.contains("filter"));
   }
 
   @Test
@@ -204,26 +373,19 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
 
     // Efficient mode: knn rebuilt with filter inside, wrapped in WrapperQueryBuilder.
     // The knn JSON (including the embedded filter) is base64-encoded inside the wrapper,
-    // so we verify structure by: (1) wrapper present, (2) no bool/must in plaintext
-    // (that would be post-filter shape), (3) decode the base64 payload to confirm
-    // the filter and predicate field are embedded inside the knn query.
-    assertTrue("Explain should contain wrapper query:\n" + explain, explain.contains("wrapper"));
+    // so we verify structure by: (1) no bool/must in plaintext (that would be post-filter shape),
+    // (2) decode the base64 payload to confirm the filter and predicate field are embedded inside
+    // the knn query.
+    String sourceBuilderJson = extractSourceBuilderJson(explain);
     assertFalse(
-        "Efficient mode should not produce bool query (that is post-filter shape):\n" + explain,
-        explain.contains("\"bool\""));
+        "Efficient mode should not produce bool query (that is post-filter shape):\n"
+            + sourceBuilderJson,
+        sourceBuilderJson.contains("\"bool\""));
     assertFalse(
-        "Efficient mode should not contain must clause:\n" + explain, explain.contains("\"must\""));
+        "Efficient mode should not contain must clause:\n" + sourceBuilderJson,
+        sourceBuilderJson.contains("\"must\""));
 
-    // Extract and decode the base64 knn payload to verify filter embedding.
-    // The explain output escapes quotes as \", so match both \" and " forms.
-    java.util.regex.Matcher m =
-        java.util.regex.Pattern.compile("\\\\?\"query\\\\?\":\\\\?\"([A-Za-z0-9+/=]+)\\\\?\"")
-            .matcher(explain);
-    assertTrue("Explain should contain base64-encoded knn query:\n" + explain, m.find());
-    String knnJson =
-        new String(
-            java.util.Base64.getDecoder().decode(m.group(1)),
-            java.nio.charset.StandardCharsets.UTF_8);
+    String knnJson = decodeSoleKnnJson(explain);
     assertTrue(
         "Efficient mode knn JSON should contain filter:\n" + knnJson, knnJson.contains("filter"));
     assertTrue(


### PR DESCRIPTION
## Description

The `VectorSearchExplainIT` suite previously relied on substring-based smoke checks (`contains("wrapper")`, `contains("bool")`, `contains("filter")`) that could false-positive across distinct push-down shapes. Most notably, post-filter and efficient-mode (`filter_type=efficient`) output look similar at the substring level — both contain `wrapper`, and the substrings `bool`/`must`/`filter` appear in the explain output for both shapes due to JSON-escaped fragments.

This PR extends the structural-assertion pattern introduced for the efficient-mode test in #5331 to the rest of the high-signal explain cases.

### What changed

Added two shared helpers in `VectorSearchExplainIT`:
- `decodeSoleKnnJson(explain)` — extracts and base64-decodes the `WrapperQueryBuilder` payload, returning the inner k-NN JSON.
- `extractSourceBuilderJson(explain)` — extracts and unescapes the outer `sourceBuilder` JSON so outer-shape assertions run against unescaped content rather than escaped explain output.

Strengthened six tests to use the helpers and assert both the outer `bool`/`must`/`filter` shape and that WHERE predicates stay out of the decoded inner k-NN payload:

- `testExplainTopKProducesKnnQuery` — verifies `knn` key, embedding field, vector values, `k=5`, and no embedded filter.
- `testExplainRadialMaxDistanceProducesKnnQuery` — verifies radial `max_distance=10.5` and no embedded filter.
- `testExplainRadialMinScoreProducesKnnQuery` — verifies radial `min_score=0.8` and no embedded filter.
- `testExplainPostFilterProducesBoolQuery` — verifies outer `bool.must=[knn]/bool.filter=[term]` shape and that the `state` predicate does NOT leak into the k-NN payload.
- `testExplainCompoundPredicateProducesBoolQuery` — same guard for compound `WHERE state AND age`; both predicates must stay outside the k-NN payload.
- `testExplainRadialWithWhereProducesBoolQuery` — radial + WHERE keeps predicate in outer `bool.filter`, not embedded in radial k-NN.
- `testExplainFilterTypePostProducesBoolQuery` — explicit `filter_type=post` must produce the default post-filter shape and must NOT embed the predicate inside k-NN (key false-positive guard vs. efficient mode).

Refactored `testExplainFilterTypeEfficientProducesKnnWithFilter` onto the same helpers so its "no outer `bool`/`must`" guard is verified against unescaped `sourceBuilder` JSON rather than accidentally passing on the escaped form.

### What's intentionally out of scope

`testOrderByScoreDescExplainSucceeds` and `testExplainLimitWithinKSucceeds` are left on their existing smoke-level assertions. Those tests exist to prove that ORDER BY `_score` DESC and LIMIT ≤ k don't get rejected by validation — DSL shape for those paths is already covered by the strengthened top-k/radial cases above.

## Issues Resolved

Follow-up to #5331 — extends the structural-assertion pattern from the efficient-mode test to the remainder of the high-signal explain cases.

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).