### PR TITLE
Render date-only and time-only analytics-engine columns as SQL DATE / TIME

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -47,6 +47,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.DateType;
 import org.opensearch.analytics.schema.IpType;
 import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.calcite.type.ExprBinaryType;
@@ -292,6 +293,9 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
     }
     if (type instanceof BinaryType) {
       return BINARY;
+    }
+    if (type instanceof DateType) {
+      return DATE;
     }
     return convertRelDataTypeToExprType(type);
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -49,6 +49,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.analytics.schema.BinaryType;
 import org.opensearch.analytics.schema.DateType;
 import org.opensearch.analytics.schema.IpType;
+import org.opensearch.analytics.schema.TimeType;
 import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.calcite.type.ExprBinaryType;
 import org.opensearch.sql.calcite.type.ExprDateType;
@@ -296,6 +297,9 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
     }
     if (type instanceof DateType) {
       return DATE;
+    }
+    if (type instanceof TimeType) {
+      return TIME;
     }
     return convertRelDataTypeToExprType(type);
   }

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -10,6 +10,7 @@ import java.net.UnknownHostException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -25,6 +26,7 @@ import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.analytics.schema.BinaryType;
 import org.opensearch.analytics.schema.DateType;
 import org.opensearch.analytics.schema.IpType;
+import org.opensearch.analytics.schema.TimeType;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sql.ast.statement.ExplainMode;
@@ -247,6 +249,15 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
         return ExprValueUtils.fromObjectValue(date);
       }
     }
+    // A time-only column likewise arrives as an epoch-millisecond timestamp (on 1970-01-01); render
+    // it as a SQL TIME so it matches the v2 / Calcite path (09:00:00 rather than 1970-01-01
+    // 09:00:00).
+    if (type instanceof TimeType) {
+      LocalTime time = toLocalTime(value);
+      if (time != null) {
+        return ExprValueUtils.fromObjectValue(time);
+      }
+    }
     return ExprValueUtils.fromObjectValue(value);
   }
 
@@ -276,6 +287,37 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     }
     if (value instanceof Number number) {
       return Instant.ofEpochMilli(number.longValue()).atZone(ZoneOffset.UTC).toLocalDate();
+    }
+    return null;
+  }
+
+  /**
+   * Extracts the {@link LocalTime} (time-of-day) from a timestamp-shaped result cell. Returns
+   * {@code null} for a {@code null} cell or an unrecognized runtime type so the caller falls back
+   * to the default conversion. Epoch-based values are interpreted at UTC, matching how OpenSearch
+   * stores times (as a timestamp on 1970-01-01).
+   */
+  private static LocalTime toLocalTime(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof LocalTime localTime) {
+      return localTime;
+    }
+    if (value instanceof LocalDateTime localDateTime) {
+      return localDateTime.toLocalTime();
+    }
+    if (value instanceof Instant instant) {
+      return instant.atZone(ZoneOffset.UTC).toLocalTime();
+    }
+    if (value instanceof java.sql.Timestamp timestamp) {
+      return timestamp.toInstant().atZone(ZoneOffset.UTC).toLocalTime();
+    }
+    if (value instanceof java.sql.Time time) {
+      return time.toLocalTime();
+    }
+    if (value instanceof Number number) {
+      return Instant.ofEpochMilli(number.longValue()).atZone(ZoneOffset.UTC).toLocalTime();
     }
     return null;
   }

--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -7,6 +7,10 @@ package org.opensearch.sql.executor.analytics;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.LinkedHashMap;
@@ -19,6 +23,7 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.exec.profile.ProfiledResult;
 import org.opensearch.analytics.schema.BinaryType;
+import org.opensearch.analytics.schema.DateType;
 import org.opensearch.analytics.schema.IpType;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.core.action.ActionListener;
@@ -234,7 +239,45 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
         return ExprValueUtils.stringValue(Base64.getEncoder().encodeToString(bytes));
       }
     }
+    // A date-only column is stored (and arrives) as an epoch-millisecond timestamp; render it as a
+    // SQL DATE so it matches the v2 / Calcite path (1984-04-12 rather than 1984-04-12 00:00:00).
+    if (type instanceof DateType) {
+      LocalDate date = toLocalDate(value);
+      if (date != null) {
+        return ExprValueUtils.fromObjectValue(date);
+      }
+    }
     return ExprValueUtils.fromObjectValue(value);
