### PR TITLE
Add ci.opensearch.org maven2 mirror to avoid throttling (sql)

### DIFF
--- a/async-query-core/build.gradle
+++ b/async-query-core/build.gradle
@@ -13,6 +13,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/async-query/build.gradle
+++ b/async-query/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }
@@ -91,6 +92,7 @@ apply plugin: 'opensearch.java-agent'
 // Repository on root level is for dependencies that project code depends on. And this block must be placed after plugins{}
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
     maven {
         url 'https://jitpack.io'
@@ -169,6 +171,7 @@ allprojects {
 subprojects {
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven {
             url 'https://jitpack.io'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'java'
 
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -29,6 +29,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,6 +34,7 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -12,6 +12,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/direct-query-core/build.gradle
+++ b/direct-query-core/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/direct-query/build.gradle
+++ b/direct-query/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -58,6 +58,7 @@ boolean ignorePrometheus = ignorePrometheusProp != null && !ignorePrometheusProp
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven {
         url 'https://jitpack.io'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -43,6 +43,7 @@ ext {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven {
         url 'https://jitpack.io'

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
 
 rootProject.name = 'opensearch-sql'
 


### PR DESCRIPTION
### Description
Add ci.opensearch.org maven2 mirror to avoid throttling (sql)

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/6062

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
