### PR TITLE
[Analytics-Engine] [BugFix] Decorrelate EXISTS / IN / SOME / ANY subqueries before execution

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -13,10 +13,13 @@ import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.core.action.ActionListener;
@@ -177,9 +180,38 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
           .build();
 
   private static RelNode removeSubQueries(RelNode plan, CalcitePlanContext context) {
+    // Fast-path: skip HEP + decorrelation entirely if the plan has no RexSubQuery. Avoids HEP
+    // overhead for the typical query and keeps the rewrite a no-op for callers (incl. unit tests)
+    // whose RelNodes don't have a real RelOptCluster wired up.
+    if (!containsSubQuery(plan)) {
+      return plan;
+    }
     HepPlanner planner = new HepPlanner(SUBQUERY_REMOVE_PROGRAM);
     planner.setRoot(plan);
     RelNode withCorrelates = planner.findBestExp();
     return RelDecorrelator.decorrelateQuery(withCorrelates, context.relBuilder);
+  }
+
+  /** Walks {@code plan} and returns {@code true} as soon as any {@link RexSubQuery} is found. */
+  static boolean containsSubQuery(RelNode plan) {
+    boolean[] found = {false};
+    RexShuttle rexFinder =
+        new RexShuttle() {
+          @Override
+          public org.apache.calcite.rex.RexNode visitSubQuery(RexSubQuery sub) {
+            found[0] = true;
+            return sub;
+          }
+        };
+    plan.accept(
+        new RelHomogeneousShuttle() {
+          @Override
+          public RelNode visit(RelNode node) {
+            if (found[0]) return node;
+            node.accept(rexFinder);
+            return found[0] ? node : super.visit(node);
+          }
+        });
+    return found[0];
   }
 }

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -10,9 +10,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.ast.statement.ExplainMode;
@@ -77,15 +82,16 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     // taken by SimpleJsonResponseFormatter sees the correct value.
     ProfileMetric execMetric = QueryProfiling.current().getOrCreateMetric(MetricName.EXECUTE);
     long execStart = System.nanoTime();