+  }
+
+  /**
+   * Truncates a timestamp-shaped result cell to its {@link LocalDate}. Returns {@code null} for a
+   * {@code null} cell or an unrecognized runtime type so the caller falls back to the default
+   * conversion. Epoch-based values are interpreted at UTC, matching how OpenSearch stores dates.
+   */
+  private static LocalDate toLocalDate(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof LocalDate localDate) {
+      return localDate;
+    }
+    if (value instanceof LocalDateTime localDateTime) {
+      return localDateTime.toLocalDate();
+    }
+    if (value instanceof Instant instant) {
+      return instant.atZone(ZoneOffset.UTC).toLocalDate();
+    }
+    if (value instanceof java.sql.Timestamp timestamp) {
+      return timestamp.toInstant().atZone(ZoneOffset.UTC).toLocalDate();
+    }
+    if (value instanceof java.sql.Date date) {
+      return date.toLocalDate();
+    }
+    if (value instanceof Number number) {
+      return Instant.ofEpochMilli(number.longValue()).atZone(ZoneOffset.UTC).toLocalDate();
+    }
+    return null;
   }
 
   private Schema buildSchema(List<RelDataTypeField> fields) {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteAnalyticsDatetimeWireFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteAnalyticsDatetimeWireFormatIT.java
@@ -93,16 +93,17 @@ public class CalciteAnalyticsDatetimeWireFormatIT extends PPLIntegTestCase {
   }
 
   /**
-   * DATE-mapped col: AE widens to TIMESTAMP at scan time; value must use space separator, not ISO
-   * {@code T}.
+   * DATE-mapped col with a date-only format: the analytics engine surfaces it as a SQL {@code DATE}
+   * (via the {@code DateType} UDT), matching the v2 / Calcite path — date schema type and a
+   * date-only value, not a widened {@code TIMESTAMP}.
    */
   @Test
   public void testDateRootColumnYmdFormat() throws IOException {
     String query = "source=" + INDEX + " | where d = '2024-03-15' | fields d";
     assertRoutedToAnalyticsEngine(query);
     JSONObject result = executeQuery(query);
-    verifySchema(result, schema("d", "timestamp"));
-    verifyDataRows(result, rows("2024-03-15 00:00:00"));
+    verifySchema(result, schema("d", "date"));
+    verifyDataRows(result, rows("2024-03-15"));
   }
 
   /** TIME-mapped col: AE widens to TIMESTAMP; value must use space separator, not ISO {@code T}. */

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteAnalyticsDatetimeWireFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteAnalyticsDatetimeWireFormatIT.java
@@ -106,16 +106,18 @@ public class CalciteAnalyticsDatetimeWireFormatIT extends PPLIntegTestCase {
     verifyDataRows(result, rows("2024-03-15"));
   }
 
-  /** TIME-mapped col: AE widens to TIMESTAMP; value must use space separator, not ISO {@code T}. */
+  /**
+   * TIME-mapped col with a time-only format: the analytics engine surfaces it as a SQL {@code TIME}
+   * (via the {@code TimeType} UDT), matching the v2 / Calcite path — time schema type and a
+   * time-of-day value, not a widened {@code TIMESTAMP}.
+   */
   @Test
   public void testTimeRootColumnHmsFormat() throws IOException {
     String query = "source=" + INDEX + " | sort t | head 1 | fields t";
     assertRoutedToAnalyticsEngine(query);
     JSONObject result = executeQuery(query);
-    verifySchema(result, schema("t", "timestamp"));
-    Assert.assertFalse(
-        "Time-mapped column must not surface as ISO T-separator literal",
-        result.getJSONArray("datarows").getJSONArray(0).getString(0).contains("T"));
+    verifySchema(result, schema("t", "time"));
+    verifyDataRows(result, rows("10:30:00"));
   }
 
   /** Eval-derived TIMESTAMP follows the same wire-format contract as a root column. */


### PR DESCRIPTION
### Description

Companion SQL-plugin side of **DATE + TIME** logical-type support on the analytics-engine route. Pairs with **opensearch-project/OpenSearch#22062**, which adds `DateType` / `TimeType` Calcite UDTs to `analytics-api` and emits them for date-only / time-only-format columns.

This change consumes those UDTs in the two SQL-plugin dispatch points that already special-case `IpType` / `BinaryType`:

- **`OpenSearchTypeFactory.convertAnalyticsEngineRelDataTypeToExprType`** — maps a `DateType` column to `ExprCoreType.DATE` and a `TimeType` column to `ExprCoreType.TIME` (the response schema label).
- **`AnalyticsExecutionEngine.toExprValue`** — when the column is `DateType` / `TimeType`, materializes the cell as an `ExprDateValue` / `ExprTimeValue` by truncating the timestamp result to a `LocalDate` / `LocalTime` (epoch interpreted at UTC, matching OpenSearch storage).

Net effect on the analytics route: a date-only field renders as a SQL `DATE` (`1984-04-12`) and a time-only field as a SQL `TIME` (`09:00:00`), instead of a widened `TIMESTAMP`, matching the v2 / Calcite path. Datetime columns are unchanged.

### Pass rate (analytics route, `-Dtests.analytics.parquet_indices=true`)

| Test | before | after |
|---|---|---|
| `CalcitePPLAggregationIT.testCountByDateTypeSpanForDifferentFormats` (+paginating) | ❌ | ✅ |
| `CalcitePPLAggregationIT.testCountByDateTypeSpanWithDifferentUnits` (+paginating) | ❌ | ✅ |
| `CalcitePPLAggregationIT.testCountByTimeTypeSpanForDifferentFormats` | ❌ | ✅ |
| `CalcitePPLAggregationIT.testCountByTimeTypeSpanWithDifferentUnits` | ❌ | ✅ |
| `CalcitePPLAggregationIT.testCountByNullableTimeSpan` | ❌ | ✅ |
| `CalcitePPLAggregationIT.testCountBySpanForCustomFormats` | ❌ | ✅ |
| `CalciteAnalyticsDatetimeWireFormatIT` (date + time cols) | ❌ | ✅ |

`CalciteAnalyticsDatetimeWireFormatIT.testDateRootColumnYmdFormat` / `testTimeRootColumnHmsFormat` previously asserted the widened-timestamp behavior; they now expect `date` / `time`. The v2 / Calcite path is unaffected (this code path is analytics-route only). No regressions — only columns whose mapping format is date-only or time-only change type.

### Dependency

Compiles once OpenSearch#22062 is published to the `org.opensearch.sandbox:analytics-api` snapshot (the `DateType` / `TimeType` classes), the same cross-repo coupling the existing `IpType` / `BinaryType` consumers have. **Do not merge before #22062 lands and the snapshot is bumped.**

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
