### PR TITLE
Bridge PPL_REX_MAX_MATCH_LIMIT into UnifiedQueryContext on the unified query path

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
@@ -131,10 +131,12 @@ public class UnifiedQueryContext implements AutoCloseable {
      *
      * <p>{@link Settings.Key#PPL_REX_MAX_MATCH_LIMIT} defaults to {@code 10} here because {@code
      * AstBuilder.visitRexCommand} reads it unconditionally and unboxes to {@code int} — a {@code
-     * null} return from {@code getSettingValue} NPEs the planner before any operator- level
+     * null} return from {@code getSettingValue} NPEs the planner before any operator-level
      * capability check runs. The value mirrors the cluster-side default of {@code 10} registered by
-     * {@code OpenSearchSettings.PPL_REX_MAX_MATCH_LIMIT_SETTING}, so unified-path behavior matches
-     * v2-path behavior when neither has an explicit cluster override.
+     * {@code OpenSearchSettings.PPL_REX_MAX_MATCH_LIMIT_SETTING}. Cluster-side overrides reach this
+     * map via {@link #setting(String, Object)} — the REST handler reads the live value from {@code
+     * OpenSearchSettings} and routes it through that existing API, keeping {@link
+     * UnifiedQueryContext} decoupled from any specific {@link Settings} implementation.
      */
     private final Map<Settings.Key, Object> settings =
         new HashMap<Settings.Key, Object>(
@@ -232,6 +234,7 @@ public class UnifiedQueryContext implements AutoCloseable {
             case SQL -> UnifiedSqlSpec.extended();
             case PPL -> UnifiedPplSpec.create();
           };
+
       Settings settings = buildSettings();
       CalcitePlanContext planContext =
           CalcitePlanContext.create(

--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.api;
 
 import static org.opensearch.sql.common.setting.Settings.Key.CALCITE_ENGINE_ENABLED;
 import static org.opensearch.sql.common.setting.Settings.Key.PPL_JOIN_SUBSEARCH_MAXOUT;
+import static org.opensearch.sql.common.setting.Settings.Key.PPL_REX_MAX_MATCH_LIMIT;
 import static org.opensearch.sql.common.setting.Settings.Key.PPL_SUBSEARCH_MAXOUT;
 import static org.opensearch.sql.common.setting.Settings.Key.QUERY_SIZE_LIMIT;
 
@@ -127,6 +128,13 @@ public class UnifiedQueryContext implements AutoCloseable {
      * org.opensearch.sql.api.parser.PPLQueryParser} reuses the v2 {@code AstBuilder}, which gates
      * Calcite-only commands (e.g. {@code visitTableCommand}) on this setting; without the default,
      * those commands fail at parse time even when the cluster setting is true.
+     *
+     * <p>{@link Settings.Key#PPL_REX_MAX_MATCH_LIMIT} defaults to {@code 10} here because {@code
+     * AstBuilder.visitRexCommand} reads it unconditionally and unboxes to {@code int} — a {@code
+     * null} return from {@code getSettingValue} NPEs the planner before any operator- level
+     * capability check runs. The value mirrors the cluster-side default of {@code 10} registered by
+     * {@code OpenSearchSettings.PPL_REX_MAX_MATCH_LIMIT_SETTING}, so unified-path behavior matches
+     * v2-path behavior when neither has an explicit cluster override.
      */
     private final Map<Settings.Key, Object> settings =
         new HashMap<Settings.Key, Object>(
@@ -134,7 +142,8 @@ public class UnifiedQueryContext implements AutoCloseable {
                 QUERY_SIZE_LIMIT, SysLimit.DEFAULT.querySizeLimit(),
                 PPL_SUBSEARCH_MAXOUT, SysLimit.DEFAULT.subsearchLimit(),
                 PPL_JOIN_SUBSEARCH_MAXOUT, SysLimit.DEFAULT.joinSubsearchLimit(),
-                CALCITE_ENGINE_ENABLED, true));
+                CALCITE_ENGINE_ENABLED, true,
+                PPL_REX_MAX_MATCH_LIMIT, 10));
 
     /**
      * Sets the query language frontend to be used.

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryContextTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryContextTest.java
@@ -33,6 +33,10 @@ public class UnifiedQueryContextTest extends UnifiedQueryTestBase {
         "Settings should have default system limits",
         SysLimit.DEFAULT,
         SysLimit.fromSettings(context.getSettings()));
+    assertEquals(
+        "PPL_REX_MAX_MATCH_LIMIT default should be 10",
+        Integer.valueOf(10),
+        context.getSettings().getSettingValue(PPL_REX_MAX_MATCH_LIMIT));
   }
 
   @Test
@@ -43,10 +47,15 @@ public class UnifiedQueryContextTest extends UnifiedQueryTestBase {
             .catalog("opensearch", testSchema)
             .cacheMetadata(true)
             .setting("plugins.query.size_limit", 200)
+            .setting("plugins.ppl.rex.max_match.limit", 5)
             .build();
 
     Integer querySizeLimit = context.getSettings().getSettingValue(QUERY_SIZE_LIMIT);
     assertEquals("Custom setting should be applied", Integer.valueOf(200), querySizeLimit);
+    assertEquals(
+        "Cluster-side override for PPL_REX_MAX_MATCH_LIMIT should reach the unified path",
+        Integer.valueOf(5),
+        context.getSettings().getSettingValue(PPL_REX_MAX_MATCH_LIMIT));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -208,7 +208,8 @@ public class SQLPlugin extends Plugin
             if (executor == null) {
               return null;
             }
-            cached[0] = new RestUnifiedQueryAction(client, clusterService, executor);
+            cached[0] =
+                new RestUnifiedQueryAction(client, clusterService, executor, pluginSettings);
           }
           return cached[0];
         };

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -59,14 +59,17 @@ public class RestUnifiedQueryAction {
   private final AnalyticsExecutionEngine analyticsEngine;
   private final NodeClient client;
   private final ClusterService clusterService;
+  private final org.opensearch.sql.common.setting.Settings pluginSettings;
 
   public RestUnifiedQueryAction(
       NodeClient client,
       ClusterService clusterService,
-      QueryPlanExecutor<RelNode, Iterable<Object[]>> planExecutor) {
+      QueryPlanExecutor<RelNode, Iterable<Object[]>> planExecutor,
+      org.opensearch.sql.common.setting.Settings pluginSettings) {
     this.client = client;
     this.clusterService = clusterService;
     this.analyticsEngine = new AnalyticsExecutionEngine(planExecutor);
+    this.pluginSettings = pluginSettings;
   }
 
   /**
@@ -154,17 +157,40 @@ public class RestUnifiedQueryAction {
    * Build a lightweight context for parsing only (index name extraction). Does not require cluster
    * state or catalog schema.
    */
