### PR TITLE
[BugFix] Reject outer WHERE on vectorSearch() subqueries to prevent silently dropped filters

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/Planner.java
+++ b/core/src/main/java/org/opensearch/sql/planner/Planner.java
@@ -14,6 +14,7 @@ import org.opensearch.sql.planner.logical.LogicalRelation;
 import org.opensearch.sql.planner.optimizer.LogicalPlanOptimizer;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.storage.Table;
+import org.opensearch.sql.storage.read.TableScanBuilder;
 
 /** Planner that plans and chooses the optimal physical plan. */
 @RequiredArgsConstructor
@@ -34,7 +35,35 @@ public class Planner {
     if (table == null) {
       return plan.accept(new DefaultImplementor<>(), null);
     }
-    return table.implement(table.optimize(optimize(plan)));
+    LogicalPlan optimized = table.optimize(optimize(plan));
+    // Give scan builders a chance to reject shapes that push-down alone cannot express safely
+    // (e.g. operators that land above the scan but outside its push-down contract).
+    validateScanBuilders(optimized);
+    return table.implement(optimized);
+  }
+
+  /**
+   * Walk the optimized plan and invoke {@link TableScanBuilder#validatePlan(LogicalPlan)} on every
+   * scan builder, passing the fully optimized root so scan builders can inspect their ancestors.
+   */
+  private void validateScanBuilders(LogicalPlan optimized) {
+    optimized.accept(
+        new LogicalPlanNodeVisitor<Void, Object>() {
+          @Override
+          public Void visitNode(LogicalPlan node, Object context) {
+            for (LogicalPlan child : node.getChild()) {
+              child.accept(this, context);
+            }
+            return null;
+          }
+
+          @Override
+          public Void visitTableScanBuilder(TableScanBuilder node, Object context) {
+            node.validatePlan(optimized);
+            return null;
+          }
+        },
+        null);
   }
 
   private Table findTable(LogicalPlan plan) {

--- a/core/src/main/java/org/opensearch/sql/storage/read/TableScanBuilder.java
+++ b/core/src/main/java/org/opensearch/sql/storage/read/TableScanBuilder.java
@@ -119,6 +119,19 @@ public abstract class TableScanBuilder extends LogicalPlan {
     return false;
   }
 
+  /**
+   * Post-optimization validation hook. Called once by the planner after all push-down rules have
+   * run, with the fully optimized plan root. Subclasses may inspect the ancestors of this scan
+   * builder to reject planner shapes that push-down alone cannot express safely (for example,
+   * operators that land above the scan but outside its push-down contract and would be executed
+   * after the scan has already returned a bounded result set). Default is no-op.
+   *
+   * @param root the fully optimized logical plan containing this scan builder
+   */
+  public void validatePlan(LogicalPlan root) {
+    // no-op by default
+  }
+
   @Override
   public <R, C> R accept(LogicalPlanNodeVisitor<R, C> visitor, C context) {
     return visitor.visitTableScanBuilder(this, context);

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchSubqueryIT.java
@@ -94,6 +94,30 @@ public class VectorSearchSubqueryIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testOuterWhereWithInnerWhereStillRejected() throws IOException {
+    // Outer WHERE must be rejected even when the subquery already has its own inner WHERE.
+    // The shape reaches the planner as Filter(outer) -> Project -> Filter(inner) -> Scan, and
+    // the outer predicate is still separated from the k-NN search by the subquery project
+    // boundary. Without preserving the project marker across the inner filter, the walker
+    // would miss this shape and the outer predicate would silently produce zero rows.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT * FROM (SELECT v.firstname, v.state, v.age "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
+                        + "WHERE v.age > 10) t "
+                        + "WHERE t.state = 'TX'"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString("Outer WHERE on a vectorSearch() subquery is not supported"));
+  }
+
+  @Test
   public void testInnerWhereStillWorks() throws IOException {
     // Positive control: WHERE directly on vectorSearch() inside the subquery must still plan
     // successfully — the rejection is scoped to OUTER filters that cannot reach the push-down

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchSubqueryIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.sql;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.opensearch.client.ResponseException;
+import org.opensearch.sql.legacy.SQLIntegTestCase;
+import org.opensearch.sql.legacy.TestsConstants;
+
+/**
+ * Integration tests for vectorSearch() used inside subqueries. Locks in the rejection of outer
+ * WHERE on a vectorSearch() subquery, which would otherwise silently yield zero rows because the
+ * outer predicate is applied only after the k-NN search has already selected top-k documents by
+ * vector distance.
+ *
+ * <p>Uses _explain-only plus error-path queries, so the k-NN plugin is not required — the planner
+ * validation fires during planning, before any k-NN execution.
+ */
+public class VectorSearchSubqueryIT extends SQLIntegTestCase {
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.ACCOUNT);
+  }
+
+  private static final String TEST_INDEX = TestsConstants.TEST_INDEX_ACCOUNT;
+
+  @Test
+  public void testOuterWhereOnSubqueryRejected() throws IOException {
+    // Without the guard the outer predicate is dropped from the pushed DSL and applied only in
+    // memory after k-NN returned top-k, which can yield silent zero rows.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT * FROM (SELECT v.firstname, v.state "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t "
+                        + "WHERE t.state = 'TX'"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString("Outer WHERE on a vectorSearch() subquery is not supported"));
+    assertThat(ex.getMessage(), containsString("silently yield zero rows"));
+  }
+
+  @Test
+  public void testOuterWhereOnSubqueryRejectedWithLimit() throws IOException {
+    // Same shape with an outer LIMIT — exercises a second planner path (LogicalLimit above
+    // LogicalFilter above LogicalProject above scan builder).
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT * FROM (SELECT v.firstname, v.state "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t "
+                        + "WHERE t.state = 'TX' "
+                        + "LIMIT 3"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString("Outer WHERE on a vectorSearch() subquery is not supported"));
+  }
+
+  @Test
+  public void testOuterWhereOnSubqueryRejectedExplain() throws IOException {
+    // The guard must fire during planning, before any k-NN execution — so _explain must also
+    // return the validation error rather than a silently dropped predicate in the DSL.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                explainQuery(
+                    "SELECT * FROM (SELECT v.firstname, v.state "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t "
+                        + "WHERE t.state = 'TX'"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString("Outer WHERE on a vectorSearch() subquery is not supported"));
+  }
+
+  @Test
+  public void testInnerWhereStillWorks() throws IOException {
+    // Positive control: WHERE directly on vectorSearch() inside the subquery must still plan
+    // successfully — the rejection is scoped to OUTER filters that cannot reach the push-down
+    // contract. We use _explain because the default integ-test cluster has no k-NN plugin.
+    String explain =
+        explainQuery(
+            "SELECT * FROM (SELECT v.firstname, v.state "
+                + "FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
+                + "WHERE v.state = 'TX') t");
+
+    assertThat(explain, containsString("wrapper"));
+    // Inner WHERE should push down, so the state predicate appears in the DSL.
+    assertThat(explain, containsString("state"));
+  }
+
+  @Test
+  public void testInnerWhereWithOuterProjectStillWorks() throws IOException {
+    // Another positive control: the outer layer can still project and limit columns from the
+    // subquery without the guard firing — only outer WHERE is rejected.
+    String explain =
+        explainQuery(
+            "SELECT t.firstname FROM (SELECT v.firstname, v.state "
+                + "FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
+                + "WHERE v.state = 'TX') t "
+                + "LIMIT 3");
+
+    assertThat(explain, containsString("wrapper"));
+  }
+
+  @Test
+  public void testSubqueryNoWhereStillWorks() throws IOException {
+    // Baseline: a subquery with no WHERE anywhere must not be rejected — the guard fires only
+    // when an outer LogicalFilter sits above a subquery project boundary.
+    String explain =
+        explainQuery(
+            "SELECT * FROM (SELECT v.firstname "
+                + "FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t "
+                + "LIMIT 3");
+
+    assertThat(explain, containsString("wrapper"));
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
@@ -66,13 +66,15 @@ public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
    *       LogicalFilter}. Projects only matter below a filter, so without a filter ancestor a
    *       project is just the outer SELECT and should not trigger rejection.
    *   <li>{@code sawProjectSinceFilter} — true iff a {@link LogicalProject} has been seen between
-   *       the <em>nearest enclosing</em> filter and the current position. That project is the
-   *       subquery-boundary marker that separates "outer WHERE on a subquery" (bad) from "WHERE
-   *       directly on vectorSearch()" (fine, handled by push-down).
+   *       <em>any</em> enclosing filter ancestor and the current position. Once an outer Filter
+   *       has been separated from the scan by a Project, that separation is permanent — a lower
+   *       LogicalFilter below the Project does not undo the outer boundary.
    * </ul>
    *
-   * <p>Entering a new {@link LogicalFilter} resets {@code sawProjectSinceFilter} to false because
-   * the nearest enclosing filter is now this one, and the contract is evaluated from here down.
+   * <p>This matters for shapes like {@code Filter(outer) -> Project(subquery) -> Filter(inner) ->
+   * Scan}, where the outer predicate is still blocked from reaching the push-down contract by the
+   * subquery Project regardless of the inner filter. Resetting {@code sawProjectSinceFilter} when
+   * entering the inner filter would make the walker miss this shape.
    */
   private void checkForOuterFilter(
       LogicalPlan node, boolean insideFilter, boolean sawProjectSinceFilter) {
@@ -83,18 +85,15 @@ public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
                 + " push into the k-NN search and would be applied only after top-k results have"
                 + " been selected by vector distance, which can silently yield zero rows."
                 + " Move the predicate inside the subquery (WHERE directly on vectorSearch()) so"
-                + " it is applied during the k-NN search.");
+                + " it can participate in the vectorSearch WHERE pushdown contract.");
       }
       return;
     }
     boolean nextInsideFilter = insideFilter;
     boolean nextSawProject = sawProjectSinceFilter;
     if (node instanceof LogicalFilter) {
-      // Entering a new filter: nearest enclosing filter is now this one, reset project marker.
       nextInsideFilter = true;
-      nextSawProject = false;
     } else if (node instanceof LogicalProject && insideFilter) {
-      // A project between the nearest enclosing filter and a scan builder is the bug marker.
       nextSawProject = true;
     }
     for (LogicalPlan child : node.getChild()) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
