### PR TITLE
Fix/array type ip binary

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/ListAggFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/ListAggFunction.java
@@ -40,25 +40,24 @@ public class ListAggFunction implements UserDefinedAggFunction<ListAggFunction.L
 
   @Override
   public ListAccumulator add(ListAccumulator acc, Object... values) {
-    // Handle case where no values are passed
     if (values == null || values.length == 0) {
       return acc;
     }
 
     Object value = values[0];
 
-    // Filter out null values and enforce 100-item limit
+    // Preserve raw element type so the result matches the ARG0_ARRAY return-type
+    // declaration on PPLBuiltinOperators.LIST. Stringifying here would break Calcite's
+    // type-checking and the response-boundary UDT dispatch for ip / binary columns.
     if (value != null && acc.size() < DEFAULT_LIMIT) {
-      // Convert value to string, handling all types safely
-      String stringValue = String.valueOf(value);
-      acc.add(stringValue);
+      acc.add(value);
     }
 
     return acc;
   }
 
   public static class ListAccumulator implements Accumulator {
-    private final List<String> values;
+    private final List<Object> values;
 
     public ListAccumulator() {
       this.values = new ArrayList<>();
@@ -69,7 +68,7 @@ public class ListAggFunction implements UserDefinedAggFunction<ListAggFunction.L
       return values;
     }
 
-    public void add(String value) {
+    public void add(Object value) {
       values.add(value);
     }
 

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -216,8 +216,8 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
    *       IpFieldMapper}'s {@code valueFetcher} output).
    *   <li>{@link BinaryType} + {@code byte[]} &rarr; base64-encoded string (matches the OpenSearch
    *       {@code binary} field wire format).
-   *   <li>{@code ARRAY<IpType>} / {@code ARRAY<BinaryType>} + {@code List<byte[]>} &rarr; element-wise
-   *       UDT-aware conversion for {@code list(ip|binary)} aggregates.
+   *   <li>{@code ARRAY<IpType>} / {@code ARRAY<BinaryType>} + {@code List<byte[]>} &rarr;
+   *       element-wise UDT-aware conversion for {@code list(ip|binary)} aggregates.
    *   <li>Anything else &rarr; existing {@link ExprValueUtils#fromObjectValue} path.
    * </ul>
    *

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -26,6 +26,7 @@ import org.opensearch.sql.ast.statement.ExplainMode;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.data.model.ExprCollectionValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
@@ -215,6 +216,8 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
    *       IpFieldMapper}'s {@code valueFetcher} output).
    *   <li>{@link BinaryType} + {@code byte[]} &rarr; base64-encoded string (matches the OpenSearch
    *       {@code binary} field wire format).
+   *   <li>{@code ARRAY<IpType>} / {@code ARRAY<BinaryType>} + {@code List<byte[]>} &rarr; element-wise
+   *       UDT-aware conversion for {@code list(ip|binary)} aggregates.
    *   <li>Anything else &rarr; existing {@link ExprValueUtils#fromObjectValue} path.
    * </ul>
    *
@@ -224,17 +227,53 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
   private static ExprValue toExprValue(Object value, RelDataType type) {
     if (value instanceof byte[] bytes) {
       if (type instanceof IpType) {
-        try {
-          return ExprValueUtils.stringValue(
-              InetAddresses.toAddrString(InetAddress.getByAddress(bytes)));
-        } catch (UnknownHostException e) {
-          throw new IllegalStateException("invalid IP buffer length: " + bytes.length, e);
-        }
+        return ipBytesToExprValue(bytes);
       } else if (type instanceof BinaryType) {
-        return ExprValueUtils.stringValue(Base64.getEncoder().encodeToString(bytes));
+        return binaryBytesToExprValue(bytes);
+      }
+    }
+    if (value instanceof List<?> list) {
+      RelDataType component = type.getComponentType();
+      if (component instanceof IpType) {
+        List<ExprValue> elems = new ArrayList<>(list.size());
+        for (Object elem : list) {
+          if (elem == null) {
+            elems.add(ExprValueUtils.nullValue());
+          } else if (elem instanceof byte[] eb) {
+            elems.add(ipBytesToExprValue(eb));
+          } else {
+            elems.add(ExprValueUtils.fromObjectValue(elem));
+          }
+        }
+        return new ExprCollectionValue(elems);
+      } else if (component instanceof BinaryType) {
+        List<ExprValue> elems = new ArrayList<>(list.size());
+        for (Object elem : list) {
+          if (elem == null) {
+            elems.add(ExprValueUtils.nullValue());
+          } else if (elem instanceof byte[] eb) {
+            elems.add(binaryBytesToExprValue(eb));
+          } else {
+            elems.add(ExprValueUtils.fromObjectValue(elem));
+          }
+        }
+        return new ExprCollectionValue(elems);
       }
     }
     return ExprValueUtils.fromObjectValue(value);
+  }
+
+  private static ExprValue ipBytesToExprValue(byte[] bytes) {
+    try {
+      return ExprValueUtils.stringValue(
+          InetAddresses.toAddrString(InetAddress.getByAddress(bytes)));
+    } catch (UnknownHostException e) {
+      throw new IllegalStateException("invalid IP buffer length: " + bytes.length, e);
+    }
+  }
+
+  private static ExprValue binaryBytesToExprValue(byte[] bytes) {
+    return ExprValueUtils.stringValue(Base64.getEncoder().encodeToString(bytes));
   }
 
   private Schema buildSchema(List<RelDataTypeField> fields) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -499,9 +499,10 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
           "pattern",
           ReturnTypes.explicit(UserDefinedFunctionUtils.nullablePatternAggList),
           null);
+  // ARG0_ARRAY preserves UDT element type so AnalyticsExecutionEngine can render IP/binary byte[].
   public static final SqlAggFunction LIST =
       createUserDefinedAggFunction(
-          ListAggFunction.class, "LIST", PPLReturnTypes.STRING_ARRAY, PPLOperandTypes.ANY_SCALAR);
+          ListAggFunction.class, "LIST", PPLReturnTypes.ARG0_ARRAY, PPLOperandTypes.ANY_SCALAR);
   public static final SqlAggFunction VALUES =
       createUserDefinedAggFunction(
           ValuesAggFunction.class,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultiValueStatsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultiValueStatsIT.java
@@ -43,7 +43,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
                 "source=%s | stats list(boolean_value) as bool_list",
                 TEST_INDEX_DATATYPE_NONNUMERIC));
     verifySchema(response, schema("bool_list", "array"));
