### PR TITLE
Stabilize CalcitePPLConditionBuiltinFunctionIT on the analytics-engine route

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1147,6 +1147,23 @@ task integTestRemote(type: RestIntegTestTask) {
             //  - subsearch.maxout is lowered as a LIMIT on the in-subquery semi-join's right side,
             //    which the AE route does not honor, so the subsearch returns all rows.
             excludeTestsMatching '*CalcitePPLInSubqueryIT.testSubsearchMaxOut'
+
+            // === Excludes: CalcitePPLConditionBuiltinFunctionIT route divergences ===
+            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
+            // AnalyticsRouteLimitation); listed here so the AE-route skip set stays countable.
+            //  - isnull/isnotnull on the object/struct parent field big5.aws: objects are flattened
+            //    to dotted leaf columns and the struct parent is not a queryable column.
+            excludeTestsMatching '*CalcitePPLConditionBuiltinFunctionIT.testIsNullWithStruct'
+            excludeTestsMatching '*CalcitePPLConditionBuiltinFunctionIT.testIsNotNullWithStruct'
+            //  - isnull/isnotnull on the nested field nested_simple.address: nested fields are
+            //    stripped at index creation (the route can't store them).
+            excludeTestsMatching '*CalcitePPLConditionBuiltinFunctionIT.testIsNullWithNested'
+            excludeTestsMatching '*CalcitePPLConditionBuiltinFunctionIT.testIsNotNullWithNested'
+            //  - concat('H', null): DataFusion treats NULL as empty string; v2/Calcite propagates NULL.
+            excludeTestsMatching '*CalcitePPLConditionBuiltinFunctionIT.testNullIfWithExpression'
+            //  - earliest('now', utc_timestamp()): 'now' and utc_timestamp() resolve to the same
+            //    instant on the route (true) but differ on v2 (false).
+            excludeTestsMatching '*CalcitePPLConditionBuiltinFunctionIT.testEarliestWithEval'
         }
     }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLConditionBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLConditionBuiltinFunctionIT.java
@@ -5,7 +5,12 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
 import static org.opensearch.sql.legacy.TestsConstants.*;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.CONCAT_NULL_AS_EMPTY;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.EARLIEST_LATEST_NOW_CLOCK;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.NESTED_FIELDS;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.STRUCT_PARENT_FIELD;
 import static org.opensearch.sql.util.MatcherUtils.*;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 
@@ -22,22 +27,29 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
     super.init();
     enableCalcite();
 
+    // init() runs as @Before, before every test method. On the analytics route the parquet-backed
+    // store is append-only on same-_id PUT, so seed the extra docs only when the index is first
+    // created — otherwise they accumulate a duplicate per test method and inflate row counts.
+    boolean stateCountryWithNullExisted =
+        isIndexExist(client(), TEST_INDEX_STATE_COUNTRY_WITH_NULL);
     loadIndex(Index.STATE_COUNTRY);
     loadIndex(Index.STATE_COUNTRY_WITH_NULL);
     loadIndex(Index.CALCS);
     loadIndex(Index.NESTED_SIMPLE);
     loadIndex(Index.BIG5);
-    Request request1 =
-        new Request("PUT", "/" + TEST_INDEX_STATE_COUNTRY_WITH_NULL + "/_doc/7?refresh=true");
-    request1.setJsonEntity(
-        "{\"name\":\"   "
-            + " \",\"age\":27,\"state\":\"B.C\",\"country\":\"Canada\",\"year\":2023,\"month\":4}");
-    client().performRequest(request1);
-    Request request2 =
-        new Request("PUT", "/" + TEST_INDEX_STATE_COUNTRY_WITH_NULL + "/_doc/8?refresh=true");
-    request2.setJsonEntity(
-        "{\"name\":\"\",\"age\":57,\"state\":\"B.C\",\"country\":\"Canada\",\"year\":2023,\"month\":4}");
-    client().performRequest(request2);
+    if (!stateCountryWithNullExisted) {
+      Request request1 =
+          new Request("PUT", "/" + TEST_INDEX_STATE_COUNTRY_WITH_NULL + "/_doc/7?refresh=true");
+      request1.setJsonEntity(
+          "{\"name\":\"   "
+              + " \",\"age\":27,\"state\":\"B.C\",\"country\":\"Canada\",\"year\":2023,\"month\":4}");
+      client().performRequest(request1);
+      Request request2 =
+          new Request("PUT", "/" + TEST_INDEX_STATE_COUNTRY_WITH_NULL + "/_doc/8?refresh=true");
+      request2.setJsonEntity(
+          "{\"name\":\"\",\"age\":57,\"state\":\"B.C\",\"country\":\"Canada\",\"year\":2023,\"month\":4}");
+      client().performRequest(request2);
+    }
   }
 
   @Test
