### PR TITLE
Stabilize subquery PPL ITs on the analytics-engine route

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1135,6 +1135,18 @@ task integTestRemote(type: RestIntegTestTask) {
             //    nullable tiebreak these would need orders nulls differently than v2/Calcite.
             excludeTestsMatching '*CalcitePPLEnhancedCoalesceIT.testCoalesceWithMixedTypes'
             excludeTestsMatching '*CalcitePPLEnhancedCoalesceIT.testCoalesceBasic'
+
+            // === Excludes: CalcitePPLScalarSubqueryIT / CalcitePPLInSubqueryIT route divergences ===
+            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
+            // AnalyticsRouteLimitation); listed here so the AE-route skip set stays countable.
+            //  - Exact equality on an explicitly text-mapped field (department/occupation = '...')
+            //    in the subsearch returns no rows on the AE route (analyzed text, no .keyword).
+            excludeTestsMatching '*CalcitePPLScalarSubqueryIT.testTwoUncorrelatedScalarSubqueriesInOr'
+            excludeTestsMatching '*CalcitePPLInSubqueryIT.testInSubqueryWithTableAlias'
+            excludeTestsMatching '*CalcitePPLInSubqueryIT.testInCorrelatedSubquery'
+            //  - subsearch.maxout is lowered as a LIMIT on the in-subquery semi-join's right side,
+            //    which the AE route does not honor, so the subsearch returns all rows.
+            excludeTestsMatching '*CalcitePPLInSubqueryIT.testSubsearchMaxOut'
         }
     }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLInSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLInSubqueryIT.java
@@ -5,9 +5,12 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_OCCUPATION;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORKER;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORK_INFORMATION;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.SUBSEARCH_MAXOUT_IN_SUBQUERY;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.TEXT_FIELD_EXACT_MATCH;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -31,16 +34,22 @@ public class CalcitePPLInSubqueryIT extends PPLIntegTestCase {
     super.init();
     enableCalcite();
 
+    // init() runs as @Before, before every test method. On the analytics route the parquet-backed
+    // store is append-only on same-_id PUT, so seed the extra worker doc only when the index is
+    // first created — otherwise it accumulates a duplicate per test method and inflates row counts.
+    boolean workerExisted = isIndexExist(client(), TEST_INDEX_WORKER);
     loadIndex(Index.WORKER);
     loadIndex(Index.WORK_INFORMATION);
     loadIndex(Index.OCCUPATION);
 
-    // {"index":{"_id":"7"}}
-    // {"id":1006,"name":"Tommy","occupation":"Teacher","country":"USA","salary":30000}
-    Request request1 = new Request("PUT", "/" + TEST_INDEX_WORKER + "/_doc/7?refresh=true");
-    request1.setJsonEntity(
-        "{\"id\":1006,\"name\":\"Tommy\",\"occupation\":\"Teacher\",\"country\":\"USA\",\"salary\":30000}");
-    client().performRequest(request1);
+    if (!workerExisted) {
+      // {"index":{"_id":"7"}}
+      // {"id":1006,"name":"Tommy","occupation":"Teacher","country":"USA","salary":30000}
+      Request request1 = new Request("PUT", "/" + TEST_INDEX_WORKER + "/_doc/7?refresh=true");
+      request1.setJsonEntity(
+          "{\"id\":1006,\"name\":\"Tommy\",\"occupation\":\"Teacher\",\"country\":\"USA\",\"salary\":30000}");
+      client().performRequest(request1);
+    }
   }
 
   @Test
