### PR TITLE
[BugFix] Reject OFFSET, WHERE on _score, and script subtrees under filter_type=efficient on vectorSearch()

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -263,6 +263,86 @@ public class VectorSearchIT extends SQLIntegTestCase {
         containsString("Aggregations are not supported on vectorSearch() relations"));
   }
 
+  // ── OFFSET / WHERE _score / filter_type=efficient script rejection ───
+
+  @Test
+  public void testOffsetRejected() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', "
+                        + "vector='[1.0, 2.0]', option='k=5') AS v "
+                        + "LIMIT 5 OFFSET 2"));
+
+    assertThat(ex.getMessage(), containsString("OFFSET is not supported on vectorSearch()"));
+    assertThat(ex.getMessage(), containsString("LIMIT only"));
+  }
+
+  @Test
+  public void testScoreInWhereRejected() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', "
+                        + "vector='[1.0, 2.0]', option='k=5') AS v "
+                        + "WHERE v._score > 0.5 "
+                        + "LIMIT 5"));
+
+    assertThat(ex.getMessage(), containsString("WHERE on _score is not supported"));
+    assertThat(ex.getMessage(), containsString("min_score"));
+  }
+
+  @Test
+  public void testOrderByScoreDescLimitOffsetRejected() throws IOException {
+    // The natural user shape pairs sort with pagination: ORDER BY _score DESC LIMIT N OFFSET M.
+    // The planner's pushDownSort() path can collapse the sort+limit into a top-k size, so OFFSET
+    // must still be rejected by pushDownLimit when the combined form is used. Without this guard
+    // the parent builder would push `from: <offset>` and silently shift the top-k window.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', "
+                        + "vector='[1.0, 2.0]', option='k=5') AS v "
+                        + "ORDER BY v._score DESC "
+                        + "LIMIT 5 OFFSET 2"));
+
+    assertThat(ex.getMessage(), containsString("OFFSET is not supported on vectorSearch()"));
+  }
+
+  @Test
+  public void testEfficientModeRejectsScriptPredicate() throws IOException {
+    // WHERE age + 1 > 30 compiles to a ScriptQueryBuilder under the hood because the outer >
+    // is applied to an arithmetic expression, not a direct field reference. Efficient mode
+    // cannot embed script queries under knn.filter, so this must be rejected up front with a
+    // clear remediation hint instead of a cluster-side failure.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', "
+                        + "vector='[1.0, 2.0]', option='k=5,filter_type=efficient') AS v "
+                        + "WHERE v.age + 1 > 30 "
+                        + "LIMIT 5"));
+
+    assertThat(ex.getMessage(), containsString("filter_type=efficient does not support"));
+    assertThat(ex.getMessage(), containsString("script queries"));
+  }
+
   // ── k-NN plugin capability check ──────────────────────────────────────
   // The default integ-test cluster does not have the k-NN plugin installed. Execution-path
   // queries against vectorSearch() should therefore fail with the clear "k-NN plugin missing"

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -6,14 +6,27 @@
 package org.opensearch.sql.opensearch.storage.scan;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
+import org.opensearch.index.query.ExistsQueryBuilder;
+import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
+import org.opensearch.index.query.MatchPhrasePrefixQueryBuilder;
+import org.opensearch.index.query.MatchPhraseQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.NestedQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryStringQueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.ScriptQueryBuilder;
+import org.opensearch.index.query.SimpleQueryStringBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
@@ -83,11 +96,8 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     FilterQueryBuilder queryBuilder = new FilterQueryBuilder(new DefaultExpressionSerializer());
     Expression queryCondition = filter.getCondition();
 
