### PR TITLE
Stabilize order-dependent PPL ITs with explicit sort for multi-shard analytics runs

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1035,6 +1035,12 @@ task integTestRemote(type: RestIntegTestTask) {
         systemProperty 'tests.analytics.parquet_indices', System.getProperty("tests.analytics.parquet_indices")
     }
 
+    // Primary-shard count for analytics-backed test indices (default 1). Set to e.g. 3 to
+    // reproduce multi-shard coordination behavior on a single-node cluster.
+    if (System.getProperty("tests.analytics.num_shards") != null) {
+        systemProperty 'tests.analytics.num_shards', System.getProperty("tests.analytics.num_shards")
+    }
+
     // True only when the analytics-engine route is active (every test index parquet-backed). Matches
     // AnalyticsIndexConfig.isEnabled, which parses the value rather than checking mere presence, so a
     // `-Dtests.analytics.parquet_indices=false` run stays on the v2 path.

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
@@ -85,10 +85,12 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testBinBasicFunctionality() throws IOException {
     JSONObject result =
         executeQuery(
-            String.format("source=%s | bin age span=5 | fields age | head 3", TEST_INDEX_ACCOUNT));
+            String.format(
+                "source=%s | bin age span=5 | sort account_number | fields age | head 3",
+                TEST_INDEX_ACCOUNT));
     verifySchema(result, schema("age", null, "string"));
 
-    verifyDataRows(result, rows("30-35"), rows("35-40"), rows("25-30"));
+    verifyDataRows(result, rows("25-30"), rows("30-35"), rows("20-25"));
   }
 
   @Test
@@ -195,7 +197,9 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
     JSONObject binOnlyResult =
         executeQuery(
             String.format(
-                "source=%s" + " | bin @timestamp span=4h" + " | fields `@timestamp` | head 3",
+                "source=%s"
+                    + " | bin @timestamp span=4h"
+                    + " | fields `@timestamp` | sort `@timestamp` | head 3",
                 TEST_INDEX_TIME_DATA));
 
     // Verify schema and that binning works correctly
@@ -235,7 +239,7 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | bin @timestamp span=4mon as cate | fields"
-                    + " cate, @timestamp | head 5",
+                    + " cate, @timestamp | sort @timestamp | head 5",
                 TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("cate", null, "string"), schema("@timestamp", null, "timestamp"));
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMVAppendFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMVAppendFunctionIT.java
@@ -107,8 +107,8 @@ public class CalciteMVAppendFunctionIT extends PPLIntegTestCase {
         executeQuery(
             source(
                 TEST_INDEX_BANK,
-                "eval result = mvappend(firstname, lastname) | head 1 | fields firstname, lastname,"
-                    + " result"));
+                "eval result = mvappend(firstname, lastname) | sort account_number | head 1 |"
+                    + " fields firstname, lastname, result"));
 
     verifySchema(
         actual,
@@ -179,7 +179,7 @@ public class CalciteMVAppendFunctionIT extends PPLIntegTestCase {
             source(
                 TEST_INDEX_BANK,
                 "eval combined = mvappend(firstname, lastname) | where array_length(combined) = 2 |"
-                    + " head 1 | fields firstname, lastname, combined"));
+                    + " sort account_number | head 1 | fields firstname, lastname, combined"));
 
     verifySchema(
         actual,
@@ -198,8 +198,8 @@ public class CalciteMVAppendFunctionIT extends PPLIntegTestCase {
         executeQuery(
             source(
                 TEST_INDEX_BANK,
-                "eval result = mvappend(array(age), array(age * 2), age + 10) | head 1 | fields"
-                    + " age, result"));
+                "eval result = mvappend(array(age), array(age * 2), age + 10) | sort"
+                    + " account_number | head 1 | fields age, result"));
 
     verifySchema(actual, schema("age", "int"), schema("result", "array"));
     verifyDataRows(actual, rows(32, List.of(32, 64, 42)));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultisearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultisearchCommandIT.java
