### PR TITLE
fix(core): make appendcol row ordering deterministic on parallel engines

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -50,6 +50,7 @@ import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.ViewExpanders;
 import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
@@ -2769,11 +2770,36 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     return context.relBuilder.peek();
   }
 
+  /** Window {@code ORDER BY} keys from the current node's collation, or empty if it has none. */
+  private static List<RexNode> deriveCollationOrderKeys(CalcitePlanContext context) {
+    RelBuilder relBuilder = context.relBuilder;
+    List<RelCollation> collations =
+        relBuilder.getCluster().getMetadataQuery().collations(relBuilder.peek());
+    if (collations == null || collations.isEmpty()) {
+      return List.of();
+    }
+    List<RexNode> orderKeys = new ArrayList<>();
+    for (RelFieldCollation fieldCollation : collations.get(0).getFieldCollations()) {
+      RexNode key = relBuilder.field(fieldCollation.getFieldIndex());
+      if (fieldCollation.direction.isDescending()) {
+        key = relBuilder.desc(key);
+      }
+      if (fieldCollation.nullDirection == RelFieldCollation.NullDirection.LAST) {
+        key = relBuilder.nullsLast(key);
+      } else if (fieldCollation.nullDirection == RelFieldCollation.NullDirection.FIRST) {
+        key = relBuilder.nullsFirst(key);
+      }
+      orderKeys.add(key);
+    }
+    return orderKeys;
+  }
+
   @Override
   public RelNode visitAppendCol(AppendCol node, CalcitePlanContext context) {
     // 1. resolve main plan
     visitChildren(node, context);
-    // 2. add row_number() column to main
+    // 2. add row_number() column to main, ordered by its collation so the zip is deterministic
+    List<RexNode> mainOrderKeys = deriveCollationOrderKeys(context);
     RexNode mainRowNumber =
         PlanUtils.makeOver(
             context,
@@ -2781,7 +2807,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
             null,
             List.of(),
             List.of(),
-            List.of(),
+            mainOrderKeys,
             WindowFrame.toCurrentRow());
     context.relBuilder.projectPlus(
         context.relBuilder.alias(mainRowNumber, ROW_NUMBER_COLUMN_FOR_MAIN));
@@ -2791,7 +2817,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     transformPlanToAttachChild(node.getSubSearch(), relation);
     // 4. resolve subsearch plan
     node.getSubSearch().accept(this, context);
-    // 5. add row_number() column to subsearch
+    // 5. add row_number() column to subsearch, ordered by its collation
+    List<RexNode> subsearchOrderKeys = deriveCollationOrderKeys(context);
     RexNode subsearchRowNumber =
         PlanUtils.makeOver(
             context,
@@ -2799,7 +2826,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
             null,
             List.of(),
             List.of(),
-            List.of(),
+            subsearchOrderKeys,
             WindowFrame.toCurrentRow());
     context.relBuilder.projectPlus(
         context.relBuilder.alias(subsearchRowNumber, ROW_NUMBER_COLUMN_FOR_SUBSEARCH));
@@ -2820,6 +2847,11 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
             context.relBuilder.field(2, 1, ROW_NUMBER_COLUMN_FOR_SUBSEARCH));
     context.relBuilder.join(
         JoinAndLookupUtils.translateJoinType(Join.JoinType.FULL), joinCondition);
