### PR TITLE
Add integration test for alias with multiple backing indices

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -669,6 +669,61 @@ public class VectorSearchIT extends SQLIntegTestCase {
     assertThat(ex.getMessage(), containsString("trailing or consecutive commas"));
   }
 
+  // ── Alias with multiple backing indices ───────────────────────────────
+  // vectorSearch() accepts an alias as `table=`. When the alias points at multiple backing
+  // indices with matching knn_vector mappings, planning must succeed — the query then runs
+  // across all backing indices just like a regular alias query. Execution requires the k-NN
+  // plugin, which is not installed on the default integ-test cluster, so these tests verify
+  // the planning path via _explain only.
+
+  @Test
+  public void testExplainOverAliasWithMultipleBackingIndices() throws IOException {
+    // Create two indices with identical keyword mappings (no knn_vector, since the plugin is
+    // not installed) and a shared alias. We only assert the planner accepts the alias; whether
+    // k-NN accepts the alias at execution is a separate concern tested on a k-NN-enabled
+    // cluster.
+    String idx1 = "vector_alias_backing_1";
+    String idx2 = "vector_alias_backing_2";
+    String alias = "vector_alias_combined";
+    try {
+      deleteIndexIfExists(idx1);
+      deleteIndexIfExists(idx2);
+      createSimpleIndex(idx1);
+      createSimpleIndex(idx2);
+      addToAlias(idx1, alias);
+      addToAlias(idx2, alias);
+
+      String explain =
+          explainQuery(
+              "SELECT v._id FROM vectorSearch(table='"
+                  + alias
+                  + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v");
+
+      assertThat(explain, containsString("VectorSearchIndexScan"));
+      assertThat(explain, containsString(alias));
+    } finally {
+      deleteIndexIfExists(idx1);
+      deleteIndexIfExists(idx2);
+    }
+  }
+
+  private void createSimpleIndex(String indexName) throws IOException {
+    Request create = new Request("PUT", "/" + indexName);
+    create.setJsonEntity("{\"mappings\":{\"properties\":{\"state\":{\"type\":\"keyword\"}}}}");
+    client().performRequest(create);
+  }
+
+  private void addToAlias(String indexName, String aliasName) throws IOException {
+    Request req = new Request("POST", "/_aliases");
+    req.setJsonEntity(
+        "{\"actions\":[{\"add\":{\"index\":\""
+            + indexName
+            + "\",\"alias\":\""
+            + aliasName
+            + "\"}}]}");
+    client().performRequest(req);
+  }
+
   private void deleteIndexIfExists(String indexName) {
     try {
       client().performRequest(new Request("DELETE", "/" + indexName));

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -671,10 +671,10 @@ public class VectorSearchIT extends SQLIntegTestCase {
 
   // ── Alias with multiple backing indices ───────────────────────────────
   // vectorSearch() accepts an alias as `table=`. When the alias points at multiple backing
-  // indices with matching knn_vector mappings, planning must succeed — the query then runs
-  // across all backing indices just like a regular alias query. Execution requires the k-NN
-  // plugin, which is not installed on the default integ-test cluster, so these tests verify
-  // the planning path via _explain only.
+  // indices, planning must accept the alias string instead of treating it as a wildcard or
+  // multi-target. Execution correctness over compatible knn_vector mappings is a separate
+  // concern covered by k-NN-enabled tests/follow-up; these tests lock in planning acceptance
+  // only, via _explain on the default no-kNN cluster.
 
   @Test
   public void testExplainOverAliasWithMultipleBackingIndices() throws IOException {
@@ -682,12 +682,13 @@ public class VectorSearchIT extends SQLIntegTestCase {
     // not installed) and a shared alias. We only assert the planner accepts the alias; whether
     // k-NN accepts the alias at execution is a separate concern tested on a k-NN-enabled
     // cluster.
-    String idx1 = "vector_alias_backing_1";
-    String idx2 = "vector_alias_backing_2";
-    String alias = "vector_alias_combined";
+    // Randomized names so a stale alias/index left by an aborted prior run of this class does
+    // not shadow a fresh setup — a concrete risk on local reruns.
+    String suffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    String idx1 = "vector_alias_backing_1_" + suffix;
+    String idx2 = "vector_alias_backing_2_" + suffix;
+    String alias = "vector_alias_combined_" + suffix;
     try {
-      deleteIndexIfExists(idx1);
-      deleteIndexIfExists(idx2);
       createSimpleIndex(idx1);
       createSimpleIndex(idx2);
       addToAlias(idx1, alias);
@@ -702,6 +703,9 @@ public class VectorSearchIT extends SQLIntegTestCase {
       assertThat(explain, containsString("VectorSearchIndexScan"));
       assertThat(explain, containsString(alias));
     } finally {
+      // Deleting the backing indices removes the alias automatically, but delete the alias
+      // first for robustness against partial setup failures.
+      deleteAliasIfExists(alias);
       deleteIndexIfExists(idx1);
       deleteIndexIfExists(idx2);
     }
@@ -729,6 +733,14 @@ public class VectorSearchIT extends SQLIntegTestCase {
       client().performRequest(new Request("DELETE", "/" + indexName));
     } catch (IOException ignored) {
       // Index does not exist, which is fine.
+    }
+  }
+
+  private void deleteAliasIfExists(String aliasName) {
+    try {
+      client().performRequest(new Request("DELETE", "/_all/_alias/" + aliasName));
+    } catch (IOException ignored) {
+      // Alias does not exist, which is fine.
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds an integration test that locks in vectorSearch() planning over an alias pointing at multiple backing indices. Common multi-tenant setup where a shared alias fans out to per-tenant indices. Execution requires the k-NN plugin, so the test covers the planning path via `_explain`.

## Test plan
- [x] `:integ-test:integTest -Dtests.class=...VectorSearchIT -Dtests.method=testExplainOverAliasWithMultipleBackingIndices` passes
- [x] `spotlessCheck` clean