@@ -9,11 +9,28 @@ import java.util.function.Function;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
+import org.opensearch.sql.planner.logical.LogicalFilter;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.logical.LogicalProject;
 
 /**
- * Scan builder for vector search relations. Rejects aggregation pushdown: aggregations over
- * vectorSearch() relations are not supported in the SQL surface. Native OpenSearch k-NN does
- * support aggregations alongside similarity search; this restriction is specific to the SQL layer.
+ * Scan builder for vector search relations.
+ *
+ * <p>Rejects two planner shapes that the SQL surface cannot express safely:
+ *
+ * <ul>
+ *   <li><b>Aggregations</b> — native OpenSearch k-NN supports aggregations alongside similarity
+ *       search, but the SQL layer does not plumb them through, so we fail fast rather than return
+ *       silently unaggregated results.
+ *   <li><b>Outer WHERE over a vectorSearch() subquery</b> — when vectorSearch() is wrapped in a
+ *       subquery (e.g. {@code SELECT * FROM (SELECT v.id FROM vectorSearch(...) AS v) t WHERE
+ *       t.price < 150}), the outer predicate does not reach the push-down contract (the inner
+ *       {@link LogicalProject} sits between the outer {@link LogicalFilter} and this scan builder,
+ *       so the filter never matches the {@code filter(scanBuilder)} push-down pattern). The filter
+ *       is then applied in memory, but only <i>after</i> k-NN has already returned the top-k
+ *       documents ranked by vector distance, so the outer predicate can silently produce zero rows.
+ *       We detect this shape in {@link #validatePlan(LogicalPlan)} and reject with a clear error.
+ * </ul>
  */
 public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
 
@@ -27,5 +44,61 @@ public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
   public boolean pushDownAggregation(LogicalAggregation aggregation) {
     throw new ExpressionEvaluationException(
         "Aggregations are not supported on vectorSearch() relations.");
+  }
+
+  /**
+   * Walk the fully-optimized plan and reject the outer-WHERE-over-subquery shape. We look for a
+   * {@link LogicalFilter} whose descendant chain reaches this scan builder through one or more
+   * {@link LogicalProject} nodes (the subquery-boundary marker). A filter directly above this scan
+   * builder is fine — that WHERE has already gone through the push-down contract.
+   */
+  @Override
+  public void validatePlan(LogicalPlan root) {
+    checkForOuterFilter(root, false, false);
+  }
+
+  /**
+   * Recursive walker with two booleans that together encode the "outer filter separated by a
+   * subquery boundary" pattern:
+   *
+   * <ul>
+   *   <li>{@code insideFilter} — true iff some ancestor on the current walk path is a {@link
+   *       LogicalFilter}. Projects only matter below a filter, so without a filter ancestor a
+   *       project is just the outer SELECT and should not trigger rejection.
+   *   <li>{@code sawProjectSinceFilter} — true iff a {@link LogicalProject} has been seen between
+   *       the <em>nearest enclosing</em> filter and the current position. That project is the
+   *       subquery-boundary marker that separates "outer WHERE on a subquery" (bad) from "WHERE
+   *       directly on vectorSearch()" (fine, handled by push-down).
+   * </ul>
+   *
+   * <p>Entering a new {@link LogicalFilter} resets {@code sawProjectSinceFilter} to false because
+   * the nearest enclosing filter is now this one, and the contract is evaluated from here down.
+   */
+  private void checkForOuterFilter(
+      LogicalPlan node, boolean insideFilter, boolean sawProjectSinceFilter) {
+    if (node == this) {
+      if (insideFilter && sawProjectSinceFilter) {
+        throw new ExpressionEvaluationException(
+            "Outer WHERE on a vectorSearch() subquery is not supported: the predicate does not"
+                + " push into the k-NN search and would be applied only after top-k results have"
+                + " been selected by vector distance, which can silently yield zero rows."
+                + " Move the predicate inside the subquery (WHERE directly on vectorSearch()) so"
+                + " it is applied during the k-NN search.");
+      }
+      return;
+    }
+    boolean nextInsideFilter = insideFilter;
+    boolean nextSawProject = sawProjectSinceFilter;
+    if (node instanceof LogicalFilter) {
+      // Entering a new filter: nearest enclosing filter is now this one, reset project marker.
+      nextInsideFilter = true;
+      nextSawProject = false;
+    } else if (node instanceof LogicalProject && insideFilter) {
+      // A project between the nearest enclosing filter and a scan builder is the bug marker.
+      nextSawProject = true;
+    }
+    for (LogicalPlan child : node.getChild()) {
+      checkForOuterFilter(child, nextInsideFilter, nextSawProject);
+    }
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
@@ -66,8 +66,8 @@ public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
    *       LogicalFilter}. Projects only matter below a filter, so without a filter ancestor a
    *       project is just the outer SELECT and should not trigger rejection.
    *   <li>{@code sawProjectSinceFilter} — true iff a {@link LogicalProject} has been seen between
-   *       <em>any</em> enclosing filter ancestor and the current position. Once an outer Filter
-   *       has been separated from the scan by a Project, that separation is permanent — a lower
+   *       <em>any</em> enclosing filter ancestor and the current position. Once an outer Filter has
+   *       been separated from the scan by a Project, that separation is permanent — a lower
    *       LogicalFilter below the Project does not undo the outer boundary.
    * </ul>
    *

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
@@ -5,32 +5,53 @@
 
 package org.opensearch.sql.opensearch.storage.scan;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.opensearch.index.query.WrapperQueryBuilder;
 import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
