### PR TITLE
Bump gradle wrapper to 9.4.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=16f2b95838c1ddcf7242b1c39e7bbbb43c842f1f1a1a0dc4959b6d4d68abcac3
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-all.zip
+distributionSha256Sum=708d2c6ecc97ca9a11838ef64a6c2301151b8dd10387e22dc1a12c30557cab5b
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description
Bump the gradle wrapper from 9.2.0 to 9.4.1.

The current opensearch-build-tools used by the downstream analytics-engine integration build now requires Gradle 9.4.1+; the 9.2.0 wrapper on this branch fails with:

> Failed to apply plugin class 'org.opensearch.gradle.info.GlobalBuildInfoPlugin'.
>   > Gradle 9.4.1+ is required

Mirrors opensearch-project/geospatial#854. The new SHA256 matches the value published at https://services.gradle.org/distributions/gradle-9.4.1-all.zip.sha256.

### Related Issues
Unblocks the analytics-engine build that consumes this branch.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Verified locally: `./gradlew --version` reports Gradle 9.4.1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.