### PR TITLE
[Backport 3.7] test(sql): skip vectorSearch missing-plugin IT when k-NN is installed

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/VectorSearchIT.java
@@ -8,8 +8,10 @@ package org.opensearch.sql.sql;
 import static org.hamcrest.Matchers.containsString;
 
 import java.io.IOException;
+import org.junit.Assume;
 import org.junit.Test;
 import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.legacy.TestsConstants;
@@ -346,13 +348,22 @@ public class VectorSearchIT extends SQLIntegTestCase {
   }
 
   // ── k-NN plugin capability check ──────────────────────────────────────
-  // The default integ-test cluster does not have the k-NN plugin installed. Execution-path
+  // The plugin's own integ-test cluster does not have the k-NN plugin installed. Execution-path
   // queries against vectorSearch() should therefore fail with the clear "k-NN plugin missing"
   // error from KnnPluginCapability, while _explain continues to work because the capability
   // probe is deferred to scan open() and does not run during analysis/planning.
 
   @Test
   public void testExecutionWithoutKnnPluginReturnsCapabilityError() throws IOException {
+    // This test asserts the "k-NN plugin not installed" capability error, so it is only meaningful
+    // on a cluster WITHOUT the k-NN plugin. The OpenSearch distribution bundles opensearch-knn, so
+    // on the distribution integ-test cluster the query reaches k-NN and fails with a different
+    // ("not knn_vector type") error instead. Skip there; the missing-plugin path stays covered by
+    // the plugin's own JVM integ-test cluster, which does not ship k-NN.
+    Assume.assumeFalse(
+        "k-NN plugin is installed on this cluster; skipping missing-plugin capability check",
+        isKnnPluginInstalled());
+
     ResponseException ex =
         expectThrows(
             ResponseException.class,
@@ -750,6 +761,18 @@ public class VectorSearchIT extends SQLIntegTestCase {
       client().performRequest(new Request("DELETE", "/_all/_alias/" + aliasName));
     } catch (IOException ignored) {
       // Alias does not exist, which is fine.
+    }
+  }
+
+  // Mirrors VectorSearchExecutionIT#isKnnPluginInstalled — opensearch-knn is bundled in the
+  // OpenSearch distribution but not in the plugin's own JVM integ-test cluster.
+  private static boolean isKnnPluginInstalled() {
+    try {
+      Response response = client().performRequest(new Request("GET", "/_cat/plugins?h=component"));
+      String body = new String(response.getEntity().getContent().readAllBytes());
+      return body.contains("opensearch-knn");
+    } catch (IOException e) {
+      return false;
     }
   }
 }

--- a/release-notes/opensearch-sql.release-notes-3.7.0.0.md
+++ b/release-notes/opensearch-sql.release-notes-3.7.0.0.md
@@ -66,6 +66,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.7.0
 * Bump Gradle wrapper to 9.4.1 and workaround `@Ignore` test failure ([#5414](https://github.com/opensearch-project/sql/pull/5414))
 * Fix link checker CI failure by excluding LinkedIn URLs ([#5461](https://github.com/opensearch-project/sql/pull/5461))
 * Integration test cases for field-level security ([#5008](https://github.com/opensearch-project/sql/pull/5008))
+* Skip `vectorSearch()` missing-plugin integration test when the k-NN plugin is installed, fixing the distribution integ-test run since distributions bundle k-NN ([#5492](https://github.com/opensearch-project/sql/pull/5492))
 
 ### Documentation
 


### PR DESCRIPTION
Manual backport of #5492 to `3.7` (the automated backport workflow is currently broken).

### Description

`VectorSearchIT.testExecutionWithoutKnnPluginReturnsCapabilityError` asserts the "k-NN plugin not installed" capability error, which is only produced on a cluster **without** the k-NN plugin. The OpenSearch distribution bundles `opensearch-knn`, so on the distribution integ-test cluster the query reaches k-NN and fails with a different error (`Field 'embedding' is not knn_vector type`, HTTP 400), breaking the 3.x distribution integ-test run across all platforms.

This guards the test with `Assume.assumeFalse(isKnnPluginInstalled())` so it runs only on the no-k-NN cluster it was written for, mirroring the inverse `assumeTrue` guard already used by `VectorSearchExecutionIT`. **Test-only change — no production code.**

Needed on `3.7` because the release candidate is being built from this branch.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Backport of #5492.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.