### PR TITLE
Bring CalciteBinCommandIT and CalciteMultisearchCommandIT to parity on the analytics-engine route

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1102,6 +1102,28 @@ task integTestRemote(type: RestIntegTestTask) {
             //  - Exact == on a dynamically-mapped string (email) returns no rows: dynamic mapping
             //    omits the .keyword sub-field on the AE route.
             excludeTestsMatching '*WhereCommandIT.testDoubleEqualWithSpecialCharacters'
+
+            // === Excludes: CalciteMultisearchCommandIT route divergences ===
+            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
+            // AnalyticsRouteLimitation); listed here so the AE-route skip set stays countable.
+            //  - Same-index subsearch conflation: when every subsearch reads the same index, the AE
+            //    route applies the first subsearch's filter to all of them, so counts are wrong.
+            excludeTestsMatching '*CalciteMultisearchCommandIT.testMultisearchWithThreeSubsearches'
+            excludeTestsMatching '*CalciteMultisearchCommandIT.testMultisearchWithComplexAggregation'
+            excludeTestsMatching '*CalciteMultisearchCommandIT.testMultisearchWithoutFurtherProcessing'
+            //  - Column-order divergence: multisearch over different indices returns merged columns
+            //    in a different order than the v2/Calcite path.
+            excludeTestsMatching '*CalciteMultisearchCommandIT.testMultisearchWithTimestampInterleaving'
+
+            // === Excludes: CalciteBinCommandIT route divergences ===
+            // bin on a time field then grouping by it: the AE route types the date-histogram bucket
+            // column as string (not timestamp) AND produces a different bucket set (auto-histogram
+            // span / empty-bucket filtering differ), so both schema and row counts diverge. Each
+            // test also carries an in-test assumeNotAnalytics(...) (see AnalyticsRouteLimitation).
+            excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeField_Count'
+            excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeField_Avg'
+            excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeAndTermField_Count'
+            excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeAndTermField_Avg'
         }
     }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.sql.legacy.TestsConstants.*;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.BIN_TIME_FIELD_BUCKETING;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -872,6 +873,7 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testStatsWithBinsOnTimeField_Count() throws IOException {
     // TODO: Remove this after addressing https://github.com/opensearch-project/sql/issues/4317
     enabledOnlyWhenPushdownIsEnabled();
+    assumeNotAnalytics(BIN_TIME_FIELD_BUCKETING);
 
     JSONObject result =
         executeQuery("source=events_null | bin @timestamp bins=3 | stats count() by @timestamp");
@@ -910,6 +912,7 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testStatsWithBinsOnTimeField_Avg() throws IOException {
     // TODO: Remove this after addressing https://github.com/opensearch-project/sql/issues/4317
     enabledOnlyWhenPushdownIsEnabled();
+    assumeNotAnalytics(BIN_TIME_FIELD_BUCKETING);
 
     JSONObject result =
         executeQuery(
@@ -951,6 +954,7 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testStatsWithBinsOnTimeAndTermField_Count() throws IOException {
     // TODO: Remove this after addressing https://github.com/opensearch-project/sql/issues/4317
     enabledOnlyWhenPushdownIsEnabled();
+    assumeNotAnalytics(BIN_TIME_FIELD_BUCKETING);
 
     JSONObject result =
         executeQuery(
@@ -974,6 +978,7 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   public void testStatsWithBinsOnTimeAndTermField_Avg() throws IOException {
     // TODO: Remove this after addressing https://github.com/opensearch-project/sql/issues/4317
     enabledOnlyWhenPushdownIsEnabled();
+    assumeNotAnalytics(BIN_TIME_FIELD_BUCKETING);
 
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultisearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultisearchCommandIT.java
@@ -6,6 +6,8 @@
 package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.*;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.MULTISEARCH_COLUMN_ORDER;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.MULTISEARCH_SAME_INDEX_CONFLATION;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -65,6 +67,7 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testMultisearchWithThreeSubsearches() throws IOException {
+    assumeNotAnalytics(MULTISEARCH_SAME_INDEX_CONFLATION);
     JSONObject result =
         executeQuery(
             String.format(
@@ -81,6 +84,7 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testMultisearchWithComplexAggregation() throws IOException {
+    assumeNotAnalytics(MULTISEARCH_SAME_INDEX_CONFLATION);
     JSONObject result =
         executeQuery(
             String.format(
@@ -143,6 +147,7 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testMultisearchWithTimestampInterleaving() throws IOException {
+    assumeNotAnalytics(MULTISEARCH_COLUMN_ORDER);
     JSONObject result =
         executeQuery(
             "| multisearch [search"
@@ -353,6 +358,7 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
   /** Reproduce #5145: multisearch without further processing should return all rows. */
   @Test
   public void testMultisearchWithoutFurtherProcessing() throws IOException {
+    assumeNotAnalytics(MULTISEARCH_SAME_INDEX_CONFLATION);
     JSONObject result =
         executeQuery(
             "| multisearch [search source=opensearch-sql_test_index_time_data | where category ="

--- a/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
@@ -54,7 +54,38 @@ public enum AnalyticsRouteLimitation {
    */
   DOC_MUTATION(
       "Test mutates docs via PUT+DELETE, which DataFormatAwareEngine (analytics-engine storage"
-          + " path) does not support.");
+          + " path) does not support."),
+
+  /**
+   * When every {@code multisearch} subsearch reads the same index, the analytics-engine route
+   * applies the first subsearch's filter to all of them (each keeps its own {@code eval} label), so
+   * later subsearches silently return the first subsearch's rows. Produces wrong counts/duplication
+   * — the route can't be asserted against. Reproduces single-shard.
+   */
+  MULTISEARCH_SAME_INDEX_CONFLATION(
+      "multisearch with same-index subsearches conflates on the analytics-engine route: every"
+          + " subsearch executes the first subsearch's filter, so counts/rows are wrong."),
+
+  /**
+   * A {@code multisearch} over heterogeneous indices returns the merged columns in a different
+   * order than the v2/Calcite path (e.g. trailing fields swapped), so row-order-sensitive
+   * assertions diverge even though the values are correct.
+   */
+  MULTISEARCH_COLUMN_ORDER(
+      "multisearch over different indices returns merged columns in a different order on the"
+          + " analytics-engine route than the v2/Calcite path."),
+
+  /**
+   * Binning a time field then grouping by it ({@code bin <timefield> bins=N | stats ... by
+   * <timefield>}) diverges on the analytics-engine route: the date-histogram bucket column comes
+   * back typed {@code string} rather than {@code timestamp}, and the route produces a different
+   * bucket set (different auto-histogram span / empty buckets not filtered) so the row counts don't
+   * match the v2/Calcite path.
+   */
+  BIN_TIME_FIELD_BUCKETING(
+      "bin on a time field then grouping by it diverges on the analytics-engine route: the bucket"
+          + " column is typed string (not timestamp) and the bucket set differs from the v2/Calcite"
+          + " path.");
 
   private final String reason;
 


### PR DESCRIPTION
### Description

Brings `CalciteBinCommandIT` and `CalciteMultisearchCommandIT` to parity on the analytics-engine route (`:integ-test:integTestRemote -Dtests.analytics.parquet_indices=true`): 8 failing → 0, by skipping the tests that exercise behavior the route inherently diverges on, behind `assumeNotAnalytics(...)` plus the gradle exclude list (same pattern as #5546). All skips are no-ops off the analytics route, so the v2 / Calcite path is unchanged.

Each skip reason is recorded as an `AnalyticsRouteLimitation` constant (the single greppable registry introduced in #5546), and the excluded tests are listed in the `analyticsEnabled` block of `integ-test/build.gradle` so the AE-route skip set stays countable in one place.

### Pass rate

| IT | Route | Before | After |
|---|---|---|---|
| `CalciteBinCommandIT` | analytics-engine | 4 failing / 46 run | **0 failing — 42 pass, 4 documented skips** |
| `CalciteBinCommandIT` | v2 (`:integ-test:integTest`, fresh cluster) | 46 pass | **46 pass, 0 skip** |
| `CalciteMultisearchCommandIT` | analytics-engine | 4 failing / 21 | **0 failing — 17 pass, 4 documented skips** |
| `CalciteMultisearchCommandIT` | v2 (`:integ-test:integTest`, fresh cluster) | 21 pass | **21 pass, 0 skip** |

(Bin "run" counts exclude the 24 pre-existing `enabledOnlyWhenPushdownIsEnabled`/pushdown skips that are unrelated to this change.)

### Documented skips (inherent analytics-route divergences)

| Test(s) | Reason |
|---|---|
| `CalciteBinCommandIT`: `testStatsWithBinsOnTimeField_Count`, `_Avg`, `testStatsWithBinsOnTimeAndTermField_Count`, `_Avg` | `bin <timefield> bins=N \| stats … by <timefield>` diverges on the analytics route: the date-histogram **bucket** column comes back typed `string` rather than `timestamp`, **and** the route produces a different bucket set (different auto-histogram span / empty buckets not filtered), so both the schema type and the row counts differ. A plainly-projected `@timestamp` (not a histogram bucket) is unaffected on both routes. |
| `CalciteMultisearchCommandIT`: `testMultisearchWithThreeSubsearches`, `testMultisearchWithComplexAggregation`, `testMultisearchWithoutFurtherProcessing` | Same-index subsearch conflation: when every `multisearch` subsearch reads the same index, the analytics route applies the **first** subsearch's filter to all of them (each keeps its own `eval` label), so later subsearches silently return the first subsearch's rows → wrong counts. E.g. the three-subsearch case returns `[22,California],[22,Illinois],[22,Tennessee]` (all get IL's count) instead of `[17,CA],[22,IL],[25,TN]`. |
| `CalciteMultisearchCommandIT`: `testMultisearchWithTimestampInterleaving` | Column-order divergence: a `multisearch` over heterogeneous indices returns the merged columns in a different order than the v2/Calcite path (trailing `value`/`timestamp` swapped). Values are correct; only the column order differs. |

### Why skip instead of fix these in this PR?

These are skipped (not fixed) here for three reasons:

1. **The defects are engine-side, not SQL-plugin.** For every one of these tests the SQL-plugin lowering is correct — the Calcite `RelNode` reaching the backend is identical regardless of which engine executes it (verified via `/_plugins/_ppl/_explain`). The divergence is entirely in the analytics-engine execution path (`opensearch-project/OpenSearch`, analytics-engine sandbox), so the fix belongs in that repo, not this one. This PR is SQL-side test parity.

2. **They are not one-line capability adds — they're scheduled engine work.**
   - **bin `bins=N` on a time field:** the v2 path leans on OpenSearch's native `auto_date_histogram` (calendar-nice intervals, `timestamp`-typed output). The analytics route has no equivalent rewrite, so it runs the generic `WIDTH_BUCKET` UDF literally (raw equal-width buckets, `string`-typed label). Reaching parity needs a planner rewrite + a calendar-aware bucketing UDF — a feature, not a flag.
   - **multisearch same-index conflation:** root-caused to a **delegated-predicate** bug (it only conflates when arms filter with predicates that delegate to the Lucene backend, e.g. keyword equality; native range/int-equality predicates are correct). The shard-fragment execution model assumes one scan per fragment, so a same-table multi-arm union collapses all arms' delegated predicates onto a single scan. The fix is a deep, multi-leaf-fragment rework (or gating the co-location fast path) in the engine

3. **The most impactful one is already tracked upstream.** The same-index multisearch conflation is already captured by an `@AwaitsFix` on the QA-side `MultisearchCommandIT.testMultisearchThreeBranchesByStr0` in OpenSearch core, so the engine team already owns it. Landing the test skips here keeps the SQL-side suite green and consistent with that tracker rather than duplicating/forking the fix.

The same-index multisearch conflation in particular is **silent wrong results** (no error, just incorrect counts) and is the highest-priority follow-up of the three.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
