### PR TITLE
Resolve SQL unified query gaps for HAVING, FROM-less SELECT, window ORDER BY

### DIFF
--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
@@ -218,4 +218,137 @@ public class UnifiedQueryPlannerSqlV2Test extends UnifiedQueryTestBase {
                 LogicalTableScan(table=[[catalog, employees]])
             """);
   }
+
+  @Test
+  public void selectLiteralWithoutFrom() {
+    // FROM-less SELECT produces a one-row result via LogicalValues so the downstream
+    // Project evaluates over a single row.
+    givenQuery("SELECT 1")
+        .assertPlan(
+            """
+            LogicalSort(sort0=[$0], dir0=[ASC])
+              LogicalValues(tuples=[[{ 1 }]])
+            """);
+  }
+
+  @Test
+  public void selectExpressionWithoutFrom() {
+    givenQuery("SELECT 1 + 1")
+        .assertPlan(
+            """
+            LogicalProject(1 + 1=[+(1, 1)])
+              LogicalValues(tuples=[[{ 0 }]])
+            """);
+  }
+
+  @Test
+  public void testHavingMaxCol() {
+    givenQuery(
+            """
+            SELECT department FROM catalog.employees
+              GROUP BY department HAVING MAX(age) > 30
+            """)
+        .assertPlan(
+            """
+            LogicalProject(department=[$1])
+              LogicalFilter(condition=[>($0, 30)])
+                LogicalProject(MAX(age)=[$1], department=[$0])
+                  LogicalAggregate(group=[{0}], MAX(age)=[MAX($1)])
+                    LogicalProject(department=[$3], age=[$2])
+                      LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testScalarFnOverAggregate() {
+    givenQuery("SELECT ABS(MAX(age)) FROM catalog.employees")
+        .assertPlan(
+            """
+            LogicalProject(ABS(MAX(age))=[ABS($0)])
+              LogicalAggregate(group=[{}], MAX(age)=[MAX($0)])
+                LogicalProject(age=[$2])
+                  LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testArithmeticOnAggregates() {
+    givenQuery("SELECT MAX(age) + MIN(age) AS range_sum FROM catalog.employees")
+        .assertPlan(
+            """
+            LogicalProject(range_sum=[+($0, $1)])
+              LogicalAggregate(group=[{}], MAX(age)=[MAX($0)], MIN(age)=[MIN($0)])
+                LogicalProject(age=[$2])
+                  LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testHavingCountStar() {
+    givenQuery(
+            """
+            SELECT department FROM catalog.employees
+              GROUP BY department HAVING COUNT(*) > 5
+            """)
+        .assertPlan(
+            """
+            LogicalProject(department=[$1])
+              LogicalFilter(condition=[>($0, 5)])
+                LogicalProject(COUNT(*)=[$1], department=[$0])
+                  LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+                    LogicalProject(department=[$3])
+                      LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testHavingWithAlias() {
+    givenQuery(
+            """
+            SELECT department, COUNT(*) AS cnt FROM catalog.employees
+              GROUP BY department HAVING cnt > 1
+            """)
+        .assertPlan(
+            """
+            LogicalProject(department=[$1], cnt=[$0])
+              LogicalFilter(condition=[>($0, 1)])
+                LogicalProject(COUNT(*)=[$1], department=[$0])
+                  LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+                    LogicalProject(department=[$3])
+                      LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testHavingCompoundAnd() {
+    givenQuery(
+            """
+            SELECT department FROM catalog.employees
+              GROUP BY department HAVING MAX(age) > 30 AND MIN(age) < 50
+            """)
+        .assertPlan(
+            """
+            LogicalProject(department=[$2])
+              LogicalFilter(condition=[AND(>($0, 30), <($1, 50))])
+                LogicalProject(MAX(age)=[$1], MIN(age)=[$2], department=[$0])
+                  LogicalAggregate(group=[{0}], MAX(age)=[MAX($1)], MIN(age)=[MIN($1)])
+                    LogicalProject(department=[$3], age=[$2])
+                      LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testWindowOrderByDefaultsNullsFirst() {
+    // Window function ORDER BY without explicit NULLS FIRST/LAST defaults to NULLS FIRST,
+    // matching top-level ORDER BY semantics.
+    givenQuery(
+            """
+            SELECT name, ROW_NUMBER() OVER (ORDER BY id) AS rn FROM catalog.employees
+            """)
+        .assertPlan(
+            """
+            LogicalProject(name=[$1], rn=[ROW_NUMBER() OVER (ORDER BY $0 NULLS FIRST)])
+              LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexLambdaRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.FrameworkConfig;
+import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.tree.HighlightConfig;
 import org.opensearch.sql.calcite.utils.CalciteToolsHelper;
@@ -63,6 +64,12 @@ public class CalcitePlanContext {
   private final Stack<List<RexNode>> windowPartitions = new Stack<>();
 
   @Getter public Map<String, RexLambdaRef> rexLambdaRefMap;
+
+  /**
+   * Maps AggregateFunction AST nodes to their output field index for HAVING/post-aggregate
+   * resolution.
+   */
+  @Getter private final Map<AggregateFunction, Integer> aggregateOutputIndex = new HashMap<>();
 
   /**
    * List of captured variables from outer scope for lambda functions. When a lambda body references

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -1748,6 +1748,23 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
       reordered.addAll(aggRexList);
     }
     context.relBuilder.project(reordered);
+
+    // Register aggregate output indices for HAVING / post-aggregate resolution. clear() is safe:
+    // V2 grammar doesn't allow subqueries that nest aggregation scopes above this point.
+    context.getAggregateOutputIndex().clear();
+    int aggStartIdx = metricsFirst ? 0 : aliasedGroupByList.size();
+    for (int i = 0; i < aggExprList.size(); i++) {
+      AggregateFunction aggFunc = extractAggregateFunction(aggExprList.get(i));
+      if (aggFunc != null) {
+        context.getAggregateOutputIndex().put(aggFunc, aggStartIdx + i);
+      }
+    }
+  }
+
+  private static AggregateFunction extractAggregateFunction(UnresolvedExpression expr) {
+    if (expr instanceof AggregateFunction af) return af;
+    if (expr instanceof Alias alias) return extractAggregateFunction(alias.getDelegated());
+    return null;
   }
 
   private Optional<UnresolvedExpression> getTimeSpanField(UnresolvedExpression expr) {
@@ -4181,10 +4198,15 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
 
   @Override
   public RelNode visitValues(Values values, CalcitePlanContext context) {
-    // Accept SQL SELECT without FROM (dual table), encoded as Values([[]]) — one row, zero columns.
     List<List<Literal>> rows = values.getValues();
-    if (rows == null || rows.isEmpty() || (rows.size() == 1 && rows.get(0).isEmpty())) {
+    if (rows == null || rows.isEmpty()) {
+      // PPL empty subsearch (e.g., `... | append [ ]`): zero rows, no columns.
       context.relBuilder.values(context.relBuilder.getTypeFactory().builder().build());
+      return context.relBuilder.peek();
+    }
+    if (rows.size() == 1 && rows.get(0).isEmpty()) {
+      // SQL FROM-less SELECT (dual table) encoded as Values([[]]): one-row relation for Project.
+      context.relBuilder.push(LogicalValues.createOneRow(context.relBuilder.getCluster()));
       return context.relBuilder.peek();
     }
     throw new CalciteUnsupportedException("Inline VALUES with literal rows is unsupported");

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -108,6 +108,17 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   }
 
   @Override
+  public RexNode visitAggregateFunction(AggregateFunction node, CalcitePlanContext context) {
+    // Resolve post-aggregate AggregateFunction via registry populated in visitAggregation.
+    Integer index = context.getAggregateOutputIndex().get(node);
+    if (index == null) {
+      throw new IllegalStateException(
+          "Aggregate function " + node + " not registered (planner bug)");
+    }
+    return context.relBuilder.field(index);
+  }
+
+  @Override
   public RexNode visitLiteral(Literal node, CalcitePlanContext context) {
     RexBuilder rexBuilder = context.rexBuilder;
     RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
@@ -652,9 +663,10 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
                 field = b.desc(field);
               }
               return switch (opt.getNullOrder()) {
-                case NULL_LAST -> b.nullsLast(field);
+                // Unspecified NULLS defaults to NULLS FIRST, matching top-level ORDER BY.
+                case null -> b.nullsFirst(field);
                 case NULL_FIRST -> b.nullsFirst(field);
-                default -> field;
+                case NULL_LAST -> b.nullsLast(field);
               };
             })
         .toList();


### PR DESCRIPTION
### Description

Follow-up to #5450, addressing three more gaps in the SQL V2 path on the Analytics Engine:

- **HAVING clause**: `visitAggregateFunction` resolves via a `Map<AggregateFunction, Integer>` registry on `CalcitePlanContext`, populated by `visitAggregation` using position arithmetic.
- **FROM-less SELECT**: `visitValues` uses `LogicalValues.createOneRow` so `SELECT 1` returns one row instead of zero.
- **Window ORDER BY**: `translateOrderKeys` defaults unspecified NULLS to NULLS FIRST, matching top-level ORDER BY.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
