### PR TITLE
fix(prometheus): handle /api/v1/metadata responses without data field

### DIFF
--- a/direct-query-core/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
+++ b/direct-query-core/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
@@ -115,6 +115,9 @@ public class PrometheusClientImpl implements PrometheusClient {
     logger.debug("Received Prometheus response for query_range: code={}", response);
 
     JSONObject jsonObject = readResponse(response);
+    if (!jsonObject.has("data")) {
+      return new JSONObject();
+    }
     return jsonObject.getJSONObject("data");
   }
 
@@ -149,6 +152,9 @@ public class PrometheusClientImpl implements PrometheusClient {
 
     logger.info("Received Prometheus response for instant query: code={}", response);
     JSONObject jsonObject = readResponse(response);
+    if (!jsonObject.has("data")) {
+      return new JSONObject();
+    }
     return jsonObject.getJSONObject("data");
   }
 
@@ -167,6 +173,9 @@ public class PrometheusClientImpl implements PrometheusClient {
     Request request = new Request.Builder().url(queryUrl).build();
     Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
+    if (!jsonObject.has("data")) {
+      return new ArrayList<>();
+    }
     return toListOfLabels(jsonObject.getJSONArray("data"));
   }
 
@@ -182,6 +191,9 @@ public class PrometheusClientImpl implements PrometheusClient {
     Request request = new Request.Builder().url(queryUrl).build();
     Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
+    if (!jsonObject.has("data")) {
+      return new ArrayList<>();
+    }
     return toListOfLabels(jsonObject.getJSONArray("data"));
   }
 
@@ -196,6 +208,9 @@ public class PrometheusClientImpl implements PrometheusClient {
     Request request = new Request.Builder().url(queryUrl).build();
     Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
+    if (!jsonObject.has("data")) {
+      return new HashMap<>();
+    }
     TypeReference<HashMap<String, List<MetricMetadata>>> typeRef = new TypeReference<>() {};
     return new ObjectMapper().readValue(jsonObject.getJSONObject("data").toString(), typeRef);
   }
@@ -215,6 +230,9 @@ public class PrometheusClientImpl implements PrometheusClient {
     Request request = new Request.Builder().url(queryUrl).build();
     Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
+    if (!jsonObject.has("data")) {
+      return new ArrayList<>();
+    }
     JSONArray dataArray = jsonObject.getJSONArray("data");
     return toListOfSeries(dataArray);
   }
@@ -232,6 +250,9 @@ public class PrometheusClientImpl implements PrometheusClient {
     Request request = new Request.Builder().url(queryUrl).build();
     Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
+    if (!jsonObject.has("data")) {
+      return new JSONArray();
+    }
     return jsonObject.getJSONArray("data");
   }
 
@@ -243,6 +264,9 @@ public class PrometheusClientImpl implements PrometheusClient {
     Request request = new Request.Builder().url(queryUrl).build();
     Response response = AccessController.doPrivilegedChecked(() -> this.prometheusHttpClient.newCall(request).execute());
     JSONObject jsonObject = readResponse(response);
+    if (!jsonObject.has("data")) {
+      return new JSONObject();
+    }
     return jsonObject.getJSONObject("data");
   }
 

--- a/direct-query-core/src/test/java/org/opensearch/sql/prometheus/client/PrometheusClientImplTest.java
+++ b/direct-query-core/src/test/java/org/opensearch/sql/prometheus/client/PrometheusClientImplTest.java
@@ -1119,4 +1119,109 @@ public class PrometheusClientImplTest {
             PrometheusClientException.class, () -> nullBodyClient.getAlertmanagerStatus());
     assertTrue(exception.getMessage().contains("No response body"));
   }
