### PR TITLE
[BugFix] Tighten vectorSearch() option and vector parsing error messages

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -580,6 +580,48 @@ public class VectorSearchIT extends SQLIntegTestCase {
     assertThat(ex.getMessage(), containsString("collides"));
   }
 
+  @Test
+  public void testSemicolonSeparatorInVectorRejected() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='t', field='f', "
+                        + "vector='[1.0;2.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("vector="));
+    assertThat(ex.getMessage(), containsString("comma-separated"));
+  }
+
+  @Test
+  public void testNegativeMinScoreRejected() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='t', field='f', "
+                        + "vector='[1.0]', option='min_score=-0.5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("min_score"));
+    assertThat(ex.getMessage(), containsString("non-negative"));
+  }
+
+  @Test
+  public void testNegativeMaxDistanceRejected() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='t', field='f', "
+                        + "vector='[1.0]', option='max_distance=-1.0') AS v"));
+
+    assertThat(ex.getMessage(), containsString("max_distance"));
+    assertThat(ex.getMessage(), containsString("non-negative"));
+  }
+
   private void deleteIndexIfExists(String indexName) {
     try {
       client().performRequest(new Request("DELETE", "/" + indexName));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -622,6 +622,20 @@ public class VectorSearchIT extends SQLIntegTestCase {
     assertThat(ex.getMessage(), containsString("non-negative"));
   }
 
+  @Test
+  public void testTrailingCommaInVectorRejected() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='t', field='f', "
+                        + "vector='[1.0,2.0,]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Invalid vector component"));
+    assertThat(ex.getMessage(), containsString("trailing or consecutive commas"));
+  }
+
   private void deleteIndexIfExists(String indexName) {
     try {
       client().performRequest(new Request("DELETE", "/" + indexName));

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.opensearch.sql.common.setting.Settings;
@@ -35,9 +34,13 @@ import org.opensearch.sql.storage.Table;
 public class VectorSearchTableFunctionImplementation extends FunctionExpression
     implements TableFunctionImplementation {
 
-  /** P0 allowed option keys. Rejects unknown/future keys to prevent unvalidated DSL injection. */
-  static final Set<String> ALLOWED_OPTION_KEYS =
-      Set.of("k", "max_distance", "min_score", "filter_type");
+  /**
+   * P0 allowed option keys. Rejects unknown/future keys to prevent unvalidated DSL injection. A
+   * {@link List} (rather than a {@link Set}) so the unknown-key error message renders the supported
+   * keys in a stable, user-friendly order.
+   */
+  static final List<String> ALLOWED_OPTION_KEYS =
+      List.of("k", "max_distance", "min_score", "filter_type");
 
   /**
    * Field names must be safe for JSON interpolation: alphanumeric, dots (nested), underscores,
@@ -135,19 +138,28 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
                   + " e.g., vector='[1.0,2.0,3.0]'",
               vectorLiteral));
     }
-    String[] parts = cleaned.split(",");
+    // Preserve trailing empties (split(",", -1)) so malformed literals like "[1.0,]" or
+    // "[1.0,,2.0]" surface an explicit error instead of silently shrinking the vector.
+    String[] parts = cleaned.split(",", -1);
     float[] vector = new float[parts.length];
     for (int i = 0; i < parts.length; i++) {
+      String component = parts[i].trim();
+      if (component.isEmpty()) {
+        throw new ExpressionEvaluationException(
+            String.format(
+                "Invalid vector component at position %d: must be a number (check for"
+                    + " trailing or consecutive commas in '%s')",
+                i, vectorLiteral));
+      }
       try {
-        vector[i] = Float.parseFloat(parts[i].trim());
+        vector[i] = Float.parseFloat(component);
       } catch (NumberFormatException e) {
         throw new ExpressionEvaluationException(
-            String.format("Invalid vector component '%s': must be a number", parts[i].trim()));
+            String.format("Invalid vector component '%s': must be a number", component));
       }
       if (!Float.isFinite(vector[i])) {
         throw new ExpressionEvaluationException(
-            String.format(
-                "Invalid vector component '%s': must be a finite number", parts[i].trim()));
+            String.format("Invalid vector component '%s': must be a finite number", component));
       }
     }
     return vector;
@@ -155,10 +167,20 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
 
   static Map<String, String> parseOptions(String optionStr) {
     Map<String, String> options = new LinkedHashMap<>();
-    for (String pair : optionStr.split(",")) {
+    // A wholly empty option string is handled downstream with a clearer "missing required option"
+    // message than a generic malformed-segment error.
+    if (optionStr.trim().isEmpty()) {
+      return options;
+    }
+    // split(",", -1) preserves trailing empties so malformed inputs like "k=5," or "k=5,,k2=v"
+    // surface an explicit error instead of being silently dropped.
+    String[] pairs = optionStr.split(",", -1);
+    for (String pair : pairs) {
       String trimmed = pair.trim();
       if (trimmed.isEmpty()) {
-        continue;
+        throw new ExpressionEvaluationException(
+            "Malformed option segment '': expected key=value (check for trailing or"
+                + " consecutive commas)");
       }
       String[] kv = trimmed.split("=", 2);
       if (kv.length != 2 || kv[0].trim().isEmpty() || kv[1].trim().isEmpty()) {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -126,6 +126,15 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     if (cleaned.isEmpty()) {
       throw new ExpressionEvaluationException("Vector literal must not be empty");
     }
+    // Reject common non-comma separators before Float.parseFloat fails with a generic
+    // "Invalid vector component" that doesn't hint the user at the separator.
+    if (cleaned.indexOf(';') >= 0 || cleaned.indexOf(':') >= 0 || cleaned.indexOf('|') >= 0) {
+      throw new ExpressionEvaluationException(
+          String.format(
+              "Invalid vector literal '%s': vector= requires comma-separated components,"
+                  + " e.g., vector='[1.0,2.0,3.0]'",
+              vectorLiteral));
+    }
     String[] parts = cleaned.split(",");
     float[] vector = new float[parts.length];
     for (int i = 0; i < parts.length; i++) {
@@ -274,9 +283,20 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     }
     if (hasMaxDistance) {
       parseDoubleOption(options, "max_distance");
+      double maxDistance = Double.parseDouble(options.get("max_distance"));
+      if (maxDistance < 0) {
+        throw new ExpressionEvaluationException(
+            String.format(
+                "max_distance must be non-negative, got %s", options.get("max_distance")));
+      }
     }
     if (hasMinScore) {
       parseDoubleOption(options, "min_score");
+      double minScore = Double.parseDouble(options.get("min_score"));
+      if (minScore < 0) {
+        throw new ExpressionEvaluationException(
+            String.format("min_score must be non-negative, got %s", options.get("min_score")));
+      }
     }
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -296,16 +296,14 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     }
     // Parse and canonicalize numeric values — closes JSON injection via option values
     if (hasK) {
-      parseIntOption(options, "k");
-      int k = Integer.parseInt(options.get("k"));
+      int k = parseIntOption(options, "k");
       if (k < 1 || k > 10000) {
         throw new ExpressionEvaluationException(
             String.format("k must be between 1 and 10000, got %d", k));
       }
     }
     if (hasMaxDistance) {
-      parseDoubleOption(options, "max_distance");
-      double maxDistance = Double.parseDouble(options.get("max_distance"));
+      double maxDistance = parseDoubleOption(options, "max_distance");
       if (maxDistance < 0) {
         throw new ExpressionEvaluationException(
             String.format(
@@ -313,8 +311,7 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
       }
     }
     if (hasMinScore) {
-      parseDoubleOption(options, "min_score");
-      double minScore = Double.parseDouble(options.get("min_score"));
+      double minScore = parseDoubleOption(options, "min_score");
       if (minScore < 0) {
         throw new ExpressionEvaluationException(
             String.format("min_score must be non-negative, got %s", options.get("min_score")));
@@ -322,17 +319,18 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
     }
   }
 
-  private void parseIntOption(Map<String, String> options, String key) {
+  private int parseIntOption(Map<String, String> options, String key) {
     try {
       int value = Integer.parseInt(options.get(key));
       options.put(key, Integer.toString(value));
+      return value;
     } catch (NumberFormatException e) {
       throw new ExpressionEvaluationException(
           String.format("Option '%s' must be an integer, got '%s'", key, options.get(key)));
     }
   }
 
-  private void parseDoubleOption(Map<String, String> options, String key) {
+  private double parseDoubleOption(Map<String, String> options, String key) {
     try {
       double value = Double.parseDouble(options.get(key));
       if (!Double.isFinite(value)) {
@@ -340,6 +338,7 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
             String.format("Option '%s' must be a finite number, got '%s'", key, options.get(key)));
       }
       options.put(key, Double.toString(value));
+      return value;
     } catch (NumberFormatException e) {
       throw new ExpressionEvaluationException(
           String.format("Option '%s' must be a number, got '%s'", key, options.get(key)));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -703,12 +703,20 @@ class VectorSearchTableFunctionImplementationTest {
         createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "k=5,bogus=1");
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
-    String msg = ex.getMessage();
-    int kIdx = msg.indexOf("k");
-    int maxIdx = msg.indexOf("max_distance");
-    int minIdx = msg.indexOf("min_score");
-    int filterIdx = msg.indexOf("filter_type");
-    assertTrue(kIdx >= 0 && maxIdx > kIdx && minIdx > maxIdx && filterIdx > minIdx);
+    // Match the rendered list literal (e.g. "[k, max_distance, min_score, filter_type]") rather
+    // than searching for the substring "k", which would match the first "k" in "Unknown option
+    // key" and reduce the assertion to a tautology.
+    assertTrue(
+        ex.getMessage().contains("[k, max_distance, min_score, filter_type]"),
+        "expected stable key order in error; got: " + ex.getMessage());
+  }
+
+  @Test
+  void parseOptions_emptyStringReturnsEmptyMap() {
+    // The wholly empty option string is explicitly allowed through parseOptions so it flows to
+    // the "Missing required option" gate in validateOptions. Pins that contract.
+    Map<String, String> opts = VectorSearchTableFunctionImplementation.parseOptions("");
+    assertTrue(opts.isEmpty());
   }
 
   private VectorSearchTableFunctionImplementation createImpl() {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -517,6 +517,123 @@ class VectorSearchTableFunctionImplementationTest {
     assertTrue(ex.getMessage().contains("table"));
   }
 
+  // ── Option parsing: empty value, whitespace, unknown keys ────────────
+
+  @Test
+  void parseOptions_rejectsEmptyValue() {
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchTableFunctionImplementation.parseOptions("k="));
+    assertTrue(ex.getMessage().contains("Malformed option segment"));
+  }
+
+  @Test
+  void parseOptions_rejectsEmptyValueInMidSegment() {
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchTableFunctionImplementation.parseOptions("k=,filter_type=post"));
+    assertTrue(ex.getMessage().contains("Malformed option segment"));
+  }
+
+  @Test
+  void parseOptions_trimsWhitespaceAroundKeyAndValue() {
+    Map<String, String> options =
+        VectorSearchTableFunctionImplementation.parseOptions(" k = 5 , filter_type = post ");
+    assertEquals("5", options.get("k"));
+    assertEquals("post", options.get("filter_type"));
+  }
+
+  @Test
+  void applyArguments_rejectsUnknownOptionKey() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs(
+            "my-index", "embedding", "[1.0, 2.0]", "k=5,method_parameters.ef_search=100");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Unknown option key"));
+    assertTrue(ex.getMessage().contains("method_parameters.ef_search"));
+  }
+
+  // ── Vector parsing: non-comma separator ─────────────────────────────
+
+  @Test
+  void applyArguments_rejectsSemicolonSeparatorInVector() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0;2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("vector="));
+    assertTrue(ex.getMessage().contains("comma-separated"));
+  }
+
+  @Test
+  void applyArguments_rejectsColonSeparatorInVector() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0:2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("vector="));
+  }
+
+  @Test
+  void applyArguments_rejectsPipeSeparatorInVector() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0|2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("vector="));
+  }
+
+  // ── Option bounds: negative k, min_score, max_distance ──────────────
+
+  @Test
+  void applyArguments_negativeKMessageCitesRange() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "k=-3");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("1"));
+    assertTrue(ex.getMessage().contains("10000"));
+  }
+
+  @Test
+  void applyArguments_rejectsNegativeMinScore() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "min_score=-0.5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("min_score"));
+    assertTrue(ex.getMessage().contains("non-negative"));
+  }
+
+  @Test
+  void applyArguments_rejectsNegativeMaxDistance() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "max_distance=-1.0");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("max_distance"));
+    assertTrue(ex.getMessage().contains("non-negative"));
+  }
+
+  @Test
+  void applyArguments_acceptsZeroMinScore() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "min_score=0");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
+  @Test
+  void applyArguments_acceptsZeroMaxDistance() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "max_distance=0");
+    Table table = impl.applyArguments();
+    assertTrue(table instanceof VectorSearchIndex);
+  }
+
   private VectorSearchTableFunctionImplementation createImpl() {
     return createImplWithArgs("my-index", "embedding", "[1.0, 2.0, 3.0]", "k=5");
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -634,6 +634,83 @@ class VectorSearchTableFunctionImplementationTest {
     assertTrue(table instanceof VectorSearchIndex);
   }
 
+  // ── Vector parsing: trailing / empty components (PR #5381 review) ─────
+
+  @Test
+  void applyArguments_rejectsTrailingCommaInVector() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0,2.0,]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid vector component"));
+    assertTrue(ex.getMessage().contains("trailing or consecutive commas"));
+  }
+
+  @Test
+  void applyArguments_rejectsConsecutiveCommasInVector() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0,,2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid vector component"));
+    assertTrue(ex.getMessage().contains("trailing or consecutive commas"));
+  }
+
+  @Test
+  void applyArguments_rejectsLeadingCommaInVector() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[,1.0,2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid vector component"));
+  }
+
+  // ── Option parsing: empty segments (PR #5381 review) ─────────────────
+
+  @Test
+  void parseOptions_rejectsTrailingEmptySegment() {
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchTableFunctionImplementation.parseOptions("k=5,"));
+    assertTrue(ex.getMessage().contains("Malformed option segment"));
+    assertTrue(ex.getMessage().contains("trailing or consecutive commas"));
+  }
+
+  @Test
+  void parseOptions_rejectsLeadingEmptySegment() {
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchTableFunctionImplementation.parseOptions(",k=5"));
+    assertTrue(ex.getMessage().contains("Malformed option segment"));
+  }
+
+  @Test
+  void parseOptions_rejectsConsecutiveCommas() {
+    ExpressionEvaluationException ex =
+        assertThrows(
+            ExpressionEvaluationException.class,
+            () -> VectorSearchTableFunctionImplementation.parseOptions("k=5,,filter_type=post"));
+    assertTrue(ex.getMessage().contains("Malformed option segment"));
+  }
+
+  // ── Unknown-key error lists supported keys in stable order (PR #5381 review) ──
+
+  @Test
+  void applyArguments_unknownOptionKeyErrorListsSupportedKeysInStableOrder() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("my-index", "embedding", "[1.0, 2.0]", "k=5,bogus=1");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    String msg = ex.getMessage();
+    int kIdx = msg.indexOf("k");
+    int maxIdx = msg.indexOf("max_distance");
+    int minIdx = msg.indexOf("min_score");
+    int filterIdx = msg.indexOf("filter_type");
+    assertTrue(kIdx >= 0 && maxIdx > kIdx && minIdx > maxIdx && filterIdx > minIdx);
+  }
+
   private VectorSearchTableFunctionImplementation createImpl() {
     return createImplWithArgs("my-index", "embedding", "[1.0, 2.0, 3.0]", "k=5");
   }


### PR DESCRIPTION
## Description

Polishes validation behavior for `vectorSearch()` so malformed options and vector literals surface a clear, actionable error instead of a generic one. All changes are local-validation-only (no DSL or execution changes) and preserve existing accepted inputs.

### Option parsing

- Reject empty option values and mid-segment empty values with a `"expected key=value"` message that names the offending segment.
- Trim whitespace around option keys and values so natural spacing (e.g., `k = 5`) works.
- Reject unknown option keys with a message listing the supported set (`k`, `max_distance`, `min_score`, `filter_type`).

### Vector literal parsing

- Detect the common non-comma separators (`;`, `:`, `|`) and surface a dedicated message pointing to the correct comma-separated form, rather than the generic `"Invalid vector component"` coming out of `Float.parseFloat`.

### Numeric bounds

- Reject negative `max_distance` and `min_score` values with a clear `"must be non-negative"` requirement, while continuing to accept zero.

## Testing

- Added unit coverage in `VectorSearchTableFunctionImplementationTest` for each new error path and the zero-boundary acceptance cases.
- Added integration coverage in `VectorSearchIT` for the semicolon-separator, negative-`min_score`, and negative-`max_distance` paths.
- `./gradlew :opensearch:test --tests "*VectorSearchTableFunctionImplementationTest*"` passes.
- `./gradlew spotlessCheck :integ-test:compileTestJava` passes.
- `./gradlew :integ-test:integTest -Dtests.class="org.opensearch.sql.sql.VectorSearchIT"` passes.

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff.