### PR TITLE
[BugFix] Fix `FILTER(WHERE)` dropped on aggregates in unified SQL path

### DIFF
--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
@@ -347,6 +347,47 @@ public class UnifiedQueryPlannerSqlV2Test extends UnifiedQueryTestBase {
   }
 
   @Test
+  public void testCountStarWithFilter() {
+    givenQuery("SELECT COUNT(*) FILTER(WHERE age > 30) FROM catalog.employees")
+        .assertPlan(
+            """
+            LogicalAggregate(group=[{}], COUNT(*) FILTER(WHERE age > 30)=[COUNT() FILTER $0])
+              LogicalProject($f1=[>($2, 30)])
+                LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testFilteredAggregateWithGroupBy() {
+    givenQuery(
+            """
+            SELECT department, SUM(age) FILTER(WHERE age > 30) FROM catalog.employees
+              GROUP BY department
+            """)
+        .assertPlan(
+            """
+            LogicalAggregate(group=[{0}], SUM(age) FILTER(WHERE age > 30)=[SUM($1) FILTER $2])
+              LogicalProject(department=[$3], age=[$2], $f3=[>($2, 30)])
+                LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testMultipleFilteredAggregates() {
+    givenQuery(
+            """
+            SELECT MAX(age) FILTER(WHERE age > 30), MIN(age) FILTER(WHERE age < 50)
+              FROM catalog.employees
+            """)
+        .assertPlan(
+            """
+            LogicalAggregate(group=[{}], MAX(age) FILTER(WHERE age > 30)=[MAX($0) FILTER $1], MIN(age) FILTER(WHERE age < 50)=[MIN($0) FILTER $2])
+              LogicalProject(age=[$2], $f4=[>($2, 30)], $f5=[<($2, 50)])
+                LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
   public void testScalarFnOverAggregate() {
     givenQuery("SELECT ABS(MAX(age)) FROM catalog.employees")
         .assertPlan(

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteAggCallVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteAggCallVisitor.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.calcite;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.tools.RelBuilder.AggCall;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
@@ -46,10 +47,17 @@ public class CalciteAggCallVisitor extends AbstractNodeVisitor<AggCall, CalciteP
     }
     return BuiltinFunctionName.ofAggregation(node.getFuncName())
         .map(
-            functionName -> {
-              return PlanUtils.makeAggCall(
-                  context, functionName, node.getDistinct(), field, argList);
-            })
+            functionName ->
+                PlanUtils.makeAggCall(context, functionName, node.getDistinct(), field, argList))
+        // Apply the optional FILTER(WHERE ...) predicate; IS TRUE treats NULL as non-matching.
+        .map(
+            aggCall ->
+                node.condition() == null
+                    ? aggCall
+                    : aggCall.filter(
+                        context.rexBuilder.makeCall(
+                            SqlStdOperatorTable.IS_TRUE,
+                            rexNodeVisitor.analyze(node.condition(), context))))
         .orElseThrow(
             () ->
                 new UnsupportedOperationException("Unexpected aggregation: " + node.getFuncName()));

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -1563,6 +1563,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     List<RexInputRef> aggCallRefs = PlanUtils.getInputRefsFromAggCall(resolvedAggCallList);
     boolean hintNestedAgg = containsNestedAggregator(context.relBuilder, aggCallRefs);
     trimmedRefs.addAll(aggCallRefs);
+    trimmedRefs.addAll(getAggCallFilterRefs(aggExprList, context));
     context.relBuilder.project(trimmedRefs);
 
     // Re-resolve all attributes based on adding trimmed Project.
@@ -1793,6 +1794,21 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     if (expr instanceof AggregateFunction af) return af;
     if (expr instanceof Alias alias) return extractAggregateFunction(alias.getDelegated());
     return null;
+  }
+
+  /**
+   * Collects input refs used by aggregate FILTER(WHERE ...) predicates so trimming retains them.
+   */
+  private List<RexInputRef> getAggCallFilterRefs(
+      List<UnresolvedExpression> aggExprList, CalcitePlanContext context) {
+    List<RexInputRef> refs = new ArrayList<>();
+    for (UnresolvedExpression aggExpr : aggExprList) {
+      AggregateFunction aggFunc = extractAggregateFunction(aggExpr);
+      if (aggFunc != null && aggFunc.condition() != null) {
+        refs.addAll(PlanUtils.getInputRefs(rexVisitor.analyze(aggFunc.condition(), context)));
+      }
+    }
+    return refs;
   }
 
   private Optional<UnresolvedExpression> getTimeSpanField(UnresolvedExpression expr) {


### PR DESCRIPTION
### Description

This PR fixes aggregate `FILTER(WHERE ...)` clauses being silently dropped in the unified SQL path, where the predicate was ignored when building the Calcite `AggCall`. The filter is now applied to the aggregate call and its referenced columns are preserved through the pre-aggregation trimming projection, with no impact on PPL.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
