### PR TITLE
[Enhancement] Fix error messages for invalid index mapping

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
@@ -102,7 +102,11 @@ public class OpenSearchNodeClient implements OpenSearchClient {
       throw e;
     } catch (Exception e) {
       throw new IllegalStateException(
-          "Failed to read mapping for index pattern [" + indexExpression + "]", e);
+          "Failed to read mapping for index pattern ["
+              + String.join(",", indexExpression)
+              + "]: "
+              + e.getMessage(),
+          e);
     }
   }
 
@@ -132,7 +136,11 @@ public class OpenSearchNodeClient implements OpenSearchClient {
       throw e;
     } catch (Exception e) {
       throw new IllegalStateException(
-          "Failed to read setting for index pattern [" + indexExpression + "]", e);
+          "Failed to read setting for index pattern ["
+              + String.join(",", indexExpression)
+              + "]: "
+              + e.getMessage(),
+          e);
     }
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchRestClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchRestClient.java
@@ -80,7 +80,10 @@ public class OpenSearchRestClient implements OpenSearchClient {
           .collect(Collectors.toMap(Map.Entry::getKey, e -> new IndexMapping(e.getValue())));
     } catch (IOException e) {
       throw new IllegalStateException(
-          "Failed to get index mappings for " + String.join(",", indexExpression) + ": " + e.getMessage(),
+          "Failed to get index mappings for "
+              + String.join(",", indexExpression)
+              + ": "
+              + e.getMessage(),
           e);
     }
   }
@@ -114,7 +117,10 @@ public class OpenSearchRestClient implements OpenSearchClient {
       return result;
     } catch (IOException e) {
       throw new IllegalStateException(
-          "Failed to get max result window for " + String.join(",", indexExpression) + ": " + e.getMessage(),
+          "Failed to get max result window for "
+              + String.join(",", indexExpression)
+              + ": "
+              + e.getMessage(),
           e);
     }
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchRestClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchRestClient.java
@@ -79,7 +79,9 @@ public class OpenSearchRestClient implements OpenSearchClient {
       return response.mappings().entrySet().stream()
           .collect(Collectors.toMap(Map.Entry::getKey, e -> new IndexMapping(e.getValue())));
     } catch (IOException e) {
-      throw new IllegalStateException("Failed to get index mappings for " + indexExpression, e);
+      throw new IllegalStateException(
+          "Failed to get index mappings for " + String.join(",", indexExpression) + ": " + e.getMessage(),
+          e);
     }
   }
 
@@ -111,7 +113,9 @@ public class OpenSearchRestClient implements OpenSearchClient {
 
       return result;
     } catch (IOException e) {
-      throw new IllegalStateException("Failed to get max result window for " + indexExpression, e);
+      throw new IllegalStateException(
+          "Failed to get max result window for " + String.join(",", indexExpression) + ": " + e.getMessage(),
+          e);
     }
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -495,57 +495,62 @@ class OpenSearchNodeClientTest {
 
   @Test
   void get_index_mappings_error_message_includes_single_index() {
-    when(nodeClient.admin().indices()).thenThrow(new RuntimeException("Connection timeout"));
+    String underlyingError = "Connection timeout";
+    when(nodeClient.admin().indices()).thenThrow(new RuntimeException(underlyingError));
 
-    IllegalStateException exception = assertThrows(
-        IllegalStateException.class,
-        () -> client.getIndexMappings("test_index")
-    );
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> client.getIndexMappings("test_index"));
 
-    assertTrue(exception.getMessage().contains("test_index"));
+    assertAll(
+        () -> assertTrue(exception.getMessage().contains("test_index")),
+        () -> assertTrue(exception.getMessage().contains(underlyingError)));
   }
 
   @Test
   void get_index_mappings_error_message_includes_multiple_indices() {
-    when(nodeClient.admin().indices()).thenThrow(new RuntimeException("Access denied"));
+    String underlyingError = "Access denied";
+    when(nodeClient.admin().indices()).thenThrow(new RuntimeException(underlyingError));
 
-    IllegalStateException exception = assertThrows(
-        IllegalStateException.class,
-        () -> client.getIndexMappings("index1", "index2", "index3")
-    );
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> client.getIndexMappings("index1", "index2", "index3"));
 
     assertAll(
         () -> assertTrue(exception.getMessage().contains("index1")),
         () -> assertTrue(exception.getMessage().contains("index2")),
-        () -> assertTrue(exception.getMessage().contains("index3"))
-    );
+        () -> assertTrue(exception.getMessage().contains("index3")),
+        () -> assertTrue(exception.getMessage().contains(underlyingError)));
   }
 
   @Test
   void get_index_max_result_windows_error_message_includes_single_index() {
-    when(nodeClient.admin().indices()).thenThrow(new RuntimeException("Network error"));
+    String underlyingError = "Network error";
+    when(nodeClient.admin().indices()).thenThrow(new RuntimeException(underlyingError));
 
-    IllegalStateException exception = assertThrows(
-        IllegalStateException.class,
-        () -> client.getIndexMaxResultWindows("test_index")
-    );
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class, () -> client.getIndexMaxResultWindows("test_index"));
 
