### PR TITLE
DATE/TIME label and rendering for date-only / time-only fields

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -280,6 +280,24 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
   }
 
   /**
+   * Whether {@code type} represents a DATE for the purpose of operand-conditional return-type
+   * inference (e.g. {@code ADDDATE(date, n)} returns DATE only when the base is a date). Recognizes
+   * both the SQL-plugin DATE UDT (via {@link #convertRelDataTypeToExprType}) and the
+   * analytics-route {@link DateOnlyType} column marker, which is {@code TIMESTAMP}-backed and would
+   * otherwise be misread as TIMESTAMP. Kept separate from {@link #convertRelDataTypeToExprType} so
+   * it isn't on the general planner path that round-trips through {@link
+   * #convertExprTypeToRelDataType}.
+   */
+  public static boolean isDateExprType(RelDataType type) {
+    return type instanceof DateOnlyType || convertRelDataTypeToExprType(type) == ExprCoreType.DATE;
+  }
+
+  /** TIME counterpart of {@link #isDateExprType} — recognizes the {@link TimeOnlyType} marker. */
+  public static boolean isTimeExprType(RelDataType type) {
+    return type instanceof TimeOnlyType || convertRelDataTypeToExprType(type) == ExprCoreType.TIME;
+  }
+
+  /**
    * Result-schema-only variant of {@link #convertRelDataTypeToExprType} that recognizes the
    * analytics-engine {@link IpType} / {@link BinaryType} markers as {@link ExprCoreType#IP} /
    * {@link ExprCoreType#BINARY}.

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -279,20 +279,12 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
     return exprType;
   }
 
-  /**
-   * Whether {@code type} represents a DATE for the purpose of operand-conditional return-type
-   * inference (e.g. {@code ADDDATE(date, n)} returns DATE only when the base is a date). Recognizes
-   * both the SQL-plugin DATE UDT (via {@link #convertRelDataTypeToExprType}) and the
-   * analytics-route {@link DateOnlyType} column marker, which is {@code TIMESTAMP}-backed and would
-   * otherwise be misread as TIMESTAMP. Kept separate from {@link #convertRelDataTypeToExprType} so
-   * it isn't on the general planner path that round-trips through {@link
-   * #convertExprTypeToRelDataType}.
-   */
+  /** DATE check for return-type inference; recognizes the analytics-route {@link DateOnlyType}. */
   public static boolean isDateExprType(RelDataType type) {
     return type instanceof DateOnlyType || convertRelDataTypeToExprType(type) == ExprCoreType.DATE;
   }
 
