### PR TITLE
feat(api): register SqlLibrary operators in UnifiedQueryContext

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
@@ -23,6 +23,8 @@ import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.fun.SqlLibrary;
+import org.apache.calcite.sql.fun.SqlLibraryOperatorTableFactory;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.util.SqlOperatorTables;
@@ -248,7 +250,14 @@ public class UnifiedQueryContext implements AutoCloseable {
           .parserConfig(buildParserConfig())
           .operatorTable(
               SqlOperatorTables.chain(
-                  SqlStdOperatorTable.instance(), UnifiedFunctionSpec.RELEVANCE.operatorTable()))
+                  SqlStdOperatorTable.instance(),
+                  UnifiedFunctionSpec.RELEVANCE.operatorTable(),
+                  SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(
+                      java.util.EnumSet.of(
+                          SqlLibrary.POSTGRESQL,
+                          SqlLibrary.MYSQL,
+                          SqlLibrary.BIG_QUERY,
+                          SqlLibrary.SPARK))))
           .defaultSchema(defaultSchema)
           .traitDefs((List<RelTraitDef>) null)
           .programs(Programs.calc(DefaultRelMetadataProvider.INSTANCE))


### PR DESCRIPTION
### Description

`UnifiedQueryContext` currently registers only `SqlStdOperatorTable` and the `RELEVANCE` operator table with the Calcite validator. This means SQL queries submitted through `UnifiedQueryPlanner` cannot use library functions that live outside the SQL standard — notably the **3-argument `REGEXP_REPLACE(str, pattern, replacement)`** used by ClickBench and many real-world PostgreSQL / BigQuery queries.

Example failure before this change:

```
ClickBench Q29:
SELECT REGEXP_REPLACE(referer, '^https?://(?:www\.)?([^/]+)/.*$', '\1') AS k, ...
-> validation_exception: No match found for function signature REGEXP_REPLACE(<CHARACTER>, <CHARACTER>, <CHARACTER>)
```

### Fix

Chain `SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(EnumSet.of(POSTGRESQL, MYSQL, BIG_QUERY, SPARK))` into the operator-table chain at validator construction time (`api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java#buildFrameworkConfig`).

The same four-library set is already used elsewhere in the codebase (`RelJsonSerializer.java` deserialization) and by the PPL path which resolves functions directly to `SqlLibraryOperators.REGEXP_REPLACE_3` (`PPLFuncImpTable.java`). This brings the SQL path in line with PPL's function surface.

### Diff scope

1 file, 10 insertions / 1 deletion.

### Functions enabled

- \`REGEXP_REPLACE(str, pattern, replacement)\` — 3-arg form
- \`SAFE_DIVIDE\`, \`REGEXP_CONTAINS\`, \`CONCAT_WS\`, \`REVERSE\`, \`RIGHT\`
- All other PostgreSQL / MySQL / BigQuery / Spark library functions already depended on by PPL

### Tests

- \`:api:test\` — \`UnifiedQueryContextTest\` (7/7) and \`UnifiedQueryPlannerTest\` / \`UnifiedQueryPlannerSqlTest\` (14/14) pass
- \`:api:assemble :core:assemble :ppl:assemble\` — BUILD SUCCESSFUL
- No ambiguous-overload errors from chained libraries

### Rationale

Calcite's \`SqlLibraryOperators.REGEXP_REPLACE_3\` lives in library tables, not in \`SqlStdOperatorTable.instance()\`. Enabling the library operator table is the standard Calcite idiom and matches established project convention.