+import org.opensearch.sql.expression.DSL;
+import org.opensearch.sql.expression.NamedExpression;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
+import org.opensearch.sql.planner.logical.LogicalFilter;
+import org.opensearch.sql.planner.logical.LogicalPlan;
+import org.opensearch.sql.planner.logical.LogicalProject;
 import org.opensearch.sql.planner.logical.LogicalValues;
 
 class VectorSearchIndexScanBuilderTest {
 
-  @Test
-  void pushDownAggregationIsRejected() {
+  private VectorSearchIndexScanBuilder newScanBuilder() {
     var requestBuilder =
         new OpenSearchRequestBuilder(
             mock(OpenSearchExprValueFactory.class), 10000, mock(Settings.class));
     var queryBuilder =
         new VectorSearchQueryBuilder(
             requestBuilder, new WrapperQueryBuilder("{\"knn\":{}}"), java.util.Map.of("k", "5"));
-    var scanBuilder =
-        new VectorSearchIndexScanBuilder(queryBuilder, rb -> mock(OpenSearchIndexScan.class));
+    return new VectorSearchIndexScanBuilder(queryBuilder, rb -> mock(OpenSearchIndexScan.class));
+  }
+
+  private static LogicalProject project(LogicalPlan input) {
+    NamedExpression field = DSL.named("id", DSL.ref("id", ExprCoreType.STRING));
+    return new LogicalProject(input, ImmutableList.of(field), ImmutableList.of());
+  }
+
+  private static LogicalFilter filter(LogicalPlan input) {
+    return new LogicalFilter(
+        input, DSL.less(DSL.ref("price", ExprCoreType.INTEGER), DSL.literal(150)));
+  }
+
+  @Test
+  void pushDownAggregationIsRejected() {
+    var scanBuilder = newScanBuilder();
 
     var agg =
         new LogicalAggregation(
@@ -48,5 +69,72 @@ class VectorSearchIndexScanBuilderTest {
     assertTrue(
         ex.getMessage().contains("vectorSearch"),
         "Error should mention vectorSearch; actual: " + ex.getMessage());
+  }
+
+  @Test
+  void validatePlanRejectsOuterFilterOverSubqueryProject() {
+    // Models: SELECT * FROM (SELECT v.id FROM vs(...) AS v) t WHERE t.price < 150
+    // Shape after optimizer: Project(outer) → Filter → Project(inner) → scanBuilder
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = project(filter(project(scanBuilder)));
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> scanBuilder.validatePlan(root));
+    assertTrue(
+        ex.getMessage().contains("Outer WHERE on a vectorSearch() subquery"),
+        "Error should mention outer WHERE on subquery; actual: " + ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("silently yield zero rows"),
+        "Error should explain silent zero rows; actual: " + ex.getMessage());
+  }
+
+  @Test
+  void validatePlanRejectsDoubleWrappedOuterFilter() {
+    // Models nested subqueries:
+    //   SELECT * FROM (SELECT * FROM (SELECT v.id FROM vs(...) AS v) t1) t2 WHERE t2.price < 150
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = filter(project(project(scanBuilder)));
+
+    assertThrows(ExpressionEvaluationException.class, () -> scanBuilder.validatePlan(root));
+  }
+
+  @Test
+  void validatePlanAllowsFilterDirectlyAboveScanBuilder() {
+    // Models: SELECT v.id FROM vs(...) AS v WHERE v.gender='M'
+    // Here the filter would normally be pushed down and removed, but if it were kept (e.g. a
+    // non-pushdownable predicate), validatePlan must not reject it — it is already at the
+    // vectorSearch level, not an outer filter.
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = project(filter(scanBuilder));
+
+    assertDoesNotThrow(() -> scanBuilder.validatePlan(root));
+  }
+
+  @Test
+  void validatePlanAllowsInnerFilterWrappedInOuterProject() {
+    // Models: SELECT * FROM (SELECT v.id FROM vs(...) AS v WHERE v.gender='M') t
+    // After pushdown the inner filter may remain when non-pushdownable; importantly, there is no
+    // outer filter — only outer projects wrapping an inner filter directly on scanBuilder.
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = project(project(filter(scanBuilder)));
+
+    assertDoesNotThrow(() -> scanBuilder.validatePlan(root));
+  }
+
+  @Test
+  void validatePlanAllowsNoFilterAtAll() {
+    // Baseline: no WHERE anywhere. SELECT * FROM (SELECT v.id FROM vs(...) AS v) t
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = project(project(scanBuilder));
+
+    assertDoesNotThrow(() -> scanBuilder.validatePlan(root));
+  }
+
+  @Test
+  void validatePlanAllowsBareScanBuilder() {
+    // Defensive: a plan that is just the scan builder itself.
+    var scanBuilder = newScanBuilder();
+
+    assertDoesNotThrow(() -> scanBuilder.validatePlan(scanBuilder));
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
@@ -122,6 +122,24 @@ class VectorSearchIndexScanBuilderTest {
   }
 
   @Test
+  void validatePlanRejectsFilterProjectFilterShape() {
+    // Models: SELECT * FROM (SELECT v.id FROM vs(...) AS v WHERE v.gender='M') t
+    //          WHERE t.price < 150
+    // Shape: Filter(outer) → Project(subquery) → Filter(inner) → scanBuilder
+    // The outer filter is still separated from the scan by the subquery Project; the inner
+    // filter sitting between the Project and the scan does not erase that boundary. Without
+    // preserving the project marker across the inner filter, the walker would miss this shape.
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = filter(project(filter(scanBuilder)));
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> scanBuilder.validatePlan(root));
+    assertTrue(
+        ex.getMessage().contains("Outer WHERE on a vectorSearch() subquery"),
+        "Error should mention outer WHERE on subquery; actual: " + ex.getMessage());
+  }
+
+  @Test
   void validatePlanAllowsNoFilterAtAll() {
     // Baseline: no WHERE anywhere. SELECT * FROM (SELECT v.id FROM vs(...) AS v) t
     var scanBuilder = newScanBuilder();


### PR DESCRIPTION
## Summary

Rejects the query shape `SELECT * FROM (SELECT ... FROM vectorSearch(...)) t WHERE t.col = X`, where an outer WHERE wraps a subquery whose inner relation is a `vectorSearch()` table function. The outer predicate was silently dropped from the pushed-down DSL and applied only at the SQL layer, meaning the top-k was selected by vector distance *before* the outer predicate was evaluated. Users saw unexplained zero-row results when their predicate happened to exclude every row in the top-k.

## Fix shape

- New `TableScanBuilder.validatePlan(LogicalPlan)` hook in `core/` — default no-op, called by `Planner.plan()` after it identifies the scan builder for a relation.
- `VectorSearchIndexScanBuilder.validatePlan` (in `opensearch/`) walks the logical plan above the scan, tracks whether we are inside a LogicalFilter and whether a LogicalProject has appeared since that filter (the subquery signature), and throws a clear error if both conditions hold.
- The error points the user to moving the predicate inside the subquery (where it will reach `VectorSearchQueryBuilder.pushDownFilter` and actually influence the k-NN search).

The hook lives on `TableScanBuilder` rather than inside `VectorSearchQueryBuilder` so that (a) `VectorSearchQueryBuilder.java` (locked by another in-flight PR) is not touched, and (b) other scan builders can override `validatePlan` in the future if they develop similar constraints.

## What changed

- `core/src/main/java/org/opensearch/sql/storage/read/TableScanBuilder.java`: new `validatePlan(LogicalPlan)` method, default no-op.
- `core/src/main/java/org/opensearch/sql/planner/Planner.java`: calls `validatePlan` on each scan builder during the plan walk.
- `opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java`: overrides `validatePlan` with the filter-over-subquery guard.
- Unit tests in `VectorSearchIndexScanBuilderTest.java` cover positive and negative cases of the walker.
- New integration test class `VectorSearchSubqueryIT.java` locks in both the rejection and the "inner WHERE still works" positive control.

## Test plan

- [x] `./gradlew spotlessCheck`
- [x] `./gradlew :opensearch:test --tests "*VectorSearchIndexScanBuilderTest*"` — 6/6 new unit tests green
- [x] `./gradlew :core:test` and `./gradlew :opensearch:test` — full module test suites green
- [x] `./gradlew :integ-test:integTest -Dtests.class="*VectorSearchSubqueryIT*"` — 6/6 new ITs green
- [x] `./gradlew :integ-test:integTest -Dtests.class="*VectorSearchIT*"` — 18/18 existing vectorSearch ITs green
- [x] `./gradlew :integ-test:integTest -Dtests.class="*VectorSearchExplainIT*"` — 11/11 existing explain ITs green
