### PR TITLE
Exclude httpcore5-h2, httpcore5-reactive, httpclient5 from SQL bundle to fix jar hell

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -81,6 +81,10 @@ bundlePlugin {
     exclude 'jackson-annotations-*.jar'
     exclude 'jackson-databind-*.jar'
     exclude 'httpcore5-5*.jar'
+    // TODO: Remove the three httpcore5/httpclient5 exclusions below — and ideally this entire
+    // bundlePlugin exclusion block — once analytics-engine becomes an optional dependency via the
+    // AnalyticsFrontEndExtension SPI (opensearch-project/OpenSearch#21449). The shared-classloader
+    // jar deduplication that requires this hand-maintained list goes away with the SPI.
     exclude 'httpcore5-h2-*.jar'
     exclude 'httpcore5-reactive-*.jar'
     exclude 'httpclient5-*.jar'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -81,6 +81,9 @@ bundlePlugin {
     exclude 'jackson-annotations-*.jar'
     exclude 'jackson-databind-*.jar'
     exclude 'httpcore5-5*.jar'
+    exclude 'httpcore5-h2-*.jar'
+    exclude 'httpcore5-reactive-*.jar'
+    exclude 'httpclient5-*.jar'
     exclude 'commons-text-*.jar'
     // Calcite transitive deps now bundled in analytics-engine 3.7 — exclude from sql to avoid jar hell.
     exclude 'commons-math3-*.jar'


### PR DESCRIPTION
## Summary

Adds three missing jar exclusions to `plugin/build.gradle`'s `bundlePlugin` block so the SQL plugin install no longer trips JarHell when `analytics-engine` (in versions that ship `httpcore5-h2`/`httpcore5-reactive`/`httpclient5`) is co-installed.

## Failure being fixed

Reported by @peterzhuamazon  against the latest `feature-build-opensearch` distribution:

```
java.lang.IllegalStateException: failed to load plugin opensearch-sql due to jar hell
Caused by: java.lang.IllegalStateException: jar hell!
    class: org.apache.hc.core5.http2.H2ConnectionException
    jar1: <sql>/httpcore5-h2-5.4.jar
    jar2: <analytics-engine>/httpcore5-h2-5.4.jar
```

## Root cause

The existing exclusion list (added by #5302 to share JARs via the analytics-engine `extendedPlugins` classloader) covered `httpcore5-5*.jar`, but the `httpcore5-*` family ships in **four** variants — only the first was excluded:

| JAR | Previously excluded? |
|-----|----------------------|
| `httpcore5-5.4.jar`           | yes (`httpcore5-5*.jar`) |
| `httpcore5-h2-5.4.jar`        | **no** |
| `httpcore5-reactive-5.4.jar`  | **no** |
| `httpclient5-5.6.jar`         | **no** |

The first uncovered variant trips install; the next two would trip immediately after.

## Change

`plugin/build.gradle` — three new exclusions next to the existing `httpcore5-5*.jar`:

```gradle
exclude 'httpcore5-h2-*.jar'
exclude 'httpcore5-reactive-*.jar'
exclude 'httpclient5-*.jar'
```

## End-to-end verification

Built an OpenSearch 3.7 distro and ran `bin/opensearch-plugin install` for both bundle variants, with `opensearch-job-scheduler` + a representative `analytics-engine` (one that ships `httpcore5-h2`) pre-installed.

**Without the fix:**
```
-> Failed installing file:///tmp/.../sql-without-fix.zip
Caused by: java.lang.IllegalStateException: jar hell!
class: org.apache.hc.client5.http.AbstractClientContextBuilder
jar1: .../analytics-engine/httpclient5-5.6.jar
jar2: .../.installing-.../httpclient5-5.6.jar
```
↑ Reproduces Peter's stack (different class — JarHell catches whichever duplicate it iterates first; same root cause).

**With the fix:**
```
-> Installed opensearch-sql with folder name opensearch-sql

--- installed plugins:
analytics-engine
opensearch-job-scheduler
opensearch-sql
```

**Static check** against the currently vendored `analytics-engine-3.7.0-SNAPSHOT.zip`: zero overlapping JARs (by filename and by base name), confirming no class-level JarHell can fire for that pair.

## Caveats

- This PR is the minimum fix to clear Peter's reported failure. The `analytics-engine` build that's about to be vendored tomorrow may bundle additional JARs (e.g., `avatica-metrics`, `antlr4-runtime`, `icu4j`, `error_prone_annotations`) that overlap with SQL — those would require additional exclusions. We deliberately stop here rather than over-excluding, because excluding a JAR that the new vendored zip doesn't ship would break SQL at runtime (`ClassNotFoundException`).
- After the libs update lands tomorrow, re-run the same install verification against the new vendored zip and add exclusions for any newly-overlapping JARs.
- The longer-term fix is the `AnalyticsFrontEndExtension` SPI work in opensearch-project/OpenSearch#21449, which makes `analytics-engine` an optional dependency entirely.