-    assertTrue(exception.getMessage().contains("test_index"));
+    assertAll(
+        () -> assertTrue(exception.getMessage().contains("test_index")),
+        () -> assertTrue(exception.getMessage().contains(underlyingError)));
   }
 
   @Test
   void get_index_max_result_windows_error_message_includes_multiple_indices() {
-    when(nodeClient.admin().indices()).thenThrow(new RuntimeException("Permission denied"));
+    String underlyingError = "Permission denied";
+    when(nodeClient.admin().indices()).thenThrow(new RuntimeException(underlyingError));
 
-    IllegalStateException exception = assertThrows(
-        IllegalStateException.class,
-        () -> client.getIndexMaxResultWindows("logs-2024", "metrics-2024")
-    );
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> client.getIndexMaxResultWindows("logs-2024", "metrics-2024"));
 
     assertAll(
         () -> assertTrue(exception.getMessage().contains("logs-2024")),
-        () -> assertTrue(exception.getMessage().contains("metrics-2024"))
-    );
+        () -> assertTrue(exception.getMessage().contains("metrics-2024")),
+        () -> assertTrue(exception.getMessage().contains(underlyingError)));
   }
 
   public void mockNodeClientIndicesMappings(String indexName, String mappings) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -493,6 +493,61 @@ class OpenSearchNodeClientTest {
     assertNotNull(client.getNodeClient());
   }
 
+  @Test
+  void get_index_mappings_error_message_includes_single_index() {
+    when(nodeClient.admin().indices()).thenThrow(new RuntimeException("Connection timeout"));
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> client.getIndexMappings("test_index")
+    );
+
+    assertTrue(exception.getMessage().contains("test_index"));
+  }
+
+  @Test
+  void get_index_mappings_error_message_includes_multiple_indices() {
+    when(nodeClient.admin().indices()).thenThrow(new RuntimeException("Access denied"));
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> client.getIndexMappings("index1", "index2", "index3")
+    );
+
+    assertAll(
+        () -> assertTrue(exception.getMessage().contains("index1")),
+        () -> assertTrue(exception.getMessage().contains("index2")),
+        () -> assertTrue(exception.getMessage().contains("index3"))
+    );
+  }
+
+  @Test
+  void get_index_max_result_windows_error_message_includes_single_index() {
+    when(nodeClient.admin().indices()).thenThrow(new RuntimeException("Network error"));
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> client.getIndexMaxResultWindows("test_index")
+    );
+
+    assertTrue(exception.getMessage().contains("test_index"));
+  }
+
+  @Test
+  void get_index_max_result_windows_error_message_includes_multiple_indices() {
+    when(nodeClient.admin().indices()).thenThrow(new RuntimeException("Permission denied"));
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> client.getIndexMaxResultWindows("logs-2024", "metrics-2024")
+    );
+
+    assertAll(
+        () -> assertTrue(exception.getMessage().contains("logs-2024")),
+        () -> assertTrue(exception.getMessage().contains("metrics-2024"))
+    );
+  }
+
   public void mockNodeClientIndicesMappings(String indexName, String mappings) {
     GetMappingsResponse mockResponse = mock(GetMappingsResponse.class);
     MappingMetadata emptyMapping = mock(MappingMetadata.class);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
@@ -531,6 +531,65 @@ class OpenSearchRestClientTest {
     assertEquals(Optional.empty(), client.getNodeClient());
   }
 
+  @Test
+  void get_index_mappings_error_message_includes_single_index() throws IOException {
+    when(restClient.indices().getMapping(any(GetMappingsRequest.class), any()))
+        .thenThrow(new IOException("Network timeout"));
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> client.getIndexMappings("test_index")
+    );
+
+    assertTrue(exception.getMessage().contains("test_index"));
+  }
+
+  @Test
+  void get_index_mappings_error_message_includes_multiple_indices() throws IOException {
+    when(restClient.indices().getMapping(any(GetMappingsRequest.class), any()))
+        .thenThrow(new IOException("Connection refused"));
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> client.getIndexMappings("index1", "index2", "index3")
+    );
+
+    assertAll(
+        () -> assertTrue(exception.getMessage().contains("index1")),
+        () -> assertTrue(exception.getMessage().contains("index2")),
+        () -> assertTrue(exception.getMessage().contains("index3"))
+    );
+  }
+
+  @Test
+  void get_index_max_result_windows_error_message_includes_single_index() throws IOException {
+    when(restClient.indices().getSettings(any(GetSettingsRequest.class), any()))
+        .thenThrow(new IOException("Authentication failed"));
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> client.getIndexMaxResultWindows("test_index")
+    );
+
+    assertTrue(exception.getMessage().contains("test_index"));
+  }
+
+  @Test
+  void get_index_max_result_windows_error_message_includes_multiple_indices() throws IOException {
+    when(restClient.indices().getSettings(any(GetSettingsRequest.class), any()))
+        .thenThrow(new IOException("Timeout"));
+
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class,
+        () -> client.getIndexMaxResultWindows("logs-2024", "metrics-2024")
+    );
+
+    assertAll(
+        () -> assertTrue(exception.getMessage().contains("logs-2024")),
+        () -> assertTrue(exception.getMessage().contains("metrics-2024"))
+    );
+  }
+
   private Map<String, MappingMetadata> mockFieldMappings(String indexName, String mappings)
       throws IOException {
     return ImmutableMap.of(indexName, IndexMetadata.fromXContent(createParser(mappings)).mapping());

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
@@ -533,61 +533,66 @@ class OpenSearchRestClientTest {
 
   @Test
   void get_index_mappings_error_message_includes_single_index() throws IOException {
+    String underlyingError = "Network timeout";
     when(restClient.indices().getMapping(any(GetMappingsRequest.class), any()))
-        .thenThrow(new IOException("Network timeout"));
+        .thenThrow(new IOException(underlyingError));
 
-    IllegalStateException exception = assertThrows(
-        IllegalStateException.class,
-        () -> client.getIndexMappings("test_index")
-    );
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> client.getIndexMappings("test_index"));
 
-    assertTrue(exception.getMessage().contains("test_index"));
+    assertAll(
+        () -> assertTrue(exception.getMessage().contains("test_index")),
+        () -> assertTrue(exception.getMessage().contains(underlyingError)));
   }
 
   @Test
   void get_index_mappings_error_message_includes_multiple_indices() throws IOException {
+    String underlyingError = "Connection refused";
     when(restClient.indices().getMapping(any(GetMappingsRequest.class), any()))
-        .thenThrow(new IOException("Connection refused"));
+        .thenThrow(new IOException(underlyingError));
 
-    IllegalStateException exception = assertThrows(
-        IllegalStateException.class,
-        () -> client.getIndexMappings("index1", "index2", "index3")
-    );
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> client.getIndexMappings("index1", "index2", "index3"));
 
     assertAll(
         () -> assertTrue(exception.getMessage().contains("index1")),
         () -> assertTrue(exception.getMessage().contains("index2")),
-        () -> assertTrue(exception.getMessage().contains("index3"))
-    );
+        () -> assertTrue(exception.getMessage().contains("index3")),
+        () -> assertTrue(exception.getMessage().contains(underlyingError)));
   }
 
   @Test
   void get_index_max_result_windows_error_message_includes_single_index() throws IOException {
+    String underlyingError = "Authentication failed";
     when(restClient.indices().getSettings(any(GetSettingsRequest.class), any()))
-        .thenThrow(new IOException("Authentication failed"));
+        .thenThrow(new IOException(underlyingError));
 
-    IllegalStateException exception = assertThrows(
-        IllegalStateException.class,
-        () -> client.getIndexMaxResultWindows("test_index")
-    );
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class, () -> client.getIndexMaxResultWindows("test_index"));
 
