### PR TITLE
Publish failure metrics for SQL analytics engine execution path

### DIFF
--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -197,14 +197,14 @@ public class RestSqlAction extends BaseRestHandler {
                   handleException(restChannel, e);
                 }
               },
-              this::handleException)
+              RestSqlAction::handleException)
           .accept(channel);
     } catch (Exception e) {
       handleException(channel, e);
     }
   }
 
-  private void handleException(RestChannel restChannel, Exception exception) {
+  public static void handleException(RestChannel restChannel, Exception exception) {
     RestStatus status = getRestStatus(exception);
     logAndPublishMetrics(status, exception);
     reportError(restChannel, exception, status);
@@ -337,12 +337,13 @@ public class RestSqlAction extends BaseRestHandler {
         || e instanceof ExpressionEvaluationException;
   }
 
-  private void sendResponse(
+  private static void sendResponse(
       final RestChannel channel, final String message, final RestStatus status) {
     channel.sendResponse(new BytesRestResponse(status, message));
   }
 
-  private void reportError(final RestChannel channel, final Exception e, final RestStatus status) {
+  private static void reportError(
+      final RestChannel channel, final Exception e, final RestStatus status) {
     sendResponse(
         channel, ErrorMessageFactory.createErrorMessage(e, status.getStatus()).toString(), status);
   }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -263,8 +263,7 @@ public class SQLPlugin extends Plugin
 
               @Override
               public void onFailure(Exception e) {
-                channel.sendResponse(
-                    new BytesRestResponse(RestSqlAction.getRestStatus(e), e.getMessage()));
+                RestSqlAction.handleException(channel, e);
               }
             });
       } else {
@@ -282,8 +281,7 @@ public class SQLPlugin extends Plugin
 
               @Override
               public void onFailure(Exception e) {
-                channel.sendResponse(
-                    new BytesRestResponse(RestSqlAction.getRestStatus(e), e.getMessage()));
+                RestSqlAction.handleException(channel, e);
               }
             });
       }


### PR DESCRIPTION
### Description

This PR fixes the SQL analytics engine (AE) execution path so failures now publish failure metrics and are logged, consistent with the SQL V2 path. The PPL AE path needs no change — failures already propagate to the top-level listener callback in `RestPPLQueryAction.onFailure()`.

#### Example

Use the unsupported SEC_TO_TIME function to trigger a backend failure on both endpoints, followed by the stats. Both `failed_request_count_syserr` (SQL) and `ppl_failed_request_count_syserr` (PPL) now increment correctly on AE failures, with no double-counting:

```
$ curl -s -X POST "localhost:9200/_plugins/_sql" -H 'Content-Type: application/json' \
   -d '{"query":"SELECT SEC_TO_TIME(3661) FROM test_basic"}'

$ curl -s -X POST "localhost:9200/_plugins/_ppl" -H 'Content-Type: application/json' \
   -d '{"query":"source=test_basic | eval t = SEC_TO_TIME(3661)"}'
 {
   "error": {
     "reason": "There was internal problem at backend",
     "details": "No backend supports scalar function [SEC_TO_TIME] among [datafusion]",
     "type": "IllegalStateException"
   },
   "status": 500
 }

$ curl -s -X GET "localhost:9200/_plugins/_sql/stats?pretty"
 {
   "request_total": 3,
   "request_count": 3,
   "failed_request_count_cuserr": 0,
   "failed_request_count_syserr": 3,
   ...
   "ppl_request_total": 4,
   "ppl_request_count": 4,
   "ppl_failed_request_count_cuserr": 0,
   "ppl_failed_request_count_syserr": 4
 }
```

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5246

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