-    verifyDataRows(response, rows(List.of("true")));
+    verifyDataRows(response, rows(List.of(true)));
   }
 
   @Test
@@ -53,7 +53,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | stats list(byte_number) as byte_list", TEST_INDEX_DATATYPE_NUMERIC));
     verifySchema(response, schema("byte_list", "array"));
-    verifyDataRows(response, rows(List.of("4")));
+    verifyDataRows(response, rows(List.of(4)));
   }
 
   @Test
@@ -63,7 +63,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | stats list(short_number) as short_list", TEST_INDEX_DATATYPE_NUMERIC));
     verifySchema(response, schema("short_list", "array"));
-    verifyDataRows(response, rows(List.of("3")));
+    verifyDataRows(response, rows(List.of(3)));
   }
 
   @Test
@@ -73,7 +73,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | stats list(integer_number) as int_list", TEST_INDEX_DATATYPE_NUMERIC));
     verifySchema(response, schema("int_list", "array"));
-    verifyDataRows(response, rows(List.of("2")));
+    verifyDataRows(response, rows(List.of(2)));
   }
 
   @Test
@@ -83,7 +83,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | stats list(long_number) as long_list", TEST_INDEX_DATATYPE_NUMERIC));
     verifySchema(response, schema("long_list", "array"));
-    verifyDataRows(response, rows(List.of("1")));
+    verifyDataRows(response, rows(List.of(1)));
   }
 
   @Test
@@ -93,7 +93,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | stats list(float_number) as float_list", TEST_INDEX_DATATYPE_NUMERIC));
     verifySchema(response, schema("float_list", "array"));
-    verifyDataRows(response, rows(List.of("6.2")));
+    verifyDataRows(response, rows(List.of(6.2)));
   }
 
   @Test