-    assertTrue(exception.getMessage().contains("test_index"));
+    assertAll(
+        () -> assertTrue(exception.getMessage().contains("test_index")),
+        () -> assertTrue(exception.getMessage().contains(underlyingError)));
   }
 
   @Test
   void get_index_max_result_windows_error_message_includes_multiple_indices() throws IOException {
+    String underlyingError = "Timeout";
     when(restClient.indices().getSettings(any(GetSettingsRequest.class), any()))
-        .thenThrow(new IOException("Timeout"));
+        .thenThrow(new IOException(underlyingError));
 
-    IllegalStateException exception = assertThrows(
-        IllegalStateException.class,
-        () -> client.getIndexMaxResultWindows("logs-2024", "metrics-2024")
-    );
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> client.getIndexMaxResultWindows("logs-2024", "metrics-2024"));
 
     assertAll(
         () -> assertTrue(exception.getMessage().contains("logs-2024")),
-        () -> assertTrue(exception.getMessage().contains("metrics-2024"))
-    );
+        () -> assertTrue(exception.getMessage().contains("metrics-2024")),
+        () -> assertTrue(exception.getMessage().contains(underlyingError)));
   }
 
   private Map<String, MappingMetadata> mockFieldMappings(String indexName, String mappings)


### PR DESCRIPTION
### Description
## Summary

Improves error message clarity in OpenSearch client operations by properly formatting index patterns and including underlying error details.

When operations like getIndexMappings() or getIndexMaxResultWindows() failed with multiple indices, error messages showed unhelpful Java array representations like ```[Ljava.lang.String;@12345``` instead of readable index names, and didn't include the underlying error details.

  - Format index arrays properly: Use String.join(",", indexExpression) to display index1,index2,index3 instead of Java array toString
  - Include underlying error details: Append ": " + e.getMessage() to preserve original error context
  - Consistent across both clients: Applied fix to both OpenSearchNodeClient and OpenSearchRestClient

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
