### PR TITLE
Added UDT for IP and Binary support

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -278,19 +278,15 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
   }
 
   /**
-   * Same as {@link #convertRelDataTypeToExprType(RelDataType)} but additionally recognizes the
-   * analytics-engine {@link IpType} / {@link BinaryType} markers and returns {@link
-   * ExprCoreType#IP} / {@link ExprCoreType#BINARY} for them.
+   * Result-schema-only variant of {@link #convertRelDataTypeToExprType} that recognizes the
+   * analytics-engine {@link IpType} / {@link BinaryType} markers as {@link ExprCoreType#IP} /
+   * {@link ExprCoreType#BINARY}.
    *
-   * <p>This is intentionally <em>not</em> done in the general {@link #convertRelDataTypeToExprType}
-   * path: that function is consulted by Calcite's planner- internal type coercion, which would then
-   * call {@link #convertExprTypeToRelDataType} to generate {@code CAST(... AS ExprIPType)} casts
-   * that the analytics-engine substrait converter can't handle. Restrict the UDT recognition to the
-   * result-schema build site (currently {@code AnalyticsExecutionEngine.buildSchema}) so the
-   * planner sees plain {@code BINARY} the way it did before, while the response schema still
-   * reports {@code "type":"ip"} / {@code "type":"binary"}.
+   * <p>Kept off the general path because Calcite's planner-internal coercion would round-trip
+   * through {@link #convertExprTypeToRelDataType} and synthesize {@code CAST(... AS ExprIPType)}
+   * casts the substrait converter can't handle.
    */
-  public static ExprType convertResultColumnRelDataTypeToExprType(RelDataType type) {
+  public static ExprType convertAnalyticsEngineRelDataTypeToExprType(RelDataType type) {
     if (type instanceof IpType) {
       return IP;
     }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -46,6 +46,8 @@ import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.IpType;
 import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.calcite.type.ExprBinaryType;
 import org.opensearch.sql.calcite.type.ExprDateType;
@@ -273,6 +275,29 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
           "Unsupported conversion for Relational Data type: " + type.getSqlTypeName());
     }
     return exprType;
