### PR TITLE
[Enhancement] Support bare-field join criteria `join on <field>` shorthand

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -1890,12 +1890,13 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     } else {
       // The join-with-criteria grammar doesn't allow empty join condition
       RexNode joinCondition;
-      List<String> bareFields = new ArrayList<>();
-      if (JoinAndLookupUtils.collectBareFields(node.getJoinCondition().get(), bareFields)) {
+      Optional<List<String>> bareFields =
+          JoinAndLookupUtils.collectBareFields(node.getJoinCondition().get());
+      if (bareFields.isPresent()) {
         // Bare-field shorthand `on a [AND b ...]`. Resolving by stack position rather than by
         // qualifier keeps a self-join `join on f t` a real cross-scan equi-join, not f = f.
         joinCondition =
-            bareFields.stream()
+            bareFields.get().stream()
                 .map(f -> buildJoinConditionByFieldName(context, f))
                 .reduce(context.rexBuilder::and)
                 .orElse(context.relBuilder.literal(true));

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -1889,10 +1889,22 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
       }
     } else {
       // The join-with-criteria grammar doesn't allow empty join condition
-      RexNode joinCondition =
-          node.getJoinCondition()
-              .map(c -> rexVisitor.analyzeJoinCondition(c, context))
-              .orElse(context.relBuilder.literal(true));
+      RexNode joinCondition;
+      List<String> bareFields = new ArrayList<>();
+      if (JoinAndLookupUtils.collectBareFields(node.getJoinCondition().get(), bareFields)) {
+        // Bare-field shorthand `on a [AND b ...]`. Resolving by stack position rather than by
+        // qualifier keeps a self-join `join on f t` a real cross-scan equi-join, not f = f.
+        joinCondition =
+            bareFields.stream()
+                .map(f -> buildJoinConditionByFieldName(context, f))
+                .reduce(context.rexBuilder::and)
+                .orElse(context.relBuilder.literal(true));
+      } else {
+        joinCondition =
+            node.getJoinCondition()
+                .map(c -> rexVisitor.analyzeJoinCondition(c, context))
+                .orElse(context.relBuilder.literal(true));
+      }
       if (node.getJoinType() == SEMI || node.getJoinType() == ANTI) {
         // semi and anti join only return left table outputs
         context.relBuilder.join(

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/JoinAndLookupUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/JoinAndLookupUtils.java
@@ -13,6 +13,10 @@ import java.util.stream.Collectors;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
+import org.opensearch.sql.ast.expression.And;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Lookup;
 import org.opensearch.sql.calcite.CalcitePlanContext;
@@ -35,6 +39,24 @@ public interface JoinAndLookupUtils {
       default:
         return JoinRelType.INNER;
     }
+  }
+
+  /**
+   * Collects the names of bare single-part-field join criteria (e.g. `on a AND b` -> [a, b]).
+   * Returns false for anything else (qualified field, comparison, OR); {@code out} is only valid
+   * when this returns true, so callers must check the return before reading it.
+   */
+  static boolean collectBareFields(UnresolvedExpression expr, List<String> out) {
+    if (expr instanceof And and) {
+      return collectBareFields(and.getLeft(), out) && collectBareFields(and.getRight(), out);
+    }
+    if (expr instanceof Field field
+        && field.getField() instanceof QualifiedName qn
+        && qn.getParts().size() == 1) {
+      out.add(qn.getParts().get(0));
+      return true;
+    }
+    return false;
   }
 
   /* ------For Lookup------ */

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/JoinAndLookupUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/JoinAndLookupUtils.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexNode;
@@ -42,21 +43,29 @@ public interface JoinAndLookupUtils {
   }
 
   /**
-   * Collects the names of bare single-part-field join criteria (e.g. `on a AND b` -> [a, b]).
-   * Returns false for anything else (qualified field, comparison, OR); {@code out} is only valid
-   * when this returns true, so callers must check the return before reading it.
+   * Collects the names of bare single-part-field join criteria (e.g. {@code on a AND b} -> {@code
+   * Optional.of(["a","b"])}). Returns empty for anything else (qualified field, comparison, OR).
+   * The list is only constructed when every node in the AND-tree is a bare field.
    */
-  static boolean collectBareFields(UnresolvedExpression expr, List<String> out) {
+  static Optional<List<String>> collectBareFields(UnresolvedExpression expr) {
     if (expr instanceof And and) {
-      return collectBareFields(and.getLeft(), out) && collectBareFields(and.getRight(), out);
+      return collectBareFields(and.getLeft())
+          .flatMap(
+              left ->
+                  collectBareFields(and.getRight())
+                      .map(
+                          right -> {
+                            List<String> merged = new ArrayList<>(left);
+                            merged.addAll(right);
+                            return merged;
+                          }));
     }
     if (expr instanceof Field field
         && field.getField() instanceof QualifiedName qn
-        && qn.getParts().size() == 1) {
-      out.add(qn.getParts().get(0));
-      return true;
+        && qn.getPrefix().isEmpty()) {
+      return Optional.of(new ArrayList<>(List.of(qn.getSuffix())));
     }
-    return false;
+    return Optional.empty();
   }
 
   /* ------For Lookup------ */

--- a/core/src/test/java/org/opensearch/sql/calcite/utils/JoinAndLookupUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/calcite/utils/JoinAndLookupUtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ast.expression.And;
+import org.opensearch.sql.ast.expression.Compare;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+public class JoinAndLookupUtilsTest {
+
+  @Test
+  public void collectBareFields_singleField() {
+    UnresolvedExpression expr = bareField("a");
+    Optional<List<String>> result = JoinAndLookupUtils.collectBareFields(expr);
+    assertTrue(result.isPresent());
+    assertEquals(List.of("a"), result.get());
+  }
+
+  @Test
+  public void collectBareFields_multipleFieldsAndChain() {
+    UnresolvedExpression expr = new And(bareField("a"), new And(bareField("b"), bareField("c")));
+    Optional<List<String>> result = JoinAndLookupUtils.collectBareFields(expr);
+    assertTrue(result.isPresent());
+    assertEquals(List.of("a", "b", "c"), result.get());
+  }
+
+  @Test
+  public void collectBareFields_mixedConditionReturnsEmpty() {
+    // `a AND l.x = r.x` — the Compare node makes this not all-bare-fields
+    UnresolvedExpression compare =
+        new Compare("=", qualifiedField("l", "x"), qualifiedField("r", "x"));
+    UnresolvedExpression expr = new And(bareField("a"), compare);
+    Optional<List<String>> result = JoinAndLookupUtils.collectBareFields(expr);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void collectBareFields_qualifiedFieldReturnsEmpty() {
+    // A two-part name like `t.x` is not a bare field
+    UnresolvedExpression expr = qualifiedField("t", "x");
+    Optional<List<String>> result = JoinAndLookupUtils.collectBareFields(expr);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void collectBareFields_mixedLeftSideReturnsEmptyNoPartialState() {
+    // Compare on left, bare field on right — must return empty (not ["b"])
+    UnresolvedExpression compare = new Compare("=", bareField("x"), bareField("y"));
+    UnresolvedExpression expr = new And(compare, bareField("b"));
+    Optional<List<String>> result = JoinAndLookupUtils.collectBareFields(expr);
+    assertTrue(result.isEmpty());
+  }
+
+  private static Field bareField(String name) {
+    return new Field(QualifiedName.of(name));
+  }
+
+  private static Field qualifiedField(String qualifier, String name) {
+    return new Field(QualifiedName.of(qualifier, name));
+  }
+}

--- a/docs/user/ppl/cmd/join.md
+++ b/docs/user/ppl/cmd/join.md
@@ -29,6 +29,9 @@ source = table1 | left anti join left = l right = r on l.a = r.a table2
 source = table1 | join left = l right = r [ source = table2 | where d > 10 | head 5 ]
 source = table1 | inner join on table1.a = table2.a table2 | fields table1.a, table2.a, table1.b, table1.c
 source = table1 | inner join on a = c table2 | fields a, b, c, d
+source = table1 | inner join on a table2 | fields a, table2.a, b, c
+source = table1 | inner join on a AND b table2 | fields a, table2.a, b, table2.b
+source = table1 | join on a table2 | fields a, table2.a, b, c
 source = table1 as t1 | join left = l right = r on l.a = r.a table2 as t2 | fields l.a, r.a
 source = table1 as t1 | join left = l right = r on l.a = r.a table2 as t2 | fields t1.a, t2.a
 source = table1 | join left = l right = r on l.a = r.a [ source = table2 ] as s | fields l.a, s.a
@@ -40,7 +43,7 @@ The basic `join` syntax supports the following parameters.
 
 | Parameter | Required/Optional | Description |
 | --- | --- | --- |
-| `<joinCriteria>` | Required | A comparison expression specifying how to join the datasets. Must be placed after the `on` or `where` keyword in the query. |
+| `<joinCriteria>` | Required | A comparison expression specifying how to join the datasets. Must be placed after the `on` or `where` keyword in the query. A bare field name `f` (or `f AND g ...`) is shorthand for an equi-join on the common field(s) and keeps both key columns. |
 | `<right-dataset>` | Required | The right dataset, which can be an index or a subsearch, with or without an alias. |
 | `joinType` | Optional | The type of join to perform. Valid values are `left`, `semi`, `anti`, and performance-sensitive types (`right`, `full`, and `cross`). Default is `inner`. |
 | `left` | Optional | An alias for the left dataset (typically a subsearch) used to avoid ambiguous field names. Specify as `left = <leftAlias>`. |
@@ -71,7 +74,7 @@ The extended `join` syntax supports the following parameters.
 
 | Parameter | Required/Optional | Description |
 | --- | --- | --- |
-| `<joinCriteria>` | Required | A comparison expression specifying how to join the datasets. Must be placed after the `on` or `where` keyword in the query. |
+| `<joinCriteria>` | Required | A comparison expression specifying how to join the datasets. Must be placed after the `on` or `where` keyword in the query. A bare field name `f` (or `f AND g ...`) is shorthand for an equi-join on the common field(s); it keeps both key columns and differs from `<join-field-list>`, which merges duplicates. |
 | `<right-dataset>` | Required | The right dataset, which can be an index or a subsearch, with or without an alias. |  
 | `type` | Optional | The join type when using extended syntax. Valid values are `left`, `outer` (same as `left`), `semi`, `anti`, and performance-sensitive types (`right`, `full`, and `cross`). Default is `inner`. |
 | `<join-field-list>` | Optional | A list of fields used to build the join criteria. These fields must exist in both datasets. If not specified, all fields common to both datasets are used as join keys. |

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJoinIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJoinIT.java
@@ -935,7 +935,7 @@ public class CalcitePPLJoinIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | inner join on name %s | fields name, age, state, country, occupation,"
-                    + " salary",
+                    + " salary | sort name, occupation",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
     verifySchema(
         actual,
@@ -945,21 +945,23 @@ public class CalcitePPLJoinIT extends PPLIntegTestCase {
         schema("country", "string"),
         schema("occupation", "string"),
         schema("salary", "int"));
-    verifyDataRows(
+    // Rows are listed in the `sort name, occupation` order so verifyDataRowsInOrder also
+    // validates the sort (David/Doctor < David/Unemployed, then Hello, Jake, Jane, John).
+    verifyDataRowsInOrder(
         actual,
-        rows("Jake", 70, "California", "USA", "Engineer", 100000),
-        rows("Hello", 30, "New York", "USA", "Artist", 70000),
-        rows("John", 25, "Ontario", "Canada", "Doctor", 120000),
-        rows("Jane", 20, "Quebec", "Canada", "Scientist", 90000),
         rows("David", 40, "Washington", "USA", "Doctor", 120000),
-        rows("David", 40, "Washington", "USA", "Unemployed", 0));
+        rows("David", 40, "Washington", "USA", "Unemployed", 0),
+        rows("Hello", 30, "New York", "USA", "Artist", 70000),
+        rows("Jake", 70, "California", "USA", "Engineer", 100000),
+        rows("Jane", 20, "Quebec", "Canada", "Scientist", 90000),
+        rows("John", 25, "Ontario", "Canada", "Doctor", 120000));
 
     // The shorthand and the explicit qualified-equality form are output-identical.
     JSONObject explicitForm =
         executeQuery(
             String.format(
                 "source=%s | inner join on %s.name = %s.name %s | fields name, age, state, country,"
-                    + " occupation, salary",
+                    + " occupation, salary | sort name, occupation",
                 TEST_INDEX_STATE_COUNTRY,
                 TEST_INDEX_STATE_COUNTRY,
                 TEST_INDEX_OCCUPATION,
@@ -973,13 +975,14 @@ public class CalcitePPLJoinIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | join on name %s | fields name, age, state, occupation, salary",
+                "source=%s | join on name %s | fields name, age, state, occupation, salary | sort"
+                    + " name, occupation",
                 TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
     JSONObject explicitForm =
         executeQuery(
             String.format(
                 "source=%s | join on %s.name = %s.name %s | fields name, age, state, occupation,"
-                    + " salary",
+                    + " salary | sort name, occupation",
                 TEST_INDEX_STATE_COUNTRY,
                 TEST_INDEX_STATE_COUNTRY,
                 TEST_INDEX_OCCUPATION,
@@ -1017,8 +1020,8 @@ public class CalcitePPLJoinIT extends PPLIntegTestCase {
 
   @Test
   public void testAliasedSelfJoinWithImplicitField() throws IOException {
-    // Self-join on the unique `name`: a real equi-join matches each of the 8 rows to itself (8
-    // rows), not the 64-row cross product a tautology would give.
+    // Self-join on the unique `name`: a real equi-join yields 8 rows, not the 64-row cross product
+    // a tautology would give.
     JSONObject actual =
         executeQuery(
             String.format(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJoinIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJoinIT.java
@@ -929,6 +929,106 @@ public class CalcitePPLJoinIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testJoinWithImplicitField() throws IOException {
+    // Keep-both, so co-named columns (other than the key) resolve to the left side.
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | inner join on name %s | fields name, age, state, country, occupation,"
+                    + " salary",
+                TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
+    verifySchema(
+        actual,
+        schema("name", "string"),
+        schema("age", "int"),
+        schema("state", "string"),
+        schema("country", "string"),
+        schema("occupation", "string"),
+        schema("salary", "int"));
+    verifyDataRows(
+        actual,
+        rows("Jake", 70, "California", "USA", "Engineer", 100000),
+        rows("Hello", 30, "New York", "USA", "Artist", 70000),
+        rows("John", 25, "Ontario", "Canada", "Doctor", 120000),
+        rows("Jane", 20, "Quebec", "Canada", "Scientist", 90000),
+        rows("David", 40, "Washington", "USA", "Doctor", 120000),
+        rows("David", 40, "Washington", "USA", "Unemployed", 0));
+
+    // The shorthand and the explicit qualified-equality form are output-identical.
+    JSONObject explicitForm =
+        executeQuery(
+            String.format(
+                "source=%s | inner join on %s.name = %s.name %s | fields name, age, state, country,"
+                    + " occupation, salary",
+                TEST_INDEX_STATE_COUNTRY,
+                TEST_INDEX_STATE_COUNTRY,
+                TEST_INDEX_OCCUPATION,
+                TEST_INDEX_OCCUPATION));
+    assertJsonEquals(explicitForm.toString(), actual.toString());
+  }
+
+  @Test
+  public void testJoinNoPrefixImplicitField() throws IOException {
+    // No-prefix `join on name` matches the explicit qualified form, not the field-list `join name`.
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | join on name %s | fields name, age, state, occupation, salary",
+                TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
+    JSONObject explicitForm =
+        executeQuery(
+            String.format(
+                "source=%s | join on %s.name = %s.name %s | fields name, age, state, occupation,"
+                    + " salary",
+                TEST_INDEX_STATE_COUNTRY,
+                TEST_INDEX_STATE_COUNTRY,
+                TEST_INDEX_OCCUPATION,
+                TEST_INDEX_OCCUPATION));
+    assertJsonEquals(explicitForm.toString(), actual.toString());
+  }
+
+  @Test
+  public void testLeftJoinWithImplicitField() throws IOException {
+    // Keep-both does not coalesce, so unmatched-left rows keep the non-null left key, not a NULL.
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | left join on name %s | fields name, age, state, occupation, salary",
+                TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
+    verifySchema(
+        actual,
+        schema("name", "string"),
+        schema("age", "int"),
+        schema("state", "string"),
+        schema("occupation", "string"),
+        schema("salary", "int"));
+    verifyDataRows(
+        actual,
+        rows("Jake", 70, "California", "Engineer", 100000),
+        rows("Hello", 30, "New York", "Artist", 70000),
+        rows("John", 25, "Ontario", "Doctor", 120000),
+        rows("Jane", 20, "Quebec", "Scientist", 90000),
+        rows("David", 40, "Washington", "Doctor", 120000),
+        rows("David", 40, "Washington", "Unemployed", 0),
+        rows("Jim", 27, "B.C", null, null),
+        rows("Peter", 57, "B.C", null, null),
+        rows("Rick", 70, "B.C", null, null));
+  }
+
+  @Test
+  public void testAliasedSelfJoinWithImplicitField() throws IOException {
+    // Self-join on the unique `name`: a real equi-join matches each of the 8 rows to itself (8
+    // rows), not the 64-row cross product a tautology would give.
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | inner join left=l right=r on name %s | fields name, r.name",
+                TEST_INDEX_STATE_COUNTRY, TEST_INDEX_STATE_COUNTRY));
+    verifyNumOfRows(actual, 8);
+    verifySchema(actual, schema("name", "string"), schema("r.name", "string"));
+  }
+
+  @Test
   public void testJoinComparing() throws IOException {
     JSONObject actual =
         executeQuery(

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -729,8 +729,9 @@ sourceFilterArg
 
 // join
 joinCommand
-   : JOIN (joinOption)* (fieldList)? right = tableOrSubqueryClause
-   | sqlLikeJoinType? JOIN (joinOption)* sideAlias joinHintList? joinCriteria right = tableOrSubqueryClause
+   // Criteria alt listed first - so `join on a` reads `on` as the criteria keyword, not a field.
+   : sqlLikeJoinType? JOIN (joinOption)* sideAlias joinHintList? joinCriteria right = tableOrSubqueryClause
+   | JOIN (joinOption)* (fieldList)? right = tableOrSubqueryClause
    ;
 
 sqlLikeJoinType

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -326,6 +326,8 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     if (ctx.fieldList() != null) {
       joinFields = Optional.of(getFieldList(ctx.fieldList()));
     }
+    // Keep a bare `on <field>` criteria verbatim; the planner expands it to an equi-join. Folding
+    // it into joinFields here would instead merge the key into one column.
     return new Join(
         projectExceptMeta(right),
         leftAlias,

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
@@ -1050,6 +1050,38 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
   }
 
   @Test
+  public void testJoinWithImplicitFieldMaxGreaterThanZero() {
+    // Bare-field shorthand combined with a max=N dedup wrapper. Keep-both renames the
+    // unaliased right-side key to `DEPT.DEPTNO`, and the dedup subquery wraps the right input.
+    String ppl = "source=EMP | inner join max=1 on DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalProject(DEPTNO=[$0], DNAME=[$1], LOC=[$2])\n"
+            + "      LogicalFilter(condition=[<=($3, 1)])\n"
+            + "        LogicalProject(DEPTNO=[$0], DNAME=[$1], LOC=[$2],"
+            + " _row_number_dedup_=[ROW_NUMBER() OVER (PARTITION BY $0)])\n"
+            + "          LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `t1`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `t1`.`DNAME`, `t1`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN (SELECT `DEPTNO`, `DNAME`, `LOC`\n"
+            + "FROM (SELECT `DEPTNO`, `DNAME`, `LOC`, ROW_NUMBER() OVER (PARTITION BY `DEPTNO`)"
+            + " `_row_number_dedup_`\n"
+            + "FROM `scott`.`DEPT`) `t`\n"
+            + "WHERE `_row_number_dedup_` <= 1) `t1` ON `EMP`.`DEPTNO` = `t1`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
   public void testJoinWithMaxEqualsZero() {
     String ppl = "source=EMP | join type=outer max=0 DEPTNO DEPT";
     RelNode root = getRelNode(ppl);
@@ -1275,6 +1307,28 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
   }
 
   @Test
+  public void testAntiJoinWithImplicitField() {
+    // Anti shares semi's early-return left-only branch (no keep-both project wrapper). Every one
+    // of the 14 EMP rows matches a DEPT row, so the anti join returns none.
+    String ppl = "source=EMP | anti join on DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalJoin(condition=[=($7, $8)], joinType=[anti])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 0);
+
+    String expectedSparkSql =
+        "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE NOT EXISTS (SELECT 1\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`)";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
   public void testJoinWithImplicitFieldMultiField() {
     String ppl = "source=EMP | inner join on DEPTNO AND SAL EMP";
     RelNode root = getRelNode(ppl);
@@ -1289,8 +1343,8 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     verifyLogical(root, expectedLogical);
   }
 
-  // Self-join joins the two scans by position, so the key is a real equi-join across them, not the
-  // EMP.DEPTNO=EMP.DEPTNO tautology a qualifier rewrite would collapse to.
+  // Self-join resolves by position, so the key is a real equi-join across the two scans, not an
+  // EMP.DEPTNO=EMP.DEPTNO tautology.
   @Test
   public void testJoinWithImplicitFieldSelfJoin() {
     String ppl = "source=EMP | inner join on DEPTNO EMP";
@@ -1306,13 +1360,15 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     verifyLogical(root, expectedLogical);
   }
 
-  // ENAME is not in DEPT, so the right-side lookup fails. Match the field name only; Calcite's
-  // full message is version-dependent.
+  // ENAME is not in DEPT, so the bare field resolves positionally against the right input and
+  // Calcite throws `field [ENAME] not found` (an IllegalArgumentException, not a semantic check).
+  // We assert that exact phrase; it is Calcite's own RelBuilder.field wording, so a Calcite
+  // upgrade that rewords the message would require updating this substring.
   @Test
   public void testJoinWithImplicitFieldNotOnBothSides() {
     String ppl = "source=EMP | inner join on ENAME DEPT";
-    Throwable t = Assert.assertThrows(RuntimeException.class, () -> getRelNode(ppl));
-    verifyErrorMessageContains(t, "ENAME");
+    Throwable t = Assert.assertThrows(IllegalArgumentException.class, () -> getRelNode(ppl));
+    verifyErrorMessageContains(t, "field [ENAME] not found");
   }
 
   @Test
@@ -1359,8 +1415,8 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
-  // Right side is a subquery, not a table: the bare field still resolves (no underlying table name
-  // is needed), and the right key takes the subquery alias.
+  // Right side is an aliased subquery: positional resolution works, and the right key surfaces
+  // under the subquery alias.
   @Test
   public void testJoinWithImplicitFieldAliasedSubquery() {
     String ppl = "source=EMP | inner join on DEPTNO [ source=DEPT ] as d";
@@ -1375,7 +1431,7 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
     verifyResultCount(root, 14);
   }
 
-  // Unaliased subquery: resolves by position with no alias and no reachable table name.
+  // Unaliased subquery: positional resolution needs no alias, so this still works.
   @Test
   public void testJoinWithImplicitFieldUnaliasedSubquery() {
     String ppl = "source=EMP | inner join on DEPTNO [ source=DEPT ]";
@@ -1402,6 +1458,36 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + "  LogicalJoin(condition=[=($7, $15)], joinType=[inner])\n"
             + "    LogicalTableScan(table=[[scott, EMP]])\n"
             + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testJoinMixedConditionFallsThrough() {
+    // A comparison in the AND-chain isn't a bare field, so the whole condition is analyzed
+    // normally.
+    String ppl = "source=EMP | join left=l right=r on SAL > 1000 AND l.DEPTNO = r.DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[AND(>($5, 1000), =($7, $8))], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testJoinMixedConditionWithInequality() {
+    // Qualified equality plus an inequality: no bare fields, so it's analyzed as a normal
+    // condition.
+    String ppl = "source=EMP | join left=l right=r on l.DEPTNO = r.DEPTNO AND l.SAL > 1000 DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[AND(=($7, $8), >($5, 1000))], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
     verifyLogical(root, expectedLogical);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLJoinTest.java
@@ -1163,4 +1163,245 @@ public class CalcitePPLJoinTest extends CalcitePPLAbstractTest {
             + "LEFT JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
+
+  // A join-type prefix or alias is required for `on`/`where` to read as the criteria keyword
+  // rather than as a field list.
+  @Test
+  public void testJoinWithImplicitField() {
+    String ppl = "source=EMP | inner join on DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testJoinWithImplicitFieldAlias() {
+    String ppl = "source=EMP | join left=l right=r on DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], r.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `r.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testJoinWithImplicitFieldWhereKeyword() {
+    String ppl = "source=EMP | inner join where DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testLeftJoinWithImplicitField() {
+    String ppl = "source=EMP | left join on DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[left])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LEFT JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testSemiJoinWithImplicitField() {
+    String ppl = "source=EMP | semi join on DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalJoin(condition=[=($7, $8)], joinType=[semi])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n"
+            + "  LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        "SELECT *\n"
+            + "FROM `scott`.`EMP`\n"
+            + "WHERE EXISTS (SELECT 1\n"
+            + "FROM `scott`.`DEPT`\n"
+            + "WHERE `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`)";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testJoinWithImplicitFieldMultiField() {
+    String ppl = "source=EMP | inner join on DEPTNO AND SAL EMP";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], EMP.EMPNO=[$8], EMP.ENAME=[$9], EMP.JOB=[$10],"
+            + " EMP.MGR=[$11], EMP.HIREDATE=[$12], EMP.SAL=[$13], EMP.COMM=[$14],"
+            + " EMP.DEPTNO=[$15])\n"
+            + "  LogicalJoin(condition=[AND(=($7, $15), =($5, $13))], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  // Self-join joins the two scans by position, so the key is a real equi-join across them, not the
+  // EMP.DEPTNO=EMP.DEPTNO tautology a qualifier rewrite would collapse to.
+  @Test
+  public void testJoinWithImplicitFieldSelfJoin() {
+    String ppl = "source=EMP | inner join on DEPTNO EMP";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], EMP.EMPNO=[$8], EMP.ENAME=[$9], EMP.JOB=[$10],"
+            + " EMP.MGR=[$11], EMP.HIREDATE=[$12], EMP.SAL=[$13], EMP.COMM=[$14],"
+            + " EMP.DEPTNO=[$15])\n"
+            + "  LogicalJoin(condition=[=($7, $15)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  // ENAME is not in DEPT, so the right-side lookup fails. Match the field name only; Calcite's
+  // full message is version-dependent.
+  @Test
+  public void testJoinWithImplicitFieldNotOnBothSides() {
+    String ppl = "source=EMP | inner join on ENAME DEPT";
+    Throwable t = Assert.assertThrows(RuntimeException.class, () -> getRelNode(ppl));
+    verifyErrorMessageContains(t, "ENAME");
+  }
+
+  @Test
+  public void testJoinNoPrefixImplicitField() {
+    String ppl = "source=EMP | join on DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testJoinNoPrefixImplicitFieldWhereKeyword() {
+    String ppl = "source=EMP | join where DEPTNO DEPT";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+
+    String expectedSparkSql =
+        "SELECT `EMP`.`EMPNO`, `EMP`.`ENAME`, `EMP`.`JOB`, `EMP`.`MGR`, `EMP`.`HIREDATE`,"
+            + " `EMP`.`SAL`, `EMP`.`COMM`, `EMP`.`DEPTNO`, `DEPT`.`DEPTNO` `DEPT.DEPTNO`,"
+            + " `DEPT`.`DNAME`, `DEPT`.`LOC`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "INNER JOIN `scott`.`DEPT` ON `EMP`.`DEPTNO` = `DEPT`.`DEPTNO`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  // Right side is a subquery, not a table: the bare field still resolves (no underlying table name
+  // is needed), and the right key takes the subquery alias.
+  @Test
+  public void testJoinWithImplicitFieldAliasedSubquery() {
+    String ppl = "source=EMP | inner join on DEPTNO [ source=DEPT ] as d";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], d.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+  }
+
+  // Unaliased subquery: resolves by position with no alias and no reachable table name.
+  @Test
+  public void testJoinWithImplicitFieldUnaliasedSubquery() {
+    String ppl = "source=EMP | inner join on DEPTNO [ source=DEPT ]";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], DEPT.DEPTNO=[$8], DNAME=[$9], LOC=[$10])\n"
+            + "  LogicalJoin(condition=[=($7, $8)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, DEPT]])\n";
+    verifyLogical(root, expectedLogical);
+    verifyResultCount(root, 14);
+  }
+
+  // Aliases make the self-join meaningful: the right columns surface under `r`.
+  @Test
+  public void testJoinWithImplicitFieldAliasedSelfJoin() {
+    String ppl = "source=EMP | inner join left=l right=r on DEPTNO EMP";
+    RelNode root = getRelNode(ppl);
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5],"
+            + " COMM=[$6], DEPTNO=[$7], r.EMPNO=[$8], r.ENAME=[$9], r.JOB=[$10], r.MGR=[$11],"
+            + " r.HIREDATE=[$12], r.SAL=[$13], r.COMM=[$14], r.DEPTNO=[$15])\n"
+            + "  LogicalJoin(condition=[=($7, $15)], joinType=[inner])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n"
+            + "    LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.sql.ast.dsl.AstDSL.agg;
 import static org.opensearch.sql.ast.dsl.AstDSL.aggregate;
 import static org.opensearch.sql.ast.dsl.AstDSL.alias;
+import static org.opensearch.sql.ast.dsl.AstDSL.and;
 import static org.opensearch.sql.ast.dsl.AstDSL.appendPipe;
 import static org.opensearch.sql.ast.dsl.AstDSL.argument;
 import static org.opensearch.sql.ast.dsl.AstDSL.booleanLiteral;
@@ -77,6 +78,7 @@ import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.AD;
 import org.opensearch.sql.ast.tree.Chart;
 import org.opensearch.sql.ast.tree.GraphLookup;
+import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Kmeans;
 import org.opensearch.sql.ast.tree.ML;
 import org.opensearch.sql.ast.tree.RareTopN.CommandType;
@@ -1851,5 +1853,90 @@ public class AstBuilderTest extends AstPlanningTestBase {
   @Test
   public void testMaxoutAsFieldName() {
     plan("source=t | eval maxout = 1");
+  }
+
+  // These assert on joinCondition/joinFields rather than full Join equality, since JoinHint has no
+  // equals().
+  @Test
+  public void testJoinWithImplicitFieldKeepsBareField() {
+    Join shorthand = (Join) plan("source=t1 | inner join on a AND b t2");
+    assertTrue(shorthand.getJoinFields().isEmpty());
+    assertEquals(Optional.of(and(field("a"), field("b"))), shorthand.getJoinCondition());
+  }
+
+  @Test
+  public void testJoinWithSingleImplicitFieldKeepsBareField() {
+    Join shorthand = (Join) plan("source=t1 | inner join on a t2");
+    assertTrue(shorthand.getJoinFields().isEmpty());
+    assertEquals(Optional.of(field("a")), shorthand.getJoinCondition());
+  }
+
+  @Test
+  public void testJoinWithMultipleImplicitFieldsFlattenInOrder() {
+    Join join = (Join) plan("source=t1 | inner join on a AND b AND c t2");
+    assertTrue(join.getJoinFields().isEmpty());
+    assertEquals(
+        Optional.of(and(and(field("a"), field("b")), field("c"))), join.getJoinCondition());
+  }
+
+  @Test
+  public void testJoinWithImplicitFieldWhereKeywordKeepsBareField() {
+    Join join = (Join) plan("source=t1 | inner join where a t2");
+    assertTrue(join.getJoinFields().isEmpty());
+    assertEquals(Optional.of(field("a")), join.getJoinCondition());
+  }
+
+  @Test
+  public void testJoinWithQualifiedConditionIsNotRewritten() {
+    Join join = (Join) plan("source=t1 | inner join on l.a = r.a t2");
+    assertEquals(
+        Optional.of(compare("=", field(qualifiedName("l", "a")), field(qualifiedName("r", "a")))),
+        join.getJoinCondition());
+    assertTrue(join.getJoinFields().isEmpty());
+  }
+
+  // No-prefix form: the grammar reorder lets `on` read as the criteria keyword, not a field.
+  @Test
+  public void testJoinNoPrefixImplicitFieldKeepsBareField() {
+    Join join = (Join) plan("source=t1 | join on a t2");
+    assertTrue(join.getJoinFields().isEmpty());
+    assertEquals(Optional.of(field("a")), join.getJoinCondition());
+  }
+
+  @Test
+  public void testJoinNoPrefixImplicitFieldWhereKeepsBareField() {
+    Join join = (Join) plan("source=t1 | join where a t2");
+    assertTrue(join.getJoinFields().isEmpty());
+    assertEquals(Optional.of(field("a")), join.getJoinCondition());
+  }
+
+  @Test
+  public void testJoinWithImplicitFieldKeepsAliasesOnNode() {
+    Join join = (Join) plan("source=t1 | join left = l right = r on a t2");
+    assertTrue(join.getJoinFields().isEmpty());
+    assertEquals(Optional.of(field("a")), join.getJoinCondition());
+    assertEquals(Optional.of("l"), join.getLeftAlias());
+    assertEquals(Optional.of("r"), join.getRightAlias());
+  }
+
+  // The reorder must not change the field-list form.
+  @Test
+  public void testJoinFieldListStillParsesAsFieldList() {
+    Join join = (Join) plan("source=t1 | join a t2");
+    assertEquals(Optional.empty(), join.getJoinCondition());
+    assertEquals(Optional.of(List.of(field("a"))), join.getJoinFields());
+  }
+
+  @Test
+  public void testJoinNoPrefixComparisonStaysCondition() {
+    Join join = (Join) plan("source=t1 | join on a = b t2");
+    assertTrue(join.getJoinCondition().isPresent());
+    assertTrue(join.getJoinFields().isEmpty());
+  }
+
+  // A prefix with a bare field but no on/where is still a field list, so this is a syntax error.
+  @Test
+  public void testJoinPrefixWithoutCriteriaKeywordIsSyntaxError() {
+    assertThrows(SyntaxCheckException.class, () -> plan("source=t1 | inner join a t2"));
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -620,6 +620,28 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testJoinWithImplicitField() {
+    // The AST keeps the bare field, so the anonymized query shows `on identifier`, not a rewrite.
+    assertEquals(
+        "source=table | inner join max=*** on identifier table | fields + identifier",
+        anonymize("source=t | inner join on id s | fields id"));
+    assertEquals(
+        "source=table as identifier | inner join max=*** left = identifier right = identifier on"
+            + " identifier table as identifier | fields + identifier",
+        anonymize("source=t | join left = l right = r on id s | fields id"));
+    assertEquals(
+        "source=table | inner join max=*** on identifier and identifier table | fields +"
+            + " identifier",
+        anonymize("source=t | inner join on id AND uid s | fields id"));
+    assertEquals(
+        "source=table | inner join max=*** on identifier table | fields + identifier",
+        anonymize("source=t | inner join where id s | fields id"));
+    assertEquals(
+        "source=table | inner join max=*** on identifier table | fields + identifier",
+        anonymize("source=t | join on id s | fields id"));
+  }
+
+  @Test
   public void testLookup() {
     assertEquals(
         "source=table | lookup table DEPTNO replace LOC",


### PR DESCRIPTION
### Description

Lets `join` `on`/`where` criteria accept a **bare field name** (or an `AND` chain of bare fields) as shorthand for the qualified equality on that common field. Before this change, the only way to join on a shared column was to spell out both qualifiers:

```
source=t1 | inner join on a t2          == on t1.a = t2.a
source=t1 | inner join on a AND b t2     == on t1.a = t2.a AND t1.b = t2.b
source=t1 | join on a t2                 == on t1.a = t2.a   (no prefix/alias)
```

The shorthand behaves **exactly** like the explicit `on l.f = r.f` it sugars: it **keeps both key columns** (the right key surfaced as `<rightAlias>.f`, or `<rightTable>.f` when no alias is given). This is intentionally different from the field-list join `join f t2`, which merges the duplicate key into a single column.

Two things made this more than a one-line grammar tweak, and shaped the design:

1. **Grammar ambiguity.** `on` is a keyword that can also be an identifier, so the no-prefix form `join on a t2` was greedily consumed by the field-list alternative — `on` parsed as a *field name*, failing with `field [on] not found`. Reordering the `joinCommand` alternatives so the criteria alternative is listed first makes ANTLR ALL(*) prefer reading `on` as the criteria keyword on genuine ambiguity, with zero change to the field-list form's behavior.
2. **Qualifier resolution.** A bare `on a` carries no table qualifier, but the keep-both planner branch needs `left.a = right.a`. Resolution is done in the **planner** (`CalciteRelNodeVisitor.visitJoin`), where both inputs are already on the RelBuilder stack: each bare field is resolved **by stack position** (`LEFT.f = RIGHT.f`) via the existing `buildJoinConditionByFieldName` helper. The unresolved AST keeps the criteria exactly as the user wrote it (`on a`), so explain/anonymizer reflect the original query. Because matching is positional rather than by qualifier, a self-join `join on f t` is a genuine cross-scan equi-join (`=($7, $15)`), not the `f = f` tautology a name-based rewrite would collapse to.

The keep-both column-rename logic is **unchanged** — it works off the output row types, independent of how the join condition was built. A mixed condition that isn't all bare fields (e.g. `on a AND b.x = c.y`) is detected as not-bare and falls through to the normal `analyzeJoinCondition` path untouched.

Resolves #5484.

### Grammar precedence change

This PR reorders the two `joinCommand` alternatives so the **criteria** alternative is listed first:

```antlr
joinCommand
   // Criteria alt listed first - so `join on a` reads `on` as the criteria keyword, not a field.
   : sqlLikeJoinType? JOIN (joinOption)* sideAlias joinHintList? joinCriteria right = tableOrSubqueryClause
   | JOIN (joinOption)* (fieldList)? right = tableOrSubqueryClause
   ;
```

**This is broader than the new shorthand.** ANTLR's ALL(*) picks the first-listed alternative on genuine ambiguity, so the reorder changes the parse path of **all** join queries, not just the new bare-field form. Without it, the no-prefix form `join on a <right>` would let the field-list alternative greedily consume `on` as a field name instead of as the criteria keyword.

**Existing behavior was re-verified, not assumed.** Two guard tests pin the unchanged paths:

- `testJoinFieldListStillParsesAsFieldList` — `source=t1 | join a t2` still parses as a field-list join (`getJoinFields() == [a]`, no condition).
- `testJoinPrefixWithoutCriteriaKeywordIsSyntaxError` — `source=t1 | inner join a t2` (a prefix with a bare field but no `on`/`where`) is still a `SyntaxCheckException`.

**Edge case (verified).** `ON` and `WHERE` are both reachable as bare-field identifiers via `keywordsCanBeId`, and `joinCriteria: (ON | WHERE) logicalExpression` treats them identically. So a field literally named `on` or `where` in the no-prefix form (`join on t2` / `join where t2`) shifts from a field-list parse to a criteria parse. This is acceptable: `on`/`where` are keyword-like, and their use as bare field-list identifiers in a join prefix was already ambiguous/undocumented.

### Changes

| Area | File | Change |
| --- | --- | --- |
| Grammar | `ppl/src/main/antlr/OpenSearchPPLParser.g4` | Reorder `joinCommand` so the criteria alternative precedes the field-list alternative, so `join on a` reads `on` as the criteria keyword instead of a field |
| Parser | `ppl/.../ppl/parser/AstBuilder.java` | Leave a bare single-part field (or `AND` chain) as the join condition rather than treating it as a field list — the unresolved AST reflects what the user wrote |
| Planner | `core/.../calcite/CalciteRelNodeVisitor.java` | `visitJoin` criteria branch detects a bare-field condition and builds the equi-join by stack position (`LEFT.f = RIGHT.f`) via the existing `buildJoinConditionByFieldName`; otherwise falls through to `analyzeJoinCondition` unchanged |
| Util | `core/.../calcite/utils/JoinAndLookupUtils.java` | `collectBareFields` detects a bare single-part field / AND-chain and returns `Optional<List<String>>` (the name list is assembled only when every node is a bare field) |
| Docs | `docs/user/ppl/cmd/join.md` | Shorthand examples in both syntax sections, `<joinCriteria>` parameter description, and the field-dedup limitation note |
| Tests | `ppl/.../calcite/CalcitePPLJoinTest.java`, `ppl/.../parser/AstBuilderTest.java`, `ppl/.../utils/PPLQueryDataAnonymizerTest.java`, `core/.../calcite/utils/JoinAndLookupUtilsTest.java` | Plan-shape, AST-parse, anonymizer, and bare-field-detector coverage |
| QA (IT) | `integ-test/.../calcite/remote/CalcitePPLJoinIT.java` | End-to-end coverage on a live cluster |

### Testing

`CalcitePPLJoinIT` on a live cluster, exercising the new shorthand against pre-change behavior:

| Test | Exercises | Before | After |
| --- | --- | --- | --- |
| `testJoinWithImplicitField` | `inner join on name` — keep-both; asserts shorthand output is identical to explicit `on l.name = r.name`; result asserted in sort order via `verifyDataRowsInOrder` | ❌ | ✅ |
| `testJoinNoPrefixImplicitField` | `join on name` — no prefix; `on` parsed as the criteria keyword, identical to the explicit form (not the field-list merge) | ❌ | ✅ |
| `testLeftJoinWithImplicitField` | `left join on name` — unmatched-left rows keep the left key (no NULL key; keep-both does not coalesce) | ❌ | ✅ |
| `testAliasedSelfJoinWithImplicitField` | self-join on a unique key — a real equi-join (8 rows), not the 64-row cross product a tautology would give | ❌ | ✅ |

> Before = the same query run against pre-change code (parse/plan error — the bare field was read as a field name, e.g. `field [on] not found`).

Unit suites (all green, run locally):

- `CalcitePPLJoinTest`: **57** — plan shape for single/multi-field, alias, `where`, no-prefix, left/semi/anti, self-join (real equi-join), `max=N` dedup wrapper, mixed-condition fall-through, and not-on-both-sides cases.
- `AstBuilderTest`: **158** — rewrite-vs-passthrough decisions (bare field kept; qualified/comparison criteria untouched; field-list still parses as a field list; prefix-without-criteria is a syntax error).
- `PPLQueryDataAnonymizerTest`: **119** — shorthand anonymizes correctly (renders `on identifier`).
- `JoinAndLookupUtilsTest`: **5** — `collectBareFields` over single field, AND-chain, qualified field, mixed condition, and the no-partial-state case.

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] New functionality has javadoc added.
- [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed. <!-- N/A: enhances the existing `join` command rather than adding a new one; the anonymizer item is covered by a new PPLQueryDataAnonymizerTest case. -->
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). <!-- N/A: no REST/API-spec surface change. -->
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
