### PR TITLE
Default empty array() return type to ARRAY<VARCHAR>

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ArrayFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ArrayFunctionImpl.java
@@ -50,14 +50,7 @@ public class ArrayFunctionImpl extends ImplementorUDF {
         RelDataType originalType =
             SqlLibraryOperators.ARRAY.getReturnTypeInference().inferReturnType(sqlOperatorBinding);
         RelDataType innerType = originalType.getComponentType();
-        // For empty `array()` Calcite infers element type as NULL, which downstream
-        // serializers (notably the analytics-engine route's substrait converter)
-        // reject with "Unable to convert the type UNKNOWN". Default to VARCHAR — the
-        // result is empty either way, so the chosen scalar element type doesn't
-        // affect any value computation, but it gives the call a substrait-serializable
-        // type. Existing v2-engine tests (which feed Object lists straight through to
-        // ExprCollectionValue) are unaffected because the empty list contains no
-        // elements that need to be cast.
+        // Default empty/unknown element type to VARCHAR — see PR description for why.
         if (innerType == null || isUnknownLikeType(innerType.getSqlTypeName())) {
           innerType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
         }

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ArrayFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ArrayFunctionImpl.java
@@ -50,6 +50,17 @@ public class ArrayFunctionImpl extends ImplementorUDF {
         RelDataType originalType =
             SqlLibraryOperators.ARRAY.getReturnTypeInference().inferReturnType(sqlOperatorBinding);
         RelDataType innerType = originalType.getComponentType();
+        // For empty `array()` Calcite infers element type as NULL, which downstream
+        // serializers (notably the analytics-engine route's substrait converter)
+        // reject with "Unable to convert the type UNKNOWN". Default to VARCHAR — the
+        // result is empty either way, so the chosen scalar element type doesn't
+        // affect any value computation, but it gives the call a substrait-serializable
+        // type. Existing v2-engine tests (which feed Object lists straight through to
+        // ExprCollectionValue) are unaffected because the empty list contains no
+        // elements that need to be cast.
+        if (innerType == null || isUnknownLikeType(innerType.getSqlTypeName())) {
+          innerType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+        }
         return createArrayType(
             typeFactory, typeFactory.createTypeWithNullability(innerType, true), true);
       } catch (Exception e) {
@@ -61,6 +72,17 @@ public class ArrayFunctionImpl extends ImplementorUDF {
   @Override
   public UDFOperandMetadata getOperandMetadata() {
     return null;
+  }
+
+  /**
+   * Calcite's {@link SqlLibraryOperators#ARRAY} infers a {@code NULL}-element array for an empty
+   * call list and an {@code UNKNOWN}-element array when type inference can't pick one (e.g. all
+   * operands are typeless nulls). Either of those bubbles up to the analytics-engine route's
+   * substrait converter as "Unable to convert the type UNKNOWN" — substrait has no encoding for
+   * either marker. Treat both as needing a concrete fallback.
+   */
+  private static boolean isUnknownLikeType(SqlTypeName sqlTypeName) {
+    return sqlTypeName == SqlTypeName.NULL || sqlTypeName == SqlTypeName.UNKNOWN;
   }
 
   public static class ArrayImplementor implements NotNullImplementor {

--- a/core/src/test/java/org/opensearch/sql/expression/function/CollectionUDF/ArrayFunctionImplTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/CollectionUDF/ArrayFunctionImplTest.java
@@ -14,6 +14,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.ExplicitOperatorBinding;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
@@ -301,5 +307,80 @@ public class ArrayFunctionImplTest {
     assertEquals("x", list.get(0));
     assertNull(list.get(1), "Null should be preserved during CHAR type conversion");
     assertEquals("y", list.get(2));
+  }
+
+  // ==================== RETURN-TYPE INFERENCE TESTS ====================
+  // These tests cover the return-type fallback the analytics-engine route depends on:
+  // when Calcite can't infer a concrete element type (no operands, or all-null operands),
+  // we substitute VARCHAR so the call's return type is substrait-serializable. Without the
+  // fallback Calcite emits ARRAY<NULL> / ARRAY<UNKNOWN>, which fails substrait conversion
+  // with "Unable to convert the type UNKNOWN" downstream.
+
+  /** array() — empty operand list — returns ARRAY<VARCHAR>. */
+  @Test
+  public void testReturnTypeForEmptyCallIsVarcharArray() {
+    RelDataType returnType = inferReturnType();
+    assertEquals(SqlTypeName.ARRAY, returnType.getSqlTypeName());
+    RelDataType element = returnType.getComponentType();
+    assertNotNull(element);
+    assertEquals(SqlTypeName.VARCHAR, element.getSqlTypeName());
+    assertTrue(element.isNullable(), "Element type should be nullable per existing semantics");
+  }
+
+  /** array(NULL) — single typeless-null operand — also falls back to ARRAY<VARCHAR>. */
+  @Test
+  public void testReturnTypeForAllNullOperandsIsVarcharArray() {
+    RelDataTypeFactory typeFactory = newTypeFactory();
+    RelDataType nullType = typeFactory.createSqlType(SqlTypeName.NULL);
+    RelDataType returnType = inferReturnType(nullType);
+    assertEquals(SqlTypeName.ARRAY, returnType.getSqlTypeName());
+    RelDataType element = returnType.getComponentType();
+    assertNotNull(element);
+    assertEquals(SqlTypeName.VARCHAR, element.getSqlTypeName());
+  }
+
+  /** array(1) — INTEGER operand — preserves the inferred element type (no fallback). */
+  @Test
+  public void testReturnTypeForIntegerOperandPreservesType() {
+    RelDataTypeFactory typeFactory = newTypeFactory();
+    RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    RelDataType returnType = inferReturnType(intType);
+    assertEquals(SqlTypeName.ARRAY, returnType.getSqlTypeName());
+    RelDataType element = returnType.getComponentType();
+    assertNotNull(element);
+    assertEquals(
+        SqlTypeName.INTEGER,
+        element.getSqlTypeName(),
+        "Concrete element types must not be affected by the VARCHAR fallback");
+  }
+
+  /** array('a', 'b') — VARCHAR operands — already VARCHAR, fallback path doesn't fire. */
+  @Test
+  public void testReturnTypeForVarcharOperandPreservesType() {
+    RelDataTypeFactory typeFactory = newTypeFactory();
+    RelDataType varcharType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
+    RelDataType returnType = inferReturnType(varcharType, varcharType);
+    assertEquals(SqlTypeName.ARRAY, returnType.getSqlTypeName());
+    assertEquals(SqlTypeName.VARCHAR, returnType.getComponentType().getSqlTypeName());
+  }
+
+  /**
+   * Helper — invokes {@code new ArrayFunctionImpl().getReturnTypeInference().inferReturnType(...)}
+   * via Calcite's {@link ExplicitOperatorBinding}, which is the public test harness for exercising
+   * a return-type inference against a specific operand-type list. We bind it to {@link
+   * SqlLibraryOperators#ARRAY} so the inference's internal call to {@code
+   * SqlLibraryOperators.ARRAY.getReturnTypeInference().inferReturnType(...)} resolves the same
+   * operator the lambda delegates to.
+   */
+  private static RelDataType inferReturnType(RelDataType... operandTypes) {
+    RelDataTypeFactory typeFactory = newTypeFactory();
+    ExplicitOperatorBinding binding =
+        new ExplicitOperatorBinding(
+            typeFactory, SqlLibraryOperators.ARRAY, Arrays.asList(operandTypes));
+    return new ArrayFunctionImpl().getReturnTypeInference().inferReturnType(binding);
+  }
+
+  private static RelDataTypeFactory newTypeFactory() {
+    return new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
   }
 }


### PR DESCRIPTION
### Description

PPL's `array()` no-arg form currently returns `ARRAY<NULL>` (and `ARRAY<UNKNOWN>` when all operands are typeless nulls). The Calcite engine's in-process executor tolerates either: `ArrayImplementor.internalCast` only consumes the element type when there are elements to cast, so an empty list flows straight through to `ExprCollectionValue` regardless of the declared element type.

The **analytics-engine route** is stricter. When isthmus walks a RexCall like `mvjoin(array(), '-')`, it eventually feeds the first operand's type to `io.substrait.isthmus.TypeConverter.toSubstrait`, which throws `UnsupportedOperationException: Unable to convert the type UNKNOWN`. Substrait has no on-wire encoding for NULL/UNKNOWN element types, so the planner can't serialize the call at all. Two ITs hit this directly:

- `CalciteArrayFunctionIT.testMvjoinWithEmptyArray`
- `CalciteArrayFunctionIT.testMvdedupWithEmptyArray`

Substituting `VARCHAR` when the inferred element type is `NULL` or `UNKNOWN` gives the call a substrait-serializable type without affecting any value computation — the result list is empty either way.

### Test plan
- `:core:test --tests "*ArrayFunction*"` — passes (no existing test asserted on the empty-array element type).
- `CalciteArrayFunctionIT` force-routed through the analytics-engine path via opensearch-project/OpenSearch#21554's plugin set — pass-rate **26/60 → 28/60**, with `testMvjoinWithEmptyArray` and `testMvdedupWithEmptyArray` newly green.

Companion to opensearch-project/OpenSearch#21554.