### PR TITLE
Mark vectorSearch() experimental and default to efficient filtering

### DIFF
--- a/docs/user/dql/vector-search.rst
+++ b/docs/user/dql/vector-search.rst
@@ -22,6 +22,10 @@ It relies on the OpenSearch `k-NN plugin
 map the vector field as ``knn_vector`` and the index must be created with
 ``index.knn: true``.
 
+The SQL layer translates ``vectorSearch()`` into an OpenSearch search
+request whose body is native k-NN query DSL; the query vector is parsed
+into a numeric array before that DSL is emitted.
+
 Relevance is expressed through the OpenSearch ``_score`` metadata field, and
 results are returned ordered by ``_score DESC`` by default.
 
@@ -53,12 +57,12 @@ Arguments
 - ``table``: single concrete index or alias to search. Wildcards
   (``*``), comma-separated multi-index targets, ``_all``, ``.``, and
   ``..`` are not supported. The target index must have
-  ``index.knn: true`` and map the target field as ``knn_vector``. An
-  alias that resolves to multiple backing indices is accepted: the k-NN
-  query fans out across all backing indices and the combined top-k
-  results are returned, provided every backing index has
-  ``index.knn: true`` and the same ``knn_vector`` mapping for the
-  target field.
+  ``index.knn: true`` and map the target field as ``knn_vector``. A
+  normal alias name is accepted. If the alias resolves to multiple
+  backing indices, the SQL layer does not prevalidate that every
+  backing index has a compatible ``knn_vector`` mapping, dimension, or
+  engine; OpenSearch execution remains the source of truth for those
+  checks.
 - ``field``: name of the ``knn_vector`` field.
 - ``vector``: query vector as a JSON-style array of numbers, passed as a
   string (for example, ``'[0.1, 0.2, 0.3]'``). Components must be
@@ -189,15 +193,21 @@ Two placement strategies are available via the ``filter_type`` option:
   ``filter_type=post``. See the `k-NN filtering guide
   <https://docs.opensearch.org/latest/vector-search/filter-search-knn/efficient-knn-filtering/>`_
   for engine and method requirements.
-- ``post``: the ``WHERE`` predicate is applied as a non-scoring
-  ``bool.filter`` alongside the k-NN query. The k-NN query runs first and
-  its results are then filtered.
+- ``post``: the k-NN query is placed in a scoring (``bool.must``)
+  context and the ``WHERE`` predicate is placed as a non-scoring
+  ``bool.filter`` outside the k-NN clause. This is Boolean filter
+  placement, not the REST ``post_filter`` parameter, and may return
+  fewer than ``k`` rows when the filter is selective.
 
 Full-text predicates (``match``, ``match_phrase``, ``multi_match``, and
-the rest of the full-text family) under a ``WHERE`` clause are applied
-as filters alongside the k-NN query: they restrict which candidates are
-retained but do not combine their relevance scores with ``_score``.
-``vectorSearch()`` is not a hybrid vector + text relevance scorer.
+the rest of the full-text family) under a ``WHERE`` clause are used as
+filters, not as hybrid keyword-vector score fusion. Their placement
+follows ``filter_type``: the default (``efficient``) embeds supported
+full-text predicates under ``knn.filter``, while ``post`` places them
+in ``bool.filter`` outside the k-NN clause. In both cases they restrict
+which candidates are retained but their text relevance score does not
+combine with the vector ``_score``. ``vectorSearch()`` is not a hybrid
+vector + text relevance scorer.
 
 Behavior depends on whether ``filter_type`` is specified:
 
@@ -231,10 +241,10 @@ Behavior depends on whether ``filter_type`` is specified:
   server-side. If predicate translation itself fails, the query returns
   an error; there is no silent in-memory fallback under explicit
   ``post``. Use ``filter_type=post`` when the predicate shape is not
-  supported by ``efficient`` pre-filtering.
+  supported by efficient filtering.
 
-Example 4: Default pre-filtering (no ``filter_type``)
------------------------------------------------------
+Example 4: Default efficient filtering (no ``filter_type``)
+-----------------------------------------------------------
 
 ::
 
@@ -279,12 +289,13 @@ Scoring, sorting, and limits
 ============================
 
 - ``vectorSearch()`` exposes the OpenSearch ``_score`` metadata field on the
-  alias. Select it as ``<alias>._score``.
+  alias. For an alias ``v``, select it as ``v._score``.
 - ``_score`` can be selected and referenced in ``ORDER BY``, but it cannot
   appear in ``WHERE``. Use ``option='min_score=...'`` for score-threshold
   vector search.
 - Results are returned in ``_score DESC`` order by default. The only
-  supported ``ORDER BY`` expression is ``<alias>._score DESC``.
+  supported ``ORDER BY`` expression is ``<alias>._score DESC`` (for
+  example, ``v._score DESC``).
 - In top-k mode (``k=N``), ``LIMIT n`` is optional; when present, ``n`` must
   be ``≤ k``.
 - In radial mode (``max_distance`` or ``min_score``), ``LIMIT`` is required.
@@ -298,13 +309,13 @@ The following are not supported on ``vectorSearch()``:
 - ``GROUP BY`` and aggregations directly over a ``vectorSearch()``
   relation are not supported and return an error.
 - Operators wrapped around a ``vectorSearch()`` subquery are rejected