@@ -325,8 +325,10 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "| multisearch "
-                    + "[search source=%s | fields firstname, balance | head 2] "
-                    + "[search source=%s | fields description, place_id | head 2]",
+                    + "[search source=%s | sort account_number | fields firstname, balance"
+                    + " | head 2] "
+                    + "[search source=%s | sort place_id | fields description, place_id"
+                    + " | head 2]",
                 TEST_INDEX_ACCOUNT, TEST_INDEX_LOCATIONS_TYPE_CONFLICT));
 
     verifySchema(
@@ -338,8 +340,8 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
 
     verifyDataRows(
         result,
+        rows("Bradshaw", 16623L, null, null),
         rows("Amber", 39225L, null, null),
-        rows("Hattie", 5686L, null, null),
         rows(null, null, "Central Park", 1001),
         rows(null, null, "Times Square", 1002));
   }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAggregationIT.java
@@ -542,8 +542,8 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | head 5 | stats count(datetime0) by span(datetime0, 15minute) as"
-                    + " datetime_span",
+                "source=%s | sort key | head 5 | stats count(datetime0) by span(datetime0,"
+                    + " 15minute) as datetime_span",
                 TEST_INDEX_CALCS));
     verifySchema(
         actual, schema("datetime_span", "timestamp"), schema("count(datetime0)", "bigint"));
@@ -558,8 +558,8 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
     actual =
         executeQuery(
             String.format(
-                "source=%s | head 5 | stats count(datetime0) by span(datetime0, 5second) as"
-                    + " datetime_span",
+                "source=%s | sort key | head 5 | stats count(datetime0) by span(datetime0,"
+                    + " 5second) as datetime_span",
                 TEST_INDEX_CALCS));
     verifySchema(
         actual, schema("datetime_span", "timestamp"), schema("count(datetime0)", "bigint"));
@@ -574,8 +574,8 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
     actual =
         executeQuery(
             String.format(
-                "source=%s | head 5 | stats count(datetime0) by span(datetime0, 3month) as"
-                    + " datetime_span",
+                "source=%s | sort key | head 5 | stats count(datetime0) by span(datetime0,"
+                    + " 3month) as datetime_span",
                 TEST_INDEX_CALCS));
     verifySchema(
         actual, schema("datetime_span", "timestamp"), schema("count(datetime0)", "bigint"));
@@ -587,8 +587,8 @@ public class CalcitePPLAggregationIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | head 5 | stats count(datetime0), count(datetime1) by span(time1,"
-                    + " 15minute) as time_span",
+                "source=%s | sort key | head 5 | stats count(datetime0), count(datetime1) by"
+                    + " span(time1, 15minute) as time_span",
                 TEST_INDEX_CALCS));
     verifySchema(
         actual,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEnhancedCoalesceIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEnhancedCoalesceIT.java
@@ -73,8 +73,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce(name, 123, 'unknown') | fields name, result |"
-                    + " head 1",
+                "source=%s | eval result = coalesce(name, 123, 'unknown') | sort - age | fields"
+                    + " name, result | head 1",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("name", "string"), schema("result", "string"));
@@ -100,8 +100,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce(name, age, year, month) | fields name, age,"
-                    + " year, month, result | head 2",
+                "source=%s | eval result = coalesce(name, age, year, month) | sort - age | fields"
+                    + " name, age, year, month, result | head 2",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(
@@ -139,8 +139,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce(nonexistent_field, name) | fields name, result"
-                    + " | head 2",
+                "source=%s | eval result = coalesce(nonexistent_field, name) | sort - age"
+                    + " | fields name, result | head 2",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("name", "string"), schema("result", "string"));
@@ -234,7 +234,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce('', name) | fields name, result | head 1",
+                "source=%s | eval result = coalesce('', name) | sort - age | fields name, result"
+                    + " | head 1",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("name", "string"), schema("result", "string"));
@@ -247,7 +248,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce(' ', name) | fields name, result | head 1",
+                "source=%s | eval result = coalesce(' ', name) | sort - age | fields name, result"
+                    + " | head 1",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("name", "string"), schema("result", "string"));
@@ -274,8 +276,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce(age, year, 999) | fields age, year, result |"
-                    + " head 2",
+                "source=%s | eval result = coalesce(age, year, 999) | sort - age | fields age,"
+                    + " year, result | head 2",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("age", "int"), schema("year", "int"), schema("result", "int"));
@@ -288,7 +290,7 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eval result = coalesce(nonexistent_field, age,"
-                    + " 'default') | fields age, result | head 2",
+                    + " 'default') | sort - age | fields age, result | head 2",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("age", "int"), schema("result", "string"));
@@ -300,8 +302,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce(age, year, month) | fields age, year, month,"
-                    + " result | head 2",
+                "source=%s | eval result = coalesce(age, year, month) | sort - age | fields age,"
+                    + " year, month, result | head 2",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLGrokIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLGrokIT.java
@@ -34,7 +34,8 @@ public class CalcitePPLGrokIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 Locale.ROOT,
-                "source = %s | grok email '%s' | head 3 | fields email, host",
+                "source = %s | grok email '%s' | sort account_number | head 3 | fields email,"
+                    + " host",
                 TEST_INDEX_BANK,
                 ".+@%{HOSTNAME:host}"));
     verifySchema(result, schema("email", "string"), schema("host", "string"));
