### PR TITLE
[BugFix] Fix SQL aggregate window with ORDER BY defaulting to whole partition

### DIFF
--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
@@ -425,6 +425,33 @@ public class UnifiedQueryPlannerSqlV2Test extends UnifiedQueryTestBase {
   }
 
   @Test
+  public void testCountDistinctWindowWithOrderBy() {
+    // No frame printed: RANGE .. CURRENT ROW is Calcite's default for ORDER BY.
+    givenQuery(
+            """
+            SELECT department, COUNT(DISTINCT name) OVER(ORDER BY department) FROM catalog.employees
+            """)
+        .assertPlan(
+            """
+            LogicalProject(department=[$3], COUNT(DISTINCT name) OVER(ORDER BY department)=[COUNT(DISTINCT $1) OVER (ORDER BY $3 NULLS FIRST)])
+              LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testSumWindowWithPartitionAndOrderBy() {
+    givenQuery(
+            """
+            SELECT name, SUM(age) OVER(PARTITION BY department ORDER BY age) FROM catalog.employees
+            """)
+        .assertPlan(
+            """
+            LogicalProject(name=[$1], SUM(age) OVER(PARTITION BY department ORDER BY age)=[SUM($2) OVER (PARTITION BY $3 ORDER BY $2 NULLS FIRST)])
+              LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
   public void testWindowOrderByDefaultsNullsFirst() {
     // Window function ORDER BY without explicit NULLS FIRST/LAST defaults to NULLS FIRST,
     // matching top-level ORDER BY semantics.

--- a/core/src/main/java/org/opensearch/sql/ast/expression/WindowBound.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/WindowBound.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.ast.expression;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 public abstract class WindowBound {
@@ -25,6 +26,7 @@ public abstract class WindowBound {
     }
   }
 
+  @EqualsAndHashCode(callSuper = false)
   public static class CurrentRowWindowBound extends WindowBound {
     CurrentRowWindowBound() {}
 

--- a/core/src/main/java/org/opensearch/sql/ast/expression/WindowFrame.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/WindowFrame.java
@@ -40,6 +40,13 @@ public class WindowFrame extends UnresolvedExpression {
         AstDSL.stringLiteral("CURRENT ROW"));
   }
 
+  public static WindowFrame rangeToCurrentRow() {
+    return WindowFrame.of(
+        FrameType.RANGE,
+        AstDSL.stringLiteral("UNBOUNDED PRECEDING"),
+        AstDSL.stringLiteral("CURRENT ROW"));
+  }
+
   public static WindowFrame of(FrameType type, String lower, String upper) {
     return WindowFrame.of(type, AstDSL.stringLiteral(lower), AstDSL.stringLiteral(upper));
   }

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -222,7 +222,14 @@ public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<Unresol
               .map(item -> ImmutablePair.of(createSortOption(item), visit(item.expression())))
               .collect(Collectors.toList());
     }
-    return new WindowFunction(visit(ctx.function), partitionByList, sortList);
+    UnresolvedExpression function = visit(ctx.function);
+    WindowFunction windowFunction = new WindowFunction(function, partitionByList, sortList);
+
+    // Aggregate window with ORDER BY defaults to a running RANGE frame (ranking ignores it).
+    if (function instanceof AggregateFunction && !sortList.isEmpty()) {
+      windowFunction.setWindowFrame(WindowFrame.rangeToCurrentRow());
+    }
+    return windowFunction;
   }
 
   @Override

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -44,6 +44,8 @@ import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.RelevanceFieldList;
+import org.opensearch.sql.ast.expression.WindowFrame;
+import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.common.antlr.CaseInsensitiveCharStream;
 import org.opensearch.sql.common.antlr.SyntaxAnalysisErrorListener;
@@ -308,12 +310,23 @@ class AstExpressionBuilderTest {
 
   @Test
   public void canBuildAggregateWindowFunction() {
+    WindowFunction expected =
+        new WindowFunction(
+            aggregate("AVG", qualifiedName("age")),
+            ImmutableList.of(qualifiedName("state")),
+            ImmutableList.of(ImmutablePair.of(new SortOption(null, null), qualifiedName("age"))));
+    expected.setWindowFrame(WindowFrame.rangeToCurrentRow());
+    assertEquals(expected, buildExprAst("AVG(age) OVER (PARTITION BY state ORDER BY age)"));
+  }
+
+  @Test
+  public void canBuildAggregateWindowFunctionWithoutOrderBy() {
     assertEquals(
         window(
             aggregate("AVG", qualifiedName("age")),
             ImmutableList.of(qualifiedName("state")),
-            ImmutableList.of(ImmutablePair.of(new SortOption(null, null), qualifiedName("age")))),
-        buildExprAst("AVG(age) OVER (PARTITION BY state ORDER BY age)"));
+            ImmutableList.of()),
+        buildExprAst("AVG(age) OVER (PARTITION BY state)"));
   }
 
   @Test


### PR DESCRIPTION
### Description
In the unified SQL path, an aggregate window function with an `ORDER BY` but no explicit frame (e.g. `COUNT(DISTINCT x) OVER(ORDER BY y)`) defaulted to the whole partition, returning the partition-wide total on every row. This PR defaults such aggregate windows to `ROWS UNBOUNDED PRECEDING .. CURRENT ROW` so each row reflects a running aggregate — PPL window functions carry no `ORDER BY` and are unaffected.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