@@ -54,6 +66,8 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testIsNullWithStruct() throws IOException {
+    // Queries the object/struct parent field 'aws' directly.
+    assumeNotAnalytics(STRUCT_PARENT_FIELD);
     JSONObject actual = executeQuery("source=big5 | where isnull(aws) | fields aws");
     verifySchema(actual, schema("aws", "struct"));
     verifyNumOfRows(actual, 0);
@@ -61,6 +75,8 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testIsNullWithNested() throws IOException {
+    // Queries a nested field; the route strips nested fields at index creation.
+    assumeNotAnalytics(NESTED_FIELDS);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -124,6 +140,8 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testIsNotNullWithStruct() throws IOException {
+    // Queries the object/struct parent field 'aws' directly.
+    assumeNotAnalytics(STRUCT_PARENT_FIELD);
     JSONObject actual = executeQuery("source=big5 | where isnotnull(aws) | fields aws");
     verifySchema(actual, schema("aws", "struct"));
     verifyNumOfRows(actual, 3);
@@ -131,6 +149,8 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testIsNotNullWithNested() throws IOException {
+    // Queries a nested field; the route strips nested fields at index creation.
+    assumeNotAnalytics(NESTED_FIELDS);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -165,6 +185,8 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testNullIfWithExpression() throws IOException {
+    // concat('H', name) over the null-name row diverges (NULL-as-empty vs NULL-propagating).
+    assumeNotAnalytics(CONCAT_NULL_AS_EMPTY);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -354,6 +376,8 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testEarliestWithEval() throws IOException {
+    // earliest('now', utc_timestamp()) resolves true on the route but false on v2 (clock source).
+    assumeNotAnalytics(EARLIEST_LATEST_NOW_CLOCK);
     JSONObject actual =
         executeQuery(
             String.format(

--- a/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
@@ -133,7 +133,42 @@ public enum AnalyticsRouteLimitation {
   SUBSEARCH_MAXOUT_IN_SUBQUERY(
       "subsearch.maxout is not honored on the analytics-engine route: the LIMIT lowered onto the"
           + " in-subquery semi-join's right side is dropped, so the subsearch returns all rows"
-          + " regardless of the cap.");
+          + " regardless of the cap."),
+
+  /**
+   * Querying an {@code object}/struct parent field directly (e.g. {@code isnull(aws)} where {@code
+   * aws} is an {@code object}) fails on the analytics-engine route with {@code FIELD_NOT_FOUND}.
+   * The route flattens objects into dotted leaf columns — {@code aws.cloudwatch.log_group} scans
+   * fine — but the struct parent is not exposed as a queryable column. Distinct from {@link
+   * #NESTED_FIELDS}: {@code object} parents survive in the OpenSearch mapping (they aren't stripped
+   * at load) yet still can't be referenced as a whole.
+   */
+  STRUCT_PARENT_FIELD(
+      "Querying an object/struct parent field directly is unsupported on the analytics-engine"
+          + " route: objects are flattened to dotted leaf columns and the parent resolves to"
+          + " FIELD_NOT_FOUND."),
+
+  /**
+   * {@code concat()} over a NULL argument diverges: the analytics-engine route (DataFusion) treats
+   * NULL as an empty string (e.g. {@code concat('H', null)} = {@code 'H'}), whereas the v2/Calcite
+   * engine propagates NULL ({@code concat('H', null)} = {@code null}). Any expression that depends
+   * on the NULL-propagating behavior over a possibly-null operand diverges.
+   */
+  CONCAT_NULL_AS_EMPTY(
+      "concat() treats a NULL argument as an empty string on the analytics-engine route (DataFusion"
+          + " semantics), whereas the v2/Calcite engine propagates NULL."),
+
+  /**
+   * {@code earliest('now', <ts>)} / {@code latest('now', <ts>)} where {@code <ts>} is {@code
+   * utc_timestamp()} diverge: on the analytics-engine route the relative-time {@code 'now'} and
+   * {@code utc_timestamp()} resolve to the same instant (so {@code earliest('now', now)} is {@code
+   * true}), whereas on the v2/Calcite path they differ (it is {@code false}) — a clock-source
+   * divergence between the relative-time evaluation and {@code utc_timestamp()}.
+   */
+  EARLIEST_LATEST_NOW_CLOCK(
+      "earliest/latest with relative-time 'now' against utc_timestamp() diverges on the"
+          + " analytics-engine route: 'now' and utc_timestamp() resolve to the same instant"
+          + " (earliest('now', now) is true), but differ on the v2/Calcite path (false).");
 
   private final String reason;
 


### PR DESCRIPTION
### Description

Brings `CalcitePPLConditionBuiltinFunctionIT` to parity on the analytics-engine route (`-Dtests.analytics.parquet_indices=true`), where every test-created index is composite/parquet-backed and PPL queries route through the analytics engine (DataFusion). The IT already passes on the v2/Calcite route; this change is test-only.

#### Root cause 1 — append-only accumulation (fixes 12 of 18 failures)

`init()` seeds two extra docs (`_id 7`, `_id 8`) into `state_country_with_null` via unconditional raw `PUT`s. `init()` runs as `@Before`, before **every** test method, and `preserveClusterUponCompletion()` keeps indices across methods. On the analytics-engine parquet-backed store a `PUT` with an existing `_id` **appends a new row** instead of replacing, so the two docs accumulated one duplicate per method and inflated row counts across the suite (the `was` counts grow monotonically: 13, 16, 25, 26, 32, 36, 42, 45, 47, 50, 52). The bulk `loadIndex(...)` calls don't have this problem because they're already `isIndexExist`-guarded. Fix: capture `isIndexExist(...)` **before** `loadIndex` creates the index, then seed the extra docs only on first creation. End state is identical on the v2/Calcite route.

#### Root cause 2 — four unsupported behaviors on the route (the remaining 6 failures)

These are genuine analytics-engine behaviors, not test bugs (each verified directly against the route). They're skipped via the `assumeNotAnalytics(...)` registry (`AnalyticsRouteLimitation`) introduced in #5551, plus matching `excludeTestsMatching` entries in `integTestRemote` so the skip set stays countable in one place. `NESTED_FIELDS` is reused; three new `AnalyticsRouteLimitation` constants:

- **`STRUCT_PARENT_FIELD`** — querying an `object`/struct parent field directly (`isnull(aws)` / `isnotnull(aws)` on `big5.aws`) resolves to `FIELD_NOT_FOUND`. The route flattens objects into dotted leaf columns (`aws.cloudwatch.log_group` scans fine) but the struct parent is not a queryable column. Distinct from `NESTED_FIELDS`: `object` parents survive in the OpenSearch mapping but still can't be referenced as a whole. (`testIsNullWithStruct`, `testIsNotNullWithStruct`)
- **`NESTED_FIELDS`** (reused) — `nested_simple.address` is type `nested`, which the route cannot store, so the test infra strips it at index creation (#5541) and the field resolves to `FIELD_NOT_FOUND`. (`testIsNullWithNested`, `testIsNotNullWithNested`)
- **`CONCAT_NULL_AS_EMPTY`** — DataFusion `concat` treats NULL as an empty string (`concat('H', null) = 'H'`), whereas v2/Calcite propagates NULL (`= null`), so the null-name row diverges. (`testNullIfWithExpression`)
- **`EARLIEST_LATEST_NOW_CLOCK`** — `earliest('now', utc_timestamp())`: the relative-time `'now'` and `utc_timestamp()` resolve to the same instant on the route (`now >= now` → `true`), but differ on v2/Calcite (`false`) — a clock-source divergence. (`testEarliestWithEval`)

### Results

Run via `:integ-test:integTestRemote` against an analytics `:run` cluster.

| Test class | Analytics route — before | Analytics route — after | v2/Calcite route |
|---|---|---|---|
| `CalcitePPLConditionBuiltinFunctionIT` | 6/24 pass, 18 fail | **18/18 run, 0 fail** (6 excluded) | 24/24 pass |

On the analytics route the skipped tests are removed by `excludeTestsMatching` so they don't run; each also carries an in-test `assumeNotAnalytics(...)` as a safety net. The v2/Calcite route runs all 24 (the gradle excludes apply only to `integTestRemote`, and `assumeNotAnalytics` is a no-op when the analytics flag is off).

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
