### PR TITLE
[Maintenance] Bump to 3.7.0-SNAPSHOT and fix OpenSearchJsonContent for Jackson 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.6.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.7.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         version_tokens = opensearch_version.tokenize('-')

--- a/legacy/src/main/java/org/opensearch/sql/legacy/domain/hints/HintFactory.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/domain/hints/HintFactory.java
@@ -5,15 +5,14 @@
 
 package org.opensearch.sql.legacy.domain.hints;
 
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.common.xcontent.yaml.YamlXContentParser;
+import org.opensearch.common.xcontent.yaml.YamlXContent;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.sql.legacy.exception.SqlParseException;
 
 /** Created by Eliran on 5/9/2015. */
@@ -104,13 +103,9 @@ public class HintFactory {
           builder.append(highlights[i]);
         }
         String heighlightParam = builder.toString();
-        YAMLFactory yamlFactory = new YAMLFactory();
-        YAMLParser yamlParser = null;
-        try {
-          yamlParser = yamlFactory.createParser(heighlightParam.toCharArray());
-          YamlXContentParser yamlXContentParser =
-              new YamlXContentParser(
-                  NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, yamlParser);
+        try (XContentParser yamlXContentParser =
+            YamlXContent.yamlXContent.createParser(
+                NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, heighlightParam)) {
           Map<String, Object> map = yamlXContentParser.map();
           hintParams.add(map);
         } catch (IOException e) {

--- a/legacy/src/main/java/org/opensearch/sql/legacy/query/QueryAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/query/QueryAction.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.legacy.query;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,8 +13,9 @@ import java.util.Optional;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.common.xcontent.json.JsonXContentParser;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
@@ -88,16 +88,15 @@ public abstract class QueryAction {
 
   protected void updateRequestWithCollapse(Select select, SearchRequestBuilder request)
       throws SqlParseException {
-    JsonFactory jsonFactory = new JsonFactory();
     for (Hint hint : select.getHints()) {
       if (hint.getType() == HintType.COLLAPSE
           && hint.getParams() != null
           && 0 < hint.getParams().length) {
-        try (JsonXContentParser parser =
-            new JsonXContentParser(
+        try (XContentParser parser =
+            JsonXContent.jsonXContent.createParser(
                 NamedXContentRegistry.EMPTY,
                 LoggingDeprecationHandler.INSTANCE,
-                jsonFactory.createParser(hint.getParams()[0].toString()))) {
+                hint.getParams()[0].toString())) {
           request.setCollapse(CollapseBuilder.fromXContent(parser));
         } catch (IOException e) {
           throw new SqlParseException("could not parse collapse hint: " + e.getMessage());

--- a/legacy/src/main/java/org/opensearch/sql/legacy/query/maker/AggMaker.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/query/maker/AggMaker.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.legacy.query.maker;
 
 import com.alibaba.druid.sql.ast.expr.SQLAggregateOption;
-import com.fasterxml.jackson.core.JsonFactory;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.ZoneOffset;
@@ -19,7 +18,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.json.JsonXContent;
-import org.opensearch.common.xcontent.json.JsonXContentParser;
 import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -340,11 +338,9 @@ public class AggMaker {
               terms.order(BucketOrder.key(false));
             } else {
               List<BucketOrder> orderElements = new ArrayList<>();
-              try (JsonXContentParser parser =
-                  new JsonXContentParser(
-                      NamedXContentRegistry.EMPTY,
-                      LoggingDeprecationHandler.INSTANCE,
-                      new JsonFactory().createParser(value))) {
+              try (XContentParser parser =
+                  JsonXContent.jsonXContent.createParser(
+                      NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, value)) {
                 XContentParser.Token currentToken = parser.nextToken();
                 if (currentToken == XContentParser.Token.START_OBJECT) {
                   orderElements.add(InternalOrder.Parser.parseOrderParam(parser));

--- a/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequest.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequest.java
@@ -5,14 +5,13 @@
 
 package org.opensearch.sql.legacy.request;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import java.io.IOException;
 import java.util.Collections;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
-import org.opensearch.common.xcontent.json.JsonXContentParser;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -90,10 +89,10 @@ public class SqlRequest {
       String filter = getFilterObjectAsString(jsonContent);
       SearchModule searchModule = new SearchModule(Settings.EMPTY, Collections.emptyList());
       XContentParser parser =
-          new JsonXContentParser(
+          JsonXContent.jsonXContent.createParser(
               new NamedXContentRegistry(searchModule.getNamedXContents()),
               LoggingDeprecationHandler.INSTANCE,
-              new JsonFactory().createParser(filter));
+              filter);
 
       // nextToken is called before passing the parser to fromXContent since the fieldName will be
       // null if the

--- a/legacy/src/main/java/org/opensearch/sql/legacy/utils/JsonPrettyFormatter.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/utils/JsonPrettyFormatter.java
@@ -5,11 +5,10 @@
 
 package org.opensearch.sql.legacy.utils;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import java.io.IOException;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.json.JsonXContentParser;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
@@ -26,10 +25,8 @@ public class JsonPrettyFormatter {
     // turn _explain response into pretty formatted Json
     XContentBuilder contentBuilder = XContentFactory.jsonBuilder().prettyPrint();
     try (XContentParser contentParser =
-        new JsonXContentParser(
-            NamedXContentRegistry.EMPTY,
-            LoggingDeprecationHandler.INSTANCE,
-            new JsonFactory().createParser(jsonString))) {
+        JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString)) {
       contentBuilder.copyCurrentStructure(contentParser);
     }
     return contentBuilder.toString();

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -19,7 +19,7 @@ import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.Numbers;
 import org.opensearch.common.geo.GeoPoint;
 import org.opensearch.common.geo.GeoUtils;
-import org.opensearch.common.xcontent.json.JsonXContentParser;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
@@ -149,10 +149,10 @@ public class OpenSearchJsonContent implements Content {
   public Pair<Double, Double> geoValue() {
     final JsonNode value = value();
     try (XContentParser parser =
-        new JsonXContentParser(
+        JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY,
             DeprecationHandler.IGNORE_DEPRECATIONS,
-            value.traverse())) {
+            value.toString())) {
       parser.nextToken();
       GeoPoint point = new GeoPoint();
       GeoUtils.parseGeoPoint(parser, point, true);


### PR DESCRIPTION
### Description
OpenSearch 3.7.0-SNAPSHOT migrates XContent's Jackson dependency from Jackson 2 (`com.fasterxml.jackson`) to Jackson 3 (`tools.jackson`). OpenSearchJsonContent still holds a Jackson 2 JsonNode, so `value.traverse()` no longer matches the `JsonXContentParser` constructor signature.

Switch to the high-level `JsonXContent.jsonXContent.createParser(String)` factory, which insulates callers from the underlying Jackson version.

### Related Issues
* Relate (CI failures of) https://github.com/opensearch-project/sql/pull/5296

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
