### PR TITLE
Bring CalcitePPLEnhancedCoalesceIT to parity on the analytics-engine route

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1124,6 +1124,17 @@ task integTestRemote(type: RestIntegTestTask) {
             excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeField_Avg'
             excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeAndTermField_Count'
             excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeAndTermField_Avg'
+
+            // === Excludes: CalcitePPLEnhancedCoalesceIT route divergences ===
+            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
+            // AnalyticsRouteLimitation). The other ordering-sensitive coalesce tests were fixed in
+            // place with an explicit `sort` instead of being skipped.
+            //  - COALESCE over all-untyped-null operands is rejected by the capability registry.
+            excludeTestsMatching '*CalcitePPLEnhancedCoalesceIT.testCoalesceWithAllNonExistentFields'
+            //  - head N without a sort unique over the head window is non-deterministic, and the
+            //    nullable tiebreak these would need orders nulls differently than v2/Calcite.
+            excludeTestsMatching '*CalcitePPLEnhancedCoalesceIT.testCoalesceWithMixedTypes'
+            excludeTestsMatching '*CalcitePPLEnhancedCoalesceIT.testCoalesceBasic'
         }
     }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEnhancedCoalesceIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEnhancedCoalesceIT.java
@@ -6,6 +6,8 @@
 package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.*;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.COALESCE_ALL_NULL_OPERANDS;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.HEAD_WITHOUT_STABLE_SORT;
 import static org.opensearch.sql.util.MatcherUtils.*;
 
 import java.io.IOException;
