### PR TITLE
Skip AnalyticsEngineCompatIT when analytics-engine plugin is absent

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/plugin/AnalyticsEngineCompatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/plugin/AnalyticsEngineCompatIT.java
@@ -5,17 +5,55 @@
 
 package org.opensearch.sql.plugin;
 
+import static org.junit.Assume.assumeTrue;
+
+import java.io.IOException;
+import org.junit.Before;
 import org.junit.Test;
-import org.opensearch.test.rest.OpenSearchRestTestCase;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.sql.legacy.OpenSearchSQLRestTestCase;
+import org.opensearch.sql.legacy.TestUtils;
 
 /**
  * Smoke test: verifies that opensearch-sql loads cleanly alongside arrow-flight-rpc and
  * analytics-engine. A successful cluster start is the only assertion — no sql-specific logic runs.
+ *
+ * <p>This test is only meaningful when the analytics-engine plugin is installed; the dedicated
+ * {@code :integ-test:analyticsEngineCompatIT} Gradle task bundles the plugin stack for exactly that
+ * purpose. Other lanes can still discover this class — notably the distribution integ-test
+ * pipeline, which scans every {@code *IT} class against the built distribution and may run with the
+ * security plugin enabled and without analytics-engine. A {@code build.gradle} exclude does not
+ * protect against that pipeline, so the test guards itself instead:
+ *
+ * <ul>
+ *   <li>It extends {@link OpenSearchSQLRestTestCase} so the REST client honours the {@code https},
+ *       {@code user}, and {@code password} system properties of a secured cluster (a bare {@code
+ *       OpenSearchRestTestCase} speaks plain HTTP and gets its connection closed during client init
+ *       on a TLS-secured port).
+ *   <li>It skips via an assumption when analytics-engine is absent, so a build without the plugin
+ *       reports the test as skipped rather than failed.
+ * </ul>
  */
-public class AnalyticsEngineCompatIT extends OpenSearchRestTestCase {
+public class AnalyticsEngineCompatIT extends OpenSearchSQLRestTestCase {
+
+  /**
+   * Skips the suite unless the analytics-engine plugin is installed. Runs after the framework has
+   * established the (security-aware) REST client, so the lookup itself succeeds on both plain and
+   * secured clusters.
+   */
+  @Before
+  public void requireAnalyticsEngine() throws IOException {
+    Response response = client().performRequest(new Request("GET", "/_cat/plugins?h=component"));
+    String installedPlugins = TestUtils.getResponseBody(response, true);
+    assumeTrue(
+        "analytics-engine plugin not installed — skipping coexistence smoke test",
+        installedPlugins.contains("analytics-engine"));
+  }
 
   @Test
   public void testClusterStarted() {
-    // If the cluster booted, all three plugins loaded without classloader errors.
+    // If the cluster booted with analytics-engine present, all plugins loaded without classloader
+    // errors. The assumption above guarantees we only assert this where it is meaningful.
   }
 }


### PR DESCRIPTION
### Description

`AnalyticsEngineCompatIT` is a coexistence smoke test whose only assertion is that the cluster boots. It is meant to run **only** in the dedicated `:integ-test:analyticsEngineCompatIT` Gradle task, which bundles the arrow + analytics-engine plugin stack on a non-security cluster.

The distribution integ-test pipeline behaves differently: it scans every `*IT` class against the built distribution and runs the `with-security` variant **without** the analytics-engine plugin. In that lane the test fails before any test body runs:

```
org.opensearch.sql.plugin.AnalyticsEngineCompatIT.testClusterStarted
  → org.apache.hc.core5.http.ConnectionClosedException: Connection closed by peer
      at OpenSearchRestTestCase.initClient(OpenSearchRestTestCase.java:216)
```

Root cause: the test extends a bare `OpenSearchRestTestCase`, which speaks plain HTTP. Against a TLS-secured cluster the security plugin closes the connection during client init. The existing `build.gradle` exclude only governs this repo's own `integTest` task — it does not cover the external distribution pipeline that discovers the class generically.

### Fix

Make the test self-inert no matter how it is discovered:

- **Extend `OpenSearchSQLRestTestCase`** so the REST client honours the `https` / `user` / `password` system properties of a secured cluster (TLS trust + basic auth), instead of failing the connection.
- **Skip via an assumption** (`assumeTrue`) when the analytics-engine plugin is not installed — verified through `_cat/plugins`. A build without the plugin now reports the test as **skipped** rather than **failed**.

Resulting behaviour:

| Lane | Before | After |
|---|---|---|
| `analyticsEngineCompatIT` task (plugin present) | pass | pass |
| Distribution build, no security, no analytics-engine | n/a | **skipped** |
| Distribution build, with security, no analytics-engine | **FAIL** (connection closed) | **skipped** |

### Check List
- [x] New functionality includes testing — change is itself an integration test; behaviour validated against secured / unsecured / plugin-absent lanes.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.