### PR TITLE
Use Object type for queryCtx in AnalyticsExecutionEngine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -82,15 +82,14 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
   }
 
   /**
-   * Overload that threads a {@link org.opensearch.analytics.QueryRequestContext} snapshot down to
-   * the analytics-engine's plan executor via {@link
-   * org.opensearch.analytics.exec.QueryPlanExecutor}'s opaque context slot. The snapshot is
-   * captured once at query entry so planner and executor see the same cluster state.
+   * Overload that threads a QueryRequestContext snapshot down to the analytics-engine's plan
+   * executor via {@link org.opensearch.analytics.exec.QueryPlanExecutor}'s opaque context slot. The
+   * snapshot is captured once at query entry so planner and executor see the same cluster state.
    */
   public void execute(
       RelNode plan,
       CalcitePlanContext context,
-      org.opensearch.analytics.QueryRequestContext queryCtx,
+      Object queryCtx,
       ResponseListener<QueryResponse> listener) {
     // QueryPlanExecutor became asynchronous in analytics-framework 3.7 — execution is dispatched
     // to a worker pool and results arrive on the listener. Record the execute metric in the
@@ -153,7 +152,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
   public void executeWithProfile(
       RelNode plan,
       CalcitePlanContext context,
-      org.opensearch.analytics.QueryRequestContext queryCtx,
+      Object queryCtx,
       ResponseListener<QueryResponse> listener) {
 
     planExecutor.executeWithProfile(


### PR DESCRIPTION
### Description

The `QueryRequestContext` class lives in `analytics-engine` (plugin), not `analytics-api` (library). The `core` module only has a `compileOnly` dependency on `analytics-api`, so referencing `QueryRequestContext` directly causes compilation failures when the published `analytics-api` SNAPSHOT does not include it.

Since `QueryPlanExecutor.execute()` takes `Object` as the context parameter anyway, this PR changes the parameter type from `org.opensearch.analytics.QueryRequestContext` to `Object`. The value is passed through opaquely — no type-specific operations are performed on it in this module.

### Issues Resolved

Fixes snapshot publish failure: `cannot find symbol: class QueryRequestContext in package org.opensearch.analytics`

### Check List
- [x] New functionality includes testing
  - N/A — type-only change, no behavioral difference
- [x] Commits are signed with DCO