### PR TITLE
Propagate correct HTTP status for security exceptions on SQL analytic…

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/security/AnalyticsEngineSecurityIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/security/AnalyticsEngineSecurityIT.java
@@ -263,12 +263,6 @@ public class AnalyticsEngineSecurityIT extends SecurityTestBase {
     }
   }
 
-  // TODO: The SQL endpoint (/_plugins/_sql) returns 500 instead of 403 for security exceptions.
-  // The legacy RestSqlAction error handling wraps OpenSearchSecurityException as a generic 500
-  // Internal Server Error rather than propagating the 403 Forbidden status. The authorization
-  // IS denied (query does not execute), but the HTTP status is incorrect. These tests accept
-  // either 403 or 500 until the SQL plugin's error propagation is fixed.
-
   @Test
   public void testSQLQueryDeniedForUnauthorizedUser() throws IOException {
     ResponseException e =
@@ -276,11 +270,7 @@ public class AnalyticsEngineSecurityIT extends SecurityTestBase {
             ResponseException.class,
             () ->
                 executeSQLAsUser("SELECT name, age FROM " + TEST_INDEX + " LIMIT 3", DENIED_USER));
-    assertTrue(
-        "Expected 403 or 500 with security exception, got "
-            + e.getResponse().getStatusLine().getStatusCode(),
-        e.getResponse().getStatusLine().getStatusCode() == 403
-            || e.getResponse().getStatusLine().getStatusCode() == 500);
+    assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
   }
 
   @Test
@@ -291,11 +281,7 @@ public class AnalyticsEngineSecurityIT extends SecurityTestBase {
             () ->
                 executeSQLAsUser(
                     "SELECT name, age FROM " + FORBIDDEN_INDEX + " LIMIT 3", ALLOWED_USER));
-    assertTrue(
-        "Expected 403 or 500 with security exception, got "
-            + e.getResponse().getStatusLine().getStatusCode(),
-        e.getResponse().getStatusLine().getStatusCode() == 403
-            || e.getResponse().getStatusLine().getStatusCode() == 500);
+    assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
   }
 
   @Test
@@ -306,11 +292,7 @@ public class AnalyticsEngineSecurityIT extends SecurityTestBase {
             () ->
                 executeSQLAsUser(
                     "SELECT name, age FROM " + TEST_INDEX + " LIMIT 3", SEARCH_ONLY_USER));
-    assertTrue(
-        "Expected 403 or 500 with security exception, got "
-            + e.getResponse().getStatusLine().getStatusCode(),
-        e.getResponse().getStatusLine().getStatusCode() == 403
-            || e.getResponse().getStatusLine().getStatusCode() == 500);
+    assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
   }
 
   /** Executes a PPL query via the production SQL plugin endpoint (/_plugins/_ppl). */

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -210,7 +210,7 @@ public class RestSqlAction extends BaseRestHandler {
     reportError(restChannel, exception, status);
   }
 
-  private static RestStatus getRestStatus(Exception ex) {
+  public static RestStatus getRestStatus(Exception ex) {
     int code = getRawErrorCode(ex);
     return RestStatus.fromCode(code);
   }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -263,8 +263,10 @@ public class SQLPlugin extends Plugin
 
               @Override
               public void onFailure(Exception e) {
-                channel.sendResponse(
-                    new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
+                RestStatus status = (e instanceof org.opensearch.OpenSearchException osEx)
+                    ? osEx.status()
+                    : RestStatus.INTERNAL_SERVER_ERROR;
+                channel.sendResponse(new BytesRestResponse(status, e.getMessage()));
               }
             });
       } else {
@@ -282,8 +284,10 @@ public class SQLPlugin extends Plugin
 
               @Override
               public void onFailure(Exception e) {
-                channel.sendResponse(
-                    new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
+                RestStatus status = (e instanceof org.opensearch.OpenSearchException osEx)
+                    ? osEx.status()
+                    : RestStatus.INTERNAL_SERVER_ERROR;
+                channel.sendResponse(new BytesRestResponse(status, e.getMessage()));
               }
             });
       }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -263,9 +263,10 @@ public class SQLPlugin extends Plugin
 
               @Override
               public void onFailure(Exception e) {
-                RestStatus status = (e instanceof org.opensearch.OpenSearchException osEx)
-                    ? osEx.status()
-                    : RestStatus.INTERNAL_SERVER_ERROR;
+                RestStatus status =
+                    (e instanceof org.opensearch.OpenSearchException osEx)
+                        ? osEx.status()
+                        : RestStatus.INTERNAL_SERVER_ERROR;
                 channel.sendResponse(new BytesRestResponse(status, e.getMessage()));
               }
             });
@@ -284,9 +285,10 @@ public class SQLPlugin extends Plugin
 
               @Override
               public void onFailure(Exception e) {
-                RestStatus status = (e instanceof org.opensearch.OpenSearchException osEx)
-                    ? osEx.status()
-                    : RestStatus.INTERNAL_SERVER_ERROR;
+                RestStatus status =
+                    (e instanceof org.opensearch.OpenSearchException osEx)
+                        ? osEx.status()
+                        : RestStatus.INTERNAL_SERVER_ERROR;
                 channel.sendResponse(new BytesRestResponse(status, e.getMessage()));
               }
             });

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -263,11 +263,8 @@ public class SQLPlugin extends Plugin
 
               @Override
               public void onFailure(Exception e) {
-                RestStatus status =
-                    (e instanceof org.opensearch.OpenSearchException osEx)
-                        ? osEx.status()
-                        : RestStatus.INTERNAL_SERVER_ERROR;
-                channel.sendResponse(new BytesRestResponse(status, e.getMessage()));
+                channel.sendResponse(
+                    new BytesRestResponse(RestSqlAction.getRestStatus(e), e.getMessage()));
               }
             });
       } else {
@@ -285,11 +282,8 @@ public class SQLPlugin extends Plugin
 
               @Override
               public void onFailure(Exception e) {
-                RestStatus status =
-                    (e instanceof org.opensearch.OpenSearchException osEx)
-                        ? osEx.status()
-                        : RestStatus.INTERNAL_SERVER_ERROR;
-                channel.sendResponse(new BytesRestResponse(status, e.getMessage()));
+                channel.sendResponse(
+                    new BytesRestResponse(RestSqlAction.getRestStatus(e), e.getMessage()));
               }
             });
       }


### PR DESCRIPTION
### Description
The SQL plugin's unified query handler (/_plugins/_sql) returned HTTP 500 for all exceptions from the analytics engine path, including security exceptions that should be 403 Forbidden. This caused authorization denials to appear as internal server errors to users.

Fix: Check if the exception is an OpenSearchException and extract its proper HTTP status (e.g., 403 for OpenSearchSecurityException) instead of hardcoding 500. Both the explain and execute paths are fixed.

Also updates AnalyticsEngineSecurityIT SQL deny tests to assert 403 directly, removing the previous workaround that accepted either 403 or 500.

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [x] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