+  }
+
+  /**
+   * Same as {@link #convertRelDataTypeToExprType(RelDataType)} but additionally recognizes the
+   * analytics-engine {@link IpType} / {@link BinaryType} markers and returns {@link
+   * ExprCoreType#IP} / {@link ExprCoreType#BINARY} for them.
+   *
+   * <p>This is intentionally <em>not</em> done in the general {@link #convertRelDataTypeToExprType}
+   * path: that function is consulted by Calcite's planner- internal type coercion, which would then
+   * call {@link #convertExprTypeToRelDataType} to generate {@code CAST(... AS ExprIPType)} casts
+   * that the analytics-engine substrait converter can't handle. Restrict the UDT recognition to the
+   * result-schema build site (currently {@code AnalyticsExecutionEngine.buildSchema}) so the
+   * planner sees plain {@code BINARY} the way it did before, while the response schema still
+   * reports {@code "type":"ip"} / {@code "type":"binary"}.
+   */
+  public static ExprType convertResultColumnRelDataTypeToExprType(RelDataType type) {
+    if (type instanceof IpType) {
+      return IP;
+    }
+    if (type instanceof BinaryType) {
+      return BINARY;
+    }
+    return convertRelDataTypeToExprType(type);
   }
 
   public static ExprValue getExprValueByExprType(ExprType type, Object value) {

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -5,7 +5,10 @@
 
 package org.opensearch.sql.executor.analytics;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +17,9 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.IpType;
+import org.opensearch.common.network.InetAddresses;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.ast.statement.ExplainMode;
 import org.opensearch.sql.calcite.CalcitePlanContext;
@@ -123,13 +129,46 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     for (Object[] row : rows) {
       Map<String, ExprValue> valueMap = new LinkedHashMap<>();
       for (int i = 0; i < fields.size(); i++) {
-        String columnName = fields.get(i).getName();
+        RelDataTypeField field = fields.get(i);
         Object value = (i < row.length) ? row[i] : null;
-        valueMap.put(columnName, ExprValueUtils.fromObjectValue(value));
+        valueMap.put(field.getName(), toExprValue(value, field.getType()));
       }
       results.add(ExprTupleValue.fromExprValueMap(valueMap));
     }
     return results;
+  }
+
+  /**
+   * Converts a single result cell to an {@link ExprValue}, dispatching on the column's UDT when
+   * present so {@code byte[]} payloads are rendered correctly:
+   *
+   * <ul>
+   *   <li>{@link IpType} + {@code byte[]} &rarr; canonical address string (matches {@code
+   *       IpFieldMapper}'s {@code valueFetcher} output).
+   *   <li>{@link BinaryType} + {@code byte[]} &rarr; base64-encoded string (matches the OpenSearch
+   *       {@code binary} field wire format).
+   *   <li>Anything else &rarr; existing {@link ExprValueUtils#fromObjectValue} path.
+   * </ul>
+   *
+   * <p>Without this dispatch, {@code fromObjectValue} throws {@code unsupported object class [B} on
+   * byte[] cells, and IP buffers leak through as raw 16-byte ipv4-mapped-ipv6 garbage.
+   */
+  private static ExprValue toExprValue(Object value, RelDataType type) {
+    if (value instanceof byte[] bytes) {
+      if (type instanceof IpType) {
+        try {
+          return ExprValueUtils.stringValue(
+              InetAddresses.toAddrString(InetAddress.getByAddress(bytes)));
+        } catch (UnknownHostException e) {
+          // Defensive: backend gave us a buffer that isn't 4 or 16 bytes. Fall through to
+          // the default handling so the user sees a clear error rather than a malformed
+          // address string.
+        }
+      } else if (type instanceof BinaryType) {
+        return ExprValueUtils.stringValue(Base64.getEncoder().encodeToString(bytes));
+      }
+    }
+    return ExprValueUtils.fromObjectValue(value);
   }
 
   private Schema buildSchema(List<RelDataTypeField> fields) {
@@ -143,7 +182,10 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
 
   private ExprType convertType(RelDataType type) {
     try {
-      return OpenSearchTypeFactory.convertRelDataTypeToExprType(type);
+      // Use the result-column variant so the response schema reports `ip` / `binary` for
+      // analytics-engine UDTs, while the planner's coercion path keeps using the basic
+      // {@link OpenSearchTypeFactory#convertRelDataTypeToExprType} that maps VARBINARY → BINARY.
+      return OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(type);
     } catch (IllegalArgumentException e) {
       return org.opensearch.sql.data.type.ExprCoreType.UNKNOWN;
     }

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -160,9 +160,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
           return ExprValueUtils.stringValue(
               InetAddresses.toAddrString(InetAddress.getByAddress(bytes)));
         } catch (UnknownHostException e) {
-          // Defensive: backend gave us a buffer that isn't 4 or 16 bytes. Fall through to
-          // the default handling so the user sees a clear error rather than a malformed
-          // address string.
+          throw new IllegalStateException("invalid IP buffer length: " + bytes.length, e);
         }
       } else if (type instanceof BinaryType) {
         return ExprValueUtils.stringValue(Base64.getEncoder().encodeToString(bytes));
@@ -182,10 +180,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
 
   private ExprType convertType(RelDataType type) {
     try {
-      // Use the result-column variant so the response schema reports `ip` / `binary` for
-      // analytics-engine UDTs, while the planner's coercion path keeps using the basic
-      // {@link OpenSearchTypeFactory#convertRelDataTypeToExprType} that maps VARBINARY → BINARY.
-      return OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(type);
+      return OpenSearchTypeFactory.convertAnalyticsEngineRelDataTypeToExprType(type);
     } catch (IllegalArgumentException e) {
       return org.opensearch.sql.data.type.ExprCoreType.UNKNOWN;
     }

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -270,7 +270,6 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.YEAR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.YEARWEEK;
 
 import com.google.common.collect.ImmutableMap;
-import inet.ipaddr.IPAddress;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -285,7 +284,6 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
-import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexLambda;
@@ -315,10 +313,8 @@ import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
-import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.sql.expression.function.CollectionUDF.MVIndexFunctionImp;
-import org.opensearch.sql.utils.IPUtils;
 
 public class PPLFuncImpTable {
   private static final Logger logger = LogManager.getLogger(PPLFuncImpTable.class);
@@ -913,29 +909,18 @@ public class PPLFuncImpTable {
       registerDivideFunction(DIVIDE);
       registerDivideFunction(DIVIDEFUNCTION);
       registerOperator(SHA2, PPLBuiltinOperators.SHA2);
+      // CIDRMATCH typecheck-only registration. The runtime UDF (CidrMatchFunction)
+      // accepts (IP, STRING) and (STRING, STRING); the second register(...) below
+      // adds (BINARY, STRING) so calls against ip/binary columns (VARBINARY in the
+      // analytics-engine schema) typecheck and survive. The actual dispatch — literal
+      // const-fold and byte-range rewrite — happens downstream in
+      // analytics-backend-datafusion's CidrMatchFunctionAdapter, which runs in the
+      // analytics-engine plan walk and intercepts the call before Substrait conversion.
       registerOperator(CIDRMATCH, PPLBuiltinOperators.CIDRMATCH);
-      // (VARBINARY, VARCHAR) overload for ip / binary columns. The lambda parses the cidr
-      // literal at plan time and emits AND(col >= low, col <= high) directly.
-      // Only literal cidrs are expanded.
       register(
           CIDRMATCH,
           (FunctionImp2)
-              (builder, col, cidr) -> {
-                if (cidr instanceof RexLiteral lit
-                    && col.getType().getSqlTypeName() == SqlTypeName.VARBINARY) {
-                  byte[][] range = parseCidrToIpv6Range(lit.getValueAs(String.class));
-                  RelDataType varbinary =
-                      builder.getTypeFactory().createSqlType(SqlTypeName.VARBINARY);
-                  RexNode low = builder.makeLiteral(new ByteString(range[0]), varbinary, false);
-                  RexNode high = builder.makeLiteral(new ByteString(range[1]), varbinary, false);
-                  // makeCall(AND, ...) auto-flattens at construction, so no Filter.isFlat issue.
-                  return builder.makeCall(
-                      SqlStdOperatorTable.AND,
-                      builder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, col, low),
-                      builder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, col, high));
-                }
-                return builder.makeCall(PPLBuiltinOperators.CIDRMATCH, col, cidr);
-              },
+              (builder, col, cidr) -> builder.makeCall(PPLBuiltinOperators.CIDRMATCH, col, cidr),
           PPLTypeChecker.family(SqlTypeFamily.BINARY, SqlTypeFamily.STRING));
       registerOperator(INTERNAL_GROK, PPLBuiltinOperators.GROK);
       registerOperator(INTERNAL_PARSE, PPLBuiltinOperators.PARSE);
@@ -1626,23 +1611,5 @@ public class PPLFuncImpTable {
       return udfOperandMetadata.getInnerTypeChecker();
     }
     return typeChecker;
-  }
-
-  /**
-   * Parses a CIDR string and returns its lower and upper bounds in canonical 16-byte IPv6-mapped
-   * form. Used by the (BINARY, STRING) {@code cidrmatch} overload to expand into a byte-range
-   * conjunction at plan time.
-   *
-   * <p>Delegates to {@link IPUtils#toRange(String)} for parsing; converts both bounds to IPv6 to
-   * guarantee 16-byte output regardless of whether the input cidr is IPv4 or IPv6.
-   */
-  private static byte[][] parseCidrToIpv6Range(String cidr) {
-    if (cidr == null) {
-      throw new SemanticCheckException("cidrmatch range argument is null");
-    }
-    IPAddress range = IPUtils.toRange(cidr);
-    byte[] low = range.getLower().toIPv6().getBytes();
-    byte[] high = range.getUpper().toIPv6().getBytes();
-    return new byte[][] {low, high};
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -909,19 +909,7 @@ public class PPLFuncImpTable {
       registerDivideFunction(DIVIDE);
       registerDivideFunction(DIVIDEFUNCTION);
       registerOperator(SHA2, PPLBuiltinOperators.SHA2);
-      // CIDRMATCH typecheck-only registration. The runtime UDF (CidrMatchFunction)
-      // accepts (IP, STRING) and (STRING, STRING); the second register(...) below
-      // adds (BINARY, STRING) so calls against ip/binary columns (VARBINARY in the
-      // analytics-engine schema) typecheck and survive. The actual dispatch — literal
-      // const-fold and byte-range rewrite — happens downstream in
-      // analytics-backend-datafusion's CidrMatchFunctionAdapter, which runs in the
-      // analytics-engine plan walk and intercepts the call before Substrait conversion.
       registerOperator(CIDRMATCH, PPLBuiltinOperators.CIDRMATCH);
-      register(
-          CIDRMATCH,
-          (FunctionImp2)
-              (builder, col, cidr) -> builder.makeCall(PPLBuiltinOperators.CIDRMATCH, col, cidr),
-          PPLTypeChecker.family(SqlTypeFamily.BINARY, SqlTypeFamily.STRING));
       registerOperator(INTERNAL_GROK, PPLBuiltinOperators.GROK);
       registerOperator(INTERNAL_PARSE, PPLBuiltinOperators.PARSE);
       registerOperator(MATCH, PPLBuiltinOperators.MATCH);

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/CidrMatchFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/CidrMatchFunction.java
@@ -30,6 +30,9 @@ import org.opensearch.sql.expression.ip.IPFunctions;
  * <ul>
  *   <li>(STRING, STRING) -> BOOLEAN
  *   <li>(IP, STRING) -> BOOLEAN
+ *   <li>(BINARY, STRING) -> BOOLEAN — accepts VARBINARY-backed ip columns in the
+ *       analytics-engine schema; the backend's CidrMatchFunctionAdapter rewrites
+ *       these before they reach DataFusion.
  * </ul>
  */
 public class CidrMatchFunction extends ImplementorUDF {
@@ -50,7 +53,8 @@ public class CidrMatchFunction extends ImplementorUDF {
     return UDFOperandMetadata.wrapUDT(
         List.of(
             List.of(ExprCoreType.IP, ExprCoreType.STRING),
-            List.of(ExprCoreType.STRING, ExprCoreType.STRING)));
+            List.of(ExprCoreType.STRING, ExprCoreType.STRING),
+            List.of(ExprCoreType.BINARY, ExprCoreType.STRING)));
   }
 
   public static class CidrMatchImplementor implements NotNullImplementor {

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/CidrMatchFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/CidrMatchFunction.java
@@ -30,9 +30,8 @@ import org.opensearch.sql.expression.ip.IPFunctions;
  * <ul>
  *   <li>(STRING, STRING) -> BOOLEAN
  *   <li>(IP, STRING) -> BOOLEAN
- *   <li>(BINARY, STRING) -> BOOLEAN — accepts VARBINARY-backed ip columns in the
- *       analytics-engine schema; the backend's CidrMatchFunctionAdapter rewrites
- *       these before they reach DataFusion.
+ *   <li>(BINARY, STRING) -> BOOLEAN — accepts VARBINARY-backed ip columns in the analytics-engine
+ *       schema; the backend's CidrMatchFunctionAdapter rewrites these before they reach DataFusion.
  * </ul>
  */
 public class CidrMatchFunction extends ImplementorUDF {

--- a/core/src/test/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactoryTest.java
+++ b/core/src/test/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactoryTest.java
@@ -16,9 +16,12 @@ import java.util.List;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
+import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.IpType;
 import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
 
 public class OpenSearchTypeFactoryTest {
 
@@ -281,5 +284,60 @@ public class OpenSearchTypeFactoryTest {
     assertNotNull(result);
     assertEquals(SqlTypeName.VARBINARY, result.getSqlTypeName());
     assertTrue(result.isNullable());
+  }
+
+  // ---------- convertResultColumnRelDataTypeToExprType ----------
+  //
+  // The result-column variant is the one called from
+  // {@code AnalyticsExecutionEngine.buildSchema} so the response reports
+  // {@code "type": "ip"} / {@code "binary"} for projected analytics-engine UDTs.
+  // It must add UDT recognition without disturbing the planner-internal
+  // {@link OpenSearchTypeFactory#convertRelDataTypeToExprType} path that
+  // Calcite's coercion machinery uses (a previous attempt to merge them broke
+  // {@code where host = '1.2.3.4'} with synthetic {@code IP(string)} casts).
+
+  @Test
+  public void testConvertResultColumnIpTypeReturnsIpExprType() {
+    ExprType result =
+        OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(new IpType(true));
+    assertEquals(ExprCoreType.IP, result);
+  }
+
+  @Test
+  public void testConvertResultColumnBinaryTypeReturnsBinaryExprType() {
+    ExprType result =
+        OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(new BinaryType(true));
+    assertEquals(ExprCoreType.BINARY, result);
+  }
+
+  @Test
+  public void testConvertResultColumnPlainVarbinaryFallsBackToBinary() {
+    // Plain VARBINARY (no UDT marker) must keep returning BINARY ExprType — verifies
+    // the new function delegates to the original convertRelDataTypeToExprType for
+    // non-UDT inputs rather than diverging.
+    RelDataType varbinary = TYPE_FACTORY.createSqlType(SqlTypeName.VARBINARY);
+    ExprType result = OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(varbinary);
+    assertEquals(ExprCoreType.BINARY, result);
+  }
+
+  @Test
+  public void testConvertResultColumnDelegatesParityForNonUdtTypes() {
+    // For every non-UDT RelDataType the result-column variant must produce the
+    // same ExprType as the planner-internal variant. Drift here would mean the
+    // response schema labels diverge from what Calcite's coercion sees.
+    RelDataType[] samples =
+        new RelDataType[] {
+          TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT),
+          TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR),
+          TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN),
+          TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE),
+          TYPE_FACTORY.createSqlType(SqlTypeName.TIMESTAMP),
+        };
+    for (RelDataType t : samples) {
+      assertEquals(
+          OpenSearchTypeFactory.convertRelDataTypeToExprType(t),
+          OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(t),
+          "Result-column variant must agree with the general variant for " + t.getSqlTypeName());
+    }
   }
 }

