### PR TITLE
[Bug Fix] Fix PPL syntax highlighting accepting invalid `field=`/comparison source fields

### DIFF
--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -422,11 +422,11 @@ rareTopOption
    ;
 
 grokCommand
-   : GROK (source_field = expression) (pattern = stringLiteral)
+   : GROK (source_field = valueExpression) (pattern = stringLiteral)
    ;
 
 parseCommand
-   : PARSE (source_field = expression) (pattern = stringLiteral)
+   : PARSE (source_field = valueExpression) (pattern = stringLiteral)
    ;
 
 spathCommand
@@ -434,8 +434,8 @@ spathCommand
    ;
 
 spathParameter
-   : (INPUT EQUAL input = expression)
-   | (OUTPUT EQUAL output = expression)
+   : (INPUT EQUAL input = fieldExpression)
+   | (OUTPUT EQUAL output = fieldExpression)
    | ((PATH EQUAL)? path = indexablePath)
    ;
 
@@ -478,7 +478,7 @@ patternsMethod
    ;
 
 patternsCommand
-   : PATTERNS (source_field = expression) (statsByClause)? (patternsCommandOption)* (patternsParameter)*
+   : PATTERNS (source_field = valueExpression) (statsByClause)? (patternsCommandOption)* (patternsParameter)*
    ;
 
 patternsCommandOption

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -954,6 +954,69 @@ public class AstBuilderTest extends AstPlanningTestBase {
     assertEqual("source=t | spath input=f output=o", spath(relation("t"), "f", "o", null));
   }
 
+  // Narrowing source_field from `expression` to `valueExpression` rejects misparse-as-comparison.
+
+  @Test
+  public void testGrokCommandRejectsNamedFieldParameter() {
+    assertThrows(SyntaxCheckException.class, () -> plan("source=t | grok field=raw \"pattern\""));
+  }
+
+  @Test
+  public void testParseCommandRejectsNamedFieldParameter() {
+    assertThrows(SyntaxCheckException.class, () -> plan("source=t | parse field=raw \"pattern\""));
+  }
+
+  @Test
+  public void testPatternsCommandRejectsNamedFieldParameter() {
+    assertThrows(SyntaxCheckException.class, () -> plan("source=t | patterns field=raw"));
+  }
+
+  @Test
+  public void testGrokCommandRejectsComparisonSourceField() {
+    assertThrows(SyntaxCheckException.class, () -> plan("source=t | grok raw > 0 \"pattern\""));
+  }
+
+  @Test
+  public void testGrokCommandRejectsKeywordNamedParameter() {
+    // Covers a searchableKeyWord beyond FIELD (max_match=body misparses today too).
+    assertThrows(
+        SyntaxCheckException.class, () -> plan("source=t | grok max_match=body \"pattern\""));
+  }
+
+  @Test
+  public void testSpathCommandRejectsComparisonInInput() {
+    assertThrows(SyntaxCheckException.class, () -> plan("source=t | spath input=a=b"));
+  }
+
+  @Test
+  public void testSpathCommandRejectsComparisonInOutput() {
+    assertThrows(SyntaxCheckException.class, () -> plan("source=t | spath input=f output=a=b"));
+  }
+
+  @Test
+  public void testSpathCommandRejectsFunctionCallInput() {
+    // spath stringifies its input; a function call is not a valid field path.
+    assertThrows(
+        SyntaxCheckException.class, () -> plan("source=t | spath input=substring(doc,1,3)"));
+  }
+
+  @Test
+  public void testGrokCommandStillAcceptsDottedAndKeywordFields() {
+    plan("source=t | grok log.message \"pattern\""); // dotted path
+    plan("source=t | grok source \"pattern\""); // keyword-as-id field name
+  }
+
+  @Test
+  public void testParseCommandStillAcceptsFunctionCallSource() {
+    // Regression guard: this is what narrowing all the way to fieldExpression would have broken.
+    plan("source=t | parse substring(raw, 1, 5) \"pattern\"");
+  }
+
+  @Test
+  public void testPatternsCommandStillAcceptsDottedFieldWithOptions() {
+    plan("source=t | patterns log.message method=simple_pattern mode=label");
+  }
+
   @Test
   public void testKmeansCommand() {
     assertEqual(


### PR DESCRIPTION
### Description

The grammar typed the source field of `grok`/`parse`/`patterns` (and `spath` `input=`/`output=`) as the broad `expression` rule. Any `<name>=<name>` form (e.g. `grok field=body "..."`, `grok foo=bar "..."`) matched the `compareExpr` alternative and was silently accepted — parsed as a comparison instead of a syntax error. On clusters >= 3.6 where the Explore editor uses the runtime grammar bundle (via `/_plugins/_ppl/_grammar`), there was no error highlighting at all for these forms. The documented form is positional (`grok <field> <pattern>`).

This narrows each source-field slot to the tightest rule matching the command's contract, tightening both the server parser (rejects at parse time instead of misparsing) and the grammar bundle the Explore editor consumes:

- grok / parse / patterns: `expression` → `valueExpression` (drops comparisons, keeps function-call/arithmetic sources like `parse DATE_FORMAT(...) '...'`)
- spath input/output: `expression` → `fieldExpression` (source is stringified into a field name, never evaluated)

### Testing

- 8 negative tests asserting `SyntaxCheckException` for invalid forms
- 3 positive regression guards (dotted/keyword fields, function-call source, patterns with options)
- Verified server-side: `POST /_plugins/_ppl` with invalid forms returns 400; valid forms execute correctly

### Related Issues
Resolves #5558

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command checklist all confirmed.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.