### PR TITLE
Fix singleton stack-corruption NPE in DatetimeUdtNormalizeRule

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeExtension.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeExtension.java
@@ -22,7 +22,8 @@ public class DatetimeExtension implements LanguageExtension {
 
   @Override
   public List<RelShuttle> postAnalysisRules() {
-    return List.of(DatetimeUdtNormalizeRule.INSTANCE, DatetimeOutputCastRule.INSTANCE);
+    // Fresh instances per plan() because RelHomogeneousShuttle inherits a stateful stack.
+    return List.of(new DatetimeUdtNormalizeRule(), new DatetimeOutputCastRule());
   }
 
   /** Maps datetime UDT types to their standard Calcite equivalents. */

--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeOutputCastRule.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeOutputCastRule.java
@@ -9,8 +9,6 @@ import static org.opensearch.sql.api.spec.datetime.DatetimeExtension.UdtMapping.
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
@@ -21,11 +19,13 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/** Wraps the root output with CAST(datetime → VARCHAR) for PPL wire-format compatibility. */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+/**
+ * Wraps the root output with CAST(datetime → VARCHAR) for PPL wire-format compatibility.
+ *
+ * <p>Not a singleton: {@link RelHomogeneousShuttle} inherits a stateful {@code stack} field from
+ * {@link org.apache.calcite.rel.RelShuttleImpl}, so a fresh instance must be used per plan().
+ */
 class DatetimeOutputCastRule extends RelHomogeneousShuttle {
-
-  static final DatetimeOutputCastRule INSTANCE = new DatetimeOutputCastRule();
 
   @Override
   public RelNode visit(RelNode other) {

--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeUdtNormalizeRule.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeUdtNormalizeRule.java
@@ -6,8 +6,6 @@
 package org.opensearch.sql.api.spec.datetime;
 
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
@@ -22,11 +20,11 @@ import org.opensearch.sql.api.spec.datetime.DatetimeExtension.UdtMapping;
 /**
  * Temporary patch that rewrites datetime UDT return types on RexCall nodes to standard Calcite
  * types.
+ *
+ * <p>Not a singleton: {@link RelHomogeneousShuttle} inherits a stateful {@code stack} field from
+ * {@link org.apache.calcite.rel.RelShuttleImpl}, so a fresh instance must be used per plan().
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 class DatetimeUdtNormalizeRule extends RelHomogeneousShuttle {
-
-  static final DatetimeUdtNormalizeRule INSTANCE = new DatetimeUdtNormalizeRule();
 
   @Override
   public RelNode visit(RelNode other) {

--- a/api/src/test/java/org/opensearch/sql/api/spec/datetime/DatetimeExtensionTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/spec/datetime/DatetimeExtensionTest.java
@@ -173,6 +173,27 @@ public class DatetimeExtensionTest extends UnifiedQueryTestBase implements Resul
   }
 
   @Test
+  public void testSequentialPlanCallsDoNotCorruptShuttleStack() {
+    // Regression test: DatetimeUdtNormalizeRule extends RelHomogeneousShuttle which inherits a
+    // stateful Deque<RelNode> stack field. Earlier implementations used a static INSTANCE shared
+    // across all plan() calls; under workloads with aggregations (especially count + distinct_count
+    // over datetime columns), the shared stack would desynchronize and visitChild's pop would throw
+    // NoSuchElementException on subsequent plan calls. Running several distinct plans through the
+    // same context confirms each invocation gets a fresh shuttle.
+    for (int i = 0; i < 5; i++) {
+      planner.plan(
+          "source = catalog.events"
+              + " | stats count() as field_count, distinct_count(created_at) as distinct_count");
+      planner.plan(
+          "source = catalog.events"
+              + " | eval ts = TIMESTAMP(name)"
+              + " | stats count() as field_count, distinct_count(ts) as distinct_count");
+      planner.plan(
+          "source = catalog.events | where created_at > \"2024-01-01\" | fields hire_date");
+    }
+  }
+
+  @Test
   public void testOutputCastCanCompileAndExecute() throws Exception {
     RelNode plan =
         planner.plan("source = catalog.events | fields hire_date, start_time, created_at");

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteDatetimeUdtNormalizeRegressionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteDatetimeUdtNormalizeRegressionIT.java
@@ -5,11 +5,15 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import static org.junit.Assert.assertNotNull;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_FORMATS;
 
-import java.io.IOException;
-import org.json.JSONObject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
@@ -17,18 +21,18 @@ import org.opensearch.sql.ppl.PPLIntegTestCase;
  * Regression IT for the {@code DatetimeUdtNormalizeRule} / {@code DatetimeOutputCastRule}
  * singleton-stack-corruption bug.
  *
- * <p>Both rules extend Calcite's {@code RelHomogeneousShuttle}, which inherits a stateful {@code
- * Deque<RelNode>} stack from {@code RelShuttleImpl}. Earlier code returned the same {@code
- * INSTANCE} of each rule from {@code DatetimeExtension.postAnalysisRules()} on every {@code
- * UnifiedQueryPlanner.plan()} call. If any traversal ever finished with an unbalanced stack,
- * residual entries persisted to the next query and the next {@code visitChild()} popped a stale or
- * empty stack — surfacing as {@code NoSuchElementException} at {@code RelShuttleImpl.visitChild}
- * line 67.
+ * <p>Both rules extend Calcite's {@code RelHomogeneousShuttle}, which inherits a stateful
+ * non-thread-safe {@code ArrayDeque<RelNode>} stack from {@code RelShuttleImpl}. Earlier code
+ * returned the same {@code INSTANCE} of each rule from {@code
+ * DatetimeExtension.postAnalysisRules()} on every {@code UnifiedQueryPlanner.plan()} call. Under
+ * parallel query load — exactly what a dashboard "field statistics" panel issues when it probes
+ * every field in an index concurrently — multiple cluster threads call {@code plan()}
+ * simultaneously and their push/pop on the shared stack interleave, leaving residual entries that
+ * surface on a subsequent traversal as {@code NoSuchElementException} at {@code
+ * RelShuttleImpl.visitChild} line 67 (the {@code stack.pop()} in the {@code finally} block).
  *
- * <p>The failure was reported as intermittent on dashboards issuing field-statistics queries of the
- * shape {@code stats count() as field_count, distinct_count(field)} against parquet-backed indices.
- * This IT runs the same query shape repeatedly against a parquet-backed (composite) index with
- * multiple datetime columns to exercise the analytics-engine route end-to-end.
+ * <p>This IT reproduces the production failure by firing many {@code distinct_count} queries over
+ * datetime fields concurrently against a parquet-backed (composite) index.
  *
  * <p>Run via:
  *
@@ -43,75 +47,107 @@ import org.opensearch.sql.ppl.PPLIntegTestCase;
  */
 public class CalciteDatetimeUdtNormalizeRegressionIT extends PPLIntegTestCase {
 
-  /** Number of repetitions per test. Singleton bug surfaces order-dependent across plan() calls. */
-  private static final int ITERATIONS = 20;
+  /** Concurrency level — matches the rough parallelism of a dashboard field-stats panel. */
+  private static final int PARALLELISM = 8;
+
+  /** Total queries fired per test. */
+  private static final int QUERIES = 80;
 
   @Override
   public void init() throws Exception {
     super.init();
     enableCalcite();
 
-    // DATE_FORMATS index has many date columns of different formats / precisions, which is what
-    // dashboard field-statistics panels iterate over. Loaded through the helper so that with
-    // -Dtests.analytics.parquet_indices=true it gets provisioned as a parquet-backed composite
-    // index — required for analytics-engine routing.
+    // DATE_FORMATS has many datetime columns of different formats/precisions. With
+    // -Dtests.analytics.parquet_indices=true the helper provisions it as a parquet-backed
+    // composite index — required for analytics-engine routing.
     loadIndex(Index.DATE_FORMATS);
   }
 
   @Test
-  public void testSequentialStatsDistinctCountOverDatetime() throws IOException {
-    // Bug repro: each iteration runs a stats + distinct_count over a datetime field. With the
-    // singleton rule, residual entries on the shuttle's internal stack from the previous plan()
-    // would cause NoSuchElementException on a subsequent traversal. With fresh instances per
-    // plan(), the stack is always empty at entry and the iterations all succeed.
-    String query =
-        String.format(
-            "source=%s | stats count() as field_count, distinct_count(epoch_millis) as"
-                + " distinct_count",
-            TEST_INDEX_DATE_FORMATS);
-    for (int i = 0; i < ITERATIONS; i++) {
-      JSONObject result = executeQuery(query);
-      // Sanity: response was returned without a cluster-side exception.
-      assertNotNull("iteration " + i + " produced no result", result);
-    }
-  }
-
-  @Test
-  public void testInterleavedStatsAndDatetimeProjection() throws IOException {
-    // Bug repro variant: interleave stats+distinct_count with a plain datetime projection that
-    // exercises the DatetimeOutputCastRule. Different plan shapes per iteration push the rule
-    // through different visitChild paths and surface stack desync faster.
-    for (int i = 0; i < ITERATIONS; i++) {
-      executeQuery(
-          String.format(
-              "source=%s | stats count() as field_count, distinct_count(epoch_millis) as"
-                  + " distinct_count",
-              TEST_INDEX_DATE_FORMATS));
-      executeQuery(
-          String.format(
-              "source=%s | fields epoch_millis, epoch_second, date_optional_time",
-              TEST_INDEX_DATE_FORMATS));
-      executeQuery(
-          String.format(
-              "source=%s | stats count() as field_count, distinct_count(epoch_second) as"
-                  + " distinct_count",
-              TEST_INDEX_DATE_FORMATS));
-    }
-  }
-
-  @Test
-  public void testDistinctCountOverMultipleDatetimeFields() throws IOException {
-    // Bug repro variant: iterate distinct_count over different datetime fields in sequence —
-    // mirrors the dashboard field-statistics tab that probes every field in the index.
-    String[] datetimeFields = {
+  public void testConcurrentStatsDistinctCountOverDatetime() throws Exception {
+    String[] fields = {
       "epoch_millis", "epoch_second", "date_optional_time", "strict_date_optional_time"
     };
-    for (int i = 0; i < ITERATIONS; i++) {
-      String field = datetimeFields[i % datetimeFields.length];
-      executeQuery(
+    List<String> queries = new ArrayList<>(QUERIES);
+    for (int i = 0; i < QUERIES; i++) {
+      String field = fields[i % fields.length];
+      queries.add(
           String.format(
               "source=%s | stats count() as field_count, distinct_count(%s) as distinct_count",
               TEST_INDEX_DATE_FORMATS, field));
+    }
+    executeConcurrent(queries);
+  }
+
+  @Test
+  public void testConcurrentMixedDatetimePlans() throws Exception {
+    // Mix three plan shapes: stats+distinct_count, plain field projection (datetime cast), and
+    // stats by a different field. Different plan shapes push the singleton shuttle through
+    // different visitChild call counts — making cross-query stack pollution more likely.
+    List<String> shapes =
+        List.of(
+            "source=%s | stats count() as field_count, distinct_count(epoch_millis) as"
+                + " distinct_count",
+            "source=%s | fields epoch_millis, epoch_second, date_optional_time",
+            "source=%s | stats count() as field_count, distinct_count(epoch_second) as"
+                + " distinct_count by date_optional_time");
+    List<String> queries = new ArrayList<>(QUERIES);
+    for (int i = 0; i < QUERIES; i++) {
+      queries.add(String.format(shapes.get(i % shapes.size()), TEST_INDEX_DATE_FORMATS));
+    }
+    executeConcurrent(queries);
+  }
+
+  /**
+   * Fire all queries through a fixed-size thread pool. Asserts every query completes without
+   * exception. With the singleton bug present this triggers {@code NoSuchElementException} on at
+   * least one task once the stack interleaving corrupts state.
+   */
+  private void executeConcurrent(List<String> queries) throws Exception {
+    var executor = Executors.newFixedThreadPool(PARALLELISM);
+    try {
+      List<CompletableFuture<Void>> futures = new ArrayList<>(queries.size());
+      AtomicInteger failures = new AtomicInteger();
+      List<Throwable> errors = new ArrayList<>();
+      for (String query : queries) {
+        futures.add(
+            CompletableFuture.runAsync(
+                () -> {
+                  try {
+                    executeQuery(query);
+                  } catch (Exception e) {
+                    failures.incrementAndGet();
+                    synchronized (errors) {
+                      errors.add(e);
+                    }
+                  }
+                },
+                executor));
+      }
+      for (CompletableFuture<Void> f : futures) {
+        try {
+          f.get(60, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+          failures.incrementAndGet();
+          synchronized (errors) {
+            errors.add(e.getCause());
+          }
+        }
+      }
+      if (failures.get() > 0) {
+        StringBuilder msg = new StringBuilder();
+        msg.append(failures.get()).append("/").append(queries.size()).append(" queries failed:");
+        synchronized (errors) {
+          for (int i = 0; i < Math.min(3, errors.size()); i++) {
+            msg.append("\n  - ").append(errors.get(i));
+          }
+        }
+        throw new AssertionError(msg.toString());
+      }
+    } finally {
+      executor.shutdown();
+      executor.awaitTermination(30, TimeUnit.SECONDS);
     }
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteDatetimeUdtNormalizeRegressionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteDatetimeUdtNormalizeRegressionIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.junit.Assert.assertNotNull;
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_FORMATS;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+/**
+ * Regression IT for the {@code DatetimeUdtNormalizeRule} / {@code DatetimeOutputCastRule}
+ * singleton-stack-corruption bug.
+ *
+ * <p>Both rules extend Calcite's {@code RelHomogeneousShuttle}, which inherits a stateful {@code
+ * Deque<RelNode>} stack from {@code RelShuttleImpl}. Earlier code returned the same {@code
+ * INSTANCE} of each rule from {@code DatetimeExtension.postAnalysisRules()} on every {@code
+ * UnifiedQueryPlanner.plan()} call. If any traversal ever finished with an unbalanced stack,
+ * residual entries persisted to the next query and the next {@code visitChild()} popped a stale or
+ * empty stack — surfacing as {@code NoSuchElementException} at {@code RelShuttleImpl.visitChild}
+ * line 67.
+ *
+ * <p>The failure was reported as intermittent on dashboards issuing field-statistics queries of the
+ * shape {@code stats count() as field_count, distinct_count(field)} against parquet-backed indices.
+ * This IT runs the same query shape repeatedly against a parquet-backed (composite) index with
+ * multiple datetime columns to exercise the analytics-engine route end-to-end.
+ *
+ * <p>Run via:
+ *
+ * <pre>{@code
+ * ./gradlew :integ-test:integTestRemote \
+ *   -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9300 \
+ *   -Dtests.clustername=runTask \
+ *   -Dtests.analytics.force_routing=true \
+ *   -Dtests.analytics.parquet_indices=true \
+ *   --tests org.opensearch.sql.calcite.remote.CalciteDatetimeUdtNormalizeRegressionIT
+ * }</pre>
+ */
+public class CalciteDatetimeUdtNormalizeRegressionIT extends PPLIntegTestCase {
+
+  /** Number of repetitions per test. Singleton bug surfaces order-dependent across plan() calls. */
+  private static final int ITERATIONS = 20;
+
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+
+    // DATE_FORMATS index has many date columns of different formats / precisions, which is what
+    // dashboard field-statistics panels iterate over. Loaded through the helper so that with
+    // -Dtests.analytics.parquet_indices=true it gets provisioned as a parquet-backed composite
+    // index — required for analytics-engine routing.
+    loadIndex(Index.DATE_FORMATS);
+  }
+
+  @Test
+  public void testSequentialStatsDistinctCountOverDatetime() throws IOException {
+    // Bug repro: each iteration runs a stats + distinct_count over a datetime field. With the
+    // singleton rule, residual entries on the shuttle's internal stack from the previous plan()
+    // would cause NoSuchElementException on a subsequent traversal. With fresh instances per
+    // plan(), the stack is always empty at entry and the iterations all succeed.
+    String query =
+        String.format(
+            "source=%s | stats count() as field_count, distinct_count(epoch_millis) as"
+                + " distinct_count",
+            TEST_INDEX_DATE_FORMATS);
+    for (int i = 0; i < ITERATIONS; i++) {
+      JSONObject result = executeQuery(query);
+      // Sanity: response was returned without a cluster-side exception.
+      assertNotNull("iteration " + i + " produced no result", result);
+    }
+  }
+
+  @Test
+  public void testInterleavedStatsAndDatetimeProjection() throws IOException {
+    // Bug repro variant: interleave stats+distinct_count with a plain datetime projection that
+    // exercises the DatetimeOutputCastRule. Different plan shapes per iteration push the rule
+    // through different visitChild paths and surface stack desync faster.
+    for (int i = 0; i < ITERATIONS; i++) {
+      executeQuery(
+          String.format(
+              "source=%s | stats count() as field_count, distinct_count(epoch_millis) as"
+                  + " distinct_count",
+              TEST_INDEX_DATE_FORMATS));
+      executeQuery(
+          String.format(
+              "source=%s | fields epoch_millis, epoch_second, date_optional_time",
+              TEST_INDEX_DATE_FORMATS));
+      executeQuery(
+          String.format(
+              "source=%s | stats count() as field_count, distinct_count(epoch_second) as"
+                  + " distinct_count",
+              TEST_INDEX_DATE_FORMATS));
+    }
+  }
+
+  @Test
+  public void testDistinctCountOverMultipleDatetimeFields() throws IOException {
+    // Bug repro variant: iterate distinct_count over different datetime fields in sequence —
+    // mirrors the dashboard field-statistics tab that probes every field in the index.
+    String[] datetimeFields = {
+      "epoch_millis", "epoch_second", "date_optional_time", "strict_date_optional_time"
+    };
+    for (int i = 0; i < ITERATIONS; i++) {
+      String field = datetimeFields[i % datetimeFields.length];
+      executeQuery(
+          String.format(
+              "source=%s | stats count() as field_count, distinct_count(%s) as distinct_count",
+              TEST_INDEX_DATE_FORMATS, field));
+    }
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePlannerConcurrencyIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePlannerConcurrencyIT.java
@@ -18,21 +18,23 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 /**
- * Regression IT for the {@code DatetimeUdtNormalizeRule} / {@code DatetimeOutputCastRule}
- * singleton-stack-corruption bug.
+ * Integration tests for {@code UnifiedQueryPlanner} state isolation under concurrent load.
  *
- * <p>Both rules extend Calcite's {@code RelHomogeneousShuttle}, which inherits a stateful
- * non-thread-safe {@code ArrayDeque<RelNode>} stack from {@code RelShuttleImpl}. Earlier code
- * returned the same {@code INSTANCE} of each rule from {@code
- * DatetimeExtension.postAnalysisRules()} on every {@code UnifiedQueryPlanner.plan()} call. Under
- * parallel query load — exactly what a dashboard "field statistics" panel issues when it probes
- * every field in an index concurrently — multiple cluster threads call {@code plan()}
- * simultaneously and their push/pop on the shared stack interleave, leaving residual entries that
- * surface on a subsequent traversal as {@code NoSuchElementException} at {@code
- * RelShuttleImpl.visitChild} line 67 (the {@code stack.pop()} in the {@code finally} block).
+ * <p>The planner's post-analysis pipeline (extensions registered via {@code
+ * LanguageSpec.postAnalysisRules}) uses Calcite {@code RelShuttle} subclasses. {@code
+ * RelShuttleImpl} inherits a non-thread-safe {@code ArrayDeque<RelNode>} stack used by {@code
+ * visitChild}'s push/pop. Any extension that returns the same shuttle instance across {@code
+ * plan()} calls is unsafe under concurrent load: cluster threads call {@code plan()} simultaneously
+ * and their push/pop on the shared stack interleave, leaving residual entries that surface on a
+ * subsequent traversal as {@code NoSuchElementException} at {@code RelShuttleImpl.visitChild} line
+ * 67 (the {@code stack.pop()} in the {@code finally} block).
  *
- * <p>This IT reproduces the production failure by firing many {@code distinct_count} queries over
- * datetime fields concurrently against a parquet-backed (composite) index.
+ * <p>The test methods here fire many queries through a thread pool to exercise concurrent {@code
+ * plan()} invocations. New planner-level concurrency / state-isolation regressions belong in this
+ * class. The current cases cover {@code DatetimeExtension}'s {@code RelHomogeneousShuttle}
+ * subclasses ({@code DatetimeUdtNormalizeRule}, {@code DatetimeOutputCastRule}) which were
+ * previously returned as static {@code INSTANCE}s and caused the production failure that motivated
+ * this suite.
  *
  * <p>Run via:
  *
@@ -42,10 +44,10 @@ import org.opensearch.sql.ppl.PPLIntegTestCase;
  *   -Dtests.clustername=runTask \
  *   -Dtests.analytics.force_routing=true \
  *   -Dtests.analytics.parquet_indices=true \
- *   --tests org.opensearch.sql.calcite.remote.CalciteDatetimeUdtNormalizeRegressionIT
+ *   --tests org.opensearch.sql.calcite.remote.CalcitePlannerConcurrencyIT
  * }</pre>
  */
-public class CalciteDatetimeUdtNormalizeRegressionIT extends PPLIntegTestCase {
+public class CalcitePlannerConcurrencyIT extends PPLIntegTestCase {
 
   /** Concurrency level — matches the rough parallelism of a dashboard field-stats panel. */
   private static final int PARALLELISM = 8;
@@ -83,8 +85,8 @@ public class CalciteDatetimeUdtNormalizeRegressionIT extends PPLIntegTestCase {
   @Test
   public void testConcurrentMixedDatetimePlans() throws Exception {
     // Mix three plan shapes: stats+distinct_count, plain field projection (datetime cast), and
-    // stats by a different field. Different plan shapes push the singleton shuttle through
-    // different visitChild call counts — making cross-query stack pollution more likely.
+    // stats by a different field. Different plan shapes push the planner's post-analysis shuttles
+    // through different visitChild call counts — amplifying any cross-query stack pollution.
     List<String> shapes =
         List.of(
             "source=%s | stats count() as field_count, distinct_count(epoch_millis) as"
@@ -101,8 +103,8 @@ public class CalciteDatetimeUdtNormalizeRegressionIT extends PPLIntegTestCase {
 
   /**
    * Fire all queries through a fixed-size thread pool. Asserts every query completes without
-   * exception. With the singleton bug present this triggers {@code NoSuchElementException} on at
-   * least one task once the stack interleaving corrupts state.
+   * exception. With a shuttle-state-leak bug present this triggers {@code NoSuchElementException}
+   * on at least one task once the stack interleaving corrupts state.
    */
   private void executeConcurrent(List<String> queries) throws Exception {
     var executor = Executors.newFixedThreadPool(PARALLELISM);


### PR DESCRIPTION
## What this fixes

Some PPL queries to parquet-backed indices return HTTP 500 with
`NoSuchElementException` when several queries hit the cluster at the same time
— the failure mode reported on dashboard "field statistics" panels that probe
many fields in parallel. Affected query shape:

```
source = my_index | stats count() as field_count, distinct_count(<datetime_field>) as distinct_count
```

The failure is intermittent: same query passes or fails depending on what
other queries run at the same time.

## Why it happens

The unified query API runs two Calcite rewrites on every plan — one normalizes
datetime UDT types (`DatetimeUdtNormalizeRule`), one casts datetime output to
varchar (`DatetimeOutputCastRule`). Both extend `RelHomogeneousShuttle`, which
in Calcite inherits a `Deque<RelNode> stack` field used internally for
push/pop during tree traversal. **That stack is a plain non-thread-safe
`ArrayDeque`.**

`DatetimeExtension.postAnalysisRules()` returned a static `INSTANCE` of each
rule, so every `plan()` call shared the same shuttle — and the same stack.
When dashboard issues N field-stats queries at once, N cluster threads call
`plan()` concurrently. Their `push` and `pop` operations on the shared
`ArrayDeque` interleave, leaving residual entries on the stack. A subsequent
traversal then tries to `pop()` an entry that isn't there, and the cluster
returns 500 with this stack trace:

```
java.util.NoSuchElementException
  at java.util.ArrayDeque.pop(ArrayDeque.java:591)
  at org.apache.calcite.rel.RelShuttleImpl.visitChild(RelShuttleImpl.java:67)  ← finally{ stack.pop() }
  at org.apache.calcite.rel.RelShuttleImpl.visit(RelShuttleImpl.java:151)
  at org.opensearch.sql.api.spec.datetime.DatetimeUdtNormalizeRule.visit(DatetimeUdtNormalizeRule.java:33)
  at org.apache.calcite.rel.RelHomogeneousShuttle.visit(RelHomogeneousShuttle.java:43)
  at org.apache.calcite.rel.logical.LogicalAggregate.accept(LogicalAggregate.java:159)
```

`RelShuttleImpl` was never designed to be a singleton: the stack is per-shuttle
mutable state. Sharing it across queries is unsafe regardless of timing — the
race just amplifies the chance of a visible failure.

## What this PR changes

`api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeExtension.java`
now returns a **fresh instance per `plan()` call**:

```diff
   @Override
   public List<RelShuttle> postAnalysisRules() {
-    return List.of(DatetimeUdtNormalizeRule.INSTANCE, DatetimeOutputCastRule.INSTANCE);
+    // Fresh instances per plan() because RelHomogeneousShuttle inherits a stateful stack.
+    return List.of(new DatetimeUdtNormalizeRule(), new DatetimeOutputCastRule());
   }
```

The `INSTANCE` constants and the Lombok `@NoArgsConstructor(PRIVATE)` are
removed from both rules. Class JavaDoc on each rule now explicitly warns
against making it a singleton again.

## Test plan

| Cluster state | `testConcurrentStatsDistinctCountOverDatetime` | `testConcurrentMixedDatetimePlans` |
|---|---|---|
| **Without fix** (singleton `INSTANCE`)         | **2/80 queries fail** with `NoSuchElementException` (HTTP 500) | **3/80 fail** with same error |
| **With fix** (fresh instances per `plan()`)    | **80/80 pass**                                                | **80/80 pass** |

Reproduced and verified end-to-end via the analytics-engine path with
parquet-backed indices:

```bash
./gradlew :integ-test:integTestRemote \
  -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9300 \
  -Dtests.clustername=runTask \
  -Dtests.analytics.force_routing=true \
  -Dtests.analytics.parquet_indices=true \
  --tests "*CalciteDatetimeUdtNormalizeRegressionIT"
```

The IT (`CalciteDatetimeUdtNormalizeRegressionIT`) fires 80 queries across an
8-thread pool against a parquet-backed `DATE_FORMATS` index with multiple
datetime columns — mirroring the dashboard field-stats workload.

- [x] `:api:test` and `:core:test` pass
- [x] `:api:spotlessCheck` passes
- [x] Concurrent IT reliably reproduces the failure against unfixed code
- [x] Same IT passes 0/80 failures against fixed code
- [x] Unit test `testSequentialPlanCallsDoNotCorruptShuttleStack` in
      `DatetimeExtensionTest` guards against future reintroduction of the
      singleton