### PR TITLE
Use leastRestrictive for mvappend element-type widening

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/MVAppendFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/MVAppendFunctionImpl.java
@@ -20,6 +20,7 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 
@@ -78,18 +79,23 @@ public class MVAppendFunctionImpl extends ImplementorUDF {
     if (current == null) {
       return candidate;
     }
-    // Widen via Calcite's leastRestrictive (the same routine SqlLibraryOperators.ARRAY uses
-    // for its return-type inference) instead of strict Object.equals. {@code Object.equals}
-    // returns false for type pairs that only differ in nullability tag — e.g. {@code array(1, 2)}
-    // synthesizes INTEGER NULLABLE for its component while a literal {@code 3} is INTEGER NOT
-    // NULL — which then fell into the {@code ANY} fallback. Calcite's {@code ANY} type isn't
-    // substrait-serializable, so any analytics-engine query passing through {@code mvappend}
-    // with mixed-nullability operands or with widenable numerics (INT + DOUBLE) would fail
-    // substrait conversion with "Unable to convert the type ANY". {@code leastRestrictive}
-    // returns null when no common type exists (genuinely incompatible types like INT + VARCHAR);
-    // fall back to ANY in that case to preserve the original behavior on those queries.
-    RelDataType least = typeFactory.leastRestrictive(java.util.List.of(current, candidate));
-    return least != null ? least : typeFactory.createSqlType(SqlTypeName.ANY);
+    if (current.equals(candidate)) {
+      return current;
+    }
+    // Tolerate a nullability-only mismatch by widening to the nullable form. {@code Object.equals}
+    // distinguishes INTEGER NULLABLE from INTEGER NOT NULL — e.g. {@code array(1, 2)} synthesizes
+    // an INTEGER NULLABLE component while a bare literal {@code 3} is INTEGER NOT NULL — which
+    // would otherwise fall into the {@code ANY} fallback. Calcite's {@code ANY} type isn't
+    // substrait-serializable, so any analytics-engine query passing through {@code mvappend} with
+    // mixed-nullability operands would fail substrait conversion with "Unable to convert the type
+    // ANY". For genuinely different types (INT + DOUBLE, INT + VARCHAR, …) keep the {@code ANY}
+    // fallback unchanged: the Calcite engine relies on {@code Object[]} runtime semantics to
+    // preserve heterogeneous values as-is, and widening to a single numeric type would corrupt
+    // values at codegen time (e.g. casting integer 1 to {@code DECIMAL(11,1)}).
+    if (SqlTypeUtil.equalSansNullability(typeFactory, current, candidate)) {
+      return typeFactory.createTypeWithNullability(current, true);
+    }
+    return typeFactory.createSqlType(SqlTypeName.ANY);
   }
 
   public static class MVAppendImplementor implements NotNullImplementor {

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/MVAppendFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/MVAppendFunctionImpl.java
@@ -78,12 +78,18 @@ public class MVAppendFunctionImpl extends ImplementorUDF {
     if (current == null) {
       return candidate;
     }
-
-    if (!current.equals(candidate)) {
-      return typeFactory.createSqlType(SqlTypeName.ANY);
-    } else {
-      return current;
-    }
+    // Widen via Calcite's leastRestrictive (the same routine SqlLibraryOperators.ARRAY uses
+    // for its return-type inference) instead of strict Object.equals. {@code Object.equals}
+    // returns false for type pairs that only differ in nullability tag — e.g. {@code array(1, 2)}
+    // synthesizes INTEGER NULLABLE for its component while a literal {@code 3} is INTEGER NOT
+    // NULL — which then fell into the {@code ANY} fallback. Calcite's {@code ANY} type isn't
+    // substrait-serializable, so any analytics-engine query passing through {@code mvappend}
+    // with mixed-nullability operands or with widenable numerics (INT + DOUBLE) would fail
+    // substrait conversion with "Unable to convert the type ANY". {@code leastRestrictive}
+    // returns null when no common type exists (genuinely incompatible types like INT + VARCHAR);
+    // fall back to ANY in that case to preserve the original behavior on those queries.
+    RelDataType least = typeFactory.leastRestrictive(java.util.List.of(current, candidate));
+    return least != null ? least : typeFactory.createSqlType(SqlTypeName.ANY);
   }
 
   public static class MVAppendImplementor implements NotNullImplementor {

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/MVAppendFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/MVAppendFunctionImpl.java
@@ -7,7 +7,10 @@ package org.opensearch.sql.expression.function.CollectionUDF;
 
 import static org.apache.calcite.sql.type.SqlTypeUtil.createArrayType;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
+import org.apache.calcite.adapter.enumerable.EnumUtils;
 import org.apache.calcite.adapter.enumerable.NotNullImplementor;
 import org.apache.calcite.adapter.enumerable.NullPolicy;
 import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
@@ -20,7 +23,6 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 
@@ -82,33 +84,71 @@ public class MVAppendFunctionImpl extends ImplementorUDF {
     if (current.equals(candidate)) {
       return current;
     }
-    // Tolerate a nullability-only mismatch by widening to the nullable form. {@code Object.equals}
-    // distinguishes INTEGER NULLABLE from INTEGER NOT NULL — e.g. {@code array(1, 2)} synthesizes
-    // an INTEGER NULLABLE component while a bare literal {@code 3} is INTEGER NOT NULL — which
-    // would otherwise fall into the {@code ANY} fallback. Calcite's {@code ANY} type isn't
-    // substrait-serializable, so any analytics-engine query passing through {@code mvappend} with
-    // mixed-nullability operands would fail substrait conversion with "Unable to convert the type
-    // ANY". For genuinely different types (INT + DOUBLE, INT + VARCHAR, …) keep the {@code ANY}
-    // fallback unchanged: the Calcite engine relies on {@code Object[]} runtime semantics to
-    // preserve heterogeneous values as-is, and widening to a single numeric type would corrupt
-    // values at codegen time (e.g. casting integer 1 to {@code DECIMAL(11,1)}).
-    if (SqlTypeUtil.equalSansNullability(typeFactory, current, candidate)) {
-      return typeFactory.createTypeWithNullability(current, true);
+    // Widen via Calcite's {@code leastRestrictive} — the same routine
+    // {@code SqlLibraryOperators.ARRAY} uses for its return-type inference. For genuinely
+    // incompatible operand types (INT + VARCHAR, …) it returns null; fall back to {@code ANY}
+    // there to preserve the in-process Calcite engine's {@code Object[]} runtime semantics
+    // that pre-existing tests rely on. Promote DECIMAL → DOUBLE on the way through: the row
+    // codec on the analytics-engine route maps DECIMAL cells to {@code FloatingPoint(DOUBLE)}
+    // anyway, and an explicit DECIMAL element type triggers Calcite's element coercion to
+    // BigDecimal, which downstream Avatica array accessors and the JSON formatter render
+    // inconsistently across paths.
+    RelDataType least = typeFactory.leastRestrictive(java.util.List.of(current, candidate));
+    if (least == null) {
+      return typeFactory.createSqlType(SqlTypeName.ANY);
     }
-    return typeFactory.createSqlType(SqlTypeName.ANY);
+    if (least.getSqlTypeName() == SqlTypeName.DECIMAL) {
+      return typeFactory.createTypeWithNullability(
+          typeFactory.createSqlType(SqlTypeName.DOUBLE), true);
+    }
+    return least;
   }
 
   public static class MVAppendImplementor implements NotNullImplementor {
     @Override
     public Expression implement(
         RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
+      // Pre-cast each scalar operand to the call's element Java class so the result list is
+      // homogeneously typed. Avatica's {@code AbstractCursor.ArrayAccessor} dispatches the
+      // per-element accessor by the declared SQL type — e.g. {@code DoubleAccessor.getDouble}
+      // does {@code (Double) value} — and would throw a runtime ClassCastException on an
+      // {@code Integer} cell when the call's element type widens to DOUBLE. Array operands
+      // pass through; their element-type alignment is the planner's responsibility.
+      RelDataType elementType = call.getType().getComponentType();
+      Class<?> elementClass =
+          elementType == null ? Object.class : boxedJavaClass(elementType.getSqlTypeName());
+      List<Expression> coerced = new ArrayList<>(translatedOperands.size());
+      for (int i = 0; i < translatedOperands.size(); i++) {
+        Expression op = translatedOperands.get(i);
+        RelDataType opType = call.getOperands().get(i).getType();
+        if (opType.getComponentType() != null || elementClass == Object.class) {
+          coerced.add(op);
+        } else {
+          coerced.add(EnumUtils.convert(op, elementClass));
+        }
+      }
       return Expressions.call(
           Types.lookupMethod(MVAppendFunctionImpl.class, "mvappend", Object[].class),
-          Expressions.newArrayInit(Object.class, translatedOperands));
+          Expressions.newArrayInit(Object.class, coerced));
     }
   }
 
   public static Object mvappend(Object... args) {
     return MVAppendCore.collectElements(args);
+  }
+
+  private static Class<?> boxedJavaClass(SqlTypeName sqlType) {
+    return switch (sqlType) {
+      case BOOLEAN -> Boolean.class;
+      case TINYINT -> Byte.class;
+      case SMALLINT -> Short.class;
+      case INTEGER -> Integer.class;
+      case BIGINT -> Long.class;
+      case FLOAT, REAL -> Float.class;
+      case DOUBLE -> Double.class;
+      case DECIMAL -> BigDecimal.class;
+      case CHAR, VARCHAR -> String.class;
+      default -> Object.class;
+    };
   }
 }


### PR DESCRIPTION
### Description

`MVAppendFunctionImpl.updateMostGeneralType` used strict `Object.equals` to compare each operand's component type against the running "most general" type, falling back to Calcite's `ANY` on any mismatch. `Object.equals` returns false for type pairs that differ only in nullability tag — e.g. `array(1, 2)` synthesizes `INTEGER NULLABLE` for its component while literal `3` is `INTEGER NOT NULL` — and for straightforwardly-widenable numerics like INT + DECIMAL.

The Calcite engine's enumerable runtime tolerates `ANY` because `MVAppendImplementor.implement` processes elements through `Object[]` — the declared element type is unused at execution time. The **analytics-engine route** is stricter: substrait can't serialize `ANY`, so isthmus throws `UnsupportedOperationException: Unable to convert the type ANY` during substrait conversion.

Two changes:

1. **`updateMostGeneralType` widens via `RelDataTypeFactory.leastRestrictive`** — the same routine `SqlLibraryOperators.ARRAY` uses for its return-type inference. For genuinely incompatible operand types (INT + VARCHAR, …) `leastRestrictive` returns null; fall back to `ANY` there to preserve the existing in-process Calcite engine `Object[]` runtime semantics that the `mvappend(1, 'text', 2.5)`-style tests rely on. Promote DECIMAL → DOUBLE on the way through: `RowResponseCodec` maps DECIMAL cells to `FloatingPoint(DOUBLE)` anyway, and an explicit DECIMAL element type triggers Calcite's element coercion to BigDecimal, which the JSON formatter renders inconsistently across paths.

2. **`MVAppendImplementor.implement` pre-casts each scalar operand to the call's element Java class** via `EnumUtils.convert`. Without this, Avatica's `AbstractCursor.ArrayAccessor` dispatches the per-element accessor by the declared SQL type — e.g. `DoubleAccessor.getDouble` does `(Double) value` — and would throw a runtime `ClassCastException` on an `Integer` cell when the call's element type widens to DOUBLE. Array operands pass through; their element-type alignment is the planner's responsibility.

A previous revision of this PR went straight to `leastRestrictive` widening and triggered a runtime corruption (`mvappend(1, 2.5)` → `[0, 2.5]`) for exactly the Avatica-cast reason above. The pre-cast in `MVAppendImplementor` resolves that without reintroducing the regression.

### Test plan

- `./gradlew :core:test --tests "*MVAppend*"` → green.
- `./gradlew :integ-test:integTest --tests "org.opensearch.sql.calcite.remote.CalciteMVAppendFunctionIT"` (Calcite engine path) → **15/15 pass**.
- `./gradlew :integ-test:integTest --tests "org.opensearch.sql.calcite.remote.CalciteArrayFunctionIT"` → **60/60 pass** (no regression on the sister IT).

### Analytics-engine compatibility

Verified end-to-end against the analytics-engine path per the [Mustang + SQL plugin SOP](https://github.com/ahkcs/sql/commit/29339c9c0316d5bad43b5bcb13cc91627b54b1d9): cluster started with `arrow-flight-rpc + opensearch-job-scheduler + analytics-engine + composite-engine + parquet-data-format + analytics-backend-lucene + analytics-backend-datafusion + opensearch-sql-plugin`, this PR's SQL plugin republished to maven local on top of `feature/ppl-coverage-bundle` (rebased onto post-#5430 main), `:integ-test:integTestRemote` against the running cluster with `tests.analytics.{parquet_indices,force_routing}=true`. Re-measured after PR #5430 (analytics-engine PPL integration) landed in main; the OpenSearch companion #21554 is in `upstream/main` as commit `4dea6c4253c`.

#### `CalciteMVAppendFunctionIT` (force-routed through analytics-engine)

| Status | Before (current main, no PR) | After (this PR) |
|---|---|---|
| Passed | 7/15 | **10/15** |
| Failed | 8/15 | 5/15 |

Newly passing on the analytics-engine route as a direct result of this PR:

| Test | Operand types | Why it now passes |
|---|---|---|
| `testMvappendWithMixedArrayAndScalar` | `ARRAY<INT>`, INT, INT | nullability-only mismatch → bridged by `leastRestrictive` |
| `testMvappendWithIntAndDouble` | INT, DECIMAL | widens to DOUBLE via DECIMAL → DOUBLE promotion + operand pre-cast |
| `testMvappendWithNumericArrays` | `ARRAY<INT>`, `ARRAY<INT>` (with nullability skew) | nullability-only mismatch → bridged by `leastRestrictive` |

The other 7 passing tests already pass on current main without this PR (uniform-type signatures and pure-array operands, including `testMvappendWithComplexExpression` which was independently fixed upstream).

#### Remaining 5 failures (all are documented architectural limits, not regressions)

| # | Test | Operand types | Why it still fails |
|---:|---|---|---|
| 1 | `testMvappendWithMixedTypes` | INT, VARCHAR, DECIMAL | genuinely heterogeneous → `ARRAY<ANY>` (substrait can't encode) |
| 2 | `testMvappendWithFieldsAndLiterals` | INT, VARCHAR, VARCHAR | INT + VARCHAR → `ARRAY<ANY>` |
| 3 | `testMvappendWithEmptyArray` | `ARRAY<VARCHAR>` (#5421 default), INT, INT | VARCHAR + INT → `ARRAY<ANY>`. The empty-array `array()` is bound to `empty_arr` via `eval`; at MVAppend's type-inference site we see the column reference, not the literal, so per-call detection can't reach back through the project chain. |
| 4 | `testMvappendWithNull` | VARCHAR, INT, INT | VARCHAR + INT → `ARRAY<ANY>` (`nullif(1, 1)` is INTEGER-typed, not NULL-typed) |
| 5 | `testMvappendInWhereClause` | VARCHAR, VARCHAR | analytics-engine `OpenSearchFilterRule.resolveViableBackends` extracts only the predicate's TOP operator (EQUALS) and checks it against the field's storage type (ARRAY); doesn't walk into nested calls, so `array_length(combined) = 2` is rejected as "EQUALS on ARRAY field". Tracked separately as a planner refactor; not specific to mvappend. |

Calcite's `ANY` is a JVM `Object[]` pass-through with no substrait/Arrow/DataFusion equivalent. Resolving (1)–(4) would require either changing PPL's mvappend contract from heterogeneous-`Object[]` to a uniform stringified type (breaks user expectations) or shipping Arrow Union arrays through the wire format (multi-PR upstream work). Documented in the corresponding "What's left" section of opensearch-project/OpenSearch#21554.

### Companion changes

- **opensearch-project/sql#5421** (merged) — defaults empty `array()` element type to `ARRAY<VARCHAR>` in PPL's `ArrayFunctionImpl`. Required for empty-array tests in `CalciteArrayFunctionIT` (`testMvjoinWithEmptyArray`, `testMvdedupWithEmptyArray`, `testMvzip*EmptyArray`, `testMvfindWithEmptyArray`) to pass on the analytics-engine route.

- **opensearch-project/OpenSearch#21554** — onboards the eight PPL collection functions to the analytics-engine route, plus a load-bearing Rust-side fix that calls `udf::register_all` on FFM-created session contexts (without it, `mvappend` / `mvfind` / `mvzip` / `convert_tz` all fail end-to-end with "Unsupported function name" regardless of the SQL-side widening here).

