### PR TITLE
Exclude AnalyticsEngineCompatIT from the main integTest task

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -766,6 +766,12 @@ integTest {
     // Exclude this IT, because they executed in another task (:integTestWithSecurity)
     exclude 'org/opensearch/sql/security/**'
 
+    // Exclude the analytics-engine smoke test, because it executes in another task
+    // (:analyticsEngineCompatIT) against a cluster that bundles the analytics-engine plugin
+    // stack. Running it here against the plain integTest/remoteCluster (no analytics-engine)
+    // is pointless and leaves it exposed to suite-wide infra flakiness.
+    exclude 'org/opensearch/sql/plugin/**'
+
     // Workaround for Gradle 9.4.1 ClassCastException in TestEventReporterAsListener.started
     // (line 58) — the bridge casts a parent test descriptor's reporter to
     // GroupTestEventReporterInternal but a class-level @Ignore produces a non-composite parent

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -770,7 +770,7 @@ integTest {
     // (:analyticsEngineCompatIT) against a cluster that bundles the analytics-engine plugin
     // stack. Running it here against the plain integTest/remoteCluster (no analytics-engine)
     // is pointless and leaves it exposed to suite-wide infra flakiness.
-    exclude 'org/opensearch/sql/plugin/**'
+    exclude 'org/opensearch/sql/plugin/AnalyticsEngineCompatIT.class'
 
     // Workaround for Gradle 9.4.1 ClassCastException in TestEventReporterAsListener.started
     // (line 58) — the bridge casts a parent test descriptor's reporter to


### PR DESCRIPTION
### Description

`AnalyticsEngineCompatIT` (package `org.opensearch.sql.plugin`) is a smoke test that only makes sense against a cluster bundling the analytics-engine plugin stack. It is provisioned and run by its **dedicated** `:analyticsEngineCompatIT` task, whose cluster (`testClusters.analyticsEngineCompat`) adds `arrow-base`, `arrow-flight-rpc`, and `analytics-engine` alongside `opensearch-sql`.

The main `integTest` task selects tests by **exclusion**. It already excludes `org/opensearch/sql/security/**` ("executed in another task"), but it never excluded the plugin package — so the smoke test *also* ran inside the main `integTest` suite against the plain `integTest`/`remoteCluster` clusters, neither of which has the analytics-engine plugin. (`integTestWithSecurity` is unaffected because it uses an *include* filter scoped to `org.opensearch.sql.security.*`.)

There, the test is pointless and exposed to suite-wide infra flakiness. In a recent CI run it was the descriptor recorded as the single failure after the test JVM wedged for ~4.5h (JobSweeper kept ticking for ~3.5h before the REST connection finally dropped with `ConnectionClosedException`). The empty test body cannot itself hang — it was simply the last test in the order when the wedged JVM died.

### Fix

Mirror the existing `security/**` exclusion for `org/opensearch/sql/plugin/**` in the main `integTest` task. The compat test continues to run via its dedicated `:analyticsEngineCompatIT` task, which correctly provisions its dependency.

This is purely a test-isolation/wiring fix in `integ-test/build.gradle`; no production or test source changes.

### Verification

- `./gradlew :integ-test:integTest --dry-run` configures the full task graph successfully with the new exclusion.
- The exclude pattern is identical in form to the adjacent, working `org/opensearch/sql/security/**` exclusion.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.