+
+    // sort by the row numbers (nulls last) so the output order is stable across backends
+    context.relBuilder.sort(
+        context.relBuilder.nullsLast(context.relBuilder.field(ROW_NUMBER_COLUMN_FOR_MAIN)),
+        context.relBuilder.nullsLast(context.relBuilder.field(ROW_NUMBER_COLUMN_FOR_SUBSEARCH)));
 
     if (!node.isOverride()) {
       // 8. if override = false, drop both _row_number_ columns

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAppendcolTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLAppendcolTest.java
@@ -22,13 +22,16 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
             + " COMM=[$6], DEPTNO=[$7])\n"
-            + "  LogicalJoin(condition=[=($8, $9)], joinType=[full])\n"
-            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
-            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], _row_number_main_=[ROW_NUMBER() OVER ()])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalProject(_row_number_subsearch_=[ROW_NUMBER() OVER ()])\n"
-            + "      LogicalFilter(condition=[=($7, 20)])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalSort(sort0=[$8], sort1=[$9], dir0=[ASC], dir1=[ASC])\n"
+            + "    LogicalJoin(condition=[=($8, $9)], joinType=[full])\n"
+            + "      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], _row_number_main_=[ROW_NUMBER() OVER (ORDER BY $0"
+            + " NULLS LAST)])\n"
+            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalProject(_row_number_subsearch_=[ROW_NUMBER() OVER (ORDER BY $0 NULLS"
+            + " LAST)])\n"
+            + "        LogicalFilter(condition=[=($7, 20)])\n"
+            + "          LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
@@ -36,12 +39,15 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
         "SELECT `t`.`EMPNO`, `t`.`ENAME`, `t`.`JOB`, `t`.`MGR`, `t`.`HIREDATE`, `t`.`SAL`,"
             + " `t`.`COMM`, `t`.`DEPTNO`\n"
             + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`,"
-            + " ROW_NUMBER() OVER () `_row_number_main_`\n"
+            + " ROW_NUMBER() OVER (ORDER BY `EMPNO` NULLS LAST) `_row_number_main_`\n"
             + "FROM `scott`.`EMP`) `t`\n"
-            + "FULL JOIN (SELECT ROW_NUMBER() OVER () `_row_number_subsearch_`\n"
+            + "FULL JOIN (SELECT ROW_NUMBER() OVER (ORDER BY `EMPNO` NULLS LAST)"
+            + " `_row_number_subsearch_`\n"
             + "FROM `scott`.`EMP`\n"
             + "WHERE `DEPTNO` = 20) `t1` ON `t`.`_row_number_main_` ="
-            + " `t1`.`_row_number_subsearch_`";
+            + " `t1`.`_row_number_subsearch_`\n"
+            + "ORDER BY `t`.`_row_number_main_` NULLS LAST, `t1`.`_row_number_subsearch_` NULLS"
+            + " LAST";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -54,16 +60,18 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
             + " COMM=[$6], DEPTNO=[$7], left_col=[$8], right_col=[$10])\n"
-            + "  LogicalJoin(condition=[=($9, $11)], joinType=[full])\n"
-            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + "  LogicalSort(sort0=[$9], sort1=[$11], dir0=[ASC], dir1=[ASC])\n"
+            + "    LogicalJoin(condition=[=($9, $11)], joinType=[full])\n"
+            + "      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
             + " SAL=[$5], COMM=[$6], DEPTNO=[$7], left_col=[$7], _row_number_main_=[ROW_NUMBER()"
-            + " OVER ()])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalProject(right_col=[$8], _row_number_subsearch_=[ROW_NUMBER() OVER ()])\n"
-            + "      LogicalFilter(condition=[=($7, 20)])\n"
-            + "        LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " OVER (ORDER BY $0 NULLS LAST)])\n"
+            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalProject(right_col=[$8], _row_number_subsearch_=[ROW_NUMBER() OVER"
+            + " (ORDER BY $0 NULLS LAST)])\n"
+            + "        LogicalFilter(condition=[=($7, 20)])\n"
+            + "          LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
             + " SAL=[$5], COMM=[$6], DEPTNO=[$7], right_col=[$7])\n"
-            + "          LogicalTableScan(table=[[scott, EMP]])\n";
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
@@ -71,14 +79,18 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
         "SELECT `t`.`EMPNO`, `t`.`ENAME`, `t`.`JOB`, `t`.`MGR`, `t`.`HIREDATE`, `t`.`SAL`,"
             + " `t`.`COMM`, `t`.`DEPTNO`, `t`.`left_col`, `t2`.`right_col`\n"
             + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`,"
-            + " `DEPTNO` `left_col`, ROW_NUMBER() OVER () `_row_number_main_`\n"
+            + " `DEPTNO` `left_col`, ROW_NUMBER() OVER (ORDER BY `EMPNO` NULLS LAST)"
+            + " `_row_number_main_`\n"
             + "FROM `scott`.`EMP`) `t`\n"
-            + "FULL JOIN (SELECT `right_col`, ROW_NUMBER() OVER () `_row_number_subsearch_`\n"
+            + "FULL JOIN (SELECT `right_col`, ROW_NUMBER() OVER (ORDER BY `EMPNO` NULLS LAST)"
+            + " `_row_number_subsearch_`\n"
             + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`,"
             + " `DEPTNO` `right_col`\n"
             + "FROM `scott`.`EMP`) `t0`\n"
             + "WHERE `DEPTNO` = 20) `t2` ON `t`.`_row_number_main_` ="
-            + " `t2`.`_row_number_subsearch_`";
+            + " `t2`.`_row_number_subsearch_`\n"
+            + "ORDER BY `t`.`_row_number_main_` NULLS LAST, `t2`.`_row_number_subsearch_` NULLS"
+            + " LAST";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -91,14 +103,17 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
             + " JOB=[CASE(=($8, $17), $11, $2)], MGR=[CASE(=($8, $17), $12, $3)],"
             + " HIREDATE=[CASE(=($8, $17), $13, $4)], SAL=[CASE(=($8, $17), $14, $5)],"
             + " COMM=[CASE(=($8, $17), $15, $6)], DEPTNO=[CASE(=($8, $17), $16, $7)])\n"
-            + "  LogicalJoin(condition=[=($8, $17)], joinType=[full])\n"
-            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
-            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], _row_number_main_=[ROW_NUMBER() OVER ()])\n"
-            + "      LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
-            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], _row_number_subsearch_=[ROW_NUMBER() OVER ()])\n"
-            + "      LogicalFilter(condition=[=($7, 20)])\n"
-            + "        LogicalTableScan(table=[[scott, EMP]])\n";
+            + "  LogicalSort(sort0=[$8], sort1=[$17], dir0=[ASC], dir1=[ASC])\n"
+            + "    LogicalJoin(condition=[=($8, $17)], joinType=[full])\n"
+            + "      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], _row_number_main_=[ROW_NUMBER() OVER (ORDER BY $0"
+            + " NULLS LAST)])\n"
+            + "        LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], _row_number_subsearch_=[ROW_NUMBER() OVER (ORDER"
+            + " BY $0 NULLS LAST)])\n"
+            + "        LogicalFilter(condition=[=($7, 20)])\n"
+            + "          LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     verifyResultCount(root, 14);
 
@@ -116,13 +131,16 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
             + " `t`.`COMM` END `COMM`, CASE WHEN `t`.`_row_number_main_` ="
             + " `t1`.`_row_number_subsearch_` THEN `t1`.`DEPTNO` ELSE `t`.`DEPTNO` END `DEPTNO`\n"
             + "FROM (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`, `DEPTNO`,"
-            + " ROW_NUMBER() OVER () `_row_number_main_`\n"
+            + " ROW_NUMBER() OVER (ORDER BY `EMPNO` NULLS LAST) `_row_number_main_`\n"
             + "FROM `scott`.`EMP`) `t`\n"
             + "FULL JOIN (SELECT `EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`, `COMM`,"
-            + " `DEPTNO`, ROW_NUMBER() OVER () `_row_number_subsearch_`\n"
+            + " `DEPTNO`, ROW_NUMBER() OVER (ORDER BY `EMPNO` NULLS LAST)"
+            + " `_row_number_subsearch_`\n"
             + "FROM `scott`.`EMP`\n"
             + "WHERE `DEPTNO` = 20) `t1` ON `t`.`_row_number_main_` ="
-            + " `t1`.`_row_number_subsearch_`";
+            + " `t1`.`_row_number_subsearch_`\n"
+            + "ORDER BY `t`.`_row_number_main_` NULLS LAST, `t1`.`_row_number_subsearch_` NULLS"
+            + " LAST";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -132,16 +150,17 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
     String expectedLogical =
         "LogicalProject(count()=[$0], DEPTNO=[$1], avg(SAL)=[$3])\n"
-            + "  LogicalJoin(condition=[=($2, $4)], joinType=[full])\n"
-            + "    LogicalProject(count()=[$1], DEPTNO=[$0], _row_number_main_=[ROW_NUMBER() OVER"
+            + "  LogicalSort(sort0=[$2], sort1=[$4], dir0=[ASC], dir1=[ASC])\n"
+            + "    LogicalJoin(condition=[=($2, $4)], joinType=[full])\n"
+            + "      LogicalProject(count()=[$1], DEPTNO=[$0], _row_number_main_=[ROW_NUMBER() OVER"
             + " ()])\n"
-            + "      LogicalAggregate(group=[{0}], count()=[COUNT()])\n"
-            + "        LogicalProject(DEPTNO=[$7])\n"
-            + "          LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalProject(avg(SAL)=[$1], _row_number_subsearch_=[ROW_NUMBER() OVER ()])\n"
-            + "      LogicalAggregate(group=[{0}], avg(SAL)=[AVG($1)])\n"
-            + "        LogicalProject(DEPTNO=[$7], SAL=[$5])\n"
-            + "          LogicalTableScan(table=[[scott, EMP]])\n";
+            + "        LogicalAggregate(group=[{0}], count()=[COUNT()])\n"
+            + "          LogicalProject(DEPTNO=[$7])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalProject(avg(SAL)=[$1], _row_number_subsearch_=[ROW_NUMBER() OVER ()])\n"
+            + "        LogicalAggregate(group=[{0}], avg(SAL)=[AVG($1)])\n"
+            + "          LogicalProject(DEPTNO=[$7], SAL=[$5])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
@@ -159,7 +178,10 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
             + "FULL JOIN (SELECT AVG(`SAL`) `avg(SAL)`, ROW_NUMBER() OVER ()"
             + " `_row_number_subsearch_`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`) `t4` ON `t1`.`_row_number_main_` = `t4`.`_row_number_subsearch_`";
+            + "GROUP BY `DEPTNO`) `t4` ON `t1`.`_row_number_main_` ="
+            + " `t4`.`_row_number_subsearch_`\n"
+            + "ORDER BY `t1`.`_row_number_main_` NULLS LAST, `t4`.`_row_number_subsearch_` NULLS"
+            + " LAST";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
@@ -171,17 +193,18 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
     String expectedLogical =
         "LogicalProject(count()=[$0], DEPTNO=[CASE(=($2, $5), $4, $1)], avg(SAL)=[$3])\n"
-            + "  LogicalJoin(condition=[=($2, $5)], joinType=[full])\n"
-            + "    LogicalProject(count()=[$1], DEPTNO=[$0], _row_number_main_=[ROW_NUMBER() OVER"
+            + "  LogicalSort(sort0=[$2], sort1=[$5], dir0=[ASC], dir1=[ASC])\n"
+            + "    LogicalJoin(condition=[=($2, $5)], joinType=[full])\n"
+            + "      LogicalProject(count()=[$1], DEPTNO=[$0], _row_number_main_=[ROW_NUMBER() OVER"
             + " ()])\n"
-            + "      LogicalAggregate(group=[{0}], count()=[COUNT()])\n"
-            + "        LogicalProject(DEPTNO=[$7])\n"
-            + "          LogicalTableScan(table=[[scott, EMP]])\n"
-            + "    LogicalProject(avg(SAL)=[$1], DEPTNO=[$0], _row_number_subsearch_=[ROW_NUMBER()"
-            + " OVER ()])\n"
-            + "      LogicalAggregate(group=[{0}], avg(SAL)=[AVG($1)])\n"
-            + "        LogicalProject(DEPTNO=[$7], SAL=[$5])\n"
-            + "          LogicalTableScan(table=[[scott, EMP]])\n";
+            + "        LogicalAggregate(group=[{0}], count()=[COUNT()])\n"
+            + "          LogicalProject(DEPTNO=[$7])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n"
+            + "      LogicalProject(avg(SAL)=[$1], DEPTNO=[$0],"
+            + " _row_number_subsearch_=[ROW_NUMBER() OVER ()])\n"
+            + "        LogicalAggregate(group=[{0}], avg(SAL)=[AVG($1)])\n"
+            + "          LogicalProject(DEPTNO=[$7], SAL=[$5])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
     String expectedResult =
         ""
@@ -200,7 +223,10 @@ public class CalcitePPLAppendcolTest extends CalcitePPLAbstractTest {
             + "FULL JOIN (SELECT AVG(`SAL`) `avg(SAL)`, `DEPTNO`, ROW_NUMBER() OVER ()"
             + " `_row_number_subsearch_`\n"
             + "FROM `scott`.`EMP`\n"
-            + "GROUP BY `DEPTNO`) `t4` ON `t1`.`_row_number_main_` = `t4`.`_row_number_subsearch_`";
+            + "GROUP BY `DEPTNO`) `t4` ON `t1`.`_row_number_main_` ="
+            + " `t4`.`_row_number_subsearch_`\n"
+            + "ORDER BY `t1`.`_row_number_main_` NULLS LAST, `t4`.`_row_number_subsearch_` NULLS"
+            + " LAST";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }


### PR DESCRIPTION
### What's broken

`appendcol` pairs the wrong rows together on parallel engines (analytics engine via DataFusion, Spark pushdown), and rows come out in scrambled order.

Internally `appendcol` lowers to:

```
main      → ROW_NUMBER() OVER ()
subsearch → ROW_NUMBER() OVER ()
FULL JOIN on (main_rownum = subsearch_rownum)
(no trailing sort)
```

That only works on a single-threaded engine. On a parallel one, row numbers are assigned arbitrarily and the join then glues the wrong subsearch row onto the wrong main row.

### Root cause, step by step (using the IT data)

#### Step 1 — what `appendcol` does mechanically

`testAppendCol` query:

```
source=account | stats sum(age) as sum by gender, state | sort gender, state
  | appendcol [ stats count(age) as cnt by gender | sort gender ]
  | fields gender, state, sum, cnt | head 10
```

**Main** (after `stats sum(age) by gender, state | sort gender, state`) — many rows, one per `(gender, state)`. F rows come first alphabetically, then M rows:

```
F/AK   sum=317
F/AL   sum=397
F/AR   sum=229
F/AZ   sum=238
…
M/AK   sum=…
M/MD   sum=580
…
```

**Subsearch** (`stats count(age) by gender | sort gender`) — exactly 2 rows:

```
F   cnt=493     ← count of all F docs
M   cnt=507     ← count of all M docs
```

`appendcol` (1) numbers each main row, (2) numbers each subsearch row, (3) `FULL JOIN`s on those row numbers.

#### Step 2 — on v2 (serial), row numbers follow input order

```
Main:    _rn_main_       Sub:        _rn_sub_
F/AK     1               F  cnt=493  1
F/AL     2               M  cnt=507  2
F/AR     3
…
```

Join on `_rn_main_ = _rn_sub_`:

| Main | paired with | Result |
|---|---|---|
| F/AK (1) | F, 493 (1) | **F/AK gets cnt=493** ✅ |
| F/AL (2) | M, 507 (2) | **F/AL gets cnt=507** ✅ (M's count lands on an F row — that's the positional zip) |
| F/AR (3)+ | nothing | cnt=null ✅ |

After `head 10`: `F/AK, F/AL, F/AR, F/AZ, F/CA, F/CO, F/CT, F/DC, F/DE, F/FL` — exactly what the IT asserts.

#### Step 3 — on the analytics route (DataFusion, parallel), row numbers are arbitrary

`ROW_NUMBER() OVER ()` ignores input order on a parallel engine. Example random assignment:

```
Main:    _rn_main_         Sub:        _rn_sub_
F/AK     13   ← arbitrary  F  cnt=493  2   ← arbitrary
F/AL     5                 M  cnt=507  1
F/AR     28
…
M/MD     1    ← happened to get 1
```

Same `FULL JOIN`:

| Main | paired with | Result |
|---|---|---|
| M/MD (1) | M, 507 (1) | M/MD gets cnt=507 (coincidentally self-consistent) |
| some main row (2) | F, 493 (2) | some random main row gets cnt=493 |
| F/AK (13) | nothing | **F/AK gets cnt=null** ❌ (should be 493) |
| F/AL (5) | nothing | **F/AL gets cnt=null** ❌ (should be 507) |
| … | nothing | null |

This matches the actual IT failure:

```
Expected: [F,AK,317,493], [F,AL,397,507], [F,AR,229,null], …, [F,FL,310,null]
Actual contained: ["M","MD",580,507]    ← M row leaked into top-10
```

M/MD leaked into the top 10 (sort order was lost too), and the `cnt` values landed on the wrong main rows entirely.

#### Step 4 — a downstream sort can't fix this

What if we add `| sort gender, state` at the end to "fix the order"?

```
F/AK, sum=317, cnt=null     ← still wrong, IT wants 493
F/AL, sum=397, cnt=null     ← still wrong, IT wants 507
F/AR, sum=229, cnt=null
…
M/MD, sum=580, cnt=507      ← the wrong-attached cnt is still attached
```

A sort only reorders tuples; it can't pry one open and swap `cnt` values between rows. The exact tuple `[F, AK, 317, 493]` the IT asserts **doesn't exist** anywhere in the broken output — no row anywhere has `F/AK` paired with `493`. No `verifyDataRowsInAnyOrder` or trailing sort can recover that.

#### Step 5 — the fix, applied to the same scenario

The wrong pairing is committed inside `visitAppendCol` (Step 3). Once those tuples exist, no downstream PPL command can undo them — so the lowering itself must produce deterministic row numbers. Two changes do that:

**(a) Fill the window's `OVER (???)` with the upstream sort's collation:**

```
Main:      ROW_NUMBER() OVER (ORDER BY gender, state)
Subsearch: ROW_NUMBER() OVER (ORDER BY gender)
```

DataFusion is now obliged to sort by those keys before numbering, so it assigns the same numbers v2 would:

```
Main:    _rn_main_       Sub:        _rn_sub_
F/AK     1               F  cnt=493  1
F/AL     2               M  cnt=507  2
F/AR     3
F/AZ     4
…
```

The `FULL JOIN` on row numbers now pairs correctly: `F/AK ↔ F(493)`, `F/AL ↔ M(507)`, rest `null`. **The tuples are right** — `[F, AK, 317, 493]` and `[F, AL, 397, 507]` exist in memory.

**(b) Add a trailing `sort by _rn_main_, _rn_sub_ (NULLS LAST)` after the join:**

DataFusion's hash join can still scramble output order even when the individual tuples are correct. The trailing sort puts them back in row-number order, which (by Piece a) is the upstream sort order:

```
F/AK, sum=317, cnt=493     ← _rn_main_ = 1
F/AL, sum=397, cnt=507     ← _rn_main_ = 2
F/AR, sum=229, cnt=null    ← _rn_main_ = 3
F/AZ, sum=238, cnt=null    ← _rn_main_ = 4
…
```

After `head 10`: the same 10 F-rows v2 produced (`F/AK … F/FL`), with the right `cnt` on each. The IT now passes 2/2 on the analytics route.

Both pieces are required — (a) alone leaves the post-join output scrambled by the hash join; (b) alone sorts by row numbers that are themselves random.

### Where the `ROW_NUMBER() OVER (...)` is emitted

The window expression is built inside `visitAppendCol` via a helper `PlanUtils.makeOver`:

```java
RexNode mainRowNumber = PlanUtils.makeOver(
    context,
    BuiltinFunctionName.ROW_NUMBER,
    null,
    List.of(),
    List.of(),                       // partition keys (empty)
    mainOrderKeys,                   // ← the ORDER BY list — this is what we change
    WindowFrame.toCurrentRow());

context.relBuilder.projectPlus(
    context.relBuilder.alias(mainRowNumber, ROW_NUMBER_COLUMN_FOR_MAIN));
```

End-to-end path of the offending construct:

```
PPL "| appendcol [...]"
   ↓  parser → AST AppendCol
visitAppendCol → PlanUtils.makeOver(... orderKeys=??? ...)
   ↓  produces a RexOver { ROW_NUMBER, OVER(orderKeys=???) }
LogicalProject(..., _row_number_main_=[ROW_NUMBER() OVER (???)])
   ↓  Calcite → Substrait
DataFusion's window operator runs it
```

Before the fix, `mainOrderKeys` was hard-coded to `List.of()`, so DataFusion saw bare `OVER ()` and assigned numbers arbitrarily.

### Fix

Two changes in `visitAppendCol`:

1. **Fill the `???`**: change `mainOrderKeys` from hard-coded `List.of()` to `deriveCollationOrderKeys(context)`, which reads the upstream collation via `RelMetadataQuery.collations(peek())`. So `OVER ()` becomes `OVER (ORDER BY <upstream sort>)` — deterministic on DataFusion.
2. **Trailing sort** by the row-number columns after the FULL JOIN, so the final output order doesn't depend on join execution (same pattern `streamstats` already uses).

No behavior change on v2/Calcite (its serial execution already produced this order).

### Results

`CalcitePPLAppendcolIT`:

| | Analytics engine | v2/Calcite |
|---|---|---|
| Before | 0/2 | 2/2 |
| After  | **2/2** | **2/2** |

### Testing

- `CalcitePPLAppendcolTest` (5 unit tests, regenerated plans) ✅
- `CalcitePPLAppendcolIT` 2/2 on both paths ✅
- `NewAddedCommandsIT.testAppendcol` ✅
- `appendcol.md` doctest ✅ (no doc edits needed)
- `spotlessCheck` clean ✅

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented (n/a — behavior-preserving fix).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