-  when they would run after the top-k rows have already been selected
-  by vector distance, because they can silently yield zero or
-  incorrect rows. Specifically, an outer ``WHERE``, ``ORDER BY``,
-  ``OFFSET`` (non-zero), ``GROUP BY``, aggregation, or ``DISTINCT``
-  applied to a ``vectorSearch()`` subquery returns an error. Place
-  ``WHERE`` predicates inside the subquery, directly on the
-  ``vectorSearch()`` alias, so that they participate in ``WHERE``
+  when they would run after ``vectorSearch()`` has already produced a
+  finite result set, because they can silently yield zero, skipped, or
+  incorrectly ordered rows. Specifically, an outer ``WHERE``,
+  ``ORDER BY``, ``OFFSET`` (non-zero), ``GROUP BY``, aggregation, or
+  ``DISTINCT`` applied to a ``vectorSearch()`` subquery returns an
+  error. Place ``WHERE`` predicates inside the subquery, directly on
+  the ``vectorSearch()`` alias, so that they participate in ``WHERE``
   pushdown. A plain outer ``LIMIT`` (without ``OFFSET``) wrapping a
   ``vectorSearch()`` subquery is allowed and caps the returned rows.
 - ``JOIN`` between a ``vectorSearch()`` relation and another relation is

--- a/docs/user/dql/vector-search.rst
+++ b/docs/user/dql/vector-search.rst
@@ -18,7 +18,7 @@ pushdown behavior may change in future releases based on feedback.
 The ``vectorSearch()`` table function runs a k-NN query against a ``knn_vector``
 field and exposes the matching documents as a relation in the ``FROM`` clause.
 It relies on the OpenSearch `k-NN plugin
-<https://docs.opensearch.org/latest/vector-search/>`_ — the target index must
+<https://docs.opensearch.org/latest/vector-search/>`_. The target index must
 map the vector field as ``knn_vector`` and the index must be created with
 ``index.knn: true``.
 
@@ -50,18 +50,23 @@ error. ``_explain`` continues to work without the plugin.
 Arguments
 ---------
 
-- ``table`` — single concrete index or alias to search. Wildcards
+- ``table``: single concrete index or alias to search. Wildcards
   (``*``), comma-separated multi-index targets, ``_all``, ``.``, and
   ``..`` are not supported. The target index must have
-  ``index.knn: true`` and map the target field as ``knn_vector``.
-- ``field`` — name of the ``knn_vector`` field.
-- ``vector`` — query vector as a JSON-style array of numbers, passed as a
+  ``index.knn: true`` and map the target field as ``knn_vector``. An
+  alias that resolves to multiple backing indices is accepted: the k-NN
+  query fans out across all backing indices and the combined top-k
+  results are returned, provided every backing index has
+  ``index.knn: true`` and the same ``knn_vector`` mapping for the
+  target field.
+- ``field``: name of the ``knn_vector`` field.
+- ``vector``: query vector as a JSON-style array of numbers, passed as a
   string (for example, ``'[0.1, 0.2, 0.3]'``). Components must be
   comma-separated finite numbers. Semicolon, colon, and pipe separators
   are not supported, and empty components (for example, ``'[1.0,,2.0]'``
   or ``'[1.0,]'``) return an error. The vector dimension must match the
   ``knn_vector`` mapping on the target index.
-- ``option`` — comma-separated ``key=value`` pairs. Exactly one of ``k``,
+- ``option``: comma-separated ``key=value`` pairs. Exactly one of ``k``,
   ``max_distance``, or ``min_score`` is required. ``filter_type`` is
   optional.
 
@@ -71,14 +76,15 @@ Supported option keys
 Option keys are lower-case and case-sensitive. ``K=5`` or
 ``Filter_Type=post`` returns an "Unknown option key" error.
 
-- ``k`` — top-k mode. Integer between 1 and 10000. The query returns up to
+- ``k``: top-k mode. Integer between 1 and 10000. The query returns up to
   ``k`` nearest neighbors.
-- ``max_distance`` — radial mode. Non-negative number. Returns all
-  documents within the given distance of the query vector. ``LIMIT`` is
-  required.
-- ``min_score`` — radial mode. Non-negative number. Returns all documents
-  with score at or above the given threshold. ``LIMIT`` is required.
-- ``filter_type`` — ``post`` or ``efficient``. Controls how a ``WHERE``
+- ``max_distance``: radial mode. Non-negative number. Matches documents
+  within the given distance of the query vector. ``LIMIT`` is required and
+  caps the returned rows.
+- ``min_score``: radial mode. Non-negative number. Matches documents with
+  score at or above the given threshold. ``LIMIT`` is required and caps
+  the returned rows.
+- ``filter_type``: ``post`` or ``efficient``. Controls how a ``WHERE``
   clause is applied. See `Filtering`_.
 
 ``k``, ``max_distance``, and ``min_score`` are mutually exclusive; specify
@@ -129,9 +135,9 @@ reduces the row count, but ``n`` must not exceed ``k``.
 Example 2: Radial search (``max_distance``)
 -------------------------------------------
 
