### PR TITLE
Bring CalciteWhereCommandIT to parity on the analytics-engine route

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1082,6 +1082,26 @@ task integTestRemote(type: RestIntegTestTask) {
             // CalciteAliasFieldAggregationIT: raw-PUT alias index can't be created on the AE route
             // and every test queries alias fields directly — whole class doomed.
             excludeTestsMatching 'org.opensearch.sql.calcite.remote.CalciteAliasFieldAggregationIT'
+
+            // === Excludes: WhereCommandIT / CalciteWhereCommandIT route divergences (#5546) ===
+            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
+            // AnalyticsRouteLimitation); listed here so the AE-route skip set stays countable in one
+            // place. Reasons:
+            //  - Nested-field queries: the parquet/composite store has no nested-document support, so
+            //    nested fields are stripped at load (#5541). Defined only in CalciteWhereCommandIT.
+            excludeTestsMatching '*CalciteWhereCommandIT.testFilterOnComputedNestedFields'
+            excludeTestsMatching '*CalciteWhereCommandIT.testFilterOnNestedAndRootFields'
+            excludeTestsMatching '*CalciteWhereCommandIT.testFilterOnNestedFields'
+            excludeTestsMatching '*CalciteWhereCommandIT.testFilterOnMultipleCascadedNestedFields'
+            excludeTestsMatching '*CalciteWhereCommandIT.testScriptFilterOnDifferentNestedHierarchyShouldThrow'
+            excludeTestsMatching '*CalciteWhereCommandIT.testAggFilterOnNestedFields'
+            //  - _id metadata field not exposed on parquet-backed scans. Defined in the base
+            //    WhereCommandIT and inherited by CalciteWhereCommandIT; the glob matches both runs.
+            excludeTestsMatching '*WhereCommandIT.testWhereWithMetadataFields'
+            excludeTestsMatching '*WhereCommandIT.testWhereWithMetadataFields2'
+            //  - Exact == on a dynamically-mapped string (email) returns no rows: dynamic mapping
+            //    omits the .keyword sub-field on the AE route.
+            excludeTestsMatching '*WhereCommandIT.testDoubleEqualWithSpecialCharacters'
         }
     }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExpandCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExpandCommandIT.java
