### PR TITLE
[BugFix] Validate table name and reject duplicate or positional args in vectorSearch()

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -301,7 +301,7 @@ public class VectorSearchIT extends SQLIntegTestCase {
     assertThat(explain, containsString("wrapper"));
   }
 
-  // ── Argument shape validation (PR B) ──────────────────────────────────
+  // ── Argument shape validation ─────────────────────────────────────────
 
   @Test
   public void testInvalidTableNameRejected() throws IOException {

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -300,4 +300,138 @@ public class VectorSearchIT extends SQLIntegTestCase {
 
     assertThat(explain, containsString("wrapper"));
   }
+
+  // ── Argument shape validation (PR B) ──────────────────────────────────
+
+  @Test
+  public void testInvalidTableNameRejected() throws IOException {
+    // A slash is outside the SAFE_FIELD_NAME regex and is not a valid OpenSearch index character,
+    // so it should be rejected at the SQL layer before any cluster call is attempted.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='idx/evil', field='f', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Invalid table name"));
+  }
+
+  @Test
+  public void testDuplicateNamedArgRejected() throws IOException {
+    // Previously this crashed the server with 500 ArrayIndexOutOfBoundsException. Must now
+    // surface as a clean 400 with a user-facing message.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='a', table='b', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Duplicate argument name"));
+  }
+
+  @Test
+  public void testUnknownNamedArgRejected() throws IOException {
+    // A grammar-legal but unknown name must surface as a clean 400 from the resolver.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(bogus='idx', field='f', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Unknown argument name"));
+  }
+
+  @Test
+  public void testPositionalArgRejected() throws IOException {
+    // The real shape a user would hit: `vectorSearch('idx', field=..., vector=..., option=...)`.
+    // The V2 grammar now accepts this form so the AstBuilder can surface a clean
+    // SemanticCheckException instead of letting the request fall back to the legacy SQL engine,
+    // which previously returned 200 with zero rows.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch('idx', field='embedding', "
+                        + "vector='[1.0, 1.0]', option='k=3') AS v LIMIT 3"));
+
+    assertThat(ex.getMessage(), containsString("requires named arguments"));
+  }
+
+  @Test
+  public void testCaseInsensitiveDuplicateArgRejected() throws IOException {
+    // Argument names are normalized to lower-case, so `table` and `TABLE` must be treated as the
+    // same key and rejected as a duplicate rather than silently keeping one of the two values.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='a', TABLE='b', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Duplicate argument name"));
+  }
+
+  @Test
+  public void testTableNameAllRejected() throws IOException {
+    // `_all` would fan out to every index. The preview contract is a single concrete index or
+    // alias, so it must be rejected explicitly rather than allowed to route broadly.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='_all', field='f', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Invalid table name"));
+  }
+
+  @Test
+  public void testTableNameSingleDotRejected() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='.', field='f', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Invalid table name"));
+  }
+
+  @Test
+  public void testTableNameDoubleDotRejected() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='..', field='f', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Invalid table name"));
+  }
+
+  @Test
+  public void testMissingRequiredArgRejected() throws IOException {
+    // Omitting a required named argument (here: `field`) must produce a clean 400 rather than a
+    // NullPointerException or a legacy-engine fallback.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='a', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("requires 4 arguments"));
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -10,6 +10,7 @@ import static org.opensearch.sql.opensearch.storage.VectorSearchTableFunctionRes
 import static org.opensearch.sql.opensearch.storage.VectorSearchTableFunctionResolver.TABLE;
 import static org.opensearch.sql.opensearch.storage.VectorSearchTableFunctionResolver.VECTOR;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,8 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
 
   /**
    * Field names must be safe for JSON interpolation: alphanumeric, dots (nested), underscores,
-   * hyphens. Rejects characters that could corrupt the WrapperQueryBuilder JSON.
+   * hyphens. Rejects characters that could corrupt the WrapperQueryBuilder JSON. The same regex is
+   * reused for table names so user-supplied identifiers cannot break out of the JSON context.
    */
   private static final Pattern SAFE_FIELD_NAME = Pattern.compile("^[a-zA-Z0-9._\\-]+$");
 
@@ -99,6 +101,7 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     // clusters without k-NN.
     validateNamedArgs();
     String tableName = getArgumentValue(TABLE);
+    validateTableName(tableName);
     String fieldName = getArgumentValue(FIELD);
     validateFieldName(fieldName);
     String vectorLiteral = getArgumentValue(VECTOR);
@@ -162,8 +165,12 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     return options;
   }
 