-Return every document within a maximum distance of the query vector.
-``LIMIT`` is required for radial searches — without it the result set is
-unbounded::
+Return up to the specified ``LIMIT`` documents within a maximum distance
+of the query vector. ``LIMIT`` is required for radial searches; without
+it the result set would be unbounded::
 
     POST /_plugins/_sql
     {
@@ -150,7 +156,9 @@ unbounded::
 Example 3: Radial search (``min_score``)
 ----------------------------------------
 
-Return every document whose score is at least the given threshold::
+Return up to the specified ``LIMIT`` documents whose score is at or
+above the given threshold. ``LIMIT`` is required for radial searches;
+without it the result set would be unbounded::
 
     POST /_plugins/_sql
     {
@@ -174,41 +182,56 @@ pushed down to OpenSearch when it can be translated to an OpenSearch filter.
 Two placement strategies are available via the ``filter_type`` option:
 
 - ``efficient`` (default): the ``WHERE`` predicate is embedded directly
-  inside the k-NN query (``knn.filter``), enabling pre-filtering during
-  the ANN search. See the `k-NN filtering guide
+  inside the k-NN query (``knn.filter``), enabling native efficient
+  k-NN filtering during vector search. Efficient filtering depends on
+  native k-NN engine and method support; if the target index does not
+  support ``knn.filter`` for the configured engine and method, set
+  ``filter_type=post``. See the `k-NN filtering guide
   <https://docs.opensearch.org/latest/vector-search/filter-search-knn/efficient-knn-filtering/>`_
   for engine and method requirements.
 - ``post``: the ``WHERE`` predicate is applied as a non-scoring
   ``bool.filter`` alongside the k-NN query. The k-NN query runs first and
   its results are then filtered.
 
+Full-text predicates (``match``, ``match_phrase``, ``multi_match``, and
+the rest of the full-text family) under a ``WHERE`` clause are applied
+as filters alongside the k-NN query: they restrict which candidates are
+retained but do not combine their relevance scores with ``_score``.
+``vectorSearch()`` is not a hybrid vector + text relevance scorer.
+
 Behavior depends on whether ``filter_type`` is specified:
 
 - **Omitted (default, ``efficient``)**: the ``WHERE`` predicate is
-  embedded under ``knn.filter`` so the k-NN engine pre-filters candidates
-  during the ANN search. A query with no ``WHERE`` clause is valid.
-  ``efficient`` supports simple native filters: ``term``, ``range``,
-  ``wildcard``, ``exists``, full-text family (``match``, ``match_phrase``,
-  ``match_phrase_prefix``, ``match_bool_prefix``, ``multi_match``,
-  ``query_string``, ``simple_query_string``), and boolean combinations of
-  those filters. Predicates that compile to script queries (arithmetic,
-  function calls on indexed fields, ``CASE``, date math), nested
-  predicates, and other query shapes are not supported under
-  ``knn.filter`` and return an error. Set ``filter_type=post`` to apply
-  such predicates after the k-NN search.
+  embedded under ``knn.filter`` so the k-NN engine applies native
+  efficient filtering during vector search. A query with no ``WHERE``
+  clause is valid. ``efficient`` supports simple native filters:
+  ``term``, ``range``, ``wildcard``, ``exists``, full-text family
+  (``match``, ``match_phrase``, ``match_phrase_prefix``,
+  ``match_bool_prefix``, ``multi_match``, ``query_string``,
+  ``simple_query_string``), and boolean combinations of those filters.
+  Predicates that compile to script queries (arithmetic, function calls
+  on indexed fields, ``CASE``, date math), nested predicates, and other
+  query shapes are not supported under ``knn.filter`` and return an
+  error. Set ``filter_type=post`` to apply such predicates after the
+  k-NN search. If the predicate cannot be translated to an OpenSearch
+  filter query at all (a distinct translation failure from the
+  unsupported-shape cases above), the default path falls back to
+  evaluating the ``WHERE`` clause in memory after the k-NN results are
+  returned.
 - **Explicit ``efficient``**: same contract as the default. Specifying
-  it is equivalent and is useful when a query should be explicit about
-  the placement strategy.
+  it is useful when a query should be explicit about the placement
+  strategy and should fail if the predicate cannot be safely embedded
+  under ``knn.filter``.
 - **Explicit ``post``**: a ``WHERE`` clause is required and must be
   translatable to an OpenSearch filter query. Predicates that translate
   to native OpenSearch queries are pushed down as a ``bool.filter``
   alongside the k-NN query. Predicates that do not have a native
   equivalent (for example, arithmetic or function calls on indexed
   fields) are pushed down as an OpenSearch script query and evaluated
-  server-side. Only when predicate translation itself fails does the
-  engine fall back to evaluating the ``WHERE`` clause in memory after
-  the k-NN results are returned. Use ``filter_type=post`` when the
-  predicate shape is not supported by ``efficient`` pre-filtering.
+  server-side. If predicate translation itself fails, the query returns
+  an error; there is no silent in-memory fallback under explicit
+  ``post``. Use ``filter_type=post`` when the predicate shape is not
+  supported by ``efficient`` pre-filtering.
 
 Example 4: Default pre-filtering (no ``filter_type``)
 -----------------------------------------------------
@@ -230,10 +253,10 @@ Example 4: Default pre-filtering (no ``filter_type``)
     }
 
 The predicate is embedded under ``knn.filter`` so the k-NN engine
-pre-filters candidates during the ANN search.
+applies native efficient filtering during vector search.
 
-Example 5: Post-filtering fallback
-----------------------------------
+Example 5: Post-filtering for predicates not supported by efficient mode
+------------------------------------------------------------------------
 
 Use ``filter_type=post`` for predicates that do not fit the ``efficient``
 allow-list, such as arithmetic or function calls on indexed fields::
@@ -272,14 +295,18 @@ Limitations
 
 The following are not supported on ``vectorSearch()``:
 
-- ``GROUP BY`` and aggregations over a ``vectorSearch()`` relation are
-  not supported and return an error.
-- An outer ``WHERE`` clause applied to a ``vectorSearch()`` subquery is
-  not supported and returns an error, because the predicate would be
-  evaluated only after the top-k rows have been selected by vector
-  distance and can silently yield zero rows. Place the predicate inside
-  the subquery, directly on the ``vectorSearch()`` alias, so that it
-  participates in ``WHERE`` pushdown.
+- ``GROUP BY`` and aggregations directly over a ``vectorSearch()``
+  relation are not supported and return an error.
+- Operators wrapped around a ``vectorSearch()`` subquery are rejected
+  when they would run after the top-k rows have already been selected
+  by vector distance, because they can silently yield zero or
+  incorrect rows. Specifically, an outer ``WHERE``, ``ORDER BY``,
+  ``OFFSET`` (non-zero), ``GROUP BY``, aggregation, or ``DISTINCT``
+  applied to a ``vectorSearch()`` subquery returns an error. Place
+  ``WHERE`` predicates inside the subquery, directly on the
+  ``vectorSearch()`` alias, so that they participate in ``WHERE``
+  pushdown. A plain outer ``LIMIT`` (without ``OFFSET``) wrapping a
+  ``vectorSearch()`` subquery is allowed and caps the returned rows.
 - ``JOIN`` between a ``vectorSearch()`` relation and another relation is
   not supported.
 - ``UNION`` / ``INTERSECT`` / ``EXCEPT`` combining a ``vectorSearch()``

--- a/docs/user/dql/vector-search.rst
+++ b/docs/user/dql/vector-search.rst
@@ -1,7 +1,7 @@
 
-=============
-Vector Search
-=============
+==============================
+Vector Search [Experimental]
+==============================
 
 .. rubric:: Table of contents
 
@@ -11,6 +11,9 @@ Vector Search
 
 Introduction
 ============
+
+``vectorSearch()`` is an experimental feature. Syntax, options, and
+pushdown behavior may change in future releases based on feedback.
 
 The ``vectorSearch()`` table function runs a k-NN query against a ``knn_vector``
 field and exposes the matching documents as a relation in the ``FROM`` clause.
@@ -170,42 +173,45 @@ A ``WHERE`` clause on non-vector fields of the ``vectorSearch()`` alias is
 pushed down to OpenSearch when it can be translated to an OpenSearch filter.
 Two placement strategies are available via the ``filter_type`` option:
 
-- ``post`` — the ``WHERE`` predicate is applied as a non-scoring
+- ``efficient`` (default): the ``WHERE`` predicate is embedded directly
+  inside the k-NN query (``knn.filter``), enabling pre-filtering during
+  the ANN search. See the `k-NN filtering guide
+  <https://docs.opensearch.org/latest/vector-search/filter-search-knn/efficient-knn-filtering/>`_
+  for engine and method requirements.
+- ``post``: the ``WHERE`` predicate is applied as a non-scoring
   ``bool.filter`` alongside the k-NN query. The k-NN query runs first and
   its results are then filtered.
-- ``efficient`` — the ``WHERE`` predicate is embedded directly inside the
-  k-NN query (``knn.filter``), enabling pre-filtering during the ANN search.
-  See the `k-NN filtering guide <https://docs.opensearch.org/latest/vector-search/filter-search-knn/efficient-knn-filtering/>`_
-  for engine and method requirements.
 
 Behavior depends on whether ``filter_type`` is specified:
 
-- **Omitted** — pushdown is attempted using the ``post`` placement.
-  Predicates that translate to native OpenSearch queries are pushed down as a
-  ``bool.filter`` alongside the k-NN query. Predicates that do not have a
-  native equivalent (for example, arithmetic or function calls on indexed
-  fields) are pushed down as an OpenSearch script query and evaluated
-  server-side. Only when predicate translation itself fails does the engine
-  fall back to evaluating the ``WHERE`` clause in memory after the k-NN
-  results are returned. A query with no ``WHERE`` clause is valid.
-- **Explicit ``post``** — a ``WHERE`` clause is required and must be
-  translatable to an OpenSearch filter query. If the ``WHERE`` clause is
-  missing or cannot be translated, the query fails with an error.
-  Specifying ``filter_type=post`` explicitly is useful when the query
-  should fail with an error instead of silently falling back to
-  in-memory filtering.
-- **Explicit ``efficient``** — a ``WHERE`` clause is required and must
-  compile to a filter shape that can be embedded under ``knn.filter``.
+- **Omitted (default, ``efficient``)**: the ``WHERE`` predicate is
+  embedded under ``knn.filter`` so the k-NN engine pre-filters candidates
+  during the ANN search. A query with no ``WHERE`` clause is valid.
   ``efficient`` supports simple native filters: ``term``, ``range``,
   ``wildcard``, ``exists``, full-text family (``match``, ``match_phrase``,
   ``match_phrase_prefix``, ``match_bool_prefix``, ``multi_match``,
   ``query_string``, ``simple_query_string``), and boolean combinations of
   those filters. Predicates that compile to script queries (arithmetic,
-  function calls, ``CASE``, date math), nested predicates, and other
-  query shapes are not supported in this mode and return an error.
+  function calls on indexed fields, ``CASE``, date math), nested
+  predicates, and other query shapes are not supported under
+  ``knn.filter`` and return an error. Set ``filter_type=post`` to apply
+  such predicates after the k-NN search.
+- **Explicit ``efficient``**: same contract as the default. Specifying
+  it is equivalent and is useful when a query should be explicit about
+  the placement strategy.
+- **Explicit ``post``**: a ``WHERE`` clause is required and must be
+  translatable to an OpenSearch filter query. Predicates that translate
+  to native OpenSearch queries are pushed down as a ``bool.filter``
+  alongside the k-NN query. Predicates that do not have a native
+  equivalent (for example, arithmetic or function calls on indexed
+  fields) are pushed down as an OpenSearch script query and evaluated
+  server-side. Only when predicate translation itself fails does the
+  engine fall back to evaluating the ``WHERE`` clause in memory after
+  the k-NN results are returned. Use ``filter_type=post`` when the
+  predicate shape is not supported by ``efficient`` pre-filtering.
 
