### PR TITLE
Fix SQL query routing to analytics engine after V2 parser change

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -13,12 +13,6 @@ import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.
 import java.util.Map;
 import java.util.Optional;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.sql.SqlCall;
-import org.apache.calcite.sql.SqlIdentifier;
-import org.apache.calcite.sql.SqlJoin;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlSelect;
-import org.apache.calcite.sql.util.SqlBasicVisitor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -213,12 +207,8 @@ public class RestUnifiedQueryAction {
    */
   private static Optional<String> extractIndexName(
       String query, QueryType queryType, UnifiedQueryContext context) {
-    if (queryType == QueryType.PPL) {
-      UnresolvedPlan unresolvedPlan = (UnresolvedPlan) context.getParser().parse(query);
-      return Optional.ofNullable(unresolvedPlan.accept(new IndexNameExtractor(), null));
-    }
-    SqlNode sqlNode = (SqlNode) context.getParser().parse(query);
-    return Optional.ofNullable(extractTableNameFromSqlNode(sqlNode));
+    UnresolvedPlan unresolvedPlan = (UnresolvedPlan) context.getParser().parse(query);
+    return Optional.ofNullable(unresolvedPlan.accept(new IndexNameExtractor(), null));
   }
 
   /** AST visitor that extracts the source index name from a Relation node (PPL path). */
@@ -227,29 +217,6 @@ public class RestUnifiedQueryAction {
     public String visitRelation(Relation node, Void context) {
       return node.getTableQualifiedName().toString();
     }
-  }
-
-  /** SqlNode visitor that extracts the source table name from a SQL parse tree. */
-  private static class SqlTableNameExtractor extends SqlBasicVisitor<String> {
-    @Override
-    public String visit(SqlCall call) {
-      if (call instanceof SqlSelect select) {
-        return select.getFrom().accept(this);
-      }
-      if (call instanceof SqlJoin join) {
-        return join.getLeft().accept(this);
-      }
-      return null;
-    }
-
-    @Override
-    public String visit(SqlIdentifier id) {
-      return id.toString();
-    }
-  }
-
-  private static String extractTableNameFromSqlNode(SqlNode sqlNode) {
-    return sqlNode.accept(new SqlTableNameExtractor());
   }
 
   private static RelNode addQuerySizeLimit(RelNode plan, CalcitePlanContext context) {

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -90,9 +90,74 @@ public class RestUnifiedQueryActionTest {
   }
 
   @Test
+  public void sqlQueryRoutesToAnalyticsForPluggableIndex() {
+    registerIndex(
+        "parquet_logs",
+        Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
+            .build());
+
+    assertTrue(action.isAnalyticsIndex("SELECT * FROM parquet_logs", QueryType.SQL));
+    assertTrue(
+        action.isAnalyticsIndex(
+            "SELECT ts, level FROM parquet_logs WHERE level = 'ERROR'", QueryType.SQL));
+  }
+
+  @Test
+  public void sqlQueryWithSchemaRoutesToAnalytics() {
+    registerIndex(
+        "parquet_logs",
+        Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
+            .build());
+
+    assertTrue(action.isAnalyticsIndex("SELECT * FROM opensearch.parquet_logs", QueryType.SQL));
+  }
+
+  @Test
+  public void sqlQueryRoutesToLuceneForNonPluggableIndex() {
+    registerIndex("plain_logs", Settings.EMPTY);
+
+    assertFalse(action.isAnalyticsIndex("SELECT * FROM plain_logs", QueryType.SQL));
+  }
+
+  @Test
+  public void sqlQueryRoutesToLuceneForMissingIndex() {
+    assertFalse(action.isAnalyticsIndex("SELECT * FROM does_not_exist", QueryType.SQL));
+  }
+
+  @Test
   public void nullAndEmptyQueriesRouteToLucene() {
     assertFalse(action.isAnalyticsIndex(null, QueryType.PPL));
     assertFalse(action.isAnalyticsIndex("", QueryType.PPL));
+    assertFalse(action.isAnalyticsIndex(null, QueryType.SQL));
+    assertFalse(action.isAnalyticsIndex("", QueryType.SQL));
+  }
+
+  @Test
+  public void showStatementRoutesToLucene() {
+    registerIndex(
+        "parquet_logs",
+        Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
+            .build());
+
+    assertFalse(action.isAnalyticsIndex("SHOW TABLES LIKE 'parquet_logs'", QueryType.SQL));
+  }
+
+  @Test
+  public void describeStatementRoutesToLucene() {
+    registerIndex(
+        "parquet_logs",
+        Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
+            .build());
+
+    assertFalse(action.isAnalyticsIndex("DESCRIBE TABLES LIKE 'parquet_logs'", QueryType.SQL));
   }
 
   private void registerIndex(String name, Settings settings) {


### PR DESCRIPTION
### Description

The switch from Calcite parser to SQL V2 parser in PR #5438 changed the SQL parse result type from `SqlNode` to `UnresolvedPlan`. This broke `extractIndexName()` in `RestUnifiedQueryAction` and caused all SQL queries to fall through to the V2 engine instead of routing to the analytics engine.

> TODO: Need to add sanity IT with analytics engine once stable.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
