### PR TITLE
[Analytic Engine] Skip PUT+DELETE doc-fixture tests on the analytics-engine storage matrix

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExpandCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExpandCommandIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ARRAY;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
 import static org.opensearch.sql.util.MatcherUtils.rows;
@@ -295,6 +296,10 @@ public class CalciteExpandCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testExpandEmptyArray() throws Exception {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     final int docId = 6;
     Request insertRequest =
         new Request(
@@ -324,6 +329,10 @@ public class CalciteExpandCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testExpandOnNullField() throws Exception {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     final int docId = 6;
     Request insertRequest =
         new Request(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteStreamstatsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteStreamstatsCommandIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.*;
 import static org.opensearch.sql.util.MatcherUtils.*;
 
@@ -507,6 +508,10 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testStreamstatsGlobal() throws IOException {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     final int docId = 5;
     Request insertRequest =
         new Request(
@@ -666,6 +671,10 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testStreamstatsReset() throws IOException {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     final int docId = 5;
     Request insertRequest =
         new Request(
@@ -934,6 +943,10 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testMultipleStreamstatsWithNull2() throws IOException {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     final int docId = 5;
     Request insertRequest =
         new Request(

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.ppl;
 
+import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE;
 import static org.opensearch.sql.util.MatcherUtils.rows;
@@ -1565,6 +1566,10 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testCompareAgainstUTCDate() throws IOException {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
     String isoTimestamp = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
     String pplTimestamp = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.ppl;
 
+import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.*;
 import static org.opensearch.sql.util.MatcherUtils.columnName;
 import static org.opensearch.sql.util.MatcherUtils.rows;
@@ -1053,6 +1054,10 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchTimeModifierWithSnappedWeek() throws IOException {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     // Test whether alignment to weekday works
 
     final int docId = 101;
@@ -1141,6 +1146,10 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchWithRelativeTimeModifiers() throws IOException {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     final int docId = 101;
 
     LocalDateTime currentTime = LocalDateTime.now(ZoneOffset.UTC);
@@ -1189,6 +1198,10 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchWithTimeUnitSnapping() throws IOException {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     final int docId = 101;
 
     LocalDateTime currentHour = LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
@@ -1237,6 +1250,10 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchWithQuarterlyModifiers() throws IOException {
+    assumeFalse(
+        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
+            + " (analytics-engine storage path) does not support.",
+        isAnalyticsParquetIndicesEnabled());
     final int docId = 101;
 
     LocalDateTime currentQuarter =


### PR DESCRIPTION
### Description
Bucket # 22 of the AE-storage failure report (8 failures: `unsupported_operation_exception — delete operation not supported.`) is **not** a SQL plugin bug. The exception originates in OpenSearch core's storage layer:

- `server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java:691` — `delete(...)` throws `UnsupportedEncodingException("delete operation not supported.")`
- `server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java:774` — `prepareDelete(...)` throws `UnsupportedOperationException("delete operation not supported.")`

`DataFormatAwareEngine` is the engine that backs analytics-engine indices (parquet / composite). It's append-only by design — per-doc delete is not implemented.

The failing tests are 10 PPL / Calcite integration tests that mutate a shared test index as part of their fixture:

```text
PUT /<index>/_doc/<id>?refresh=true   ← seed a tailored doc for this test
... run query, assert ...
DELETE /<index>/_doc/<id>?refresh=true ← clean up to keep the shared index pristine
```

This pattern works fine against the default Lucene-backed engine. When the suite is launched with `-Dtests.analytics.parquet_indices=true` (the AE-storage matrix), the cleanup DELETE trips `DataFormatAwareEngine.delete()` and the test fails — even though the SQL/PPL behavior under test would otherwise pass.

### Fix
Skip these specific tests on the AE-storage matrix using the existing helper `PPLIntegTestCase.isAnalyticsParquetIndicesEnabled()` paired with `Assume.assumeFalse(...)`. This is the precedent already established in `StatsCommandIT` (4 sites) and `CalciteAnalyticsDatetimeWireFormatIT.init()`.

### Impact
| Mode | Behavior |
| --- | --- |
| Default `integTest` / `integTestRemote` (mainline CI) | unchanged — `assumeFalse(false)` is a no-op, tests run and assert as before |
| `-Dtests.analytics.parquet_indices=true` (AE-storage matrix) | 10 affected tests are skipped (logged with reason); bucket # 22 in the report disappears |

No assertion is changed, no fixture is refactored, no Lucene-path coverage is lost.

### Out of scope
- Engine-level support for delete on `DataFormatAwareEngine` — major design question, not a test-fix concern.
- Refactoring the affected tests to use per-test indices (drop+recreate instead of per-doc DELETE) — would also fix the issue but is significantly more invasive and unnecessary for clearing the report.

### Test plan
- [ ] CI: default `integTest` / `integTestRemote` passes (no behavior change on Lucene path).
- [ ] Manual: re-run the AE-storage matrix and confirm bucket # 22 no longer appears.
- [ ] `./gradlew :integ-test:spotlessApply` ran clean.
- [ ] `./gradlew :integ-test:compileTestJava` ran clean.