### PR TITLE
Fix SQL query routing to analytics engine

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -10,6 +10,7 @@ import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
 import static org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.SQL_WORKER_THREAD_POOL_NAME;
 import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.calcite.rel.RelNode;
@@ -17,7 +18,9 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOrderBy;
 import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -214,13 +217,14 @@ public class RestUnifiedQueryAction {
    * node. Uses the context's parser which supports both PPL and SQL.
    */
   private static Optional<String> extractIndexName(
-      String query, QueryType queryType, UnifiedQueryContext context) {
+      String query, QueryType queryType, UnifiedQueryContext context) throws Exception {
     if (queryType == QueryType.PPL) {
       UnresolvedPlan unresolvedPlan = (UnresolvedPlan) context.getParser().parse(query);
       return Optional.ofNullable(unresolvedPlan.accept(new IndexNameExtractor(), null));
     }
-    SqlNode sqlNode = (SqlNode) context.getParser().parse(query);
-    return Optional.ofNullable(extractTableNameFromSqlNode(sqlNode));
+    SqlNode sqlNode = SqlParser.create(query).parseQuery();
+    String tableName = extractTableNameFromSqlNode(sqlNode);
+    return Optional.ofNullable(tableName != null ? tableName.toLowerCase(Locale.ROOT) : null);
   }
 
   /** AST visitor that extracts the source index name from a Relation node (PPL path). */
@@ -235,6 +239,9 @@ public class RestUnifiedQueryAction {
   private static class SqlTableNameExtractor extends SqlBasicVisitor<String> {
     @Override
     public String visit(SqlCall call) {
+      if (call instanceof SqlOrderBy orderBy) {
+        return orderBy.query.accept(this);
+      }
       if (call instanceof SqlSelect select) {
         return select.getFrom().accept(this);
       }

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -66,6 +66,29 @@ public class RestUnifiedQueryActionTest {
   }
 
   @Test
+  public void sqlQueryRoutesToAnalyticsForCompositeIndex() {
+    registerIndex(
+        "parquet_logs",
+        Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
+            .build());
+
+    assertTrue(action.isAnalyticsIndex("SELECT ts, msg FROM parquet_logs", QueryType.SQL));
+    assertTrue(action.isAnalyticsIndex("SELECT ts FROM parquet_logs LIMIT 10", QueryType.SQL));
+    assertTrue(
+        action.isAnalyticsIndex(
+            "SELECT score, name FROM parquet_logs WHERE score > 90", QueryType.SQL));
+  }
+
+  @Test
+  public void sqlQueryRoutesToLuceneForNonCompositeIndex() {
+    registerIndex("plain_logs", Settings.EMPTY);
+
+    assertFalse(action.isAnalyticsIndex("SELECT ts FROM plain_logs", QueryType.SQL));
+  }
+
+  @Test
   public void pluggableEnabledButLuceneFormatRoutesToLucene() {
     registerIndex(
         "lucene_logs",


### PR DESCRIPTION
### Description

SQL plugin appears to be falling back to the V2 engine instead of using the analytics engine due to the recent move to V2. It seems like when we are making our routing decision to see if we can use analytics engine we [fetch a parser ](https://github.com/opensearch-project/sql/blob/main/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java#L222)from the context such that we can parse the raw query and inspect the index (to determine if it's analytics plugin compatible).

However, this no longer returns a `SqlNode` as we are now using the `SqlV2QueryParser`. This causes a casting exception to be thrown and caught upstream, where we fallback to the regular SQL V2 engine.

Added a test which fails on main but passes with this PR.

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [x] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