@@ -340,6 +349,8 @@ public class CalcitePPLInSubqueryIT extends PPLIntegTestCase {
 
   @Test
   public void testInSubqueryWithTableAlias() throws IOException {
+    // Subsearch filters a text-mapped field with exact equality (i.department = 'DATA').
+    assumeNotAnalytics(TEXT_FIELD_EXACT_MATCH);
     JSONObject result =
         executeQuery(
             String.format(
@@ -358,6 +369,8 @@ public class CalcitePPLInSubqueryIT extends PPLIntegTestCase {
 
   @Test
   public void testInCorrelatedSubquery() throws IOException {
+    // Subsearch filters a text-mapped field with exact equality (occupation = 'Engineer').
+    assumeNotAnalytics(TEXT_FIELD_EXACT_MATCH);
     JSONObject result =
         executeQuery(
             String.format(
@@ -372,6 +385,7 @@ public class CalcitePPLInSubqueryIT extends PPLIntegTestCase {
 
   @Test
   public void testSubsearchMaxOut() throws IOException {
+    assumeNotAnalytics(SUBSEARCH_MAXOUT_IN_SUBQUERY);
     setSubsearchMaxOut(1);
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLScalarSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLScalarSubqueryIT.java
@@ -5,9 +5,11 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_OCCUPATION;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORKER;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORK_INFORMATION;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.TEXT_FIELD_EXACT_MATCH;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -27,16 +29,22 @@ public class CalcitePPLScalarSubqueryIT extends PPLIntegTestCase {
     super.init();
     enableCalcite();
 
+    // init() runs as @Before, before every test method. On the analytics route the parquet-backed
+    // store is append-only on same-_id PUT, so seed the extra worker doc only when the index is
+    // first created — otherwise it accumulates a duplicate per test method and inflates row counts.
+    boolean workerExisted = isIndexExist(client(), TEST_INDEX_WORKER);
     loadIndex(Index.WORKER);
     loadIndex(Index.WORK_INFORMATION);
     loadIndex(Index.OCCUPATION);
 
-    // {"index":{"_id":"7"}}
-    // {"id":1006,"name":"Tommy","occupation":"Teacher","country":"USA","salary":30000}
-    Request request1 = new Request("PUT", "/" + TEST_INDEX_WORKER + "/_doc/7?refresh=true");
-    request1.setJsonEntity(
-        "{\"id\":1006,\"name\":\"Tommy\",\"occupation\":\"Teacher\",\"country\":\"USA\",\"salary\":30000}");
-    client().performRequest(request1);
+    if (!workerExisted) {
+      // {"index":{"_id":"7"}}
+      // {"id":1006,"name":"Tommy","occupation":"Teacher","country":"USA","salary":30000}
+      Request request1 = new Request("PUT", "/" + TEST_INDEX_WORKER + "/_doc/7?refresh=true");
+      request1.setJsonEntity(
+          "{\"id\":1006,\"name\":\"Tommy\",\"occupation\":\"Teacher\",\"country\":\"USA\",\"salary\":30000}");
+      client().performRequest(request1);
+    }
   }
 
   @Test
@@ -230,6 +238,8 @@ public class CalcitePPLScalarSubqueryIT extends PPLIntegTestCase {
 
   @Test
   public void testTwoUncorrelatedScalarSubqueriesInOr() throws IOException {
+    // Subsearch filters a text-mapped field with exact equality (department = 'DATA').
+    assumeNotAnalytics(TEXT_FIELD_EXACT_MATCH);
     JSONObject result =
         executeQuery(
             String.format(

--- a/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
@@ -48,6 +48,19 @@ public enum AnalyticsRouteLimitation {
           + " analyzed text field."),
 
   /**
+   * Exact equality ({@code =} / {@code ==}) on an explicitly {@code text}-mapped field (no {@code
+   * .keyword} sub-field) returns no rows on the analytics-engine route — the DataFusion scan can't
+   * match on an analyzed text field. The sibling of {@link #DYNAMIC_STRING_NO_KEYWORD} for fields
+   * that are mapped {@code text} on purpose rather than by dynamic mapping. Verified directly:
+   * {@code where department = 'DATA'} returns no rows while {@code like(department, 'DATA')} and
+   * keyword-field equality both work.
+   */
+  TEXT_FIELD_EXACT_MATCH(
+      "Exact equality (= / ==) on an explicitly text-mapped field (no .keyword sub-field) returns"
+          + " no rows on the analytics-engine route: the DataFusion scan can't match on an analyzed"
+          + " text field. Use like() or a keyword field instead."),
+
+  /**
    * The analytics-engine storage path ({@code DataFormatAwareEngine}) does not support in-place
    * document mutation, so tests that seed state via raw {@code PUT}+{@code DELETE} can't run on
    * this route.
@@ -108,7 +121,19 @@ public enum AnalyticsRouteLimitation {
   HEAD_WITHOUT_STABLE_SORT(
       "head N without a sort on a key that is unique over the head window is non-deterministic on"
           + " the analytics-engine route, and a nullable tiebreak orders nulls differently than the"
-          + " v2/Calcite path.");
+          + " v2/Calcite path."),
+
+  /**
+   * The {@code subsearch.maxout} cap on an {@code in}-subquery is lowered as a {@code LIMIT} on the
+   * right-hand side of the semi-join ({@code LogicalSystemLimit(fetch=N, type=SUBSEARCH_MAXOUT)}).
+   * The analytics-engine route does not honor that LIMIT, so the subsearch returns all rows
+   * regardless of the cap. Verified: with {@code subsearch.maxout=1} an {@code id in [...]}
+   * subquery still returns every matching row.
+   */
+  SUBSEARCH_MAXOUT_IN_SUBQUERY(
+      "subsearch.maxout is not honored on the analytics-engine route: the LIMIT lowered onto the"
+          + " in-subquery semi-join's right side is dropped, so the subsearch returns all rows"
+          + " regardless of the cap.");
 
   private final String reason;
 


### PR DESCRIPTION
### Description

Brings `CalcitePPLScalarSubqueryIT` and `CalcitePPLInSubqueryIT` to parity on the analytics-engine route (`-Dtests.analytics.parquet_indices=true`), where every test-created index is composite/parquet-backed and PPL queries route through the analytics engine (DataFusion). Both ITs already pass on the v2/Calcite route; this change is test-only.

#### Root cause 1 — append-only accumulation (fixes 19 of 23 failures)

Both ITs seed an extra `worker` doc (`_id 7`, "Tommy") via an unconditional raw `PUT` in `init()`. `init()` runs as `@Before`, before **every** test method, and `preserveClusterUponCompletion()` keeps indices across methods. On the analytics-engine parquet-backed store a `PUT` with an existing `_id` **appends a new row** instead of replacing, so Tommy accumulated one duplicate per test method and inflated row counts across the suite (e.g. a 7-row expectation returned 20 = 6 bulk docs + 14 duplicate Tommys).

The bulk `loadIndex(...)` calls don't have this problem because they're already `isIndexExist`-guarded. Fix: capture `isIndexExist(...)` **before** `loadIndex` creates the index, then seed Tommy only on first creation. End state is identical on the v2/Calcite route.

#### Root cause 2 — two unsupported behaviors on the route (the remaining 4 failures)

These are genuine analytics-engine behaviors, not test bugs (each verified directly against the route). They're skipped via the `assumeNotAnalytics(...)` registry (`AnalyticsRouteLimitation`) introduced in #5551, plus matching `excludeTestsMatching` entries in `integTestRemote` so the skip set stays countable in one place. Two new `AnalyticsRouteLimitation` constants:

- **`TEXT_FIELD_EXACT_MATCH`** — exact equality (`=` / `==`) on an explicitly `text`-mapped field (no `.keyword` sub-field) returns no rows on the DataFusion scan. The sibling of the existing `DYNAMIC_STRING_NO_KEYWORD` for fields mapped `text` on purpose rather than by dynamic mapping. Verified directly: `where department = 'DATA'` returns no rows, while `like(department, 'DATA')` and keyword-field equality both work. Covers `testTwoUncorrelatedScalarSubqueriesInOr`, `testInSubqueryWithTableAlias`, `testInCorrelatedSubquery` (each filters `department`/`occupation` with `=` in the subsearch).
- **`SUBSEARCH_MAXOUT_IN_SUBQUERY`** — the `subsearch.maxout` cap is lowered as a `LIMIT` on the right-hand side of the IN-subquery semi-join (`LogicalSystemLimit(fetch=N, type=SUBSEARCH_MAXOUT)`), which the route does not honor, so the subsearch returns all rows regardless of the cap. Verified: with `subsearch.maxout=1` an `id in [...]` subquery still returns every matching row. Covers `testSubsearchMaxOut`.

> Note on the text-equality root cause: an earlier revision of this PR described it as "text fields can't do exact match", which was too coarse — `testSelfInSubquery` filters a text field (`country = 'USA'`) inside a self-index subquery and passes. Re-verified directly against the cluster: standalone text `=` returns no rows for every text field, keyword `=` works, and `like()` works; the three skipped tests all hinge on a text `=` filter in a cross-index subsearch. The gap is the analyzed-text exact-match scan limitation (same family as `DYNAMIC_STRING_NO_KEYWORD`), now captured precisely in `TEXT_FIELD_EXACT_MATCH`.

### Results

Run via `:integ-test:integTestRemote` against an analytics `:run` cluster.

| Test class | Analytics route — before | Analytics route — after | v2/Calcite route |
|---|---|---|---|
| `CalcitePPLScalarSubqueryIT` | 2/14 pass, 12 fail | **13/13 run, 0 fail** (1 excluded) | 14/14 pass |
| `CalcitePPLInSubqueryIT` | 7/18 pass, 11 fail | **14/15 run, 0 fail** (3 excluded; 1 pre-existing `@Ignore`) | 17/18 pass (1 `@Ignore`) |

On the analytics route the skipped tests are removed by `excludeTestsMatching` so they don't run; each also carries an in-test `assumeNotAnalytics(...)` as a safety net. The v2/Calcite route runs all of them (the gradle excludes apply only to `integTestRemote`, and `assumeNotAnalytics` is a no-op when the analytics flag is off).

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