-Example 4: Implicit pushdown (no ``filter_type``)
--------------------------------------------------
+Example 4: Default pre-filtering (no ``filter_type``)
+-----------------------------------------------------
 
 ::
 
@@ -223,10 +229,14 @@ Example 4: Implicit pushdown (no ``filter_type``)
       """
     }
 
-Example 5: Efficient (pre-)filtering
-------------------------------------
+The predicate is embedded under ``knn.filter`` so the k-NN engine
+pre-filters candidates during the ANN search.
 
-::
+Example 5: Post-filtering fallback
+----------------------------------
+
+Use ``filter_type=post`` for predicates that do not fit the ``efficient``
+allow-list, such as arithmetic or function calls on indexed fields::
 
     POST /_plugins/_sql
     {
@@ -236,9 +246,9 @@ Example 5: Efficient (pre-)filtering
           table='my_vectors',
           field='embedding',
           vector='[0.1, 0.2, 0.3]',
-          option='k=10,filter_type=efficient'
+          option='k=10,filter_type=post'
         ) AS v
-        WHERE v.category = 'books'
+        WHERE v.price * 1.1 < 100
       """
     }
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExecutionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExecutionIT.java
@@ -135,14 +135,16 @@ public class VectorSearchExecutionIT extends SQLIntegTestCase {
   public void testPostFilterReturnsOnlyMatchingDocs() throws IOException {
     // Query from cluster B with WHERE state='TX' forces POST filtering to surface TX docs
     // (cluster A) even though the vector is closer to cluster B. k=10 covers all 6 docs so
-    // post-filtering to state='TX' deterministically yields exactly {1,2,3}.
+    // post-filtering to state='TX' deterministically yields exactly {1,2,3}. filter_type=post
+    // is specified explicitly because the default placement is EFFICIENT — this test
+    // guarantees POST continues to work when the user opts into it.
     JSONObject result =
         executeJdbcRequest(
             "SELECT v._id, v._score "
                 + "FROM vectorSearch(table='"
                 + TEST_INDEX
                 + "', field='embedding', "
-                + "vector='[9.0, 9.0]', option='k=10') AS v "
+                + "vector='[9.0, 9.0]', option='k=10,filter_type=post') AS v "
                 + "WHERE v.state = 'TX' "
                 + "LIMIT 10");
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchExplainIT.java
@@ -164,10 +164,10 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
         "Radial without WHERE should not embed a filter:\n" + knnJson, knnJson.contains("filter"));
   }
 
