### PR TITLE
Add explain to AnalyticsExecutionEngine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/ExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/ExecutionEngine.java
@@ -13,6 +13,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.apache.calcite.rel.RelNode;
+import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.sql.ast.statement.ExplainMode;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.common.response.ResponseListener;
@@ -80,6 +81,8 @@ public interface ExecutionEngine {
     private final Schema schema;
     private final List<ExprValue> results;
     private final Cursor cursor;
+    @lombok.Setter private QueryProfile profile;
+    @lombok.Setter private Throwable error;
   }
 
   @Data

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -17,6 +17,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.analytics.schema.BinaryType;
 import org.opensearch.analytics.schema.IpType;
 import org.opensearch.common.network.InetAddresses;
@@ -143,6 +144,52 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     } catch (Exception e) {
       listener.onFailure(e);
     }
+  }
+
+  /**
+   * Executes the query with profiling enabled. Returns results + stage timing profile. Called when
+   * {@code profile=true} is set on the request.
+   */
+  public void executeWithProfile(
+      RelNode plan,
+      CalcitePlanContext context,
+      org.opensearch.analytics.QueryRequestContext queryCtx,
+      ResponseListener<QueryResponse> listener) {
+
+    planExecutor.executeWithProfile(
+        plan,
+        queryCtx,
+        new ActionListener<>() {
+          @Override
+          public void onResponse(ProfiledResult result) {
+            try {
+              // ProfiledResult delivers the profile on BOTH success and failure paths
+              // so users get stage timing visibility even when a query partially fails.
+              QueryResponse response = buildProfiledResponse(plan, result);
+              listener.onResponse(response);
+            } catch (Exception e) {
+              listener.onFailure(e);
+            }
+          }
+
+          @Override
+          public void onFailure(Exception e) {
+            listener.onFailure(e);
+          }
+        });
+  }
+
+  private QueryResponse buildProfiledResponse(RelNode plan, ProfiledResult result) {
+    List<RelDataTypeField> fields = plan.getRowType().getFieldList();
+    Schema schema = buildSchema(fields);
+    List<ExprValue> results =
+        result.rows() != null ? convertRows(result.rows(), fields) : List.of();
+    QueryResponse response = new QueryResponse(schema, results, Cursor.None);
+    response.setProfile(result.profile());
+    if (!result.isSuccess()) {
+      response.setError(result.failure());
+    }
+    return response;
   }
 
   private List<ExprValue> convertRows(Iterable<Object[]> rows, List<RelDataTypeField> fields) {

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -525,6 +525,43 @@ testClusters.analyticsEngineSecurityIT {
 
 configureSecurityPlugin(testClusters.analyticsEngineSecurityIT)
 
+task analyticsEngineProfileIT(type: RestIntegTestTask) {
+    dependsOn downloadAnalyticsEngineZip, downloadArrowFlightRpcZip, downloadArrowBaseZip, downloadAnalyticsBackendLuceneZip, downloadParquetDataFormatZip, downloadCompositeEngineZip, downloadAnalyticsBackendDatafusionZip
+    dependsOn ':opensearch-sql-plugin:bundlePlugin'
+
+    systemProperty 'tests.security.manager', 'false'
+
+    filter {
+        includeTestsMatching 'org.opensearch.sql.analytics.AnalyticsEngineProfileIT'
+    }
+}
+
+testClusters.analyticsEngineProfileIT {
+    testDistribution = 'archive'
+    plugin(getJobSchedulerPlugin())
+    plugin(getArrowBasePlugin())
+    plugin(getArrowFlightRpcPlugin())
+    plugin(getAnalyticsEnginePlugin())
+    plugin(getAnalyticsBackendLucenePlugin())
+    plugin(getAnalyticsBackendDatafusionPlugin())
+    plugin(getParquetDataFormatPlugin())
+    plugin(getCompositeEnginePlugin())
+    plugin ":opensearch-sql-plugin"
+    // Arrow Flight / streaming transport requirements
+    jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
+    systemProperty 'io.netty.allocator.numDirectArenas', '1'
+    systemProperty 'io.netty.noUnsafe', 'false'
+    systemProperty 'io.netty.tryUnsafe', 'true'
+    systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
+    systemProperty 'opensearch.experimental.feature.pluggable.dataformat.enabled', 'true'
+    systemProperty 'opensearch.experimental.feature.transport.stream.enabled', 'true'
+    // Native library path for DataFusion/parquet — pass via -PnativeLibPath=/path/to/release/
+    if (project.findProperty('nativeLibPath')) {
+        systemProperty 'java.library.path', project.findProperty('nativeLibPath')
+    }
+}
+
 task integJdbcTest(type: RestIntegTestTask) {
     testClusters.findAll {c -> c.clusterName == "integJdbcTest"}.first().with {
         plugin ":opensearch-sql-plugin"
@@ -707,6 +744,9 @@ integTest {
 
     exclude 'org/opensearch/sql/doctest/**/*IT.class'
     exclude 'org/opensearch/sql/correctness/**'
+
+    // Exclude tests that require the analytics engine plugin stack (run separately via dedicated tasks)
+    exclude 'org/opensearch/sql/analytics/AnalyticsEngineProfileIT.class'
 
     // Explain IT is dependent on internal implementation of old engine so it's not necessary
     // to run these with new engine and not necessary to make this consistent with old engine.

--- a/integ-test/src/test/java/org/opensearch/sql/analytics/AnalyticsEngineProfileIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/analytics/AnalyticsEngineProfileIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.analytics;
+
+import java.io.IOException;
+import java.util.Locale;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+
+/**
+ * Integration tests for the analytics engine profile API (profile=true). Verifies that PPL and SQL
+ * queries with profile=true return stage profiling, and that /_explain returns only the logical
+ * plan without execution.
+ *
+ * <p>Runs against the analyticsEngineProfileIT cluster which has the full analytics engine stack.
+ */
+public class AnalyticsEngineProfileIT extends OpenSearchRestTestCase {
+
+  private static final String INDEX = "profile_test";
+  private static boolean initialized = false;
+
+  private void ensureSetup() throws IOException {
+    if (initialized) return;
+    enableCalcite();
+    createCompositeIndex();
+    ingestData();
+    initialized = true;
+  }
+
+  private void enableCalcite() throws IOException {
+    Request req = new Request("PUT", "/_cluster/settings");
+    req.setJsonEntity("{\"persistent\":{\"plugins.calcite.enabled\":true}}");
+    client().performRequest(req);
+  }
+
+  private void createCompositeIndex() throws IOException {
+    try {
+      Request req = new Request("PUT", "/" + INDEX);
+      req.setJsonEntity(
+          """
+          {
+            "settings": {
+              "number_of_shards": 2,
+              "number_of_replicas": 0,
+              "index.pluggable.dataformat.enabled": true,
+              "index.pluggable.dataformat": "composite"
+            },
+            "mappings": {
+              "properties": {
+                "name": {"type": "keyword"},
+                "score": {"type": "double"}
+              }
+            }
+          }
+          """);
+      client().performRequest(req);
+    } catch (ResponseException e) {
+      if (e.getResponse().getStatusLine().getStatusCode() != 400) throw e;
+      // Index already exists
+    }
+  }
+
+  private void ingestData() throws IOException {
+    Request bulk = new Request("POST", "/_bulk");
+    bulk.addParameter("refresh", "true");
+    bulk.setJsonEntity(
+        String.format(
+            Locale.ROOT,
+            """
+            {"index":{"_index":"%s"}}
+            {"name":"alice","score":95.5}
+            {"index":{"_index":"%s"}}
+            {"name":"bob","score":87.3}
+            {"index":{"_index":"%s"}}
+            {"name":"carol","score":91.0}
+            """,
+            INDEX,
+            INDEX,
+            INDEX));
+    RequestOptions.Builder opts = RequestOptions.DEFAULT.toBuilder();
+    opts.addHeader("Content-Type", "application/x-ndjson");
+    bulk.setOptions(opts);
+    client().performRequest(bulk);
+  }
+
+  @Test
+  public void testPplProfileReturnsStages() throws IOException {
+    ensureSetup();
+    JSONObject result =
+        executeWithProfile("source = " + INDEX + " | stats avg(score) by name", "/_plugins/_ppl");
+
+    assertTrue("has schema", result.has("schema"));
+    assertTrue("has datarows", result.has("datarows"));
+    assertTrue("has profile", result.has("profile"));
+
+    JSONObject profile = result.getJSONObject("profile");
+    assertTrue("has query_id", profile.has("query_id"));
+    assertTrue("has planning_time_ms", profile.has("planning_time_ms"));
+    assertTrue("has execution_time_ms", profile.has("execution_time_ms"));
+    assertTrue("has full_plan", profile.has("full_plan"));
+
+    JSONArray stages = profile.getJSONArray("stages");
+    assertTrue("at least one stage", stages.length() >= 1);
+
+    JSONObject stage = stages.getJSONObject(0);
+    assertTrue("stage has stage_id", stage.has("stage_id"));
+    assertTrue("stage has execution_type", stage.has("execution_type"));
+    assertTrue("stage has state", stage.has("state"));
+    assertTrue("stage has elapsed_ms", stage.has("elapsed_ms"));
+    assertTrue("stage has tasks", stage.has("tasks"));
+  }
+
+  @Test
+  public void testSqlProfileReturnsStages() throws IOException {
+    ensureSetup();
+    JSONObject result = executeWithProfile("SELECT * FROM " + INDEX, "/_plugins/_sql");
+
+    assertTrue("has schema", result.has("schema"));
+    assertTrue("has datarows", result.has("datarows"));
+    assertTrue("has profile", result.has("profile"));
+
+    JSONObject profile = result.getJSONObject("profile");
+    assertTrue("has query_id", profile.has("query_id"));
+    assertTrue("has stages", profile.has("stages"));
+    JSONArray stages = profile.getJSONArray("stages");
+    assertTrue("at least one stage", stages.length() >= 1);
+  }
+
+  @Test
+  public void testPplProfileStagesShowSucceeded() throws IOException {
+    ensureSetup();
+    JSONObject result =
+        executeWithProfile("source = " + INDEX + " | fields name, score", "/_plugins/_ppl");
+
+    JSONObject profile = result.getJSONObject("profile");
+    JSONArray stages = profile.getJSONArray("stages");
+
+    for (int i = 0; i < stages.length(); i++) {
+      JSONObject stage = stages.getJSONObject(i);
+      assertEquals("stage succeeded", "SUCCEEDED", stage.getString("state"));
+      assertTrue("elapsed_ms non-negative", stage.getLong("elapsed_ms") >= 0);
+    }
+  }
+
+  @Test
+  public void testPplProfileTasksHaveNodeAndTiming() throws IOException {
+    ensureSetup();
+    JSONObject result =
+        executeWithProfile("source = " + INDEX + " | fields name", "/_plugins/_ppl");
+
+    JSONObject profile = result.getJSONObject("profile");
+    JSONArray stages = profile.getJSONArray("stages");
+
+    boolean foundTasks = false;
+    for (int i = 0; i < stages.length(); i++) {
+      JSONArray tasks = stages.getJSONObject(i).getJSONArray("tasks");
+      if (tasks.length() > 0) {
+        foundTasks = true;
+        JSONObject task = tasks.getJSONObject(0);
+        assertTrue("task has node", task.has("node"));
+        assertTrue("task has state", task.has("state"));
+        assertTrue("task has elapsed_ms", task.has("elapsed_ms"));
+      }
+    }
+    assertTrue("at least one stage has tasks", foundTasks);
+  }
+
+  @Test
+  public void testPplExplainReturnsOnlyPlan() throws IOException {
+    ensureSetup();
+    Request request = new Request("POST", "/_plugins/_ppl/_explain");
+    request.setJsonEntity(
+        String.format(Locale.ROOT, "{\"query\": \"source = %s | fields name, score\"}", INDEX));
+    Response response = client().performRequest(request);
+    JSONObject result = new JSONObject(entityAsString(response));
+
+    assertTrue("has calcite", result.has("calcite"));
+    JSONObject calcite = result.getJSONObject("calcite");
+    assertTrue("has logical", calcite.has("logical"));
+    assertFalse("no profile in explain", calcite.has("profile"));
+  }
+
+  @Test
+  public void testSqlExplainReturnsOnlyPlan() throws IOException {
+    ensureSetup();
+    Request request = new Request("POST", "/_plugins/_sql/_explain");
+    request.setJsonEntity(String.format(Locale.ROOT, "{\"query\": \"SELECT * FROM %s\"}", INDEX));
+    Response response = client().performRequest(request);
+    JSONObject result = new JSONObject(entityAsString(response));
+
+    assertTrue("has calcite", result.has("calcite"));
+    JSONObject calcite = result.getJSONObject("calcite");
+    assertTrue("has logical", calcite.has("logical"));
+    assertFalse("no profile in explain", calcite.has("profile"));
+  }
+
+  private JSONObject executeWithProfile(String query, String endpoint) throws IOException {
+    Request request = new Request("POST", endpoint);
+    request.setJsonEntity(
+        String.format(Locale.ROOT, "{\"query\": \"%s\", \"profile\": true}", query));
+    Response response = client().performRequest(request);
+    return new JSONObject(entityAsString(response));
+  }
+
+  private static String entityAsString(Response response) throws IOException {
+    return new String(
+        response.getEntity().getContent().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+  }
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
@@ -137,7 +138,10 @@ public class RestUnifiedQueryAction {
                   // schema we plan against and the state the executor uses are the same view.
                   org.opensearch.analytics.QueryRequestContext queryCtx =
                       contextProvider.getContext();
-                  UnifiedQueryContext context = buildContext(queryType, profiling, queryCtx);
+                  // Disable SQL-layer phase profiling when analytics engine profiling is active.
+                  // Our QueryProfile (stages, tasks, timing) is strictly more detailed and replaces
+                  // it.
+                  UnifiedQueryContext context = buildContext(queryType, false, queryCtx);
                   ActionListener<TransportPPLQueryResponse> closingListener =
                       wrapWithContextClose(context, listener);
                   try {
@@ -145,11 +149,19 @@ public class RestUnifiedQueryAction {
                     RelNode plan = planner.plan(query);
                     CalcitePlanContext planContext = context.getPlanContext();
                     plan = addQuerySizeLimit(plan, planContext);
-                    analyticsEngine.execute(
-                        plan,
-                        planContext,
-                        queryCtx,
-                        createQueryListener(queryType, closingListener));
+                    if (profiling) {
+                      analyticsEngine.executeWithProfile(
+                          plan,
+                          planContext,
+                          queryCtx,
+                          createQueryListener(queryType, closingListener));
+                    } else {
+                      analyticsEngine.execute(
+                          plan,
+                          planContext,
+                          queryCtx,
+                          createQueryListener(queryType, closingListener));
+                    }
                   } catch (Exception e) {
                     closingListener.onFailure(e);
                   }
@@ -270,6 +282,10 @@ public class RestUnifiedQueryAction {
             formatter.format(
                 new QueryResult(
                     response.getSchema(), response.getResults(), response.getCursor(), langSpec));
+        if (response.getProfile() != null) {
+          // Append profile and error (if any) to the JSON response
+          result = appendProfileToJson(result, response.getProfile(), response.getError());
+        }
         transportListener.onResponse(new TransportPPLQueryResponse(result));
       }
 
@@ -278,6 +294,32 @@ public class RestUnifiedQueryAction {
         transportListener.onFailure(e);
       }
     };
+  }
+
+  private static String appendProfileToJson(String json, QueryProfile profile, Throwable error) {
+    try {
+      StringBuilder extra = new StringBuilder();
+      // Append profile
+      org.opensearch.core.xcontent.XContentBuilder builder =
+          org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+      profile.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+      extra.append(",\"profile\":").append(builder.toString());
+      // Append error if query partially failed
+      if (error != null) {
+        extra
+            .append(",\"error\":{\"type\":\"")
+            .append(error.getClass().getSimpleName())
+            .append("\",\"reason\":\"")
+            .append(error.getMessage() != null ? error.getMessage().replace("\"", "\\\"") : "")
+            .append("\"}");
+      }
+      if (json.endsWith("}")) {
+        return json.substring(0, json.length() - 1) + extra + "}";
+      }
+      return json;
+    } catch (Exception e) {
+      return json;
+    }
   }
 
   private static Runnable withCurrentContext(final Runnable task) {


### PR DESCRIPTION
### Description
Connects SQL plugin `AnalyticsExecutionEngine` explain API with analytics engine `executeWithProfile` path. Providing per execution stage profiling for queries executed on this endpoint.

Note that `_explain` API on a an analytics engine index will provide the logical plan, execute the query, and provide profiling information for each execution stage. In contrast non analytics engine indices will only return the logical plan.

### Testing

## 1. Publish SQL Plugin to Maven Local

```bash
./gradlew :opensearch-sql-plugin:publishToMavenLocal
```

## 2. Start Single-Node Cluster

```bash
./gradlew run -Dsandbox.enabled=true \
  -PinstalledPlugins="['opensearch-job-scheduler:3.7.0.0-SNAPSHOT', 'arrow-flight-rpc', 'analytics-engine', 'parquet-data-format', 'analytics-backend-datafusion', 'analytics-backend-lucene', 'composite-engine', 'opensearch-sql-plugin:3.7.0.0-SNAPSHOT']" \
  -Dtests.jvm.argline="-Dopensearch.experimental.feature.pluggable.dataformat.enabled=true -Dopensearch.experimental.feature.transport.stream.enabled=true"
```

## 3. Create Parquet-Backed Index

```bash
curl -X PUT "localhost:9200/test_parquet" -H 'Content-Type: application/json' -d'
{
  "settings": {
    "index.number_of_shards": 2,
    "index.number_of_replicas": 0,
    "index.pluggable.dataformat.enabled": true,
    "index.pluggable.dataformat": "composite"
  },
  "mappings": {
    "properties": {
      "name": {"type": "keyword"},
      "age": {"type": "integer"},
      "score": {"type": "double"}
    }
  }
}'
```

## 4. Ingest Sample Data

```bash
curl -X POST "localhost:9200/test_parquet/_bulk" -H 'Content-Type: application/x-ndjson' -d'
{"index":{}}
{"name":"alice","age":30,"score":95.5}
{"index":{}}
{"name":"bob","age":25,"score":87.3}
{"index":{}}
{"name":"carol","age":35,"score":91.0}
'

curl -X POST "localhost:9200/test_parquet/_refresh"
```

## 5. Run Explain Query (SQL Plugin Path)

PPL:
```bash
curl -s -X POST "localhost:9200/_plugins/_ppl" -H 'Content-Type: application/json' -d'{"query": "source = test_parquet | stats avg(score) by name", "profile":
  true}'.
```
SQL:
```
  curl -s -X POST "localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' -d'{"query": "SELECT * FROM test_parquet", "profile": true}' | python3 -m json.tool
```

### Result

```json
  {
      "schema": [
          {
              "name": "avg(score)",
              "type": "double"
          },
          {
              "name": "name",
              "type": "string"
          }
      ],
      "datarows": [
          [
              87.3,
              "bob"
          ],
          [
              91.0,
              "carol"
          ],
          [
              95.5,
              "alice"
          ]
      ],
      "total": 3,
      "size": 3,
      "profile": {
          "query_id": "137d705b-93f6-4c7a-b3a0-f11960165d06",
          "full_plan": [
              "OpenSearchProject(avg(score)=[$1], name=[$0], viableBackends=[[datafusion]])",
              "  OpenSearchProject(name=[$0], avg(score)=[ANNOTATED_PROJECT_EXPR(id=2, backends=[datafusion], /($1, $2))], viableBackends=[[datafusion]])",
              "    OpenSearchAggregate(group=[{0}], $f1=[SUM($1)], $f2=[SUM($2)], mode=[FINAL], viableBackends=[[datafusion]])",
              "      OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])",
              "        OpenSearchAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[COUNT($1)], mode=[PARTIAL], viableBackends=[[datafusion]])",
              "          OpenSearchTableScan(table=[[test_parquet]], viableBackends=[[datafusion]])"
          ],
          "planning_time_ms": 415,
          "execution_time_ms": 206,
          "stages": [
              {
                  "stage_id": 0,
                  "execution_type": "SHARD_FRAGMENT",
                  "distribution": "SINGLETON",
                  "state": "SUCCEEDED",
                  "start_ms": 1780329915288,
                  "end_ms": 1780329915484,
                  "elapsed_ms": 196,
                  "rows_processed": 3,
                  "tasks_completed": 2,
                  "tasks_failed": 0,
                  "fragment": [
                      "OpenSearchAggregate(group=[{0}], agg#0=[SUM($1)], agg#1=[COUNT($1)], mode=[PARTIAL], viableBackends=[[datafusion]])",
                      "  OpenSearchTableScan(table=[[test_parquet]], viableBackends=[[datafusion]])"
                  ],
                  "tasks": [
                      {
                          "node": "XheBg1xKSbaentG9W9g4vw/shard[0]",
                          "state": "FINISHED",
                          "elapsed_ms": 195
                      },
                      {
                          "node": "XheBg1xKSbaentG9W9g4vw/shard[1]",
                          "state": "FINISHED",
                          "elapsed_ms": 180
                      }
                  ]
              },
              {
                  "stage_id": 1,
                  "execution_type": "COORDINATOR_REDUCE",
                  "state": "SUCCEEDED",
                  "start_ms": 1780329915288,
                  "end_ms": 1780329915494,
                  "elapsed_ms": 206,
                  "rows_processed": 0,
                  "tasks_completed": 1,
                  "tasks_failed": 0,
                  "fragment": [
                      "OpenSearchProject(avg(score)=[$1], name=[$0], viableBackends=[[datafusion]])",
                      "  OpenSearchProject(name=[$0], avg(score)=[ANNOTATED_PROJECT_EXPR(id=2, backends=[datafusion], /($1, $2))], viableBackends=[[datafusion]])",
                      "    OpenSearchAggregate(group=[{0}], $f1=[SUM($1)], $f2=[SUM($2)], mode=[FINAL], viableBackends=[[datafusion]])",
                      "      OpenSearchExchangeReducer(viableBackends=[[datafusion]], exchange=[ExchangeInfo[distributionType=SINGLETON, partitionKeyIndices=[]]])",
                      "        OpenSearchStageInputScan(childStageId=[0], viableBackends=[[datafusion]])"
                  ],
                  "tasks": [
                      {
                          "node": "1.0",
                          "state": "FINISHED",
                          "elapsed_ms": 206
                      }
                  ]
              }
          ]
      }
  }
```



### Related Issues
N/A

### Check List
~~- [ ] New functionality includes testing.~~ <- Tested locally, no IT suite for analytics plugin at this time
- [ ] New functionality has been documented. <- TODO as follow up if design does not change
- [x] New functionality has javadoc added.
- [x] New functionality has a user manual doc added.
- [x] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
