### PR TITLE
[BugFix] Rewrite IS NOT NULL / IS NULL to native exists DSL in v2 filter pushdown

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/ExistsPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/ExistsPushdownIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.sql;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+import org.opensearch.sql.legacy.TestsConstants;
+
+/**
+ * Explain-plan integration tests asserting that {@code IS NOT NULL} / {@code IS NULL} predicates
+ * push down as native OpenSearch {@code exists} DSL rather than as serialized script queries.
+ *
+ * <p>Before this change both predicates serialized through the compounded script engine, producing
+ * a {@code "script"} clause in the pushdown DSL. After this change the v2 filter builder emits
+ * {@code {"exists": {"field": ...}}} directly for {@code IS NOT NULL}, and a {@code bool} query
+ * with a single {@code must_not[exists]} child for {@code IS NULL}. This matches what downstream
+ * tooling, serverless / AOSS, and the Calcite path already produce.
+ */
+public class ExistsPushdownIT extends SQLIntegTestCase {
+
+  // Anchored on the surrounding `sourceBuilder=...`, `pitId=` tokens in OpenSearchRequest's
+  // toString() output. Test-only coupling: if that request-string format changes (token renamed,
+  // pitId removed), this helper breaks even when the DSL shape is still correct. Update the regex
+  // anchors if that happens.
+  private static final Pattern SOURCE_BUILDER_JSON =
+      Pattern.compile("sourceBuilder=(\\{.*?\\}), pitId=", Pattern.DOTALL);
+
+  /** Extracts and unescapes the sourceBuilder JSON embedded in the explain request string. */
+  private static String extractSourceBuilderJson(String explain) {
+    Matcher m = SOURCE_BUILDER_JSON.matcher(explain);
+    assertTrue("Explain should contain sourceBuilder JSON:\n" + explain, m.find());
+    return m.group(1).replace("\\\"", "\"");
+  }
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.ACCOUNT);
+  }
+
+  private static final String TEST_INDEX = TestsConstants.TEST_INDEX_ACCOUNT;
+
+  @Test
+  public void testIsNotNullPushesDownAsExistsQuery() throws IOException {
+    String explain =
+        explainQuery("SELECT age FROM " + TEST_INDEX + " WHERE age IS NOT NULL LIMIT 1");
+    String sourceBuilder = extractSourceBuilderJson(explain);
+
+    assertTrue(
+        "IS NOT NULL should push down as native exists DSL:\n" + sourceBuilder,
+        sourceBuilder.contains("\"exists\""));
+    assertTrue(
+        "IS NOT NULL exists DSL should target the 'age' field:\n" + sourceBuilder,
+        sourceBuilder.contains("\"field\":\"age\""));
+    assertFalse(
+        "IS NOT NULL should not fall through to a script query:\n" + sourceBuilder,
+        sourceBuilder.contains("\"script\""));
+  }
+
+  @Test
+  public void testIsNullPushesDownAsMustNotExistsQuery() throws IOException {
+    String explain = explainQuery("SELECT age FROM " + TEST_INDEX + " WHERE age IS NULL LIMIT 1");
+    String sourceBuilder = extractSourceBuilderJson(explain);
+
+    assertTrue(
+        "IS NULL should push down as bool/must_not[exists] DSL:\n" + sourceBuilder,
+        sourceBuilder.contains("\"must_not\""));
+    assertTrue(
+        "IS NULL should wrap a native exists clause:\n" + sourceBuilder,
+        sourceBuilder.contains("\"exists\""));
+    assertTrue(
+        "IS NULL exists DSL should target the 'age' field:\n" + sourceBuilder,
+        sourceBuilder.contains("\"field\":\"age\""));
+    assertFalse(
+        "IS NULL should not fall through to a script query:\n" + sourceBuilder,
+        sourceBuilder.contains("\"script\""));
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilder.java
@@ -29,6 +29,7 @@ import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.opensearch.storage.script.CompoundedScriptEngine.ScriptEngineType;
 import org.opensearch.sql.opensearch.storage.script.core.ExpressionScript;
+import org.opensearch.sql.opensearch.storage.script.filter.lucene.ExistsQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.LikeQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.LuceneQuery;
 import org.opensearch.sql.opensearch.storage.script.filter.lucene.NestedQuery;
@@ -86,6 +87,8 @@ public class FilterQueryBuilder extends ExpressionNodeVisitor<QueryBuilder, Obje
           .put(BuiltinFunctionName.WILDCARD_QUERY.getName(), new WildcardQuery())
           .put(BuiltinFunctionName.WILDCARDQUERY.getName(), new WildcardQuery())
           .put(BuiltinFunctionName.NESTED.getName(), new NestedQuery())
+          .put(BuiltinFunctionName.IS_NULL.getName(), new ExistsQuery(true /* negated */))
+          .put(BuiltinFunctionName.IS_NOT_NULL.getName(), new ExistsQuery(false))
           .build();
 
   /**

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/ExistsQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/ExistsQuery.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.opensearch.storage.script.filter.lucene;
+
+import static org.opensearch.sql.analysis.NestedAnalyzer.isNestedFunction;
+
+import lombok.RequiredArgsConstructor;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.sql.expression.FunctionExpression;
+import org.opensearch.sql.expression.ReferenceExpression;
+
+/**
+ * Lucene query that builds a native {@code exists} DSL fragment for {@code IS NULL} / {@code IS NOT
+ * NULL} predicates.
+ *
+ * <p>This replaces the previous behavior of serializing these unary predicates as compounded script
+ * queries. The native {@code exists} query is cheaper, AOSS / serverless compatible, and the
+ * expected DSL shape downstream consumers look for.
+ *
+ * <p>Unlike most {@link LuceneQuery} subclasses this predicate family is unary (a single reference
+ * argument) rather than the standard {ref, literal} pair, so this class overrides both {@link
+ * #canSupport(FunctionExpression)} and {@link #build(FunctionExpression)}.
+ *
+ * <p>Nested-field predicates are intentionally NOT supported here: OpenSearch DSL does not handle
+ * {@code IS_NULL} / {@code IS_NOT_NULL} on nested fields correctly (see the equivalent guard in
+ * {@code PredicateAnalyzer} for the Calcite path). When the reference is a nested function, {@link
+ * #canSupport} returns {@code false} and {@link
+ * org.opensearch.sql.opensearch.storage.script.filter.FilterQueryBuilder} falls back to the script
+ * query path, preserving correctness.
+ */
+@RequiredArgsConstructor
+public class ExistsQuery extends LuceneQuery {
+
+  /** When true, the predicate is {@code IS NULL} and the exists query is wrapped in must_not. */
+  private final boolean negated;
+
+  @Override
+  public boolean canSupport(FunctionExpression func) {
+    return func.getArguments().size() == 1
+        && func.getArguments().get(0) instanceof ReferenceExpression
+        && !isNestedFunction(func.getArguments().get(0));
+  }
+
+  @Override
+  public QueryBuilder build(FunctionExpression func) {
+    ReferenceExpression ref = (ReferenceExpression) func.getArguments().get(0);
+    String fieldName = ref.getRawPath();
+    QueryBuilder existsQuery = QueryBuilders.existsQuery(fieldName);
+    if (negated) {
+      return QueryBuilders.boolQuery().mustNot(existsQuery);
+    }
+    return existsQuery;
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/ExistsQuery.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/filter/lucene/ExistsQuery.java
@@ -45,6 +45,17 @@ public class ExistsQuery extends LuceneQuery {
         && !isNestedFunction(func.getArguments().get(0));
   }
 
+  /**
+   * Unary IS NULL / IS NOT NULL has no {@code arg[1]}, so we must never route through {@link
+   * org.opensearch.sql.opensearch.storage.script.filter.lucene.NestedQuery#buildNested} — that path
+   * reads {@code func.getArguments().get(1)} and would throw. Returning {@code false} here forces
+   * {@code FilterQueryBuilder} to fall back to the script-query path for nested-field predicates.
+   */
+  @Override
+  public boolean isNestedPredicate(FunctionExpression func) {
+    return false;
+  }
+
   @Override
   public QueryBuilder build(FunctionExpression func) {
     ReferenceExpression ref = (ReferenceExpression) func.getArguments().get(0);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -174,20 +174,35 @@ class FilterQueryBuilderTest {
   }
 
   @Test
-  void should_build_script_query_for_unsupported_lucene_query() {
-    mockToStringSerializer();
+  void should_build_exists_query_for_is_not_null() {
     assertJsonEquals(
         "{\n"
-            + "  \"script\" : {\n"
-            + "    \"script\" : {\n"
-            + "      \"source\" : \"{\\\"langType\\\":\\\"v2\\\",\\\"script\\\":\\\"is not"
-            + " null(age)\\\"}\",\n"
-            + "      \"lang\" : \"opensearch_compounded_script\"\n"
-            + "    },\n"
+            + "  \"exists\" : {\n"
+            + "    \"field\" : \"age\",\n"
             + "    \"boost\" : 1.0\n"
             + "  }\n"
             + "}",
         buildQuery(DSL.isnotnull(ref("age", INTEGER))));
+  }
+
+  @Test
+  void should_build_must_not_exists_query_for_is_null() {
+    assertJsonEquals(
+        "{\n"
+            + "  \"bool\" : {\n"
+            + "    \"must_not\" : [\n"
+            + "      {\n"
+            + "        \"exists\" : {\n"
+            + "          \"field\" : \"age\",\n"
+            + "          \"boost\" : 1.0\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"adjust_pure_negative\" : true,\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}",
+        buildQuery(DSL.is_null(ref("age", INTEGER))));
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -206,6 +206,51 @@ class FilterQueryBuilderTest {
   }
 
   @Test
+  void should_fallback_to_script_for_nested_is_not_null() {
+    // Nested IS_NOT_NULL must NOT route through NestedQuery.buildNested(): that path reads
+    // arg[1] and unary IS_NOT_NULL only has arg[0]. ExistsQuery.isNestedPredicate() returns
+    // false precisely to force the script fallback here.
+    mockToStringSerializer();
+    assertJsonEquals(
+        "{\n"
+            + "  \"script\" : {\n"
+            + "    \"script\" : {\n"
+            + "      \"source\" :"
+            + " \"{\\\"langType\\\":\\\"v2\\\",\\\"script\\\":\\\"is"
+            + " not null(FunctionExpression(functionName=nested, arguments=[message.info,"
+            + " message]))\\\"}\",\n"
+            + "      \"lang\" : \"opensearch_compounded_script\"\n"
+            + "    },\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            DSL.isnotnull(
+                DSL.nested(DSL.ref("message.info", STRING), DSL.ref("message", STRING)))));
+  }
+
+  @Test
+  void should_fallback_to_script_for_nested_is_null() {
+    // Symmetric to the IS_NOT_NULL case: must not crash with an arg[1] lookup via NestedQuery.
+    mockToStringSerializer();
+    assertJsonEquals(
+        "{\n"
+            + "  \"script\" : {\n"
+            + "    \"script\" : {\n"
+            + "      \"source\" :"
+            + " \"{\\\"langType\\\":\\\"v2\\\",\\\"script\\\":\\\"is"
+            + " null(FunctionExpression(functionName=nested, arguments=[message.info,"
+            + " message]))\\\"}\",\n"
+            + "      \"lang\" : \"opensearch_compounded_script\"\n"
+            + "    },\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            DSL.is_null(DSL.nested(DSL.ref("message.info", STRING), DSL.ref("message", STRING)))));
+  }
+
+  @Test
   void should_build_script_query_for_function_expression() {
     mockToStringSerializer();
     assertJsonEquals(


### PR DESCRIPTION
## Summary

- Rewrites `IS NOT NULL` / `IS NULL` pushdown in the v2 `FilterQueryBuilder` from a serialized compounded script query to native OpenSearch `exists` DSL.
- Closes tracker row "Pushdown coverage - IS NOT NULL pushes script instead of exists".
- Affects all v2 SQL queries, not just `vectorSearch()` table-function queries.

## DSL shape: before / after

Before (both predicates serialized through the script engine):

```json
{"script": {"script": {"source": "{\"langType\":\"v2\",\"script\":\"is not null(age)\"}", ...}}}
```

After:

```
IS NOT NULL col  ->  {"exists": {"field": "col"}}
IS NULL col      ->  {"bool": {"must_not": [{"exists": {"field": "col"}}]}}
```

Native `exists` is cheaper to evaluate, supported on AOSS / serverless, and matches what the Calcite `PredicateAnalyzer` already emits for these predicates.

## Design

New `ExistsQuery` lucene query class in `opensearch/.../storage/script/filter/lucene/` overrides the `LuceneQuery.canSupport` / `build` pair to accept a single `ReferenceExpression` argument (the base class contract is binary `{ref, literal}`). Two instances are registered in `FilterQueryBuilder.luceneQueries`:

```
.put(BuiltinFunctionName.IS_NULL.getName(), new ExistsQuery(true /* negated */))
.put(BuiltinFunctionName.IS_NOT_NULL.getName(), new ExistsQuery(false))
```

Nested-field predicates are explicitly guarded: `ExistsQuery.canSupport` returns false when the argument is a `nested()` function. This mirrors the equivalent guard in `PredicateAnalyzer` ("OpenSearch DSL does not handle IS_NULL / IS_NOT_NULL on nested fields correctly"). When `canSupport` returns false, the default branch in `FilterQueryBuilder.visitFunction` falls through to the script query path, preserving prior behavior for that edge case.

## Test plan

- [x] `./gradlew spotlessCheck` - clean
- [x] `./gradlew :opensearch:test --tests "*FilterQueryBuilderTest*"` - green
  - Replaced `should_build_script_query_for_unsupported_lucene_query` with two focused assertions: `should_build_exists_query_for_is_not_null` and `should_build_must_not_exists_query_for_is_null`, pinning the new DSL shape.
- [x] `./gradlew :integ-test:integTest -Dtests.class="*ExistsPushdownIT*"` - green
  - New IT `ExistsPushdownIT` covers both senses via `_explain` against `TEST_INDEX_ACCOUNT`, asserting `"exists"` is present and `"script"` is absent in the source builder JSON.
- [x] `./gradlew :integ-test:integTest -Dtests.class="*AggregationIT*"` - green
  - Regression check: existing `where int0 IS NOT NULL` and `where int0 IS NULL` queries continue to produce correct result-level output.


## Follow-up: nested unary predicate fallback (commit `aba5e89`)

Addresses reviewer feedback that `ExistsQuery.canSupport()` returning `false` for nested arguments was not sufficient: `FilterQueryBuilder.visitFunction()` has a second dispatch that checks `isNestedPredicate()` when `canSupport()` is false, and the inherited `LuceneQuery.isNestedPredicate()` returns `true` for any function whose `arg[0]` is a nested reference. Unary `IS NULL` / `IS NOT NULL` could therefore still route into `NestedQuery.buildNested()`, which reads `arg[1]` and would throw.

The follow-up commit overrides `ExistsQuery.isNestedPredicate()` to return `false`, forcing the script-query fallback for nested-field predicates. Two new regression unit tests (`should_fallback_to_script_for_nested_is_not_null`, `should_fallback_to_script_for_nested_is_null`) lock in the fallback in `FilterQueryBuilderTest`.

- [x] `./gradlew :opensearch:test --tests "*FilterQueryBuilderTest*"` - green (including two new nested fallback tests)
- [x] `./gradlew :integ-test:integTest -Dtests.class="*ExistsPushdownIT*"` - green
