### PR TITLE
Carry CalciteFieldFormatCommandIT through the helper-managed index path

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteFieldFormatCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteFieldFormatCommandIT.java
@@ -12,6 +12,7 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
+import org.opensearch.sql.legacy.TestUtils;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 public class CalciteFieldFormatCommandIT extends PPLIntegTestCase {
@@ -23,26 +24,48 @@ public class CalciteFieldFormatCommandIT extends PPLIntegTestCase {
 
     loadIndex(Index.BANK);
 
-    // Create test data for string concatenation
-    Request request1 = new Request("PUT", "/test_eval/_doc/1?refresh=true");
-    request1.setJsonEntity("{\"name\": \"Alice\", \"age\": 25, \"title\": \"Engineer\"}");
-    client().performRequest(request1);
+    // Pre-create test_eval through the helper so the analytics-engine compatibility run
+    // (tests.analytics.parquet_indices=true) provisions it as a parquet-backed composite
+    // index. Plain auto-mapping via the doc PUTs would create a Lucene-backed index, which
+    // the analytics-engine planner cannot scan ("No backend can scan all requested fields").
+    // Explicit mapping pins types so both v2 (verifySchema "string"/"bigint") and analytics
+    // paths see the same shape regardless of dynamic-mapping behavior on the parquet engine.
+    // Guarded by isIndexExist for idempotency — init() runs before each @Test method.
+    if (!TestUtils.isIndexExist(client(), "test_eval")) {
+      String testEvalMapping =
+          "{\"mappings\":{\"properties\":{"
+              + "\"name\":{\"type\":\"keyword\"},"
+              + "\"age\":{\"type\":\"long\"},"
+              + "\"title\":{\"type\":\"keyword\"}}}}";
+      TestUtils.createIndexByRestClient(client(), "test_eval", testEvalMapping);
 
-    Request request2 = new Request("PUT", "/test_eval/_doc/2?refresh=true");
-    request2.setJsonEntity("{\"name\": \"Bob\", \"age\": 30, \"title\": \"Manager\"}");
-    client().performRequest(request2);
+      // Create test data for string concatenation
+      Request request1 = new Request("PUT", "/test_eval/_doc/1?refresh=true");
+      request1.setJsonEntity("{\"name\": \"Alice\", \"age\": 25, \"title\": \"Engineer\"}");
+      client().performRequest(request1);
 
-    Request request3 = new Request("PUT", "/test_eval/_doc/3?refresh=true");
-    request3.setJsonEntity("{\"name\": \"Charlie\", \"age\": null, \"title\": \"Analyst\"}");
-    client().performRequest(request3);
+      Request request2 = new Request("PUT", "/test_eval/_doc/2?refresh=true");
+      request2.setJsonEntity("{\"name\": \"Bob\", \"age\": 30, \"title\": \"Manager\"}");
+      client().performRequest(request2);
+
+      Request request3 = new Request("PUT", "/test_eval/_doc/3?refresh=true");
+      request3.setJsonEntity("{\"name\": \"Charlie\", \"age\": null, \"title\": \"Analyst\"}");
+      client().performRequest(request3);
+    }
   }
 
   @Test
   public void testFieldFormatStringConcatenation() throws IOException {
+    // Pin the projection so column order is deterministic across execution paths — the
+    // analytics-engine route reads parquet schema in storage order, which can differ from the
+    // v2 / Lucene path's _source-iteration order. Adding an explicit | fields makes the test
+    // a strict assertion on the fieldformat expression rather than a coincidence of projection
+    // order.
     JSONObject result =
         executeQuery(
             StringEscapeUtils.escapeJson(
-                "source=test_eval | fieldformat greeting = 'Hello ' + name"));
+                "source=test_eval | fieldformat greeting = 'Hello ' + name | fields name, title,"
+                    + " age, greeting"));
     verifySchema(
         result,
         schema("name", "string"),


### PR DESCRIPTION
## Summary

Same shape as #5407 for `CalciteEvalCommandIT`. The IT's `init()` previously created the in-test `test_eval` index via direct `PUT /test_eval/_doc/N` requests, relying on dynamic mapping. Two problems:

1. The doc PUTs auto-create the index with whatever settings the cluster defaults to. The analytics-engine compatibility path (force-routing on; `tests.analytics.parquet_indices=true`) needs parquet-backed indices, which `TestUtils.createIndexByRestClient` applies via `TestUtils.makeParquetBacked` when the system property is set. Direct PUTs sidestep that helper, so `test_eval` lands as Lucene-backed and the analytics planner rejects it with `No backend can scan all requested fields on index [test_eval]`. All four otherwise-working tests fail at execution.
2. `init()` runs before every `@Test` method. The doc PUTs are doc-level idempotent, so re-running was wasteful but not failing. Once we switch to `createIndexByRestClient`, the index-level PUT is no longer idempotent and re-running throws `resource_already_exists_exception`.

Both addressed in one change:

- `test_eval` is created via `TestUtils.createIndexByRestClient` with an explicit mapping (`name`/`title`=keyword, `age`=long). The helper honours `tests.analytics.parquet_indices=true` and produces a parquet-backed index for the analytics-engine sweep; on the v2 path the helper is a no-op around the index PUT, so behaviour is unchanged.
- The whole `init` body is guarded by `TestUtils.isIndexExist` — same idempotency idiom that `loadIndex` uses for predefined fixtures. First `@Test` method provisions; subsequent methods skip.

Also pins the projection order on `testFieldFormatStringConcatenation`. The original query had no `| fields` clause and relied on the implicit projection's column order — v2 returns Lucene-source insertion order, analytics returns parquet-storage order (alphabetical), so the assertion only matched on v2 by coincidence. Adding `| fields name, title, age, greeting` makes the assertion deterministic across paths; the existing expected rows already match this order, so v2 behaviour is preserved. The other four tests already have explicit `| fields ...` clauses.

No semantic change for the v2 path: the explicit mapping types (keyword, long, keyword) resolve to the same PPL types (`"string"`, `"bigint"`, `"string"`) that dynamic mapping inferred, and `fieldformat` reads from `_source` either way.

## Pass rate

`CalciteFieldFormatCommandIT` against a runTask cluster with `analytics-engine` + `opensearch-sql-plugin` installed, invoked via `:integ-test:analyticsCompatibilityTest --tests 'org.opensearch.sql.calcite.remote.CalciteFieldFormatCommandIT'`:

| Test | Before | After |
|---|---|---|
| `testFieldFormatStringConcatenation` | ❌ `No backend can scan all requested fields on index [test_eval]` | ✅ |
| `testFieldFormatStringConcatenationWithNullField` | ❌ same | ✅ |
| `testFieldFormatStringConcatWithSuffix` | ❌ same | ✅ |
| `testFieldFormatStringConcatWithPrefixSuffix` | ❌ same | ✅ |
| `testFieldFormatStringConcatenationWithNullFieldToString` | ❌ same | ❌ `No backend supports scalar function [TOSTRING] among [datafusion]` |
| **Total (analytics path)** | **0 / 5** | **4 / 5** |
| **Total (v2 path)** | **5 / 5** | **5 / 5** *(no regression)* |

The remaining `tostring()`-using test is blocked on a multi-mode UDF (`binary` / `hex` / `commas` / `duration` / `duration_millis`) that the analytics path doesn't yet wire — tracked as out of scope here, plausible follow-up estimated at ~1 day for a native Rust UDF + Substrait extension + Java adapter.

## Test plan

- [x] `./gradlew :integ-test:integTest --tests 'org.opensearch.sql.calcite.remote.CalciteFieldFormatCommandIT'` — **5 / 5 green** (v2 path, no regression).
- [x] `./gradlew :integ-test:analyticsCompatibilityTest --tests 'org.opensearch.sql.calcite.remote.CalciteFieldFormatCommandIT'` against a runTask cluster — **4 / 5 pass** (was 0 / 5 before this PR).

## Related

- #5407 (the equivalent fix for `CalciteEvalCommandIT`).
- The analytics-route wiring for `fieldformat` itself (no code change needed — `fieldformat` lowers to `Eval` with `CONCAT` + `CAST`, both already wired) is QA-pinned in opensearch-project/OpenSearch#21544.

## Note on base

This PR targets `feature/mustang-ppl-integration` rather than `main` so it lands alongside the rest of the analytics-engine compatibility scaffolding (`analyticsCompatibilityTest` task, `tests.analytics.parquet_indices` propagation, `loadIndex` parquet-aware variant) that the helper-managed pattern relies on. The change is purely additive over the mustang feature branch.