### PR TITLE
Carry CalciteEvalCommandIT through the helper-managed index path

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -557,6 +557,40 @@ integTest {
     // Exclude this IT, because they executed in another task (:integTestWithSecurity)
     exclude 'org/opensearch/sql/security/**'
 
+    // Workaround for Gradle 9.4.1 ClassCastException in TestEventReporterAsListener.started
+    // (line 58) — the bridge casts a parent test descriptor's reporter to
+    // GroupTestEventReporterInternal but a class-level @Ignore produces a non-composite parent
+    // descriptor with a leaf reporter, so the cast fails and aborts the entire integTest task
+    // even though the tests would have been skipped anyway. The bridge is registered by Gradle's
+    // own AbstractTestTask (we can't bypass it from user code), so the only available remedy is
+    // to keep these classes off the test runner's input set. Net behaviour for CI: still
+    // skipped, just at the build layer instead of inside JUnit. Remove once Gradle ships a fix.
+    // OrderIT is already excluded above.
+    exclude 'org/opensearch/sql/calcite/remote/CalciteInformationSchemaCommandIT.class'
+    exclude 'org/opensearch/sql/calcite/remote/CalciteJsonFunctionsIT.class'
+    exclude 'org/opensearch/sql/calcite/remote/CalcitePrometheusDataSourceCommandsIT.class'
+    exclude 'org/opensearch/sql/calcite/remote/CalciteShowDataSourcesCommandIT.class'
+    exclude 'org/opensearch/sql/legacy/AggregationIT.class'
+    exclude 'org/opensearch/sql/legacy/DateFormatIT.class'
+    exclude 'org/opensearch/sql/legacy/DateFunctionsIT.class'
+    exclude 'org/opensearch/sql/legacy/HashJoinIT.class'
+    exclude 'org/opensearch/sql/legacy/HavingIT.class'
+    exclude 'org/opensearch/sql/legacy/JSONRequestIT.class'
+    exclude 'org/opensearch/sql/legacy/JoinIT.class'
+    exclude 'org/opensearch/sql/legacy/MathFunctionsIT.class'
+    exclude 'org/opensearch/sql/legacy/MetricsIT.class'
+    exclude 'org/opensearch/sql/legacy/MultiQueryIT.class'
+    exclude 'org/opensearch/sql/legacy/NestedFieldQueryIT.class'
+    exclude 'org/opensearch/sql/legacy/PreparedStatementIT.class'
+    exclude 'org/opensearch/sql/legacy/QueryFunctionsIT.class'
+    exclude 'org/opensearch/sql/legacy/QueryIT.class'
+    exclude 'org/opensearch/sql/legacy/SQLFunctionsIT.class'
+    exclude 'org/opensearch/sql/legacy/ShowIT.class'
+    exclude 'org/opensearch/sql/legacy/SourceFieldIT.class'
+    exclude 'org/opensearch/sql/legacy/SubqueryIT.class'
+    exclude 'org/opensearch/sql/ppl/JsonFunctionsIT.class'
+    exclude 'org/opensearch/sql/sql/ExpressionIT.class'
+
     finalizedBy 'printIntegTestPaths'
 }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteEvalCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteEvalCommandIT.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