-  /** TIME counterpart of {@link #isDateExprType} — recognizes the {@link TimeOnlyType} marker. */
+  /** TIME counterpart of {@link #isDateExprType}; recognizes {@link TimeOnlyType}. */
   public static boolean isTimeExprType(RelDataType type) {
     return type instanceof TimeOnlyType || convertRelDataTypeToExprType(type) == ExprCoreType.TIME;
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -47,7 +47,9 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.DateOnlyType;
 import org.opensearch.analytics.schema.IpType;
+import org.opensearch.analytics.schema.TimeOnlyType;
 import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.calcite.type.ExprBinaryType;
 import org.opensearch.sql.calcite.type.ExprDateType;
@@ -292,6 +294,13 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
     }
     if (type instanceof BinaryType) {
       return BINARY;
+    }
+    // span() over date / time UDT — schema label is DATE / TIME, not TIMESTAMP.
+    if (type instanceof DateOnlyType) {
+      return DATE;
+    }
+    if (type instanceof TimeOnlyType) {
+      return TIME;
     }
     return convertRelDataTypeToExprType(type);
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/PPLReturnTypes.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/PPLReturnTypes.java
@@ -35,8 +35,6 @@ public final class PPLReturnTypes {
   public static SqlReturnTypeInference TIME_APPLY_RETURN_TYPE =
       opBinding -> {
         RelDataType temporalType = opBinding.getOperandType(0);
-        // isTimeExprType so a TimeOnlyType column (analytics-route TIMESTAMP-backed time marker) is
-        // recognized as TIME; otherwise ADDTIME/SUBTIME on a time column lose the TIME return type.
         if (OpenSearchTypeFactory.isTimeExprType(temporalType)) {
           return UserDefinedFunctionUtils.NULLABLE_TIME_UDT;
         }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/PPLReturnTypes.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/PPLReturnTypes.java
@@ -12,7 +12,6 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.apache.calcite.sql.type.SqlTypeUtil;
-import org.opensearch.sql.data.type.ExprCoreType;
 
 /**
  * Return types used in PPL. This class complements the {@link
@@ -36,8 +35,9 @@ public final class PPLReturnTypes {
   public static SqlReturnTypeInference TIME_APPLY_RETURN_TYPE =
       opBinding -> {
         RelDataType temporalType = opBinding.getOperandType(0);
-        if (ExprCoreType.TIME.equals(
-            OpenSearchTypeFactory.convertRelDataTypeToExprType(temporalType))) {
+        // isTimeExprType so a TimeOnlyType column (analytics-route TIMESTAMP-backed time marker) is
+        // recognized as TIME; otherwise ADDTIME/SUBTIME on a time column lose the TIME return type.
+        if (OpenSearchTypeFactory.isTimeExprType(temporalType)) {
           return UserDefinedFunctionUtils.NULLABLE_TIME_UDT;
         }
         return UserDefinedFunctionUtils.NULLABLE_TIMESTAMP_UDT;

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -20,7 +20,9 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.DateOnlyType;
 import org.opensearch.analytics.schema.IpType;
+import org.opensearch.analytics.schema.TimeOnlyType;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.ast.statement.ExplainMode;
@@ -52,6 +54,10 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
   // post-processing (see DataFusion list_merge), arriving as "1970-01-01[ T]HH:mm:ss[.frac]".
   private static final Pattern EPOCH_DATE_TIME_PREFIX =
       Pattern.compile("^1970-01-01[ T](\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)$");
+
+  // DateOnlyType wire is Timestamp(ms) at midnight — keep the date, drop the time.
+  private static final Pattern DATE_WITH_MIDNIGHT_TIME =
+      Pattern.compile("^(\\d{4}-\\d{2}-\\d{2})[ T]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?$");
 
   private final QueryPlanExecutor<RelNode, Iterable<Object[]>> planExecutor;
 
@@ -212,7 +218,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     return results;
   }
 
-  /** Renders byte[] as IP/base64 per UDT, strips epoch-date prefix from TIME list elements. */
+  /** Renders UDT cells (IP/binary byte[]; date / time string) and strips TIME prefixes in lists. */
   private static ExprValue toExprValue(Object value, RelDataType type) {
     if (value instanceof byte[] bytes) {
       if (type instanceof IpType) {
@@ -224,6 +230,20 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
         }
       } else if (type instanceof BinaryType) {
         return ExprValueUtils.stringValue(Base64.getEncoder().encodeToString(bytes));
+      }
+    }
+    // DateOnlyType scalar — strip midnight time suffix off the Timestamp(ms) wire.
+    if (type instanceof DateOnlyType && value instanceof String s) {
+      var m = DATE_WITH_MIDNIGHT_TIME.matcher(s);
+      if (m.matches()) {
+        return ExprValueUtils.stringValue(m.group(1));
+      }
+    }
+    // TimeOnlyType scalar — strip 1970-01-01 prefix off the Timestamp(ms) wire.
+    if (type instanceof TimeOnlyType && value instanceof String s) {
+      var m = EPOCH_DATE_TIME_PREFIX.matcher(s);
+      if (m.matches()) {
+        return ExprValueUtils.stringValue(m.group(1));
       }
     }
     if (value instanceof List<?> list) {

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -12,6 +12,7 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
@@ -46,6 +47,11 @@ import org.opensearch.sql.planner.physical.PhysicalPlan;
  * analytics engine, and converts the raw results into {@link QueryResponse}.
  */
 public class AnalyticsExecutionEngine implements ExecutionEngine {
+
+  // TIME-typed list elements round-trip via Timestamp and bypass ArrowValues' scalar
+  // post-processing (see DataFusion list_merge), arriving as "1970-01-01[ T]HH:mm:ss[.frac]".
+  private static final Pattern EPOCH_DATE_TIME_PREFIX =
+      Pattern.compile("^1970-01-01[ T](\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)$");
 
   private final QueryPlanExecutor<RelNode, Iterable<Object[]>> planExecutor;
 
@@ -206,21 +212,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     return results;
   }
 
-  /**
-   * Converts a single result cell to an {@link ExprValue}, dispatching on the column's UDT when
-   * present so {@code byte[]} payloads are rendered correctly:
-   *
-   * <ul>
-   *   <li>{@link IpType} + {@code byte[]} &rarr; canonical address string (matches {@code
-   *       IpFieldMapper}'s {@code valueFetcher} output).
-   *   <li>{@link BinaryType} + {@code byte[]} &rarr; base64-encoded string (matches the OpenSearch
-   *       {@code binary} field wire format).
-   *   <li>Anything else &rarr; existing {@link ExprValueUtils#fromObjectValue} path.
-   * </ul>
-   *
-   * <p>Without this dispatch, {@code fromObjectValue} throws {@code unsupported object class [B} on
-   * byte[] cells, and IP buffers leak through as raw 16-byte ipv4-mapped-ipv6 garbage.
-   */
+  /** Renders byte[] as IP/base64 per UDT, strips epoch-date prefix from TIME list elements. */
   private static ExprValue toExprValue(Object value, RelDataType type) {
     if (value instanceof byte[] bytes) {
       if (type instanceof IpType) {
@@ -234,7 +226,23 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
         return ExprValueUtils.stringValue(Base64.getEncoder().encodeToString(bytes));
       }
     }
+    if (value instanceof List<?> list) {
+      return ExprValueUtils.collectionValue(stripEpochDatePrefixInList(list));
+    }
     return ExprValueUtils.fromObjectValue(value);
+  }
+
+  private static List<Object> stripEpochDatePrefixInList(List<?> list) {
+    List<Object> out = new ArrayList<>(list.size());
+    for (Object element : list) {
+      if (element instanceof String s) {
+        var m = EPOCH_DATE_TIME_PREFIX.matcher(s);
+        out.add(m.matches() ? m.group(1) : s);
+      } else {
+        out.add(element);
+      }
+    }
+    return out;
   }
 
   private Schema buildSchema(List<RelDataTypeField> fields) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/AddSubDateFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/AddSubDateFunction.java
@@ -63,7 +63,10 @@ public class AddSubDateFunction extends ImplementorUDF {
     return opBinding -> {
       RelDataType temporalType = opBinding.getOperandType(0);
       RelDataType temporalDeltaType = opBinding.getOperandType(1);
-      if (OpenSearchTypeFactory.convertRelDataTypeToExprType(temporalType) == ExprCoreType.DATE
+      // isDateExprType (not convertRelDataTypeToExprType == DATE) so a DateOnlyType column — the
+      // analytics-route TIMESTAMP-backed date marker — is recognized as DATE; otherwise ADDDATE/
+      // SUBDATE on a date column would mis-declare TIMESTAMP and lose the DATE return type.
+      if (OpenSearchTypeFactory.isDateExprType(temporalType)
           && SqlTypeFamily.NUMERIC.contains(temporalDeltaType)) {
         return NULLABLE_DATE_UDT;
       } else {

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/AddSubDateFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/AddSubDateFunction.java
@@ -63,9 +63,6 @@ public class AddSubDateFunction extends ImplementorUDF {
     return opBinding -> {
       RelDataType temporalType = opBinding.getOperandType(0);
       RelDataType temporalDeltaType = opBinding.getOperandType(1);
-      // isDateExprType (not convertRelDataTypeToExprType == DATE) so a DateOnlyType column — the
-      // analytics-route TIMESTAMP-backed date marker — is recognized as DATE; otherwise ADDDATE/
-      // SUBDATE on a date column would mis-declare TIMESTAMP and lose the DATE return type.
       if (OpenSearchTypeFactory.isDateExprType(temporalType)
           && SqlTypeFamily.NUMERIC.contains(temporalDeltaType)) {
         return NULLABLE_DATE_UDT;

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -242,7 +242,8 @@ class AnalyticsExecutionEngineTest {
   /** DateOnlyType — schema reports DATE, value strips midnight suffix. */
   @Test
   void executeRelNode_dateOnlyTypeStripsTimeSuffix() {
-    RelNode relNode = mockRelNodeWithType("d", new DateOnlyType(RelDataTypeSystem.DEFAULT, true));
+    RelNode relNode =
+        mockRelNodeWithType("d", new DateOnlyType(RelDataTypeSystem.DEFAULT, true, 3));
     Iterable<Object[]> rows = Collections.singletonList(new Object[] {"1984-04-12 00:00:00"});
     stubExecutorWith(relNode, rows);
 
@@ -257,7 +258,8 @@ class AnalyticsExecutionEngineTest {
   /** TimeOnlyType — schema reports TIME, value strips 1970-01-01 prefix. */
   @Test
   void executeRelNode_timeOnlyTypeStripsEpochDatePrefix() {
-    RelNode relNode = mockRelNodeWithType("t", new TimeOnlyType(RelDataTypeSystem.DEFAULT, true));
+    RelNode relNode =
+        mockRelNodeWithType("t", new TimeOnlyType(RelDataTypeSystem.DEFAULT, true, 3));
     Iterable<Object[]> rows = Collections.singletonList(new Object[] {"1970-01-01 09:00:00"});
     stubExecutorWith(relNode, rows);
 

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.DateOnlyType;
 import org.opensearch.analytics.schema.IpType;
+import org.opensearch.analytics.schema.TimeOnlyType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.SysLimit;
@@ -235,6 +237,36 @@ class AnalyticsExecutionEngineTest {
         "U29tZSBiaW5hcnkgYmxvYg==",
         response.getResults().get(0).tupleValue().get("blob").value(),
         "byte[] should base64-encode to match OpenSearch binary wire format. " + dump);
+  }
+
+  /** DateOnlyType — schema reports DATE, value strips midnight suffix. */
+  @Test
+  void executeRelNode_dateOnlyTypeStripsTimeSuffix() {
+    RelNode relNode = mockRelNodeWithType("d", new DateOnlyType(RelDataTypeSystem.DEFAULT, true));
+    Iterable<Object[]> rows = Collections.singletonList(new Object[] {"1984-04-12 00:00:00"});
+    stubExecutorWith(relNode, rows);
+
+    QueryResponse response = executeAndCapture(relNode);
+    String dump = dumpResponse(response);
+
+    assertEquals(ExprCoreType.DATE, response.getSchema().getColumns().get(0).getExprType(), dump);
+    assertEquals(
+        "1984-04-12", response.getResults().get(0).tupleValue().get("d").stringValue(), dump);
+  }
+
+  /** TimeOnlyType — schema reports TIME, value strips 1970-01-01 prefix. */
+  @Test
+  void executeRelNode_timeOnlyTypeStripsEpochDatePrefix() {
+    RelNode relNode = mockRelNodeWithType("t", new TimeOnlyType(RelDataTypeSystem.DEFAULT, true));
+    Iterable<Object[]> rows = Collections.singletonList(new Object[] {"1970-01-01 09:00:00"});
+    stubExecutorWith(relNode, rows);
+
+    QueryResponse response = executeAndCapture(relNode);
+    String dump = dumpResponse(response);
+
+    assertEquals(ExprCoreType.TIME, response.getSchema().getColumns().get(0).getExprType(), dump);
+    assertEquals(
+        "09:00:00", response.getResults().get(0).tupleValue().get("t").stringValue(), dump);
   }
 
   /** TIME-typed list elements arrive as "1970-01-01[ T]HH:mm:ss[.frac]" — strip the prefix. */

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -237,6 +237,35 @@ class AnalyticsExecutionEngineTest {
         "byte[] should base64-encode to match OpenSearch binary wire format. " + dump);
   }
 
+  /** TIME-typed list elements arrive as "1970-01-01[ T]HH:mm:ss[.frac]" — strip the prefix. */
+  @Test
+  void executeRelNode_listOfStringStripsEpochDatePrefix() {
+    SqlTypeFactoryImpl typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    RelDataType arrayOfVarchar =
+        typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.VARCHAR), -1);
+    RelNode relNode = mockRelNodeWithType("time_list", arrayOfVarchar);
+    java.util.List<String> input =
+        Arrays.asList(
+            "1970-01-01 19:36:22",
+            "1970-01-01T02:05:25",
+            "1970-01-01 12:34:56.123456789",
+            "2020-10-13 13:00:00",
+            "hello");
+    stubExecutorWith(relNode, Collections.singletonList(new Object[] {input}));
+
+    QueryResponse response = executeAndCapture(relNode);
+    String dump = dumpResponse(response);
+
+    java.util.List<String> result =
+        response.getResults().get(0).tupleValue().get("time_list").collectionValue().stream()
+            .map(org.opensearch.sql.data.model.ExprValue::stringValue)
+            .toList();
+    assertEquals(
+        Arrays.asList("19:36:22", "02:05:25", "12:34:56.123456789", "2020-10-13 13:00:00", "hello"),
+        result,
+        dump);
+  }
+
   @Test
   void executeRelNode_emptyResults() {
     RelNode relNode = mockRelNode("name", SqlTypeName.VARCHAR);


### PR DESCRIPTION
## Summary

Sibling to [opensearch-project/OpenSearch#22045](https://github.com/opensearch-project/OpenSearch/pull/22045). Two `sql/core` changes that complete the PPL `DATE` / `TIME` story for analytics-engine columns whose `format` mapping is logically date-only or time-only:

- The user-visible response schema labels them as `date` / `time` (not `timestamp`).
- The bucket / scalar values render as `YYYY-MM-DD` / `HH:mm:ss` (no `00:00:00` suffix on dates, no `1970-01-01` prefix on times).
- `ADDDATE` / `SUBDATE` / `ADDTIME` / `SUBTIME` over those columns preserve `DATE` / `TIME` as the return type instead of widening to `TIMESTAMP`.

The OpenSearch sandbox PR introduces the `DateOnlyType` / `TimeOnlyType` UDT markers and the `DateFormatClassifier`. This PR teaches `sql/core` to recognize those markers in three places.

## Commits

### `TIME-typed list elements format as HH:mm:ss`
`AnalyticsExecutionEngine.toExprValue` strips the `1970-01-01[ T]` prefix from `list()`-aggregation elements so `stats list(<TIME-typed field>)` returns `["19:36:22"]` instead of `["1970-01-01 19:36:22"]`. The list path bypasses the sandbox-side `ArrowValues` scalar formatter (DataFusion's `list_merge` doesn't carry column-level type hints), so the regex strip lives here.

### `span() output column type for date/time UDT`
- `OpenSearchTypeFactory.convertAnalyticsEngineRelDataTypeToExprType`: `DateOnlyType` → `DATE`, `TimeOnlyType` → `TIME` (schema label).
- `AnalyticsExecutionEngine.toExprValue`: scalar values strip the midnight time suffix for `DateOnlyType` and the `1970-01-01` prefix for `TimeOnlyType`.

### `Preserve DATE/TIME return type for ADDDATE/SUBDATE/ADDTIME/SUBTIME` (cherry-pick from @mch2)
- New `OpenSearchTypeFactory.isDateExprType` / `isTimeExprType` helpers recognize the UDT markers as logically `DATE` / `TIME`.
- `PPLReturnTypes.TIME_APPLY_RETURN_TYPE` and `AddSubDateFunction` use these helpers so `ADDDATE(date_col, N)` reports `DATE` (not `TIMESTAMP`).

## Query shapes fixed

```ppl
source=date_formats | head 1 | eval d = basic_date | fields d
# was: schema d:timestamp, value "1984-04-12 00:00:00"
# now: schema d:date,      value "1984-04-12"

source=date_formats | head 1 | eval t = hour_minute_second | fields t
# was: schema t:timestamp, value "1970-01-01 09:00:00"
# now: schema t:time,      value "09:00:00"

source=calcs | head 1 | eval l = list(time1) | fields l
# was: ["1970-01-01 19:36:22"]
# now: ["19:36:22"]

source=date_formats | head 1 | eval r = ADDDATE(basic_date, 5) | fields r
# was: schema r:timestamp
# now: schema r:date         (return type follows operand type)
```

## Test plan

- [x] `:core:check` (compile + unit + spotless + jacoco) green.
- [x] Manual verification of all 4 query shapes against a Variant-B cluster running OpenSearch PR #22045.
- [ ] Existing IT tests; the 18 sandbox-side ITs that depend on this PR are gated `@AwaitsFix` until this lands.