-  /** Reject non-named arguments and null arg names early. */
+  /**
+   * Reject non-named arguments, null arg names, and duplicate named arguments early. Runs before
+   * any list-index-based lookup so a malformed argument list can never cause an AIOOBE downstream.
+   */
   private void validateNamedArgs() {
+    HashSet<String> seen = new HashSet<>();
     for (Expression arg : arguments) {
       if (!(arg instanceof NamedArgumentExpression)) {
         throw new ExpressionEvaluationException(
@@ -177,6 +184,39 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
             "vectorSearch() requires named arguments (e.g., table='index'), "
                 + "but received an argument with no name");
       }
+      if (!seen.add(name.toLowerCase(java.util.Locale.ROOT))) {
+        throw new ExpressionEvaluationException(
+            "Duplicate argument name '"
+                + name
+                + "' in vectorSearch(); each named argument may appear at most once");
+      }
+    }
+  }
+
+  /**
+   * Reject table names with characters that could corrupt the WrapperQueryBuilder JSON or escape
+   * the target index name. Allows alphanumeric, dots, underscores, and hyphens (the characters
+   * OpenSearch index names already permit). Explicitly rejects the `_all` routing target and the
+   * pathologic `.` / `..` names because those either fan out to every index or are not valid
+   * concrete index names. Other native-invalid names (leading dot, leading hyphen, bare underscore,
+   * uppercase, and so on) are intentionally passed through for the OpenSearch client to reject with
+   * its own error message.
+   */
+  private void validateTableName(String tableName) {
+    if (!SAFE_FIELD_NAME.matcher(tableName).matches()) {
+      throw new ExpressionEvaluationException(
+          String.format(
+              "Invalid table name '%s': must contain only alphanumeric characters,"
+                  + " dots, underscores, or hyphens",
+              tableName));
+    }
+    String lower = tableName.toLowerCase(java.util.Locale.ROOT);
+    if (lower.equals("_all") || tableName.equals(".") || tableName.equals("..")) {
+      throw new ExpressionEvaluationException(
+          String.format(
+              "Invalid table name '%s': vectorSearch() requires a single concrete index or alias;"
+                  + " '_all', '.', and '..' are not supported",
+              tableName));
     }
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolver.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolver.java
@@ -7,10 +7,13 @@ package org.opensearch.sql.opensearch.storage;
 
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
+import java.util.HashSet;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.NamedArgumentExpression;
 import org.opensearch.sql.expression.function.FunctionBuilder;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.expression.function.FunctionResolver;
@@ -63,10 +66,44 @@ public class VectorSearchTableFunctionResolver implements FunctionResolver {
 
   private void validateArguments(List<Expression> arguments) {
     if (arguments.size() != ARGUMENT_NAMES.size()) {
-      throw new IllegalArgumentException(
+      throw new ExpressionEvaluationException(
           String.format(
               "vectorSearch requires %d arguments (%s), got %d",
               ARGUMENT_NAMES.size(), String.join(", ", ARGUMENT_NAMES), arguments.size()));
     }
+    // Shape check at the resolver so positional or unknown-named args produce a clean 400 before
+    // planning proceeds. The Implementation layer repeats the non-named and duplicate-name checks
+    // as defense-in-depth; the unknown-name allowlist is enforced only here because the
+    // Implementation looks up values by known keys and does not need to re-validate the allowlist.
+    HashSet<String> seen = new HashSet<>();
+    for (Expression arg : arguments) {
+      if (!(arg instanceof NamedArgumentExpression)) {
+        throw new ExpressionEvaluationException(
+            "vectorSearch() requires named arguments (e.g., table='index'), "
+                + "but received: "
+                + arg.getClass().getSimpleName());
+      }
+      String name = ((NamedArgumentExpression) arg).getArgName();
+      if (name == null || name.isEmpty()) {
+        throw new ExpressionEvaluationException(
+            "vectorSearch() requires named arguments (e.g., table='index'), "
+                + "but received an argument with no name");
+      }
+      String lower = name.toLowerCase(java.util.Locale.ROOT);
+      if (!ARGUMENT_NAMES.contains(lower)) {
+        throw new ExpressionEvaluationException(
+            String.format(
+                "Unknown argument name '%s' in vectorSearch(); allowed names are %s",
+                name, ARGUMENT_NAMES));
+      }
+      if (!seen.add(lower)) {
+        throw new ExpressionEvaluationException(
+            "Duplicate argument name '"
+                + name
+                + "' in vectorSearch(); each named argument may appear at most once");
+      }
+    }
+    // At this point `seen` holds exactly ARGUMENT_NAMES.size() entries (no duplicates, no unknowns,
+    // and arity matches), so every required name is present. No separate missing-name check needed.
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -458,6 +458,65 @@ class VectorSearchTableFunctionImplementationTest {
     assertEquals("post", options.get("filter_type"));
   }
 
+  @Test
+  void applyArguments_rejectsInvalidTableName() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("idx\"; DROP", "embedding", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid table name"));
+    assertTrue(
+        ex.getMessage()
+            .contains("must contain only alphanumeric characters, dots, underscores, or hyphens"));
+  }
+
+  @Test
+  void applyArguments_rejectsAllRoutingTarget() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("_all", "embedding", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid table name"));
+    assertTrue(ex.getMessage().contains("_all"));
+  }
+
+  @Test
+  void applyArguments_rejectsSingleDotTable() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs(".", "embedding", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid table name"));
+  }
+
+  @Test
+  void applyArguments_rejectsDoubleDotTable() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("..", "embedding", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid table name"));
+  }
+
+  @Test
+  void validateNamedArgs_rejectsDuplicateNames() {
+    // Two occurrences of "table" reach the Implementation layer directly (bypassing the resolver).
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> args =
+        List.of(
+            DSL.namedArgument("table", DSL.literal("a")),
+            DSL.namedArgument("table", DSL.literal("b")),
+            DSL.namedArgument("vector", DSL.literal("[1.0]")),
+            DSL.namedArgument("option", DSL.literal("k=5")));
+    VectorSearchTableFunctionImplementation impl =
+        new VectorSearchTableFunctionImplementation(
+            functionName, args, client, settings, knnCapability);
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Duplicate argument name"));
+    assertTrue(ex.getMessage().contains("table"));
+  }
+
   private VectorSearchTableFunctionImplementation createImpl() {
     return createImplWithArgs("my-index", "embedding", "[1.0, 2.0, 3.0]", "k=5");
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolverTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionResolverTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.DSL;
 import org.opensearch.sql.expression.Expression;
 import org.opensearch.sql.expression.function.FunctionBuilder;
@@ -78,9 +79,10 @@ class VectorSearchTableFunctionResolverTest {
     Pair<FunctionSignature, FunctionBuilder> resolution = resolver.resolve(functionSignature);
     FunctionBuilder builder = resolution.getValue();
 
-    IllegalArgumentException ex =
+    ExpressionEvaluationException ex =
         assertThrows(
-            IllegalArgumentException.class, () -> builder.apply(functionProperties, expressions));
+            ExpressionEvaluationException.class,
+            () -> builder.apply(functionProperties, expressions));
     assertTrue(ex.getMessage().contains("requires 4 arguments"));
   }
 
@@ -103,9 +105,10 @@ class VectorSearchTableFunctionResolverTest {
     Pair<FunctionSignature, FunctionBuilder> resolution = resolver.resolve(functionSignature);
     FunctionBuilder builder = resolution.getValue();
 
-    IllegalArgumentException ex =
+    ExpressionEvaluationException ex =
         assertThrows(
-            IllegalArgumentException.class, () -> builder.apply(functionProperties, expressions));
+            ExpressionEvaluationException.class,
+            () -> builder.apply(functionProperties, expressions));
     assertTrue(ex.getMessage().contains("requires 4 arguments"));
   }
 
@@ -122,9 +125,84 @@ class VectorSearchTableFunctionResolverTest {
     Pair<FunctionSignature, FunctionBuilder> resolution = resolver.resolve(functionSignature);
     FunctionBuilder builder = resolution.getValue();
 
-    IllegalArgumentException ex =
+    ExpressionEvaluationException ex =
         assertThrows(
-            IllegalArgumentException.class, () -> builder.apply(functionProperties, expressions));
+            ExpressionEvaluationException.class,
+            () -> builder.apply(functionProperties, expressions));
     assertTrue(ex.getMessage().contains("requires 4 arguments"));
+  }
+
+  @Test
+  void resolve_rejectsPositionalArgument() {
+    VectorSearchTableFunctionResolver resolver =
+        new VectorSearchTableFunctionResolver(client, settings);
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    // One positional literal mixed with three named arguments. Arity passes, but the resolver
+    // must reject this before planning so the SQL layer returns a clean 400 rather than a 200
+    // with zero rows.
+    List<Expression> expressions =
+        List.of(
+            DSL.literal("my-index"),
+            DSL.namedArgument("field", DSL.literal("embedding")),
+            DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")),
+            DSL.namedArgument("option", DSL.literal("k=5")));
+    FunctionSignature functionSignature =
+        new FunctionSignature(
+            functionName, expressions.stream().map(Expression::type).collect(Collectors.toList()));
+    FunctionBuilder builder = resolver.resolve(functionSignature).getValue();
+
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> builder.apply(functionProperties, expressions));
+    assertTrue(ex.getMessage().contains("requires named arguments"));
+  }
+
+  @Test
+  void resolve_rejectsDuplicateNamedArgument() {
+    VectorSearchTableFunctionResolver resolver =
+        new VectorSearchTableFunctionResolver(client, settings);
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> expressions =
+        List.of(
+            DSL.namedArgument("table", DSL.literal("a")),
+            DSL.namedArgument("table", DSL.literal("b")),
+            DSL.namedArgument("vector", DSL.literal("[1.0]")),
+            DSL.namedArgument("option", DSL.literal("k=5")));
+    FunctionSignature functionSignature =
+        new FunctionSignature(
+            functionName, expressions.stream().map(Expression::type).collect(Collectors.toList()));
+    FunctionBuilder builder = resolver.resolve(functionSignature).getValue();
+
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> builder.apply(functionProperties, expressions));
+    assertTrue(ex.getMessage().contains("Duplicate argument name"));
+    assertTrue(ex.getMessage().contains("table"));
+  }
+
+  @Test
+  void resolve_rejectsUnknownArgumentName() {
+    VectorSearchTableFunctionResolver resolver =
+        new VectorSearchTableFunctionResolver(client, settings);
+    FunctionName functionName = FunctionName.of("vectorsearch");
+    List<Expression> expressions =
+        List.of(
+            DSL.namedArgument("table", DSL.literal("my-index")),
+            DSL.namedArgument("field", DSL.literal("embedding")),
+            DSL.namedArgument("vector", DSL.literal("[1.0, 2.0]")),
+            DSL.namedArgument("bogus", DSL.literal("k=5")));
+    FunctionSignature functionSignature =
+        new FunctionSignature(
+            functionName, expressions.stream().map(Expression::type).collect(Collectors.toList()));
+    FunctionBuilder builder = resolver.resolve(functionSignature).getValue();
+
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> builder.apply(functionProperties, expressions));
+    assertTrue(ex.getMessage().contains("Unknown argument name"));
+    assertTrue(ex.getMessage().contains("bogus"));
   }
 }

