### PR TITLE
Fix CalcitePPLAggregationIT on the analytics-engine route (parquet testSimpleCount0 + APPROX_COUNT_DISTINCT name)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -521,7 +521,8 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
   public static final SqlAggFunction DISTINCT_COUNT_APPROX =
       createUserDefinedAggFunction(
           DistinctCountApproxLogicalAggFunction.class,
-          "DISTINCT_COUNT_APPROX",
+          // Substrait-standard name the analytics-engine backend resolves by (V3 overrides it).
+          "APPROX_COUNT_DISTINCT",
           ReturnTypes.BIGINT_FORCE_NULLABLE,
           null);
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
-import org.opensearch.client.Request;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
@@ -52,16 +51,11 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
 
   @Test
   public void testSimpleCount0() throws IOException {
-    Request request1 = new Request("PUT", "/test/_doc/1?refresh=true");
-    request1.setJsonEntity("{\"name\": \"hello\", \"age\": 20}");
-    client().performRequest(request1);
-    Request request2 = new Request("PUT", "/test/_doc/2?refresh=true");
-    request2.setJsonEntity("{\"name\": \"world\", \"age\": 30}");
-    client().performRequest(request2);
-
-    JSONObject actual = executeQuery("source=test | stats count() as c");
+    // A bare auto-created index isn't parquet-backed; use the parquet-aware bank index (7 docs).
+    JSONObject actual =
+        executeQuery(String.format("source=%s | stats count() as c", TEST_INDEX_BANK));
     verifySchema(actual, schema("c", "bigint"));
-    verifyDataRows(actual, rows(2));
+    verifyDataRows(actual, rows(7));
   }
 
   @Test


### PR DESCRIPTION
### Description

Two small fixes that make `CalcitePPLAggregationIT` pass on the analytics-engine route (`-Dtests.analytics.parquet_indices=true`). Both are no-ops on the v2 / Calcite path.

**1. `testSimpleCount0` — use a parquet-backed index.** The test built an ad-hoc `test` index with raw `_doc` PUTs; a bare auto-created index isn't composite/parquet-backed, so `RestUnifiedQueryAction.isAnalyticsIndex` doesn't route it to the analytics engine. Switched to `TEST_INDEX_BANK` (loaded in `init()` via `loadIndex`, which injects the parquet settings when the flag is set, 7 docs), and dropped the now-unused `Request` import. Verified passing on both routes.

**2. `distinct_count_approx` — emit the Substrait-standard operator name.** `PPLBuiltinOperators.DISTINCT_COUNT_APPROX` created its `SqlAggFunction` with the runtime-resolution name `"DISTINCT_COUNT_APPROX"`. The analytics-engine (DataFusion) backend resolves aggregates by the Calcite/Substrait-standard name `APPROX_COUNT_DISTINCT`, so `distinct_count_approx()` failed to bind on the analytics route. Emit `APPROX_COUNT_DISTINCT` instead (the Java field name and PPL function name are unchanged). 

The OpenSearch V3 / Lucene path is unaffected: it overrides this operator via the external HyperLogLog registration in `OpenSearchExecutionEngine` (whose name is unchanged), so explain output and execution on that path are byte-identical — verified by the unchanged `explain_*distinct_count*` / `explain_*dc*` expected-output files and the `CalciteExplainIT` distinct-count tests still passing. The analytics-route binding (`APPROX_COUNT_DISTINCT` → DataFusion `approx_distinct`) is completed by **opensearch-project/OpenSearch#22013**.

### Testing

| Test | route | before | after |
|---|---|---|---|
| `testSimpleCount0` | v2 / analytics | ✅ / ❌ | ✅ / ✅ |
| `CalciteExplainIT` distinct-count/dc explain (5) | v2 | ✅ | ✅ (unchanged) |
| `testCountDistinctApprox` / `…WithAlias` | analytics | ❌ | ✅ once #22013 is in the analytics base¹ |

¹ The operator rename is verified to be a no-op on v2 (external HLL registration takes precedence). The analytics-route pass for `distinct_count_approx` is completed by OpenSearch#22013 (already merged on `main`); local verification of that leg requires an analytics cluster built on a base that includes #22013.

Diagnosis / analytics-engine side by Sandesh Kumar.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