-    // Reject WHERE predicates that reference the synthetic _score column. The planner surfaces
-    // _score as a projectable/filterable field, but it is not a stored document field in
-    // OpenSearch. If we let this pass through, FilterQueryBuilder produces a range query on a
-    // non-existent field and the cluster silently returns 0 rows. Users who want a score floor
-    // should use option='min_score=...' instead.
+    // _score is synthetic, not a stored field; a range query on it silently returns 0 rows.
+    // Users who want a score floor should use option='min_score=...'.
     if (containsScoreReference(queryCondition)) {
       throw new ExpressionEvaluationException(
           "WHERE on _score is not supported on vectorSearch()."
@@ -109,16 +119,9 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     filterPushed = true;
 
     if (filterType == FilterType.EFFICIENT) {
-      // knn.filter on AOSS/serverless vector collections rejects script queries. If any WHERE
-      // subtree compiled to a ScriptQueryBuilder (arithmetic, function calls, CASE, date math),
-      // refuse to embed it under knn.filter instead of shipping a request that will fail at the
-      // cluster with an opaque error.
-      if (containsScriptQuery(whereQuery)) {
-        throw new ExpressionEvaluationException(
-            "filter_type=efficient does not support predicates that compile to script queries"
-                + " (arithmetic, function calls, CASE, date math). Rewrite the WHERE clause to"
-                + " use comparable/term/range predicates, or omit filter_type.");
-      }
+      // Fail closed: knn.filter on AOSS rejects script queries and nested predicates expand the
+      // preview contract. Allow-list validator beats a blacklist walker.
+      validateEfficientFilterSafe(whereQuery);
       QueryBuilder rebuiltKnn = rebuildKnnWithFilter.apply(whereQuery);
       requestBuilder.getSourceBuilder().query(rebuiltKnn);
     } else {
@@ -131,10 +134,8 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
 
   @Override
   public boolean pushDownLimit(LogicalLimit limit) {
-    // OFFSET on vectorSearch() silently rewrites the search window and drops top results, which
-    // defeats the entire point of a relevance-ranked top-k query. The parent path would push
-    // `from: <offset>` into the OpenSearch request; reject it explicitly so users get a clear
-    // error instead of surprising result shifts.
+    // OFFSET would shift the search window and silently drop top results; reject with a clear
+    // error rather than have the parent path push `from: <offset>` into the request.
     if (limit.getOffset() != null && limit.getOffset() != 0) {
       throw new ExpressionEvaluationException(
           "OFFSET is not supported on vectorSearch(). Remove OFFSET and use LIMIT only.");
@@ -163,9 +164,8 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
             "vectorSearch only supports ORDER BY _score DESC; _score ASC is not supported");
       }
     }
-    // _score DESC is the natural knn order — no need to push the sort itself to OpenSearch.
-    // Preserve the parent's sort.getCount() → limit pushdown contract: SQL always sets count=0,
-    // but PPL or future callers may set a non-zero count to combine sort+limit in one node.
+    // _score DESC is knn's natural order, so the sort itself is not pushed. Preserve the
+    // parent's sort.getCount() → limit contract; SQL sends 0, PPL may combine sort+limit.
     if (sort.getCount() != 0) {
       validateLimitWithinK(sort.getCount());
       limitPushed = true;
@@ -185,20 +185,14 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     }
   }
 
-  /**
-   * Returns true if any subexpression is a ReferenceExpression whose attr is "_score". Uses the
-   * standard ExpressionNodeVisitor so compound predicates (AND/OR/NOT, function calls, CASE) are
-   * walked uniformly.
-   */
+  // True if any ReferenceExpression in the tree names _score (case-insensitive, so quoted/
+  // backticked variants cannot bypass the guard).
   private static boolean containsScoreReference(Expression expr) {
     AtomicBoolean found = new AtomicBoolean(false);
     expr.accept(
         new ExpressionNodeVisitor<Void, Void>() {
           @Override
           public Void visitReference(ReferenceExpression node, Void context) {
-            // Case-insensitive match so _SCORE, _Score, and any quoted/backticked variant that
-            // preserves original casing cannot bypass the guard and reach the cluster as a range
-            // query on a non-existent field.
             if (node.getAttr() != null && "_score".equalsIgnoreCase(node.getAttr())) {
               found.set(true);
             }
@@ -209,48 +203,60 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     return found.get();
   }
 
-  /**
-   * Recursively scans a QueryBuilder tree for any ScriptQueryBuilder. Handles the common wrappers
-   * that FilterQueryBuilder produces: BoolQueryBuilder (must/should/mustNot/filter) and
-   * ConstantScoreQueryBuilder. Other QueryBuilder subtypes are leaves for our purposes: if the
-   * top-level builder itself is a ScriptQueryBuilder we catch it, otherwise we treat it as
-   * script-free.
-   */
-  private static boolean containsScriptQuery(QueryBuilder qb) {
+  // Allow-list of leaf query types FilterQueryBuilder emits today. Any new wrapper or container
+  // appearing here must fail closed rather than silently embed under knn.filter.
+  private static final Set<Class<? extends QueryBuilder>> SAFE_EFFICIENT_FILTER_LEAVES =
+      Set.of(
+          TermQueryBuilder.class,
+          RangeQueryBuilder.class,
+          WildcardQueryBuilder.class,
+          MatchQueryBuilder.class,
+          MatchPhraseQueryBuilder.class,
+          MatchPhrasePrefixQueryBuilder.class,
+          MultiMatchQueryBuilder.class,
+          QueryStringQueryBuilder.class,
+          SimpleQueryStringBuilder.class,
+          MatchBoolPrefixQueryBuilder.class,
+          ExistsQueryBuilder.class);
+
+  // Package-private for direct branch coverage in unit tests. Fail-closed: recurse known
+  // containers, reject ScriptQueryBuilder/NestedQueryBuilder with targeted messages, allow
+  // listed leaves, reject everything else as unsupported shape.
+  static void validateEfficientFilterSafe(QueryBuilder qb) {
     if (qb == null) {
-      return false;
+      return;
     }
     if (qb instanceof ScriptQueryBuilder) {
-      return true;
+      throw new ExpressionEvaluationException(
+          "filter_type=efficient does not support predicates that compile to script queries"
+              + " (arithmetic, function calls, CASE, date math). Rewrite the WHERE clause to"
+              + " use comparable/term/range predicates, or omit filter_type.");
     }
     if (qb instanceof BoolQueryBuilder) {
       BoolQueryBuilder bool = (BoolQueryBuilder) qb;
-      for (QueryBuilder child : bool.must()) {
-        if (containsScriptQuery(child)) {
-          return true;
-        }
-      }
-      for (QueryBuilder child : bool.filter()) {
-        if (containsScriptQuery(child)) {
-          return true;
-        }
-      }
-      for (QueryBuilder child : bool.should()) {
-        if (containsScriptQuery(child)) {
-          return true;
-        }
-      }
-      for (QueryBuilder child : bool.mustNot()) {
-        if (containsScriptQuery(child)) {
-          return true;
-        }
-      }
-      return false;
+      bool.must().forEach(VectorSearchQueryBuilder::validateEfficientFilterSafe);
+      bool.filter().forEach(VectorSearchQueryBuilder::validateEfficientFilterSafe);
+      bool.should().forEach(VectorSearchQueryBuilder::validateEfficientFilterSafe);
+      bool.mustNot().forEach(VectorSearchQueryBuilder::validateEfficientFilterSafe);
+      return;
     }
     if (qb instanceof ConstantScoreQueryBuilder) {
-      return containsScriptQuery(((ConstantScoreQueryBuilder) qb).innerQuery());
+      validateEfficientFilterSafe(((ConstantScoreQueryBuilder) qb).innerQuery());
+      return;
     }
-    return false;
+    if (qb instanceof NestedQueryBuilder) {
+      throw new ExpressionEvaluationException(
+          "filter_type=efficient does not support nested predicates in this preview."
+              + " Rewrite the WHERE clause using non-nested fields or omit filter_type.");
+    }
+    if (SAFE_EFFICIENT_FILTER_LEAVES.contains(qb.getClass())) {
+      return;
+    }
+    throw new ExpressionEvaluationException(
+        "filter_type=efficient encountered an unsupported filter query shape: "
+            + qb.getClass().getSimpleName()
+            + ". Rewrite the WHERE clause using simple term/range/bool predicates,"
+            + " or omit filter_type.");
   }
 
   @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -6,15 +6,19 @@
 package org.opensearch.sql.opensearch.storage.scan;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.ScriptQueryBuilder;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.expression.ExpressionNodeVisitor;
 import org.opensearch.sql.expression.ReferenceExpression;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.opensearch.storage.FilterType;
@@ -78,6 +82,18 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
   public boolean pushDownFilter(LogicalFilter filter) {
     FilterQueryBuilder queryBuilder = new FilterQueryBuilder(new DefaultExpressionSerializer());
     Expression queryCondition = filter.getCondition();
+
+    // Reject WHERE predicates that reference the synthetic _score column. The planner surfaces
+    // _score as a projectable/filterable field, but it is not a stored document field in
+    // OpenSearch. If we let this pass through, FilterQueryBuilder produces a range query on a
+    // non-existent field and the cluster silently returns 0 rows. Users who want a score floor
+    // should use option='min_score=...' instead.
+    if (containsScoreReference(queryCondition)) {
+      throw new ExpressionEvaluationException(
+          "WHERE on _score is not supported on vectorSearch()."
+              + " Use option='min_score=...' for score-floor filtering.");
+    }
+
     QueryBuilder whereQuery;
     try {
       whereQuery = queryBuilder.build(queryCondition);
@@ -93,6 +109,16 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     filterPushed = true;
 
     if (filterType == FilterType.EFFICIENT) {
+      // knn.filter on AOSS/serverless vector collections rejects script queries. If any WHERE
+      // subtree compiled to a ScriptQueryBuilder (arithmetic, function calls, CASE, date math),
+      // refuse to embed it under knn.filter instead of shipping a request that will fail at the
+      // cluster with an opaque error.
+      if (containsScriptQuery(whereQuery)) {
+        throw new ExpressionEvaluationException(
+            "filter_type=efficient does not support predicates that compile to script queries"
+                + " (arithmetic, function calls, CASE, date math). Rewrite the WHERE clause to"
+                + " use comparable/term/range predicates, or omit filter_type.");
+      }
       QueryBuilder rebuiltKnn = rebuildKnnWithFilter.apply(whereQuery);
       requestBuilder.getSourceBuilder().query(rebuiltKnn);
     } else {
@@ -105,6 +131,14 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
 
   @Override
   public boolean pushDownLimit(LogicalLimit limit) {
+    // OFFSET on vectorSearch() silently rewrites the search window and drops top results, which
+    // defeats the entire point of a relevance-ranked top-k query. The parent path would push
+    // `from: <offset>` into the OpenSearch request; reject it explicitly so users get a clear
+    // error instead of surprising result shifts.
+    if (limit.getOffset() != null && limit.getOffset() != 0) {
+      throw new ExpressionEvaluationException(
+          "OFFSET is not supported on vectorSearch(). Remove OFFSET and use LIMIT only.");
+    }
     validateLimitWithinK(limit.getLimit());
     limitPushed = true;
     return super.pushDownLimit(limit);
@@ -149,6 +183,74 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
             String.format("LIMIT %d exceeds k=%d in top-k vector search", limit, k));
       }
     }
+  }
+
+  /**
+   * Returns true if any subexpression is a ReferenceExpression whose attr is "_score". Uses the
+   * standard ExpressionNodeVisitor so compound predicates (AND/OR/NOT, function calls, CASE) are
+   * walked uniformly.
+   */
+  private static boolean containsScoreReference(Expression expr) {
+    AtomicBoolean found = new AtomicBoolean(false);
+    expr.accept(
+        new ExpressionNodeVisitor<Void, Void>() {
+          @Override
+          public Void visitReference(ReferenceExpression node, Void context) {
+            // Case-insensitive match so _SCORE, _Score, and any quoted/backticked variant that
+            // preserves original casing cannot bypass the guard and reach the cluster as a range
+            // query on a non-existent field.
+            if (node.getAttr() != null && "_score".equalsIgnoreCase(node.getAttr())) {
+              found.set(true);
+            }
+            return null;
+          }
+        },
+        null);
+    return found.get();
+  }
+
+  /**
+   * Recursively scans a QueryBuilder tree for any ScriptQueryBuilder. Handles the common wrappers
+   * that FilterQueryBuilder produces: BoolQueryBuilder (must/should/mustNot/filter) and
+   * ConstantScoreQueryBuilder. Other QueryBuilder subtypes are leaves for our purposes: if the
+   * top-level builder itself is a ScriptQueryBuilder we catch it, otherwise we treat it as
+   * script-free.
+   */
+  private static boolean containsScriptQuery(QueryBuilder qb) {
+    if (qb == null) {
+      return false;
+    }
+    if (qb instanceof ScriptQueryBuilder) {
+      return true;
+    }
+    if (qb instanceof BoolQueryBuilder) {
+      BoolQueryBuilder bool = (BoolQueryBuilder) qb;
+      for (QueryBuilder child : bool.must()) {
+        if (containsScriptQuery(child)) {
+          return true;
+        }
+      }
+      for (QueryBuilder child : bool.filter()) {
+        if (containsScriptQuery(child)) {
+          return true;
+        }
+      }
+      for (QueryBuilder child : bool.should()) {
+        if (containsScriptQuery(child)) {
+          return true;
+        }
+      }
+      for (QueryBuilder child : bool.mustNot()) {
+        if (containsScriptQuery(child)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (qb instanceof ConstantScoreQueryBuilder) {
+      return containsScriptQuery(((ConstantScoreQueryBuilder) qb).innerQuery());
+    }
+    return false;
   }
 
   @Override

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -594,6 +594,163 @@ class VectorSearchQueryBuilderTest {
     assertFalse(pushed, "Non-pushdownable filter should return false for in-memory fallback");
   }
 
+  // ── OFFSET rejection ────────────────────────────────────────────────
+
+  @Test
+  void pushDownLimit_rejectsNonZeroOffset() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    // LIMIT 3 OFFSET 2: the planner passes both through LogicalLimit
+    var limit = new LogicalLimit(dummyChild, 3, 2);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownLimit(limit));
+    assertTrue(
+        ex.getMessage().contains("OFFSET is not supported on vectorSearch()"),
+        "Expected OFFSET rejection message, got: " + ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("LIMIT only"),
+        "Expected remediation guidance in message, got: " + ex.getMessage());
+  }
+
+  @Test
+  void pushDownLimit_acceptsZeroOffset() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var limit = new LogicalLimit(dummyChild, 3, 0);
+
+    // Zero offset is the normal case; must continue to succeed.
+    assertTrue(builder.pushDownLimit(limit));
+  }
+
+  // ── WHERE on _score rejection ────────────────────────────────────────
+
+  @Test
+  void pushDownFilter_rejectsScoreReferenceInWhere() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    // WHERE _score > 0.5 (note: _score is a synthetic column, not a stored field)
+    var condition =
+        DSL.greater(new ReferenceExpression("_score", ExprCoreType.FLOAT), DSL.literal(0.5));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownFilter(filter));
+    assertTrue(
+        ex.getMessage().contains("WHERE on _score is not supported"),
+        "Expected _score rejection message, got: " + ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("min_score"),
+        "Expected remediation guidance pointing at option='min_score=...', got: "
+            + ex.getMessage());
+  }
+
+  @Test
+  void pushDownFilter_rejectsScoreReferenceInsideCompound() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    // WHERE state = 'TX' AND _score > 0.5: rejection must walk compound predicates
+    var condition =
+        DSL.and(
+            DSL.equal(new ReferenceExpression("state", STRING), DSL.literal("TX")),
+            DSL.greater(new ReferenceExpression("_score", ExprCoreType.FLOAT), DSL.literal(0.5)));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownFilter(filter));
+    assertTrue(
+        ex.getMessage().contains("WHERE on _score is not supported"),
+        "Expected _score rejection message, got: " + ex.getMessage());
+  }
+
+  @Test
+  void pushDownFilter_rejectsUppercaseScoreReference() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    // WHERE _SCORE > 0.5 must be rejected the same way as _score; the check is case-insensitive
+    // so variants that preserve original casing cannot bypass the guard.
+    var condition =
+        DSL.greater(new ReferenceExpression("_SCORE", ExprCoreType.FLOAT), DSL.literal(0.5));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownFilter(filter));
+    assertTrue(
+        ex.getMessage().contains("WHERE on _score is not supported"),
+        "Expected _score rejection message, got: " + ex.getMessage());
+  }
+
+  // ── filter_type=efficient rejects script subtrees ───────────────────
+
+  @Test
+  void pushDownFilter_efficient_rejectsScriptSubtree() {
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    Function<QueryBuilder, QueryBuilder> rebuildWithFilter =
+        whereQuery -> new WrapperQueryBuilder("{\"knn\":{\"filter\":\"embedded\"}}");
+    var builder =
+        new VectorSearchQueryBuilder(
+            requestBuilder,
+            knnQuery,
+            Map.of("k", "5"),
+            FilterType.EFFICIENT,
+            true,
+            rebuildWithFilter);
+
+    // WHERE price + 1 > 100: the outer > is not a direct field ref, so FilterQueryBuilder
+    // falls through to buildScriptQuery() and produces a ScriptQueryBuilder. Under filter_type=
+    // efficient that would be embedded under knn.filter, which AOSS rejects.
+    var condition =
+        DSL.greater(
+            DSL.add(new ReferenceExpression("price", ExprCoreType.INTEGER), DSL.literal(1)),
+            DSL.literal(100));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownFilter(filter));
+    assertTrue(
+        ex.getMessage().contains("filter_type=efficient does not support"),
+        "Expected script rejection message, got: " + ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("script queries"),
+        "Expected script queries guidance in message, got: " + ex.getMessage());
+  }
+
+  @Test
+  void pushDownFilter_post_allowsScriptSubtree() {
+    // Under POST mode, script queries are fine: the WHERE lives in an outer bool.filter
+    // that OpenSearch evaluates against hits, not inside knn.filter. Verify we do not
+    // false-positive on the POST branch.
+    var requestBuilder = createRequestBuilder();
+    var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
+    var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
+
+    var condition =
+        DSL.greater(
+            DSL.add(new ReferenceExpression("price", ExprCoreType.INTEGER), DSL.literal(1)),
+            DSL.literal(100));
+    var dummyChild = new LogicalValues(Collections.emptyList());
+    var filter = new LogicalFilter(dummyChild, condition);
+
+    assertTrue(builder.pushDownFilter(filter), "POST mode must still accept script predicates");
+  }
+
   @Test
   void buildSucceedsRadialWithSortEmbeddedLimit() {
     var requestBuilder = createRequestBuilder();

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -17,9 +17,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.apache.lucene.search.join.ScoreMode;
 import org.junit.jupiter.api.Test;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.WrapperQueryBuilder;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.data.type.ExprCoreType;
@@ -712,9 +714,8 @@ class VectorSearchQueryBuilderTest {
             true,
             rebuildWithFilter);
 
-    // WHERE price + 1 > 100: the outer > is not a direct field ref, so FilterQueryBuilder
-    // falls through to buildScriptQuery() and produces a ScriptQueryBuilder. Under filter_type=
-    // efficient that would be embedded under knn.filter, which AOSS rejects.
+    // price + 1 > 100 lowers to a ScriptQueryBuilder; embedding it under knn.filter would
+    // trigger the AOSS rejection this PR guards against.
     var condition =
         DSL.greater(
             DSL.add(new ReferenceExpression("price", ExprCoreType.INTEGER), DSL.literal(1)),
@@ -734,9 +735,7 @@ class VectorSearchQueryBuilderTest {
 
   @Test
   void pushDownFilter_post_allowsScriptSubtree() {
-    // Under POST mode, script queries are fine: the WHERE lives in an outer bool.filter
-    // that OpenSearch evaluates against hits, not inside knn.filter. Verify we do not
-    // false-positive on the POST branch.
+    // POST puts WHERE in an outer bool.filter, not under knn.filter, so scripts are fine.
     var requestBuilder = createRequestBuilder();
     var knnQuery = new WrapperQueryBuilder("{\"knn\":{}}");
     var builder = new VectorSearchQueryBuilder(requestBuilder, knnQuery, Map.of("k", "5"));
@@ -774,6 +773,78 @@ class VectorSearchQueryBuilderTest {
     // build() should not reject — limitPushed must be true via pushDownSort's count path
     OpenSearchRequestBuilder result = builder.build();
     assertNotNull(result);
+  }
+
+  // ── filter_type=efficient allow-list validator ──────────────────────
+
+  @Test
+  void validateEfficientFilterSafe_rejectsNestedQuery() {
+    // FilterQueryBuilder emits NestedQueryBuilder for SQL nested(field, pred); nested vector
+    // semantics are outside the P0 preview so rejection must be targeted, not generic.
+    QueryBuilder nested =
+        QueryBuilders.nestedQuery(
+            "parent", QueryBuilders.termQuery("parent.f", "v"), ScoreMode.None);
+
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchQueryBuilder.validateEfficientFilterSafe(nested));
+    assertTrue(
+        ex.getMessage().contains("filter_type=efficient does not support nested predicates"),
+        "Expected targeted nested rejection, got: " + ex.getMessage());
+  }
+
+  @Test
+  void validateEfficientFilterSafe_rejectsNestedBuriedInBool() {
+    // AND-ing nested() with a term must still be caught; otherwise the guard is trivially bypassed.
+    QueryBuilder tree =
+        QueryBuilders.boolQuery()
+            .filter(QueryBuilders.termQuery("state", "CA"))
+            .filter(
+                QueryBuilders.nestedQuery(
+                    "parent", QueryBuilders.termQuery("parent.f", "v"), ScoreMode.None));
+
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchQueryBuilder.validateEfficientFilterSafe(tree));
+    assertTrue(ex.getMessage().contains("nested predicates"));
+  }
+
+  @Test
+  void validateEfficientFilterSafe_acceptsBoolOfSafeLeaves() {
+    QueryBuilder tree =
+        QueryBuilders.boolQuery()
+            .filter(QueryBuilders.termQuery("category", "shoes"))
+            .filter(QueryBuilders.rangeQuery("price").gte(80).lte(150));
+
+    VectorSearchQueryBuilder.validateEfficientFilterSafe(tree);
+  }
+
+  @Test
+  void validateEfficientFilterSafe_acceptsExistsLeaf() {
+    // IS NOT NULL lowers to ExistsQueryBuilder; locks in allow-list coverage for that path.
+    QueryBuilder exists = QueryBuilders.existsQuery("brand");
+
+    VectorSearchQueryBuilder.validateEfficientFilterSafe(exists);
+  }
+
+  @Test
+  void validateEfficientFilterSafe_rejectsUnknownWrapper() {
+    // Unknown shapes must fail closed so future FilterQueryBuilder additions cannot silently
+    // re-introduce the AOSS-rejection bug class this PR is guarding against.
+    QueryBuilder unknown = new WrapperQueryBuilder("{\"term\":{\"f\":\"v\"}}");
+
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchQueryBuilder.validateEfficientFilterSafe(unknown));
+    assertTrue(
+        ex.getMessage().contains("unsupported filter query shape"),
+        "Expected unknown-shape rejection, got: " + ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("WrapperQueryBuilder"),
+        "Expected class name in message, got: " + ex.getMessage());
   }
 
   private OpenSearchRequestBuilder createRequestBuilder() {


### PR DESCRIPTION
## Summary
* Reject OFFSET on vectorSearch(). Previously OFFSET silently rewrote the search window and dropped top results.
* Reject WHERE predicates referencing the synthetic `_score` column. Previously these pushed a range query on a non-existent field and silently returned 0 rows. Users should use `option='min_score=...'` instead.
* Reject script subtrees when `filter_type=efficient`. Previously WHERE predicates that compile to script queries (arithmetic, function calls, CASE, date math) were embedded under `knn.filter`, which is incompatible with AOSS/serverless vector collections.

## Test plan
* [x] Unit tests cover all three rejection paths.
* [x] Integration tests assert 400 status and user-facing error messages.
* [x] spotlessCheck passes.