### PR TITLE
[BugFix] Fix `SHOW`/`DESCRIBE` statement routing under `cluster.pluggable.dataformat` setting

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -63,6 +63,7 @@ import org.opensearch.script.ScriptEngine;
 import org.opensearch.script.ScriptService;
 import org.opensearch.sql.ast.statement.ExplainMode;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.common.utils.QueryContext;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelper;
 import org.opensearch.sql.datasources.auth.DataSourceUserAuthorizationHelperImpl;
@@ -241,6 +242,7 @@ public class SQLPlugin extends Plugin
           || !unifiedQueryHandler.isAnalyticsIndex(sqlRequest.getQuery(), QueryType.SQL)) {
         return false;
       }
+      LOGGER.info("[{}] Routing SQL query to analytics engine", QueryContext.getRequestId());
       if (sqlRequest.isExplainRequest()) {
         unifiedQueryHandler.explain(
             sqlRequest.getQuery(),

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -13,6 +13,7 @@ import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.
 import java.util.Map;
 import java.util.Optional;
 import org.apache.calcite.rel.RelNode;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -40,6 +41,7 @@ import org.opensearch.sql.plugin.transport.TransportPPLQueryResponse;
 import org.opensearch.sql.protocol.response.QueryResult;
 import org.opensearch.sql.protocol.response.format.ResponseFormatter;
 import org.opensearch.sql.protocol.response.format.SimpleJsonResponseFormatter;
+import org.opensearch.sql.utils.SystemIndexUtils;
 import org.opensearch.transport.client.node.NodeClient;
 
 /**
@@ -95,7 +97,17 @@ public class RestUnifiedQueryAction {
         .equals(
             IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(
                 clusterService.getSettings()))) {
-      return true;
+      // Analytics engine can't serve system catalog; SHOW/DESCRIBE fall back to default pipeline
+      try (UnifiedQueryContext context = buildParsingContext(queryType)) {
+        boolean systemCatalog =
+            extractIndexName(query, queryType, context)
+                .map(RestUnifiedQueryAction::isSystemCatalog)
+                .orElse(false);
+        return !systemCatalog;
+      } catch (Exception e) {
+        // Check legacy-syntax SHOW/DESCRIBE; otherwise let AE handle and surface the error.
+        return !isLegacySystemCatalogQuery(query);
+      }
     }
     try (UnifiedQueryContext context = buildParsingContext(queryType)) {
       return extractIndexName(query, queryType, context)
@@ -105,6 +117,16 @@ public class RestUnifiedQueryAction {
     } catch (Exception e) {
       return false;
     }
+  }
+
+  private static boolean isSystemCatalog(String name) {
+    return SystemIndexUtils.isSystemIndex(name)
+        || SystemIndexUtils.DATASOURCES_TABLE_NAME.equals(name);
+  }
+
+  private static boolean isLegacySystemCatalogQuery(String query) {
+    String trimmed = query.trim();
+    return Strings.CI.startsWith(trimmed, "SHOW ") || Strings.CI.startsWith(trimmed, "DESCRIBE ");
   }
 
   private String stripSchemaPrefix(String indexName) {

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
@@ -14,6 +14,8 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.calcite.rel.RelNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -58,6 +60,8 @@ import org.opensearch.transport.client.node.NodeClient;
 /** Send PPL query transport action. */
 public class TransportPPLQueryAction
     extends HandledTransportAction<ActionRequest, TransportPPLQueryResponse> {
+
+  private static final Logger LOG = LogManager.getLogger(TransportPPLQueryAction.class);
 
   private final Injector injector;
 
@@ -171,6 +175,7 @@ public class TransportPPLQueryAction
     // Route to analytics engine for non-Lucene (e.g., Parquet-backed) indices.
     if (unifiedQueryHandler != null
         && unifiedQueryHandler.isAnalyticsIndex(transformedRequest.getRequest(), QueryType.PPL)) {
+      LOG.info("[{}] Routing PPL query to analytics engine", QueryContext.getRequestId());
       if (transformedRequest.isExplainRequest()) {
         unifiedQueryHandler.explain(
             transformedRequest.getRequest(),

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.transport.client.node.NodeClient;
 
@@ -142,7 +143,7 @@ public class RestUnifiedQueryActionTest {
   }
 
   @Test
-  public void showStatementRoutesToLucene() {
+  public void showStatementNotRoutedToAnalyticsEngine() {
     registerIndex(
         "parquet_logs",
         Settings.builder()
@@ -154,7 +155,7 @@ public class RestUnifiedQueryActionTest {
   }
 
   @Test
-  public void describeStatementRoutesToLucene() {
+  public void describeStatementNotRoutedToAnalyticsEngine() {
     registerIndex(
         "parquet_logs",
         Settings.builder()
@@ -163,6 +164,79 @@ public class RestUnifiedQueryActionTest {
             .build());
 
     assertFalse(action.isAnalyticsIndex("DESCRIBE TABLES LIKE 'parquet_logs'", QueryType.SQL));
+  }
+
+  @Test
+  public void showStatementNotRoutedToAnalyticsEngineUnderClusterComposite() {
+    enableClusterComposite();
+    assertFalse(action.isAnalyticsIndex("SHOW TABLES LIKE 'parquet_logs'", QueryType.SQL));
+  }
+
+  @Test
+  public void describeStatementNotRoutedToAnalyticsEngineUnderClusterComposite() {
+    enableClusterComposite();
+    assertFalse(action.isAnalyticsIndex("DESCRIBE TABLES LIKE 'parquet_logs'", QueryType.SQL));
+  }
+
+  @Test
+  public void dataQueryStillRoutesToAnalyticsUnderClusterComposite() {
+    enableClusterComposite();
+    assertTrue(action.isAnalyticsIndex("SELECT * FROM parquet_logs", QueryType.SQL));
+  }
+
+  @Test
+  public void unparseableQueryRoutesToAnalyticsUnderClusterComposite() {
+    enableClusterComposite();
+    // malformed -> AE re-parses & reports
+    assertTrue(action.isAnalyticsIndex("SELECT FROM WHERE", QueryType.SQL));
+  }
+
+  @Test
+  public void legacyShowNotRoutedToAnalyticsEngineUnderClusterComposite() {
+    enableClusterComposite();
+    // unquoted LIKE is rejected by the V2 parser, but still belongs on the default pipeline
+    assertFalse(action.isAnalyticsIndex("SHOW TABLES LIKE %", QueryType.SQL));
+  }
+
+  @Test
+  public void legacyDescribeNotRoutedToAnalyticsEngineUnderClusterComposite() {
+    enableClusterComposite();
+    // legacy DESCRIBE syntax is rejected by the V2 parser, but belongs on the default pipeline
+    assertFalse(action.isAnalyticsIndex("DESCRIBE my_index", QueryType.SQL));
+  }
+
+  @Test
+  public void pplDescribeNotRoutedToAnalyticsEngineUnderClusterComposite() {
+    enableClusterComposite();
+    assertFalse(action.isAnalyticsIndex("describe parquet_logs", QueryType.PPL));
+  }
+
+  @Test
+  public void pplShowDatasourcesNotRoutedToAnalyticsEngineUnderClusterComposite() {
+    enableClusterComposite();
+    assertFalse(action.isAnalyticsIndex("show datasources", QueryType.PPL));
+  }
+
+  @Test
+  public void pplDataQueryStillRoutesToAnalyticsUnderClusterComposite() {
+    enableClusterComposite();
+    assertTrue(action.isAnalyticsIndex("source = parquet_logs | fields ts", QueryType.PPL));
+  }
+
+  @Test
+  public void pplUnparseableQueryRoutesToAnalyticsUnderClusterComposite() {
+    enableClusterComposite();
+    // malformed -> AE re-parses & reports
+    assertTrue(action.isAnalyticsIndex("source = parquet_logs | | fields ts", QueryType.PPL));
+  }
+
+  private void enableClusterComposite() {
+    when(clusterService.getSettings())
+        .thenReturn(
+            Settings.builder()
+                .put(
+                    IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
+                .build());
   }
 
   private void registerIndex(String name, Settings settings) {


### PR DESCRIPTION
### Description
PR #5486 introduced the `cluster.pluggable.dataformat` setting. When enabled, all queries are routed to the Analytics Engine, which does not support `SHOW` or `DESCRIBE` statement, causing both to fail. This PR fixes the routing by:

1. Under `cluster.pluggable.dataformat=composite`, `SHOW TABLES`, `DESCRIBE`, and `SHOW DATASOURCES` queries are now routed back to default query pipeline instead of analytics engine.
2. Legacy-syntax `SHOW`/`DESCRIBE` statements that the V2 parser rejects (e.g. unquoted SHOW TABLES LIKE %) are also routed back to the default pipeline, which falls back to the legacy engine.

Additionally, added query-routing logging at both the SQL and PPL call sites for traceability when a query is routed to the analytics engine.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
