### PR TITLE
test(sql): skip vectorSearch missing-plugin IT when k-NN is installed

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -8,8 +8,10 @@ package org.opensearch.sql.sql;
 import static org.hamcrest.Matchers.containsString;
 
 import java.io.IOException;
+import org.junit.Assume;
 import org.junit.Test;
 import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.legacy.TestsConstants;
@@ -346,13 +348,22 @@ public class VectorSearchIT extends SQLIntegTestCase {
   }
 
   // ── k-NN plugin capability check ──────────────────────────────────────
-  // The default integ-test cluster does not have the k-NN plugin installed. Execution-path
+  // The plugin's own integ-test cluster does not have the k-NN plugin installed. Execution-path
   // queries against vectorSearch() should therefore fail with the clear "k-NN plugin missing"
   // error from KnnPluginCapability, while _explain continues to work because the capability
   // probe is deferred to scan open() and does not run during analysis/planning.
 
   @Test
   public void testExecutionWithoutKnnPluginReturnsCapabilityError() throws IOException {
+    // This test asserts the "k-NN plugin not installed" capability error, so it is only meaningful
+    // on a cluster WITHOUT the k-NN plugin. The OpenSearch distribution bundles opensearch-knn, so
+    // on the distribution integ-test cluster the query reaches k-NN and fails with a different
+    // ("not knn_vector type") error instead. Skip there; the missing-plugin path stays covered by
+    // the plugin's own JVM integ-test cluster, which does not ship k-NN.
+    Assume.assumeFalse(
+        "k-NN plugin is installed on this cluster; skipping missing-plugin capability check",
+        isKnnPluginInstalled());
+
     ResponseException ex =
         expectThrows(
             ResponseException.class,
@@ -750,6 +761,18 @@ public class VectorSearchIT extends SQLIntegTestCase {
       client().performRequest(new Request("DELETE", "/_all/_alias/" + aliasName));
     } catch (IOException ignored) {
       // Alias does not exist, which is fine.
+    }
+  }
+
+  // Mirrors VectorSearchExecutionIT#isKnnPluginInstalled — opensearch-knn is bundled in the
+  // OpenSearch distribution but not in the plugin's own JVM integ-test cluster.
+  private static boolean isKnnPluginInstalled() {
+    try {
+      Response response = client().performRequest(new Request("GET", "/_cat/plugins?h=component"));
+      String body = new String(response.getEntity().getContent().readAllBytes());
+      return body.contains("opensearch-knn");
+    } catch (IOException e) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
### Description

`VectorSearchIT.testExecutionWithoutKnnPluginReturnsCapabilityError` asserts the user-facing error produced **when the k-NN plugin is not installed**:

> `vectorSearch() requires the k-NN plugin, which is not installed on this cluster.`

That assertion is only valid on a cluster **without** k-NN. The SQL plugin's own JVM integ-test cluster has no k-NN, so the test passes in this repo's CI. But the **OpenSearch distribution bundles `opensearch-knn`**, so on the distribution integ-test cluster (`opensearch-build`) the query actually reaches k-NN and fails with a *different* error — `Field 'embedding' is not knn_vector type` (HTTP 400) — because the test's `account` index has no real `knn_vector` field.

This makes the test fail deterministically across **all platforms** in the 3.x distribution integ-test run, blocking the release.

```
Expected: a string containing "vectorSearch() requires the k-NN plugin, which is not installed on this cluster."
     but: was "...status line [HTTP/1.1 400 Bad Request]... Field 'embedding' is not knn_vector type"
```

### Fix

Guard the test with `Assume.assumeFalse(isKnnPluginInstalled())` so it runs only on the no-k-NN cluster it was written for. This mirrors the inverse `Assume.assumeTrue(isKnnPluginInstalled())` guard already used by `VectorSearchExecutionIT`, and reuses the same `/_cat/plugins` detection helper.

- The missing-plugin path stays covered on the plugin's own JVM integ-test cluster (no k-NN).
- The happy path is covered by `VectorSearchExecutionIT` on k-NN-enabled clusters.
- **No production code changes** — test-only.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).