### PR TITLE
[BugFix] Preserve aggregate aliases for unified query SQL

### DIFF
--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
@@ -278,6 +278,57 @@ public class UnifiedQueryPlannerSqlV2Test extends UnifiedQueryTestBase {
   }
 
   @Test
+  public void testGroupByAggregateAlias() {
+    givenQuery(
+            """
+            SELECT department, SUM(age) AS total FROM catalog.employees GROUP BY department
+            """)
+        .assertPlan(
+            """
+            LogicalProject(department=[$0], total=[$1])
+              LogicalAggregate(group=[{0}], SUM(age)=[SUM($1)])
+                LogicalProject(department=[$3], age=[$2])
+                  LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testOrderByAggregateAlias() {
+    givenQuery(
+            """
+            SELECT department, COUNT(*) AS cnt FROM catalog.employees
+              GROUP BY department ORDER BY cnt DESC LIMIT 3
+            """)
+        .assertPlan(
+            """
+            LogicalSort(sort0=[$1], dir0=[DESC-nulls-last])
+              LogicalProject(department=[$1], cnt=[$0])
+                LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[3])
+                  LogicalProject(COUNT(*)=[$1], department=[$0])
+                    LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+                      LogicalProject(department=[$3])
+                        LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testAliasPreservedInOutputSchema() {
+    givenQuery("SELECT COUNT(*) AS cnt FROM catalog.employees").assertFields("cnt");
+
+    givenQuery("SELECT department, COUNT(*) AS cnt FROM catalog.employees GROUP BY department")
+        .assertFields("department", "cnt");
+
+    givenQuery("SELECT department, COUNT(*) FROM catalog.employees GROUP BY department")
+        .assertFields("department", "COUNT(*)");
+
+    givenQuery("SELECT MAX(age) + MIN(age) AS range_sum FROM catalog.employees")
+        .assertFields("range_sum");
+
+    givenQuery("SELECT id, name, age AS years, department FROM catalog.employees")
+        .assertFields("id", "name", "years", "department");
+  }
+
+  @Test
   public void testHavingMaxCol() {
     givenQuery(
             """

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -481,9 +481,28 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
       if (!context.isResolvingSubquery()) {
         context.setProjectVisited(true);
       }
-      context.relBuilder.project(expandedFields);
+
+      // Force the projection on a rename: without it, Calcite omits the project node when the
+      // columns are unchanged (same fields and order), so an alias like COUNT(*) AS cnt is lost.
+      boolean force = isRenameFieldsProject(expandedFields, currentFields);
+      context.relBuilder.project(expandedFields, ImmutableList.of(), force);
     }
     return context.relBuilder.peek();
+  }
+
+  private static boolean isRenameFieldsProject(List<RexNode> fields, List<String> currentFields) {
+    for (RexNode r : fields) {
+      if (r.getKind() == AS) {
+        RexCall as = (RexCall) r;
+        if (as.getOperands().get(0) instanceof RexInputRef ref) {
+          String name = ((RexLiteral) as.getOperands().get(1)).getValueAs(String.class);
+          if (!name.equals(currentFields.get(ref.getIndex()))) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 
   private boolean isSingleAllFieldsProject(Project node) {


### PR DESCRIPTION
### Description

This PR fixes SQL aggregate aliases being lost in the unified query SQL path — e.g. `SELECT city, COUNT(*) AS cnt FROM t GROUP BY city` returned the column as `COUNT(*)` instead of `cnt`.

- **Root cause:** when a projection only renames a column without adding/removing/reordering, `RelBuilder.project` (default `force=false`) treats it as a no-op and skips emitting the `LogicalProject` (this minimizes the plan tree, since names of intermediate projections don't matter). We now force the SELECT projection to materialize when it renames a field, so the alias survives in the output schema.
- **PPL impact:** PPL never produces an `AS` RexCall through this path (`rename`/`eval`/`fields`/`stats` build output names differently), so the change never triggers for PPL.

### Related Issues

Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