@@ -37,7 +39,7 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
 
   @Test
   public void testCoalesceBasic() throws IOException {
-
+    assumeNotAnalytics(HEAD_WITHOUT_STABLE_SORT);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -53,7 +55,7 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
 
   @Test
   public void testCoalesceWithMixedTypes() throws IOException {
-
+    assumeNotAnalytics(HEAD_WITHOUT_STABLE_SORT);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -121,7 +123,7 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eval result1 = coalesce(name, 'default'), result2 = coalesce(result1,"
-                    + " age) | fields name, age, result1, result2 | head 2",
+                    + " age) | sort - age | fields name, age, result1, result2 | head 2",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(
@@ -153,8 +155,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce(field1, field2, name, 'fallback') | fields"
-                    + " name, result | head 1",
+                "source=%s | eval result = coalesce(field1, field2, name, 'fallback') | sort - age"
+                    + " | fields name, result | head 1",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("name", "string"), schema("result", "string"));
@@ -163,7 +165,7 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
 
   @Test
   public void testCoalesceWithAllNonExistentFields() throws IOException {
-
+    assumeNotAnalytics(COALESCE_ALL_NULL_OPERANDS);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -221,7 +223,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
     JSONObject actual =
         executeQuery(
             String.format(
-                "source=%s | eval result = coalesce(null, age) | fields age, result | head 3",
+                "source=%s | eval result = coalesce(null, age) | sort - age | fields age, result |"
+                    + " head 3",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("age", "int"), schema("result", "int"));
@@ -263,7 +266,7 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
         executeQuery(
             String.format(
                 "source=%s | eval empty_field = '' | eval result = coalesce(empty_field, name) |"
-                    + " fields name, result | head 1",
+                    + " sort - age | fields name, result | head 1",
                 TEST_INDEX_STATE_COUNTRY_WITH_NULL));
 
     verifySchema(actual, schema("name", "string"), schema("result", "string"));

--- a/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
@@ -85,7 +85,30 @@ public enum AnalyticsRouteLimitation {
   BIN_TIME_FIELD_BUCKETING(
       "bin on a time field then grouping by it diverges on the analytics-engine route: the bucket"
           + " column is typed string (not timestamp) and the bucket set differs from the v2/Calcite"
-          + " path.");
+          + " path."),
+
+  /**
+   * {@code COALESCE} over operands that are all untyped NULL (e.g. {@code coalesce(field1, field2,
+   * field3)} where every field is missing from the mapping) is rejected by the analytics-engine
+   * capability registry with {@code No backend supports scalar function [COALESCE] among
+   * [datafusion]}. The v2/Calcite path returns an {@code undefined}-typed null instead (#5175).
+   */
+  COALESCE_ALL_NULL_OPERANDS(
+      "COALESCE over all-untyped-null operands is unsupported on the analytics-engine route (the"
+          + " capability registry rejects it); the v2/Calcite path returns an undefined-typed"
+          + " null."),
+
+  /**
+   * A {@code head N} without a stable {@code sort} returns a non-deterministic row set on the
+   * analytics-engine route — raw-{@code PUT} docs land in a separate segment and can sort ahead of
+   * the bulk-loaded docs. Adding a {@code sort} fixes it only when the sort key is unique over the
+   * head window; when ties fall back to a nullable key, null placement diverges between the
+   * v2/Calcite and analytics routes, so the row set still differs.
+   */
+  HEAD_WITHOUT_STABLE_SORT(
+      "head N without a sort on a key that is unique over the head window is non-deterministic on"
+          + " the analytics-engine route, and a nullable tiebreak orders nulls differently than the"
+          + " v2/Calcite path.");
 
   private final String reason;
 


### PR DESCRIPTION
### Description

Brings `CalcitePPLEnhancedCoalesceIT` to parity on the analytics-engine route (`:integ-test:integTestRemote -Dtests.analytics.parquet_indices=true`): 4 failing → 0. `coalesce` itself computes correctly on the route (it's wired via `STANDARD_PROJECT_OPS`); every failure was a row-ordering or capability edge case, not a coalesce bug.

**Where a `sort` makes the test deterministic, the test is fixed in place — not skipped.** Only the cases a `sort` can't make correct on both routes are skipped, behind `assumeNotAnalytics(...)` + the gradle exclude list (the `AnalyticsRouteLimitation` registry / pattern from #5546).

### Fixed in place with an explicit `sort` (no skip)

These used `head N` without a sort. On the analytics route the scan surfaces the raw-`PUT` docs (added in `init()`) ahead of the bulk-loaded docs, so `head` returned a different row set. Adding `sort - age` makes them deterministic **with their original expectations unchanged**, because the sort key is unique over the head window (or the tie projects identical values):

| Test | Fix |
|---|---|
| `testCoalesceNested` (`head 2`) | `sort - age` — top-2 ages (70, 30) unique |
| `testCoalesceEmptyFieldWithFallback` (`head 1`) | `sort - age` — max age (70) unique |
| `testCoalesceWithMultipleNonExistentFields` (`head 1`) | `sort - age` — max age (70) unique |
| `testCoalesceWithNullLiteralAndIntegerField` (`head 3`) | `sort - age` — the age=25 tie projects identical `[25, 25]`, so the expectation holds regardless of tie order |

### Skipped on the analytics route (a `sort` can't fix these)

| Test(s) | Reason |
|---|---|
| `testCoalesceBasic`, `testCoalesceWithMixedTypes` (`head 3`) | The third row needs a **nullable tiebreak**: at the age=25 tie, the real doc (`John`) vs. a raw-`PUT` null-name doc. Null placement under sort diverges between the v2/Calcite and analytics routes, so no `sort` makes the expectation hold on both. |
| `testCoalesceWithAllNonExistentFields` | `coalesce(field1, field2, field3)` where every operand is untyped NULL is rejected by the analytics-engine capability registry: `No backend supports scalar function [COALESCE] among [datafusion]`. The v2/Calcite path returns an `undefined`-typed null instead (#5175). Genuine engine-side gap. |

### Pass rate

| Route | Before | After |
|---|---|---|
| analytics-engine (`:integTestRemote -Dtests.analytics.parquet_indices=true`) | 4 failing / 19 | **0 failing — 16 run, 3 excluded** (stable across 3 reruns) |
| v2 (`:integ-test:integTest`, fresh cluster) | 19 pass | **19 pass, 0 skip** |

### Note for reviewers

The skips are genuine route divergences (recorded as `AnalyticsRouteLimitation` constants): the COALESCE-over-all-null-operands one is an engine capability gap, and the `head`-without-stable-sort + nullable-tiebreak one is a route ordering difference that a test-side sort can't reconcile. The four `sort` fixes are pure determinism additions — expectations and the v2 path are unchanged.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
