### PR TITLE
Fix doctest job-scheduler dependency resolution for 3.8.0

### DIFF
--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -15,6 +15,20 @@ plugins {
 
 apply plugin: 'opensearch.testclusters'
 
+configurations {
+    zipArchive
+}
+
+repositories {
+    mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
+    mavenCentral()
+}
+
+dependencies {
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
+}
+
 def path = project(':').projectDir
 // temporary fix, because currently we are under migration to new architecture. Need to run ./gradlew run from
 // plugin module, and will only build ppl in it.
@@ -156,19 +170,13 @@ check.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
 clean.dependsOn(stopPrometheus)
 
-// 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
-String opensearch_no_snapshot = opensearch_version.replace('-SNAPSHOT', '')
-String[] version_tokens = opensearch_no_snapshot.tokenize('-')
-String opensearch_build = version_tokens[0] + '.0'
-if (version_tokens.length > 1) {
-    opensearch_build += '-' + version_tokens[1]
+def getJobSchedulerPlugin() {
+    provider { (RegularFile) (() ->
+        configurations.zipArchive.asFileTree.matching {
+            include '**/opensearch-job-scheduler*'
+        }.singleFile )
+    }
 }
-String mlCommonsRemoteFile = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot + '/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-' + opensearch_build + '.zip'
-String mlCommonsPlugin = 'opensearch-ml'
-
-String bwcOpenSearchJSDownload = 'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' + opensearch_no_snapshot + '/latest/linux/x64/tar/builds/' +
-        'opensearch/plugins/opensearch-job-scheduler-' + opensearch_build + '.zip'
-String jsPlugin = 'opensearch-job-scheduler'
 
 testClusters {
     docTestCluster {
@@ -194,7 +202,7 @@ testClusters {
             }
         }))
         */
-        plugin(getJobSchedulerPlugin(jsPlugin, bwcOpenSearchJSDownload))
+        plugin(getJobSchedulerPlugin())
         plugin ':opensearch-sql-plugin'
         testDistribution = 'archive'
     }
@@ -202,51 +210,4 @@ testClusters {
 tasks.register("runRestTestCluster", RunTask) {
     description = 'Runs OpenSearch SQL plugin'
     useCluster testClusters.docTestCluster;
-}
-
-
-def getJobSchedulerPlugin(String jsPlugin, String bwcOpenSearchJSDownload) {
-    return provider(new Callable<RegularFile>() {
-        @Override
-        RegularFile call() throws Exception {
-            return new RegularFile() {
-                @Override
-                File getAsFile() {
-                    // Use absolute paths
-                    String basePath = new File('.').getCanonicalPath()
-                    File dir = new File(basePath + File.separator + 'doctest' + File.separator + jsPlugin)
-
-                    // Log the directory path for debugging
-                    println("Creating directory: " + dir.getAbsolutePath())
-
-                    // Create directory if it doesn't exist
-                    if (!dir.exists()) {
-                        if (!dir.mkdirs()) {
-                            throw new IOException("Failed to create directory: " + dir.getAbsolutePath())
-                        }
-                    }
-
-                    // Define the file path
-                    File f = new File(dir, jsPlugin + '-' + opensearch_build + '.zip')
-
-                    // Download file if it doesn't exist
-                    if (!f.exists()) {
-                        println("Downloading file from: " + bwcOpenSearchJSDownload)
-                        println("Saving to file: " + f.getAbsolutePath())
-
-                        new URL(bwcOpenSearchJSDownload).withInputStream { ins ->
-                            f.withOutputStream { it << ins }
-                        }
-                    }
-
-                    // Check if the file was created successfully
-                    if (!f.exists()) {
-                        throw new FileNotFoundException("File was not created: " + f.getAbsolutePath())
-                    }
-
-                    return fileTree(f.getParent()).matching { include f.getName() }.singleFile
-                }
-            }
-        }
-    })
 }


### PR DESCRIPTION
### Description
CI server goes brrrr

Apparently we've been running doctest against the distribution build this entire time, instead of snapshots like with the rest of our infra. Weird.

### Related Issues
Failing CI

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
