### PR TITLE
Fix PPL REST handler returning 500 for OpenSearchRejectedExecutionException

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLQueryAction.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -65,13 +66,10 @@ public class RestPPLQueryAction extends BaseRestHandler {
     if (ex instanceof OpenSearchException) {
       return ((OpenSearchException) ex).status().getStatus();
     }
-    // Possible future work: We currently do this on exception types, when we have more robust
-    // ErrorCodes in more locations it may be worth switching this to be based on those instead.
-    // That lets us identify specific error cases at a granularity higher than exception types.
     if (isClientError(ex)) {
       return 400;
     }
-    return 500;
+    return ExceptionsHelper.status(ex).getStatus();
   }
 
   private static RestStatus loggedErrorCode(Exception ex) {

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestPPLQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestPPLQueryActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.plugin.rest;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+import org.junit.Test;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.exception.QueryEngineException;
+
+/** Unit tests for error status mapping in {@link RestPPLQueryAction}. */
+public class RestPPLQueryActionTest {
+
+  /**
+   * Invokes the private static getRawErrorCode via reflection so we can verify
+   * the status mapping for various exception types.
+   */
+  private static int getRawErrorCode(Exception ex) throws Exception {
+    Method method =
+        RestPPLQueryAction.class.getDeclaredMethod("getRawErrorCode", Exception.class);
+    method.setAccessible(true);
+    return (int) method.invoke(null, ex);
+  }
+
+  @Test
+  public void testRejectedExecutionReturns429() throws Exception {
+    OpenSearchRejectedExecutionException ex =
+        new OpenSearchRejectedExecutionException("admission control backpressure", false);
+    assertEquals(429, getRawErrorCode(ex));
+  }
+
+  @Test
+  public void testOpenSearchStatusExceptionPreservesStatus() throws Exception {
+    OpenSearchStatusException ex =
+        new OpenSearchStatusException("not found", RestStatus.NOT_FOUND);
+    assertEquals(404, getRawErrorCode(ex));
+  }
+
+  @Test
+  public void testIndexNotFoundReturns404() throws Exception {
+    // IndexNotFoundException extends OpenSearchException with status NOT_FOUND
+    IndexNotFoundException ex = new IndexNotFoundException("missing_index");
+    assertEquals(404, getRawErrorCode(ex));
+  }
+
+  @Test
+  public void testSyntaxCheckExceptionReturns400() throws Exception {
+    SyntaxCheckException ex = new SyntaxCheckException("bad syntax");
+    assertEquals(400, getRawErrorCode(ex));
+  }
+
+  @Test
+  public void testQueryEngineExceptionReturns400() throws Exception {
+    QueryEngineException ex = new QueryEngineException("semantic error");
+    assertEquals(400, getRawErrorCode(ex));
+  }
+
+  @Test
+  public void testGenericRuntimeExceptionReturns500() throws Exception {
+    RuntimeException ex = new RuntimeException("unexpected failure");
+    assertEquals(500, getRawErrorCode(ex));
+  }
+}


### PR DESCRIPTION
### Description
### Description

`RestPPLQueryAction.getRawErrorCode()` has a hardcoded `return 500` fallback for exceptions that don't match `OpenSearchException` or the known client-error list. `OpenSearchRejectedExecutionException` extends `RejectedExecutionException` → `RuntimeException` (not `OpenSearchException`), so it always fell through to the 500 path — even though OpenSearch core's `ExceptionsHelper.status()` already maps it to `TOO_MANY_REQUESTS` (429).

This affects any backend that throws `OpenSearchRejectedExecutionException` through the PPL query path (e.g., admission control rejections from the analytics engine under memory pressure).

### Changes

- Replace `return 500` with `return ExceptionsHelper.status(ex).getStatus()` — delegates to the same mapping used by DSL `_search` and the rest of OpenSearch
- Remove a stale comment about future ErrorCode-based mapping
- Add `RestPPLQueryActionTest` with unit tests covering the key exception→status mappings

### Testing

**Unit tests** (all pass):
- `testRejectedExecutionReturns429` — the primary fix scenario
- `testOpenSearchStatusExceptionPreservesStatus` — verifies OpenSearchException path still works (404)
- `testIndexNotFoundReturns404` — IndexNotFoundException (extends OpenSearchException)
- `testSyntaxCheckExceptionReturns400` — client error path
- `testQueryEngineExceptionReturns400` — client error path
- `testGenericRuntimeExceptionReturns500` — unknown exceptions still return 500

**Full plugin test suite**: `./gradlew :opensearch-sql-plugin:test` — all existing tests pass.

**Manual end-to-end verification** (local single-node cluster with DataFusion analytics backend):
1. Injected a Rust-side memory admission rejection (`admission_rejected_error`) in the native query engine
2. `NativeErrorConverter` correctly converted the native error string to `OpenSearchRejectedExecutionException`
3. **Before fix**: PPL `/_plugins/_ppl` returned HTTP 500 / INTERNAL_SERVER_ERROR
4. **After fix**: PPL `/_plugins/_ppl` returned HTTP 429 / TOO_MANY_REQUESTS
5. DSL `/_search` path confirmed returning 429 both before and after (it already uses `ExceptionsHelper.status()`)
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
