### PR TITLE
[BugFix] Fix `GROUP BY` expression resolution in `SELECT`/`HAVING`/`ORDER BY`

### DIFF
--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
@@ -506,4 +506,45 @@ public class UnifiedQueryPlannerSqlV2Test extends UnifiedQueryTestBase {
               LogicalTableScan(table=[[catalog, employees]])
             """);
   }
+
+  @Test
+  public void testGroupByExpression() {
+    givenQuery("SELECT LENGTH(name), COUNT(*) FROM catalog.employees GROUP BY LENGTH(name)")
+        .assertPlan(
+            """
+            LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+              LogicalProject(LENGTH(name)=[CHAR_LENGTH($1)])
+                LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testHavingOnGroupByExpression() {
+    givenQuery(
+            "SELECT COUNT(*) FROM catalog.employees GROUP BY LENGTH(name) HAVING LENGTH(name) > 3")
+        .assertPlan(
+            """
+            LogicalProject(COUNT(*)=[$0])
+              LogicalFilter(condition=[>($1, 3)])
+                LogicalProject(COUNT(*)=[$1], LENGTH(name)=[$0])
+                  LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+                    LogicalProject(LENGTH(name)=[CHAR_LENGTH($1)])
+                      LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testOrderByGroupByExpression() {
+    givenQuery(
+            """
+            SELECT LENGTH(name) FROM catalog.employees GROUP BY LENGTH(name) ORDER BY LENGTH(name)
+            """)
+        .assertPlan(
+            """
+            LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
+              LogicalAggregate(group=[{0}])
+                LogicalProject(LENGTH(name)=[CHAR_LENGTH($1)])
+                  LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -22,6 +22,7 @@ import org.apache.calcite.rex.RexLambdaRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.opensearch.sql.ast.expression.AggregateFunction;
+import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.tree.HighlightConfig;
 import org.opensearch.sql.calcite.utils.CalciteToolsHelper;
@@ -70,6 +71,9 @@ public class CalcitePlanContext {
    * resolution.
    */
   @Getter private final Map<AggregateFunction, Integer> aggregateOutputIndex = new HashMap<>();
+
+  /** Maps GROUP BY Function AST nodes to their output field index for post-aggregate resolution. */
+  @Getter private final Map<Function, Integer> groupKeyOutputIndex = new HashMap<>();
 
   /**
    * List of captured variables from outer scope for lambda functions. When a lambda body references

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -1788,11 +1788,28 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
         context.getAggregateOutputIndex().put(aggFunc, aggStartIdx + i);
       }
     }
+
+    // Register group-by expression output indices so post-aggregate references resolve to them;
+    // clear() safe as above.
+    context.getGroupKeyOutputIndex().clear();
+    int groupStartIdx = metricsFirst ? aggRexList.size() : 0;
+    for (int i = 0; i < groupExprList.size(); i++) {
+      Function groupFunc = extractFunction(groupExprList.get(i));
+      if (groupFunc != null) {
+        context.getGroupKeyOutputIndex().put(groupFunc, groupStartIdx + i);
+      }
+    }
   }
 
   private static AggregateFunction extractAggregateFunction(UnresolvedExpression expr) {
     if (expr instanceof AggregateFunction af) return af;
     if (expr instanceof Alias alias) return extractAggregateFunction(alias.getDelegated());
+    return null;
+  }
+
+  private static Function extractFunction(UnresolvedExpression expr) {
+    if (expr instanceof Function f) return f;
+    if (expr instanceof Alias alias) return extractFunction(alias.getDelegated());
     return null;
   }
 

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -563,6 +563,11 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
 
   @Override
   public RexNode visitFunction(Function node, CalcitePlanContext context) {
+    // Resolve a group-by expression to its group-key output index.
+    Integer groupKeyIndex = context.getGroupKeyOutputIndex().get(node);
+    if (groupKeyIndex != null) {
+      return context.relBuilder.field(groupKeyIndex);
+    }
     List<UnresolvedExpression> args = node.getFuncArgs();
     List<RexNode> arguments = new ArrayList<>();
 


### PR DESCRIPTION
### Description
A `SELECT`, `HAVING` or `ORDER BY` expression matching a `GROUP BY` expression (e.g. `SELECT LENGTH(name) FROM t GROUP BY LENGTH(name)`) failed with "Field [name] not found", because it was re-evaluated against base fields that no longer exist after aggregation. This change makes such an expression reuse the already-computed group-key column. There is no impact on PPL, since PPL grouping clauses only allow field references and `span` (never scalar function expressions).

- Known limitation: the group-by function expression must be matched by exact function name, so a case-mismatched reference such as `SELECT length(name) … GROUP BY LENGTH(name)` is not resolved and would require larger changes to canonicalize identifier names during AST building/analysis.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