@@ -49,7 +50,10 @@ public class CalcitePPLGrokIT extends PPLIntegTestCase {
   public void testGrokAddressOverriding() throws IOException {
     JSONObject preGrokResult =
         executeQuery(
-            String.format(Locale.ROOT, "source = %s | head 3 | fields address", TEST_INDEX_BANK));
+            String.format(
+                Locale.ROOT,
+                "source = %s | sort account_number | head 3 | fields address",
+                TEST_INDEX_BANK));
     verifySchema(preGrokResult, schema("address", "string"));
     verifyDataRows(
         preGrokResult,
@@ -61,7 +65,7 @@ public class CalcitePPLGrokIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 Locale.ROOT,
-                "source = %s | grok address '%s' | head 3 | fields address",
+                "source = %s | grok address '%s' | sort account_number | head 3 | fields address",
                 TEST_INDEX_BANK,
                 "%{NUMBER} %{GREEDYDATA:address}"));
     verifySchema(result, schema("address", "string"));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLPatternsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLPatternsIT.java
@@ -37,7 +37,8 @@ public class CalcitePPLPatternsIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source = %s | patterns email mode=label | head 1 | fields email, patterns_field",
+                "source = %s | patterns email mode=label | sort account_number | head 1 | fields"
+                    + " email, patterns_field",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("email", "string"), schema("patterns_field", "string"));
     verifyDataRows(result, rows("amberduke@pyrami.com", "<*>@<*>.<*>"));
@@ -48,8 +49,8 @@ public class CalcitePPLPatternsIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source = %s | patterns email mode=label show_numbered_token=true | head 1 | fields"
-                    + " email, patterns_field, tokens",
+                "source = %s | patterns email mode=label show_numbered_token=true | sort"
+                    + " account_number | head 1 | fields email, patterns_field, tokens",
                 TEST_INDEX_BANK));
     verifySchema(
         result,
@@ -100,7 +101,7 @@ public class CalcitePPLPatternsIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source = %s | patterns email mode=label show_numbered_token=true pattern='@.*' |"
-                    + " head 1 | fields email, patterns_field, tokens",
+                    + " sort account_number | head 1 | fields email, patterns_field, tokens",
                 TEST_INDEX_BANK));
     verifySchema(
         result,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLTrendlineIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLTrendlineIT.java
@@ -33,8 +33,8 @@ public class CalcitePPLTrendlineIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where balance > 30000 | trendline sma(3, balance) as balance_trend |"
-                    + " fields balance_trend",
+                "source=%s | where balance > 30000 | sort account_number | trendline sma(3,"
+                    + " balance) as balance_trend | fields balance_trend",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("balance_trend", "double"));
     verifyDataRows(
@@ -46,8 +46,8 @@ public class CalcitePPLTrendlineIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where balance > 30000 | trendline wma(3, balance) as balance_trend |"
-                    + " fields balance_trend",
+                "source=%s | where balance > 30000 | sort account_number | trendline wma(3,"
+                    + " balance) as balance_trend | fields balance_trend",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("balance_trend", "double"));
     verifyDataRows(
@@ -59,8 +59,8 @@ public class CalcitePPLTrendlineIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where balance > 30000 | trendline sma(2, balance) as sma wma(3,"
-                    + " balance) as wma | fields balance, sma, wma",
+                "source=%s | where balance > 30000 | sort account_number | trendline sma(2,"
+                    + " balance) as sma wma(3, balance) as wma | fields balance, sma, wma",
                 TEST_INDEX_BANK));
     verifySchema(
         result, schema("balance", "bigint"), schema("sma", "double"), schema("wma", "double"));
