### PR TITLE
[Bacport 3.7] Exclude AnalyticsEngineCompatIT from the main integTest task

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -726,6 +726,12 @@ integTest {
     // Exclude this IT, because they executed in another task (:integTestWithSecurity)
     exclude 'org/opensearch/sql/security/**'
 
+    // Exclude the analytics-engine smoke test, because it executes in another task
+    // (:analyticsEngineCompatIT) against a cluster that bundles the analytics-engine plugin
+    // stack. Running it here against the plain integTest/remoteCluster (no analytics-engine)
+    // is pointless and leaves it exposed to suite-wide infra flakiness.
+    exclude 'org/opensearch/sql/plugin/AnalyticsEngineCompatIT.class'
+
     // Workaround for Gradle 9.4.1 ClassCastException in TestEventReporterAsListener.started
     // (line 58) — the bridge casts a parent test descriptor's reporter to
     // GroupTestEventReporterInternal but a class-level @Ignore produces a non-composite parent


### PR DESCRIPTION
### Description

Manual port to `3.7` of the same fix proposed for `main` in #5501.

`AnalyticsEngineCompatIT` (package `org.opensearch.sql.plugin`) is a smoke test that only makes sense against a cluster bundling the analytics-engine plugin stack. It is provisioned and run by its **dedicated** `:analyticsEngineCompatIT` task, whose cluster (`testClusters.analyticsEngineCompat`) adds `arrow-base`, `arrow-flight-rpc`, and `analytics-engine` alongside `opensearch-sql`.

The main `integTest` task selects tests by **exclusion**. It already excludes `org/opensearch/sql/security/**` ("executed in another task"), but it never excluded this smoke test — so it *also* ran inside the main `integTest` suite against the plain `integTest`/`remoteCluster` clusters, neither of which has the analytics-engine plugin. (`integTestWithSecurity` is unaffected because it uses an *include* filter scoped to `org.opensearch.sql.security.*`.)

There, the test is pointless and exposed to suite-wide infra flakiness. In a recent CI run it was the descriptor recorded as the single failure after the test JVM wedged for ~4.5h (the empty test body cannot itself hang — it was just the last test in the order when the wedged JVM's REST connection dropped with `ConnectionClosedException`).

### Fix

Exclude the specific `org/opensearch/sql/plugin/AnalyticsEngineCompatIT.class` in the main `integTest` task, matching the per-class exclude style already used there (e.g. `legacy/ExplainIT.class`). The compat test continues to run via its dedicated `:analyticsEngineCompatIT` task, which correctly provisions its dependency.

This is purely a test-isolation/wiring fix in `integ-test/build.gradle`; no production or test source changes.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.