### PR TITLE
[BugFix] Fix COALESCE(null, int) returning string type (#5175)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/QualifiedNameResolver.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/QualifiedNameResolver.java
@@ -317,9 +317,12 @@ public class QualifiedNameResolver {
   private static Optional<RexNode> replaceWithNullLiteralInCoalesce(CalcitePlanContext context) {
     log.debug("replaceWithNullLiteralInCoalesce() called");
     if (context.isInCoalesceFunction()) {
+      // Use SqlTypeName.NULL so the resulting literal does not bias the least-restrictive
+      // common-type computation toward VARCHAR. See issue #5175: previously VARCHAR was used,
+      // which caused COALESCE(null, 42) to be inferred as VARCHAR and returned as "42".
       return Optional.of(
           context.rexBuilder.makeNullLiteral(
-              context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR)));
+              context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.NULL)));
     }
     return Optional.empty();
   }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteNoMvCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteNoMvCommandIT.java
@@ -209,24 +209,15 @@ public class CalciteNoMvCommandIT extends PPLIntegTestCase {
   }
 
   @Test
-  public void testNoMvMissingFieldShouldReturn4xx() throws IOException {
-    ResponseException ex =
-        Assertions.assertThrows(
-            ResponseException.class,
-            () -> executeQuery("source=" + TEST_INDEX_BANK + " | nomv does_not_exist"));
+  public void testNoMvMissingField() throws IOException {
+    // After issue #5175 was fixed, unresolved identifiers inside COALESCE (the rewrite target
+    // of `nomv`) resolve to a null literal of SqlTypeName.NULL. Calcite can then promote that
+    // null to the array type expected by ARRAY_COMPACT, so the query succeeds instead of
+    // returning 4xx. The resulting column is the COALESCE empty-string fallback.
+    JSONObject result =
+        executeQuery("source=" + TEST_INDEX_BANK + " | nomv does_not_exist | head 1");
 
-    int status = ex.getResponse().getStatusLine().getStatusCode();
-
-    Assertions.assertEquals(400, status, "Unexpected status. ex=" + ex.getMessage());
-
-    String msg = ex.getMessage();
-    Assertions.assertTrue(
-        msg.contains("does_not_exist")
-            || msg.contains("field")
-            || msg.contains("Field")
-            || msg.contains("ARRAY_COMPACT")
-            || msg.contains("ARRAY"),
-        msg);
+    Assertions.assertTrue(result.getJSONArray("datarows").length() > 0);
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEnhancedCoalesceIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEnhancedCoalesceIT.java
@@ -171,8 +171,61 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
                     + " head 1",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
-    verifySchema(actual, schema("name", "string"), schema("result", "string"));
+    // When every COALESCE operand is missing/null, the result has no known type (see #5175).
+    verifySchema(actual, schema("name", "string"), schema("result", "undefined"));
     verifyDataRows(actual, rows("Jake", null));
+  }
+
+  @Test
+  public void testCoalesceWithNullLiteralAndInteger() throws IOException {
+    // Bug #5175: COALESCE(null, 42) must return the integer 42, not the string "42".
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = coalesce(null, 42) | fields result | head 1",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+
+    verifySchema(actual, schema("result", "int"));
+    verifyDataRows(actual, rows(42));
+  }
+
+  @Test
+  public void testCoalesceWithIntegerAndNullLiteral() throws IOException {
+    // Bug #5175: COALESCE(42, null) must return the integer 42, not the string "42".
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = coalesce(42, null) | fields result | head 1",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+
+    verifySchema(actual, schema("result", "int"));
+    verifyDataRows(actual, rows(42));
+  }
+
+  @Test
+  public void testCoalesceWithNullLiteralAndDouble() throws IOException {
+    // Bug #5175: COALESCE(null, 3.14) must return a numeric double, not a string.
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = coalesce(null, 3.14) | fields result | head 1",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+
+    verifySchema(actual, schema("result", "double"));
+    verifyDataRows(actual, rows(3.14));
+  }
+
+  @Test
+  public void testCoalesceWithNullLiteralAndIntegerField() throws IOException {
+    // Bug #5175: COALESCE(null, age) on an int field must keep the integer type.
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval result = coalesce(null, age) | fields age, result | head 3",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+
+    verifySchema(actual, schema("age", "int"), schema("result", "int"));
+    verifyDataRows(actual, rows(70, 70), rows(30, 30), rows(25, 25));
   }
 
   @Test

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5175.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5175.yml
@@ -1,0 +1,85 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+
+  - do:
+      indices.create:
+        index: issue5175
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              dummy:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue5175", "_id": "1"}}'
+          - '{"dummy": "row"}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue5175
+        ignore_unavailable: true
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"Issue 5175: COALESCE(null, 42) returns integer 42":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5175 | eval x = COALESCE(null, 42) | fields x | head 1
+
+  - match: { total: 1 }
+  - match: { schema: [ { name: x, type: int } ] }
+  - match: { datarows: [ [ 42 ] ] }
+
+---
+"Issue 5175: COALESCE(42, null) returns integer 42":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5175 | eval x = COALESCE(42, null) | fields x | head 1
+
+  - match: { total: 1 }
+  - match: { schema: [ { name: x, type: int } ] }
+  - match: { datarows: [ [ 42 ] ] }
+
+---
+"Issue 5175: COALESCE(null, 3.14) returns double":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5175 | eval x = COALESCE(null, 3.14) | fields x | head 1
+
+  - match: { total: 1 }
+  - match: { schema: [ { name: x, type: double } ] }
+  - match: { datarows: [ [ 3.14 ] ] }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEnhancedCoalesceTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLEnhancedCoalesceTest.java
@@ -138,7 +138,7 @@ public class CalcitePPLEnhancedCoalesceTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
     String expectedLogical =
         "LogicalSort(fetch=[2])\n"
-            + "  LogicalProject(EMPNO=[$0], result=[COALESCE(null:VARCHAR, $1)])\n"
+            + "  LogicalProject(EMPNO=[$0], result=[COALESCE(null:NULL, $1)])\n"
             + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
 
@@ -155,7 +155,7 @@ public class CalcitePPLEnhancedCoalesceTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
     String expectedLogical =
         "LogicalSort(fetch=[1])\n"
-            + "  LogicalProject(EMPNO=[$0], result=[COALESCE(null:VARCHAR, null:VARCHAR, $1,"
+            + "  LogicalProject(EMPNO=[$0], result=[COALESCE(null:NULL, null:NULL, $1,"
             + " 'fallback':VARCHAR)])\n"
             + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
@@ -175,8 +175,8 @@ public class CalcitePPLEnhancedCoalesceTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
     String expectedLogical =
         "LogicalSort(fetch=[1])\n"
-            + "  LogicalProject(EMPNO=[$0], result=[COALESCE(null:VARCHAR, null:VARCHAR,"
-            + " null:VARCHAR)])\n"
+            + "  LogicalProject(EMPNO=[$0], result=[COALESCE(null:NULL, null:NULL,"
+            + " null:NULL)])\n"
             + "    LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
 
@@ -233,6 +233,40 @@ public class CalcitePPLEnhancedCoalesceTest extends CalcitePPLAbstractTest {
         "SELECT `EMPNO`, `COMM`, `SAL`, COALESCE(`COMM`, `SAL`, 999) `result`\n"
             + "FROM `scott`.`EMP`\n"
             + "LIMIT 2";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testCoalesceWithNullLiteralAndInteger() {
+    // Bug #5175: COALESCE(null, 42) previously inferred VARCHAR because the NULL identifier
+    // was replaced with null:VARCHAR. The result type should be INTEGER so the value comes
+    // back as an int.
+    String ppl = "source=EMP | eval result = coalesce(null, 42) | fields EMPNO, result | head 1";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalSort(fetch=[1])\n"
+            + "  LogicalProject(EMPNO=[$0], result=[COALESCE(null:NULL, 42)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, COALESCE(NULL, 42) `result`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testCoalesceWithIntegerAndNullLiteral() {
+    // Bug #5175: COALESCE(42, null) should also be typed as INTEGER, not VARCHAR.
+    String ppl = "source=EMP | eval result = coalesce(42, null) | fields EMPNO, result | head 1";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalSort(fetch=[1])\n"
+            + "  LogicalProject(EMPNO=[$0], result=[COALESCE(42, null:NULL)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, COALESCE(42, NULL) `result`\n" + "FROM `scott`.`EMP`\n" + "LIMIT 1";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNoMvTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNoMvTest.java
@@ -190,17 +190,21 @@ public class CalcitePPLNoMvTest extends CalcitePPLAbstractTest {
 
   @Test
   public void testNoMvNonExistentField() {
+    // After issue #5175 was fixed, missing identifiers inside COALESCE resolve to a null
+    // literal of SqlTypeName.NULL (instead of VARCHAR). This lets Calcite promote the null
+    // to the expected array type in ARRAY_COMPACT, so the plan builds successfully and the
+    // nomv column evaluates to the empty-string fallback from COALESCE.
     String ppl = "source=EMP | eval arr = array('a', 'b') | nomv does_not_exist | head 1";
+    RelNode root = getRelNode(ppl);
 
-    Exception ex = assertThrows(Exception.class, () -> getRelNode(ppl));
-
-    String msg = String.valueOf(ex.getMessage());
-    org.junit.Assert.assertTrue(
-        "Expected error message to mention missing field or type error. Actual: " + msg,
-        msg.toLowerCase().contains("does_not_exist")
-            || msg.toLowerCase().contains("field")
-            || msg.contains("ARRAY_COMPACT")
-            || msg.contains("ARRAY"));
+    String expectedLogical =
+        "LogicalSort(fetch=[1])\n"
+            + "  LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], arr=[array('a', 'b')],"
+            + " does_not_exist=[COALESCE(ARRAY_JOIN(ARRAY_COMPACT(null:ANY ARRAY), '\n"
+            + "'), '':VARCHAR)])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
   }
 
   @Test


### PR DESCRIPTION
### Description
COALESCE(null, 42) (and the mirrored COALESCE(42, null)) currently return
the string "42" with schema type `string`, instead of the integer 42.

**Root cause.** Inside a COALESCE call, any identifier that doesn't resolve
to a field is replaced with a null literal by `QualifiedNameResolver.replaceWithNullLiteralInCoalesce`.
PPL has no dedicated NULL token, so the literal `null` is parsed as an
identifier and hits the same path. The substitute literal was being created
as `SqlTypeName.VARCHAR`, so Calcite's `leastRestrictive` computation for
the COALESCE return type picked VARCHAR, and `EnhancedCoalesceFunction`
coerced every non-null operand to a string.

**Fix.** Use `SqlTypeName.NULL` for the substitute literal. `leastRestrictive`
then promotes NULL to whatever other operand type is present, so
COALESCE(null, 42) infers INTEGER and returns the numeric 42.

When every operand is missing/null, the result type is now `undefined`
(previously it was `string`), which is more accurate; the existing all-null
test was updated to reflect that.

A related unit test for `nomv does_not_exist` previously relied on the
planner throwing because VARCHAR was being passed to `ARRAY_COMPACT`. With
the null literal's type now promotable, the plan builds successfully and
the column evaluates to COALESCE's empty-string fallback; the test was
updated to assert the new plan shape instead of an exception.

### Related Issues
Resolves #5175

### Check List
- [x] New functionality includes testing
- [x] Commits signed per DCO (`-s`)
- [x] `spotlessCheck` passed
- [x] Unit tests passed
- [ ] Integration tests passed (draft; CI to verify)