### PR TITLE
fix(integ): repair two pre-existing IT failures on main (QueryValidationIT error type, NoMv explain flake)

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -2888,10 +2888,13 @@ public class CalciteExplainIT extends ExplainIT {
             "source=%s | fields firstname, age | eval names = array(firstname) | nomv names |"
                 + " fields names",
             TEST_INDEX_BANK);
-    var result = explainQueryYaml(query);
+    // Assert on the LOGICAL plan only: nomv lowers to MVJOIN -> ARRAY_JOIN, which is stable in the
+    // logical plan regardless of pushdown. The physical section's rendering varies with the
+    // pushdown setting (e.g. under CalciteNoPushdownIT), so scanning the whole output is flaky.
+    String logical = logicalPlan(explainQueryYaml(query));
     Assert.assertTrue(
-        "Expected explain to contain ARRAY_JOIN function",
-        result.toLowerCase().contains("array_join"));
+        "Expected logical plan to contain ARRAY_JOIN function",
+        logical.toLowerCase().contains("array_join"));
   }
 
   @Test
@@ -2901,10 +2904,24 @@ public class CalciteExplainIT extends ExplainIT {
             "source=%s | eval full_name = concat(firstname, ' J.') | eval name_array ="
                 + " array(full_name) | nomv name_array | fields name_array",
             TEST_INDEX_BANK);
-    var result = explainQueryYaml(query);
+    String logical = logicalPlan(explainQueryYaml(query)).toLowerCase();
     Assert.assertTrue(
-        "Expected explain to contain both CONCAT and ARRAY_JOIN",
-        result.toLowerCase().contains("concat") && result.toLowerCase().contains("array_join"));
+        "Expected logical plan to contain both CONCAT and ARRAY_JOIN",
+        logical.contains("concat") && logical.contains("array_join"));
+  }
+
+  /**
+   * Return just the {@code logical:} section of a YAML explain result (everything before the {@code
+   * physical:} key). The logical plan is deterministic across pushdown on/off, whereas the physical
+   * section's rendering varies — so assertions on plan content should target the logical plan to
+   * avoid flakiness.
+   *
+   * <p>Splits on the line-anchored top-level {@code "\nphysical:"} key so a string value that
+   * happens to contain {@code "physical:"} inside the logical section can't truncate the plan.
+   */
+  private static String logicalPlan(String explainYaml) {
+    int physicalIdx = explainYaml.indexOf("\nphysical:");
+    return physicalIdx >= 0 ? explainYaml.substring(0, physicalIdx) : explainYaml;
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
@@ -117,7 +117,10 @@ public class QueryValidationIT extends SQLIntegTestCase {
 
     expectResponseException()
         .hasStatusCode(BAD_REQUEST)
-        .hasErrorType("ErrorReport")
+        // #5532 unwraps ErrorReport to its cause in the SQL error formatter, so the reported type
+        // is
+        // now the underlying SemanticCheckException, not the ErrorReport wrapper.
+        .hasErrorType("SemanticCheckException")
         .containsMessage("Alias field [source_alias] refers to unresolved path [source.keyword]")
         .whenExecute(String.format(Locale.ROOT, "SELECT * FROM %s", index));
   }


### PR DESCRIPTION
### Description

Repairs two pre-existing IT failures on `main` (both in `integ-test`, test-only, no production change).

**1. `QueryValidationIT.testAliasToKeywordMultiFieldFailsWithBadRequest`** — #5532 changed the SQL error formatter to unwrap `ErrorReport` to its cause, so the reported `type` is now the underlying `SemanticCheckException`, not the `ErrorReport` wrapper. The query is still correctly rejected with 400; only the error-envelope `type` changed. Updated the expected type to match.

**2. `CalciteExplainIT.testNoMvBasic` / `testNoMvWithEval`** — the assertion scanned the full logical+physical explain YAML for `ARRAY_JOIN`, but the **physical** section renders differently when pushdown is disabled (`CalciteNoPushdownIT`), making the test flaky on some runners. `nomv` lowers to `MVJOIN → ARRAY_JOIN`, which is stable in the **logical** plan regardless of pushdown (verified with pushdown on and off). Assert on the logical section only.

### Testing

Ran against an OpenSearch cluster:
- `QueryValidationIT` — full class passes (target test + siblings).
- `CalciteExplainIT.testNoMvBasic` / `testNoMvWithEval` — pass; logical plan confirmed to contain `ARRAY_JOIN` with pushdown both enabled and disabled.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
