### PR TITLE
[Feature] Fail fast at execution time when k-NN plugin is missing

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -262,4 +262,42 @@ public class VectorSearchIT extends SQLIntegTestCase {
         ex.getMessage(),
         containsString("Aggregations are not supported on vectorSearch() relations"));
   }
+
+  // ── k-NN plugin capability check ──────────────────────────────────────
+  // The default integ-test cluster does not have the k-NN plugin installed. Execution-path
+  // queries against vectorSearch() should therefore fail with the clear "k-NN plugin missing"
+  // error from KnnPluginCapability, while _explain continues to work because the capability
+  // probe is deferred to scan open() and does not run during analysis/planning.
+
+  @Test
+  public void testExecutionWithoutKnnPluginReturnsCapabilityError() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
+                        + "LIMIT 5"));
+
+    assertThat(ex.getMessage(), containsString("k-NN plugin"));
+    assertThat(ex.getMessage(), containsString("not installed"));
+  }
+
+  @Test
+  public void testExplainWithoutKnnPluginStillWorks() throws IOException {
+    // _explain only parses and plans the query. It must NOT require the k-NN plugin — the
+    // capability probe is intentionally deferred to scan open() so pluginless clusters can
+    // still inspect query plans. If this test starts failing with "k-NN plugin not installed",
+    // the probe has leaked back into an analysis-time path.
+    String explain =
+        explainQuery(
+            "SELECT v._id FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
+                + "LIMIT 5");
+
+    assertThat(explain, containsString("wrapper"));
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -13,7 +13,9 @@ import org.opensearch.index.query.WrapperQueryBuilder;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
+import org.opensearch.sql.opensearch.storage.capability.KnnPluginCapability;
 import org.opensearch.sql.opensearch.storage.scan.OpenSearchIndexScan;
+import org.opensearch.sql.opensearch.storage.scan.VectorSearchIndexScan;
 import org.opensearch.sql.opensearch.storage.scan.VectorSearchIndexScanBuilder;
 import org.opensearch.sql.opensearch.storage.scan.VectorSearchQueryBuilder;
 import org.opensearch.sql.storage.read.TableScanBuilder;
@@ -27,6 +29,27 @@ public class VectorSearchIndex extends OpenSearchIndex {
   private final float[] vector;
   private final Map<String, String> options;
   private final FilterType filterType; // null means default (POST)
+  // Nullable for back-compat with existing tests and the non-vector-search constructor. When
+  // present, the scan defers a lazy k-NN plugin probe to open() so execution fails fast with a
+  // clear SQL error if the plugin is missing.
+  private final KnnPluginCapability knnCapability;
+
+  public VectorSearchIndex(
+      OpenSearchClient client,
+      Settings settings,
+      String indexName,
+      String field,
+      float[] vector,
+      Map<String, String> options,
+      FilterType filterType,
+      KnnPluginCapability knnCapability) {
+    super(client, settings, indexName);
+    this.field = field;
+    this.vector = vector;
+    this.options = options;
+    this.filterType = filterType;
+    this.knnCapability = knnCapability;
+  }
 
   public VectorSearchIndex(
       OpenSearchClient client,
@@ -36,11 +59,7 @@ public class VectorSearchIndex extends OpenSearchIndex {
       float[] vector,
       Map<String, String> options,
       FilterType filterType) {
-    super(client, settings, indexName);
-    this.field = field;
-    this.vector = vector;
-    this.options = options;
-    this.filterType = filterType;
+    this(client, settings, indexName, field, vector, options, filterType, null);
   }
 
   /** Default constructor — preserves existing call sites; uses no explicit filter type. */
@@ -51,7 +70,7 @@ public class VectorSearchIndex extends OpenSearchIndex {
       String field,
       float[] vector,
       Map<String, String> options) {
-    this(client, settings, indexName, field, vector, options, null);
+    this(client, settings, indexName, field, vector, options, null, null);
   }
 
   @Override
@@ -89,11 +108,15 @@ public class VectorSearchIndex extends OpenSearchIndex {
     }
 
     Function<OpenSearchRequestBuilder, OpenSearchIndexScan> createScanOperator =
-        rb ->
-            new OpenSearchIndexScan(
-                getClient(),
-                rb.getMaxResponseSize(),
-                rb.build(getIndexName(), cursorKeepAlive, getClient(), getFieldTypes().isEmpty()));
+        rb -> {
+          var request =
+              rb.build(getIndexName(), cursorKeepAlive, getClient(), getFieldTypes().isEmpty());
+          if (knnCapability != null) {
+            return new VectorSearchIndexScan(
+                getClient(), rb.getMaxResponseSize(), request, knnCapability);
+          }
+          return new OpenSearchIndexScan(getClient(), rb.getMaxResponseSize(), request);
+        };
     return new VectorSearchIndexScanBuilder(queryBuilder, createScanOperator);
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -93,7 +93,10 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
 
   @Override
   public Table applyArguments() {
-    knnCapability.requireInstalled();
+    // Local validation runs first so that malformed queries return stable SQL validation errors
+    // regardless of cluster state. The k-NN plugin presence is checked later, lazily at scan
+    // open() time, so analysis-time paths (_explain, local validation) stay functional on
+    // clusters without k-NN.
     validateNamedArgs();
     String tableName = getArgumentValue(TABLE);
     String fieldName = getArgumentValue(FIELD);
@@ -112,7 +115,7 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     }
 
     return new VectorSearchIndex(
-        client, settings, tableName, fieldName, vector, options, filterType);
+        client, settings, tableName, fieldName, vector, options, filterType, knnCapability);
   }
 
   private float[] parseVector(String vectorLiteral) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -28,6 +28,7 @@ import org.opensearch.sql.expression.env.Environment;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.TableFunctionImplementation;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.storage.capability.KnnPluginCapability;
 import org.opensearch.sql.storage.Table;
 
 public class VectorSearchTableFunctionImplementation extends FunctionExpression
@@ -47,17 +48,20 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
   private final List<Expression> arguments;
   private final OpenSearchClient client;
   private final Settings settings;
+  private final KnnPluginCapability knnCapability;
 
   public VectorSearchTableFunctionImplementation(
       FunctionName functionName,
       List<Expression> arguments,
       OpenSearchClient client,
-      Settings settings) {
+      Settings settings,
+      KnnPluginCapability knnCapability) {
     super(functionName, arguments);
     this.functionName = functionName;
     this.arguments = arguments;
     this.client = client;
     this.settings = settings;
+    this.knnCapability = knnCapability;
   }
 
   @Override
@@ -89,6 +93,7 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
 
   @Override
   public Table applyArguments() {
+    knnCapability.requireInstalled();
     validateNamedArgs();
     String tableName = getArgumentValue(TABLE);
     String fieldName = getArgumentValue(FIELD);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolver.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolver.java
@@ -8,7 +8,6 @@ package org.opensearch.sql.opensearch.storage;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.expression.Expression;
@@ -17,8 +16,8 @@ import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.FunctionResolver;
 import org.opensearch.sql.expression.function.FunctionSignature;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.storage.capability.KnnPluginCapability;
 
-@RequiredArgsConstructor
 public class VectorSearchTableFunctionResolver implements FunctionResolver {
 
   public static final String VECTOR_SEARCH = "vectorsearch";
@@ -30,6 +29,18 @@ public class VectorSearchTableFunctionResolver implements FunctionResolver {
 
   private final OpenSearchClient client;
   private final Settings settings;
+  private final KnnPluginCapability knnCapability;
+
+  public VectorSearchTableFunctionResolver(OpenSearchClient client, Settings settings) {
+    this(client, settings, new KnnPluginCapability(client));
+  }
+
+  VectorSearchTableFunctionResolver(
+      OpenSearchClient client, Settings settings, KnnPluginCapability knnCapability) {
+    this.client = client;
+    this.settings = settings;
+    this.knnCapability = knnCapability;
+  }
 
   @Override
   public Pair<FunctionSignature, FunctionBuilder> resolve(FunctionSignature unresolvedSignature) {
@@ -40,7 +51,7 @@ public class VectorSearchTableFunctionResolver implements FunctionResolver {
         (functionProperties, arguments) -> {
           validateArguments(arguments);
           return new VectorSearchTableFunctionImplementation(
-              functionName, arguments, client, settings);
+              functionName, arguments, client, settings, knnCapability);
         };
     return Pair.of(functionSignature, functionBuilder);
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/capability/KnnPluginCapability.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/capability/KnnPluginCapability.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.capability;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.transport.client.node.NodeClient;
+
+/**
+ * Probes the cluster's Nodes Info API once and caches whether the k-NN plugin is installed, so
+ * vectorSearch() fails fast with a clear error when the plugin is absent instead of surfacing a
+ * native OpenSearch error deep in execution.
+ *
+ * <p>The probe requires a {@link NodeClient}. In REST-client mode (standalone SQL service) the node
+ * client is absent and the check is skipped — execution-time errors remain the signal there.
+ *
+ * <p>The check runs lazily on the first vectorSearch() invocation so cluster boot is unaffected.
+ */
+public class KnnPluginCapability {
+
+  /**
+   * Canonical k-NN plugin class. Using the class name (not artifact name) so the check is stable
+   * across packaging variants.
+   */
+  private static final String KNN_PLUGIN_CLASSNAME = "org.opensearch.knn.plugin.KNNPlugin";
+
+  private final OpenSearchClient client;
+  private final AtomicReference<Boolean> cached = new AtomicReference<>();
+
+  public KnnPluginCapability(OpenSearchClient client) {
+    this.client = client;
+  }
+
+  /**
+   * Throws {@link ExpressionEvaluationException} with a user-facing message if the k-NN plugin is
+   * not installed on any node in the cluster. The result is cached after the first successful
+   * probe; probe failures are not cached so the next call retries.
+   */
+  public void requireInstalled() {
+    Boolean hit = cached.get();
+    if (hit == null) {
+      Optional<Boolean> probed = probe();
+      if (probed.isEmpty()) {
+        // Probe unavailable (REST-client mode, no NodeClient). Don't block — execution-time
+        // errors will surface if k-NN is genuinely missing.
+        return;
+      }
+      hit = probed.get();
+      cached.set(hit);
+    }
+    if (!hit) {
+      throw new ExpressionEvaluationException(
+          "vectorSearch() requires the k-NN plugin, which is not installed on this cluster."
+              + " Install opensearch-knn or use a cluster that has it.");
+    }
+  }
+
+  private Optional<Boolean> probe() {
+    Optional<NodeClient> maybeNode = client.getNodeClient();
+    if (maybeNode.isEmpty()) {
+      return Optional.empty();
+    }
+    NodeClient node = maybeNode.get();
+    try {
+      NodesInfoRequest request = new NodesInfoRequest().clear().addMetric("plugins");
+      NodesInfoResponse response = node.admin().cluster().nodesInfo(request).actionGet();
+      boolean installed =
+          response.getNodes().stream()
+              .map(info -> info.getInfo(PluginsAndModules.class))
+              .filter(Objects::nonNull)
+              .flatMap(p -> p.getPluginInfos().stream())
+              .map(PluginInfo::getClassname)
+              .anyMatch(KNN_PLUGIN_CLASSNAME::equals);
+      return Optional.of(installed);
+    } catch (Exception e) {
+      // Probe failed (IO error, timeout). Don't cache — let the next call retry.
+      return Optional.empty();
+    }
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/capability/KnnPluginCapability.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/capability/KnnPluginCapability.java
@@ -24,7 +24,9 @@ import org.opensearch.transport.client.node.NodeClient;
  * <p>The probe requires a {@link NodeClient}. In REST-client mode (standalone SQL service) the node
  * client is absent and the check is skipped — execution-time errors remain the signal there.
  *
- * <p>The check runs lazily on the first vectorSearch() invocation so cluster boot is unaffected.
+ * <p>The check runs lazily at scan open() — i.e. only when a vectorSearch() query is actually
+ * executed — so analysis-time paths like _explain and local argument validation keep working on
+ * clusters without k-NN.
  */
 public class KnnPluginCapability {
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScan.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.scan;
+
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.request.OpenSearchRequest;
+import org.opensearch.sql.opensearch.storage.capability.KnnPluginCapability;
+
+/**
+ * OpenSearch scan for vector-search relations. Delegates everything to {@link OpenSearchIndexScan}
+ * except for {@link #open()}, where it first verifies the k-NN plugin is installed so we fail fast
+ * with a clear SQL error before the native request would fail deep in execution. The check is
+ * deferred to open() (not applyArguments() or the scan builder) so that analysis-time paths like
+ * _explain continue to work on clusters without k-NN.
+ */
+public class VectorSearchIndexScan extends OpenSearchIndexScan {
+
+  private final KnnPluginCapability knnCapability;
+
+  public VectorSearchIndexScan(
+      OpenSearchClient client,
+      int maxResponseSize,
+      OpenSearchRequest request,
+      KnnPluginCapability knnCapability) {
+    super(client, maxResponseSize, request);
+    this.knnCapability = knnCapability;
+  }
+
+  @Override
+  public void open() {
+    knnCapability.requireInstalled();
+    super.open();
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
@@ -11,10 +11,9 @@ import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
 
 /**
- * Scan builder for vector search relations. Rejects aggregation pushdown as a SQL preview
- * constraint: aggregations over vectorSearch() relations are not supported in the current preview.
- * Native OpenSearch k-NN does support aggregations alongside similarity search; this restriction is
- * specific to the SQL surface and may be lifted in a later release.
+ * Scan builder for vector search relations. Rejects aggregation pushdown: aggregations over
+ * vectorSearch() relations are not supported in the SQL surface. Native OpenSearch k-NN does
+ * support aggregations alongside similarity search; this restriction is specific to the SQL layer.
  */
 public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
 
@@ -27,6 +26,6 @@ public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
   @Override
   public boolean pushDownAggregation(LogicalAggregation aggregation) {
     throw new ExpressionEvaluationException(
-        "Aggregations are not supported on vectorSearch() relations in the SQL preview.");
+        "Aggregations are not supported on vectorSearch() relations.");
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -68,12 +68,11 @@ class VectorSearchTableFunctionImplementationTest {
   }
 
   @Test
-  void testApplyArgumentsPropagatesKnnCapabilityFailure() {
-    // If the capability check fires, applyArguments() must not proceed to build the table.
-    KnnPluginCapability throwingCapability = org.mockito.Mockito.mock(KnnPluginCapability.class);
-    org.mockito.Mockito.doThrow(new ExpressionEvaluationException("k-NN plugin not installed"))
-        .when(throwingCapability)
-        .requireInstalled();
+  void testApplyArgumentsDoesNotProbeKnnCapability() {
+    // Contract: applyArguments() runs during analysis (including _explain) and must NOT invoke
+    // the k-NN plugin probe. The probe is deferred to scan open() so pluginless clusters can
+    // still explain and validate vectorSearch() queries locally.
+    KnnPluginCapability observingCapability = org.mockito.Mockito.mock(KnnPluginCapability.class);
     FunctionName functionName = FunctionName.of("vectorsearch");
     List<Expression> args =
         List.of(
@@ -83,10 +82,9 @@ class VectorSearchTableFunctionImplementationTest {
             DSL.namedArgument("option", DSL.literal("k=5")));
     VectorSearchTableFunctionImplementation impl =
         new VectorSearchTableFunctionImplementation(
-            functionName, args, client, settings, throwingCapability);
-    ExpressionEvaluationException ex =
-        assertThrows(ExpressionEvaluationException.class, impl::applyArguments);
-    assertTrue(ex.getMessage().contains("k-NN plugin"));
+            functionName, args, client, settings, observingCapability);
+    impl.applyArguments();
+    org.mockito.Mockito.verify(observingCapability, org.mockito.Mockito.never()).requireInstalled();
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -22,6 +22,7 @@ import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.storage.capability.KnnPluginCapability;
 import org.opensearch.sql.storage.Table;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +31,11 @@ class VectorSearchTableFunctionImplementationTest {
   @Mock private OpenSearchClient client;
 
   @Mock private Settings settings;
+
+  // No-op capability — tests in this class don't exercise the k-NN plugin probe.
+  // Dedicated tests for the probe live in KnnPluginCapabilityTest.
+  private final KnnPluginCapability knnCapability =
+      org.mockito.Mockito.mock(KnnPluginCapability.class);
 
   @Test
   void testValueOfThrows() {
@@ -59,6 +65,28 @@ class VectorSearchTableFunctionImplementationTest {
     VectorSearchTableFunctionImplementation impl = createImpl();
     Table table = impl.applyArguments();
     assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void testApplyArgumentsPropagatesKnnCapabilityFailure() {
+    // If the capability check fires, applyArguments() must not proceed to build the table.
+    KnnPluginCapability throwingCapability = org.mockito.Mockito.mock(KnnPluginCapability.class);
+    org.mockito.Mockito.doThrow(new ExpressionEvaluationException("k-NN plugin not installed"))
+        .when(throwingCapability)
+        .requireInstalled();
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> args =
+        List.of(
+            DSL.namedArgument("table", DSL.literal("my-index")),
+            DSL.namedArgument("field", DSL.literal("embedding")),
+            DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")),
+            DSL.namedArgument("option", DSL.literal("k=5")));
+    VectorSearchTableFunctionImplementation impl =
+        new VectorSearchTableFunctionImplementation(
+            functionName, args, client, settings, throwingCapability);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, impl::applyArguments);
+    assertTrue(ex.getMessage().contains("k-NN plugin"));
   }
 
   @Test
@@ -183,7 +211,8 @@ class VectorSearchTableFunctionImplementationTest {
             DSL.namedArgument("field", DSL.literal("embedding")),
             DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")));
     VectorSearchTableFunctionImplementation impl =
-        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+        new VectorSearchTableFunctionImplementation(
+            functionName, args, client, settings, knnCapability);
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
     assertEquals("Missing required argument: option", ex.getMessage());
@@ -297,7 +326,8 @@ class VectorSearchTableFunctionImplementationTest {
     FunctionName functionName = FunctionName.of("vectorsearch");
     List<Expression> args = List.of(DSL.literal("my-index"));
     VectorSearchTableFunctionImplementation impl =
-        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+        new VectorSearchTableFunctionImplementation(
+            functionName, args, client, settings, knnCapability);
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
     assertTrue(ex.getMessage().contains("requires named arguments"));
@@ -313,7 +343,8 @@ class VectorSearchTableFunctionImplementationTest {
             DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")),
             DSL.namedArgument("option", DSL.literal("k=5")));
     VectorSearchTableFunctionImplementation impl =
-        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+        new VectorSearchTableFunctionImplementation(
+            functionName, args, client, settings, knnCapability);
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
     assertTrue(ex.getMessage().contains("requires named arguments"));
@@ -383,7 +414,8 @@ class VectorSearchTableFunctionImplementationTest {
             DSL.namedArgument("VECTOR", DSL.literal("[1.0, 2.0]")),
             DSL.namedArgument("OPTION", DSL.literal("k=5")));
     VectorSearchTableFunctionImplementation impl =
-        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+        new VectorSearchTableFunctionImplementation(
+            functionName, args, client, settings, knnCapability);
     Table table = impl.applyArguments();
     assertTrue(table instanceof VectorSearchIndex);
   }
@@ -398,7 +430,8 @@ class VectorSearchTableFunctionImplementationTest {
             DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")),
             DSL.namedArgument("option", DSL.literal("k=5,filter_type=invalid")));
     VectorSearchTableFunctionImplementation impl =
-        new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+        new VectorSearchTableFunctionImplementation(
+            functionName, args, client, settings, knnCapability);
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, impl::applyArguments);
     assertTrue(ex.getMessage().contains("filter_type must be one of"));
@@ -440,6 +473,7 @@ class VectorSearchTableFunctionImplementationTest {
             DSL.namedArgument("field", DSL.literal(field)),
             DSL.namedArgument("vector", DSL.literal(vector)),
             DSL.namedArgument("option", DSL.literal(option)));
-    return new VectorSearchTableFunctionImplementation(functionName, args, client, settings);
+    return new VectorSearchTableFunctionImplementation(
+        functionName, args, client, settings, knnCapability);
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/capability/KnnPluginCapabilityTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/capability/KnnPluginCapabilityTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.capability;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.action.admin.cluster.node.info.NodeInfo;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.ClusterAdminClient;
+import org.opensearch.transport.client.node.NodeClient;
+
+@ExtendWith(MockitoExtension.class)
+class KnnPluginCapabilityTest {
+
+  @Mock private OpenSearchClient client;
+  @Mock private NodeClient nodeClient;
+  @Mock private AdminClient adminClient;
+  @Mock private ClusterAdminClient clusterAdminClient;
+  @Mock private ActionFuture<NodesInfoResponse> nodesInfoFuture;
+
+  @Test
+  void skipsWhenNodeClientAbsent() {
+    when(client.getNodeClient()).thenReturn(Optional.empty());
+    KnnPluginCapability capability = new KnnPluginCapability(client);
+    // No exception — REST-client mode cannot probe; execution-time errors remain the signal.
+    assertDoesNotThrow(capability::requireInstalled);
+  }
+
+  @Test
+  void passesWhenKnnPluginInstalled() {
+    stubNodesInfo(pluginInfo("org.opensearch.knn.plugin.KNNPlugin"));
+    KnnPluginCapability capability = new KnnPluginCapability(client);
+    assertDoesNotThrow(capability::requireInstalled);
+  }
+
+  @Test
+  void throwsWhenKnnPluginAbsent() {
+    stubNodesInfo(pluginInfo("org.opensearch.security.OpenSearchSecurityPlugin"));
+    KnnPluginCapability capability = new KnnPluginCapability(client);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, capability::requireInstalled);
+    assertTrue(
+        ex.getMessage().contains("k-NN plugin"),
+        "Expected k-NN plugin message, got: " + ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("not installed"),
+        "Expected 'not installed' phrasing, got: " + ex.getMessage());
+  }
+
+  @Test
+  void cachesSuccessfulProbeResult() {
+    stubNodesInfo(pluginInfo("org.opensearch.knn.plugin.KNNPlugin"));
+    KnnPluginCapability capability = new KnnPluginCapability(client);
+    capability.requireInstalled();
+    capability.requireInstalled();
+    capability.requireInstalled();
+    // Probe fires once regardless of how many times requireInstalled() is called.
+    verify(clusterAdminClient, times(1)).nodesInfo(any(NodesInfoRequest.class));
+  }
+
+  @Test
+  void cachesNegativeProbeResult() {
+    stubNodesInfo(pluginInfo("org.opensearch.security.OpenSearchSecurityPlugin"));
+    KnnPluginCapability capability = new KnnPluginCapability(client);
+    assertThrows(ExpressionEvaluationException.class, capability::requireInstalled);
+    assertThrows(ExpressionEvaluationException.class, capability::requireInstalled);
+    verify(clusterAdminClient, times(1)).nodesInfo(any(NodesInfoRequest.class));
+  }
+
+  @Test
+  void doesNotCacheOnProbeFailure() {
+    when(client.getNodeClient()).thenReturn(Optional.of(nodeClient));
+    when(nodeClient.admin()).thenReturn(adminClient);
+    when(adminClient.cluster()).thenReturn(clusterAdminClient);
+    when(clusterAdminClient.nodesInfo(any(NodesInfoRequest.class))).thenReturn(nodesInfoFuture);
+    when(nodesInfoFuture.actionGet()).thenThrow(new RuntimeException("transport error"));
+
+    KnnPluginCapability capability = new KnnPluginCapability(client);
+    assertDoesNotThrow(capability::requireInstalled); // probe failed — treat as unknown
+    assertDoesNotThrow(capability::requireInstalled);
+    // Probe retries on each call after a failure — failures are not cached.
+    verify(clusterAdminClient, times(2)).nodesInfo(any(NodesInfoRequest.class));
+  }
+
+  private void stubNodesInfo(PluginInfo... plugins) {
+    when(client.getNodeClient()).thenReturn(Optional.of(nodeClient));
+    when(nodeClient.admin()).thenReturn(adminClient);
+    when(adminClient.cluster()).thenReturn(clusterAdminClient);
+    when(clusterAdminClient.nodesInfo(any(NodesInfoRequest.class))).thenReturn(nodesInfoFuture);
+
+    NodeInfo nodeInfo = mock(NodeInfo.class);
+    PluginsAndModules pam = mock(PluginsAndModules.class);
+    when(nodeInfo.getInfo(PluginsAndModules.class)).thenReturn(pam);
+    when(pam.getPluginInfos()).thenReturn(List.of(plugins));
+
+    NodesInfoResponse response = mock(NodesInfoResponse.class);
+    when(response.getNodes()).thenReturn(List.of(nodeInfo));
+    when(nodesInfoFuture.actionGet()).thenReturn(response);
+  }
+
+  private PluginInfo pluginInfo(String classname) {
+    PluginInfo pluginInfo = mock(PluginInfo.class);
+    when(pluginInfo.getClassname()).thenReturn(classname);
+    return pluginInfo;
+  }
+}

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.scan;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.opensearch.client.OpenSearchClient;
+import org.opensearch.sql.opensearch.request.OpenSearchRequest;
+import org.opensearch.sql.opensearch.storage.capability.KnnPluginCapability;
+
+class VectorSearchIndexScanTest {
+
+  @Test
+  void openProbesKnnPluginBeforeFetch() {
+    OpenSearchClient client = mock(OpenSearchClient.class);
+    OpenSearchRequest request = mock(OpenSearchRequest.class);
+    KnnPluginCapability capability = mock(KnnPluginCapability.class);
+    doThrow(new ExpressionEvaluationException("k-NN plugin missing"))
+        .when(capability)
+        .requireInstalled();
+
+    VectorSearchIndexScan scan = new VectorSearchIndexScan(client, 10, request, capability);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, scan::open);
+    assertTrue(ex.getMessage().contains("k-NN plugin"));
+    // Capability threw, so the underlying client must not have been touched for this scan.
+    verify(client, never()).search(request);
+  }
+}


### PR DESCRIPTION
## Summary
- Today, when `vectorSearch()` is invoked on a cluster without the k-NN plugin, the query proceeds and surfaces a cryptic native OpenSearch error deep in execution. This PR adds a lazy capability probe that runs at scan open() time and throws a clear message when k-NN is absent.
- `KnnPluginCapability` probes Nodes Info once via `NodeClient` and caches the result (positive or negative). Probe failures (IO, timeout) are not cached — subsequent calls retry. If no `NodeClient` is available (REST-client / standalone mode), the check is skipped and execution-time errors remain the signal there.
- The probe runs at `VectorSearchIndexScan.open()`, **not** during analysis (`applyArguments()`). This preserves the existing contract that `_explain` and local argument validation work on clusters without k-NN — the probe only fires when a vectorSearch() query is actually executed.

## Scope
This is "fail fast at execution time when a NodeClient is available," not universal fail-fast. In REST-client / standalone SQL-service mode, the probe is skipped and the clear error only fires on NodeClient-hosted clusters. Cross-cluster wiring is out of scope.

## Why not check at plugin registration?
Failing at registration would break introspection (`SHOW FUNCTIONS`, etc.) on clusters without k-NN, and would couple SQL-plugin boot to k-NN-plugin boot order. Lazy probing avoids both problems and still fails fast at first use.

## Why check class name, not artifact name?
Using the canonical plugin class name (`org.opensearch.knn.plugin.KNNPlugin`) keeps the check stable across repackaging / shading variants.

## Why defer the check to scan open() instead of applyArguments()?
`applyArguments()` runs during analysis for both `_query` and `_explain`. Placing the check there regressed two existing contracts on pluginless clusters:
1. `VectorSearchExplainIT` explicitly asserts "_explain only parses and plans the query and does NOT require the k-NN plugin."
2. `VectorSearchIT` is the local SQL validation suite — malformed queries should return stable SQL errors regardless of cluster state.

Scan `open()` runs only on the execute path; `_explain` walks the built plan without opening it, so explain continues to work without k-NN.

## Behavior matrix
| Scenario | Result |
|---|---|
| k-NN installed, NodeClient available | Probe once at first execute, cache true, subsequent calls are no-ops |
| k-NN absent, NodeClient available | Probe once at first execute, cache false, subsequent executes throw `ExpressionEvaluationException` |
| NodeClient absent (REST-client mode) | Skip probe; execution-time errors remain the signal |
| Probe transport error | Don't cache; retry on next call |
| `_explain` on any cluster | Probe does not run; existing plan shape returned |
| Local SQL validation (malformed query) on pluginless cluster | Existing SQL validation errors; probe does not run |

## User-facing error
```
vectorSearch() requires the k-NN plugin, which is not installed on this cluster.
Install opensearch-knn or use a cluster that has it.
```

## Test plan
- [x] `./gradlew :opensearch:test --tests "*KnnPluginCapability*"` — probe behavior unit tests
- [x] `./gradlew :opensearch:test --tests "*VectorSearchIndexScan*"` — new test confirms `open()` invokes the probe and throws before touching the client
- [x] `./gradlew :opensearch:test --tests "*VectorSearchTableFunctionImplementation*"` — includes new `testApplyArgumentsDoesNotProbeKnnCapability` guarding the analysis-time contract
- [x] `./gradlew :opensearch:test` — full module green
- [x] `./gradlew :integ-test:integTest --tests "*VectorSearchExplainIT"` — pluginless `_explain` keeps working
- [x] `./gradlew :integ-test:integTest --tests "*VectorSearchIT"` — includes two new ITs:
  - `testExecutionWithoutKnnPluginReturnsCapabilityError` — execute path on pluginless cluster returns the clear "k-NN plugin not installed" error
  - `testExplainWithoutKnnPluginStillWorks` — guards the explain contract so future probe relocations can't silently break it
- [x] `./gradlew :opensearch:spotlessCheck :integ-test:spotlessCheck`