### PR TITLE
fix(integ): align DateTimeComparisonIT today's date to UTC

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeComparisonIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeComparisonIT.java
@@ -17,6 +17,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.TimeZone;
 import org.junit.After;
@@ -133,7 +134,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareEqTimestampWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIMESTAMP('2020-09-16 00:00:00') = DATE('2020-09-16')", "ts_d_t", true),
@@ -148,7 +149,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareEqDateWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("DATE('2020-09-16') = TIMESTAMP('2020-09-16 00:00:00')", "d_ts_t", true),
@@ -163,7 +164,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareEqTimeWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIME('10:20:30') = TIMESTAMP('" + today + " 10:20:30')", "t_ts_t", true),
@@ -178,7 +179,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareNeqTimestampWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIMESTAMP('2020-09-16 10:20:30') != DATE('1961-04-12')", "ts_d_t", true),
@@ -193,7 +194,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareNeqDateWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("DATE('2020-09-16') != TIMESTAMP('1961-04-12 09:07:00')", "d_ts_t", true),
@@ -208,7 +209,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareNeqTimeWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIME('22:15:07') != TIMESTAMP('1984-12-15 22:15:07')", "t_ts_t", true),
@@ -223,7 +224,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareLtTimestampWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIMESTAMP('2020-09-16 10:20:30') < DATE('2077-04-12')", "ts_d_t", true),
@@ -252,7 +253,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareLtTimeWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIME('22:15:07') < TIMESTAMP('2242-12-15 22:15:07')", "t_ts_t", true),
@@ -267,7 +268,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareGtTimestampWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIMESTAMP('2020-09-16 10:20:30') > DATE('1961-04-12')", "ts_d_t", true),
@@ -296,7 +297,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareGtTimeWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIME('22:15:07') > TIMESTAMP('1984-12-15 22:15:07')", "t_ts_t", true),
@@ -311,7 +312,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareLteTimestampWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIMESTAMP('2020-09-16 10:20:30') <= DATE('2077-04-12')", "ts_d_t", true),
@@ -340,7 +341,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareLteTimeWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIME('10:20:30') <= TIMESTAMP('" + today + " 10:20:30')", "t_ts_t", true),
@@ -355,7 +356,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareGteTimestampWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIMESTAMP('2020-09-16 10:20:30') >= DATE('1961-04-12')", "ts_d_t", true),
@@ -384,7 +385,7 @@ public class DateTimeComparisonIT extends PPLIntegTestCase {
 
   @ParametersFactory(argumentFormatting = "%1$s => %3$s")
   public static Iterable<Object[]> compareGteTimeWithOtherTypes() {
-    var today = LocalDate.now().toString();
+    var today = LocalDate.now(ZoneOffset.UTC).toString();
     return Arrays.asList(
         $$(
             $("TIME('10:20:30') >= TIMESTAMP('" + today + " 10:20:30')", "t_ts_t", true),


### PR DESCRIPTION
## Summary
- `DateTimeComparisonIT` builds its TIME/DATE/TIMESTAMP comparison parameters with `LocalDate.now().toString()` (JVM-local zone).
- The analytics-engine route lowers `CURRENT_DATE` through DataFusion using UTC.
- When a run starts after 17:00 PDT (= 00:00 UTC of the next day) — or any equivalent zone offset where the local date is one day behind UTC — the JVM date and the engine date disagree by one day. TIME-to-{DATE,TIMESTAMP} coercion then produces tomorrow's timestamp and 24 parameterized cases fail with `expected=true got=false` (and the inverse).
- Switch to `LocalDate.now(ZoneOffset.UTC)` so the test parameters use the same date the engine uses, regardless of when or where the run starts. Pure test fix; no production code touched.

## Before / After

`CalciteDateTimeComparisonIT` against the analytics-engine route, run started at 18:43 PDT on 2026-06-10 (UTC date already 2026-06-11):

| | tests | failures | errors | TIME-vs-{DATE,TIMESTAMP} cases pass |
|---|---:|---:|---:|---:|
| before | 191 | **24** | 0 | 72/96 |
| after  | 191 | **0**  | 0 | **96/96** |

The 24 failures previously fell into two report buckets keyed on the assertion message (one for `true`-expected, one for `false`-expected), each with 12 instances — e.g. `TIME('00:00:00') = DATE('2026-06-10') => true` and `TIME('00:00:00') != DATE('2026-06-10') => false`. Both buckets evaporate with this change.

## Test plan
- [x] Run `./gradlew :integ-test:integTestRemote --tests 'org.opensearch.sql.calcite.remote.CalciteDateTimeComparisonIT'` against an analytics-engine cluster — 191/0/0.
- [x] Verified `grep 'LocalDate.now()' DateTimeComparisonIT.java` returns no matches after the change (all 14 use sites updated).