### PR TITLE
Improve exception handling in `UnifiedQueryPlanner`

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -19,10 +19,14 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.util.SqlVisitor;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.sql.api.parser.UnifiedQueryParser;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.exception.QueryEngineException;
+import org.opensearch.sql.exception.SemanticCheckException;
 
 /**
  * {@code UnifiedQueryPlanner} provides a high-level API for parsing and analyzing queries using the
@@ -30,6 +34,8 @@ import org.opensearch.sql.common.antlr.SyntaxCheckException;
  * such as Spark or command-line tools, abstracting away Calcite internals.
  */
 public class UnifiedQueryPlanner {
+
+  private static final Logger LOG = LogManager.getLogger(UnifiedQueryPlanner.class);
 
   /** Planning strategy selected at construction time based on query type. */
   private final PlanningStrategy strategy;
@@ -65,10 +71,21 @@ public class UnifiedQueryPlanner {
             }
             return plan;
           });
-    } catch (SyntaxCheckException | UnsupportedOperationException e) {
+    } catch (SyntaxCheckException
+        | QueryEngineException
+        | UnsupportedOperationException
+        | IllegalArgumentException e) {
+      LOG.error("Failed to plan query: {}", e.getMessage());
       throw e;
+    } catch (AssertionError e) {
+      // Calcite throws assertion error directly when building bad RelNode
+      String message = "Failed to plan query: invalid plan structure";
+      LOG.error(message, e);
+      throw new SemanticCheckException(message, e);
     } catch (Exception e) {
-      throw new IllegalStateException("Failed to plan query", e);
+      String message = "Failed to plan query: unexpected error";
+      LOG.error(message, e);
+      throw new IllegalStateException(message, e);
     }
   }
 

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
@@ -14,6 +14,7 @@ import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.junit.Test;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.executor.QueryType;
 
 public class UnifiedQueryPlannerTest extends UnifiedQueryTestBase {
@@ -114,5 +115,33 @@ public class UnifiedQueryPlannerTest extends UnifiedQueryTestBase {
   @Test(expected = SyntaxCheckException.class)
   public void testPlanPropagatingSyntaxCheckException() {
     planner.plan("source = catalog.employees | eval"); // Trigger syntax error from parser
+  }
+
+  @Test
+  public void syntaxErrorIsRethrownAsSyntaxCheckException() {
+    givenInvalidQuery("INVALID +++")
+        .assertErrorType(SyntaxCheckException.class)
+        .assertErrorMessageContains("is not a valid term");
+  }
+
+  @Test
+  public void semanticErrorIsRethrownAsSemanticCheckException() {
+    givenInvalidQuery("source = catalog.employees | rename id* as x*y*")
+        .assertErrorType(SemanticCheckException.class)
+        .assertErrorMessageEquals("Source and target patterns have different wildcard counts");
+  }
+
+  @Test
+  public void assertionErrorIsWrappedAsSemanticCheckException() {
+    // Remove when the underlying Calcite assertion is fixed.
+    givenInvalidQuery(
+            """
+            source = catalog.employees
+            | eval ts = timestamp('2024-01-01')
+            | stats max(ts)
+            """)
+        .assertErrorType(SemanticCheckException.class)
+        .assertErrorMessageEquals("Failed to plan query: invalid plan structure")
+        .assertCauseType(AssertionError.class);
   }
 }

--- a/api/src/testFixtures/java/org/opensearch/sql/api/QueryPlanAssertion.java
+++ b/api/src/testFixtures/java/org/opensearch/sql/api/QueryPlanAssertion.java
@@ -118,5 +118,40 @@ public interface QueryPlanAssertion {
           "Expected error to contain: " + expected + "\nActual: " + msg, msg.contains(expected));
       return this;
     }
+
+    /** Assert the outer error type matches the expected class. */
+    public QueryErrorAssert assertErrorType(Class<? extends Throwable> expected) {
+      assertTrue(
+          "Expected " + expected.getSimpleName() + " but got " + error.getClass().getSimpleName(),
+          expected.isInstance(error));
+      return this;
+    }
+
+    /** Assert the outer error message exactly matches expected. */
+    public QueryErrorAssert assertErrorMessageEquals(String expected) {
+      assertEquals(expected, error.getMessage());
+      return this;
+    }
+
+    /** Assert the outer error message contains the expected substring. */
+    public QueryErrorAssert assertErrorMessageContains(String substring) {
+      String msg = error.getMessage();
+      assertTrue(
+          "Expected message to contain '" + substring + "' but was: " + msg,
+          msg != null && msg.contains(substring));
+      return this;
+    }
+
+    /** Assert the immediate cause is of the expected type. */
+    public QueryErrorAssert assertCauseType(Class<? extends Throwable> expected) {
+      assertNotNull("Expected a cause but was null", error.getCause());
+      assertTrue(
+          "Expected cause "
+              + expected.getSimpleName()
+              + " but got "
+              + error.getCause().getClass().getSimpleName(),
+          expected.isInstance(error.getCause()));
+      return this;
+    }
   }
 }


### PR DESCRIPTION
### Description

Tighten exception handling, improve error classification, and add structured logging in `UnifiedQueryPlanner.plan()`.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5246 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
