### PR TITLE
Preserve original expression text as column name in unified SQL

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/spec/search/SearchExtension.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/search/SearchExtension.java
@@ -22,6 +22,8 @@ public class SearchExtension implements LanguageSpec.LanguageExtension {
 
   @Override
   public List<SqlVisitor<SqlNode>> postParseRules() {
-    return List.of(NamedArgRewriter.INSTANCE);
+    return List.of(
+        SelectItemAliasRewriter.INSTANCE, // TODO: non-search-specific and temporarily placed here
+        NamedArgRewriter.INSTANCE);
   }
 }

--- a/api/src/main/java/org/opensearch/sql/api/spec/search/SelectItemAliasRewriter.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/search/SelectItemAliasRewriter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec.search;
+
+import java.util.function.UnaryOperator;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWriterConfig;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.util.SqlShuttle;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Wraps unnamed SELECT-list items with {@code AS <text>} so Calcite uses the expression text as the
+ * column name instead of synthetic {@code EXPR$N}.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SelectItemAliasRewriter extends SqlShuttle {
+
+  public static final SelectItemAliasRewriter INSTANCE = new SelectItemAliasRewriter();
+
+  /** Unparse config: bare identifiers (e.g., {@code SUM(a)} not {@code SUM(`a`)}). */
+  private static final UnaryOperator<SqlWriterConfig> UNPARSE_CONFIG =
+      c ->
+          c.withDialect(AnsiSqlDialect.DEFAULT)
+              .withQuoteAllIdentifiers(false)
+              .withAlwaysUseParentheses(false)
+              .withSelectListItemsOnSeparateLines(false)
+              .withUpdateSetListNewline(false)
+              .withIndentation(0);
+
+  @Override
+  public @Nullable SqlNode visit(SqlCall call) {
+    SqlCall visited = (SqlCall) super.visit(call);
+    if (visited instanceof SqlSelect select) {
+      SqlNodeList list = select.getSelectList();
+      for (int i = 0; i < list.size(); i++) {
+        list.set(i, aliasIfNeeded(list.get(i)));
+      }
+    }
+    return visited;
+  }
+
+  private static SqlNode aliasIfNeeded(SqlNode item) {
+    if (item.getKind() == SqlKind.AS
+        || item.getKind() == SqlKind.SELECT
+        || item instanceof SqlIdentifier) {
+      return item;
+    }
+    return SqlValidatorUtil.addAlias(item, item.toSqlString(UNPARSE_CONFIG).getSql());
+  }
+}

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
@@ -257,4 +257,22 @@ public class UnifiedQueryPlannerSqlTest extends UnifiedQueryTestBase {
             """)
         .assertErrorMessage("Encountered");
   }
+
+  @Test
+  public void testUnnamedMixedAggregates() {
+    givenQuery(
+            """
+            SELECT id, COUNT(*), AVG(age) FROM catalog.employees\
+            """)
+        .assertFields("id", "COUNT(*)", "AVG(age)");
+  }
+
+  @Test
+  public void testExplicitAliasStillWorks() {
+    givenQuery(
+            """
+            SELECT COUNT(*) AS cnt FROM catalog.employees\
+            """)
+        .assertFields("cnt");
+  }
 }

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedRelevanceSearchSqlTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedRelevanceSearchSqlTest.java
@@ -137,7 +137,7 @@ public class UnifiedRelevanceSearchSqlTest extends UnifiedQueryTestBase {
             """)
         .assertPlan(
             """
-            LogicalProject(EXPR$0=[UPPER($1)])
+            LogicalProject(UPPER(name)=[UPPER($1)])
               LogicalTableScan(table=[[catalog, employees]])
             """);
   }