@@ -77,8 +77,8 @@ public class CalcitePPLTrendlineIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where balance > 30000 | trendline sma(2, balance) | fields"
-                    + " balance, balance_trendline",
+                "source=%s | where balance > 30000 | sort account_number | trendline sma(2,"
+                    + " balance) | fields balance, balance_trendline",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("balance", "bigint"), schema("balance_trendline", "double"));
     verifyDataRows(
@@ -90,8 +90,8 @@ public class CalcitePPLTrendlineIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | where balance > 30000 | trendline sma(2, balance) as balance | fields"
-                    + " balance",
+                "source=%s | where balance > 30000 | sort account_number | trendline sma(2,"
+                    + " balance) as balance | fields balance",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("balance", "double"));
     verifyDataRows(result, rows((Object) null), rows(36031.5), rows(36689), rows(44313));
@@ -115,7 +115,8 @@ public class CalcitePPLTrendlineIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | trendline sma(2, balance) | fields" + " balance, balance_trendline",
+                "source=%s | sort account_number | trendline sma(2, balance) | fields"
+                    + " balance, balance_trendline",
                 TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifySchema(result, schema("balance", "bigint"), schema("balance_trendline", "double"));
     verifyDataRows(

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestUtils.java
@@ -65,8 +65,18 @@ public class TestUtils {
      */
     public static final String ENABLED_PROP = "tests.analytics.parquet_indices";
 
+    /**
+     * System property overriding the number of primary shards for analytics-backed test indices.
+     * Defaults to 1 (single-shard). Set to e.g. "3" for multi-shard coverage runs.
+     */
+    public static final String NUM_SHARDS_PROP = "tests.analytics.num_shards";
+
     public static boolean isEnabled() {
       return Boolean.parseBoolean(System.getProperty(ENABLED_PROP, "false"));
+    }
+
+    public static int getNumShards() {
+      return Integer.parseInt(System.getProperty(NUM_SHARDS_PROP, "1"));
     }
 
     // Composite-store format values shared by the index-level and cluster-level settings below.
@@ -86,7 +96,7 @@ public class TestUtils {
           jsonObject.has("settings") ? jsonObject.getJSONObject("settings") : new JSONObject();
       JSONObject indexSettings =
           settings.has("index") ? settings.getJSONObject("index") : new JSONObject();
-      indexSettings.put("number_of_shards", 1);
+      indexSettings.put("number_of_shards", getNumShards());
       indexSettings.put("pluggable.dataformat.enabled", true);
       indexSettings.put("pluggable.dataformat", DATAFORMAT_COMPOSITE);
       indexSettings.put("composite.primary_data_format", PRIMARY_FORMAT_PARQUET);

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/HeadCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/HeadCommandIT.java
@@ -38,27 +38,32 @@ public class HeadCommandIT extends PPLIntegTestCase {
   @Test
   public void testHead() throws IOException {
     JSONObject result =
-        executeQuery(String.format("source=%s | fields firstname, age | head", TEST_INDEX_ACCOUNT));
+        executeQuery(
+            String.format(
+                "source=%s | sort account_number | fields firstname, age | head",
+                TEST_INDEX_ACCOUNT));
     verifyDataRows(
         result,
+        rows("Bradshaw", 29),
         rows("Amber", 32),
+        rows("Roberta", 22),
+        rows("Levine", 26),
+        rows("Rodriquez", 31),
+        rows("Leola", 30),
         rows("Hattie", 36),
-        rows("Nanette", 28),
-        rows("Dale", 33),
-        rows("Elinor", 36),
-        rows("Virginia", 39),
-        rows("Dillard", 34),
-        rows("Mcgee", 39),
-        rows("Aurelia", 37),
-        rows("Fulton", 23));
+        rows("Levy", 22),
+        rows("Jan", 35),
+        rows("Opal", 39));
   }
 
   @Test
   public void testHeadWithNumber() throws IOException {
     JSONObject result =
         executeQuery(
-            String.format("source=%s | fields firstname, age | head 3", TEST_INDEX_ACCOUNT));
-    verifyDataRows(result, rows("Amber", 32), rows("Hattie", 36), rows("Nanette", 28));
+            String.format(
+                "source=%s | sort account_number | fields firstname, age | head 3",
+                TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Bradshaw", 29), rows("Amber", 32), rows("Roberta", 22));
   }
 
   @Ignore("Fix https://github.com/opensearch-project/sql/issues/703#issuecomment-1211422130")
@@ -87,24 +92,26 @@ public class HeadCommandIT extends PPLIntegTestCase {
     setMaxResultWindow(TEST_INDEX_ACCOUNT, 10);
     JSONObject result =
         executeQuery(
-            String.format("source=%s | fields firstname, age | head 15", TEST_INDEX_ACCOUNT));
+            String.format(
+                "source=%s | sort account_number | fields firstname, age | head 15",
+                TEST_INDEX_ACCOUNT));
     verifyDataRows(
         result,
+        rows("Bradshaw", 29),
         rows("Amber", 32),
+        rows("Roberta", 22),
+        rows("Levine", 26),
+        rows("Rodriquez", 31),
+        rows("Leola", 30),
         rows("Hattie", 36),
+        rows("Levy", 22),
+        rows("Jan", 35),
+        rows("Opal", 39),
+        rows("Dominique", 37),
+        rows("Jenkins", 20),
+        rows("Stafford", 20),
         rows("Nanette", 28),
-        rows("Dale", 33),
-        rows("Elinor", 36),
-        rows("Virginia", 39),
-        rows("Dillard", 34),
-        rows("Mcgee", 39),
-        rows("Aurelia", 37),
-        rows("Fulton", 23),
-        rows("Burton", 31),
-        rows("Josie", 32),
-        rows("Hughes", 30),
-        rows("Hall", 25),
-        rows("Deidre", 33));
+        rows("Erma", 39));
   }
 
   @Ignore("Fix https://github.com/opensearch-project/sql/issues/703#issuecomment-1211422130")
@@ -138,7 +145,9 @@ public class HeadCommandIT extends PPLIntegTestCase {
   public void testHeadWithNumberAndFrom() throws IOException {
     JSONObject result =
         executeQuery(
-            String.format("source=%s | fields firstname, age | head 3 from 4", TEST_INDEX_ACCOUNT));
-    verifyDataRows(result, rows("Elinor", 36), rows("Virginia", 39), rows("Dillard", 34));
+            String.format(
+                "source=%s | sort account_number | fields firstname, age | head 3 from 4",
+                TEST_INDEX_ACCOUNT));
+    verifyDataRows(result, rows("Rodriquez", 31), rows("Leola", 30), rows("Hattie", 36));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/TrailingPipeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/TrailingPipeIT.java
@@ -34,8 +34,10 @@ public class TrailingPipeIT extends PPLIntegTestCase {
   @Test
   public void testTrailingPipeAfterSource() throws IOException {
     // Query with trailing pipe should produce same results as without
-    JSONObject resultWithout = executeQuery(String.format("source=%s", TEST_INDEX_ACCOUNT));
-    JSONObject resultWith = executeQuery(String.format("source=%s |", TEST_INDEX_ACCOUNT));
+    JSONObject resultWithout =
+        executeQuery(String.format("source=%s | sort account_number", TEST_INDEX_ACCOUNT));
+    JSONObject resultWith =
+        executeQuery(String.format("source=%s | sort account_number |", TEST_INDEX_ACCOUNT));
 
     // Both should return the same data
     assertTrue(resultWithout.similar(resultWith));
@@ -52,11 +54,13 @@ public class TrailingPipeIT extends PPLIntegTestCase {
     JSONObject resultWithout =
         executeQuery(
             String.format(
-                "source=%s | where age > 30 | fields firstname, age", TEST_INDEX_ACCOUNT));
+                "source=%s | where age > 30 | sort account_number | fields firstname, age",
+                TEST_INDEX_ACCOUNT));
     JSONObject resultWith =
         executeQuery(
             String.format(
-                "source=%s | where age > 30 | fields firstname, age |", TEST_INDEX_ACCOUNT));
+                "source=%s | where age > 30 | sort account_number | fields firstname, age |",
+                TEST_INDEX_ACCOUNT));
 
     assertTrue(resultWithout.similar(resultWith));
   }
@@ -71,10 +75,14 @@ public class TrailingPipeIT extends PPLIntegTestCase {
   public void testTrailingPipeAfterHead() throws IOException {
     JSONObject resultWithout =
         executeQuery(
-            String.format("source=%s | fields firstname, age | head 3", TEST_INDEX_ACCOUNT));
+            String.format(
+                "source=%s | sort account_number | fields firstname, age | head 3",
+                TEST_INDEX_ACCOUNT));
     JSONObject resultWith =
         executeQuery(
-            String.format("source=%s | fields firstname, age | head 3 |", TEST_INDEX_ACCOUNT));
+            String.format(
+                "source=%s | sort account_number | fields firstname, age | head 3 |",
+                TEST_INDEX_ACCOUNT));
 
     assertTrue(resultWithout.similar(resultWith));
   }