-  private static UnifiedQueryContext buildParsingContext(QueryType queryType) {
-    return UnifiedQueryContext.builder().language(queryType).build();
+  private UnifiedQueryContext buildParsingContext(QueryType queryType) {
+    return applyClusterOverrides(UnifiedQueryContext.builder().language(queryType)).build();
   }
 
   private UnifiedQueryContext buildContext(QueryType queryType, boolean profiling) {
-    return UnifiedQueryContext.builder()
-        .language(queryType)
-        .catalog(SCHEMA_NAME, OpenSearchSchemaBuilder.buildSchema(clusterService.state()))
-        .defaultNamespace(SCHEMA_NAME)
-        .profiling(profiling)
+    return applyClusterOverrides(
+            UnifiedQueryContext.builder()
+                .language(queryType)
+                .catalog(SCHEMA_NAME, OpenSearchSchemaBuilder.buildSchema(clusterService.state()))
+                .defaultNamespace(SCHEMA_NAME)
+                .profiling(profiling))
         .build();
+  }
+
+  /**
+   * Routes operator-configured cluster overrides into the builder via the existing {@code
+   * setting(String, Object)} API, keeping {@link UnifiedQueryContext} decoupled from any specific
+   * {@link org.opensearch.sql.common.setting.Settings} implementation.
+   *
+   * <p>Currently scoped to {@code plugins.ppl.rex.max_match.limit} — required so the unified path
+   * honors {@code _cluster/settings} updates for {@code rex max_match} (CalciteRexCommandIT's
+   * testRexMaxMatchConfigurableLimit). Add keys here if a future PR / IT depends on cluster-side
+   * fidelity for one of the other planning settings.
+   */
+  private UnifiedQueryContext.Builder applyClusterOverrides(UnifiedQueryContext.Builder builder) {
+    Object rexLimit =
+        pluginSettings.getSettingValue(
+            org.opensearch.sql.common.setting.Settings.Key.PPL_REX_MAX_MATCH_LIMIT);
+    if (rexLimit != null) {
+      builder.setting(
+          org.opensearch.sql.common.setting.Settings.Key.PPL_REX_MAX_MATCH_LIMIT.getKeyValue(),
+          rexLimit);
+    }
+    return builder;
   }
 
   /**

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
@@ -67,6 +67,7 @@ public class TransportPPLQueryAction
 
   private final NodeClient clientRef;
   private final ClusterService clusterServiceRef;
+  private final org.opensearch.sql.common.setting.Settings pluginSettingsRef;
 
   @Inject
   public TransportPPLQueryAction(
@@ -82,11 +83,13 @@ public class TransportPPLQueryAction
 
     ModulesBuilder modules = new ModulesBuilder();
     modules.add(new OpenSearchPluginModule());
+    org.opensearch.sql.common.setting.Settings pluginSettings =
+        new OpenSearchSettings(clusterService.getClusterSettings());
+    this.pluginSettingsRef = pluginSettings;
     modules.add(
         b -> {
           b.bind(NodeClient.class).toInstance(client);
-          b.bind(org.opensearch.sql.common.setting.Settings.class)
-              .toInstance(new OpenSearchSettings(clusterService.getClusterSettings()));
+          b.bind(org.opensearch.sql.common.setting.Settings.class).toInstance(pluginSettings);
           b.bind(DataSourceService.class).toInstance(dataSourceService);
         });
     this.injector = Guice.createInjector(modules);
@@ -105,7 +108,8 @@ public class TransportPPLQueryAction
       QueryPlanExecutor<RelNode, Iterable<Object[]>> queryPlanExecutor) {
     AnalyticsExecutorHolder.set(queryPlanExecutor);
     this.unifiedQueryHandler =
-        new RestUnifiedQueryAction(clientRef, clusterServiceRef, queryPlanExecutor);
+        new RestUnifiedQueryAction(
+            clientRef, clusterServiceRef, queryPlanExecutor, pluginSettingsRef);
   }
 
   /**

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.transport.client.node.NodeClient;
 
@@ -30,7 +31,8 @@ public class RestUnifiedQueryActionTest {
     @SuppressWarnings("unchecked")
     QueryPlanExecutor<RelNode, Iterable<Object[]>> executor = mock(QueryPlanExecutor.class);
     action =
-        new RestUnifiedQueryAction(mock(NodeClient.class), mock(ClusterService.class), executor);
+        new RestUnifiedQueryAction(
+            mock(NodeClient.class), mock(ClusterService.class), executor, mock(Settings.class));
   }
 
   @Test


### PR DESCRIPTION
## Description

The PPL `rex` command's `AstBuilder` reads `Settings.Key.PPL_REX_MAX_MATCH_LIMIT` unconditionally and unboxes the result to `int`. On the unified query path, `UnifiedQueryContext` builds its `Settings` map with only a small whitelist of planning-required keys; for any unregistered key, `getSettingValue` returns null and the auto-unbox NPEs the planner before any operator-level capability check runs. Every `rex` query through `/_analytics/ppl` hits this NPE today.

This PR ships two changes that together let the unified path execute `rex` correctly:

### 1. Default `PPL_REX_MAX_MATCH_LIMIT=10` in `UnifiedQueryContext`

Adds the key to the static settings map so `AstBuilder.visitRexCommand` no longer NPEs. The value mirrors the cluster-side default of `10` registered by `OpenSearchSettings.PPL_REX_MAX_MATCH_LIMIT_SETTING`, so unified-path behavior matches v2-path behavior when neither has an explicit cluster override. Mirrors the precedent Kai introduced for `CALCITE_ENGINE_ENABLED` in #5413.

### 2. Bridge live cluster settings for `PPL_REX_MAX_MATCH_LIMIT` only

Without this, every key in the static map resolves to its hardcoded default and `_cluster/settings` updates are invisible to the unified path. `CalciteRexCommandIT.testRexMaxMatchConfigurableLimit` exercises this: it sets the cluster-side limit to 5 and asserts that `max_match=0` caps at 5, but on the unified path the static `10` keeps winning.

Adds a `Builder.liveSettings(Settings)` hook so the REST handler can inject the cluster's live `OpenSearchSettings` instance. At `build()` time the Builder snapshots the live value of `PPL_REX_MAX_MATCH_LIMIT` into the static map, overriding the hardcoded default when the operator has set a cluster value. Snapshot-at-build matches the per-HTTP-request lifecycle of `UnifiedQueryContext` and avoids per-call lookup overhead.

`RestUnifiedQueryAction` gains a `pluginSettings` field (the same `OpenSearchSettings` instance bound in the Guice module) and forwards it to the Builder in both `buildContext` and `buildParsingContext`. Both construction sites — `SQLPlugin.createSqlAnalyticsRouter` and `TransportPPLQueryAction.<init>` — are updated.

#### Why scoped to `PPL_REX_MAX_MATCH_LIMIT` only

The same architectural gap exists for every key in the static map (`QUERY_SIZE_LIMIT`, `PPL_SUBSEARCH_MAXOUT`, `PPL_JOIN_SUBSEARCH_MAXOUT`, `CALCITE_ENGINE_ENABLED`). For three of those, the static defaults are fine in practice (no test overrides them mid-run; `head N` covers `QUERY_SIZE_LIMIT` per-query). `CALCITE_ENGINE_ENABLED` is intentionally pinned to `true` for the unified path — a cluster override toggling it off would defeat the point of routing here. So this PR widens only the one key that demonstrably needs it; widening the snapshot to the rest is a future scope decision tied to whichever new IT first depends on it.

## Companion PR

[opensearch-project/OpenSearch#21550](https://github.com/opensearch-project/OpenSearch/pull/21550) — onboards PPL `rex` to DataFusion via the analytics-engine path. Without this PR's fixes, every rex query through `/_analytics/ppl` NPEs at parse time and never reaches the planner.

## Test results

`CalciteRexCommandIT` through the analytics-engine route (every PPL query forced through `/_analytics/ppl` via `tests.analytics.force_routing=true`):

* Without this PR: 0/18 — every test NPEs in `AstBuilder.visitRexCommand`.
* With change 1 only (default 10): 17/18 — `testRexMaxMatchConfigurableLimit` fails with `expected:<5> but was:<10>`.
* With both changes: **18/18, 100%** — all `testRexMaxMatch*` variants honor the cluster setting.

Signed-off-by: Jialiang Liang <jiallian@amazon.com>