### PR TITLE
test(integ-test): provision special-index search test through parquet-backed create on the analytics route

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -54,15 +54,18 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchCommandWithSpecialIndexName() throws IOException {
-    // Route through TestUtils so the analytics-engine parquet-indices toggle
-    // (tests.analytics.parquet_indices=true) applies the composite/parquet
-    // settings; without them the analytics-engine planner can't find a backend
-    // for the scan and the query 500s.
-    org.opensearch.sql.legacy.TestUtils.createIndexByRestClient(client(), "logs-2021.01.11", null);
+    // A minimal `{"properties":{}}` mapping is required so the analytics-engine
+    // catalog (OpenSearchSchemaBuilder.buildSchema) actually surfaces the index —
+    // mapping-less indices are skipped and the parser then fails with
+    // "Table 'logs-2021.01.11' not found". Routing through TestUtils also
+    // honors the tests.analytics.parquet_indices toggle.
+    String minimalMapping = "{\"mappings\":{\"properties\":{}}}";
+    org.opensearch.sql.legacy.TestUtils.createIndexByRestClient(
+        client(), "logs-2021.01.11", minimalMapping);
     verifyDataRows(executeQuery("search source=logs-2021.01.11"));
 
     org.opensearch.sql.legacy.TestUtils.createIndexByRestClient(
-        client(), "logs-7.10.0-2021.01.11", null);
+        client(), "logs-7.10.0-2021.01.11", minimalMapping);
     verifyDataRows(executeQuery("search source=logs-7.10.0-2021.01.11"));
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -54,10 +54,15 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchCommandWithSpecialIndexName() throws IOException {
-    executeRequest(new Request("PUT", "/logs-2021.01.11"));
+    // Route through TestUtils so the analytics-engine parquet-indices toggle
+    // (tests.analytics.parquet_indices=true) applies the composite/parquet
+    // settings; without them the analytics-engine planner can't find a backend
+    // for the scan and the query 500s.
+    org.opensearch.sql.legacy.TestUtils.createIndexByRestClient(client(), "logs-2021.01.11", null);
     verifyDataRows(executeQuery("search source=logs-2021.01.11"));
 
-    executeRequest(new Request("PUT", "/logs-7.10.0-2021.01.11"));
+    org.opensearch.sql.legacy.TestUtils.createIndexByRestClient(
+        client(), "logs-7.10.0-2021.01.11", null);
     verifyDataRows(executeQuery("search source=logs-7.10.0-2021.01.11"));
   }
 


### PR DESCRIPTION
### What this PR does

Rebased onto current `main`. The two original *correctness* commits were dropped — both are now redundant with merged work:

| Dropped commit | Why it's no longer needed |
|---|---|
| `Preserve datetime schema-column types in AnalyticsExecutionEngine` | Superseded by #5454 + [opensearch-project/OpenSearch#21748](https://github.com/opensearch-project/OpenSearch/pull/21748), which delete `DatetimeOutputCastRule` / `DatetimeOutputCastRewriter`. Datetime root columns are no longer wrapped in `CAST(... AS VARCHAR)`, so `AnalyticsExecutionEngine` reports the real `timestamp` / `date` / `time` type natively. There is no cast slot left to recover from. |
| `Convert byte[] cells to base64 for IP / BINARY` | Superseded by #5463 (*Added UDT for IP and Binary support*), which dispatches on `IpType` / `BinaryType` in `AnalyticsExecutionEngine.toExprValue` and renders IP cells in canonical dotted form — strictly better than the base64 fallback. The `unsupported object class [B` crash is gone. |

What remains are two `integ-test`-only commits for `testSearchCommandWithSpecialIndexName`:

1. Route the `logs-2021.01.11` / `logs-7.10.0-2021.01.11` creates through `TestUtils.createIndexByRestClient` so the `tests.analytics.parquet_indices` toggle backs them with composite/parquet storage (the raw `PUT`s bypassed it).
2. Pass a minimal `{"mappings":{"properties":{}}}` body so `OpenSearchSchemaBuilder.buildSchema` surfaces the otherwise mapping-less index in the analytics catalog.

No `main`-code changes.

### Effect on the analytics-engine route

These commits fix the SQL-side plumbing but **do not flip the test green** on the analytics route — they advance its failure *throw site*:

- **Before:** `Table 'logs-2021.01.11' not found` (the catalog never surfaced the index).
- **After:** `IllegalStateException: Cannot apply function on indexer class org.opensearch.index.engine.DataFormatAwareEngine directly on IndexShard` — the composite engine can't open an empty parquet shard. That's an analytics-engine-side concern, tracked separately.

On the legacy / Calcite path the create still produces a plain Lucene index and the test passes exactly as before.

### Pass rate — `CalciteSearchCommandIT` on the analytics route (`-Dtests.analytics.parquet_indices=true`)

Run against current `main` (which already carries #5454 / #21748 / #5463) on a force-routed parquet cluster:

| Step | PASS / 52 |
|---|---|
| Rebased `main` baseline | 26 |
| + this PR | **26** |

The two commits don't change the pass rate — they correct SQL-side plumbing and shift one test's failure to the analytics-engine layer. The 25 failures are all the Lucene-secondary `query_string` family (numeric / date-range literal re-typing, compound-AND, wildcard vs NOT semantics), which is fixed upstream in the analytics engine, not in this repo.

### Check list

- [x] Commits are signed per the DCO using `--signoff`
