### PR TITLE
Fix distribution build: pin analytics-api dep to 3.7.0-SNAPSHOT

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -160,7 +160,7 @@ dependencies {
 
     api project(":ppl")
     api project(':api')
-    implementation 'org.opensearch.sandbox:analytics-api:3.7.0-SNAPSHOT'
+    implementation "org.opensearch.sandbox:analytics-api:${opensearch_version.tokenize('-')[0]}-SNAPSHOT"
     api project(':legacy')
     api project(':opensearch')
     api project(':prometheus')

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -160,7 +160,7 @@ dependencies {
 
     api project(":ppl")
     api project(':api')
-    implementation("org.opensearch.sandbox:analytics-api:${opensearch_version}")
+    implementation 'org.opensearch.sandbox:analytics-api:3.7.0-SNAPSHOT'
     api project(':legacy')
     api project(':opensearch')
     api project(':prometheus')


### PR DESCRIPTION
## Summary

Pin `analytics-api` to `3.7.0-SNAPSHOT` in `plugin/build.gradle`. The previous `${opensearch_version}` resolves to `3.7.0` in release builds, but sandbox artifacts are never published with a release coordinate, so the build fails:

```
Could not find org.opensearch.sandbox:analytics-api:3.7.0
```

Same hardcoded snapshot pattern is already used in `core/build.gradle:67` for the same artifact.

Resolves #5434

## Test plan

- [x] `./gradlew assemble -DskipTests=true` (snapshot mode) — passes
- [x] `bash scripts/build.sh -v 3.7.0 -p linux -a arm64 -s false -o builds` reproduced locally — passes (was failing on `main`)
- [x] Plugin loads cleanly into a 3.7.0 distribution alongside 10 sibling plugins; cluster reaches GREEN
- [x] CI distribution build passes