--- a/api/src/test/java/org/opensearch/sql/api/spec/search/SelectItemAliasRewriterTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/spec/search/SelectItemAliasRewriterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.junit.Test;
+import org.opensearch.sql.api.spec.UnifiedSqlSpec;
+
+/** Unit tests for {@link SelectItemAliasRewriter}. */
+public class SelectItemAliasRewriterTest {
+
+  /** Production parser config from {@link UnifiedSqlSpec}. */
+  private static final SqlParser.Config PARSER_CONFIG = UnifiedSqlSpec.extended().parserConfig();
+
+  @Test
+  public void testAliasesUnnamedExpression() throws Exception {
+    SqlNode result = rewrite("SELECT COUNT(*) FROM t");
+    assertContains(result, "AS `COUNT(*)`");
+  }
+
+  @Test
+  public void testPreservesExplicitAlias() throws Exception {
+    SqlNode result = rewrite("SELECT COUNT(*) AS cnt FROM t");
+    assertContains(result, "SELECT COUNT(*) AS `cnt`");
+  }
+
+  @Test
+  public void testSkipsSimpleIdentifier() throws Exception {
+    SqlNode result = rewrite("SELECT name FROM t");
+    assertContains(result, "SELECT `name`");
+  }
+
+  @Test
+  public void testSkipsStar() throws Exception {
+    SqlNode result = rewrite("SELECT * FROM t");
+    assertContains(result, "SELECT *");
+  }
+
+  @Test
+  public void testSkipsQualifiedStar() throws Exception {
+    SqlNode result = rewrite("SELECT t.* FROM t");
+    assertContains(result, "SELECT `t`.*");
+  }
+
+  @Test
+  public void testSkipsScalarSubquery() throws Exception {
+    // Avoids producing a column name like "SELECT MAX(x) AS MAX(x) FROM u" from our own
+    // recursion. Calcite will fall back to EXPR$N, matching Flink/Druid/Drill default.
+    SqlNode result = rewrite("SELECT (SELECT MAX(x) FROM u) FROM t");
+    assertContains(result, "SELECT (SELECT MAX(`x`) AS `MAX(x)` FROM `u`) FROM `t`");
+  }
+
+  @Test
+  public void testRecursesIntoSubquery() throws Exception {
+    SqlNode result = rewrite("SELECT x FROM (SELECT COUNT(*) FROM t) s");
+    assertContains(result, "AS `COUNT(*)`");
+  }
+
+  @Test
+  public void testHandlesMixedItemsCorrectly() throws Exception {
+    SqlNode result = rewrite("SELECT id, COUNT(*), name AS n FROM t");
+    assertContains(result, "SELECT `id`, COUNT(*) AS `COUNT(*)`, `name` AS `n`");
+  }
+
+  @Test
+  public void testPreservesIdentifierInAggregate() throws Exception {
+    SqlNode result = rewrite("SELECT SUM(MyCol), SUM(x + 1) FROM t");
+    assertContains(result, "AS `SUM(MyCol)`");
+    assertContains(result, "AS `SUM(x + 1)`");
+  }
+
+  private static SqlNode rewrite(String sql) throws Exception {
+    return parse(sql).accept(SelectItemAliasRewriter.INSTANCE);
+  }
+
+  private static SqlNode parse(String sql) throws Exception {
+    return SqlParser.create(sql, PARSER_CONFIG).parseStmt();
+  }
+
+  private static void assertContains(SqlNode node, String expected) {
+    String actual = node.toString().replaceAll("\\r\\n", "\n").replaceAll("\\n", " ");
+    assertTrue(
+        "Expected to contain: " + expected + "\nActual: " + actual, actual.contains(expected));
+  }
+}


### PR DESCRIPTION
### Description

This PR preserves the original expression text as column names by adding a SqlNode rewriter to the existing `LanguageSpec.postParseRules` hook, instead of Calcite's default synthetic `EXPR$0`, `EXPR$1`, etc.

Examples:

```
SELECT COUNT() FROM t       -> COUNT()   (was EXPR$0)
SELECT SUM(MyCol)            -> SUM(MyCol)
SELECT UPPER(name), age + 1  -> UPPER(name), age + 1
SELECT name, *, x AS y       -> unchanged
```

Implementation notes:

1. **Column-naming conventions vary across engines**: See [comparison table](https://github.com/opensearch-project/sql/issues/5332#issuecomment-4355686910). This PR produces canonical built-in function names with bare user identifiers (`COUNT(*)`, `SUM(MyCol)`, `UPPER(name)`).

2. **Verbatim preservation (V2/PPL V3/MySQL) is debatable**: SQL treats unquoted function names as case-insensitive (`COUNT` == `count`), so canonical labels are spec-consistent. Verbatim text also couples column names to source formatting — `SUM(x)+1` and `SUM(x) + 1` would produce different labels for the same query. We'll revisit verbatim preservation in https://github.com/opensearch-project/sql/issues/5346.

### Related Issues

Resolves #5332

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
