### PR TITLE
Recover ANY-typed column schema on the analytics route (fixes eval max/min)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -32,6 +32,7 @@ import org.opensearch.sql.common.response.ResponseListener;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.executor.ExecutionContext;
 import org.opensearch.sql.executor.ExecutionEngine;
@@ -123,7 +124,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
                   try {
                     List<RelDataTypeField> fields = plan.getRowType().getFieldList();
                     List<ExprValue> results = convertRows(rows, fields);
-                    Schema schema = buildSchema(fields);
+                    Schema schema = buildSchema(fields, results);
                     profileCtx
                         .getOrCreateMetric(MetricName.EXECUTE)
                         .set(System.nanoTime() - execStart);
@@ -193,9 +194,9 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
 
   private QueryResponse buildProfiledResponse(RelNode plan, ProfiledResult result) {
     List<RelDataTypeField> fields = plan.getRowType().getFieldList();
-    Schema schema = buildSchema(fields);
     List<ExprValue> results =
         result.rows() != null ? convertRows(result.rows(), fields) : List.of();
+    Schema schema = buildSchema(fields, results);
     QueryResponse response = new QueryResponse(schema, results, Cursor.None);
     response.setProfile(result.profile());
     if (!result.isSuccess()) {
@@ -265,10 +266,20 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
     return out;
   }
 
-  private Schema buildSchema(List<RelDataTypeField> fields) {
+  private Schema buildSchema(List<RelDataTypeField> fields, List<ExprValue> results) {
     List<Schema.Column> columns = new ArrayList<>();
     for (RelDataTypeField field : fields) {
       ExprType exprType = convertType(field.getType());
+      // A column whose planned type is ANY (e.g. the SCALAR_MAX/SCALAR_MIN UDFs declare ANY since
+      // they accept mixed numeric/string operands) maps to UNDEFINED. Recover the concrete type
+      // from the first row's runtime value, mirroring OpenSearchExecutionEngine.buildResultSet on
+      // the Calcite path so both routes report the same schema type.
+      if (exprType == ExprCoreType.UNDEFINED && !results.isEmpty()) {
+        ExprValue cell = results.getFirst().tupleValue().get(field.getName());
+        if (cell != null && !cell.isNull() && !cell.isMissing()) {
+          exprType = cell.type();
+        }
+      }
       columns.add(new Schema.Column(field.getName(), null, exprType));
     }
     return new Schema(columns);

--- a/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngineTest.java
@@ -167,6 +167,39 @@ class AnalyticsExecutionEngineTest {
         6.0, response.getResults().get(0).tupleValue().get("d").value(), "double value. " + dump);
   }
 
+  /**
+   * A column whose planned type is ANY (e.g. the SCALAR_MAX/SCALAR_MIN UDFs declare ANY) maps to
+   * UNDEFINED; recover the concrete type from the first row's runtime value so the schema matches
+   * the Calcite path instead of reporting "undefined".
+   */
+  @Test
+  void executeRelNode_anyColumnRecoversTypeFromFirstRow() {
+    RelNode relNode = mockRelNode("age", SqlTypeName.BIGINT, "new", SqlTypeName.ANY);
+    Iterable<Object[]> rows = Arrays.asList(new Object[] {2L, 3}, new Object[] {4L, 4});
+    stubExecutorWith(relNode, rows);
+
+    QueryResponse response = executeAndCapture(relNode);
+    String dump = dumpResponse(response);
+
+    // 'new' is ANY in the plan but the first row's value is an Integer → schema reports INTEGER.
+    assertEquals(ExprCoreType.LONG, response.getSchema().getColumns().get(0).getExprType(), dump);
+    assertEquals(
+        ExprCoreType.INTEGER, response.getSchema().getColumns().get(1).getExprType(), dump);
+  }
+
+  /** ANY column with no rows to derive from stays UNDEFINED (mirrors the Calcite path fallback). */
+  @Test
+  void executeRelNode_anyColumnEmptyResultsStaysUndefined() {
+    RelNode relNode = mockRelNode("new", SqlTypeName.ANY);
+    stubExecutorWith(relNode, Collections.emptyList());
+
+    QueryResponse response = executeAndCapture(relNode);
+    String dump = dumpResponse(response);
+
+    assertEquals(
+        ExprCoreType.UNDEFINED, response.getSchema().getColumns().get(0).getExprType(), dump);
+  }
+
   @Test
   void executeRelNode_temporalTypes() {
     RelNode relNode =

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1164,6 +1164,18 @@ task integTestRemote(type: RestIntegTestTask) {
             //  - earliest('now', utc_timestamp()): 'now' and utc_timestamp() resolve to the same
             //    instant on the route (true) but differ on v2 (false).
             excludeTestsMatching '*CalcitePPLConditionBuiltinFunctionIT.testEarliestWithEval'
+
+            // === Excludes: CalcitePPLEvalMaxMinFunctionIT route divergences ===
+            // The AnalyticsExecutionEngine ANY-rescue (this PR) fixes the homogeneous max()/min()
+            // schema types, so most of the class now passes on the AE route. Three tests still
+            // diverge; each carries an in-test assumeNotAnalytics(...) (see AnalyticsRouteLimitation).
+            //  - Mixed numeric+string operands throw 'Cannot infer return type for GREATEST' (the
+            //    DataFusion GREATEST/LEAST can't unify heterogeneous operand types).
+            excludeTestsMatching '*CalcitePPLEvalMaxMinFunctionIT.testEvalMaxNumericAndString'
+            excludeTestsMatching '*CalcitePPLEvalMaxMinFunctionIT.testEvalMinNumericAndString'
+            //  - max() over int operands reports bigint on the AE route (DataFusion widens integers
+            //    to Int64) where the v2/Calcite path reports int.
+            excludeTestsMatching '*CalcitePPLEvalMaxMinFunctionIT.testEvalMaxNumeric'
         }
     }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEvalMaxMinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEvalMaxMinFunctionIT.java
@@ -7,6 +7,8 @@ package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DOG;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NULL_MISSING;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.EVAL_MAX_MIN_INT_WIDENING;
+import static org.opensearch.sql.util.AnalyticsRouteLimitation.EVAL_MAX_MIN_MIXED_TYPES;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -28,6 +30,8 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testEvalMaxNumeric() throws Exception {
+    // max(1, 3, age) selects an int-valued result; the AE route reports it as bigint.
+    assumeNotAnalytics(EVAL_MAX_MIN_INT_WIDENING);
     JSONObject result =
         executeQuery(
             String.format(
@@ -49,6 +53,8 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testEvalMaxNumericAndString() throws Exception {
+    // Mixed numeric+string operands -> 'Cannot infer return type for GREATEST' on the AE route.
+    assumeNotAnalytics(EVAL_MAX_MIN_MIXED_TYPES);
     JSONObject result =
         executeQuery(
             String.format(
@@ -83,6 +89,8 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testEvalMinNumericAndString() throws Exception {
+    // Mixed numeric+string operands -> 'Cannot infer return type for GREATEST' on the AE route.
+    assumeNotAnalytics(EVAL_MAX_MIN_MIXED_TYPES);
     JSONObject result =
         executeQuery(
             String.format(

--- a/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/AnalyticsRouteLimitation.java
@@ -168,7 +168,31 @@ public enum AnalyticsRouteLimitation {
   EARLIEST_LATEST_NOW_CLOCK(
       "earliest/latest with relative-time 'now' against utc_timestamp() diverges on the"
           + " analytics-engine route: 'now' and utc_timestamp() resolve to the same instant"
-          + " (earliest('now', now) is true), but differ on the v2/Calcite path (false).");
+          + " (earliest('now', now) is true), but differ on the v2/Calcite path (false)."),
+
+  /**
+   * eval {@code max(...)} / {@code min(...)} over operands that mix numeric and string types (e.g.
+   * {@code max(14, age, 'Fred', holdersName)}) throws {@code SqlValidatorException: Cannot infer
+   * return type for GREATEST} on the analytics-engine route. The SCALAR_MAX/SCALAR_MIN UDF is
+   * converted to a DataFusion {@code GREATEST}/{@code LEAST} during Substrait conversion, and that
+   * operator can't unify heterogeneous operand types. The v2/Calcite path applies OpenSearch's
+   * mixed-type comparison (strings sort above numbers) and returns a result.
+   */
+  EVAL_MAX_MIN_MIXED_TYPES(
+      "eval max()/min() over mixed numeric+string operands throws 'Cannot infer return type for"
+          + " GREATEST' on the analytics-engine route: the DataFusion GREATEST/LEAST can't unify"
+          + " heterogeneous operand types."),
+
+  /**
+   * eval {@code max(...)} / {@code min(...)} over all-integer operands reports the result column as
+   * {@code bigint} on the analytics-engine route — DataFusion widens integer results to Int64 —
+   * whereas the v2/Calcite path reports {@code int} when the selected value fits in an int. The
+   * values match; only the schema's integer width differs.
+   */
+  EVAL_MAX_MIN_INT_WIDENING(
+      "eval max()/min() over integer operands reports the result column as bigint on the"
+          + " analytics-engine route (DataFusion widens integers to Int64), whereas the v2/Calcite"
+          + " path reports int.");
 
   private final String reason;
 


### PR DESCRIPTION
### Description

Brings `CalcitePPLEvalMaxMinFunctionIT` to parity on the analytics-engine route (`-Dtests.analytics.parquet_indices=true`) by **fixing a real schema-type defect** on the analytics path, then skipping the two genuinely-unsupported residual cases. The IT passes on the v2/Calcite route; the engine fix is shared, the skips are analytics-route-only.

#### The defect (commit 1)

PPL `eval max(...)` / `min(...)` lower to the `SCALAR_MAX` / `SCALAR_MIN` UDFs, which **declare their return type as `ANY`** (they accept mixed numeric/string operands, with OpenSearch's "strings sort above numbers" semantics). `ANY` maps to `UNDEFINED` → the schema reports the result column as `"undefined"`.

The v2/Calcite path already handles this: `OpenSearchExecutionEngine.buildResultSet` sees `ANY` and **recovers the concrete type from the first row's runtime `ExprValue`**. The analytics path (`AnalyticsExecutionEngine.buildSchema`) built the schema **purely from the planned `RelDataType`**, with no such recovery — so the column came back `undefined` even though the values were correct.

Fix: mirror the Calcite-path behavior in `AnalyticsExecutionEngine.buildSchema` — when a column's converted type is `UNDEFINED` and a result row exists, take the concrete type from the first row's value. The rows are already converted before the schema is built, so there's no extra work. Behavior on the v2 path is unchanged. This is generic — it fixes *any* `ANY`-typed UDF column on the analytics route, not just max/min. Covered by two new `AnalyticsExecutionEngineTest` cases (recovery from first row; stays `UNDEFINED` when empty, matching the Calcite fallback).

#### Residual divergences (commit 2)

With the fix, **5 of 8 tests pass** on the analytics route. The remaining 3 are genuine route behaviors, skipped via `assumeNotAnalytics(...)` + `excludeTestsMatching`:

- **`EVAL_MAX_MIN_MIXED_TYPES`** (2 tests) — mixed numeric+string operands (`max(14, age, 'Fred', holdersName)`) throw `SqlValidatorException: Cannot infer return type for GREATEST`. The UDF is converted to a DataFusion `GREATEST`/`LEAST` during Substrait conversion (in OpenSearch core), which can't unify heterogeneous operand types. Out of scope for this repo.
- **`EVAL_MAX_MIN_INT_WIDENING`** (1 test) — `max(1, 3, age)` reports `bigint` on the route (DataFusion widens integer results to Int64) where v2/Calcite reports `int`. Values match; only the integer width differs.

### Results

Run via `:integ-test:integTestRemote` against an analytics `:run` cluster.

| Test class | Analytics route — before | Analytics route — after | v2/Calcite route |
|---|---|---|---|
| `CalcitePPLEvalMaxMinFunctionIT` | 0/8 pass, 8 fail | **5/8 pass, 3 excluded, 0 fail** | 8/8 pass |

The 8 failures before split into 6 `undefined`-schema (now fixed by the engine change) and 2 mixed-type 500s. After the fix, 5 pass; the 3 skips are 2 mixed-type + 1 int-widening. The v2 route runs all 8 (the engine fix doesn't change v2 types; `assumeNotAnalytics` is a no-op off-route; gradle excludes apply only to `integTestRemote`).

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
