### PR TITLE
Exclude jsr305 from SQL bundle to fix jar hell with arrow-flight-rpc

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -101,6 +101,9 @@ bundlePlugin {
     exclude 'json-smart-*.jar'
     exclude 'accessors-smart-*.jar'
     exclude 'asm-9*.jar'
+    // jsr305 is also bundled by arrow-flight-rpc (an extendedPlugins parent of analytics-engine,
+    // which we extend); both shipping it caused jar hell at plugin install time.
+    exclude 'jsr305-*.jar'
 }
 
 publishing {


### PR DESCRIPTION
## Summary

The SQL plugin currently fails to install on top of `analytics-engine` + `arrow-flight-rpc` with:

```
IllegalStateException: jar hell!
class: javax.annotation.CheckForNull
jar1: .../installing-.../jsr305-3.0.2.jar
jar2: .../plugins/arrow-flight-rpc/jsr305-3.0.2.jar
    at org.opensearch.common.bootstrap.JarHell.checkClass(JarHell.java:316)
    at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:792)
```

`arrow-flight-rpc` (a transitive parent of `analytics-engine` via `extendedPlugins`) bundles `jsr305-3.0.2.jar`, and the SQL plugin currently bundles the same artifact. With both plugins shipping the same jar, `PluginsService.checkBundleJarHell` rejects the SQL install.

This PR excludes `jsr305-*.jar` from the SQL bundle so the arrow-flight-rpc copy (already on the shared classloader) is the only one on disk. Same pattern as #5400.

## Stop-gap until #5403 lands

This is a band-aid. The real fix is **#5403** (open against the same base branch), which makes `analytics-engine` an optional `extendedPlugins` dependency via the supported `;optional=true` syntax:

- `PluginInfo.java:190-191` — parses `optional=true` off the `extendedPlugins` entry
- `PluginsService.java:794-796` — `checkBundleJarHell` skips the cross-check entirely when the dependency is optional

Once #5403 merges, the entire `bundlePlugin { exclude '<artifact>-*.jar' }` block at `plugin/build.gradle:67-107` becomes obsolete and this whole class of breakage stops happening on every analytics-engine zip bump. So if #5403 lands first, please close this PR rather than merging it; if this lands first, it can be reverted as part of #5403's diff.

## Test plan

- [ ] `./gradlew :plugin:bundlePlugin` and confirm the resulting zip no longer contains `jsr305-3.0.2.jar`
- [ ] Install `arrow-flight-rpc` + `analytics-engine` + this SQL build on a local OpenSearch 3.7 node and confirm `bin/opensearch-plugin install` succeeds
- [ ] Smoke-test a PPL query end-to-end on the analytics-engine path to confirm `javax.annotation.*` classes still resolve at runtime via the shared classloader

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).