### PR TITLE
Add integration test coverage for no-kNN paths and multi-backing-index alias

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -362,7 +362,7 @@ public class VectorSearchIT extends SQLIntegTestCase {
                         + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
                         + "LIMIT 5"));
 
-    // Lock in the full user-facing sentence, not just loose substrings — the exact wording is
+    // Lock in the full user-facing sentence, not just loose substrings. The exact wording is
     // part of the contract and regressions should fail loudly rather than keep passing on a
     // subtly reworded message.
     assertThat(
@@ -691,7 +691,7 @@ public class VectorSearchIT extends SQLIntegTestCase {
     // k-NN accepts the alias at execution is a separate concern tested on a k-NN-enabled
     // cluster.
     // Randomized names so a stale alias/index left by an aborted prior run of this class does
-    // not shadow a fresh setup — a concrete risk on local reruns.
+    // not shadow a fresh setup, which is a concrete risk on local reruns.
     String suffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
     String idx1 = "vector_alias_backing_1_" + suffix;
     String idx2 = "vector_alias_backing_2_" + suffix;

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -677,11 +677,78 @@ public class VectorSearchIT extends SQLIntegTestCase {
     assertThat(ex.getMessage(), containsString("trailing or consecutive commas"));
   }
 
+  // ── Alias with multiple backing indices ───────────────────────────────
+  // vectorSearch() accepts an alias as `table=`. When the alias points at multiple backing
+  // indices, planning must accept the alias string instead of treating it as a wildcard or
+  // multi-target. Execution correctness over compatible knn_vector mappings is a separate
+  // concern covered by k-NN-enabled tests/follow-up; these tests lock in planning acceptance
+  // only, via _explain on the default no-kNN cluster.
+
+  @Test
+  public void testExplainOverAliasWithMultipleBackingIndices() throws IOException {
+    // Create two indices with identical keyword mappings (no knn_vector, since the plugin is
+    // not installed) and a shared alias. We only assert the planner accepts the alias; whether
+    // k-NN accepts the alias at execution is a separate concern tested on a k-NN-enabled
+    // cluster.
+    // Randomized names so a stale alias/index left by an aborted prior run of this class does
+    // not shadow a fresh setup — a concrete risk on local reruns.
+    String suffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    String idx1 = "vector_alias_backing_1_" + suffix;
+    String idx2 = "vector_alias_backing_2_" + suffix;
+    String alias = "vector_alias_combined_" + suffix;
+    try {
+      createSimpleIndex(idx1);
+      createSimpleIndex(idx2);
+      addToAlias(idx1, alias);
+      addToAlias(idx2, alias);
+
+      String explain =
+          explainQuery(
+              "SELECT v._id FROM vectorSearch(table='"
+                  + alias
+                  + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v");
+
+      assertThat(explain, containsString("VectorSearchIndexScan"));
+      assertThat(explain, containsString(alias));
+    } finally {
+      // Deleting the backing indices removes the alias automatically, but delete the alias
+      // first for robustness against partial setup failures.
+      deleteAliasIfExists(alias);
+      deleteIndexIfExists(idx1);
+      deleteIndexIfExists(idx2);
+    }
+  }
+
+  private void createSimpleIndex(String indexName) throws IOException {
+    Request create = new Request("PUT", "/" + indexName);
+    create.setJsonEntity("{\"mappings\":{\"properties\":{\"state\":{\"type\":\"keyword\"}}}}");
+    client().performRequest(create);
+  }
+
+  private void addToAlias(String indexName, String aliasName) throws IOException {
+    Request req = new Request("POST", "/_aliases");
+    req.setJsonEntity(
+        "{\"actions\":[{\"add\":{\"index\":\""
+            + indexName
+            + "\",\"alias\":\""
+            + aliasName
+            + "\"}}]}");
+    client().performRequest(req);
+  }
+
   private void deleteIndexIfExists(String indexName) {
     try {
       client().performRequest(new Request("DELETE", "/" + indexName));
     } catch (IOException ignored) {
       // Index does not exist, which is fine.
+    }
+  }
+
+  private void deleteAliasIfExists(String aliasName) {
+    try {
+      client().performRequest(new Request("DELETE", "/_all/_alias/" + aliasName));
+    } catch (IOException ignored) {
+      // Alias does not exist, which is fine.
     }
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -362,8 +362,13 @@ public class VectorSearchIT extends SQLIntegTestCase {
                         + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
                         + "LIMIT 5"));
 
-    assertThat(ex.getMessage(), containsString("k-NN plugin"));
-    assertThat(ex.getMessage(), containsString("not installed"));
+    // Lock in the full user-facing sentence, not just loose substrings — the exact wording is
+    // part of the contract and regressions should fail loudly rather than keep passing on a
+    // subtly reworded message.
+    assertThat(
+        ex.getMessage(),
+        containsString(
+            "vectorSearch() requires the k-NN plugin, which is not installed on this cluster."));
   }
 
   @Test
@@ -379,6 +384,9 @@ public class VectorSearchIT extends SQLIntegTestCase {
                 + "', field='embedding', vector='[1.0, 2.0]', option='k=5') AS v "
                 + "LIMIT 5");
 
+    // Assert the scan-operator name, not just "wrapper": the name confirms the plan reached
+    // the vectorSearch scan builder rather than some other scan shape.
+    assertThat(explain, containsString("VectorSearchIndexScan"));
     assertThat(explain, containsString("wrapper"));
   }
 


### PR DESCRIPTION
## Summary
- Strengthens the existing no-kNN integration tests to assert the full user-facing error sentence and the `VectorSearchIndexScan` operator name, not just loose substrings.
- Adds a new integration test that locks in planning acceptance of an alias with multiple backing indices — complements the existing wildcard/comma multi-target rejection tests.

## Test plan
- [x] `:integ-test:integTest -Dtests.class="*VectorSearchIT" -Dtests.method="testExecutionWithoutKnnPluginReturnsCapabilityError"` passes
- [x] `:integ-test:integTest -Dtests.class="*VectorSearchIT" -Dtests.method="testExplainWithoutKnnPluginStillWorks"` passes
- [x] `:integ-test:integTest -Dtests.class="*VectorSearchIT" -Dtests.method="testExplainOverAliasWithMultipleBackingIndices"` passes
- [x] `spotlessCheck` clean