### PR TITLE
Route analytics queries by index setting

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -76,7 +76,7 @@ public class RestUnifiedQueryAction {
   /**
    * Returns true iff the target index has {@link
    * IndexSettings#PLUGGABLE_DATAFORMAT_ENABLED_SETTING} set and {@link
-   * IndexSettings#PLUGGABLE_DATAFORMAT_VALUE_SETTING} is {@code "parquet"}, routing it to
+   * IndexSettings#PLUGGABLE_DATAFORMAT_VALUE_SETTING} is {@code "composite"}, routing it to
    * DataFusion instead of the Calcite→DSL path.
    *
    * <p>Note: This creates a separate UnifiedQueryContext for parsing. The context cannot be shared
@@ -110,7 +110,7 @@ public class RestUnifiedQueryAction {
     }
     var settings = indexMetadata.getSettings();
     return IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(settings)
-        && "parquet".equals(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(settings));
+        && "composite".equals(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(settings));
   }
 
   /** Execute a query through the unified query pipeline on the sql-worker thread pool. */

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -25,7 +25,7 @@ import org.opensearch.transport.client.node.NodeClient;
 
 /**
  * Tests for analytics index routing in RestUnifiedQueryAction. Routing requires both {@code
- * index.pluggable.dataformat.enabled=true} and {@code index.pluggable.dataformat=parquet}.
+ * index.pluggable.dataformat.enabled=true} and {@code index.pluggable.dataformat=composite}.
  */
 public class RestUnifiedQueryActionTest {
 
@@ -57,7 +57,7 @@ public class RestUnifiedQueryActionTest {
         "parquet_logs",
         Settings.builder()
             .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
-            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
             .build());
 
     assertTrue(action.isAnalyticsIndex("source = parquet_logs | fields ts", QueryType.PPL));


### PR DESCRIPTION
## Summary
- Route queries to the analytics engine based on index settings instead of table-name prefix convention
- Check both `index.pluggable.dataformat.enabled=true` AND `index.pluggable.dataformat=composite` before routing to the analytics path
- If pluggable dataformat is enabled but the value is not `composite` (e.g. `lucene`), fall through to the standard Calcite→DSL path
- Add `pluginSettings` to `RestUnifiedQueryAction` to support cluster-level setting overrides (rex max_match limit)

## Test plan
- [x] Unit tests for routing logic (`RestUnifiedQueryActionTest`)
  - Composite format routes to analytics
  - Lucene format routes to old path
  - Missing index routes to old path
  - Null/empty queries route to old path