### PR TITLE
Reject outer ORDER BY / OFFSET / aggregation / DISTINCT over subqueries

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchSubqueryIT.java
@@ -167,6 +167,24 @@ public class VectorSearchSubqueryIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void testInnerOrderByScoreDescInSubqueryAllowed() throws IOException {
+    // Positive control: inner ORDER BY _score DESC on the vectorSearch() relation inside the
+    // subquery is the only supported sort, and must continue to plan successfully even when
+    // wrapped in an outer SELECT. Proves the walker does not over-reject sort shapes that are
+    // below the subquery Project rather than above it.
+    String explain =
+        explainQuery(
+            "SELECT * FROM (SELECT v.firstname, v._score "
+                + "FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
+                + "ORDER BY v._score DESC) t "
+                + "LIMIT 3");
+
+    assertThat(explain, containsString("wrapper"));
+  }
+
+  @Test
   public void testOuterOrderByOnSubqueryRejected() throws IOException {
     // Outer ORDER BY over a vectorSearch() subquery would run on a truncated top-k slice rather
     // than the full relation, silently reordering only the already-ANN-selected rows.

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchSubqueryIT.java
@@ -165,4 +165,124 @@ public class VectorSearchSubqueryIT extends SQLIntegTestCase {
 
     assertThat(explain, containsString("wrapper"));
   }
+
+  @Test
+  public void testOuterOrderByOnSubqueryRejected() throws IOException {
+    // Outer ORDER BY over a vectorSearch() subquery would run on a truncated top-k slice rather
+    // than the full relation, silently reordering only the already-ANN-selected rows.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                explainQuery(
+                    "SELECT * FROM (SELECT v.firstname, v.state "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t "
+                        + "ORDER BY t.state"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString("Outer ORDER BY on a vectorSearch() subquery is not supported"));
+  }
+
+  @Test
+  public void testOuterOffsetOnSubqueryRejected() throws IOException {
+    // Outer OFFSET silently drops top-k rows by vector distance. The inner query already caps at
+    // k and any outer OFFSET shifts that window in an opaque way, so reject it.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                explainQuery(
+                    "SELECT * FROM (SELECT v.firstname "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t "
+                        + "LIMIT 3 OFFSET 2"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString("Outer OFFSET on a vectorSearch() subquery is not supported"));
+  }
+
+  @Test
+  public void testOuterLimitWithoutOffsetOnSubqueryAllowed() throws IOException {
+    // Positive control: outer LIMIT without OFFSET just caps the row count and must plan without
+    // error. Locks in the offset==0 boundary of the OFFSET rejection.
+    String explain =
+        explainQuery(
+            "SELECT * FROM (SELECT v.firstname "
+                + "FROM vectorSearch(table='"
+                + TEST_INDEX
+                + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t "
+                + "LIMIT 3");
+
+    assertThat(explain, containsString("wrapper"));
+  }
+
+  @Test
+  public void testOuterAggregationOnSubqueryRejected() throws IOException {
+    // Outer aggregation (here COUNT(*)) over a vectorSearch() subquery would run on the
+    // truncated top-k slice, producing a count that silently depends on k rather than the full
+    // population. vectorSearch() does not support aggregations, so reject the outer-subquery
+    // variant with the same subquery-boundary walker that catches outer WHERE.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                explainQuery(
+                    "SELECT COUNT(*) FROM (SELECT v.firstname "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString(
+            "Outer GROUP BY / aggregation / DISTINCT on a vectorSearch() subquery is not"
+                + " supported"));
+  }
+
+  @Test
+  public void testOuterGroupByOnSubqueryRejected() throws IOException {
+    // GROUP BY rewrites to LogicalAggregation and is caught by the same subquery-boundary walker.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                explainQuery(
+                    "SELECT t.state, COUNT(*) FROM (SELECT v.firstname, v.state "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t "
+                        + "GROUP BY t.state"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString(
+            "Outer GROUP BY / aggregation / DISTINCT on a vectorSearch() subquery is not"
+                + " supported"));
+  }
+
+  @Test
+  public void testOuterDistinctOnSubqueryRejected() throws IOException {
+    // SELECT DISTINCT rewrites to a LogicalAggregation with empty aggregator list and the select
+    // items as the group-by list. The subquery-boundary walker must catch this shape too.
+    ResponseException ex =
+        expectThrows(
+            ResponseException.class,
+            () ->
+                explainQuery(
+                    "SELECT DISTINCT t.state FROM (SELECT v.firstname, v.state "
+                        + "FROM vectorSearch(table='"
+                        + TEST_INDEX
+                        + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v) t"));
+
+    assertThat(
+        ex.getMessage(),
+        containsString(
+            "Outer GROUP BY / aggregation / DISTINCT on a vectorSearch() subquery is not"
+                + " supported"));
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
@@ -27,10 +27,10 @@ import org.opensearch.sql.planner.logical.LogicalSort;
  *   <li><b>Outer operators over a vectorSearch() subquery</b> — when vectorSearch() is wrapped in a
  *       subquery (e.g. {@code SELECT * FROM (SELECT v.id FROM vectorSearch(...) AS v) t WHERE
  *       t.price < 150}), outer WHERE / ORDER BY / OFFSET / GROUP BY / aggregation / DISTINCT do not
- *       reach the push-down contract (the inner {@link LogicalProject} sits between the outer
- *       operator and this scan builder, so those nodes never match the direct-adjacency push-down
- *       patterns). They would then be applied in memory <i>after</i> k-NN has already returned
- *       top-k documents ranked by vector distance, which can silently yield zero rows or
+ *       participate in the vectorSearch pushdown contract (the inner {@link LogicalProject} sits
+ *       between the outer operator and this scan builder, so those nodes never match the
+ *       direct-adjacency push-down patterns). They would then be applied in memory <i>after</i>
+ *       top-k results have been selected by vector distance, which can silently yield zero rows or
  *       mis-ordered results. We detect these shapes in {@link #validatePlan(LogicalPlan)} and
  *       reject with a clear error.
  * </ul>
@@ -128,15 +128,33 @@ public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
     return null;
   }
 
+  // Operator-specific messages: the generic "move it inside the subquery" advice is only right
+  // for WHERE and for ORDER BY _score DESC. OFFSET, aggregation, GROUP BY, and DISTINCT are
+  // themselves unsupported on vectorSearch() directly, so the message must not claim a workaround
+  // that would only trip the user on a second validation error.
   private static String rejectionMessage(String outerOp) {
-    return "Outer "
-        + outerOp
-        + " on a vectorSearch() subquery is not supported: the operator does not push into the"
-        + " k-NN search and would be applied only after top-k results have been selected by"
-        + " vector distance, which can silently yield zero rows or mis-ordered results."
-        + " Move the "
-        + outerOp
-        + " inside the subquery (directly on vectorSearch()) so it can participate in the"
-        + " vectorSearch push-down contract.";
+    switch (outerOp) {
+      case "WHERE":
+        return "Outer WHERE on a vectorSearch() subquery is not supported: the predicate does not"
+            + " participate in the vectorSearch pushdown contract and would be applied only"
+            + " after top-k results have been selected by vector distance, which can silently"
+            + " yield zero rows. Move the WHERE into the same SELECT block as vectorSearch() so"
+            + " it participates in the vectorSearch WHERE pushdown contract.";
+      case "ORDER BY":
+        return "Outer ORDER BY on a vectorSearch() subquery is not supported: sorting does not"
+            + " participate in the vectorSearch pushdown contract and would be applied only"
+            + " after top-k results have been selected by vector distance, which can yield"
+            + " mis-ordered results. Use ORDER BY <alias>._score DESC in the same SELECT block"
+            + " as vectorSearch(), or omit ORDER BY.";
+      case "OFFSET":
+        return "Outer OFFSET on a vectorSearch() subquery is not supported. OFFSET is not"
+            + " supported on vectorSearch(); use LIMIT only.";
+      case "GROUP BY / aggregation / DISTINCT":
+        return "Outer GROUP BY / aggregation / DISTINCT on a vectorSearch() subquery is not"
+            + " supported. Aggregations and DISTINCT are not supported on vectorSearch()"
+            + " relations.";
+      default:
+        return "Outer " + outerOp + " on a vectorSearch() subquery is not supported.";
+    }
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilder.java
@@ -10,26 +10,29 @@ import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
 import org.opensearch.sql.planner.logical.LogicalFilter;
+import org.opensearch.sql.planner.logical.LogicalLimit;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalProject;
+import org.opensearch.sql.planner.logical.LogicalSort;
 
 /**
  * Scan builder for vector search relations.
  *
- * <p>Rejects two planner shapes that the SQL surface cannot express safely:
+ * <p>Rejects planner shapes that the SQL surface cannot express safely:
  *
  * <ul>
  *   <li><b>Aggregations</b> — native OpenSearch k-NN supports aggregations alongside similarity
  *       search, but the SQL layer does not plumb them through, so we fail fast rather than return
  *       silently unaggregated results.
- *   <li><b>Outer WHERE over a vectorSearch() subquery</b> — when vectorSearch() is wrapped in a
+ *   <li><b>Outer operators over a vectorSearch() subquery</b> — when vectorSearch() is wrapped in a
  *       subquery (e.g. {@code SELECT * FROM (SELECT v.id FROM vectorSearch(...) AS v) t WHERE
- *       t.price < 150}), the outer predicate does not reach the push-down contract (the inner
- *       {@link LogicalProject} sits between the outer {@link LogicalFilter} and this scan builder,
- *       so the filter never matches the {@code filter(scanBuilder)} push-down pattern). The filter
- *       is then applied in memory, but only <i>after</i> k-NN has already returned the top-k
- *       documents ranked by vector distance, so the outer predicate can silently produce zero rows.
- *       We detect this shape in {@link #validatePlan(LogicalPlan)} and reject with a clear error.
+ *       t.price < 150}), outer WHERE / ORDER BY / OFFSET / GROUP BY / aggregation / DISTINCT do not
+ *       reach the push-down contract (the inner {@link LogicalProject} sits between the outer
+ *       operator and this scan builder, so those nodes never match the direct-adjacency push-down
+ *       patterns). They would then be applied in memory <i>after</i> k-NN has already returned
+ *       top-k documents ranked by vector distance, which can silently yield zero rows or
+ *       mis-ordered results. We detect these shapes in {@link #validatePlan(LogicalPlan)} and
+ *       reject with a clear error.
  * </ul>
  */
 public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
@@ -47,57 +50,93 @@ public class VectorSearchIndexScanBuilder extends OpenSearchIndexScanBuilder {
   }
 
   /**
-   * Walk the fully-optimized plan and reject the outer-WHERE-over-subquery shape. We look for a
-   * {@link LogicalFilter} whose descendant chain reaches this scan builder through one or more
-   * {@link LogicalProject} nodes (the subquery-boundary marker). A filter directly above this scan
-   * builder is fine — that WHERE has already gone through the push-down contract.
+   * Walk the fully-optimized plan and reject outer-operator-over-subquery shapes. We look for an
+   * outer {@link LogicalFilter}, {@link LogicalSort}, {@link LogicalLimit} with non-zero offset, or
+   * {@link LogicalAggregation} whose descendant chain reaches this scan builder through one or more
+   * {@link LogicalProject} nodes (the subquery-boundary marker). An operator directly above this
+   * scan builder is fine — those go through the push-down contract in the query builder.
    */
   @Override
   public void validatePlan(LogicalPlan root) {
-    checkForOuterFilter(root, false, false);
+    checkForOuterOperator(root, null, false);
   }
 
   /**
-   * Recursive walker with two booleans that together encode the "outer filter separated by a
-   * subquery boundary" pattern:
+   * Recursive walker that tracks the outermost "risky" operator seen on the current walk path and
+   * whether a {@link LogicalProject} has been crossed since then:
    *
    * <ul>
-   *   <li>{@code insideFilter} — true iff some ancestor on the current walk path is a {@link
-   *       LogicalFilter}. Projects only matter below a filter, so without a filter ancestor a
+   *   <li>{@code outerOp} — name of the outermost filter/sort/offset/aggregation ancestor, or
+   *       {@code null} if none. Projects only matter below such an operator — without one, a
    *       project is just the outer SELECT and should not trigger rejection.
-   *   <li>{@code sawProjectSinceFilter} — true iff a {@link LogicalProject} has been seen between
-   *       <em>any</em> enclosing filter ancestor and the current position. Once an outer Filter has
-   *       been separated from the scan by a Project, that separation is permanent — a lower
-   *       LogicalFilter below the Project does not undo the outer boundary.
+   *   <li>{@code sawProjectSinceOuter} — true iff a {@link LogicalProject} has been seen between
+   *       the outermost risky ancestor and the current position. Once separation by a Project has
+   *       been established, it is permanent — a lower {@link LogicalFilter} below the Project does
+   *       not undo the outer boundary.
    * </ul>
    *
    * <p>This matters for shapes like {@code Filter(outer) -> Project(subquery) -> Filter(inner) ->
    * Scan}, where the outer predicate is still blocked from reaching the push-down contract by the
-   * subquery Project regardless of the inner filter. Resetting {@code sawProjectSinceFilter} when
-   * entering the inner filter would make the walker miss this shape.
+   * subquery Project regardless of the inner filter. Resetting on the inner filter would make the
+   * walker miss this shape.
    */
-  private void checkForOuterFilter(
-      LogicalPlan node, boolean insideFilter, boolean sawProjectSinceFilter) {
+  private void checkForOuterOperator(
+      LogicalPlan node, String outerOp, boolean sawProjectSinceOuter) {
     if (node == this) {
-      if (insideFilter && sawProjectSinceFilter) {
-        throw new ExpressionEvaluationException(
-            "Outer WHERE on a vectorSearch() subquery is not supported: the predicate does not"
-                + " push into the k-NN search and would be applied only after top-k results have"
-                + " been selected by vector distance, which can silently yield zero rows."
-                + " Move the predicate inside the subquery (WHERE directly on vectorSearch()) so"
-                + " it can participate in the vectorSearch WHERE pushdown contract.");
+      if (outerOp != null && sawProjectSinceOuter) {
+        throw new ExpressionEvaluationException(rejectionMessage(outerOp));
       }
       return;
     }
-    boolean nextInsideFilter = insideFilter;
-    boolean nextSawProject = sawProjectSinceFilter;
-    if (node instanceof LogicalFilter) {
-      nextInsideFilter = true;
-    } else if (node instanceof LogicalProject && insideFilter) {
+    String nextOuterOp = outerOp;
+    boolean nextSawProject = sawProjectSinceOuter;
+    if (outerOp == null) {
+      String operator = classifyOuterOperator(node);
+      if (operator != null) {
+        nextOuterOp = operator;
+      }
+    } else if (node instanceof LogicalProject) {
       nextSawProject = true;
     }
     for (LogicalPlan child : node.getChild()) {
-      checkForOuterFilter(child, nextInsideFilter, nextSawProject);
+      checkForOuterOperator(child, nextOuterOp, nextSawProject);
     }
+  }
+
+  /**
+   * Returns a user-facing label for operators that cannot safely sit above a vectorSearch()
+   * subquery, or {@code null} for operators that are fine (Project, scan, etc.). {@link
+   * LogicalLimit} with {@code offset == 0} is safe — plain LIMIT wrapping a subquery just caps the
+   * row count. Non-zero OFFSET skips top-k rows by distance and is rejected.
+   */
+  private static String classifyOuterOperator(LogicalPlan node) {
+    if (node instanceof LogicalFilter) {
+      return "WHERE";
+    }
+    if (node instanceof LogicalSort) {
+      return "ORDER BY";
+    }
+    if (node instanceof LogicalAggregation) {
+      return "GROUP BY / aggregation / DISTINCT";
+    }
+    if (node instanceof LogicalLimit) {
+      Integer offset = ((LogicalLimit) node).getOffset();
+      if (offset != null && offset != 0) {
+        return "OFFSET";
+      }
+    }
+    return null;
+  }
+
+  private static String rejectionMessage(String outerOp) {
+    return "Outer "
+        + outerOp
+        + " on a vectorSearch() subquery is not supported: the operator does not push into the"
+        + " k-NN search and would be applied only after top-k results have been selected by"
+        + " vector distance, which can silently yield zero rows or mis-ordered results."
+        + " Move the "
+        + outerOp
+        + " inside the subquery (directly on vectorSearch()) so it can participate in the"
+        + " vectorSearch push-down contract.";
   }
 }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchIndexScanBuilderTest.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.opensearch.index.query.WrapperQueryBuilder;
+import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
@@ -23,8 +24,10 @@ import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory;
 import org.opensearch.sql.opensearch.request.OpenSearchRequestBuilder;
 import org.opensearch.sql.planner.logical.LogicalAggregation;
 import org.opensearch.sql.planner.logical.LogicalFilter;
+import org.opensearch.sql.planner.logical.LogicalLimit;
 import org.opensearch.sql.planner.logical.LogicalPlan;
 import org.opensearch.sql.planner.logical.LogicalProject;
+import org.opensearch.sql.planner.logical.LogicalSort;
 import org.opensearch.sql.planner.logical.LogicalValues;
 
 class VectorSearchIndexScanBuilderTest {
@@ -47,6 +50,22 @@ class VectorSearchIndexScanBuilderTest {
   private static LogicalFilter filter(LogicalPlan input) {
     return new LogicalFilter(
         input, DSL.less(DSL.ref("price", ExprCoreType.INTEGER), DSL.literal(150)));
+  }
+
+  private static LogicalSort sort(LogicalPlan input) {
+    return new LogicalSort(
+        input,
+        ImmutableList.of(
+            org.apache.commons.lang3.tuple.Pair.of(
+                Sort.SortOption.DEFAULT_DESC, DSL.ref("price", ExprCoreType.INTEGER))));
+  }
+
+  private static LogicalLimit limit(LogicalPlan input, int offset) {
+    return new LogicalLimit(input, 10, offset);
+  }
+
+  private static LogicalAggregation aggregation(LogicalPlan input) {
+    return new LogicalAggregation(input, Collections.emptyList(), Collections.emptyList(), false);
   }
 
   @Test
@@ -154,5 +173,62 @@ class VectorSearchIndexScanBuilderTest {
     var scanBuilder = newScanBuilder();
 
     assertDoesNotThrow(() -> scanBuilder.validatePlan(scanBuilder));
+  }
+
+  @Test
+  void validatePlanRejectsOuterSortOverSubqueryProject() {
+    // Models: SELECT * FROM (SELECT v.id FROM vs(...) AS v) t ORDER BY t.price
+    // Shape: Sort(outer) → Project(subquery) → scanBuilder
+    // Outer ORDER BY would be applied only after top-k ANN results, producing an order the user
+    // did not ask for (vector distance ordering leaks through when rows are fewer than expected).
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = sort(project(scanBuilder));
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> scanBuilder.validatePlan(root));
+    assertTrue(
+        ex.getMessage().contains("Outer ORDER BY on a vectorSearch() subquery"),
+        "Error should mention outer ORDER BY on subquery; actual: " + ex.getMessage());
+  }
+
+  @Test
+  void validatePlanRejectsOuterOffsetOverSubqueryProject() {
+    // Models: SELECT * FROM (SELECT v.id FROM vs(...) AS v) t LIMIT 10 OFFSET 5
+    // Outer OFFSET silently skips the top-N nearest rows chosen by ANN, so the remaining rows
+    // would be a truncated tail of the k-NN result set rather than the user's intended window.
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = limit(project(scanBuilder), 5);
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> scanBuilder.validatePlan(root));
+    assertTrue(
+        ex.getMessage().contains("Outer OFFSET on a vectorSearch() subquery"),
+        "Error should mention outer OFFSET on subquery; actual: " + ex.getMessage());
+  }
+
+  @Test
+  void validatePlanAllowsOuterLimitWithoutOffsetOverSubquery() {
+    // Outer LIMIT with offset=0 just caps row count and is safe over a subquery — reject only
+    // non-zero OFFSET. Locks in the offset==0 boundary of the guard.
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = limit(project(scanBuilder), 0);
+
+    assertDoesNotThrow(() -> scanBuilder.validatePlan(root));
+  }
+
+  @Test
+  void validatePlanRejectsOuterAggregationOverSubqueryProject() {
+    // Models: SELECT COUNT(*) FROM (SELECT v.id FROM vs(...) AS v) t
+    // (Or outer GROUP BY / DISTINCT, both of which rewrite to LogicalAggregation.) The outer
+    // aggregation would run on a truncated top-k slice rather than a meaningful population,
+    // masking the fact that aggregations are not supported on vectorSearch() in this preview.
+    var scanBuilder = newScanBuilder();
+    LogicalPlan root = aggregation(project(scanBuilder));
+
+    ExpressionEvaluationException ex =
+        assertThrows(ExpressionEvaluationException.class, () -> scanBuilder.validatePlan(root));
+    assertTrue(
+        ex.getMessage().contains("Outer GROUP BY / aggregation / DISTINCT on a vectorSearch()"),
+        "Error should mention outer aggregation on subquery; actual: " + ex.getMessage());
   }
 }


### PR DESCRIPTION
## Summary
Extends the vectorSearch() subquery-boundary walker to reject outer `ORDER BY`, `OFFSET`, `GROUP BY`, aggregation, and `DISTINCT` in addition to outer `WHERE`. Previously these would be applied in memory after k-NN had already returned the top-k by vector distance, silently yielding zero rows or mis-ordered results.

Outer `LIMIT` without `OFFSET` remains allowed and is locked in by a positive test.

## Test plan
- [x] New unit tests in `VectorSearchIndexScanBuilderTest` for outer Sort / Limit-with-offset / Limit-without-offset / Aggregation
- [x] New ITs in `VectorSearchSubqueryIT` for outer `ORDER BY`, `OFFSET`, `LIMIT` (positive), `COUNT(*)`, `GROUP BY`, `DISTINCT`
- [x] `:opensearch:test` and `:integ-test:integTest -Dtests.class=...VectorSearchSubqueryIT` pass locally
- [x] `spotlessCheck` clean