+import org.opensearch.sql.legacy.TestUtils;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class CalciteEvalCommandIT extends PPLIntegTestCase {
@@ -26,23 +27,46 @@ public class CalciteEvalCommandIT extends PPLIntegTestCase {
 
     loadIndex(Index.BANK);
 
-    // Create test data for string concatenation
-    Request request1 = new Request("PUT", "/test_eval/_doc/1?refresh=true");
-    request1.setJsonEntity("{\"name\": \"Alice\", \"age\": 25, \"title\": \"Engineer\"}");
-    client().performRequest(request1);
+    // Pre-create test_eval through the helper so the analytics-engine compatibility run
+    // (tests.analytics.parquet_indices=true) provisions it as a parquet-backed composite
+    // index. Plain auto-mapping via the doc PUTs would create a Lucene-backed index, which
+    // the analytics-engine planner cannot scan ("No backend can scan all requested fields").
+    // Explicit mapping pins types so both v2 (verifySchema "string"/"bigint") and analytics
+    // paths see the same shape regardless of dynamic-mapping behavior on the parquet engine.
+    // Guarded by isIndexExist for idempotency — init() runs before each @Test method.
+    if (!TestUtils.isIndexExist(client(), "test_eval")) {
+      String testEvalMapping =
+          "{\"mappings\":{\"properties\":{"
+              + "\"name\":{\"type\":\"keyword\"},"
+              + "\"age\":{\"type\":\"long\"},"
+              + "\"title\":{\"type\":\"keyword\"}}}}";
+      TestUtils.createIndexByRestClient(client(), "test_eval", testEvalMapping);
 
-    Request request2 = new Request("PUT", "/test_eval/_doc/2?refresh=true");
-    request2.setJsonEntity("{\"name\": \"Bob\", \"age\": 30, \"title\": \"Manager\"}");
-    client().performRequest(request2);
+      // Create test data for string concatenation
+      Request request1 = new Request("PUT", "/test_eval/_doc/1?refresh=true");
+      request1.setJsonEntity("{\"name\": \"Alice\", \"age\": 25, \"title\": \"Engineer\"}");
+      client().performRequest(request1);
 
-    Request request3 = new Request("PUT", "/test_eval/_doc/3?refresh=true");
-    request3.setJsonEntity("{\"name\": \"Charlie\", \"age\": null, \"title\": \"Analyst\"}");
-    client().performRequest(request3);
+      Request request2 = new Request("PUT", "/test_eval/_doc/2?refresh=true");
+      request2.setJsonEntity("{\"name\": \"Bob\", \"age\": 30, \"title\": \"Manager\"}");
+      client().performRequest(request2);
+
+      Request request3 = new Request("PUT", "/test_eval/_doc/3?refresh=true");
+      request3.setJsonEntity("{\"name\": \"Charlie\", \"age\": null, \"title\": \"Analyst\"}");
+      client().performRequest(request3);
+    }
   }
 
   @Test
   public void testEvalStringConcatenation() throws IOException {
-    JSONObject result = executeQuery("source=test_eval | eval greeting = 'Hello ' + name");
+    // Pin the projection so column order is deterministic across execution paths — the
+    // analytics-engine route reads parquet schema in storage order, which can differ from the
+    // v2 / Lucene path's _source-iteration order. Adding an explicit | fields makes the test
+    // a strict assertion on the eval expression rather than a coincidence of projection order.
+    JSONObject result =
+        executeQuery(
+            "source=test_eval | eval greeting = 'Hello ' + name | fields name, title, age,"
+                + " greeting");
     verifySchema(
         result,
         schema("name", "string"),


### PR DESCRIPTION
## Description

Two things this PR carries together (commit-separated for clean review):

1. **Carry `CalciteEvalCommandIT` through the helper-managed index path** (`28a58536d`) — provisions the inline `test_eval` index via `TestUtils.createIndexByRestClient` instead of direct `PUT /test_eval/_doc/N`, so the analytics-engine compatibility run (`tests.analytics.parquet_indices=true`) gets a parquet-backed index. Mirrors the helper-managed pattern that `CalciteFillNullCommandIT` and `CalcitePPLAppendCommandIT` already use via `loadIndex(Index.X)`.

2. **Workaround for Gradle 9.4.1 `TestEventReporterAsListener` cast bug** (`435827e99`) — excludes `@Ignore`-annotated test classes from `integTest` so the task no longer aborts mid-run on this branch's CI.

---

### 1. Helper-managed `test_eval` provisioning

#### Why this matters

When the analytics-engine compatibility path is active (`tests.analytics.force_routing=true` and `tests.analytics.parquet_indices=true`), every test-created index needs parquet-backed storage so the DataFusion backend can scan it — `TestUtils.makeParquetBacked` handles the injection inside `createIndexByRestClient`. Direct `PUT /test_eval/_doc/N` calls bypass that helper, so the index lands Lucene-backed and the analytics planner rejects every query with `No backend can scan all requested fields on index [test_eval]`.

The three tests that use `test_eval` fail on the analytics route today; only `testEvalStringConcatenationWithExistingData` (which uses `loadIndex(Index.BANK)`) survives. With this change, `test_eval` is created via the same helper as every other fixture and inherits the parquet flag automatically.

The companion analytics-engine wiring (CONCAT/CAST/SAFE_CAST capabilities + null-propagating concat adapter) lands separately in [opensearch-project/OpenSearch#21498](https://github.com/opensearch-project/OpenSearch/pull/21498). On its own, this PR is a no-op for the v2 / Calcite path — once both this and the core PR are merged, `CalciteEvalCommandIT` goes from 1/4 to 4/4 on the analytics route.

#### Changes

1. **Helper-managed `test_eval` provisioning.** `init()` now calls `TestUtils.createIndexByRestClient(client(), "test_eval", testEvalMapping)` with an explicit mapping (`name`/`title` = `keyword`, `age` = `long`). The helper is a thin wrapper around the index PUT on the v2 path (no-op when `tests.analytics.parquet_indices` is unset), so v2 behaviour is unchanged.

2. **Idempotency guard.** The whole init body is wrapped in `TestUtils.isIndexExist(client(), "test_eval")` — same pattern `loadIndex` uses for predefined fixtures. `init()` runs before every `@Test` method; first run provisions, subsequent runs skip. Without the guard, `createIndexByRestClient` (unlike the original doc-level PUT) would throw `resource_already_exists_exception` on the second invocation.

3. **Pinned projection order on `testEvalStringConcatenation`.** The original query had no `| fields` clause and relied on the implicit projection's column order, which differs between paths (v2 returns `_source`-iteration order, analytics returns parquet-storage order). Added `| fields name, title, age, greeting` to make the assertion deterministic. Expected rows already match this order, so v2 behaviour is preserved.

#### V2-path impact

| Surface | Before | After |
|---|---|---|
| `name` PPL type | `string` (text → string) | `string` (keyword → string) |
| `age` PPL type | `bigint` | `bigint` |
| `title` PPL type | `string` | `string` |
| Eval read source | `_source` | `_source` |
| Concat result | `"Hello Alice"` | `"Hello Alice"` |
| Test 1 expected row order | `[name, title, age, greeting]` (matched by coincidence) | `[name, title, age, greeting]` (now pinned) |

`verifySchema(schema("name", "string"))` matches both `text+keyword` (dynamic) and `keyword` (explicit) — PPL maps both to the same logical type. No assertion changes were needed.

---

### 2. Gradle 9.4.1 `@Ignore` cast workaround

#### Why this is in this PR

CI on this branch (post-#5406 wrapper bump to 9.4.1) aborts the `:integ-test:integTest` task with:

```
Test process encountered an unexpected problem.
> class org.gradle.api.internal.tasks.testing.LifecycleTrackingTestEventReporter cannot be cast to class
  org.gradle.api.internal.tasks.testing.GroupTestEventReporterInternal
```

…even though no test assertion fails. Without a workaround, this PR's tests would be invisible — the task crashes before final result aggregation. Folding the workaround into this PR unblocks our CI; the workaround is a base-branch concern but the symptom blocks every PR until landed.

#### Root cause (verified via `javap` against `gradle-testing-base-9.4.1.jar`)

- `org/gradle/api/tasks/testing/AbstractTestTask` (line 263) instantiates `TestEventReporterAsListener` — Gradle's internal bridge from `TestListenerInternal` to the new `TestEventReporter` API.
- `TestEventReporterAsListener.started` line 58 stores a per-descriptor reporter in a map keyed by id and, on each child event, casts the parent's stored reporter to `GroupTestEventReporterInternal`.
- A **class-level `@Ignore`** produces a non-composite parent descriptor with a *leaf* `TestEventReporter` rather than a group reporter — the cast fails. First failure in CI: `CalciteInformationSchemaCommandIT.testTablesFromPrometheusCatalog` (that class is `@Ignore`'d for #3455).
- The bridge is instantiated by Gradle's own `AbstractTestTask`, **not** by `OpenSearchTestBasePlugin.addTestListener(ErrorReportingTestListener)`. Migrating `ErrorReportingTestListener` to the new event-reporter API would not stop the bridge from firing.

#### Workaround

Exclude all `@Ignore`-annotated test classes from `integTest`. The classes were already skipped at the JUnit layer; this just moves the skip earlier (build layer) so the buggy bridge never sees them.

| | Before | After |
|---|---|---|
| `@Ignore`'d test runtime status | Skipped (JUnit) | Not run (Gradle exclude) |
| Pass/fail outcome | Skipped | Skipped (effectively — same as not-run for CI gating) |
| Skipped-test count in dashboards | Includes `@Ignore`'d | One-time delta (excludes them) |
| `integTest` task aborts mid-run | ❌ yes (cast crash) | ✅ no |
| `testLogging.events "failed"` per-test message | Preserved | Preserved |

24 classes excluded (one — `OrderIT` — was already excluded by the existing block). Source: `grep -rln '^@Ignore' integ-test/src/test/java` minus already-excluded paths.

**This block should be removed once Gradle ships a fix for the bridge cast.** Given the bug is in Gradle's own internal class, the proper long-term fix is upstream — file an issue on `gradle/gradle` referencing the `TestEventReporterAsListener.started:58` site if not already filed.

---

### Test results

|  | v2 path (this PR alone) | analytics route (this PR + core #21498) |
|---|---|---|
| `testEvalStringConcatenation` | passes | passes |
| `testEvalStringConcatenationWithNullField` | passes | passes |
| `testEvalStringConcatenationWithLiterals` | passes | passes |
| `testEvalStringConcatenationWithExistingData` | passes | passes |
| Analytics-route status | unchanged (1/4) | **4/4** |
| `:integ-test:integTest` task | crashes pre-PR (Gradle 9.4.1 bug) | **runs to completion** |

### Forward note

The same direct-`PUT` pattern that this PR fixes for `CalciteEvalCommandIT` exists in roughly a dozen other Calcite ITs (`CalcitePPLAggregationIT`, `CalcitePPLBasicIT`, `CalciteFieldFormatCommandIT`, `CalcitePPLCaseFunctionIT`, etc.). Each will need the same one-line carryover when its corresponding command lands on the analytics route. This PR addresses only the eval surface.

### By submitting this pull request

- [x] All commits are signed per the [DCO](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] My code follows the [code of conduct](https://opensearch.org/codeofconduct.html) of this project.
- [x] My change requires changes to the documentation. — N/A (test-infra change)
- [x] I have updated the documentation accordingly. — N/A
- [x] I have added tests to cover my changes. — Existing tests; this PR carries them through the helper-managed path so they survive on the analytics route.