+    final RelNode executablePlan = removeSubQueries(plan, context);
 
     planExecutor.execute(
-        plan,
+        executablePlan,
         null,
         new ActionListener<>() {
           @Override
           public void onResponse(Iterable<Object[]> rows) {
             try {
-              List<RelDataTypeField> fields = plan.getRowType().getFieldList();
+              List<RelDataTypeField> fields = executablePlan.getRowType().getFieldList();
               List<ExprValue> results = convertRows(rows, fields);
               Schema schema = buildSchema(fields);
               execMetric.set(System.nanoTime() - execStart);
@@ -109,6 +115,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
       CalcitePlanContext context,
       ResponseListener<ExplainResponse> listener) {
     try {
+      plan = removeSubQueries(plan, context);
       String logical = RelOptUtil.toString(plan, mode.toExplainLevel());
       ExplainResponse response =
           new ExplainResponse(new ExplainResponseNodeV2(logical, null, null));
@@ -147,5 +154,32 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     } catch (IllegalArgumentException e) {
       return org.opensearch.sql.data.type.ExprCoreType.UNKNOWN;
     }
+  }
+
+  /**
+   * Converts every {@link org.apache.calcite.rex.RexSubQuery} in the plan to a {@code
+   * LogicalCorrelate}, then decorrelates back to standard join shapes (LEFT_SEMI / LEFT_ANTI /
+   * INNER). The analytics-engine planner has no RexSubQuery handler — it routes filter / project
+   * expressions through a {@code ScalarFunction} table that doesn't include EXISTS / IN / SOME /
+   * ANY operators, so an un-removed subquery surfaces as {@code "Unrecognized filter operator
+   * [EXISTS / EXISTS]"} at the filter rule. The legacy engine path picks this up implicitly inside
+   * Calcite's {@code RelRunner.prepareStatement}, which is skipped on the analytics route.
+   *
+   * <p>Scoped to the analytics path only — placing this on {@link AnalyticsExecutionEngine} (rather
+   * than on the central {@code UnifiedQueryPlanner}) keeps the legacy path's RelNode pipeline
+   * untouched.
+   */
+  private static final HepProgram SUBQUERY_REMOVE_PROGRAM =
+      new HepProgramBuilder()
+          .addRuleInstance(CoreRules.FILTER_SUB_QUERY_TO_CORRELATE)
+          .addRuleInstance(CoreRules.PROJECT_SUB_QUERY_TO_CORRELATE)
+          .addRuleInstance(CoreRules.JOIN_SUB_QUERY_TO_CORRELATE)
+          .build();
+
+  private static RelNode removeSubQueries(RelNode plan, CalcitePlanContext context) {
+    HepPlanner planner = new HepPlanner(SUBQUERY_REMOVE_PROGRAM);
+    planner.setRoot(plan);
+    RelNode withCorrelates = planner.findBestExp();
+    return RelDecorrelator.decorrelateQuery(withCorrelates, context.relBuilder);
   }
 }

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.executor.analytics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,9 +21,12 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.BeforeEach;
@@ -274,6 +278,55 @@ class AnalyticsExecutionEngineTest {
             + errorRef.get().getClass().getSimpleName()
             + " - "
             + errorRef.get().getMessage());
+  }
+
+  // --- Subquery-removal discriminator (see {@link AnalyticsExecutionEngine#containsSubQuery}) ---
+  //
+  // {@code containsSubQuery} gates the SubQueryRemoveRule + RelDecorrelator chain we run inside
+  // {@code execute()} / {@code explain()}. The chain is Calcite-tested, but the *discriminator*
+  // is plugin code; if it falsely returns true for a vanilla mock RelNode the existing
+  // execute-path tests in this class break with "NullPointerException: cluster" inside HepPlanner.
+  // If it falsely returns false on a plan that does contain a RexSubQuery, the EXISTS-subquery
+  // regression we shipped this fix for would silently reappear.
+
+  @Test
+  void containsSubQuery_falseForPlanWithoutSubQuery() {
+    // A plain mocked RelNode has no RexNodes — Mockito default returns null from accept(...),
+    // which keeps the shuttle from ever reaching visitSubQuery.
+    RelNode plan = mock(RelNode.class);
+
+    assertFalse(
+        AnalyticsExecutionEngine.containsSubQuery(plan),
+        "containsSubQuery should report false on a plan with no RexSubQuery — otherwise the"
+            + " HepPlanner / RelDecorrelator path would fire on plans that have no subqueries to"
+            + " remove (and on tests that pass mocked RelNodes without a real cluster).");
+  }
+
+  @Test
+  void containsSubQuery_trueWhenRelNodeExposesRexSubQueryDuringTraversal() {
+    // Stub the RelNode.accept(RexShuttle) call to feed a RexSubQuery into the shuttle, mirroring
+    // what a real LogicalFilter(condition=[EXISTS(subq)]) would do during traversal.
+    RelNode plan = mock(RelNode.class);
+    RexSubQuery subQuery = mock(RexSubQuery.class);
+    when(plan.accept(any(RelShuttle.class)))
+        .thenAnswer(
+            inv -> {
+              RelShuttle shuttle = inv.getArgument(0);
+              return shuttle.visit(plan);
+            });
+    when(plan.accept(any(RexShuttle.class)))
+        .thenAnswer(
+            inv -> {
+              RexShuttle rex = inv.getArgument(0);
+              rex.visitSubQuery(subQuery);
+              return null;
+            });
+
+    assertTrue(
+        AnalyticsExecutionEngine.containsSubQuery(plan),
+        "containsSubQuery should detect a RexSubQuery surfaced through the node's"
+            + " accept(RexShuttle) — the discriminator is what gates the EXISTS/IN/SOME/ANY"
+            + " removal pass.");
   }
 
   // --- helpers ---


### PR DESCRIPTION
## Description

PPL queries that contain `EXISTS` / `NOT EXISTS` / `IN` / `SOME` / `ANY` subqueries — and the `subsearch` shapes that lower to them — currently crash on the analytics-engine route with:

```
HTTP/1.1 500 Internal Server Error
{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "Unrecognized filter operator [EXISTS / EXISTS]",
    "type": "IllegalStateException"
  }
}
```

The whole class `CalcitePPLExistsSubqueryIT` (19 tests) fails this way against an analytics-engine-routed cluster. This PR fixes the *root cause* of that signature.

## Root cause

The full failure path:

```
PPL `... | where [exists ...]`
  → CalciteRelNodeVisitor.analyze(...)
  → LogicalFilter(condition=[EXISTS({...subquery...})])         ← RexSubQuery of SqlKind.EXISTS
  → UnifiedQueryPlanner.plan() returns as-is
  → AnalyticsExecutionEngine.execute() → analytics-engine PlannerImpl
  → OpenSearchFilterRule.resolveViableBackends(predicate)
  → ScalarFunction.fromSqlOperatorWithFallback(EXISTS) returns null
  → throw IllegalStateException("Unrecognized filter operator [EXISTS / EXISTS]")
```

Where:

* **Error site**: `sandbox/plugins/analytics-engine/.../OpenSearchFilterRule.java:155-160` — analytics-engine resolves every leaf predicate through `ScalarFunction.fromSqlOperatorWithFallback`, which doesn't (and shouldn't) cover `RexSubQuery` operators. `RexSubQuery` extends `RexCall`, so the upstream `instanceof RexCall` check waves it through.

* **Why the legacy engine works**: the legacy path reaches `CalciteToolsHelper.RelRunner.run(...) → runner.prepareStatement(rel)` which internally runs `SubQueryRemoveRule` + decorrelation inside Calcite's Volcano-driven physical conversion. The analytics path goes `AnalyticsExecutionEngine → QueryPlanExecutor.execute`, bypassing that pipeline entirely.

* **Search the SQL plugin tree for `SubQueryRemoveRule`, `CoreRules.FILTER_SUB_QUERY_TO_CORRELATE`, `RelDecorrelator.decorrelateQuery`** — zero call sites. Nothing in the unified pipeline removes subqueries for the analytics route.