-  // ── Post-filter DSL shape ────────────────────────────────────────────
+  // ── Default (EFFICIENT) pre-filter DSL shape ────────────────────────
 
   @Test
-  public void testExplainPostFilterProducesBoolQuery() throws IOException {
+  public void testExplainDefaultFilterProducesKnnWithFilter() throws IOException {
     String explain =
         explainQuery(
             "SELECT v._id, v._score "
@@ -178,22 +178,15 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "WHERE v.state = 'TX' "
                 + "LIMIT 10");
 
-    // Post-filter shape: outer bool.must=[knn], bool.filter=[term] — WHERE lives OUTSIDE the knn
-    // payload. Verify by decoding the wrapper and asserting the predicate field is NOT embedded.
+    // Default (EFFICIENT) shape: WHERE is embedded inside knn.filter, the knn JSON is base64-
+    // encoded inside a WrapperQueryBuilder, and there is no outer bool/must wrapping.
     String sourceBuilderJson = extractSourceBuilderJson(explain);
-    assertTrue(
-        "Explain should contain bool query:\n" + sourceBuilderJson,
+    assertFalse(
+        "Default EFFICIENT mode should not produce bool query:\n" + sourceBuilderJson,
         sourceBuilderJson.contains("\"bool\""));
-    assertTrue(
-        "Explain should contain must clause (knn in scoring context):\n" + sourceBuilderJson,
+    assertFalse(
+        "Default EFFICIENT mode should not contain must clause:\n" + sourceBuilderJson,
         sourceBuilderJson.contains("\"must\""));
-    assertTrue(
-        "Explain should contain filter clause (WHERE in non-scoring context):\n"
-            + sourceBuilderJson,
-        sourceBuilderJson.contains("\"filter\""));
-    assertTrue(
-        "Explain should contain the outer state predicate:\n" + sourceBuilderJson,
-        sourceBuilderJson.contains("\"state.keyword\""));
 
     String knnJson = decodeSoleKnnJson(explain);
     assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
@@ -201,16 +194,16 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
         "knn JSON should target the embedding field:\n" + knnJson,
         knnJson.contains("\"embedding\""));
     assertTrue("knn JSON should contain k=10:\n" + knnJson, knnJson.contains("\"k\":10"));
-    assertFalse(
-        "Post-filter mode must not embed the WHERE predicate inside knn:\n" + knnJson,
-        knnJson.contains("state"));
-    assertFalse(
-        "Post-filter mode must not embed a filter inside knn:\n" + knnJson,
+    assertTrue(
+        "Default EFFICIENT mode must embed filter inside knn:\n" + knnJson,
         knnJson.contains("filter"));
+    assertTrue(
+        "Default EFFICIENT mode must embed the WHERE predicate inside knn:\n" + knnJson,
+        knnJson.contains("state"));
   }
 
   @Test
-  public void testExplainCompoundPredicateProducesBoolQuery() throws IOException {
+  public void testExplainDefaultCompoundPredicateProducesKnnWithFilter() throws IOException {
     String explain =
         explainQuery(
             "SELECT v._id, v._score "
@@ -221,25 +214,15 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "WHERE v.state = 'TX' AND v.age > 30 "
                 + "LIMIT 10");
 
-    // Compound post-filter still uses outer bool.must=[knn]/bool.filter=[predicates]. Both WHERE
-    // predicates must stay outside the knn payload; otherwise efficient mode could false-positive.
+    // Compound default-mode WHERE must also route through knn.filter: no outer bool/must, and
+    // both predicate fields embedded inside the knn payload.
     String sourceBuilderJson = extractSourceBuilderJson(explain);
-    assertTrue(
-        "Explain should contain bool query:\n" + sourceBuilderJson,
+    assertFalse(
+        "Default EFFICIENT mode should not produce bool query:\n" + sourceBuilderJson,
         sourceBuilderJson.contains("\"bool\""));
-    assertTrue(
-        "Explain should contain must clause (knn in scoring context):\n" + sourceBuilderJson,
+    assertFalse(
+        "Default EFFICIENT mode should not contain must clause:\n" + sourceBuilderJson,
         sourceBuilderJson.contains("\"must\""));
-    assertTrue(
-        "Explain should contain filter clause (compound WHERE in non-scoring context):\n"
-            + sourceBuilderJson,
-        sourceBuilderJson.contains("\"filter\""));
-    assertTrue(
-        "Explain should contain the outer state predicate:\n" + sourceBuilderJson,
-        sourceBuilderJson.contains("\"state.keyword\""));
-    assertTrue(
-        "Explain should contain the outer age predicate:\n" + sourceBuilderJson,
-        sourceBuilderJson.contains("\"age\""));
 
     String knnJson = decodeSoleKnnJson(explain);
     assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
@@ -247,19 +230,19 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
         "knn JSON should target the embedding field:\n" + knnJson,
         knnJson.contains("\"embedding\""));
     assertTrue("knn JSON should contain k=10:\n" + knnJson, knnJson.contains("\"k\":10"));
-    assertFalse(
-        "Compound post-filter must not embed the state predicate inside knn:\n" + knnJson,
-        knnJson.contains("state"));
-    assertFalse(
-        "Compound post-filter must not embed the age predicate inside knn:\n" + knnJson,
-        knnJson.contains("age"));
-    assertFalse(
-        "Compound post-filter must not embed a filter inside knn:\n" + knnJson,
+    assertTrue(
+        "Compound default EFFICIENT must embed filter inside knn:\n" + knnJson,
         knnJson.contains("filter"));
+    assertTrue(
+        "Compound default EFFICIENT must embed the state predicate inside knn:\n" + knnJson,
+        knnJson.contains("state"));
+    assertTrue(
+        "Compound default EFFICIENT must embed the age predicate inside knn:\n" + knnJson,
+        knnJson.contains("age"));
   }
 
   @Test
-  public void testExplainRadialWithWhereProducesBoolQuery() throws IOException {
+  public void testExplainDefaultRadialWithWhereProducesKnnWithFilter() throws IOException {
     String explain =
         explainQuery(
             "SELECT v._id, v._score "
@@ -270,22 +253,15 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
                 + "WHERE v.state = 'TX' "
                 + "LIMIT 100");
 
-    // Radial + WHERE should also keep the WHERE predicate in the outer bool.filter rather than
-    // embedding it into the radial knn payload.
+    // Radial + default WHERE must also use the EFFICIENT shape: no outer bool/must, radial
+    // parameters preserved inside the knn payload, and the WHERE predicate embedded alongside.
     String sourceBuilderJson = extractSourceBuilderJson(explain);
-    assertTrue(
-        "Explain should contain bool query:\n" + sourceBuilderJson,
+    assertFalse(
+        "Default EFFICIENT mode should not produce bool query:\n" + sourceBuilderJson,
         sourceBuilderJson.contains("\"bool\""));
-    assertTrue(
-        "Explain should contain must clause (knn in scoring context):\n" + sourceBuilderJson,
+    assertFalse(
+        "Default EFFICIENT mode should not contain must clause:\n" + sourceBuilderJson,
         sourceBuilderJson.contains("\"must\""));
-    assertTrue(
-        "Explain should contain filter clause (WHERE in non-scoring context):\n"
-            + sourceBuilderJson,
-        sourceBuilderJson.contains("\"filter\""));
-    assertTrue(
-        "Explain should contain the outer state predicate:\n" + sourceBuilderJson,
-        sourceBuilderJson.contains("\"state.keyword\""));
 
     String knnJson = decodeSoleKnnJson(explain);
     assertTrue("knn JSON should contain knn key:\n" + knnJson, knnJson.contains("\"knn\""));
@@ -295,12 +271,12 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
     assertTrue(
         "knn JSON should contain max_distance=10.5:\n" + knnJson,
         knnJson.contains("\"max_distance\":10.5"));
-    assertFalse(
-        "Radial post-filter must not embed the WHERE predicate inside knn:\n" + knnJson,
-        knnJson.contains("state"));
-    assertFalse(
-        "Radial post-filter must not embed a filter inside knn:\n" + knnJson,
+    assertTrue(
+        "Radial default EFFICIENT must embed filter inside knn:\n" + knnJson,
         knnJson.contains("filter"));
+    assertTrue(
+        "Radial default EFFICIENT must embed the WHERE predicate inside knn:\n" + knnJson,
+        knnJson.contains("state"));
   }
 
   // ── Sort + LIMIT explain ─────────────────────────────────────────────
@@ -456,13 +432,16 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
 
   @Test
   public void testBetweenPushesAsRange() throws IOException {
+    // Pin filter_type=post to keep the regression guard aimed at the post-filter serialization
+    // path: these assertions lock in the outer bool/must/filter shape that only appears when
+    // WHERE is applied alongside knn rather than embedded under knn.filter.
     String explain =
         explainQuery(
             "SELECT v._id, v._score "
                 + "FROM vectorSearch(table='"
                 + TEST_INDEX
                 + "', field='embedding', "
-                + "vector='[1.0, 2.0, 3.0]', option='k=10') AS v "
+                + "vector='[1.0, 2.0, 3.0]', option='k=10,filter_type=post') AS v "
                 + "WHERE v.balance BETWEEN 50 AND 200 "
                 + "LIMIT 10");
 
@@ -513,13 +492,16 @@ public class VectorSearchExplainIT extends SQLIntegTestCase {
 
   @Test
   public void testNotInPushesAsMustNotTerms() throws IOException {
+    // Pin filter_type=post to keep the regression guard aimed at the post-filter serialization
+    // path: these assertions lock in the outer bool/must/filter shape that only appears when
+    // WHERE is applied alongside knn rather than embedded under knn.filter.
     String explain =
         explainQuery(
             "SELECT v._id, v._score "
                 + "FROM vectorSearch(table='"
                 + TEST_INDEX
                 + "', field='embedding', "
-                + "vector='[1.0, 2.0, 3.0]', option='k=10') AS v "
+                + "vector='[1.0, 2.0, 3.0]', option='k=10,filter_type=post') AS v "
                 + "WHERE v.gender NOT IN ('M', 'F') "
                 + "LIMIT 10");
 

--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -340,7 +340,8 @@ public class VectorSearchIT extends SQLIntegTestCase {
                         + "WHERE v.age + 1 > 30 "
                         + "LIMIT 5"));
 
-    assertThat(ex.getMessage(), containsString("filter_type=efficient does not support"));
+    assertThat(
+        ex.getMessage(), containsString("vectorSearch WHERE pre-filtering does not support"));
     assertThat(ex.getMessage(), containsString("script queries"));
   }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/VectorSearchIndex.java
@@ -28,7 +28,7 @@ public class VectorSearchIndex extends OpenSearchIndex {
   private final String field;
   private final float[] vector;
   private final Map<String, String> options;
-  private final FilterType filterType; // null means default (POST)
+  private final FilterType filterType; // null means default (EFFICIENT)
   // Nullable for back-compat with existing tests and the non-vector-search constructor. When
   // present, the scan defers a lazy k-NN plugin probe to open() so execution fails fast with a
   // clear SQL error if the plugin is missing.
@@ -62,7 +62,10 @@ public class VectorSearchIndex extends OpenSearchIndex {
     this(client, settings, indexName, field, vector, options, filterType, null);
   }
 
-  /** Default constructor — preserves existing call sites; uses no explicit filter type. */
+  /**
+   * Default constructor — preserves existing call sites; uses no explicit filter type, so the scan
+   * falls back to the default placement ({@link FilterType#EFFICIENT}).
+   */
   public VectorSearchIndex(
       OpenSearchClient client,
       Settings settings,
@@ -97,7 +100,7 @@ public class VectorSearchIndex extends OpenSearchIndex {
         whereQuery -> new WrapperQueryBuilder(buildKnnQueryJson(whereQuery.toString()));
 
     boolean filterTypeExplicit = filterType != null;
-    FilterType effectiveFilterType = filterType != null ? filterType : FilterType.POST;
+    FilterType effectiveFilterType = filterType != null ? filterType : FilterType.EFFICIENT;
 
     var queryBuilder =
         new VectorSearchQueryBuilder(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilder.java
@@ -43,15 +43,18 @@ import org.opensearch.sql.planner.logical.LogicalLimit;
 import org.opensearch.sql.planner.logical.LogicalSort;
 
 /**
- * Query builder for vector search that keeps the knn query in a scoring (must) context and puts
- * WHERE filters in a non-scoring (filter) context. This prevents the knn relevance scores from
- * being destroyed when a WHERE clause is pushed down.
+ * Query builder for vector search. The knn relevance score is preserved regardless of placement
+ * strategy — in {@code EFFICIENT} mode the knn query carries its own scores, and in {@code POST}
+ * mode the knn query sits in a scoring ({@code must}) context while the WHERE clause is applied as
+ * a non-scoring ({@code filter}) clause.
  *
  * <p>Supports two filter placement strategies via {@link FilterType}:
  *
  * <ul>
- *   <li>{@code POST} — WHERE in {@code bool.filter} outside knn (post-filtering, default)
  *   <li>{@code EFFICIENT} — WHERE inside {@code knn.filter} for pre-filtering during ANN search
+ *       (default).
+ *   <li>{@code POST} — WHERE in {@code bool.filter} outside knn (post-filtering fallback, used when
+ *       the WHERE shape is not compatible with pre-filtering).
  * </ul>
  */
 public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
@@ -76,7 +79,7 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     requestBuilder.getSourceBuilder().query(knnQuery);
     this.knnQuery = knnQuery;
     this.options = options;
-    this.filterType = filterType != null ? filterType : FilterType.POST;
+    this.filterType = filterType != null ? filterType : FilterType.EFFICIENT;
     this.filterTypeExplicit = filterTypeExplicit;
     if (this.filterType == FilterType.EFFICIENT && rebuildKnnWithFilter == null) {
       throw new IllegalArgumentException(
@@ -85,7 +88,12 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     this.rebuildKnnWithFilter = rebuildKnnWithFilter;
   }
 
-  /** Default constructor — preserves existing call sites; defaults to POST, not explicit. */
+  /**
+   * Test-only constructor — pins {@link FilterType#POST} so callers that do not wire a {@code
+   * rebuildKnnWithFilter} callback (unit tests) can still exercise the push-down contract.
+   * Production callers always go through the full constructor, which defaults to {@link
+   * FilterType#EFFICIENT}.
+   */
   public VectorSearchQueryBuilder(
       OpenSearchRequestBuilder requestBuilder, QueryBuilder knnQuery, Map<String, String> options) {
     this(requestBuilder, knnQuery, options, FilterType.POST, false, null);
@@ -228,9 +236,10 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     }
     if (qb instanceof ScriptQueryBuilder) {
       throw new ExpressionEvaluationException(
-          "filter_type=efficient does not support predicates that compile to script queries"
-              + " (arithmetic, function calls, CASE, date math). Rewrite the WHERE clause to"
-              + " use comparable/term/range predicates, or omit filter_type.");
+          "vectorSearch WHERE pre-filtering does not support predicates that compile to"
+              + " script queries (arithmetic, function calls, CASE, date math). Rewrite the"
+              + " WHERE clause to use term/range/bool predicates, or set filter_type=post to"
+              + " apply the predicate after the k-NN search.");
     }
     if (qb instanceof BoolQueryBuilder) {
       BoolQueryBuilder bool = (BoolQueryBuilder) qb;
@@ -246,17 +255,18 @@ public class VectorSearchQueryBuilder extends OpenSearchIndexScanQueryBuilder {
     }
     if (qb instanceof NestedQueryBuilder) {
       throw new ExpressionEvaluationException(
-          "filter_type=efficient does not support nested predicates in this preview."
-              + " Rewrite the WHERE clause using non-nested fields or omit filter_type.");
+          "vectorSearch WHERE pre-filtering does not support nested predicates in this"
+              + " preview. Rewrite the WHERE clause using non-nested fields, or set"
+              + " filter_type=post to apply the predicate after the k-NN search.");
     }
     if (SAFE_EFFICIENT_FILTER_LEAVES.contains(qb.getClass())) {
       return;
     }
     throw new ExpressionEvaluationException(
-        "filter_type=efficient encountered an unsupported filter query shape: "
+        "vectorSearch WHERE pre-filtering encountered an unsupported filter query shape: "
             + qb.getClass().getSimpleName()
-            + ". Rewrite the WHERE clause using simple term/range/bool predicates,"
-            + " or omit filter_type.");
+            + ". Rewrite the WHERE clause using simple term/range/bool predicates, or set"
+            + " filter_type=post to apply the predicate after the k-NN search.");
   }
 
   @Override

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/scan/VectorSearchQueryBuilderTest.java
@@ -726,11 +726,14 @@ class VectorSearchQueryBuilderTest {
     ExpressionEvaluationException ex =
         assertThrows(ExpressionEvaluationException.class, () -> builder.pushDownFilter(filter));
     assertTrue(
-        ex.getMessage().contains("filter_type=efficient does not support"),
+        ex.getMessage().contains("vectorSearch WHERE pre-filtering does not support"),
         "Expected script rejection message, got: " + ex.getMessage());
     assertTrue(
         ex.getMessage().contains("script queries"),
         "Expected script queries guidance in message, got: " + ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains("filter_type=post"),
+        "Expected filter_type=post fallback guidance, got: " + ex.getMessage());
   }
 
   @Test
@@ -790,7 +793,7 @@ class VectorSearchQueryBuilderTest {
             ExpressionEvaluationException.class,
             () -> VectorSearchQueryBuilder.validateEfficientFilterSafe(nested));
     assertTrue(
-        ex.getMessage().contains("filter_type=efficient does not support nested predicates"),
+        ex.getMessage().contains("vectorSearch WHERE pre-filtering does not support nested"),
         "Expected targeted nested rejection, got: " + ex.getMessage());
   }
 


### PR DESCRIPTION
## Summary
- Mark the `vectorSearch()` table function experimental in the user doc (title `[Experimental]` suffix per repo convention, plus an experimental note under Introduction).
- Flip the default WHERE placement from post-filtering to **efficient** pre-filtering: a query without `filter_type` now embeds the predicate under `knn.filter` for ANN-time pruning. Users opt into post-filtering with `filter_type=post`.
- Reword `knn.filter` allow-list errors to neutral wording ("vectorSearch WHERE pre-filtering does not support…") with a "set `filter_type=post`" fallback hint so default-path users never see internal terminology.

## Details

**Production code flip** (end-to-end verified):
- `VectorSearchTableFunctionImplementation`: when user omits `filter_type`, `filterType = null` flows to `VectorSearchIndex`.
- `VectorSearchIndex.createScanBuilder`: `filterType == null` → `effectiveFilterType = FilterType.EFFICIENT`, `filterTypeExplicit = false`.
- `VectorSearchQueryBuilder.pushDownFilter`: EFFICIENT branch embeds the WHERE predicate inside `knn.filter` via the `rebuildKnnWithFilter` callback. No outer `bool` / `must` wrapping.
- Translation failures under the default path still fall back to in-memory filtering; explicit `filter_type=post` still requires native translation.

**Test-only constructor preserved at POST**: the 3-arg `VectorSearchQueryBuilder` constructor stays pinned to `FilterType.POST, false, null` because EFFICIENT mode requires a non-null `rebuildKnnWithFilter` callback that unit-test call sites do not wire up. The full constructor's `null → EFFICIENT` defaulting is what production uses.

**Doc updates** (`docs/user/dql/vector-search.rst`):
- Title: `Vector Search [Experimental]` (matches `endpoint.rst` house style).
- Introduction adds a short experimental note.
- Filtering section now lists **efficient (default)** first with the allow-list (term / range / wildcard / exists / full-text family / bool combinations) and explicitly calls out script / nested predicates as requiring `filter_type=post`.
- Example 4 renamed "Default pre-filtering (no `filter_type`)" and describes the `knn.filter` shape.
- Example 5 renamed "Post-filtering fallback" with an arithmetic predicate (`v.price * 1.1 < 100`) that actually requires the opt-in.

**Test updates**:
- `VectorSearchExplainIT`:
  - New default-shape tests: `testExplainDefaultFilterProducesKnnWithFilter`, `testExplainDefaultCompoundPredicateProducesKnnWithFilter`, `testExplainDefaultRadialWithWhereProducesKnnWithFilter` (assert no outer bool, `knn.filter` present, predicate field embedded).
  - `testBetweenPushesAsRange` / `testNotInPushesAsMustNotTerms` now pin `filter_type=post` explicitly to keep them aimed at the post-filter serialization path.
- `VectorSearchIT`: `testEfficientModeRejectsScriptPredicate` asserts the reworded error.
- `VectorSearchExecutionIT`: `testPostFilterReturnsOnlyMatchingDocs` pins `filter_type=post` so the test name still matches what it exercises.
- `VectorSearchQueryBuilderTest`: two assertion strings updated for the reworded allow-list errors, plus a new assertion on the `filter_type=post` fallback hint.

## Test plan
- [x] `./gradlew :opensearch:spotlessCheck :integ-test:spotlessCheck` green
- [x] `./gradlew :opensearch:test` green
- [x] `./gradlew :integ-test:integTest -Dtests.class="org.opensearch.sql.sql.VectorSearch*IT"`:
  - `VectorSearchExplainIT` 13/13
  - `VectorSearchIT` 41/41
  - `VectorSearchSubqueryIT` 14/14
  - `VectorSearchExecutionIT` 5 skipped (gated on k-NN plugin; runs locally against a k-NN-enabled cluster)
- [x] Author `Eric Wei <mengwei.eric@gmail.com>`, DCO sign-off present, no Co-Authored-By.