### PR TITLE
Exclude full-text search-filter operator tests on the analytics-engine route

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1035,12 +1035,29 @@ task integTestRemote(type: RestIntegTestTask) {
         systemProperty 'tests.analytics.parquet_indices', System.getProperty("tests.analytics.parquet_indices")
     }
 
+    // True only when the analytics-engine route is active (every test index parquet-backed). Matches
+    // AnalyticsIndexConfig.isEnabled, which parses the value rather than checking mere presence, so a
+    // `-Dtests.analytics.parquet_indices=false` run stays on the v2 path.
+    def analyticsEnabled = Boolean.parseBoolean(System.getProperty("tests.analytics.parquet_indices", "false"))
+
     // Set default query size limit
     systemProperty 'defaultQuerySizeLimit', '10000'
 
-    if (System.getProperty("tests.rest.bwcsuite") == null) {
-        filter {
+    filter {
+        if (System.getProperty("tests.rest.bwcsuite") == null) {
             excludeTestsMatching "org.opensearch.sql.bwc.*IT"
+        }
+
+        if (analyticsEnabled) {
+            // Full-text search (search-filter syntax -> Lucene query_string) needs an inverted-index
+            // reader that parquet-backed analytics indices lack, so it's unsupported on this route.
+            excludeTestsMatching '*OperatorIT.testEqualOperator'
+            excludeTestsMatching '*OperatorIT.testNotEqualOperator'
+            excludeTestsMatching '*OperatorIT.testLessOperator'
+            excludeTestsMatching '*OperatorIT.testLteOperator'
+            excludeTestsMatching '*OperatorIT.testGreaterOperator'
+            excludeTestsMatching '*OperatorIT.testGteOperator'
+            excludeTestsMatching '*OperatorIT.testNotOperator'
         }
     }
 


### PR DESCRIPTION
### Description

The 7 comparison-operator tests in `OperatorIT` / `CalciteOperatorIT` (`testEqualOperator`, `testNotEqualOperator`, `testLessOperator`, `testLteOperator`, `testGreaterOperator`, `testGteOperator`, `testNotOperator`) fail on the analytics-engine route (`-Dtests.analytics.parquet_indices=true`).

**Root cause.** They use the implicit search-filter syntax (`source=idx age = 32`), which the PPL `search` command lowers to a Lucene **`query_string`** predicate:

```
LogicalFilter(condition=[query_string(MAP('query', 'age:32'))])
```

Executing that on the analytics route fails with:

```
java.lang.NullPointerException: Cannot invoke
"org.opensearch.be.lucene.LuceneReader.searcher(...)" because "luceneReader" is null
  at io.substrait.isthmus.SubstraitRelVisitor.fromAggCall
  at org.opensearch.be.datafusion.DataFusionFragmentConvertor.convertToSubstrait
```

`query_string` is full-text search — it needs an inverted-index `LuceneReader`/searcher. A parquet-backed analytics index (`composite.primary_data_format=parquet`, no Lucene secondary) has no Lucene reader, and DataFusion is a columnar engine, not a full-text engine. So full-text search is **genuinely unsupported** on the analytics route, not a bug.

**Fix.** Exclude these tests on the analytics route, gated on `tests.analytics.parquet_indices`, following the existing `integ-test/build.gradle` exclusion pattern — recording that full-text search isn't supported there rather than changing what the tests assert. The v2 / Calcite (Lucene-backed) path is unaffected; the tests run and pass there.

### Testing

`CalciteOperatorIT` (21 tests):

| route | search-filter operator tests | rest of class |
|---|---|---|
| analytics-engine (parquet) | excluded (7) | ✅ 14/14 pass |
| v2 / Calcite | ✅ run & pass | ✅ |

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