## Fix

Run Calcite's three `SubQueryToCorrelate` rules followed by `RelDecorrelator.decorrelateQuery` on the `RelNode` just before handing it to the analytics executor (and the same in `explain()`):

```java
private static final HepProgram SUBQUERY_REMOVE_PROGRAM =
    new HepProgramBuilder()
        .addRuleInstance(CoreRules.FILTER_SUB_QUERY_TO_CORRELATE)
        .addRuleInstance(CoreRules.PROJECT_SUB_QUERY_TO_CORRELATE)
        .addRuleInstance(CoreRules.JOIN_SUB_QUERY_TO_CORRELATE)
        .build();

private static RelNode removeSubQueries(RelNode plan, CalcitePlanContext context) {
    HepPlanner planner = new HepPlanner(SUBQUERY_REMOVE_PROGRAM);
    planner.setRoot(plan);
    RelNode withCorrelates = planner.findBestExp();
    return RelDecorrelator.decorrelateQuery(withCorrelates, context.relBuilder);
}
```

**Placement matters.** I considered three locations:

| Placement | Affects legacy path? | Verdict |
|---|---|---|
| `UnifiedQueryPlanner.plan()` | Yes — every query runs the new pass | Higher blast radius |
| `AnalyticsExecutionEngine.execute()` (this PR) | **No** — only the analytics route | Surgical |
| Per-rule guard in `OpenSearchFilterRule` | Doesn't fix anything | Not a fix |

This PR uses the middle one: the rewrite fires only on the analytics route, so the legacy path's `RelNode` pipeline is byte-for-byte unchanged.

## After-fix verification

Same `CalcitePPLExistsSubqueryIT` class, same cluster, same routing (`-Dtests.analytics.parquet_indices=true`):

| Run | Pass | Fail | Failure signature |
|---|---|---|---|
| **Before** | 0 / 19 | 19 / 19 | All `IllegalStateException: Unrecognized filter operator [EXISTS / EXISTS]` |
| **After (this PR)** | 6 / 19 | 13 / 19 | All `AssertionError` (result-row mismatches) — **zero remaining `IllegalStateException`s** |

The "Unrecognized filter operator [EXISTS / EXISTS]" signature is gone from every test — the RCA is fully addressed. Per-test breakdown after the fix:

* **PASS** (6): `testEmptyExistsSubquery`, `testExistsSubqueryWithConjunction`, `testNotExistsSubquery`, `testNotExistsSubqueryInFilter`, `testSubsearchMaxOut2`, `testSubsearchMaxOut4`
* **FAIL — result mismatch only** (13): `testSimpleExistsSubquery`, `testSimpleExistsSubqueryInFilter`, `testUncorrelatedExistsSubquery`, `testUncorrelatedExistsSubqueryCheckTheReturnContentOfInnerTableIsEmptyOrNot`, `testNestedExistsSubquery`, `testExistsSubqueryAndAggregation`, `testIssue3566`, `testSubsearchMaxOut1`, `testSubsearchMaxOut3`, `testSubsearchMaxOutNegativeMeansUnlimited`, `testSubsearchMaxOutUncorrelated`, `testCorrelatedSubsearchMaxOutZeroMeansUnlimited`, `testUncorrelatedSubsearchMaxOutZeroMeansUnlimited`

The decorrelated plan for the failing tests looks correct on inspection — e.g. `testSimpleExistsSubquery` produces:

```
LogicalJoin(condition=[=(worker.id, $f0)], joinType=[inner])
  LogicalTableScan(worker)
  LogicalProject(uid=[$0], $f1=[true])
    LogicalAggregate(group=[{0}])           ← dedups inner side by uid
      LogicalProject(uid=[$3])
        LogicalFilter(condition=[IS NOT NULL($3)])
          LogicalTableScan(work_information)
```

— textbook EXISTS semantics (INNER join with the inner side group-by-deduplicated). The 2× row multiplication that's actually observed suggests the bare-group-by `LogicalAggregate(group=[{0}])` isn't preserving its dedup semantic through the analytics-engine's join + aggregate execution path. That's a separate downstream issue from the subquery-removal RCA and will be tracked under its own PR.

## Out of scope

Anything beyond the EXISTS / IN / SOME / ANY subquery-removal RCA:

* Bare-group-by `Aggregate` dedup semantics inside a join — needs analytics-engine planner / executor changes. Tracked separately; this PR doesn't change those code paths.
* `RelDecorrelator` will still raise for correlated subqueries Calcite can't decorrelate (e.g. correlated nondeterministic functions). Those queries used to crash with "Unrecognized filter operator"; with this PR they'll crash with a Calcite decorrelation message — net same outcome (failure → failure), but a different error string.

## Tests

* `:core:compileJava` — green
* `:opensearch-sql-plugin:publishToMavenLocal` — green
* `CalcitePPLExistsSubqueryIT` via `:integ-test:integTestRemote` against the analytics-engine-routed cluster — 6/19 pass, 13/19 fail with downstream result-mismatch (see verification table above)