### PR TITLE
[BugFix] Surface dedicated error for wildcard or multi-target table in vectorSearch()

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -400,6 +400,39 @@ public class VectorSearchIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testWildcardTableRejectedWithDedicatedMessage() throws IOException {
+    // Wildcards in a table name fan out to multiple indices, which vectorSearch() does not
+    // support (top-k semantics, dimension checks, and embedded filter JSON are not defined
+    // across heterogeneous shards). Surface a dedicated user-facing error instead of the
+    // generic "must contain only alphanumeric..." fallback.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='sql_vector_*', field='f', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Invalid table name"));
+    assertThat(ex.getMessage(), containsString("wildcards"));
+    assertThat(ex.getMessage(), containsString("single concrete index"));
+  }
+
+  @Test
+  public void testMultiTargetTableRejectedWithDedicatedMessage() throws IOException {
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                executeQuery(
+                    "SELECT v._id FROM vectorSearch(table='idx_a,idx_b', field='f', "
+                        + "vector='[1.0]', option='k=5') AS v"));
+
+    assertThat(ex.getMessage(), containsString("Invalid table name"));
+    assertThat(ex.getMessage(), containsString("multi-target"));
+  }
+
+  @Test
   public void testDuplicateNamedArgRejected() throws IOException {
     // Previously this crashed the server with 500 ArrayIndexOutOfBoundsException. Must now
     // surface as a clean 400 with a user-facing message.

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -203,6 +203,19 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
    * its own error message.
    */
   private void validateTableName(String tableName) {
+    // Flag wildcard and multi-target patterns with a dedicated message before the generic
+    // character-class check, so users get an actionable hint instead of "must contain only
+    // alphanumeric characters, dots, ...". vectorSearch() targets a single index because
+    // top-k semantics, dimension checks, and the embedded filter JSON are not defined across
+    // heterogeneous shards.
+    if (tableName.indexOf('*') >= 0 || tableName.indexOf(',') >= 0) {
+      throw new ExpressionEvaluationException(
+          String.format(
+              "Invalid table name '%s': vectorSearch() requires a single concrete index or alias;"
+                  + " wildcards ('*') and multi-target patterns (comma-separated) are not"
+                  + " supported",
+              tableName));
+    }
     if (!SAFE_FIELD_NAME.matcher(tableName).matches()) {
       throw new ExpressionEvaluationException(
           String.format(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -203,11 +203,8 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
    * its own error message.
    */
   private void validateTableName(String tableName) {
-    // Flag wildcard and multi-target patterns with a dedicated message before the generic
-    // character-class check, so users get an actionable hint instead of "must contain only
-    // alphanumeric characters, dots, ...". vectorSearch() targets a single index because
-    // top-k semantics, dimension checks, and the embedded filter JSON are not defined across
-    // heterogeneous shards.
+    // Dedicated error for fan-out patterns ('*' and ',') before the generic regex; see Javadoc
+    // for why vectorSearch() targets a single index.
     if (tableName.indexOf('*') >= 0 || tableName.indexOf(',') >= 0) {
       throw new ExpressionEvaluationException(
           String.format(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementation.java
@@ -196,11 +196,13 @@ public class VectorSearchTableFunctionImplementation extends FunctionExpression
   /**
    * Reject table names with characters that could corrupt the WrapperQueryBuilder JSON or escape
    * the target index name. Allows alphanumeric, dots, underscores, and hyphens (the characters
-   * OpenSearch index names already permit). Explicitly rejects the `_all` routing target and the
-   * pathologic `.` / `..` names because those either fan out to every index or are not valid
-   * concrete index names. Other native-invalid names (leading dot, leading hyphen, bare underscore,
-   * uppercase, and so on) are intentionally passed through for the OpenSearch client to reject with
-   * its own error message.
+   * OpenSearch index names already permit). Explicitly rejects wildcards ('*') and multi-target
+   * patterns (comma-separated) with a dedicated message, because vectorSearch() targets a single
+   * concrete index or alias and fan-out patterns would otherwise fall through to the generic regex
+   * message. Also rejects the `_all` routing target and the pathologic `.` / `..` names because
+   * those either fan out to every index or are not valid concrete index names. Other native-invalid
+   * names (leading dot, leading hyphen, bare underscore, uppercase, and so on) are intentionally
+   * passed through for the OpenSearch client to reject with its own error message.
    */
   private void validateTableName(String tableName) {
     // Dedicated error for fan-out patterns ('*' and ',') before the generic regex; see Javadoc

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/VectorSearchTableFunctionImplementationTest.java
@@ -499,6 +499,46 @@ class VectorSearchTableFunctionImplementationTest {
   }
 
   @Test
+  void applyArguments_rejectsWildcardTableWithDedicatedMessage() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("sql_vector_*", "embedding", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid table name"));
+    assertTrue(ex.getMessage().contains("wildcards ('*')"));
+    assertTrue(ex.getMessage().contains("single concrete index"));
+  }
+
+  @Test
+  void applyArguments_rejectsBareStarTableWithDedicatedMessage() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("*", "embedding", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("wildcards ('*')"));
+  }
+
+  @Test
+  void applyArguments_rejectsMultiTargetTableWithDedicatedMessage() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("idx_a,idx_b", "embedding", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("Invalid table name"));
+    assertTrue(ex.getMessage().contains("multi-target"));
+    assertTrue(ex.getMessage().contains("single concrete index"));
+  }
+
+  @Test
+  void applyArguments_rejectsMidNameStarTable() {
+    VectorSearchTableFunctionImplementation impl =
+        createImplWithArgs("foo*bar", "embedding", "[1.0, 2.0]", "k=5");
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> impl.applyArguments());
+    assertTrue(ex.getMessage().contains("wildcards ('*')"));
+  }
+
+  @Test
   void validateNamedArgs_rejectsDuplicateNames() {
     // Two occurrences of "table" reach the Implementation layer directly (bypassing the resolver).
     FunctionName functionName = FunctionName.of("vectorsearch");


### PR DESCRIPTION
## Description

Before this change, a table name containing a wildcard (`*`) or multi-target pattern (`a,b`) was rejected by `vectorSearch()`, but the user saw the generic fallback message:

> "Invalid table name '...': must contain only alphanumeric characters, dots, underscores, or hyphens"

That message hides the real constraint. `vectorSearch()` requires a single concrete index because top-k semantics, dimension checks, and the embedded filter JSON are not defined across heterogeneous shards.

This PR adds a dedicated check in `validateTableName()` that runs *before* the generic character-class regex and surfaces:

> "Invalid table name '...': vectorSearch() requires a single concrete index or alias; wildcards ('*') and multi-target patterns (comma-separated) are not supported"

No DSL or execution-path change. Accepted inputs are unchanged — simple names, dotted names, hyphens, and underscores all still pass.

## Testing

Unit coverage in `VectorSearchTableFunctionImplementationTest`:

- `applyArguments_rejectsWildcardTableWithDedicatedMessage` (`sql_vector_*`)
- `applyArguments_rejectsBareStarTableWithDedicatedMessage` (`*`)
- `applyArguments_rejectsMultiTargetTableWithDedicatedMessage` (`idx_a,idx_b`)
- `applyArguments_rejectsMidNameStarTable` (`foo*bar`)

Integration coverage in `VectorSearchIT`:

- `testWildcardTableRejectedWithDedicatedMessage`
- `testMultiTargetTableRejectedWithDedicatedMessage`

Local checks:

- `./gradlew :opensearch:test --tests "*VectorSearchTableFunctionImplementationTest*"` passes.
- `./gradlew spotlessCheck :integ-test:compileTestJava` passes.
- `./gradlew :integ-test:integTest -Dtests.class="org.opensearch.sql.sql.VectorSearchIT"` passes.

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff.