### PR TITLE
[BugFix] Key date_time pushdown on field type, not literal UDT (#5481)

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLBasicIT.java
@@ -512,6 +512,28 @@ public class CalcitePPLBasicIT extends PPLIntegTestCase {
         actual, rows("Nanette", "2018-06-23 00:00:00"), rows("Elinor", "2018-06-27 00:00:00"));
   }
 
+  /**
+   * Issue #5481: a timestamp range comparison AND'd with an {@code IN} clause on another field must
+   * push down and return rows. Calcite folds the {@code IN} into a {@code Sarg} and strips the
+   * timestamp literal's UDT; without the field-type-keyed fix the range query ships an unformatted
+   * date to the shard, which rejects it with a date-parse error (HTTP 500).
+   */
+  @Test
+  public void testTimestampRangeWithInClausePushDown() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where birthdate > timestamp('2018-06-01 00:00:00') | where state in"
+                    + " ('IL', 'TN', 'WA') | fields firstname, state, birthdate",
+                TEST_INDEX_BANK));
+    verifySchema(
+        actual,
+        schema("firstname", "string"),
+        schema("state", "string"),
+        schema("birthdate", "timestamp"));
+    verifyDataRows(actual, rows("Elinor", "WA", "2018-06-27 00:00:00"));
+  }
+
   @Test
   public void testXor() throws IOException {
     JSONObject result =

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLBasicIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLBasicIT.java
@@ -513,10 +513,7 @@ public class CalcitePPLBasicIT extends PPLIntegTestCase {
   }
 
   /**
-   * Issue #5481: a timestamp range comparison AND'd with an {@code IN} clause on another field must
-   * push down and return rows. Calcite folds the {@code IN} into a {@code Sarg} and strips the
-   * timestamp literal's UDT; without the field-type-keyed fix the range query ships an unformatted
-   * date to the shard, which rejects it with a date-parse error (HTTP 500).
+   * A timestamp range comparison AND'd with an {@code IN} clause must push down and return rows.
    */
   @Test
   public void testTimestampRangeWithInClausePushDown() throws IOException {

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5481.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5481.yml
@@ -1,0 +1,69 @@
+# Issue: https://github.com/opensearch-project/sql/issues/5481
+# A timestamp range comparison AND'd with an IN clause on another field must push down and
+# return rows. Calcite folds the IN into a Sarg and strips the timestamp literal's UDT; without
+# the field-type-keyed fix the range query ships an unformatted date and the shard rejects it.
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+
+  - do:
+      indices.create:
+        index: issue5481
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              event_time:
+                type: date
+              severity:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue5481", "_id": "1"}}'
+          - '{"event_time": "2026-05-28T10:00:00Z", "severity": "ERROR"}'
+          - '{"index": {"_index": "issue5481", "_id": "2"}}'
+          - '{"event_time": "2026-05-28T10:05:00Z", "severity": "WARN"}'
+          - '{"index": {"_index": "issue5481", "_id": "3"}}'
+          - '{"event_time": "2026-05-28T10:10:00Z", "severity": "INFO"}'
+          - '{"index": {"_index": "issue5481", "_id": "4"}}'
+          - '{"event_time": "2026-05-28T10:15:00Z", "severity": "ERROR"}'
+          - '{"index": {"_index": "issue5481", "_id": "5"}}'
+          - '{"event_time": "2026-05-28T10:20:00Z", "severity": "WARN"}'
+          - '{"index": {"_index": "issue5481", "_id": "6"}}'
+          - '{"event_time": "2026-05-28T10:25:00Z", "severity": "DEBUG"}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue5481
+        ignore_unavailable: true
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"Issue 5481: timestamp range AND keyword IN pushes down and returns rows":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=issue5481 | where event_time > timestamp('2026-05-28 10:08:00') | where severity in ('ERROR', 'WARN') | fields severity, event_time | sort event_time
+
+  - match: { total: 2 }
+  - match: { schema: [ { name: severity, type: "string" }, { name: event_time, type: "timestamp" } ] }
+  - match: { datarows: [ [ "ERROR", "2026-05-28 10:15:00" ], [ "WARN", "2026-05-28 10:20:00" ] ] }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1601,12 +1601,12 @@ public class PredicateAnalyzer {
     }
 
     private Object convertEndpointValue(Object value, boolean isTimeStamp) {
-      value = sargPointValue(value);
-      // Shared normalization entry point: a Sarg endpoint can normalize to null, and
-      // timestampValueForPushDown(value.toString()) would otherwise NPE.
+      // Shared normalization entry point: guard a null endpoint so the timestamp branch's
+      // value.toString() cannot NPE. sargPointValue never produces null from a non-null input.
       if (value == null) {
         return null;
       }
+      value = sargPointValue(value);
       return isTimeStamp ? timestampValueForPushDown(value.toString()) : value;
     }
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1378,10 +1378,10 @@ public class PredicateAnalyzer {
 
     @Override
     public QueryExpression equals(LiteralExpression literal) {
-      Object value = literal.value();
-      if (literal.isDateTime()) {
-        builder =
-            addFormatIfNecessary(literal, rangeQuery(getFieldReference()).gte(value).lte(value));
+      boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
+      Object value = endpointValue(literal, isTimeStamp);
+      if (isTimeStamp) {
+        builder = rangeQuery(getFieldReference()).gte(value).lte(value).format("date_time");
       } else {
         builder = termQuery(getFieldReferenceForTermQuery(), value);
       }
@@ -1390,12 +1390,13 @@ public class PredicateAnalyzer {
 
     @Override
     public QueryExpression notEquals(LiteralExpression literal) {
-      Object value = literal.value();
-      if (literal.isDateTime()) {
+      boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
+      Object value = endpointValue(literal, isTimeStamp);
+      if (isTimeStamp) {
         builder =
             boolQuery()
-                .should(addFormatIfNecessary(literal, rangeQuery(getFieldReference()).gt(value)))
-                .should(addFormatIfNecessary(literal, rangeQuery(getFieldReference()).lt(value)));
+                .should(rangeQuery(getFieldReference()).gt(value).format("date_time"))
+                .should(rangeQuery(getFieldReference()).lt(value).format("date_time"));
       } else {
         builder =
             boolQuery()
@@ -1408,30 +1409,73 @@ public class PredicateAnalyzer {
 
     @Override
     public QueryExpression gt(LiteralExpression literal) {
-      Object value = literal.value();
-      builder = addFormatIfNecessary(literal, rangeQuery(getFieldReference()).gt(value));
+      boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
+      Object value = endpointValue(literal, isTimeStamp);
+      RangeQueryBuilder rq = rangeQuery(getFieldReference()).gt(value);
+      if (isTimeStamp) rq.format("date_time");
+      builder = rq;
       return this;
     }
 
     @Override
     public QueryExpression gte(LiteralExpression literal) {
-      Object value = literal.value();
-      builder = addFormatIfNecessary(literal, rangeQuery(getFieldReference()).gte(value));
+      boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
+      Object value = endpointValue(literal, isTimeStamp);
+      RangeQueryBuilder rq = rangeQuery(getFieldReference()).gte(value);
+      if (isTimeStamp) rq.format("date_time");
+      builder = rq;
       return this;
     }
 
     @Override
     public QueryExpression lt(LiteralExpression literal) {
-      Object value = literal.value();
-      builder = addFormatIfNecessary(literal, rangeQuery(getFieldReference()).lt(value));
+      boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
+      Object value = endpointValue(literal, isTimeStamp);
+      RangeQueryBuilder rq = rangeQuery(getFieldReference()).lt(value);
+      if (isTimeStamp) rq.format("date_time");
+      builder = rq;
       return this;
     }
 
     @Override
     public QueryExpression lte(LiteralExpression literal) {
-      Object value = literal.value();
-      builder = addFormatIfNecessary(literal, rangeQuery(getFieldReference()).lte(value));
+      boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
+      Object value = endpointValue(literal, isTimeStamp);
+      RangeQueryBuilder rq = rangeQuery(getFieldReference()).lte(value);
+      if (isTimeStamp) rq.format("date_time");
+      builder = rq;
       return this;
+    }
+
+    /**
+     * Whether the comparison should be treated as a timestamp range. The field's type is the
+     * reliable source — {@code literal.isDateTime()} relies on the literal's UDT, which {@link
+     * org.apache.calcite.rex.RexSimplify} can strip when a sibling clause is folded into a {@code
+     * Sarg} (e.g. {@code @timestamp > X AND severityText IN (...)}). Without this defensive check,
+     * the literal arrives as VARCHAR, the raw string ships to the shard without {@code
+     * format("date_time")} or ISO-8601 normalization, and the shard's default date parser rejects
+     * the space-separated {@code "2026-05-28 16:18:43"} form. See #5481.
+     */
+    private boolean isFieldOrLiteralDateTime(LiteralExpression literal) {
+      return literal.isDateTime() || (rel != null && rel.isTimeStampType());
+    }
+
+    /**
+     * Resolves the comparison endpoint to a value the shard's date parser accepts. Mirrors the Sarg
+     * path's {@code convertEndpointValue} — when the field is a timestamp, the value is routed
+     * through {@link #timestampValueForPushDown} to land in canonical ISO-8601 regardless of the
+     * literal's surviving type.
+     */
+    private Object endpointValue(LiteralExpression literal, boolean isTimeStamp) {
+      if (!isTimeStamp) {
+        return literal.value();
+      }
+      if (literal.isDateTime()) {
+        // literal.value() already normalizes for EXPR_TIMESTAMP / EXPR_DATE literals.
+        return literal.value();
+      }
+      // Field is timestamp but literal was re-typed to VARCHAR — normalize the raw value.
+      return timestampValueForPushDown(literal.value().toString());
     }
 
     @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1447,34 +1447,16 @@ public class PredicateAnalyzer {
       return this;
     }
 
-    /**
-     * Whether the comparison should be treated as a timestamp range. The field's type is the
-     * reliable source — {@code literal.isDateTime()} relies on the literal's UDT, which {@link
-     * org.apache.calcite.rex.RexSimplify} can strip when a sibling clause is folded into a {@code
-     * Sarg} (e.g. {@code @timestamp > X AND severityText IN (...)}). Without this defensive check,
-     * the literal arrives as VARCHAR, the raw string ships to the shard without {@code
-     * format("date_time")} or ISO-8601 normalization, and the shard's default date parser rejects
-     * the space-separated {@code "2026-05-28 16:18:43"} form. See #5481.
-     */
+    // Field type is the reliable source: RexSimplify can strip the literal's UDT when a sibling
+    // clause is folded into a Sarg, leaving it as VARCHAR.
     private boolean isFieldOrLiteralDateTime(LiteralExpression literal) {
       return literal.isDateTime() || (rel != null && rel.isTimeStampType());
     }
 
-    /**
-     * Resolves the comparison endpoint to a value the shard's date parser accepts. Mirrors the Sarg
-     * path's {@code convertEndpointValue} — when the field is a timestamp, the value is routed
-     * through {@link #timestampValueForPushDown} to land in canonical ISO-8601 regardless of the
-     * literal's surviving type.
-     */
     private Object endpointValue(LiteralExpression literal, boolean isTimeStamp) {
-      if (!isTimeStamp) {
+      if (!isTimeStamp || literal.isDateTime()) {
         return literal.value();
       }
-      if (literal.isDateTime()) {
-        // literal.value() already normalizes for EXPR_TIMESTAMP / EXPR_DATE literals.
-        return literal.value();
-      }
-      // Field is timestamp but literal was re-typed to VARCHAR — normalize the raw value.
       return timestampValueForPushDown(literal.value().toString());
     }
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1379,9 +1379,11 @@ public class PredicateAnalyzer {
     @Override
     public QueryExpression equals(LiteralExpression literal) {
       boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
-      Object value = endpointValue(literal, isTimeStamp);
+      Object value = convertEndpointValue(literal.value(), isTimeStamp);
       if (isTimeStamp) {
-        builder = rangeQuery(getFieldReference()).gte(value).lte(value).format("date_time");
+        builder =
+            addFormatIfNecessary(
+                isTimeStamp, rangeQuery(getFieldReference()).gte(value).lte(value));
       } else {
         builder = termQuery(getFieldReferenceForTermQuery(), value);
       }
@@ -1391,12 +1393,14 @@ public class PredicateAnalyzer {
     @Override
     public QueryExpression notEquals(LiteralExpression literal) {
       boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
-      Object value = endpointValue(literal, isTimeStamp);
+      Object value = convertEndpointValue(literal.value(), isTimeStamp);
       if (isTimeStamp) {
         builder =
             boolQuery()
-                .should(rangeQuery(getFieldReference()).gt(value).format("date_time"))
-                .should(rangeQuery(getFieldReference()).lt(value).format("date_time"));
+                .should(
+                    addFormatIfNecessary(isTimeStamp, rangeQuery(getFieldReference()).gt(value)))
+                .should(
+                    addFormatIfNecessary(isTimeStamp, rangeQuery(getFieldReference()).lt(value)));
       } else {
         builder =
             boolQuery()
@@ -1410,54 +1414,45 @@ public class PredicateAnalyzer {
     @Override
     public QueryExpression gt(LiteralExpression literal) {
       boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
-      Object value = endpointValue(literal, isTimeStamp);
-      RangeQueryBuilder rq = rangeQuery(getFieldReference()).gt(value);
-      if (isTimeStamp) rq.format("date_time");
-      builder = rq;
+      Object value = convertEndpointValue(literal.value(), isTimeStamp);
+      builder = addFormatIfNecessary(isTimeStamp, rangeQuery(getFieldReference()).gt(value));
       return this;
     }
 
     @Override
     public QueryExpression gte(LiteralExpression literal) {
       boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
-      Object value = endpointValue(literal, isTimeStamp);
-      RangeQueryBuilder rq = rangeQuery(getFieldReference()).gte(value);
-      if (isTimeStamp) rq.format("date_time");
-      builder = rq;
+      Object value = convertEndpointValue(literal.value(), isTimeStamp);
+      builder = addFormatIfNecessary(isTimeStamp, rangeQuery(getFieldReference()).gte(value));
       return this;
     }
 
     @Override
     public QueryExpression lt(LiteralExpression literal) {
       boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
-      Object value = endpointValue(literal, isTimeStamp);
-      RangeQueryBuilder rq = rangeQuery(getFieldReference()).lt(value);
-      if (isTimeStamp) rq.format("date_time");
-      builder = rq;
+      Object value = convertEndpointValue(literal.value(), isTimeStamp);
+      builder = addFormatIfNecessary(isTimeStamp, rangeQuery(getFieldReference()).lt(value));
       return this;
     }
 
     @Override
     public QueryExpression lte(LiteralExpression literal) {
       boolean isTimeStamp = isFieldOrLiteralDateTime(literal);
-      Object value = endpointValue(literal, isTimeStamp);
-      RangeQueryBuilder rq = rangeQuery(getFieldReference()).lte(value);
-      if (isTimeStamp) rq.format("date_time");
-      builder = rq;
+      Object value = convertEndpointValue(literal.value(), isTimeStamp);
+      builder = addFormatIfNecessary(isTimeStamp, rangeQuery(getFieldReference()).lte(value));
       return this;
     }
 
-    // Field type is the reliable source: RexSimplify can strip the literal's UDT when a sibling
-    // clause is folded into a Sarg, leaving it as VARCHAR.
+    /**
+     * Whether the comparison is a timestamp/date range. The field type is the reliable signal:
+     * {@code literal.isDateTime()} reads the literal's UDT, which {@link
+     * org.apache.calcite.rex.RexSimplify} can strip (to VARCHAR) when a sibling clause is folded
+     * into a {@code Sarg}, e.g. {@code @timestamp > X AND severityText IN (...)}. Falling back to
+     * {@code rel.isTimeStampType()} keeps ISO-8601 normalization and the {@code "date_time"} format
+     * hint on the range query.
+     */
     private boolean isFieldOrLiteralDateTime(LiteralExpression literal) {
       return literal.isDateTime() || (rel != null && rel.isTimeStampType());
-    }
-
-    private Object endpointValue(LiteralExpression literal, boolean isTimeStamp) {
-      if (!isTimeStamp || literal.isDateTime()) {
-        return literal.value();
-      }
-      return timestampValueForPushDown(literal.value().toString());
     }
 
     @Override
@@ -1607,6 +1602,11 @@ public class PredicateAnalyzer {
 
     private Object convertEndpointValue(Object value, boolean isTimeStamp) {
       value = sargPointValue(value);
+      // Shared normalization entry point: a Sarg endpoint can normalize to null, and
+      // timestampValueForPushDown(value.toString()) would otherwise NPE.
+      if (value == null) {
+        return null;
+      }
       return isTimeStamp ? timestampValueForPushDown(value.toString()) : value;
     }
   }
@@ -1738,16 +1738,19 @@ public class PredicateAnalyzer {
   }
 
   /**
-   * By default, range queries on date/time need use the format of the source to parse the literal.
-   * So we need to specify that the literal has "date_time" format
+   * Range queries on date/time fields need the source format to parse the literal, so we attach the
+   * {@code "date_time"} format. The caller resolves whether the comparison is a timestamp range
+   * from the field type (see {@link SimpleQueryExpression#isFieldOrLiteralDateTime}) rather than
+   * the literal's UDT, which {@link org.apache.calcite.rex.RexSimplify} can strip when a sibling
+   * clause is folded into a {@code Sarg}.
    *
-   * @param literal literal value
-   * @param rangeQueryBuilder query builder to optionally add {@code format} expression
-   * @return existing builder with possible {@code format} attribute
+   * @param isTimeStamp whether the comparison endpoint is a timestamp/date range endpoint
+   * @param rangeQueryBuilder query builder to optionally add the {@code format} attribute
+   * @return the same builder, with {@code format("date_time")} added when {@code isTimeStamp}
    */
   private static RangeQueryBuilder addFormatIfNecessary(
-      LiteralExpression literal, RangeQueryBuilder rangeQueryBuilder) {
-    if (literal.isDateTime()) {
+      boolean isTimeStamp, RangeQueryBuilder rangeQueryBuilder) {
+    if (isTimeStamp) {
       rangeQueryBuilder.format("date_time");
     }
     return rangeQueryBuilder;

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
@@ -1178,6 +1178,107 @@ public class PredicateAnalyzerTest {
         result.toString());
   }
 
+  // Companion stripped-VARCHAR-literal tests for the remaining range shapes (equals -> gte+lte,
+  // notEquals -> two-should bool, lte -> single range). Each must produce the same DSL as its
+  // intact-UDT counterpart, proving the field-type fallback in isFieldOrLiteralDateTime keeps
+  // ISO-8601 normalization + format("date_time") on every comparison op, not just gt. See #5481.
+  @Test
+  void equals_normalizesVarcharLiteralAgainstTimestampField()
+      throws ExpressionNotAnalyzableException {
+    RexLiteral varcharLiteral = (RexLiteral) builder.makeLiteral("1987-02-03 04:34:56");
+    RexNode call = builder.makeCall(SqlStdOperatorTable.EQUALS, field4, varcharLiteral);
+    QueryBuilder result = PredicateAnalyzer.analyze(call, schema, fieldTypes);
+
+    assertInstanceOf(RangeQueryBuilder.class, result);
+    assertEquals(
+        """
+        {
+          "range" : {
+            "d" : {
+              "from" : "1987-02-03T04:34:56.000Z",
+              "to" : "1987-02-03T04:34:56.000Z",
+              "include_lower" : true,
+              "include_upper" : true,
+              "format" : "date_time",
+              "boost" : 1.0
+            }
+          }
+        }\
+        """,
+        result.toString());
+  }
+
+  @Test
+  void notEquals_normalizesVarcharLiteralAgainstTimestampField()
+      throws ExpressionNotAnalyzableException {
+    RexLiteral varcharLiteral = (RexLiteral) builder.makeLiteral("1987-02-03 04:34:56");
+    RexNode call = builder.makeCall(SqlStdOperatorTable.NOT_EQUALS, field4, varcharLiteral);
+    QueryBuilder result = PredicateAnalyzer.analyze(call, schema, fieldTypes);
+
+    assertInstanceOf(BoolQueryBuilder.class, result);
+    assertEquals(
+        """
+        {
+          "bool" : {
+            "should" : [
+              {
+                "range" : {
+                  "d" : {
+                    "from" : "1987-02-03T04:34:56.000Z",
+                    "to" : null,
+                    "include_lower" : false,
+                    "include_upper" : true,
+                    "format" : "date_time",
+                    "boost" : 1.0
+                  }
+                }
+              },
+              {
+                "range" : {
+                  "d" : {
+                    "from" : null,
+                    "to" : "1987-02-03T04:34:56.000Z",
+                    "include_lower" : true,
+                    "include_upper" : false,
+                    "format" : "date_time",
+                    "boost" : 1.0
+                  }
+                }
+              }
+            ],
+            "adjust_pure_negative" : true,
+            "boost" : 1.0
+          }
+        }\
+        """,
+        result.toString());
+  }
+
+  @Test
+  void lte_normalizesVarcharLiteralAgainstTimestampField() throws ExpressionNotAnalyzableException {
+    RexLiteral varcharLiteral = (RexLiteral) builder.makeLiteral("1987-02-03 04:34:56");
+    RexNode call = builder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, field4, varcharLiteral);
+    QueryBuilder result = PredicateAnalyzer.analyze(call, schema, fieldTypes);
+
+    assertInstanceOf(RangeQueryBuilder.class, result);
+    assertEquals(
+        """
+        {
+          "range" : {
+            "d" : {
+              "from" : null,
+              "to" : "1987-02-03T04:34:56.000Z",
+              "include_lower" : true,
+              "include_upper" : true,
+              "format" : "date_time",
+              "boost" : 1.0
+            }
+          }
+        }\
+        """,
+        result.toString());
+  }
+
   @Test
   void gte_generatesRangeQueryWithFormatForDateTime() throws ExpressionNotAnalyzableException {
     RexNode call =

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
@@ -1147,6 +1147,38 @@ public class PredicateAnalyzerTest {
         result.toString());
   }
 
+  /**
+   * RexSimplify can strip the EXPR_TIMESTAMP UDT off a literal when a sibling clause is folded into
+   * a Sarg (e.g. {@code @timestamp > X AND severityText IN (...)}), leaving the literal as plain
+   * VARCHAR. The comparison must still emit a {@code format("date_time")} range query keyed off the
+   * field's type so the shard's default date parser accepts the value.
+   */
+  @Test
+  void gt_normalizesVarcharLiteralAgainstTimestampField()
+      throws ExpressionNotAnalyzableException {
+    RexLiteral varcharLiteral = (RexLiteral) builder.makeLiteral("1987-02-03 04:34:56");
+    RexNode call = builder.makeCall(SqlStdOperatorTable.GREATER_THAN, field4, varcharLiteral);
+    QueryBuilder result = PredicateAnalyzer.analyze(call, schema, fieldTypes);
+
+    assertInstanceOf(RangeQueryBuilder.class, result);
+    assertEquals(
+        """
+        {
+          "range" : {
+            "d" : {
+              "from" : "1987-02-03T04:34:56.000Z",
+              "to" : null,
+              "include_lower" : false,
+              "include_upper" : true,
+              "format" : "date_time",
+              "boost" : 1.0
+            }
+          }
+        }\
+        """,
+        result.toString());
+  }
+
   @Test
   void gte_generatesRangeQueryWithFormatForDateTime() throws ExpressionNotAnalyzableException {
     RexNode call =

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
@@ -1154,8 +1154,7 @@ public class PredicateAnalyzerTest {
    * field's type so the shard's default date parser accepts the value.
    */
   @Test
-  void gt_normalizesVarcharLiteralAgainstTimestampField()
-      throws ExpressionNotAnalyzableException {
+  void gt_normalizesVarcharLiteralAgainstTimestampField() throws ExpressionNotAnalyzableException {
     RexLiteral varcharLiteral = (RexLiteral) builder.makeLiteral("1987-02-03 04:34:56");
     RexNode call = builder.makeCall(SqlStdOperatorTable.GREATER_THAN, field4, varcharLiteral);
     QueryBuilder result = PredicateAnalyzer.analyze(call, schema, fieldTypes);


### PR DESCRIPTION
### Description

When a timestamp comparison is AND'd with a SARG-eligible sibling (`IN`, chained `OR` of equalities), Calcite's `RexSimplify` folds the sibling into a `Sarg` and **re-types the timestamp literal** during simplification. `DATE_SUB(NOW(), INTERVAL 5 MINUTE)` loses its `EXPR_TIMESTAMP` UDT and arrives at the predicate analyzer as `VARCHAR`.

That breaks the DSL emission downstream in `SimpleQueryExpression`:

1. `LiteralExpression.value()` takes the `isString()` branch and returns the raw `RexLiteral.stringValue()` — the space-separated `"2026-05-28 16:18:43"` form, never normalized to ISO-8601.
2. `addFormatIfNecessary` skips `.format("date_time")` because `literal.isDateTime()` reads `false`.

Both checks key off the **literal's** surviving UDT, which is unreliable after `RexSimplify`. The shard receives `"2026-05-28 16:18:43"` against the default `strict_date_optional_time||epoch_millis` parser and returns HTTP 500.

### Fix

The five non-Sarg comparison paths in `SimpleQueryExpression` (`equals`, `notEquals`, `gt`, `gte`, `lt`, `lte`) now key off `rel.isTimeStampType()` — the **field's** type via `NamedFieldExpression`. This is the same defensive pattern the Sarg path in `constructQueryExpressionForSearch` (PredicateAnalyzer.java:794-796) already uses.

When the field is a timestamp:
- The endpoint value is routed through `timestampValueForPushDown` to canonicalize to ISO-8601 regardless of the literal's surviving type.
- The range query always carries `format("date_time")`.

The non-timestamp-field branch is unchanged — `termQuery` / `boolQuery` behavior for keyword/text/numeric fields is preserved exactly.

### Verification

End-to-end on a live local node with the index template and sample data from the issue:

**Before:**
```
"range":{"@timestamp":{"from":"2026-06-04 16:53:50",...}}    // no format, raw string
→ failed to parse date field [2026-06-04 16:53:50] with format [strict_date_optional_time||epoch_millis]
→ HTTP 500
```

**After:**
```
"range":{"@timestamp":{"from":"2026-06-04T17:14:01.000Z",..., "format":"date_time", ...}}
→ STATUS: OK — 2 rows returned (ERROR + WARN; INFO filtered out)
```

`:opensearch:test` passes with no changes to existing assertions; the existing `date_time` format assertions in `PredicateAnalyzerTest.java` continue to hold for the literal-typed-correctly path.

### Related Issues

Resolves opensearch-project/sql#5481

### Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New PPL command checklist all confirmed.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR created.