### PR TITLE
test(stats): pin output column order with explicit `| fields` projection in CalcitePPLEventstatsIT/CalciteStreamstatsCommandIT

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEventstatsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEventstatsIT.java
@@ -32,7 +32,7 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max",
+                    + " as max | fields name, country, state, month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -62,7 +62,7 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max",
+                    + " as max | fields name, country, state, month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -94,7 +94,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by country",
+                    + " as max by country | fields name, country, state, month, year, age, cnt,"
+                    + " avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -124,7 +125,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by country",
+                    + " as max by country | fields name, country, state, month, year, age, cnt,"
+                    + " avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -153,7 +155,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by state",
+                    + " as max by state | fields name, country, state, month, year, age, cnt, avg,"
+                    + " min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
     verifyDataRows(
         actual,
@@ -171,7 +174,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats bucket_nullable=false count() as cnt, avg(age) as avg,"
-                    + " min(age) as min, max(age) as max by country",
+                    + " min(age) as min, max(age) as max by country | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -187,7 +191,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats bucket_nullable=false count() as cnt, avg(age) as avg,"
-                    + " min(age) as min, max(age) as max by state",
+                    + " min(age) as min, max(age) as max by state | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
     verifyDataRows(
         actual,
@@ -205,7 +210,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span",
+                    + " as max by span(age, 10) as age_span | fields name, country, state, month,"
+                    + " year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -222,7 +228,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span",
+                    + " as max by span(age, 10) as age_span | fields name, country, state, month,"
+                    + " year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -241,7 +248,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span, country",
+                    + " as max by span(age, 10) as age_span, country | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -258,7 +266,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span, state",
+                    + " as max by span(age, 10) as age_span, state | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -275,7 +284,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span, country",
+                    + " as max by span(age, 10) as age_span, country | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -294,7 +304,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span, state",
+                    + " as max by span(age, 10) as age_span, state | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -328,7 +339,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats avg(age) as avg_age by state, country | eventstats"
-                    + " avg(avg_age) as avg_state_age by country",
+                    + " avg(avg_age) as avg_state_age by country | fields name, country, state,"
+                    + " month, year, age, avg_age, avg_state_age",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -345,7 +357,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats avg(age) as avg_age by state, country | eventstats"
-                    + " avg(avg_age) as avg_state_age by country",
+                    + " avg(avg_age) as avg_state_age by country | fields name, country, state,"
+                    + " month, year, age, avg_age, avg_state_age",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -365,7 +378,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | eventstats bucket_nullable=false avg(age) as avg_age by state, country"
                     + " | eventstats bucket_nullable=false avg(avg_age) as avg_state_age by"
-                    + " country",
+                    + " country | fields name, country, state, month, year, age, avg_age,"
+                    + " avg_state_age",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -386,7 +400,9 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
                 "source=%s | eventstats avg(age) as avg_age by country, state, name | eval"
                     + " avg_age_divide_20 = avg_age - 20 | eventstats avg(avg_age_divide_20) as"
                     + " avg_state_age by country, state | where avg_state_age > 0 | eventstats"
-                    + " count(avg_state_age) as count_country_age_greater_20 by country",
+                    + " count(avg_state_age) as count_country_age_greater_20 by country | fields"
+                    + " name, country, state, month, year, age, avg_age, avg_age_divide_20,"
+                    + " avg_state_age, count_country_age_greater_20",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -422,7 +438,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats stddev_pop(age), stddev_samp(age), var_pop(age),"
-                    + " var_samp(age)",
+                    + " var_samp(age) | fields name, country, state, month, year, age,"
+                    + " `stddev_pop(age)`, `stddev_samp(age)`, `var_pop(age)`, `var_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -492,7 +509,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats stddev_pop(age), stddev_samp(age), var_pop(age),"
-                    + " var_samp(age)",
+                    + " var_samp(age) | fields name, country, state, month, year, age,"
+                    + " `stddev_pop(age)`, `stddev_samp(age)`, `var_pop(age)`, `var_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -555,7 +573,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats stddev_pop(age), stddev_samp(age), var_pop(age),"
-                    + " var_samp(age) by country",
+                    + " var_samp(age) by country | fields name, country, state, month, year, age,"
+                    + " `stddev_pop(age)`, `stddev_samp(age)`, `var_pop(age)`, `var_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -571,7 +590,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | where country != 'USA' | eventstats stddev_samp(age) by span(age, 10)",
+                "source=%s | where country != 'USA' | eventstats stddev_samp(age) by span(age, 10)"
+                    + " | fields name, country, state, month, year, age, `stddev_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -586,7 +606,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats stddev_pop(age), stddev_samp(age), var_pop(age),"
-                    + " var_samp(age) by country",
+                    + " var_samp(age) by country | fields name, country, state, month, year, age,"
+                    + " `stddev_pop(age)`, `stddev_samp(age)`, `var_pop(age)`, `var_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -634,7 +655,9 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eventstats dc(state) as dc_state", TEST_INDEX_STATE_COUNTRY));
+                "source=%s | eventstats dc(state) as dc_state | fields name, country, state, month,"
+                    + " year, age, dc_state",
+                TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
         actual,