@@ -115,11 +123,13 @@ public class TrailingPipeIT extends PPLIntegTestCase {
     JSONObject resultNormal =
         executeQuery(
             String.format(
-                "source=%s | where age > 30 | fields firstname, age", TEST_INDEX_ACCOUNT));
+                "source=%s | where age > 30 | sort account_number | fields firstname, age",
+                TEST_INDEX_ACCOUNT));
     JSONObject resultWithEmpty =
         executeQuery(
             String.format(
-                "source=%s | | where age > 30 | fields firstname, age", TEST_INDEX_ACCOUNT));
+                "source=%s | | where age > 30 | sort account_number | fields firstname, age",
+                TEST_INDEX_ACCOUNT));
 
     assertTrue(resultNormal.similar(resultWithEmpty));
   }
@@ -136,12 +146,12 @@ public class TrailingPipeIT extends PPLIntegTestCase {
     JSONObject resultNormal =
         executeQuery(
             String.format(
-                "source=%s | where age > 30 | fields firstname, age | sort age",
+                "source=%s | where age > 30 | sort age, account_number | fields firstname, age",
                 TEST_INDEX_ACCOUNT));
     JSONObject resultWithEmpty =
         executeQuery(
             String.format(
-                "source=%s | | where age > 30 | | fields firstname, age | sort age",
+                "source=%s | | where age > 30 | | sort age, account_number | fields firstname, age",
                 TEST_INDEX_ACCOUNT));
 
     assertTrue(resultNormal.similar(resultWithEmpty));
@@ -159,12 +169,12 @@ public class TrailingPipeIT extends PPLIntegTestCase {
     JSONObject resultNormal =
         executeQuery(
             String.format(
-                "source=%s | where age > 30 | fields firstname, age | sort age",
+                "source=%s | where age > 30 | sort age, account_number | fields firstname, age",
                 TEST_INDEX_ACCOUNT));
     JSONObject resultWithEmpty =
         executeQuery(
             String.format(
-                "source=%s | | where age > 30 | fields firstname, age | sort age |",
+                "source=%s | | where age > 30 | sort age, account_number | fields firstname, age |",
                 TEST_INDEX_ACCOUNT));
 
     assertTrue(resultNormal.similar(resultWithEmpty));


### PR DESCRIPTION
### Description

When PPL integration-test indices are created with more than one primary shard on the analytics-engine route, the engine merges per-shard Arrow batches in **arrival order** (`RowProducingSink.feed()` has no shard-ordinal tiebreaker, unlike the Lucene path's `TopDocs.merge()` shardIndex ordering). Any test whose asserted rows depend on document encounter order — `head` without `sort`, first-row assertions after `patterns`/`grok`/`eval`, `trendline` over unsorted input, result-set truncation — fails on a 3-shard run even though it passes on 1 shard.

This PR stabilizes every such test that can be fixed by adding an explicit `| sort <unique key>` to the query:

- **bank-based tests** (bank.json is account_number-ascending): expectations unchanged.
- **accounts-based tests** (accounts.json is NOT account_number-ascending): expectations updated to the sorted rows — deterministic on every route.
- `| sort` placed before any `fields` projection that drops the sort key (verified deterministic through the projection on the multi-shard route).

It also adds a `tests.analytics.num_shards` system property (default `1`, so existing runs are unchanged) wired through `integTestRemote` and `TestUtils.AnalyticsIndexConfig`, to make multi-shard coverage runs reproducible:

```
./gradlew :integ-test:integTestRemote \
  -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9300 -Dtests.clustername=runTask \
  -Dtests.analytics.parquet_indices=true -Dtests.analytics.num_shards=3
```

### Results (suite failures on the affected classes)

| Class | 3-shard before | 3-shard after | 1-shard | regular route |
|---|---|---|---|---|
| CalciteHeadCommandIT (+ v2 HeadCommandIT) | 4 | **0** | 0 | 0 |
| TrailingPipeIT | 5+1 | **0** | 0 | 0 |
| CalcitePPLEnhancedCoalesceIT | 14 | **6** (pre-existing) | 8 → **4** | 0 |
| CalcitePPLTrendlineIT | 7 | **1** (pre-existing) | 1 | 0 |
| CalcitePPLGrokIT | 2 | **0** | 0 | 0 |
| CalciteMVAppendFunctionIT | 7 | **4** (pre-existing) | 4 | 0 |
| CalciteBinCommandIT | 8+1 | **6** (pre-existing) | 6 | 0 |
| CalcitePPLPatternsIT | 13 | **10** (see notes) | 5 | 0 |
| CalciteMultisearchCommandIT | 6 | **5** (see notes) | 6 | 0 |
| CalcitePPLAggregationIT (×2 incl. Paginating variant) | 37+37 | **34+35** (see notes) | 10+10 | 0 |
| CalciteQueryStringIT | 4 | 4 (engine-side, see notes) | 1 | 0 |
| CalciteStreamstatsCommandIT | 25 | 24 (engine-side, see notes) | 23 | 0 |

"+1" = same-family tests that passed the baseline run only by lucky arrival order and were fixed here too. All remaining failures pre-exist this PR (most also fail on 1 shard) or are multi-shard engine gaps that **cannot** be fixed test-side:

- `stats first()/last()/take()` stay non-deterministic even with a preceding `sort` — per-shard partial accumulators merge in arrival order at the coordinator. The existing `OrdinalAppendingSink` shard ordinals are not used by the gather stage; an engine-side ordinal merge would make those tests pass unmodified.
- `streamstats` computes windows per shard fragment even with a global `sort` preceding it.
- multisearch same-index subsearches execute the first subsearch's filter for both branches (silent row duplication — `| multisearch [where M] [where F] | stats count()` returns 2×M on the analytics route).
- multi-shard 500s: `derive_schema_from_partial_plan` protobuf decode failure, Substrait Float64/Int64 schema mismatch for `eval unix_timestamp(...) | stats ... by`, `TRY_CAST List(Struct) → Utf8` for BRAIN patterns.
- `query_string` intermittently drops one row across shards (16→15).

These are tracked separately for upstream engine fixes.

### Related Issues

Part of the analytics-engine PPL compatibility effort.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
