### PR TITLE
Parquet-back raw-PUT test indices on the analytics-engine route

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -66,6 +66,12 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
       initClient();
     }
 
+    // When -Dtests.analytics.parquet_indices=true, make every index (including ones a test
+    // auto-creates via a raw document PUT, which bypasses createIndexByRestClient) parquet-backed
+    // composite, so it is stored as a DataFormatAwareEngine and is actually scannable by the
+    // analytics engine it routes to. Must run before init() creates any index.
+    TestUtils.AnalyticsIndexConfig.applyClusterSettings(client());
+
     if (shouldResetQuerySizeLimit()) {
       resetQuerySizeLimit();
     }

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
@@ -68,6 +69,11 @@ public class TestUtils {
       return Boolean.parseBoolean(System.getProperty(ENABLED_PROP, "false"));
     }
 
+    // Composite-store format values shared by the index-level and cluster-level settings below.
+    private static final String DATAFORMAT_COMPOSITE = "composite";
+    private static final String PRIMARY_FORMAT_PARQUET = "parquet";
+    private static final String SECONDARY_FORMAT_LUCENE = "lucene";
+
     /**
      * Inject the parquet-backed composite-store index settings into {@code jsonObject}. No-op when
      * the config is disabled; idempotent — safe on any index-creation JSON shape.
@@ -82,11 +88,36 @@ public class TestUtils {
           settings.has("index") ? settings.getJSONObject("index") : new JSONObject();
       indexSettings.put("number_of_shards", 1);
       indexSettings.put("pluggable.dataformat.enabled", true);
-      indexSettings.put("pluggable.dataformat", "composite");
-      indexSettings.put("composite.primary_data_format", "parquet");
-      indexSettings.put("composite.secondary_data_formats", new org.json.JSONArray().put("lucene"));
+      indexSettings.put("pluggable.dataformat", DATAFORMAT_COMPOSITE);
+      indexSettings.put("composite.primary_data_format", PRIMARY_FORMAT_PARQUET);
+      indexSettings.put(
+          "composite.secondary_data_formats", new JSONArray().put(SECONDARY_FORMAT_LUCENE));
       settings.put("index", indexSettings);
       jsonObject.put("settings", settings);
+    }
+
+    /**
+     * Set the composite-store defaults at the cluster level so even indices auto-created by a raw
+     * document {@code PUT} (which bypass {@link #applyIndexCreationSettings}) are parquet-backed.
+     * Otherwise such an index inherits only the composite value — so it routes to the analytics
+     * engine — but not the {@code .enabled} flag, leaving it stored as a plain-Lucene {@code
+     * EngineBackedIndexer} that fails at query time. No-op when disabled; idempotent.
+     */
+    public static void applyClusterSettings(RestClient client) {
+      if (!isEnabled()) {
+        return;
+      }
+      JSONObject persistent =
+          new JSONObject()
+              .put("cluster.pluggable.dataformat.enabled", true)
+              .put("cluster.pluggable.dataformat", DATAFORMAT_COMPOSITE)
+              .put("cluster.composite.primary_data_format", PRIMARY_FORMAT_PARQUET)
+              .put(
+                  "cluster.composite.secondary_data_formats",
+                  new JSONArray().put(SECONDARY_FORMAT_LUCENE));
+      Request request = new Request("PUT", "/_cluster/settings");
+      request.setJsonEntity(new JSONObject().put("persistent", persistent).toString());
+      performRequest(client, request);
     }
 
     /**


### PR DESCRIPTION
### Problem

Running the Calcite IT suite through the analytics-engine route (`-Dtests.analytics.parquet_indices=true`) produces a large bucket of `StreamException[errorCode=INTERNAL] "Failed to start streaming fragment on [<index>][<shard>]"` failures, whose cluster-side cause is `UnsupportedOperationException: acquireReader is not supported in EngineBackedIndexer`.

The root cause is a **routing-vs-storage inconsistency**:

| Decision | Keys on |
|---|---|
| Route to the analytics engine (`RestUnifiedQueryAction.isAnalyticsIndex`) | `pluggable.dataformat` **value** == `composite` |
| Store as `DataFormatAwareEngine` (`IndicesService.getIndexerFactory` → `IndexSettings.isPluggableDataFormatEnabled`) | `pluggable.dataformat.`**`enabled`**`=true` (+ feature flag) |

Test indices created by a raw document `PUT` (e.g. `PUT /test/_doc/1` in a test's `init()`) bypass `AnalyticsIndexConfig.applyIndexCreationSettings` (which only stamps indices created via `createIndexByRestClient`/`loadIndex`). They inherit the composite *value* from the cluster opt-in — so they route to the analytics engine — but not the `enabled` flag, so they are stored as a plain-Lucene `EngineBackedIndexer` whose `acquireReader()` is an unimplemented stub. The query then fails with the StreamException above.

### Fix

Add `AnalyticsIndexConfig.applyClusterSettings()`, which sets the cluster-level composite defaults (`cluster.pluggable.dataformat.enabled=true`, `cluster.pluggable.dataformat=composite`, parquet primary, lucene secondary) when `tests.analytics.parquet_indices=true`, and call it from `SQLIntegTestCase.setUpIndices()` before `init()`. Every index — including raw-`PUT` ones — is then stored as a parquet-backed `DataFormatAwareEngine` that the analytics engine can actually scan. It is a **no-op unless `tests.analytics.parquet_indices=true`**, so normal CI is unchanged.

Notes:
- The lucene secondary format is required, or a parquet-only shard fails recovery (`MapperParsingException: Field [_field_names] requires [FULL_TEXT_SEARCH]`).
- `cluster.pluggable.dataformat.restrict.allowlist` is a static (non-dynamic) setting and is intentionally not set here; it belongs in the cluster node config if a run needs to exempt extra index prefixes.

### Verification (analytics route, `-Dtests.analytics.parquet_indices=true`)

`acquireReader` StreamExceptions across the affected IT classes: **59 → 0**.

| Class | Before | After |
|---|---|---|
| `CalciteNotLikeNullIT` | 0/3 (acquireReader) | **3/3** |
| `CalcitePPLLookupIT` | 1 acquireReader fail | **17/17** |
| `CalcitePPLParseIT` | 1 acquireReader fail | **6/6** |
| `CalcitePPLPluginIT` | 1 acquireReader fail | **5/5** |

Indices now execute on the real analytics + DataFusion path and return correct rows. Failures that remain on the heavier classes (aggregation, datetime, mixed-field) are **pre-existing, separately-tracked analytics-engine gaps** that the `acquireReader` stub previously masked — percentile value scaling, unsupported datetime functions (`TO_DAYS`, `ADDTIME`, …), `distinct_count_approx`, `SPAN`/timestamp type divergence, etc. They are not regressions and are out of scope for this test-infra change; once the indices are scannable they simply surface their true cause instead of the generic streaming-fragment wrapper.
