### PR TITLE
Make analytics-engine an optional dependency 

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -55,55 +55,9 @@ opensearchplugin {
     name 'opensearch-sql'
     description 'OpenSearch SQL'
     classname 'org.opensearch.sql.plugin.SQLPlugin'
-    extendedPlugins = ['opensearch-job-scheduler', 'analytics-engine']
+    extendedPlugins = ['opensearch-job-scheduler', 'analytics-engine;optional=true']
     licenseFile rootProject.file("LICENSE.txt")
     noticeFile rootProject.file("NOTICE")
-}
-
-// Exclude jars provided by the analytics-engine plugin (shared via extendedPlugins classloader).
-// MUST match what's actually in the analytics-engine ZIP to avoid both jar hell (when analytics-engine
-// ships it) and ClassNotFoundException at runtime (when it doesn't). Last verified against
-// analytics-engine-3.7.0-SNAPSHOT — keep this list aligned when bumping versions.
-bundlePlugin {
-    exclude 'calcite-core-*.jar'
-    exclude 'calcite-linq4j-*.jar'
-    exclude 'avatica-core-*.jar'
-    exclude 'guava-*.jar'
-    exclude 'failureaccess-*.jar'
-    exclude 'slf4j-api-*.jar'
-    exclude 'commons-codec-*.jar'
-    exclude 'commons-compiler-*.jar'
-    exclude 'commons-io-*.jar'
-    exclude 'commons-lang3-*.jar'
-    exclude 'janino-*.jar'
-    exclude 'joou-java-6-*.jar'
-    exclude 'json-path-*.jar'
-    exclude 'jackson-annotations-*.jar'
-    exclude 'jackson-databind-*.jar'
-    exclude 'httpcore5-5*.jar'
-    // TODO: Remove the three httpcore5/httpclient5 exclusions below — and ideally this entire
-    // bundlePlugin exclusion block — once analytics-engine becomes an optional dependency via the
-    // AnalyticsFrontEndExtension SPI (opensearch-project/OpenSearch#21449). The shared-classloader
-    // jar deduplication that requires this hand-maintained list goes away with the SPI.
-    exclude 'httpcore5-h2-*.jar'
-    exclude 'httpcore5-reactive-*.jar'
-    exclude 'httpclient5-*.jar'
-    exclude 'commons-text-*.jar'
-    // Calcite transitive deps now bundled in analytics-engine 3.7 — exclude from sql to avoid jar hell.
-    exclude 'commons-math3-*.jar'
-    exclude 'commons-dbcp2-*.jar'
-    exclude 'commons-pool2-*.jar'
-    exclude 'uzaygezen-core-*.jar'
-    exclude 'sketches-core-*.jar'
-    exclude 'memory-0*.jar'
-    exclude 'jts-io-common-*.jar'
-    exclude 'proj4j-*.jar'
-    exclude 'json-smart-*.jar'
-    exclude 'accessors-smart-*.jar'
-    exclude 'asm-9*.jar'
-    // jsr305 is also bundled by arrow-flight-rpc (an extendedPlugins parent of analytics-engine,
-    // which we extend); both shipping it caused jar hell at plugin install time.
-    exclude 'jsr305-*.jar'
 }
 
 publishing {
@@ -207,7 +161,9 @@ dependencies {
 
     api project(":ppl")
     api project(':api')
-    compileOnly files("${rootDir}/libs/analytics-framework-3.7.0-SNAPSHOT.jar")
+    // Bundled: analytics-framework interfaces must resolve even when the plugin is absent.
+    api files("${rootDir}/libs/analytics-framework-3.7.0-SNAPSHOT.jar")
+    // Not bundled: classes here (e.g. OpenSearchSchemaBuilder) only load when the plugin is installed.
     compileOnly files("${rootDir}/libs/analytics-engine-3.7.0-SNAPSHOT.jar")
     api project(':legacy')
     api project(':opensearch')

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
@@ -62,9 +62,12 @@ public class TransportPPLQueryAction
 
   private final Supplier<Boolean> pplEnabled;
 
-  private final RestUnifiedQueryAction unifiedQueryHandler;
+  /** Null when analytics-engine plugin is absent; set via {@link #setQueryPlanExecutor}. */
+  private volatile RestUnifiedQueryAction unifiedQueryHandler;
 
-  /** Constructor of TransportPPLQueryAction. */
+  private final NodeClient clientRef;
+  private final ClusterService clusterServiceRef;
+
   @Inject
   public TransportPPLQueryAction(
       TransportService transportService,
@@ -72,9 +75,10 @@ public class TransportPPLQueryAction
       NodeClient client,
       ClusterService clusterService,
       DataSourceServiceImpl dataSourceService,
-      org.opensearch.common.settings.Settings clusterSettings,
-      QueryPlanExecutor<RelNode, Iterable<Object[]>> queryPlanExecutor) {
+      org.opensearch.common.settings.Settings clusterSettings) {
     super(PPLQueryAction.NAME, transportService, actionFilters, TransportPPLQueryRequest::new);
+    this.clientRef = client;
+    this.clusterServiceRef = clusterService;
 
     ModulesBuilder modules = new ModulesBuilder();
     modules.add(new OpenSearchPluginModule());
@@ -86,9 +90,6 @@ public class TransportPPLQueryAction
           b.bind(DataSourceService.class).toInstance(dataSourceService);
         });
     this.injector = Guice.createInjector(modules);
-    AnalyticsExecutorHolder.set(queryPlanExecutor);
-    this.unifiedQueryHandler =
-        new RestUnifiedQueryAction(client, clusterService, queryPlanExecutor);
     this.pplEnabled =
         () ->
             MULTI_ALLOW_EXPLICIT_INDEX.get(clusterSettings)
@@ -96,6 +97,15 @@ public class TransportPPLQueryAction
                     injector
                         .getInstance(org.opensearch.sql.common.setting.Settings.class)
                         .getSettingValue(Settings.Key.PPL_ENABLED);
+  }
+
+  /** Invoked by Guice iff analytics-engine bound {@code QueryPlanExecutor}. */
+  @Inject(optional = true)
+  public void setQueryPlanExecutor(
+      QueryPlanExecutor<RelNode, Iterable<Object[]>> queryPlanExecutor) {
+    AnalyticsExecutorHolder.set(queryPlanExecutor);
+    this.unifiedQueryHandler =
+        new RestUnifiedQueryAction(clientRef, clusterServiceRef, queryPlanExecutor);
   }
 
   /**
@@ -134,8 +144,9 @@ public class TransportPPLQueryAction
     QueryContext.setProfile(transformedRequest.profile());
     ActionListener<TransportPPLQueryResponse> clearingListener = wrapWithProfilingClear(listener);
 
-    // Route to analytics engine for non-Lucene (e.g., Parquet-backed) indices
-    if (unifiedQueryHandler.isAnalyticsIndex(transformedRequest.getRequest(), QueryType.PPL)) {
+    // Route to analytics engine for non-Lucene (e.g., Parquet-backed) indices.
+    if (unifiedQueryHandler != null
+        && unifiedQueryHandler.isAnalyticsIndex(transformedRequest.getRequest(), QueryType.PPL)) {
       if (transformedRequest.isExplainRequest()) {
         unifiedQueryHandler.explain(
             transformedRequest.getRequest(),


### PR DESCRIPTION
## Summary

Makes `analytics-engine` an optional dependency of `opensearch-sql`. Fixes the install failure on distributions without `analytics-engine`:

```
Missing plugin [analytics-engine], dependency of [opensearch-sql]
```

Without `analytics-engine`, PPL/SQL queries route through the in-plugin v2 Calcite engine (Lucene). With it, the existing Mustang path (parquet indices → `QueryPlanExecutor`) still works.

## Changes

1. `extendedPlugins = ['opensearch-job-scheduler', 'analytics-engine;optional=true']`
2. `QueryPlanExecutor` moved from a required constructor parameter to an `@Inject(optional = true)` setter (Guice rejects optional on constructors). Guice skips the setter when the binding is absent; `unifiedQueryHandler` stays null; PPL routing falls through to the Calcite→OpenSearch path.
3. `analytics-framework.jar`: `compileOnly` → `api`. Needed so sql's classpath resolves `QueryPlanExecutor`/`SchemaProvider` standalone. `analytics-engine.jar` stays `compileOnly` — its classes (e.g. `OpenSearchSchemaBuilder`) are only reached through `RestUnifiedQueryAction`, which doesn't load when the setter is skipped.
4. Dropped the `bundlePlugin { exclude '*.jar' }` block so sql carries guava/calcite/jackson/etc. for standalone install.

## Validation

Live 2-node cluster, both configurations:

**With `analytics-engine` installed:** legacy PPL, analytics PPL (20 rows, parquet-backed), and SQL all work ✓

**Without `analytics-engine`** (only `opensearch-job-scheduler` + `opensearch-sql`): install succeeds, PPL/SQL against Lucene indices work, `parquet_*` lookup returns a clean `IndexNotFoundException` (not NPE or `NoClassDefFoundError`) ✓

## Not in this PR

- The routing heuristic (table prefix `parquet_`) is unchanged; a setting- or data-format-based trigger is a separate discussion.
- No changes in `analytics-engine` or core OpenSearch.
- No CI guard for transitive version consistency between sql and analytics-engine — worth adding as a follow-up.

---

<details>
<summary><b>Why bundling jars is safe</b> (addresses the diff analyzer findings)</summary>

The duplicated transitives (guava, calcite, jackson, etc.) are tolerated because OpenSearch explicitly supports this shape for optional deps:

- `;optional=true` is standard syntax (`PluginInfo.java:229`).
- Jar-hell cross-check between sql and analytics-engine is skipped for optional deps (`PluginsService.java:763`).
- At runtime, parent-first classloader delegation routes every shared-class lookup to analytics-engine's copy when it's installed; sql's bundled copies sit idle.

**Assumption:** sql and analytics-engine track the same transitive versions. Today both inherit from the OpenSearch root `versions.*` catalog, so they match by construction. If they drift, parent-first would silently pick analytics-engine's version — a CI guard comparing transitives would catch it.

**Alternatives considered:** a conditional exclude by deployment shape isn't viable (Gradle doesn't know at build time whether the target cluster has analytics-engine). Shipping two zips isn't supported by the OpenSearch plugin distribution model.

</details>
