### PR TITLE
Gate analytics routing on cluster.pluggable.dataformat.enabled

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -60,6 +60,15 @@ public class RestUnifiedQueryAction {
   private final org.opensearch.analytics.EngineContextProvider contextProvider;
   private final org.opensearch.sql.common.setting.Settings pluginSettings;
 
+  /**
+   * Cached value of {@link IndicesService#CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING}, kept
+   * current by a settings-update consumer. Reading {@code clusterService.getSettings()} would only
+   * ever return the node's startup settings and miss dynamic cluster-settings updates, so the live
+   * value is tracked here. Written from the cluster-state applier thread, read from the transport
+   * thread.
+   */
+  private volatile boolean clusterDataformatEnabled;
+
   public RestUnifiedQueryAction(
       NodeClient client,
       ClusterService clusterService,
@@ -71,6 +80,14 @@ public class RestUnifiedQueryAction {
     this.analyticsEngine = new AnalyticsExecutionEngine(planExecutor);
     this.contextProvider = contextProvider;
     this.pluginSettings = pluginSettings;
+    this.clusterDataformatEnabled =
+        IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(
+            clusterService.getSettings());
+    clusterService
+        .getClusterSettings()
+        .addSettingsUpdateConsumer(
+            IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING,
+            newValue -> this.clusterDataformatEnabled = newValue);
   }
 
   /**
@@ -88,15 +105,12 @@ public class RestUnifiedQueryAction {
     if (query == null || query.isEmpty()) {
       return false;
     }
-    // Cluster-level opt-in: when `cluster.pluggable.dataformat="composite"`, new indices
-    // inherit `index.pluggable.dataformat="composite"` at creation (see
-    // MetadataCreateIndexService), so every queryable target is analytics-eligible. Skip
-    // the per-index lookup — it doesn't work for aliases, wildcards, comma-lists, or data
-    // streams (Metadata#index() only resolves concrete names).
-    if ("composite"
-        .equals(
-            IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(
-                clusterService.getSettings()))) {
+    // Cluster-level opt-in: when `cluster.pluggable.dataformat.enabled=true`, new indices
+    // inherit the composite dataformat at creation (see MetadataCreateIndexService), so every
+    // queryable target is analytics-eligible. Skip the per-index lookup — it doesn't work for
+    // aliases, wildcards, comma-lists, or data streams (Metadata#index() only resolves concrete
+    // names).
+    if (clusterDataformatEnabled) {
       // Analytics engine can't serve system catalog; SHOW/DESCRIBE fall back to default pipeline
       try (UnifiedQueryContext context = buildParsingContext(queryType)) {
         boolean systemCatalog =

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -42,19 +42,23 @@ public class RestUnifiedQueryActionTest {
     metadata = mock(Metadata.class);
     when(clusterService.state()).thenReturn(clusterState);
     when(clusterState.metadata()).thenReturn(metadata);
-    // isAnalyticsIndex short-circuits on the cluster.pluggable.dataformat setting; the per-index
-    // path is only exercised when this returns something other than "composite".
+    // isAnalyticsIndex short-circuits on cluster.pluggable.dataformat.enabled; the per-index path
+    // is only exercised when the cluster-level flag is false. The flag is read once at construction
+    // from clusterService.getSettings(), so enabling it requires rebuilding the action (see
+    // enableClusterDataformat).
     when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+    action = buildAction();
+  }
 
+  private RestUnifiedQueryAction buildAction() {
     @SuppressWarnings("unchecked")
     QueryPlanExecutor<RelNode, Iterable<Object[]>> executor = mock(QueryPlanExecutor.class);
-    action =
-        new RestUnifiedQueryAction(
-            mock(NodeClient.class),
-            clusterService,
-            executor,
-            mock(EngineContextProvider.class),
-            mock(org.opensearch.sql.common.setting.Settings.class));
+    return new RestUnifiedQueryAction(
+        mock(NodeClient.class),
+        clusterService,
+        executor,
+        mock(EngineContextProvider.class),
+        mock(org.opensearch.sql.common.setting.Settings.class));
   }
 
   @Test
@@ -230,13 +234,17 @@ public class RestUnifiedQueryActionTest {
     assertTrue(action.isAnalyticsIndex("source = parquet_logs | | fields ts", QueryType.PPL));
   }
 
+  /**
+   * Turns on the cluster-level opt-in by putting {@code cluster.pluggable.dataformat.enabled=true}
+   * into the node settings and rebuilding the action, since the flag is cached at construction.
+   */
   private void enableClusterComposite() {
     when(clusterService.getSettings())
         .thenReturn(
             Settings.builder()
-                .put(
-                    IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
+                .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
                 .build());
+    action = buildAction();
   }
 
   private void registerIndex(String name, Settings settings) {


### PR DESCRIPTION
This changes the routing gate to analytics-engine to use boolean flag with settings update consumer so it can be enabled/disabled.

### Description
Gate analytics routing on cluster.pluggable.dataformat.enabled boolean.

Remove brittle string match on setting and make it match dynamic cluster level setting.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
