### PR TITLE
Support SQL query profiling with the analytics engine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -33,7 +33,7 @@ import org.opensearch.sql.executor.ExecutionContext;
 import org.opensearch.sql.executor.ExecutionEngine;
 import org.opensearch.sql.executor.pagination.Cursor;
 import org.opensearch.sql.monitor.profile.MetricName;
-import org.opensearch.sql.monitor.profile.ProfileMetric;
+import org.opensearch.sql.monitor.profile.ProfileContext;
 import org.opensearch.sql.monitor.profile.QueryProfiling;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 
@@ -81,7 +81,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     // to a worker pool and results arrive on the listener. Record the execute metric in the
     // listener callback, before delegating to the user-supplied listener, so the metric snapshot
     // taken by SimpleJsonResponseFormatter sees the correct value.
-    ProfileMetric execMetric = QueryProfiling.current().getOrCreateMetric(MetricName.EXECUTE);
+    ProfileContext profileCtx = QueryProfiling.current();
     long execStart = System.nanoTime();
 
     planExecutor.execute(
@@ -90,15 +90,22 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
         new ActionListener<>() {
           @Override
           public void onResponse(Iterable<Object[]> rows) {
-            try {
-              List<RelDataTypeField> fields = plan.getRowType().getFieldList();
-              List<ExprValue> results = convertRows(rows, fields);
-              Schema schema = buildSchema(fields);
-              execMetric.set(System.nanoTime() - execStart);
-              listener.onResponse(new QueryResponse(schema, results, Cursor.None));
-            } catch (Exception e) {
-              listener.onFailure(e);
-            }
+            QueryProfiling.withCurrentContext(
+                profileCtx,
+                () -> {
+                  try {
+                    List<RelDataTypeField> fields = plan.getRowType().getFieldList();
+                    List<ExprValue> results = convertRows(rows, fields);
+                    Schema schema = buildSchema(fields);
+                    profileCtx
+                        .getOrCreateMetric(MetricName.EXECUTE)
+                        .set(System.nanoTime() - execStart);
+                    listener.onResponse(new QueryResponse(schema, results, Cursor.None));
+                  } catch (Exception e) {
+                    listener.onFailure(e);
+                  }
+                  return null;
+                });
           }
 
           @Override

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.executor.analytics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -37,6 +38,8 @@ import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
+import org.opensearch.sql.monitor.profile.ProfileContext;
+import org.opensearch.sql.monitor.profile.QueryProfiling;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 
 class AnalyticsExecutionEngineTest {
@@ -328,6 +331,49 @@ class AnalyticsExecutionEngineTest {
             + errorRef.get().getClass().getSimpleName()
             + " - "
             + errorRef.get().getMessage());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void executeRelNode_profilePreservedOnAsyncListener() throws Exception {
+    ProfileContext expected = QueryProfiling.activate(true);
+
+    RelNode relNode = mockRelNode("col", SqlTypeName.VARCHAR);
+    Iterable<Object[]> rows = Collections.singletonList(new Object[] {"value"});
+
+    // Fire the executor's listener on a different thread to simulate async dispatch
+    doAnswer(
+            inv -> {
+              ActionListener<Iterable<Object[]>> al = inv.getArgument(2);
+              Thread t = new Thread(() -> al.onResponse(rows));
+              t.start();
+              t.join();
+              return null;
+            })
+        .when(mockExecutor)
+        .execute(eq(relNode), any(), any(ActionListener.class));
+
+    AtomicReference<ProfileContext> seen = new AtomicReference<>();
+    engine.execute(
+        relNode,
+        mockContext,
+        new ResponseListener<>() {
+          @Override
+          public void onResponse(QueryResponse response) {
+            seen.set(QueryProfiling.current());
+          }
+
+          @Override
+          public void onFailure(Exception e) {
+            throw new AssertionError(e);
+          }
+        });
+
+    try {
+      assertSame(expected, seen.get(), "Profile context not restored on async listener thread");
+    } finally {
+      QueryProfiling.clear();
+    }
   }
 
   // --- helpers ---

--- a/docs/user/interfaces/endpoint.rst
+++ b/docs/user/interfaces/endpoint.rst
@@ -266,6 +266,58 @@ Result set::
       "status": 200
     }
 
+Profile [Experimental]
+======================
+
+Description
+-----------
+
+Profiling captures per-stage timings (in milliseconds) for SQL query
+execution. To enable profiling, set ``"profile": true`` in the request
+body alongside ``"query"``.
+
+.. note::
+   The ``profile`` parameter only takes effect when the query runs on
+   the Analytics Engine. In all other cases the flag is silently ignored.
+
+   Profile output is returned only for regular query execution (not
+   ``_explain``) and only with the default ``format=jdbc``.
+
+Example
+-------
+
+Request::
+
+    POST /_plugins/_sql
+    {
+      "query": "SELECT customer_id, SUM(amount) FROM orders GROUP BY customer_id",
+      "profile": true
+    }
+
+Expected output (trimmed)::
+
+    {
+      "profile": {
+        "summary": {
+          "total_time_ms": 33.34
+        },
+        "phases": {
+          "analyze": { "time_ms": 8.68 },
+          "optimize": { "time_ms": 18.2 },
+          "execute": { "time_ms": 4.87 },
+          "format": { "time_ms": 0.05 }
+        },
+        "plan": {
+          "node": "EnumerableCalc",
+          "time_ms": 4.82,
+          "rows": 2,
+          "children": [
+            { "node": "CalciteEnumerableIndexScan", "time_ms": 4.12, "rows": 2 }
+          ]
+        }
+      }
+    }
+
 Fetch Size (PPL) [Experimental]
 ================================
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -271,7 +271,7 @@ public class SQLPlugin extends Plugin
         unifiedQueryHandler.execute(
             sqlRequest.getQuery(),
             QueryType.SQL,
-            false,
+            sqlRequest.isProfileEnabled(),
             new ActionListener<>() {
               @Override
               public void onResponse(TransportPPLQueryResponse response) {

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -118,15 +118,18 @@ public class RestUnifiedQueryAction {
         .schedule(
             withCurrentContext(
                 () -> {
-                  try (UnifiedQueryContext context = buildContext(queryType, profiling)) {
+                  UnifiedQueryContext context = buildContext(queryType, profiling);
+                  ActionListener<TransportPPLQueryResponse> closingListener =
+                      wrapWithContextClose(context, listener);
+                  try {
                     UnifiedQueryPlanner planner = new UnifiedQueryPlanner(context);
                     RelNode plan = planner.plan(query);
                     CalcitePlanContext planContext = context.getPlanContext();
                     plan = addQuerySizeLimit(plan, planContext);
                     analyticsEngine.execute(
-                        plan, planContext, createQueryListener(queryType, listener));
+                        plan, planContext, createQueryListener(queryType, closingListener));
                   } catch (Exception e) {
-                    listener.onFailure(e);
+                    closingListener.onFailure(e);
                   }
                 }),
             new TimeValue(0),
@@ -255,5 +258,18 @@ public class RestUnifiedQueryAction {
       ThreadContext.putAll(currentContext);
       task.run();
     };
+  }
+
+  private static ActionListener<TransportPPLQueryResponse> wrapWithContextClose(
+      UnifiedQueryContext context, ActionListener<TransportPPLQueryResponse> delegate) {
+    return ActionListener.runAfter(
+        delegate,
+        () -> {
+          try {
+            context.close();
+          } catch (Exception e) {
+            LOG.warn("Failed to close query context", e);
+          }
+        });
   }
 }

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -26,8 +26,9 @@ import org.opensearch.sql.protocol.response.format.Format;
 @RequiredArgsConstructor
 public class SQLQueryRequest {
   private static final String QUERY_FIELD_CURSOR = "cursor";
+  private static final String QUERY_FIELD_PROFILE = "profile";
   private static final Set<String> SUPPORTED_FIELDS =
-      Set.of("query", "fetch_size", "parameters", QUERY_FIELD_CURSOR);
+      Set.of("query", "fetch_size", "parameters", QUERY_FIELD_CURSOR, QUERY_FIELD_PROFILE);
   private static final String QUERY_PARAMS_FORMAT = "format";
   private static final String QUERY_PARAMS_SANITIZE = "sanitize";
   private static final String QUERY_PARAMS_PRETTY = "pretty";
@@ -116,6 +117,14 @@ public class SQLQueryRequest {
    */
   public boolean isExplainRequest() {
     return path.endsWith("/_explain");
+  }
+
+  /** Check if profiling should run for this request. */
+  public boolean isProfileEnabled() {
+    return jsonContent != null
+        && jsonContent.optBoolean(QUERY_FIELD_PROFILE, false)
+        && !isExplainRequest()
+        && Format.JDBC.getFormatName().equalsIgnoreCase(format);
   }
 
   public boolean isCursorCloseRequest() {

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -284,6 +284,70 @@ public class SQLQueryRequestTest {
     assertTrue(csvRequest.isSupported());
   }
 
+  @Test
+  public void should_support_query_with_profile_field() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .jsonContent("{\"query\": \"SELECT 1\", \"profile\": true}")
+            .build();
+    assertTrue(request.isSupported());
+  }
+
+  @Test
+  public void should_disable_profile_when_no_json_content() {
+    SQLQueryRequest request =
+        new SQLQueryRequest(null, "SELECT 1", "_plugins/_sql", Map.of(), null);
+    assertFalse(request.isProfileEnabled());
+  }
+
+  @Test
+  public void should_disable_profile_when_profile_field_absent() {
+    SQLQueryRequest request =
+        new SQLQueryRequest(
+            new JSONObject("{\"query\": \"SELECT 1\"}"),
+            "SELECT 1",
+            "_plugins/_sql",
+            Map.of(),
+            null);
+    assertFalse(request.isProfileEnabled());
+  }
+
+  @Test
+  public void should_enable_profile_for_jdbc_query() {
+    SQLQueryRequest request =
+        new SQLQueryRequest(
+            new JSONObject("{\"query\": \"SELECT 1\", \"profile\": true}"),
+            "SELECT 1",
+            "_plugins/_sql",
+            Map.of(),
+            null);
+    assertTrue(request.isProfileEnabled());
+  }
+
+  @Test
+  public void should_disable_profile_on_explain_path() {
+    SQLQueryRequest request =
+        new SQLQueryRequest(
+            new JSONObject("{\"query\": \"SELECT 1\", \"profile\": true}"),
+            "SELECT 1",
+            "_plugins/_sql/_explain",
+            Map.of(),
+            null);
+    assertFalse(request.isProfileEnabled());
+  }
+
+  @Test
+  public void should_disable_profile_for_non_jdbc_format() {
+    SQLQueryRequest request =
+        new SQLQueryRequest(
+            new JSONObject("{\"query\": \"SELECT 1\", \"profile\": true}"),
+            "SELECT 1",
+            "_plugins/_sql",
+            Map.of("format", "csv"),
+            null);
+    assertFalse(request.isProfileEnabled());
+  }
+
   /** SQL query request build helper to improve test data setup readability. */
   private static class SQLQueryRequestBuilder {
     private String jsonContent;


### PR DESCRIPTION
### Description

Adds a `profile` boolean field to the `/_plugins/_sql` request body to capture per-stage query timings, mirroring PPL's existing profile pattern. Also propagates the profile context across the Analytics Engine's async listener thread so profile output is visible in the response.

- **Enabled** when `"profile": true` is set on a SQL query that routes to the analytics engine.
- **Ignored for V2 SQL**: queries handled by the V2 SQL engine silently drop the flag.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5246.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