+
+  // Prometheus-compatible backends (e.g. Cortex) may return {"status":"success"} with no
+  // "data" key when there is nothing to report. Each of the following tests verifies the
+  // corresponding client method returns an empty result instead of throwing JSONException.
+
+  @Test
+  public void testGetAllMetricsReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    var result = client.getAllMetrics();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testGetAllMetricsWithParamsReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    HashMap<String, String> params = new HashMap<>();
+    params.put("limit", "10");
+    var result = client.getAllMetrics(params);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testQueryRangeReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    JSONObject result = client.queryRange("up", 1435781430L, 1435781460L, "15s");
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testQueryReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    JSONObject result = client.query("up", 1435781460L, 100, 30);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testGetLabelsReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    List<String> result = client.getLabels(new HashMap<>());
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testGetLabelReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    List<String> result = client.getLabel("job", new HashMap<>());
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testGetSeriesReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    var result = client.getSeries(new HashMap<>());
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testQueryExemplarsReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    JSONArray result = client.queryExemplars("http_request_duration_seconds_bucket", 1L, 2L);
+
+    assertNotNull(result);
+    assertEquals(0, result.length());
+  }
+
+  @Test
+  public void testGetAlertsReturnsEmptyWhenDataFieldMissing() throws IOException {
+    String emptyResponse = "{\"status\":\"success\"}";
+    mockWebServer.enqueue(new MockResponse().setBody(emptyResponse));
+
+    JSONObject result = client.getAlerts();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
 }


### PR DESCRIPTION
### Description

`PrometheusClientImpl` blindly called `response.getJSONObject("data")` / `response.getJSONArray("data")` on every Prometheus API response. The Prometheus HTTP API spec does not mandate that `data` be present, and Cortex (observed on v1.18.1) legitimately returns `{"status":"success"}` with no `data` key when the endpoint has nothing to report.

This is the default state for any Cortex backend fed via OTLP remote-write, since OTLP metrics carry no OpenMetrics `# HELP` / `# TYPE` comments for Cortex to surface. A vanilla Prometheus returns `{"status":"success","data":{}}` in the same state, so the spec allows both shapes.

The resulting `JSONException` propagates up through `PrometheusQueryHandler.getResources()` → `DirectQueryExecutorServiceImpl` and surfaces in OpenSearch Dashboards' Metrics Explore UI as "Unable to load metrics" for every metric against any Cortex-backed Prometheus datasource.

**Stack trace observed on the live EKS deployment:**

```
org.json.JSONException: JSONObject["data"] not found.
    at org.json.JSONObject.get(JSONObject.java:568)
    at org.json.JSONObject.getJSONObject(JSONObject.java:778)
    at org.opensearch.sql.prometheus.client.PrometheusClientImpl.getAllMetrics(PrometheusClientImpl.java:200)
    at org.opensearch.sql.prometheus.query.PrometheusQueryHandler.getResources(PrometheusQueryHandler.java:136)
    ...
```

### Fix

Guard each affected call site (`getAllMetrics`, `queryRange`, `query`, `getLabels`, `getLabel`, `getSeries`, `queryExemplars`, `getAlerts`) with a `response.has("data")` check, returning a type-appropriate empty value (`new JSONObject()`, `new JSONArray()`, `new ArrayList<>()`, `new HashMap<>()`) instead of throwing.

Mutable empty collections are intentional: the transport layer reflectively constructs response maps, and `Collections.emptyMap()` / `Collections.emptyList()` trigger `InaccessibleObjectException` ("module java.base does not 'opens java.util' to unnamed module") during XContent serialization.

`getRules` already routes through `normalizeRulesResponse()`, which handles the missing-`data` case, so no change was needed there. Alertmanager methods don't read a `data` field.

### Testing

- `./gradlew :direct-query-core:test` — 254 tests, 0 failures (including 9 new tests — one per patched method — each feeding `{"status":"success"}` and asserting a safe empty return).
- `./gradlew :prometheus:test` — 104 tests, 0 failures.
- End-to-end validation against a live Cortex v1.18.1 backend in Docker:
  - Direct REST: `GET /_plugins/_directquery/_resources/<ds>/api/v1/metadata` → **HTTP 200** `{"data":{}}` (was 500).
  - OpenSearch Dashboards Metrics Explore UI: loads fully with label breakdowns, no "Unable to load metrics" toast.
  - Dashboards `POST /api/enhancements/resources` for `metric_metadata` → **200** `{"data":{},"type":"prometheus"}` (was 503).

### Issues resolved

N/A — filed directly.

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).