### PR TITLE
[BugFix] Fix invalid field or index error misclassified as internal failures

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -14,6 +14,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.runtime.CalciteException;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.util.SqlVisitor;
@@ -25,6 +26,7 @@ import org.opensearch.sql.api.parser.UnifiedQueryParser;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.common.error.ErrorReport;
 import org.opensearch.sql.exception.QueryEngineException;
 import org.opensearch.sql.exception.SemanticCheckException;
 
@@ -74,13 +76,18 @@ public class UnifiedQueryPlanner {
     } catch (SyntaxCheckException
         | QueryEngineException
         | UnsupportedOperationException
-        | IllegalArgumentException e) {
-      LOG.error("Failed to plan query: {}", e.getMessage());
+        | IllegalArgumentException
+        | ErrorReport e) {
+      LOG.warn("Failed to plan query: {}", e.getMessage());
       throw e;
+    } catch (CalciteException e) {
+      // Calcite validation errors (e.g. table not found) indicate an invalid query.
+      LOG.warn("Failed to plan query, invalid query: {}", e.getMessage());
+      throw new SemanticCheckException(e.getMessage(), e);
     } catch (AssertionError e) {
       // Calcite throws assertion error directly when building bad RelNode
       String message = "Failed to plan query: invalid plan structure";
-      LOG.error(message, e);
+      LOG.warn(message, e);
       throw new SemanticCheckException(message, e);
     } catch (Exception e) {
       String message = "Failed to plan query: unexpected error";

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
@@ -10,10 +10,12 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Map;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.runtime.CalciteException;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.junit.Test;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.common.error.ErrorReport;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.executor.QueryType;
 
@@ -72,7 +74,7 @@ public class UnifiedQueryPlannerTest extends UnifiedQueryTestBase {
 
     // This is valid in SparkSQL, but Calcite requires "catalog" as the default root schema to
     // resolve it
-    assertThrows(IllegalStateException.class, () -> planner.plan("source = opensearch.employees"));
+    assertThrows(SemanticCheckException.class, () -> planner.plan("source = opensearch.employees"));
   }
 
   @Test
@@ -129,6 +131,20 @@ public class UnifiedQueryPlannerTest extends UnifiedQueryTestBase {
     givenInvalidQuery("source = catalog.employees | rename id* as x*y*")
         .assertErrorType(SemanticCheckException.class)
         .assertErrorMessageEquals("Source and target patterns have different wildcard counts");
+  }
+
+  @Test
+  public void fieldNotFoundIsRethrownAsErrorReport() {
+    givenInvalidQuery("source = catalog.employees | where unknown_field = 1")
+        .assertErrorType(ErrorReport.class)
+        .assertErrorMessageContains("Field [unknown_field] not found");
+  }
+
+  @Test
+  public void invalidTableIsRethrownAsSemanticCheckException() {
+    givenInvalidQuery("source = catalog.nonexistent_table")
+        .assertErrorType(SemanticCheckException.class)
+        .assertCauseType(CalciteException.class);
   }
 
   @Test

--- a/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/ErrorMessageFactory.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/executor/format/ErrorMessageFactory.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.legacy.executor.format;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.sql.common.error.ErrorReport;
 
 public class ErrorMessageFactory {
   /**
@@ -24,6 +25,10 @@ public class ErrorMessageFactory {
     } else if (unwrapCause(e) instanceof OpenSearchException) {
       OpenSearchException exception = (OpenSearchException) unwrapCause(e);
       return new OpenSearchErrorMessage(exception, exception.status().getStatus());
+    }
+    // Unwrap ErrorReport so the error type reflects the underlying cause, not the wrapper.
+    if (e instanceof ErrorReport) {
+      return new ErrorMessage(((ErrorReport) e).getCause(), status);
     }
     return new ErrorMessage(e, status);
   }

--- a/legacy/src/test/java/org/opensearch/sql/legacy/unittest/ErrorMessageFactoryTest.java
+++ b/legacy/src/test/java/org/opensearch/sql/legacy/unittest/ErrorMessageFactoryTest.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.OpenSearchException;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.sql.common.error.ErrorReport;
 import org.opensearch.sql.legacy.executor.format.ErrorMessage;
 import org.opensearch.sql.legacy.executor.format.ErrorMessageFactory;
 import org.opensearch.sql.legacy.executor.format.OpenSearchErrorMessage;
@@ -39,6 +40,25 @@ public class ErrorMessageFactoryTest {
     Exception exception = (Exception) openSearchThrowable;
     ErrorMessage msg =
         ErrorMessageFactory.createErrorMessage(exception, RestStatus.BAD_REQUEST.getStatus());
+    Assert.assertTrue(msg instanceof OpenSearchErrorMessage);
+  }
+
+  @Test
+  public void errorReportShouldRenderUnderlyingCauseType() {
+    Exception exception =
+        ErrorReport.wrap(new IllegalArgumentException("Field [x] not found.")).build();
+    ErrorMessage msg =
+        ErrorMessageFactory.createErrorMessage(exception, RestStatus.BAD_REQUEST.getStatus());
+    Assert.assertFalse(msg instanceof OpenSearchErrorMessage);
+    Assert.assertTrue(msg.toString().contains("IllegalArgumentException"));
+    Assert.assertFalse(msg.toString().contains("ErrorReport"));
+  }
+
+  @Test
+  public void errorReportWrappingEsExceptionShouldCreateEsErrorMessage() {
+    Exception exception = ErrorReport.wrap(new OpenSearchException(nonOpenSearchThrowable)).build();
+    ErrorMessage msg =
+        ErrorMessageFactory.createErrorMessage(exception, RestStatus.NOT_FOUND.getStatus());
     Assert.assertTrue(msg instanceof OpenSearchErrorMessage);
   }
 


### PR DESCRIPTION
### Description

The unified query path returned a 500 instead of a client error for queries referencing a non-existent index or field, because `ErrorReport` (field-not-found) and `CalciteException` (table-not-found) fell through to the catch-all and were rethrown as `IllegalStateException`. This PR fixes that by propagating `ErrorReport` unwrapped and mapping `CalciteException` to `SemanticCheckException`.

#### Example: Non-existent Index

```
  Request:
  POST /_plugins/_sql
  {"query": "SELECT * FROM nonexistent_index_xyz LIMIT 1"}

  Before:
  HTTP/1.1 500 Internal Server Error
  {
    "error": {
      "reason": "There was internal problem at backend",
      "details": "Failed to plan query: unexpected error",
      "type": "IllegalStateException"
    },
    "status": 500
  }

  After:
  HTTP/1.1 400 Bad Request
  {
    "error": {
      "reason": "Invalid SQL query",
      "details": "Table 'nonexistent_index_xyz' not found",
      "type": "SemanticCheckException"
    },
    "status": 400
  }
```
 

#### Example: Non-existent Field

```
  Request:
  POST /_plugins/_sql
  {"query": "SELECT nonexistent_field FROM sanity_test"}

  Before:
  HTTP/1.1 500 Internal Server Error
  {
    "error": {
      "reason": "There was internal problem at backend",
      "details": "Failed to plan query: unexpected error",
      "type": "IllegalStateException"
    },
    "status": 500
  }

  After:
  HTTP/1.1 400 Bad Request
  {
    "error": {
      "reason": "Invalid SQL query",
      "details": "Field [nonexistent_field] not found.",
      "type": "IllegalArgumentException"
    },
    "status": 400
  }
```

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