@@ -5,9 +5,9 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ARRAY;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -296,10 +296,7 @@ public class CalciteExpandCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testExpandEmptyArray() throws Exception {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 6;
     Request insertRequest =
         new Request(
@@ -329,10 +326,7 @@ public class CalciteExpandCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testExpandOnNullField() throws Exception {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 6;
     Request insertRequest =
         new Request(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteStreamstatsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteStreamstatsCommandIT.java
@@ -5,8 +5,8 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.*;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.*;
 
 import java.io.IOException;
@@ -508,10 +508,7 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testStreamstatsGlobal() throws IOException {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 5;
     Request insertRequest =
         new Request(
@@ -671,10 +668,7 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testStreamstatsReset() throws IOException {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 5;
     Request insertRequest =
         new Request(
@@ -943,10 +937,7 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testMultipleStreamstatsWithNull2() throws IOException {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 5;
     Request insertRequest =
         new Request(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -5,10 +5,10 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CASCADED_NESTED;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DEEP_NESTED;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.NESTED_FIELDS;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -24,11 +24,6 @@ import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.ppl.WhereCommandIT;
 
 public class CalciteWhereCommandIT extends WhereCommandIT {
-
-  private static final String NESTED_UNSUPPORTED_ON_AE =
-      "Nested-field queries can't run on the analytics-engine route: the parquet/composite store"
-          + " has no nested-document support, so nested fields are stripped from the dataset at"
-          + " load.";
 
   @Override
   public void init() throws Exception {
@@ -47,7 +42,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testFilterOnComputedNestedFields() throws IOException {
-    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(NESTED_FIELDS);
     JSONObject result =
         executeQuery(
             String.format(
@@ -60,7 +55,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testFilterOnNestedAndRootFields() throws IOException {
-    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(NESTED_FIELDS);
     JSONObject result =
         executeQuery(
             String.format(
@@ -73,7 +68,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testFilterOnNestedFields() throws IOException {
-    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(NESTED_FIELDS);
     // address is a nested object
     JSONObject result1 =
         executeQuery(
@@ -93,7 +88,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testFilterOnMultipleCascadedNestedFields() throws IOException {
-    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(NESTED_FIELDS);
     // SQL's static type system does not allow returning list[int] in place of int
     enabledOnlyWhenPushdownIsEnabled();
     JSONObject result =
@@ -137,7 +132,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testScriptFilterOnDifferentNestedHierarchyShouldThrow() throws IOException {
-    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(NESTED_FIELDS);
     enabledOnlyWhenPushdownIsEnabled();
     Throwable t =
         assertThrows(
@@ -156,7 +151,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testAggFilterOnNestedFields() throws IOException {
-    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(NESTED_FIELDS);
     enabledOnlyWhenPushdownIsEnabled();
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CASCADED_NESTED;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DEEP_NESTED;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
@@ -23,6 +24,12 @@ import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.ppl.WhereCommandIT;
 
 public class CalciteWhereCommandIT extends WhereCommandIT {
+
+  private static final String NESTED_UNSUPPORTED_ON_AE =
+      "Nested-field queries can't run on the analytics-engine route: the parquet/composite store"
+          + " has no nested-document support, so nested fields are stripped from the dataset at"
+          + " load.";
+
   @Override
   public void init() throws Exception {
     super.init();
@@ -40,6 +47,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testFilterOnComputedNestedFields() throws IOException {
+    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
     JSONObject result =
         executeQuery(
             String.format(
@@ -52,6 +60,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testFilterOnNestedAndRootFields() throws IOException {
+    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
     JSONObject result =
         executeQuery(
             String.format(
@@ -64,6 +73,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testFilterOnNestedFields() throws IOException {
+    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
     // address is a nested object
     JSONObject result1 =
         executeQuery(
@@ -83,6 +93,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testFilterOnMultipleCascadedNestedFields() throws IOException {
+    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
     // SQL's static type system does not allow returning list[int] in place of int
     enabledOnlyWhenPushdownIsEnabled();
     JSONObject result =
@@ -126,6 +137,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testScriptFilterOnDifferentNestedHierarchyShouldThrow() throws IOException {
+    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
     enabledOnlyWhenPushdownIsEnabled();
     Throwable t =
         assertThrows(
@@ -144,6 +156,7 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
 
   @Test
   public void testAggFilterOnNestedFields() throws IOException {
+    assumeFalse(NESTED_UNSUPPORTED_ON_AE, isAnalyticsParquetIndicesEnabled());
     enabledOnlyWhenPushdownIsEnabled();
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
@@ -5,9 +5,9 @@
 
 package org.opensearch.sql.ppl;
 
-import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -1566,10 +1566,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testCompareAgainstUTCDate() throws IOException {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
     String isoTimestamp = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
     String pplTimestamp = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
@@ -38,6 +38,7 @@ import org.opensearch.sql.common.setting.Settings.Key;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.legacy.TestUtils;
 import org.opensearch.sql.protocol.response.format.Format;
+import org.opensearch.sql.util.AnalyticsRouteLimitation;
 import org.opensearch.sql.util.RetryProcessor;
 
 /** OpenSearch Rest integration test base for PPL testing. */
@@ -67,6 +68,16 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
    */
   public static boolean isAnalyticsParquetIndicesEnabled() {
     return TestUtils.AnalyticsIndexConfig.isEnabled();
+  }
+
+  /**
+   * Skip the current test on the analytics-engine route because of a known limitation of that route
+   * (no-op on the v2/Calcite path). The {@link AnalyticsRouteLimitation} registry holds the reason,
+   * so a skip reads as {@code assumeNotAnalytics(NESTED_FIELDS)} and every route gap stays
+   * greppable in one place.
+   */
+  public static void assumeNotAnalytics(AnalyticsRouteLimitation limitation) {
+    Assume.assumeFalse(limitation.reason(), isAnalyticsParquetIndicesEnabled());
   }
 
   protected JSONObject executeQuery(String query) throws IOException {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -5,8 +5,8 @@
 
 package org.opensearch.sql.ppl;
 
-import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.*;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.columnName;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
@@ -1054,10 +1054,7 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchTimeModifierWithSnappedWeek() throws IOException {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     // Test whether alignment to weekday works
 
     final int docId = 101;
@@ -1146,10 +1143,7 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchWithRelativeTimeModifiers() throws IOException {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 101;
 
     LocalDateTime currentTime = LocalDateTime.now(ZoneOffset.UTC);
@@ -1198,10 +1192,7 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchWithTimeUnitSnapping() throws IOException {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 101;
 
     LocalDateTime currentHour = LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
@@ -1250,10 +1241,7 @@ public class SearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testSearchWithQuarterlyModifiers() throws IOException {
-    assumeFalse(
-        "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine"
-            + " (analytics-engine storage path) does not support.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 101;
 
     LocalDateTime currentQuarter =

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.ppl;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_TIME;
@@ -216,6 +217,10 @@ public class WhereCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testWhereWithMetadataFields() throws IOException {
+    assumeFalse(
+        "The analytics-engine route doesn't expose the _id metadata field (parquet-backed scans"
+            + " surface only mapped document fields).",
+        isAnalyticsParquetIndicesEnabled());
     JSONObject result =
         executeQuery(
             String.format("source=%s | where _id='1' | fields firstname", TEST_INDEX_ACCOUNT));
@@ -224,6 +229,10 @@ public class WhereCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testWhereWithMetadataFields2() throws IOException {
+    assumeFalse(
+        "The analytics-engine route doesn't expose the _id metadata field (parquet-backed scans"
+            + " surface only mapped document fields).",
+        isAnalyticsParquetIndicesEnabled());
     JSONObject result =
         executeQuery(String.format("source=%s | where _id='1'", TEST_INDEX_ACCOUNT));
     verifyDataRows(
@@ -531,6 +540,13 @@ public class WhereCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testDoubleEqualWithSpecialCharacters() throws IOException {
+    assumeFalse(
+        "email is dynamically mapped to a text field without a .keyword sub-field on the parquet"
+            + " route (the composite dataformat's dynamic mapping omits the keyword sub-field that"
+            + " standard OpenSearch adds), and exact equality on an analyzed text field isn't"
+            + " supported by the DataFusion scan. firstname (explicit text+keyword) still exercises"
+            + " == on the analytics route.",
+        isAnalyticsParquetIndicesEnabled());
     // Test == with strings containing special characters
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -6,10 +6,11 @@
 package org.opensearch.sql.ppl;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_TIME;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.DYNAMIC_STRING_NO_KEYWORD;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.ID_METADATA;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -217,10 +218,7 @@ public class WhereCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testWhereWithMetadataFields() throws IOException {
-    assumeFalse(
-        "The analytics-engine route doesn't expose the _id metadata field (parquet-backed scans"
-            + " surface only mapped document fields).",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(ID_METADATA);
     JSONObject result =
         executeQuery(
             String.format("source=%s | where _id='1' | fields firstname", TEST_INDEX_ACCOUNT));
@@ -229,10 +227,7 @@ public class WhereCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testWhereWithMetadataFields2() throws IOException {
-    assumeFalse(
-        "The analytics-engine route doesn't expose the _id metadata field (parquet-backed scans"
-            + " surface only mapped document fields).",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(ID_METADATA);
     JSONObject result =
         executeQuery(String.format("source=%s | where _id='1'", TEST_INDEX_ACCOUNT));
     verifyDataRows(
@@ -540,13 +535,7 @@ public class WhereCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testDoubleEqualWithSpecialCharacters() throws IOException {
-    assumeFalse(
-        "email is dynamically mapped to a text field without a .keyword sub-field on the parquet"
-            + " route (the composite dataformat's dynamic mapping omits the keyword sub-field that"
-            + " standard OpenSearch adds), and exact equality on an analyzed text field isn't"
-            + " supported by the DataFusion scan. firstname (explicit text+keyword) still exercises"
-            + " == on the analytics route.",
-        isAnalyticsParquetIndicesEnabled());
+    assumeNotAnalytics(DYNAMIC_STRING_NO_KEYWORD);
     // Test == with strings containing special characters
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.util;
+
+/**
+ * Single registry of the known behavioral divergences of the analytics-engine route
+ * (parquet/composite store + DataFusion backend, activated by {@code
+ * -Dtests.analytics.parquet_indices=true}). Each constant carries the reason a test is skipped on
+ * that route.
+ *
+ * <p>Pair it with {@code PPLIntegTestCase.assumeNotAnalytics(...)} so a skip reads as {@code
+ * assumeNotAnalytics(NESTED_FIELDS)} instead of a copy-pasted string literal. Keeping every reason
+ * here makes the full set of analytics-route gaps greppable in one place — both for humans tracking
+ * what still needs fixing and as a single block of context to hand an agent for bulk triage.
+ */
+public enum AnalyticsRouteLimitation {
+  /**
+   * The parquet/composite store has no nested-document support, so nested fields are stripped from
+   * the dataset at load (#5541) and queries that reference them resolve against fields that don't
+   * exist on this route.
+   */
+  NESTED_FIELDS(
+      "Nested-field queries can't run on the analytics-engine route: the parquet/composite store"
+          + " has no nested-document support, so nested fields are stripped from the dataset at"
+          + " load (#5541)."),
+
+  /**
+   * Parquet-backed scans surface only mapped document fields, so the {@code _id} metadata field is
+   * not exposed on this route.
+   */
+  ID_METADATA(
+      "The analytics-engine route doesn't expose the _id metadata field (parquet-backed scans"
+          + " surface only mapped document fields)."),
+
+  /**
+   * The composite dataformat's dynamic mapping gives string fields a {@code text} mapping without
+   * the {@code .keyword} sub-field that standard OpenSearch adds, so exact equality ({@code =} /
+   * {@code ==}) on a dynamically-mapped string silently returns no rows on the DataFusion scan.
+   * Explicitly mapped {@code text}+{@code keyword} fields are unaffected.
+   */
+  DYNAMIC_STRING_NO_KEYWORD(
+      "Exact equality (= / ==) on a dynamically-mapped string field returns no rows on the"
+          + " analytics-engine route: the composite dataformat's dynamic mapping omits the .keyword"
+          + " sub-field that standard OpenSearch adds, and the DataFusion scan can't match on an"
+          + " analyzed text field."),
+
+  /**
+   * The analytics-engine storage path ({@code DataFormatAwareEngine}) does not support in-place
+   * document mutation, so tests that seed state via raw {@code PUT}+{@code DELETE} can't run on
+   * this route.
+   */
+  DOC_MUTATION(
+      "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine (analytics-engine storage"
+          + " path) does not support.");
+
+  private final String reason;
+
+  AnalyticsRouteLimitation(String reason) {
+    this.reason = reason;
+  }
+
+  /** Human-readable explanation surfaced as the JUnit skip message. */
+  public String reason() {
+    return reason;
+  }
+}


### PR DESCRIPTION
### Description

Brings `CalciteWhereCommandIT` to parity on the analytics-engine route (`:integ-test:integTestRemote -Dtests.analytics.parquet_indices=true`): 9 failing → 0, by branching the tests that exercise behavior the route inherently can't support behind `isAnalyticsParquetIndicesEnabled()`. All branches are no-ops off the analytics route, so the v2 path is unchanged.

### Pass rate

| Route | Before | After |
|---|---|---|
| analytics-engine | 9 failing / 41 | **0 failing — 32 pass, 9 documented skips** |
| v2 (`:integ-test:integTest`, fresh cluster) | 41 pass | **41 pass, 0 skip** |

### Documented skips (inherent analytics-route divergences)

| Test(s) | Reason |
|---|---|
| `testFilterOnComputedNestedFields`, `testFilterOnNestedAndRootFields`, `testFilterOnNestedFields`, `testFilterOnMultipleCascadedNestedFields`, `testScriptFilterOnDifferentNestedHierarchyShouldThrow`, `testAggFilterOnNestedFields` | These query nested fields (`address.city`, `projects.name`, `author.books.*`). The parquet/composite store has no nested-document support, so nested fields are stripped from the dataset at load (#5541) and the fields don't exist on this route. |
| `testWhereWithMetadataFields`, `testWhereWithMetadataFields2` | Use `where _id='1'`. The analytics-engine route doesn't expose the `_id` metadata field — parquet-backed scans surface only mapped document fields. |
| `testDoubleEqualWithSpecialCharacters` | `email` is *dynamically* mapped to a `text` field **without** a `.keyword` sub-field on the parquet route (the composite dataformat's dynamic mapping omits the keyword sub-field that standard OpenSearch adds). Exact equality on an analyzed text field then returns no rows on the DataFusion scan. `firstname` (explicit `text`+`keyword`) still exercises `==` on the analytics route. |

### Note for reviewers

The `testDoubleEqualWithSpecialCharacters` root cause is broader than this one test: **any exact-match (`=` / `==`) on a dynamically-mapped string field silently returns 0 rows on the analytics-engine route**, because dynamic strings get no `.keyword` sub-field there. Worth tracking as a potential analytics-engine fix (have dynamic string mapping add the keyword sub-field, or make text-field equality fall back to the stored value) rather than relying on every fixture to map string fields explicitly.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
