### PR TITLE
Branch percentile and sum-null IT expectations for the analytics-engine route

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -980,7 +980,11 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
                 "source=%s | stats percentile(balance, 50) as p50, percentile(balance, 90) as p90",
                 TEST_INDEX_BANK));
     verifySchema(actual, schema("p50", "bigint"), schema("p90", "bigint"));
-    verifyDataRows(actual, rows(32838, 48086));
+    // percentile() is approximate. The analytics-engine backend (DataFusion) uses a different
+    // t-digest interpolation than the Calcite/OpenSearch percentile_approx implementation, so p90
+    // lands on a different value (p50 agrees). Both are valid approximations.
+    int expectedP90 = isAnalyticsParquetIndicesEnabled() ? 46576 : 48086;
+    verifyDataRows(actual, rows(32838, expectedP90));
   }
 
   @Test
@@ -990,14 +994,18 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | stats sum(balance) as a by age", TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifySchema(response, schema("a", null, "bigint"), schema("age", null, "int"));
+    // SUM of an all-null bucket is null per the SQL spec. The DSL-pushdown path returns 0 instead
+    // (a known pushdown quirk); the analytics-engine backend (DataFusion) follows the spec like
+    // Calcite-no-pushdown and returns null. See testSumNull and #3408.
+    Object emptySum = (isPushdownDisabled() || isAnalyticsParquetIndicesEnabled()) ? null : 0;
     verifyDataRows(
         response,
-        rows(isPushdownDisabled() ? null : 0, null),
+        rows(emptySum, null),
         rows(32838, 28),
         rows(39225, 32),
         rows(4180, 33),
         rows(48086, 34),
-        rows(isPushdownDisabled() ? null : 0, 36));
+        rows(emptySum, 36));
   }
 
   @Test
@@ -1061,7 +1069,9 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
             + "  ],\n"
             + "  \"datarows\": [\n"
             + "    [\n"
-            + (isPushdownDisabled() ? "      null\n" : "      0\n")
+            + ((isPushdownDisabled() || isAnalyticsParquetIndicesEnabled())
+                ? "      null\n"
+                : "      0\n")
             + "    ]\n"
             + "  ],\n"
             + "  \"total\": 1,\n"


### PR DESCRIPTION
### Description

`CalcitePPLAggregationIT` (and its `bucketSize=2` subclass `CalcitePPLAggregationPaginatingIT`) hard-coded three expectations from the Calcite DSL-pushdown path. When the same suite is routed through the analytics-engine (DataFusion) backend with `-Dtests.analytics.parquet_indices=true`, those expectations are wrong even though the backend behaves correctly:

- **`testPercentile`** — `percentile()` is approximate. DataFusion's t-digest interpolation returns **46576** for `percentile(balance, 90)`, where the OpenSearch/Calcite `percentile_approx` returns **48086** (`p50` agrees on both at 32838). Both are valid approximations of the same percentile; the value was confirmed deterministic across repeated runs.
- **`testSumNull` / `testSumGroupByNullValue`** — `SUM` over an all-null bucket is `null` per the SQL spec. The DSL-pushdown path returns `0` instead — a known pushdown quirk tracked in #3408. DataFusion follows the spec like the Calcite-no-pushdown path and returns `null`.

The fix branches the expected values on the existing `isAnalyticsParquetIndicesEnabled()` helper, exactly the pattern already used in `StatsCommandIT.testSumWithNull`. **No production code changes** — these are test-expectation corrections only, and the assertions remain unchanged for the default Calcite path.

### Pass rate (these test methods)

| Test method | analytics route before | analytics route after | Calcite/v2 route |
|---|---|---|---|
| `testPercentile` | ❌ | ✅ | ✅ (unchanged) |
| `testSumNull` | ❌ | ✅ | ✅ (unchanged) |
| `testSumGroupByNullValue` | ❌ | ✅ | ✅ (unchanged) |
| same 3 via `CalcitePPLAggregationPaginatingIT` | ❌ | ✅ | ✅ (unchanged) |

Verified by running `:integ-test:integTestRemote` against a 9-plugin analytics cluster both with and without `-Dtests.analytics.parquet_indices=true`.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
