### PR TITLE
fix(integ): use engine-zone today in DateTimeFunctionIT now()-based assertions

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
@@ -56,6 +56,14 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     TimeZone.setDefault(testTz);
   }
 
+  // "Today" as the query engine sees it. The analytics-engine route resolves now()/curdate()
+  // in UTC, while the v2/Calcite-over-Lucene path uses the JVM default zone (set to systemTz
+  // above). Tests that assert against an engine-supplied current date must use the matching
+  // zone, otherwise they fail by one day whenever the run straddles the UTC/local date boundary.
+  private LocalDate engineToday() {
+    return isAnalyticsParquetIndicesEnabled() ? LocalDate.now(ZoneOffset.UTC) : LocalDate.now();
+  }
+
   @Test
   public void testAddDateWithDays() throws IOException {
     var result =
@@ -82,7 +90,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
                 "source=%s | eval " + " f = adddate(TIME('07:40:00'), 0)" + " | fields f",
                 TEST_INDEX_DATE));
     verifySchema(result, schema("f", null, "timestamp"));
-    verifySome(result.getJSONArray("datarows"), rows(LocalDate.now() + " 07:40:00"));
+    verifySome(result.getJSONArray("datarows"), rows(engineToday() + " 07:40:00"));
   }
 
   @Test
@@ -128,7 +136,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     verifySome(
         result.getJSONArray("datarows"),
         rows(
-            LocalDate.now()
+            engineToday()
                 .plusDays(1)
                 .atTime(LocalTime.of(7, 40))
                 .atZone(systemTz.toZoneId())
@@ -145,7 +153,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     verifySome(
         result.getJSONArray("datarows"),
         rows(
-            LocalDate.now()
+            engineToday()
                 .atTime(LocalTime.of(8, 40))
                 .atZone(systemTz.toZoneId())
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));
@@ -278,7 +286,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     verifySome(
         result.getJSONArray("datarows"),
         rows(
-            LocalDate.now()
+            engineToday()
                 .plusDays(1)
                 .atTime(LocalTime.of(7, 40))
                 .atZone(systemTz.toZoneId())
@@ -295,7 +303,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     verifySome(
         result.getJSONArray("datarows"),
         rows(
-            LocalDate.now()
+            engineToday()
                 .atTime(LocalTime.of(8, 40))
                 .atZone(systemTz.toZoneId())
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));
@@ -460,7 +468,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     verifySome(
         result.getJSONArray("datarows"),
         rows(
-            LocalDate.now()
+            engineToday()
                 .plusDays(-1)
                 .atTime(LocalTime.of(7, 40))
                 .atZone(systemTz.toZoneId())
@@ -477,7 +485,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     verifySome(
         result.getJSONArray("datarows"),
         rows(
-            LocalDate.now()
+            engineToday()
                 .atTime(LocalTime.of(6, 40))
                 .atZone(systemTz.toZoneId())
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));
@@ -1034,7 +1042,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
                 "source=%s | eval " + " f = subdate(TIME('07:40:00'), 0)" + " | fields f",
                 TEST_INDEX_DATE));
     verifySchema(result, schema("f", null, "timestamp"));
-    verifySome(result.getJSONArray("datarows"), rows(LocalDate.now() + " 07:40:00"));
+    verifySome(result.getJSONArray("datarows"), rows(engineToday() + " 07:40:00"));
   }
 
   @Test
@@ -1080,7 +1088,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     verifySome(
         result.getJSONArray("datarows"),
         rows(
-            LocalDate.now()
+            engineToday()
                 .plusDays(-1)
                 .atTime(LocalTime.of(7, 40))
                 .atZone(systemTz.toZoneId())
@@ -1097,7 +1105,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
     verifySome(
         result.getJSONArray("datarows"),
         rows(
-            LocalDate.now()
+            engineToday()
                 .atTime(LocalTime.of(6, 40))
                 .atZone(systemTz.toZoneId())
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));


### PR DESCRIPTION
## Summary
`DateTimeFunctionIT`'s `adddate`/`subdate`-with-`TIME` tests assert against a current date the **query engine** supplies — e.g. `adddate(TIME('07:40:00'), interval 1 day)` → today+1. The expected value was computed with `LocalDate.now()` (JVM default zone), but the analytics-engine route resolves `now()`/`curdate()` in **UTC**. When a run starts after the local/UTC date boundary (e.g. 17:xx PDT = 00:xx UTC), the two dates differ by one day and the `now()`-based tests fail with an off-by-one-day timestamp.

Same class of bug fixed for `DateTimeComparisonIT` in #5543, surfacing in a different IT — newly visible because the analytics route only recently gained `now()`-family support.

## Fix
Add an `engineToday()` helper:
```java
private LocalDate engineToday() {
  return isAnalyticsParquetIndicesEnabled() ? LocalDate.now(ZoneOffset.UTC) : LocalDate.now();
}
```
and route the 10 `LocalDate.now()` assertion sites through it. The v2/Calcite-over-Lucene branch (`: LocalDate.now()`) is byte-identical to the prior behavior, so that path cannot regress; only the analytics route changes to match the engine's UTC clock. Pure test change, no production code.

## Before / After

`CalciteDateTimeFunctionIT` on the analytics-engine route, run started **17:32 PDT = 00:32 UTC** (inside the boundary window):

| Test | Before | After |
|---|---|---|
| `testDateAdd` | FAIL (off by 1 day) | **PASS** |
| `testDateSub` | FAIL | **PASS** |
| `testAddDateWithDays` | FAIL | **PASS** |
| `testSubDateDays` | FAIL | **PASS** |
| `testAddDateWithInterval` | FAIL | **PASS** |
| `testSubDateInterval` | FAIL | **PASS** |
| class total | 57/65 | **60/65** |

The 2 still-failing tests (`testDateFormat` `%c` zero-padding, `testStrftimeWithDateFields` sub-millisecond precision) are unrelated backend format/precision gaps, out of scope here.

## Test plan
- [x] `./gradlew :integ-test:integTestRemote --tests '*.CalciteDateTimeFunctionIT'` against an analytics-engine cluster, run inside the UTC-boundary window — the 6 `now()`-based tests pass.
- [x] v2 branch is byte-identical to the original `LocalDate.now()` — no behavior change off the analytics route.