--- a/core/src/test/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactoryTest.java
+++ b/core/src/test/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactoryTest.java
@@ -286,45 +286,35 @@ public class OpenSearchTypeFactoryTest {
     assertTrue(result.isNullable());
   }
 
-  // ---------- convertResultColumnRelDataTypeToExprType ----------
-  //
-  // The result-column variant is the one called from
-  // {@code AnalyticsExecutionEngine.buildSchema} so the response reports
-  // {@code "type": "ip"} / {@code "binary"} for projected analytics-engine UDTs.
-  // It must add UDT recognition without disturbing the planner-internal
-  // {@link OpenSearchTypeFactory#convertRelDataTypeToExprType} path that
-  // Calcite's coercion machinery uses (a previous attempt to merge them broke
-  // {@code where host = '1.2.3.4'} with synthetic {@code IP(string)} casts).
+  // ---------- convertAnalyticsEngineRelDataTypeToExprType ----------
+  // UDT-aware variant for the response-schema path. Must agree with the
+  // planner-internal convertRelDataTypeToExprType on every non-UDT input.
 
   @Test
-  public void testConvertResultColumnIpTypeReturnsIpExprType() {
+  public void testConvertAnalyticsEngineIpTypeReturnsIpExprType() {
     ExprType result =
-        OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(new IpType(true));
+        OpenSearchTypeFactory.convertAnalyticsEngineRelDataTypeToExprType(new IpType(true));
     assertEquals(ExprCoreType.IP, result);
   }
 
   @Test
-  public void testConvertResultColumnBinaryTypeReturnsBinaryExprType() {
+  public void testConvertAnalyticsEngineBinaryTypeReturnsBinaryExprType() {
     ExprType result =
-        OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(new BinaryType(true));
+        OpenSearchTypeFactory.convertAnalyticsEngineRelDataTypeToExprType(new BinaryType(true));
     assertEquals(ExprCoreType.BINARY, result);
   }
 
   @Test
-  public void testConvertResultColumnPlainVarbinaryFallsBackToBinary() {
-    // Plain VARBINARY (no UDT marker) must keep returning BINARY ExprType — verifies
-    // the new function delegates to the original convertRelDataTypeToExprType for
-    // non-UDT inputs rather than diverging.
+  public void testConvertAnalyticsEnginePlainVarbinaryFallsBackToBinary() {
+    // Plain VARBINARY (no UDT) must still resolve to BINARY via the delegated path.
     RelDataType varbinary = TYPE_FACTORY.createSqlType(SqlTypeName.VARBINARY);
-    ExprType result = OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(varbinary);
+    ExprType result = OpenSearchTypeFactory.convertAnalyticsEngineRelDataTypeToExprType(varbinary);
     assertEquals(ExprCoreType.BINARY, result);
   }
 
   @Test
-  public void testConvertResultColumnDelegatesParityForNonUdtTypes() {
-    // For every non-UDT RelDataType the result-column variant must produce the
-    // same ExprType as the planner-internal variant. Drift here would mean the
-    // response schema labels diverge from what Calcite's coercion sees.
+  public void testConvertAnalyticsEngineDelegatesParityForNonUdtTypes() {
+    // Parity check: drift would mean response-schema labels diverge from Calcite's view.
     RelDataType[] samples =
         new RelDataType[] {
           TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT),
@@ -336,8 +326,8 @@ public class OpenSearchTypeFactoryTest {
     for (RelDataType t : samples) {
       assertEquals(
           OpenSearchTypeFactory.convertRelDataTypeToExprType(t),
-          OpenSearchTypeFactory.convertResultColumnRelDataTypeToExprType(t),
-          "Result-column variant must agree with the general variant for " + t.getSqlTypeName());
+          OpenSearchTypeFactory.convertAnalyticsEngineRelDataTypeToExprType(t),
+          "Analytics-engine variant must agree with the general variant for " + t.getSqlTypeName());
     }
   }
 }

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -28,6 +28,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.IpType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.SysLimit;
@@ -179,6 +181,67 @@ class AnalyticsExecutionEngineTest {
 
   // Query size limit is now enforced in the RelNode plan (LogicalSystemLimit) before it reaches
   // AnalyticsExecutionEngine. The engine trusts the executor to honor the limit.
+
+  /**
+   * IP columns ship from the analytics-engine backend as raw 16-byte ipv6-mapped buffers. {@code
+   * AnalyticsExecutionEngine.toExprValue} must format them as canonical IP strings (matching {@code
+   * InetAddresses.toAddrString}) and the schema must report {@code "type": "ip"} via the {@code
+   * IpType} UDT recognition path.
+   */
+  @Test
+  void executeRelNode_ipColumnRendersAsAddressString() {
+    RelNode relNode = mockRelNodeWithType("host", new IpType(true));
+    // 1.2.3.4 in ipv4-mapped-ipv6 form: 10 zero bytes + ff ff + 4 IPv4 bytes.
+    byte[] ipv4 = new byte[16];
+    ipv4[10] = (byte) 0xff;
+    ipv4[11] = (byte) 0xff;
+    ipv4[12] = 1;
+    ipv4[13] = 2;
+    ipv4[14] = 3;
+    ipv4[15] = 4;
+    // ::1 in pure ipv6 form.
+    byte[] ipv6 = new byte[16];
+    ipv6[15] = 1;
+    Iterable<Object[]> rows = Arrays.asList(new Object[] {ipv4}, new Object[] {ipv6});
+    stubExecutorWith(relNode, rows);
+
+    QueryResponse response = executeAndCapture(relNode);
+    String dump = dumpResponse(response);
+
+    // Schema: column reports "ip", not "binary".
+    assertEquals(ExprCoreType.IP, response.getSchema().getColumns().get(0).getExprType(), dump);
+    // Cells: byte[] → formatted address string.
+    assertEquals(
+        "1.2.3.4",
+        response.getResults().get(0).tupleValue().get("host").value(),
+        "ipv4-mapped IPv6 buffer should render as dotted quad. " + dump);
+    assertEquals(
+        "::1",
+        response.getResults().get(1).tupleValue().get("host").value(),
+        "pure IPv6 buffer should render as RFC 5952 compressed form. " + dump);
+  }
+
+  /**
+   * Binary columns ship from the analytics-engine backend as raw byte buffers. The dispatch must
+   * base64-encode them (matching the OpenSearch {@code binary} field wire contract) and the schema
+   * must report {@code "type": "binary"} via the {@code BinaryType} UDT recognition path.
+   */
+  @Test
+  void executeRelNode_binaryColumnRendersAsBase64() {
+    RelNode relNode = mockRelNodeWithType("blob", new BinaryType(true));
+    Iterable<Object[]> rows =
+        Collections.singletonList(new Object[] {"Some binary blob".getBytes()});
+    stubExecutorWith(relNode, rows);
+
+    QueryResponse response = executeAndCapture(relNode);
+    String dump = dumpResponse(response);
+
+    assertEquals(ExprCoreType.BINARY, response.getSchema().getColumns().get(0).getExprType(), dump);
+    assertEquals(
+        "U29tZSBiaW5hcnkgYmxvYg==",
+        response.getResults().get(0).tupleValue().get("blob").value(),
+        "byte[] should base64-encode to match OpenSearch binary wire format. " + dump);
+  }
 
   @Test
   void executeRelNode_emptyResults() {
@@ -374,6 +437,20 @@ class AnalyticsExecutionEngineTest {
       builder.add(name, typeName);
     }
     RelDataType rowType = builder.build();
+
+    RelNode relNode = mock(RelNode.class);
+    when(relNode.getRowType()).thenReturn(rowType);
+    return relNode;
+  }
+
+  /**
+   * Same shape as {@link #mockRelNode} but accepts a fully-built {@link RelDataType} per column, so
+   * callers can pass analytics-engine UDTs ({@link IpType}, {@link BinaryType}) — those don't have
+   * a matching {@link SqlTypeName} the type factory can construct.
+   */
+  private RelNode mockRelNodeWithType(String name, RelDataType type) {
+    SqlTypeFactoryImpl typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataType rowType = typeFactory.builder().add(name, type).build();
 
     RelNode relNode = mock(RelNode.class);
     when(relNode.getRowType()).thenReturn(rowType);

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -182,12 +182,7 @@ class AnalyticsExecutionEngineTest {
   // Query size limit is now enforced in the RelNode plan (LogicalSystemLimit) before it reaches
   // AnalyticsExecutionEngine. The engine trusts the executor to honor the limit.
 
-  /**
-   * IP columns ship from the analytics-engine backend as raw 16-byte ipv6-mapped buffers. {@code
-   * AnalyticsExecutionEngine.toExprValue} must format them as canonical IP strings (matching {@code
-   * InetAddresses.toAddrString}) and the schema must report {@code "type": "ip"} via the {@code
-   * IpType} UDT recognition path.
-   */
+  /** Raw 16-byte ipv6-mapped buffer + IpType → canonical IP string + schema reports "ip". */
   @Test
   void executeRelNode_ipColumnRendersAsAddressString() {
     RelNode relNode = mockRelNodeWithType("host", new IpType(true));
@@ -221,11 +216,7 @@ class AnalyticsExecutionEngineTest {
         "pure IPv6 buffer should render as RFC 5952 compressed form. " + dump);
   }
 
-  /**
-   * Binary columns ship from the analytics-engine backend as raw byte buffers. The dispatch must
-   * base64-encode them (matching the OpenSearch {@code binary} field wire contract) and the schema
-   * must report {@code "type": "binary"} via the {@code BinaryType} UDT recognition path.
-   */
+  /** Raw byte buffer + BinaryType → base64 string + schema reports "binary". */
   @Test
   void executeRelNode_binaryColumnRendersAsBase64() {
     RelNode relNode = mockRelNodeWithType("blob", new BinaryType(true));
@@ -443,11 +434,7 @@ class AnalyticsExecutionEngineTest {
     return relNode;
   }
 
-  /**
-   * Same shape as {@link #mockRelNode} but accepts a fully-built {@link RelDataType} per column, so
-   * callers can pass analytics-engine UDTs ({@link IpType}, {@link BinaryType}) — those don't have
-   * a matching {@link SqlTypeName} the type factory can construct.
-   */
+  /** Variant of {@link #mockRelNode} that accepts a pre-built RelDataType (e.g. UDTs). */
   private RelNode mockRelNodeWithType(String name, RelDataType type) {
     SqlTypeFactoryImpl typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType rowType = typeFactory.builder().add(name, type).build();


### PR DESCRIPTION
### Description

Companion change for [opensearch-project/OpenSearch#21807](https://github.com/opensearch-project/OpenSearch/pull/21807) which adds Calcite UDTs (`IpType`, `BinaryType`) for OpenSearch `ip` and `binary` columns to the analytics-engine path. This PR teaches the SQL plugin to recognize the new UDTs at the response-schema boundary so:

- `byte[]` cells from the analytics backend get rendered as canonical IP strings / base64 strings (was: `unsupported object class [B`).
- The response schema reports `"type": "ip"` / `"type": "binary"` correctly (was: both labelled `"binary"`).
- Existing comparison and `CIDRMATCH` query shapes keep working unchanged — the UDT is invisible to Calcite's planner-internal coercion machinery.

#### Background

`OpenSearchSchemaBuilder` (in the OpenSearch sandbox) used to map both `ip` and `binary` field types to plain `SqlTypeName.VARBINARY`. That collapse caused three downstream bugs in this plugin's PPL path through the analytics engine:

1. The DataFusion backend ships back a 16-byte ipv4-mapped-ipv6 buffer; `AnalyticsExecutionEngine.convertRows` calls `ExprValueUtils.fromObjectValue(byte[])` which has no `byte[]` case → `unsupported object class [B`.
2. The response schema reports `"type": "binary"` for an IP column (because `convertRelDataTypeToExprType(VARBINARY) → BINARY` ExprType).
3. CIDRMATCH against a column was registered with `PPLTypeChecker.family(SqlTypeFamily.BINARY, SqlTypeFamily.STRING)`, with the byte-range expansion living inline at the registration site.

The companion OpenSearch PR introduces `IpType` / `BinaryType` (Calcite UDTs that extend `AbstractSqlType` with `VARBINARY` underneath) and moves CIDRMATCH dispatch into a backend `ScalarFunctionAdapter`.

#### Approach

Two response-boundary changes plus one cleanup, all minimal:

**1. Result-column UDT recognition (`OpenSearchTypeFactory`).**
New sibling function `convertAnalyticsEngineRelDataTypeToExprType` does an `instanceof` dispatch:
```java
if (type instanceof IpType) return IP;
if (type instanceof BinaryType) return BINARY;
return convertRelDataTypeToExprType(type);
```
The original `convertRelDataTypeToExprType` is **deliberately unchanged** — Calcite's coercion machinery round-trips through it, so returning `IP` ExprType for a VARBINARY column synthesizes `IP(string)` casts that DataFusion can't resolve. Keeping UDT recognition in a sibling function isolates it to the response-schema path.

**2. Per-column UDT dispatch in row conversion (`AnalyticsExecutionEngine.convertRows`).**
New static helper `toExprValue(Object value, RelDataType type)`:
- `byte[]` + `IpType` → `InetAddresses.toAddrString(InetAddress.getByAddress(bytes))` (matches `IpFieldMapper.valueFetcher` semantics: dotted-quad for IPv4 / IPv4-mapped, RFC 5952 for pure IPv6).
- `byte[]` + `BinaryType` → `Base64.getEncoder().encodeToString(bytes)` (matches the OpenSearch `binary` field wire contract).
- Otherwise → `ExprValueUtils.fromObjectValue(value)` unchanged.

`UnknownHostException` from a malformed IP buffer falls through to the default handler so the user sees a clear error rather than a malformed address string.

**3. CIDRMATCH cleanup (`PPLFuncImpTable`).**
- Removes `udf/ip/CidrMatchAdapter` and its inline registration. CIDRMATCH dispatch now lives in `CidrMatchFunctionAdapter` on the backend (in the companion OpenSearch PR), which means it serves both the production SQL-plugin variant and the sandbox test front-end with a single implementation.
- Collapses the two-line registration (typecheck + `withRexBuilderShim`) to a single typecheck-only `registerOperator(CIDRMATCH, PPLBuiltinOperators.CIDRMATCH)`.
- The runtime `CidrMatchFunction` UDF stays as the dynamic last-resort fallback.

### Testing

**Unit tests added:**
- `OpenSearchTypeFactoryTest`:
  - `testConvertResultColumnIpTypeReturnsIpExprType` — `IpType` → `ExprCoreType.IP`.
  - `testConvertResultColumnBinaryTypeReturnsBinaryExprType` — `BinaryType` → `ExprCoreType.BINARY`.
  - `testConvertResultColumnPlainVarbinaryFallsBackToBinary` — plain `VARBINARY` (no UDT) keeps returning `BINARY`.
  - `testConvertResultColumnDelegatesParityForNonUdtTypes` — for every non-UDT `RelDataType`, the result-column variant must agree with the planner-internal variant. Drift here would mean response-schema labels diverge from what Calcite's coercion sees.

- `AnalyticsExecutionEngineTest`:
  - `executeRelNode_ipColumnRendersAsAddressString` — both ipv4-mapped IPv6 (`::ffff:1.2.3.4` → `"1.2.3.4"`) and pure IPv6 (`::1`) buffers render to the right canonical form, schema reports `"ip"`.
  - `executeRelNode_binaryColumnRendersAsBase64` — `byte[]` payload base64-encodes to match OpenSearch wire format, schema reports `"binary"`.

Existing tests still pass. `[B`-class regression caught at: `physicalPlanExecute_callsOnFailure` (already in the file, exercises the same converter dispatch).

**End-to-end** (against a single-node `gradle run` cluster with the companion OpenSearch PR applied):
- `cast(host as STRING)` returns `"1.2.3.4"` / `"::1"` (was a 16-byte garbage buffer).
- `cast(blob as STRING)` matches `| fields blob` (base64-encoded).
- `where host = '1.2.3.4'` coerces cleanly with no `Unable to convert call IP(string)` regression.
- `cidrmatch(host, '1.2.3.0/24')` (column form) and `CIDRMATCH('1.2.3.4', '1.2.3.0/24')` (literal form) both return correct row counts via the backend adapter.
- Response schema labels: `"type": "ip"` for `ip` columns, `"type": "binary"` for `binary` columns.

