### PR TITLE
Register DISTINCT_COUNT_APPROX logical marker in PPLFuncImpTable

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/DistinctCountApproxLogicalAggFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/DistinctCountApproxLogicalAggFunction.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.udf.udaf;
+
+import org.opensearch.sql.calcite.udf.UserDefinedAggFunction;
+
+/**
+ * Logical marker UDAF for {@code DISTINCT_COUNT_APPROX}. Lets the PPL parser produce a RelNode that
+ * contains the operator without committing to a JVM execution path; backends are expected to push
+ * it down or rewrite it before execution:
+ *
+ * <ul>
+ *   <li>OpenSearch V3 path: {@code OpenSearchExecutionEngine#registerOpenSearchFunctions} registers
+ *       a real HyperLogLog++ implementation in {@code PPLFuncImpTable.aggExternalFunctionRegistry},
+ *       which overrides this marker (external registry has lookup precedence in {@code
+ *       getImplementation}). {@code AggregateAnalyzer} then translates the operator to OpenSearch
+ *       cardinality DSL.
+ *   <li>Unified-query / DataFusion / analytics-engine path: backend planner rewrites the RexOver to
+ *       {@code APPROX_COUNT_DISTINCT} (Calcite stdop) before substrait emission; the DataFusion
+ *       substrait reader consumes that natively.
+ * </ul>
+ *
+ * <p>This class deliberately throws on every method. Reaching a method body means a backend either
+ * failed to push down or did not register an adapter — that is a configuration bug, not a runtime
+ * fallback. {@code RelevanceQueryFunction.RelevanceQueryImplementor} (used by {@code match}, {@code
+ * match_phrase}, etc.) follows the same pattern for relevance search functions that have no JVM
+ * execution semantics.
+ */
+public class DistinctCountApproxLogicalAggFunction
+    implements UserDefinedAggFunction<DistinctCountApproxLogicalAggFunction.MarkerAccumulator> {
+
+  private static final String NOT_EXECUTABLE =
+      "DISTINCT_COUNT_APPROX logical marker reached Enumerable execution; "
+          + "an engine-specific implementation must be registered or rewritten before execution.";
+
+  @Override
+  public MarkerAccumulator init() {
+    throw new UnsupportedOperationException(NOT_EXECUTABLE);
+  }
+
+  @Override
+  public MarkerAccumulator add(MarkerAccumulator acc, Object... values) {
+    throw new UnsupportedOperationException(NOT_EXECUTABLE);
+  }
+
+  @Override
+  public Object result(MarkerAccumulator accumulator) {
+    throw new UnsupportedOperationException(NOT_EXECUTABLE);
+  }
+
+  /** Placeholder accumulator. Never actually constructed because {@link #init()} throws. */
+  public static class MarkerAccumulator implements Accumulator {
+    @Override
+    public Object value(Object... argList) {
+      throw new UnsupportedOperationException(NOT_EXECUTABLE);
+    }
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
 import org.apache.calcite.util.BuiltInMethod;
+import org.opensearch.sql.calcite.udf.udaf.DistinctCountApproxLogicalAggFunction;
 import org.opensearch.sql.calcite.udf.udaf.FirstAggFunction;
 import org.opensearch.sql.calcite.udf.udaf.LastAggFunction;
 import org.opensearch.sql.calcite.udf.udaf.ListAggFunction;
@@ -507,6 +508,22 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
           "VALUES",
           PPLReturnTypes.STRING_ARRAY,
           PPLOperandTypes.ANY_SCALAR_OPTIONAL_INTEGER);
+
+  /**
+   * Logical marker for {@code DISTINCT_COUNT_APPROX} (also exposed as {@code dc} and {@code
+   * distinct_count} aliases). PPL parser uses this to produce a RelNode; backends override or
+   * rewrite it before execution. {@code OpenSearchExecutionEngine} registers a real HyperLogLog++
+   * implementation in the external registry of {@code PPLFuncImpTable}, which has lookup precedence
+   * and serves the OpenSearch V3 path. Other backends (DataFusion / analytics-engine) rewrite the
+   * operator on their own. Operand metadata is {@code null} to match the existing external
+   * registration's permissive policy and avoid introducing new type rejections.
+   */
+  public static final SqlAggFunction DISTINCT_COUNT_APPROX =
+      createUserDefinedAggFunction(
+          DistinctCountApproxLogicalAggFunction.class,
+          "DISTINCT_COUNT_APPROX",
+          ReturnTypes.BIGINT_FORCE_NULLABLE,
+          null);
 
   public static final SqlOperator ENHANCED_COALESCE =
       new EnhancedCoalesceFunction().toUDF("COALESCE");

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -60,6 +60,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.DAY_OF_
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DAY_OF_WEEK;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DAY_OF_YEAR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DEGREES;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.DISTINCT_COUNT_APPROX;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DIVIDE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DIVIDEFUNCTION;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.DUR2SEC;
@@ -1426,6 +1427,13 @@ public class PPLFuncImpTable {
       registerOperator(INTERNAL_PATTERN, PPLBuiltinOperators.INTERNAL_PATTERN);
       registerOperator(LIST, PPLBuiltinOperators.LIST);
       registerOperator(VALUES, PPLBuiltinOperators.VALUES);
+      // Logical marker so PPL parser succeeds on dc()/distinct_count()/distinct_count_approx()
+      // regardless of which execution path the query takes. OpenSearchExecutionEngine registers
+      // a real HyperLogLog++ implementation in aggExternalFunctionRegistry which overrides this
+      // marker via the external-first lookup precedence in getImplementation(). Other backends
+      // (DataFusion / analytics-engine) rewrite the operator before substrait emission and never
+      // execute the marker.
+      registerOperator(DISTINCT_COUNT_APPROX, PPLBuiltinOperators.DISTINCT_COUNT_APPROX);
 
       register(
           AVG,


### PR DESCRIPTION
### Description

PPL parser fails with `Cannot resolve function: DISTINCT_COUNT_APPROX` on any execution path that does not construct `OpenSearchExecutionEngine` (unified-query / analytics-engine / DataFusion), because the UDAF was only registered to `PPLFuncImpTable.aggExternalFunctionRegistry` as a side effect of that constructor (`registerOpenSearchFunctions`).

This change adds a logical marker UDAF in `core` that lets PPL parser succeed on every path. Backends are expected to push down or rewrite the operator before execution.

#### Layered registration

- **`core` (this PR)**: register a marker `DistinctCountApproxLogicalAggFunction` in `PPLFuncImpTable.AggBuilder.populate()` via the new `PPLBuiltinOperators.DISTINCT_COUNT_APPROX`. Lookup precedence in `PPLFuncImpTable.getImplementation()` is `aggExternalFunctionRegistry` first, then `aggFunctionRegistry`.
- **`opensearch` (unchanged)**: `OpenSearchExecutionEngine.registerOpenSearchFunctions()` still installs the real `DistinctCountApproxAggFunction` (HyperLogLog++) into `aggExternalFunctionRegistry`. Because external is consulted first, the V3 path always sees the real implementation once the constructor has run, and the marker is effectively overridden.

This is the same pattern already used by `RelevanceQueryFunction.RelevanceQueryImplementor` for `match`/`match_phrase`/etc — relevance functions register a no-op operator whose `RelevanceQueryImplementor.implement()` throws `UnsupportedOperationException`, because their semantics live entirely on the OpenSearch index side. `DISTINCT_COUNT_APPROX` is in the same situation: real semantics on the OpenSearch side (cardinality aggregation) and on backends like DataFusion (`approx_count_distinct`).

#### Marker class behavior

`init` / `add` / `result` and the accumulator's `value` all throw `UnsupportedOperationException` with the message:

> DISTINCT_COUNT_APPROX logical marker reached Enumerable execution; an engine-specific implementation must be registered or rewritten before execution.

Reaching the body means a backend either failed to push down or did not register an adapter — surfacing this as a clear error rather than silently producing wrong results is the intended behavior.

#### V3 path behavior is preserved

- `AggregateAnalyzer` translates `DISTINCT_COUNT_APPROX` to OpenSearch `cardinality` aggregation through a `BuiltinFunctionName` switch, independent of the wrapped `SqlAggFunction` instance — unchanged by this PR.
- When V3 falls back to Calcite enumerable execution (push-down failed for some sub-plan), `RexImpTable.getAggImplementor` reads `SqlUserDefinedAggFunction.function`, which is the real `DistinctCountApproxAggFunction` registered by `OpenSearchExecutionEngine` (external takes precedence) — unchanged.
- Operand metadata for the marker is `null` to match the existing external registration's permissive type policy. No new type rejection is introduced.

#### How this unblocks unified-query / DataFusion path

`RestUnifiedQueryAction` does not construct `OpenSearchExecutionEngine`; before this change, `dc()` / `distinct_count()` / `distinct_count_approx()` failed at PPL parse stage on that path. After this change, the parser succeeds via the marker, and the downstream backend (e.g. analytics-engine's DataFusion adapter) rewrites `RexOver(DISTINCT_COUNT_APPROX)` to `APPROX_COUNT_DISTINCT` before substrait emission. End-to-end verified locally with the analytics-engine REST IT in the OpenSearch sandbox.

### Related Issues

<!-- file separately if needed -->

### Check List
- [x] New functionality includes testing.   <!-- existing dc IT cover the V3 path; new path verified externally in analytics-engine sandbox -->
- [ ] New functionality has been documented.
- [x] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).