@@ -104,7 +104,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
                 "source=%s | stats list(double_number) as double_list",
                 TEST_INDEX_DATATYPE_NUMERIC));
     verifySchema(response, schema("double_list", "array"));
-    verifyDataRows(response, rows(List.of("5.1")));
+    verifyDataRows(response, rows(List.of(5.1)));
   }
 
   @Test
@@ -188,7 +188,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
             String.format("source=%s | head 5 | stats list(int0) as int_list", TEST_INDEX_CALCS));
     verifySchema(response, schema("int_list", "array"));
     // Nulls are filtered out by list function
-    verifyDataRows(response, rows(List.of("1", "7")));
+    verifyDataRows(response, rows(List.of(1, 7)));
   }
 
   @Test
@@ -217,7 +217,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
     assert response.has("datarows");
     // Values should be collected from the first 3 rows (str2 and int2 columns)
     // The actual values depend on the test data - int2 column contains 5, -4, 5
-    verifyDataRows(response, rows(List.of("one", "two", "three"), List.of("5", "-4", "5")));
+    verifyDataRows(response, rows(List.of("one", "two", "three"), List.of(5, -4, 5)));
   }
 
   @Test
@@ -275,7 +275,7 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | head 3 | stats list(int3 + 1) as arithmetic_list", TEST_INDEX_CALCS));
     verifySchema(response, schema("arithmetic_list", "array"));
-    verifyDataRows(response, rows(List.of("9", "14", "3")));
+    verifyDataRows(response, rows(List.of(9, 14, 3)));
   }
 
   // ==================== VALUES Function Tests ====================


### PR DESCRIPTION
### Description

Companion fix for the LIST nullability change in opensearch-project/OpenSearch#21997. After that fix, `stats list(<field>)` returns HTTP 200 for 10 of 12 element types — but **`list(ip_value)`** and **`list(binary_value)`** still fail with `HTTP 400 ExpressionEvaluationException: unsupported object class [B`. This PR fixes those two.

### Root cause

Two layers, each correct in isolation:

1. `PPLBuiltinOperators.LIST` was registered with return type `PPLReturnTypes.STRING_ARRAY`, which **always** returns `ARRAY<VARCHAR>` regardless of input element type — type information is lost.
2. The UDT-aware response-boundary dispatch from #5463 (`AnalyticsExecutionEngine.toExprValue`) checks `type instanceof IpType` / `BinaryType` per cell. With the column type collapsed to `ARRAY<VARCHAR>` it never matches, so per-element `byte[]` values fall through to `ExprValueUtils.fromObjectValue`, which has no `byte[]` case and throws.

### Fix

Two small changes:

1. **`PPLBuiltinOperators.LIST`**: switch return-type inference from `STRING_ARRAY` to `ARG0_ARRAY`, so the column type at the response boundary becomes `ARRAY<IpType>` / `ARRAY<BinaryType>` (matching the existing `TAKE` registration).
2. **`AnalyticsExecutionEngine.toExprValue`**: when the column is `ARRAY<IpType>` / `ARRAY<BinaryType>`, recurse element-wise and apply the same canonical-IP-string / Base64 conversion already used for scalar `IpType` / `BinaryType` cells. Extracted the two byte[] converters into helpers (`ipBytesToExprValue`, `binaryBytesToExprValue`) so the scalar and array paths share them.

### Testing

| Query | Before | After |
|---|---|---|
| `stats list(ip_value)` | HTTP 400 `unsupported object class [B` | `[["127.0.0.1"]]` |
| `stats list(binary_value)` | HTTP 400 `unsupported object class [B` | `[["U29tZSBiaW5hcnkgYmxvYg=="]]` |
| `stats list(<other 10 types>)` | HTTP 200 | HTTP 200 (no regression) |
| \`\| fields ip_value, binary_value\` | HTTP 200 (#5463 path) | HTTP 200 (no regression) |

### Out of scope

- `VALUES` aggregate registration still uses `STRING_ARRAY`. Same fix would apply if anyone exercises `values(ip_value)` / `values(binary_value)`; flagging for follow-up.
- `ListAggFunction.java` still does `String.valueOf(byte[])` — latent on the V3 (non-analytics-engine) path. Analytics path uses DataFusion's `LOCAL_ARRAY_AGG_OP` instead, so it doesn't fire here.