@@ -659,7 +682,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eventstats dc(state) as dc_state by country",
+                "source=%s | eventstats dc(state) as dc_state by country | fields name, country,"
+                    + " state, month, year, age, dc_state",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -685,7 +709,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eventstats distinct_count(country) as dc_country",
+                "source=%s | eventstats distinct_count(country) as dc_country | fields name,"
+                    + " country, state, month, year, age, dc_country",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -711,7 +736,8 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eventstats dc(state) as dc_state",
+                "source=%s | eventstats dc(state) as dc_state | fields name, country, state, month,"
+                    + " year, age, dc_state",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -739,7 +765,9 @@ public class CalcitePPLEventstatsIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eventstats earliest(message), latest(message) by server",
+                "source=%s | eventstats earliest(message), latest(message) by server | fields"
+                    + " created_at, server, `@timestamp`, message, level, `earliest(message)`,"
+                    + " `latest(message)`",
                 TEST_INDEX_LOGS));
     verifySchema(
         actual,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteStreamstatsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteStreamstatsCommandIT.java
@@ -32,7 +32,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max",
+                    + " as max | fields name, country, state, month, year, age, cnt, avg, min,"
+                    + " max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -62,7 +63,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max",
+                    + " as max | fields name, country, state, month, year, age, cnt, avg, min,"
+                    + " max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -94,7 +96,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by country",
+                    + " as max by country | fields name, country, state, month, year, age, cnt,"
+                    + " avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -124,7 +127,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by country",
+                    + " as max by country | fields name, country, state, month, year, age, cnt,"
+                    + " avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -153,7 +157,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by state",
+                    + " as max by state | fields name, country, state, month, year, age, cnt, avg,"
+                    + " min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
     verifyDataRows(
         actual,
@@ -171,7 +176,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats bucket_nullable=false count() as cnt, avg(age) as avg,"
-                    + " min(age) as min, max(age) as max by country",
+                    + " min(age) as min, max(age) as max by country | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -200,7 +206,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats bucket_nullable=false count() as cnt, avg(age) as avg,"
-                    + " min(age) as min, max(age) as max by state",
+                    + " min(age) as min, max(age) as max by state | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
     verifyDataRows(
         actual,
@@ -218,7 +225,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span",
+                    + " as max by span(age, 10) as age_span | fields name, country, state, month,"
+                    + " year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -235,7 +243,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span",
+                    + " as max by span(age, 10) as age_span | fields name, country, state, month,"
+                    + " year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -254,7 +263,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span, country",
+                    + " as max by span(age, 10) as age_span, country | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -271,7 +281,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats count() as cnt, avg(age) as avg, min(age) as min, max(age)"
-                    + " as max by span(age, 10) as age_span, state",
+                    + " as max by span(age, 10) as age_span, state | fields name, country, state,"
+                    + " month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -288,7 +299,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats bucket_nullable=false count() as cnt, avg(age) as avg,"
-                    + " min(age) as min, max(age) as max by span(age, 10) as age_span, country",
+                    + " min(age) as min, max(age) as max by span(age, 10) as age_span, country |"
+                    + " fields name, country, state, month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -304,7 +316,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats bucket_nullable=true count() as cnt, avg(age) as avg,"
-                    + " min(age) as min, max(age) as max by span(age, 10) as age_span, country",
+                    + " min(age) as min, max(age) as max by span(age, 10) as age_span, country |"
+                    + " fields name, country, state, month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -323,7 +336,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats bucket_nullable=false count() as cnt, avg(age) as avg,"
-                    + " min(age) as min, max(age) as max by span(age, 10) as age_span, state",
+                    + " min(age) as min, max(age) as max by span(age, 10) as age_span, state |"
+                    + " fields name, country, state, month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -339,7 +353,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats bucket_nullable=true count() as cnt, avg(age) as avg,"
-                    + " min(age) as min, max(age) as max by span(age, 10) as age_span, state",
+                    + " min(age) as min, max(age) as max by span(age, 10) as age_span, state |"
+                    + " fields name, country, state, month, year, age, cnt, avg, min, max",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -357,7 +372,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats current=false avg(age) as prev_avg",
+                "source=%s | streamstats current=false avg(age) as prev_avg | fields name, country,"
+                    + " state, month, year, age, prev_avg",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -373,7 +389,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats current=false avg(age) as prev_avg",
+                "source=%s | streamstats current=false avg(age) as prev_avg | fields name, country,"
+                    + " state, month, year, age, prev_avg",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -391,7 +408,9 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats window = 3 avg(age) as avg", TEST_INDEX_STATE_COUNTRY));
+                "source=%s | streamstats window = 3 avg(age) as avg | fields name, country, state,"
+                    + " month, year, age, avg",
+                TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
         actual,
@@ -406,7 +425,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats window = 3 avg(age) as avg",
+                "source=%s | streamstats window = 3 avg(age) as avg | fields name, country, state,"
+                    + " month, year, age, avg",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -424,7 +444,9 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats window = 10 avg(age) as avg", TEST_INDEX_STATE_COUNTRY));
+                "source=%s | streamstats window = 10 avg(age) as avg | fields name, country, state,"
+                    + " month, year, age, avg",
+                TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
         actual,
@@ -452,7 +474,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats current = false window = 2 avg(age) as avg",
+                "source=%s | streamstats current = false window = 2 avg(age) as avg | fields name,"
+                    + " country, state, month, year, age, avg",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -468,7 +491,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats current = false window = 2 avg(age) as avg",
+                "source=%s | streamstats current = false window = 2 avg(age) as avg | fields name,"
+                    + " country, state, month, year, age, avg",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -496,7 +520,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
       JSONObject actual =
           executeQuery(
               String.format(
-                  "source=%s | streamstats window=2 global=false avg(age) as avg by country",
+                  "source=%s | streamstats window=2 global=false avg(age) as avg by country |"
+                      + " fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY));
 
       verifyDataRows(
@@ -510,7 +535,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
       JSONObject actual2 =
           executeQuery(
               String.format(
-                  "source=%s | streamstats window=2 global=true avg(age) as avg by country",
+                  "source=%s | streamstats window=2 global=true avg(age) as avg by country |"
+                      + " fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY));
 
       verifyDataRows(
@@ -544,7 +570,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
       JSONObject actual =
           executeQuery(
               String.format(
-                  "source=%s | streamstats window=2 global=false avg(age) as avg by country",
+                  "source=%s | streamstats window=2 global=false avg(age) as avg by country |"
+                      + " fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
       verifyDataRows(
@@ -560,7 +587,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
       JSONObject actual2 =
           executeQuery(
               String.format(
-                  "source=%s | streamstats window=2 global=true avg(age) as avg by country",
+                  "source=%s | streamstats window=2 global=true avg(age) as avg by country |"
+                      + " fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
       verifyDataRows(
@@ -598,7 +626,7 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
           executeQuery(
               String.format(
                   "source=%s | streamstats bucket_nullable=false window=2 global=true avg(age) as"
-                      + " avg by state",
+                      + " avg by state | fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
       verifyDataRows(
@@ -615,7 +643,7 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
           executeQuery(
               String.format(
                   "source=%s | streamstats bucket_nullable=true window=2 global=true avg(age) as"
-                      + " avg by state",
+                      + " avg by state | fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
       verifyDataRows(
@@ -651,7 +679,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
       JSONObject actual =
           executeQuery(
               String.format(
-                  "source=%s | streamstats window=2 reset_before=age>29 avg(age) as avg by country",
+                  "source=%s | streamstats window=2 reset_before=age>29 avg(age) as avg by country"
+                      + " | fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY));
 
       verifyDataRows(
@@ -665,7 +694,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
       JSONObject actual2 =
           executeQuery(
               String.format(
-                  "source=%s | streamstats window=2 reset_after=age>22 avg(age) as avg by country",
+                  "source=%s | streamstats window=2 reset_after=age>22 avg(age) as avg by country"
+                      + " | fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY));
 
       verifyDataRows(
@@ -699,7 +729,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
       JSONObject actual =
           executeQuery(
               String.format(
-                  "source=%s | streamstats window=2 reset_before=age>29 avg(age) as avg by country",
+                  "source=%s | streamstats window=2 reset_before=age>29 avg(age) as avg by country"
+                      + " | fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
       verifyDataRows(
@@ -715,7 +746,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
       JSONObject actual2 =
           executeQuery(
               String.format(
-                  "source=%s | streamstats window=2 reset_after=age>22 avg(age) as avg by country",
+                  "source=%s | streamstats window=2 reset_after=age>22 avg(age) as avg by country"
+                      + " | fields name, country, state, month, year, age, avg",
                   TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
       verifyDataRows(
@@ -753,7 +785,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
           executeQuery(
               String.format(
                   "source=%s | streamstats bucket_nullable=true window=2 reset_before=age>29"
-                      + " avg(age) as avg by state",
+                      + " avg(age) as avg by state | fields name, country, state, month, year,"
+                      + " age, avg",
                   TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
       verifyDataRows(
@@ -770,7 +803,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
           executeQuery(
               String.format(
                   "source=%s | streamstats bucket_nullable=false window=2 reset_after=age>22"
-                      + " avg(age) as avg by state",
+                      + " avg(age) as avg by state | fields name, country, state, month, year,"
+                      + " age, avg",
                   TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
       verifyDataRows(
@@ -812,7 +846,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats avg(age) as avg_age by state, country | streamstats"
-                    + " avg(avg_age) as avg_state_age by country",
+                    + " avg(avg_age) as avg_state_age by country | fields name, country, state,"
+                    + " month, year, age, avg_age, avg_state_age",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -830,7 +865,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats window=2 avg(age) as avg_age by state, country"
-                    + " | streamstats window=2 avg(avg_age) as avg_state_age by country",
+                    + " | streamstats window=2 avg(avg_age) as avg_state_age by country | fields"
+                    + " name, country, state, month, year, age, avg_age, avg_state_age",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -864,7 +900,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats avg(age) as avg_age by state, country | streamstats"
-                    + " avg(avg_age) as avg_state_age by country",
+                    + " avg(avg_age) as avg_state_age by country | fields name, country, state,"
+                    + " month, year, age, avg_age, avg_state_age",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -881,7 +918,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | streamstats bucket_nullable=false avg(age) as avg_age by state,"
                     + " country | streamstats bucket_nullable=false avg(avg_age) as avg_state_age"
-                    + " by country",
+                    + " by country | fields name, country, state, month, year, age, avg_age,"
+                    + " avg_state_age",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -910,7 +948,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
           executeQuery(
               String.format(
                   "source=%s | streamstats avg(age) as avg_age by state, country | streamstats"
-                      + " avg(avg_age) as avg_state_age by country",
+                      + " avg(avg_age) as avg_state_age by country | fields name, country, state,"
+                      + " month, year, age, avg_age, avg_state_age",
                   TEST_INDEX_STATE_COUNTRY));
 
       verifyDataRows(
@@ -926,7 +965,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
               String.format(
                   "source=%s | streamstats bucket_nullable=false avg(age) as avg_age by state,"
                       + " country | streamstats bucket_nullable=false avg(avg_age) as avg_state_age"
-                      + " by country",
+                      + " by country | fields name, country, state, month, year, age, avg_age,"
+                      + " avg_state_age",
                   TEST_INDEX_STATE_COUNTRY));
 
       verifyDataRows(
@@ -950,7 +990,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eventstats avg(age) as avg_age| streamstats"
-                    + " avg(age) as avg_age_stream",
+                    + " avg(age) as avg_age_stream | fields name, country, state, month, year,"
+                    + " age, avg_age, avg_age_stream",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -966,7 +1007,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | sort age | streamstats window = 2 avg(age) as avg_age ",
+                "source=%s | sort age | streamstats window = 2 avg(age) as avg_age | fields name,"
+                    + " country, state, month, year, age, avg_age",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -983,7 +1025,9 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s as l | left join left=l right=r on l.country = r.country [ source=%s |"
-                    + " streamstats window=2 avg(age) as avg_age]",
+                    + " streamstats window=2 avg(age) as avg_age] | fields l.name, l.country,"
+                    + " l.state, l.month, l.year, l.age, r.name, r.country, r.state, r.month,"
+                    + " r.year, r.age, avg_age",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -1014,7 +1058,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | where country in [ source=%s | streamstats window=2 avg(age) as"
-                    + " avg_age | where avg_age > 40 | fields country ]",
+                    + " avg_age | where avg_age > 40 | fields country ] | fields name, country,"
+                    + " state, month, year, age",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -1031,7 +1076,9 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
                 "source=%s | streamstats avg(age) as avg_age by country, state, name | eval"
                     + " avg_age_divide_20 = avg_age - 20 | streamstats avg(avg_age_divide_20) as"
                     + " avg_state_age by country, state | where avg_state_age > 0 | streamstats"
-                    + " count(avg_state_age) as count_country_age_greater_20 by country",
+                    + " count(avg_state_age) as count_country_age_greater_20 by country | fields"
+                    + " name, country, state, month, year, age, avg_age, avg_age_divide_20,"
+                    + " avg_state_age, count_country_age_greater_20",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -1047,7 +1094,9 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eval new_state=lower(state), new_country=lower(country) | streamstats"
-                    + " bucket_nullable=false avg(age) as avg_age by new_state, new_country",
+                    + " bucket_nullable=false avg(age) as avg_age by new_state, new_country |"
+                    + " fields name, country, state, month, year, age, new_state, new_country,"
+                    + " avg_age",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -1075,7 +1124,9 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eval new_state=lower(state), new_country=lower(country) | streamstats"
-                    + " bucket_nullable=true avg(age) as avg_age by new_state, new_country",
+                    + " bucket_nullable=true avg(age) as avg_age by new_state, new_country |"
+                    + " fields name, country, state, month, year, age, new_state, new_country,"
+                    + " avg_age",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -1114,7 +1165,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats stddev_pop(age), stddev_samp(age), var_pop(age),"
-                    + " var_samp(age)",
+                    + " var_samp(age) | fields name, country, state, month, year, age,"
+                    + " `stddev_pop(age)`, `stddev_samp(age)`, `var_pop(age)`, `var_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -1164,7 +1216,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats stddev_pop(age), stddev_samp(age), var_pop(age),"
-                    + " var_samp(age)",
+                    + " var_samp(age) | fields name, country, state, month, year, age,"
+                    + " `stddev_pop(age)`, `stddev_samp(age)`, `var_pop(age)`, `var_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -1216,7 +1269,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats stddev_pop(age), stddev_samp(age), var_pop(age),"
-                    + " var_samp(age) by country",
+                    + " var_samp(age) by country | fields name, country, state, month, year, age,"
+                    + " `stddev_pop(age)`, `stddev_samp(age)`, `var_pop(age)`, `var_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -1233,7 +1287,7 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | where country != 'USA' | streamstats stddev_samp(age) by span(age,"
-                    + " 10)",
+                    + " 10) | fields name, country, state, month, year, age, `stddev_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifyDataRows(
@@ -1248,7 +1302,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | streamstats stddev_pop(age), stddev_samp(age), var_pop(age),"
-                    + " var_samp(age) by country",
+                    + " var_samp(age) by country | fields name, country, state, month, year, age,"
+                    + " `stddev_pop(age)`, `stddev_samp(age)`, `var_pop(age)`, `var_samp(age)`",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifyDataRows(
@@ -1276,7 +1331,9 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats dc(state) as dc_state", TEST_INDEX_STATE_COUNTRY));
+                "source=%s | streamstats dc(state) as dc_state | fields name, country, state,"
+                    + " month, year, age, dc_state",
+                TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
         actual,
@@ -1301,7 +1358,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats dc(state) as dc_state by country",
+                "source=%s | streamstats dc(state) as dc_state by country | fields name, country,"
+                    + " state, month, year, age, dc_state",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -1327,7 +1385,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats distinct_count(country) as dc_country",
+                "source=%s | streamstats distinct_count(country) as dc_country | fields name,"
+                    + " country, state, month, year, age, dc_country",
                 TEST_INDEX_STATE_COUNTRY));
 
     verifySchemaInOrder(
@@ -1353,7 +1412,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats dc(state) as dc_state",
+                "source=%s | streamstats dc(state) as dc_state | fields name, country, state,"
+                    + " month, year, age, dc_state",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchemaInOrder(
@@ -1381,7 +1441,9 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | streamstats earliest(message), latest(message) by server",
+                "source=%s | streamstats earliest(message), latest(message) by server | fields"
+                    + " created_at, server, `@timestamp`, message, level, `earliest(message)`,"
+                    + " `latest(message)`",
                 TEST_INDEX_LOGS));
     verifySchema(
         actual,


### PR DESCRIPTION
### Description

`eventstats` and `streamstats` output schema is `[original-table-columns, agg-columns]`, where the original-columns slice inherits the catalog's iteration order. The current V3 path's catalog iterates field types through a `HashMap` (`OpenSearchDescribeIndexRequest.getFieldTypes` → `new HashMap<>().putAll(linkedHashMap)`), and that HashMap's bucket layout is a function of the field-name set's hash codes plus the JDK's resize strategy — neither alphabetical nor declaration order, just an arbitrary reorder that varies by JDK version and field-name set.

That arbitrary order is what gets baked into Calcite's `RelOptTable.rowType` when the catalog reader caches it, and the cached row type is what every `CalciteLogicalIndexScan` inherits. So the V3 path's "natural" column order for these tests is the JDK 21 HashMap bucket order for the `state_country` and `LOGS` field-name sets — alphabetical neither, declaration order neither.

This makes the IT assertions fragile in two ways:
1. A future JDK upgrade or any field-name change can silently re-shuffle the bucket order, breaking these tests with no behavior change in PPL itself.
2. Other routes that read the same `MappingMetadata.sourceAsMap()` (which OpenSearch core canonicalizes to alphabetical via `ObjectMapper.toXContent`) will return columns in alphabetical order, not the V3 HashMap order. So tests asserting V3's HashMap order can't be reused on those routes.

This PR is a **short-term workaround**, not a fix to the underlying brittleness. It appends `| fields col1, col2, ...` to every PPL query in the two stats IT classes, so the output schema is fixed by the projection list rather than by the catalog. Existing `verifySchemaInOrder` and `verifyDataRows` assertions are unchanged — they already match the projection list.

The real fix (one-line change to swap `HashMap` for `LinkedHashMap` so V3 inherits the alphabetical order OpenSearch core already canonicalizes on) is a separate, larger PR because it requires updating ~250 hardcoded HashMap-bucket-order expectations across other ITs and yaml expected-output files. This PR un-blocks `eventstats`/`streamstats` testing on the analytics-engine route in the meantime.

### Changes

- `CalcitePPLEventstatsIT.java`: 27 of 30 `executeQuery` calls gained `| fields ...`. Skipped: `testUnsupportedWindowFunctions` (exception path) and `testEventstatsEmptyRows` (asserts only row count).
- `CalciteStreamstatsCommandIT.java`: 57 of 61 calls modified. Skipped: `testStreamstatsWindowError`, `testUnsupportedWindowFunctions`, `testStreamstatsEmptyRows` for the same reasons.
- No product code changed.

### Related Issues

<!-- N/A — short-term workaround for inter-route schema-ordering inconsistency -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.