### PR TITLE
[BugFix] Handle opaque NullPointerException for unresolvable alias-type field path

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteErrorReportStageIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteErrorReportStageIT.java
@@ -11,6 +11,7 @@ import static org.opensearch.sql.util.TestUtils.getResponseBody;
 import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
@@ -213,5 +214,37 @@ public class CalciteErrorReportStageIT extends PPLIntegTestCase {
             || stageDescription.toLowerCase().contains("prepar")
             || stageDescription.toLowerCase().contains("run")
             || stageDescription.toLowerCase().contains("query"));
+  }
+
+  // An alias field whose path targets a text multi-field (e.g. "source.keyword") is not present in
+  // the flattened mapping. It used to surface an opaque NullPointerException; it must now report a
+  // structured FIELD_NOT_FOUND error with a suggestion.
+  @Test
+  public void testAliasToUnresolvablePathIncludesStructuredError() throws IOException {
+    String index = "test_alias_unresolved_keyword";
+    Request createIndex = new Request("PUT", "/" + index);
+    createIndex.setJsonEntity(
+        "{ \"mappings\": { \"properties\": {"
+            + "  \"source\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\":"
+            + " \"keyword\" } } },"
+            + "  \"source_alias\": { \"type\": \"alias\", \"path\": \"source.keyword\" } } } }");
+    client().performRequest(createIndex);
+
+    ResponseException exception =
+        assertThrows(ResponseException.class, () -> executeQuery("source=" + index));
+
+    JSONObject error =
+        new JSONObject(getResponseBody(exception.getResponse())).getJSONObject("error");
+
+    assertEquals("FIELD_NOT_FOUND", error.getString("code"));
+    assertTrue(
+        "Details should name the alias field and path",
+        error
+            .getString("details")
+            .contains("Alias field [source_alias] refers to unresolved path [source.keyword]"));
+    JSONObject context = error.getJSONObject("context");
+    assertEquals("source_alias", context.getString("alias_field"));
+    assertEquals("source.keyword", context.getString("alias_path"));
+    assertTrue("Should include a suggestion", error.has("suggestion"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
@@ -117,7 +117,7 @@ public class QueryValidationIT extends SQLIntegTestCase {
 
     expectResponseException()
         .hasStatusCode(BAD_REQUEST)
-        .hasErrorType("SemanticCheckException")
+        .hasErrorType("ErrorReport")
         .containsMessage("Alias field [source_alias] refers to unresolved path [source.keyword]")
         .whenExecute(String.format(Locale.ROOT, "SELECT * FROM %s", index));
   }

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
@@ -118,13 +118,11 @@ public class QueryValidationIT extends SQLIntegTestCase {
     expectResponseException()
         .hasStatusCode(BAD_REQUEST)
         .hasErrorType("SemanticCheckException")
-        .containsMessage(
-            "Alias field [source_alias] refers to unresolved path [source.keyword]")
+        .containsMessage("Alias field [source_alias] refers to unresolved path [source.keyword]")
         .whenExecute(String.format(Locale.ROOT, "SELECT * FROM %s", index));
   }
 
-  private static void createIndexWithMapping(String indexName, String mapping)
-      throws IOException {
+  private static void createIndexWithMapping(String indexName, String mapping) throws IOException {
     Request request = new Request("PUT", "/" + indexName);
     request.setJsonEntity(String.format(Locale.ROOT, "{ \"mappings\": %s }", mapping));
     client().performRequest(request);

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
@@ -103,6 +103,33 @@ public class QueryValidationIT extends SQLIntegTestCase {
     client().performRequest(request);
   }
 
+  // An alias field whose path targets a text multi-field (e.g. "source.keyword") must fail with a
+  // descriptive client error rather than an opaque NullPointerException.
+  @Test
+  public void testAliasToKeywordMultiFieldFailsWithBadRequest() throws IOException {
+    String index = "test_alias_unresolved_keyword";
+    createIndexWithMapping(
+        index,
+        "{ \"properties\": {"
+            + "  \"source\": { \"type\": \"text\", \"fields\": { \"keyword\": { \"type\":"
+            + " \"keyword\" } } },"
+            + "  \"source_alias\": { \"type\": \"alias\", \"path\": \"source.keyword\" } } }");
+
+    expectResponseException()
+        .hasStatusCode(BAD_REQUEST)
+        .hasErrorType("SemanticCheckException")
+        .containsMessage(
+            "Alias field [source_alias] refers to unresolved path [source.keyword]")
+        .whenExecute(String.format(Locale.ROOT, "SELECT * FROM %s", index));
+  }
+
+  private static void createIndexWithMapping(String indexName, String mapping)
+      throws IOException {
+    Request request = new Request("PUT", "/" + indexName);
+    request.setJsonEntity(String.format(Locale.ROOT, "{ \"mappings\": %s }", mapping));
+    client().performRequest(request);
+  }
+
   public ResponseExceptionAssertion expectResponseException() {
     return new ResponseExceptionAssertion(exceptionRule);
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
@@ -14,6 +14,9 @@ import java.util.function.BiConsumer;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.commons.lang3.EnumUtils;
+import org.opensearch.sql.common.error.ErrorCode;
+import org.opensearch.sql.common.error.ErrorReport;
+import org.opensearch.sql.common.error.QueryProcessingStage;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;
@@ -300,13 +303,22 @@ public class OpenSearchDataType implements ExprType, Serializable {
             String originalPath = value.getOriginalPath().get();
             OpenSearchDataType target = result.get(originalPath);
             if (target == null) {
-              throw new SemanticCheckException(
-                  String.format(
-                      "Alias field [%s] refers to unresolved path [%s]. The alias path must point"
-                          + " to an existing field in the mapping; a text multi-field (e.g."
-                          + " \"%s.keyword\") or a removed/renamed field is not a valid alias"
-                          + " target.",
-                      key, originalPath, originalPath));
+              throw ErrorReport.wrap(
+                      new SemanticCheckException(
+                          String.format(
+                              "Alias field [%s] refers to unresolved path [%s].",
+                              key, originalPath)))
+                  .code(ErrorCode.FIELD_NOT_FOUND)
+                  .stage(QueryProcessingStage.ANALYZING)
+                  .location("while resolving alias fields in the index mapping")
+                  .context("alias_field", key)
+                  .context("alias_path", originalPath)
+                  .suggestion(
+                      "The alias path must point to an existing field in the mapping; a text"
+                          + " multi-field (e.g. \""
+                          + originalPath
+                          + ".keyword\") or a removed/renamed field is not a valid alias target.")
+                  .build();
             }
             result.put(key, new OpenSearchAliasType(originalPath, target));
           }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import org.apache.commons.lang3.EnumUtils;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.SemanticCheckException;
 
 /** The extension of ExprType in OpenSearch. */
 @EqualsAndHashCode
@@ -297,7 +298,17 @@ public class OpenSearchDataType implements ExprType, Serializable {
         (key, value) -> {
           if (value instanceof OpenSearchAliasType && value.getOriginalPath().isPresent()) {
             String originalPath = value.getOriginalPath().get();
-            result.put(key, new OpenSearchAliasType(originalPath, result.get(originalPath)));
+            OpenSearchDataType target = result.get(originalPath);
+            if (target == null) {
+              throw new SemanticCheckException(
+                  String.format(
+                      "Alias field [%s] refers to unresolved path [%s]. The alias path must point"
+                          + " to an existing field in the mapping; a text multi-field (e.g."
+                          + " \"%s.keyword\") or a removed/renamed field is not a valid alias"
+                          + " target.",
+                      key, originalPath, originalPath));
+            }
+            result.put(key, new OpenSearchAliasType(originalPath, target));
           }
         });
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
@@ -41,6 +41,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.sql.common.error.ErrorCode;
+import org.opensearch.sql.common.error.ErrorReport;
+import org.opensearch.sql.common.error.QueryProcessingStage;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.SemanticCheckException;
@@ -493,16 +496,23 @@ class OpenSearchDataTypeTest {
             textKeywordType,
             "source_alias",
             new OpenSearchAliasType("source.keyword", OpenSearchDataType.of(MappingType.Invalid)));
-    SemanticCheckException keywordException =
+    ErrorReport keywordError =
         assertThrows(
-            SemanticCheckException.class,
-            () -> OpenSearchDataType.traverseAndFlatten(keywordAliasTree));
-    assertEquals(
-        "Alias field [source_alias] refers to unresolved path [source.keyword]. The alias path must"
-            + " point to an existing field in the mapping; a text multi-field (e.g."
-            + " \"source.keyword.keyword\") or a removed/renamed field is not a valid alias"
-            + " target.",
-        keywordException.getMessage());
+            ErrorReport.class, () -> OpenSearchDataType.traverseAndFlatten(keywordAliasTree));
+    assertAll(
+        () -> assertEquals(ErrorCode.FIELD_NOT_FOUND, keywordError.getCode()),
+        () -> assertEquals(QueryProcessingStage.ANALYZING, keywordError.getStage()),
+        () -> assertTrue(keywordError.getCause() instanceof SemanticCheckException),
+        () ->
+            assertEquals(
+                "Alias field [source_alias] refers to unresolved path [source.keyword].",
+                keywordError.getCause().getMessage()),
+        () -> assertEquals("source_alias", keywordError.getContext().get("alias_field")),
+        () -> assertEquals("source.keyword", keywordError.getContext().get("alias_path")),
+        () ->
+            assertTrue(
+                keywordError.getSuggestion().contains("\"source.keyword.keyword\"")
+                    && keywordError.getSuggestion().contains("not a valid alias target")));
 
     // Alias path targets a field that does not exist.
     Map<String, OpenSearchDataType> missingFieldTree =
@@ -511,15 +521,17 @@ class OpenSearchDataTypeTest {
             textType,
             "col_alias",
             new OpenSearchAliasType("missing", OpenSearchDataType.of(MappingType.Invalid)));
-    SemanticCheckException missingException =
+    ErrorReport missingError =
         assertThrows(
-            SemanticCheckException.class,
-            () -> OpenSearchDataType.traverseAndFlatten(missingFieldTree));
-    assertEquals(
-        "Alias field [col_alias] refers to unresolved path [missing]. The alias path must point to"
-            + " an existing field in the mapping; a text multi-field (e.g. \"missing.keyword\") or"
-            + " a removed/renamed field is not a valid alias target.",
-        missingException.getMessage());
+            ErrorReport.class, () -> OpenSearchDataType.traverseAndFlatten(missingFieldTree));
+    assertAll(
+        () -> assertEquals(ErrorCode.FIELD_NOT_FOUND, missingError.getCode()),
+        () -> assertTrue(missingError.getCause() instanceof SemanticCheckException),
+        () ->
+            assertEquals(
+                "Alias field [col_alias] refers to unresolved path [missing].",
+                missingError.getCause().getMessage()),
+        () -> assertEquals("missing", missingError.getContext().get("alias_path")));
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
@@ -489,32 +489,36 @@ class OpenSearchDataTypeTest {
     // Alias path targets a text multi-field, which is not in the flattened mapping.
     Map<String, OpenSearchDataType> keywordAliasTree =
         Map.of(
-            "source", textKeywordType,
+            "source",
+            textKeywordType,
             "source_alias",
-                new OpenSearchAliasType("source.keyword", OpenSearchDataType.of(MappingType.Invalid)));
+            new OpenSearchAliasType("source.keyword", OpenSearchDataType.of(MappingType.Invalid)));
     SemanticCheckException keywordException =
         assertThrows(
             SemanticCheckException.class,
             () -> OpenSearchDataType.traverseAndFlatten(keywordAliasTree));
     assertEquals(
-        "Alias field [source_alias] refers to unresolved path [source.keyword]. The alias path"
-            + " must point to an existing field in the mapping; a text multi-field (e.g."
-            + " \"source.keyword.keyword\") or a removed/renamed field is not a valid alias target.",
+        "Alias field [source_alias] refers to unresolved path [source.keyword]. The alias path must"
+            + " point to an existing field in the mapping; a text multi-field (e.g."
+            + " \"source.keyword.keyword\") or a removed/renamed field is not a valid alias"
+            + " target.",
         keywordException.getMessage());
 
     // Alias path targets a field that does not exist.
     Map<String, OpenSearchDataType> missingFieldTree =
         Map.of(
-            "col1", textType,
-            "col_alias", new OpenSearchAliasType("missing", OpenSearchDataType.of(MappingType.Invalid)));
+            "col1",
+            textType,
+            "col_alias",
+            new OpenSearchAliasType("missing", OpenSearchDataType.of(MappingType.Invalid)));
     SemanticCheckException missingException =
         assertThrows(
             SemanticCheckException.class,
             () -> OpenSearchDataType.traverseAndFlatten(missingFieldTree));
     assertEquals(
         "Alias field [col_alias] refers to unresolved path [missing]. The alias path must point to"
-            + " an existing field in the mapping; a text multi-field (e.g. \"missing.keyword\") or a"
-            + " removed/renamed field is not a valid alias target.",
+            + " an existing field in the mapping; a text multi-field (e.g. \"missing.keyword\") or"
+            + " a removed/renamed field is not a valid alias target.",
         missingException.getMessage());
   }
 

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
@@ -486,10 +486,7 @@ class OpenSearchDataTypeTest {
 
   @Test
   public void traverseAndFlatten_alias_to_unresolvable_path_throws_descriptive_error() {
-    // An alias whose path targets a text multi-field (e.g. "source.keyword"). Multi-fields are
-    // stored under OpenSearchTextType.fields, not properties, so they are never added to the
-    // flattened mapping and the alias target resolves to null. Previously this surfaced as an
-    // opaque NullPointerException (issue #5535).
+    // Alias path targets a text multi-field, which is not in the flattened mapping.
     Map<String, OpenSearchDataType> keywordAliasTree =
         Map.of(
             "source", textKeywordType,
@@ -505,7 +502,7 @@ class OpenSearchDataTypeTest {
             + " \"source.keyword.keyword\") or a removed/renamed field is not a valid alias target.",
         keywordException.getMessage());
 
-    // An alias whose path targets a field that does not exist (e.g. renamed/removed).
+    // Alias path targets a field that does not exist.
     Map<String, OpenSearchDataType> missingFieldTree =
         Map.of(
             "col1", textType,

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.exception.SemanticCheckException;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class OpenSearchDataTypeTest {
@@ -481,6 +482,43 @@ class OpenSearchDataTypeTest {
         () -> assertEquals(aliasTypeOnDouble, aliasTypeOnDouble.getExprType()),
         () -> assertEquals(ExprCoreType.DOUBLE, aliasTypeOnDouble.getOriginalExprType()),
         () -> assertEquals("original_path2", aliasTypeOnDouble.getOriginalPath().orElseThrow()));
+  }
+
+  @Test
+  public void traverseAndFlatten_alias_to_unresolvable_path_throws_descriptive_error() {
+    // An alias whose path targets a text multi-field (e.g. "source.keyword"). Multi-fields are
+    // stored under OpenSearchTextType.fields, not properties, so they are never added to the
+    // flattened mapping and the alias target resolves to null. Previously this surfaced as an
+    // opaque NullPointerException (issue #5535).
+    Map<String, OpenSearchDataType> keywordAliasTree =
+        Map.of(
+            "source", textKeywordType,
+            "source_alias",
+                new OpenSearchAliasType("source.keyword", OpenSearchDataType.of(MappingType.Invalid)));
+    SemanticCheckException keywordException =
+        assertThrows(
+            SemanticCheckException.class,
+            () -> OpenSearchDataType.traverseAndFlatten(keywordAliasTree));
+    assertEquals(
+        "Alias field [source_alias] refers to unresolved path [source.keyword]. The alias path"
+            + " must point to an existing field in the mapping; a text multi-field (e.g."
+            + " \"source.keyword.keyword\") or a removed/renamed field is not a valid alias target.",
+        keywordException.getMessage());
+
+    // An alias whose path targets a field that does not exist (e.g. renamed/removed).
+    Map<String, OpenSearchDataType> missingFieldTree =
+        Map.of(
+            "col1", textType,
+            "col_alias", new OpenSearchAliasType("missing", OpenSearchDataType.of(MappingType.Invalid)));
+    SemanticCheckException missingException =
+        assertThrows(
+            SemanticCheckException.class,
+            () -> OpenSearchDataType.traverseAndFlatten(missingFieldTree));
+    assertEquals(
+        "Alias field [col_alias] refers to unresolved path [missing]. The alias path must point to"
+            + " an existing field in the mapping; a text multi-field (e.g. \"missing.keyword\") or a"
+            + " removed/renamed field is not a valid alias target.",
+        missingException.getMessage());
   }
 
   @Test


### PR DESCRIPTION
### Description

When a mapping contains a field of `"type": "alias"` whose `"path"` points to a target that is absent from the flattened mapping — for example a text multi-field (`field.keyword`) or a removed/renamed field — `OpenSearchDataType.validateAliasType()` passed a `null` target into the `OpenSearchAliasType` constructor, which immediately dereferenced it at `super(type.getExprCoreType())`. The result was an opaque `NullPointerException` surfaced to the user with no indication that the real problem is a malformed alias in their mapping:

```json
{
  "error": {
    "reason": "Invalid SQL query",
    "details": "Cannot invoke \"org.opensearch.sql.opensearch.data.type.OpenSearchDataType.getExprCoreType()\" because \"type\" is null",
    "type": "NullPointerException"
  },
  "status": 400
}
```

**Root cause:** `traverseAndFlatten` only expands object/nested `properties` into dotted keys; it does not add text multi-fields (`.keyword`), which are stored under `OpenSearchTextType.fields`. So an alias whose `path` targets such a field (or a field that no longer exists) resolves to `null`. The `OpenSearchAliasType` constructor already guards the alias-to-alias and alias-to-object cases, but those checks run *after* the `super()` dereference, so the unresolvable-path case fell through to the NPE.

**Fix:** Guard the null target in `validateAliasType` and throw a `SemanticCheckException` that names the offending alias field and its unresolved path. `SemanticCheckException extends QueryEngineException`, which `JdbcResponseFormatter#getStatus` maps to HTTP 400 — an invalid alias mapping is a client error, so this also avoids the misleading HTTP 500 ("internal problem at backend") that a generic exception type would have produced.

After the fix:

```json
{
  "error": {
    "reason": "Invalid SQL query",
    "details": "Alias field [source_alias] refers to unresolved path [source.keyword]. The alias path must point to an existing field in the mapping; a text multi-field (e.g. \"source.keyword.keyword\") or a removed/renamed field is not a valid alias target.",
    "type": "SemanticCheckException"
  },
  "status": 400
}
```

Valid aliases (including `SELECT *` over aliases on plain text/keyword fields) are unaffected — the new branch only triggers when the resolved target is `null`, which previously always threw.

### Related Issues
Resolves #5535

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

### Update: adopt the ErrorReport report-builder interface (#5266)

Per reviewer feedback, the fix now wraps the `SemanticCheckException` in an `ErrorReport` (introduced in #5266) instead of throwing it directly. This attaches structured context as the error bubbles up: `code = FIELD_NOT_FOUND`, `stage = ANALYZING`, a location chain, the `alias_field` / `alias_path` context, and a fix suggestion.

Verified live on both endpoints (both HTTP 400, no regression for valid aliases):

- **PPL** (`_plugins/_ppl`) renders the full structured error:
  ```json
  {
    "error": {
      "reason": "Alias field [source_alias] refers to unresolved path [source.keyword].",
      "code": "FIELD_NOT_FOUND",
      "suggestion": "The alias path must point to an existing field in the mapping; a text multi-field (e.g. \"source.keyword.keyword\") or a removed/renamed field is not a valid alias target.",
      "context": { "stage": "analyzing", "stage_description": "Parsing and validating the query", "alias_field": "source_alias", "alias_path": "source.keyword" },
      "location": ["while preparing and validating the query plan", "while resolving alias fields in the index mapping"],
      "type": "SemanticCheckException"
    },
    "status": 400
  }
  ```
- **SQL** (`_plugins/_sql`) still returns a clear 400 — `RestSqlAction` unwraps `ErrorReport` to its `SemanticCheckException` cause for status classification. Note: `JdbcResponseFormatter` does not yet render the `ErrorReport` structure (it reports `type: "ErrorReport"` with just `details`); teaching the JDBC formatter to render the structured fields is a reasonable follow-up but is intentionally out of scope here to keep this change focused.

Tests: unit test asserts the `ErrorReport` code/stage/context/cause; a PPL IT in `CalciteErrorReportStageIT` asserts the structured `FIELD_NOT_FOUND` error; the SQL IT in `QueryValidationIT` asserts the 400.