--- a/sql/src/main/antlr/OpenSearchSQLParser.g4
+++ b/sql/src/main/antlr/OpenSearchSQLParser.g4
@@ -120,6 +120,7 @@ tableFunctionArgs
 
 tableFunctionArg
    : ident EQUAL_SYMBOL functionArg
+   | functionArg
    ;
 
 whereClause

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
@@ -42,6 +42,7 @@ import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.QuerySpecificationContext;
@@ -195,6 +196,26 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
 
   @Override
   public UnresolvedPlan visitTableFunctionRelation(TableFunctionRelationContext ctx) {
+    // The grammar accepts both `ident = value` and bare `value` forms for each table function
+    // argument so that the real positional shape (e.g. `vectorSearch('idx', field='f', ...)`)
+    // reaches this V2 builder instead of failing to parse and silently falling back to the
+    // legacy SQL engine. Reject the positional shape here with a SemanticCheckException so the
+    // user receives a clean 400 rather than an opaque legacy parser error.
+    ctx.tableFunctionArgs()
+        .tableFunctionArg()
+        .forEach(
+            arg -> {
+              if (arg.ident() == null) {
+                String functionName = ctx.qualifiedName().getText();
+                throw new SemanticCheckException(
+                    String.format(
+                        Locale.ROOT,
+                        "Table function '%s' requires named arguments (e.g. name='value'),"
+                            + " but received a positional argument: %s",
+                        functionName,
+                        arg.functionArg().getText()));
+              }
+            });
     ImmutableList.Builder<UnresolvedExpression> args = ImmutableList.builder();
     ctx.tableFunctionArgs()
         .tableFunctionArg()

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -44,6 +44,7 @@ import org.opensearch.sql.ast.expression.UnresolvedArgument;
 import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.exception.SemanticCheckException;
 
 class AstBuilderTest extends AstBuilderTestBase {
 
@@ -249,6 +250,22 @@ class AstBuilderTest extends AstBuilderTestBase {
                 "SELECT * FROM vectorSearch("
                     + "table='products', field='embedding', "
                     + "vector='[0.1,0.2]', option='k=10')"));
+  }
+
+  @Test
+  public void table_function_relation_rejects_positional_argument() {
+    // Grammar accepts both `ident=value` and bare `value` for each table function argument so
+    // the real positional shape reaches the V2 AstBuilder. The AstBuilder must reject it with a
+    // SemanticCheckException rather than let the request fall back to the legacy engine.
+    SemanticCheckException ex =
+        assertThrows(
+            SemanticCheckException.class,
+            () ->
+                buildAST(
+                    "SELECT * FROM vectorSearch('products', field='embedding', "
+                        + "vector='[0.1,0.2]', option='k=10') AS v"));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        ex.getMessage().contains("requires named arguments"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
* Apply the same SAFE_FIELD_NAME regex validation to `table=` that already guards `field=`. Previously `table='idx"; DROP'` reached the native layer unvalidated.
* Reject duplicate named arguments with a clean 400 error. Previously passing the same name twice (e.g. `table='a', table='b'`) crashed the server with 500 ArrayIndexOutOfBoundsException.
* Reject positional arguments. Previously mixing a positional with named args (e.g. `vectorSearch('idx', field=...)`) silently returned 200 with an empty DSL and zero rows.

Closes tracker rows 4, 5, 6 in the Vector Search Tracker.

## Test plan
* [ ] Unit tests cover all three validation paths.
* [ ] Integration tests assert 400 status and user-facing error messages.
* [ ] spotlessCheck passes.