### PR TITLE
Decouple IT from execution backend with capability-based gating

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1084,8 +1084,8 @@ task integTestRemote(type: RestIntegTestTask) {
             excludeTestsMatching 'org.opensearch.sql.calcite.remote.CalciteAliasFieldAggregationIT'
 
             // === Excludes: WhereCommandIT / CalciteWhereCommandIT route divergences (#5546) ===
-            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
-            // AnalyticsRouteLimitation); listed here so the AE-route skip set stays countable in one
+            // Each test also carries an in-test requireCapability(...) recording the reason (see
+            // Capability); listed here so the AE-route skip set stays countable in one
             // place. Reasons:
             //  - Nested-field queries: the parquet/composite store has no nested-document support, so
             //    nested fields are stripped at load (#5541). Defined only in CalciteWhereCommandIT.
@@ -1104,8 +1104,8 @@ task integTestRemote(type: RestIntegTestTask) {
             excludeTestsMatching '*WhereCommandIT.testDoubleEqualWithSpecialCharacters'
 
             // === Excludes: CalciteMultisearchCommandIT route divergences ===
-            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
-            // AnalyticsRouteLimitation); listed here so the AE-route skip set stays countable.
+            // Each test also carries an in-test requireCapability(...) recording the reason (see
+            // Capability); listed here so the AE-route skip set stays countable.
             //  - Same-index subsearch conflation: when every subsearch reads the same index, the AE
             //    route applies the first subsearch's filter to all of them, so counts are wrong.
             excludeTestsMatching '*CalciteMultisearchCommandIT.testMultisearchWithThreeSubsearches'
@@ -1119,15 +1119,15 @@ task integTestRemote(type: RestIntegTestTask) {
             // bin on a time field then grouping by it: the AE route types the date-histogram bucket
             // column as string (not timestamp) AND produces a different bucket set (auto-histogram
             // span / empty-bucket filtering differ), so both schema and row counts diverge. Each
-            // test also carries an in-test assumeNotAnalytics(...) (see AnalyticsRouteLimitation).
+            // test also carries an in-test requireCapability(...) (see Capability).
             excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeField_Count'
             excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeField_Avg'
             excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeAndTermField_Count'
             excludeTestsMatching '*CalciteBinCommandIT.testStatsWithBinsOnTimeAndTermField_Avg'
 
             // === Excludes: CalcitePPLEnhancedCoalesceIT route divergences ===
-            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
-            // AnalyticsRouteLimitation). The other ordering-sensitive coalesce tests were fixed in
+            // Each test also carries an in-test requireCapability(...) recording the reason (see
+            // Capability). The other ordering-sensitive coalesce tests were fixed in
             // place with an explicit `sort` instead of being skipped.
             //  - COALESCE over all-untyped-null operands is rejected by the capability registry.
             excludeTestsMatching '*CalcitePPLEnhancedCoalesceIT.testCoalesceWithAllNonExistentFields'
@@ -1137,8 +1137,8 @@ task integTestRemote(type: RestIntegTestTask) {
             excludeTestsMatching '*CalcitePPLEnhancedCoalesceIT.testCoalesceBasic'
 
             // === Excludes: CalcitePPLScalarSubqueryIT / CalcitePPLInSubqueryIT route divergences ===
-            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
-            // AnalyticsRouteLimitation); listed here so the AE-route skip set stays countable.
+            // Each test also carries an in-test requireCapability(...) recording the reason (see
+            // Capability); listed here so the AE-route skip set stays countable.
             //  - Exact equality on an explicitly text-mapped field (department/occupation = '...')
             //    in the subsearch returns no rows on the AE route (analyzed text, no .keyword).
             excludeTestsMatching '*CalcitePPLScalarSubqueryIT.testTwoUncorrelatedScalarSubqueriesInOr'
@@ -1149,8 +1149,8 @@ task integTestRemote(type: RestIntegTestTask) {
             excludeTestsMatching '*CalcitePPLInSubqueryIT.testSubsearchMaxOut'
 
             // === Excludes: CalcitePPLConditionBuiltinFunctionIT route divergences ===
-            // Each test also carries an in-test assumeNotAnalytics(...) recording the reason (see
-            // AnalyticsRouteLimitation); listed here so the AE-route skip set stays countable.
+            // Each test also carries an in-test requireCapability(...) recording the reason (see
+            // Capability); listed here so the AE-route skip set stays countable.
             //  - isnull/isnotnull on the object/struct parent field big5.aws: objects are flattened
             //    to dotted leaf columns and the struct parent is not a queryable column.
             excludeTestsMatching '*CalcitePPLConditionBuiltinFunctionIT.testIsNullWithStruct'
@@ -1168,7 +1168,7 @@ task integTestRemote(type: RestIntegTestTask) {
             // === Excludes: CalcitePPLEvalMaxMinFunctionIT route divergences ===
             // The AnalyticsExecutionEngine ANY-rescue (this PR) fixes the homogeneous max()/min()
             // schema types, so most of the class now passes on the AE route. Three tests still
-            // diverge; each carries an in-test assumeNotAnalytics(...) (see AnalyticsRouteLimitation).
+            // diverge; each carries an in-test requireCapability(...) (see Capability).
             //  - Mixed numeric+string operands throw 'Cannot infer return type for GREATEST' (the
             //    DataFusion GREATEST/LEAST can't unify heterogeneous operand types).
             excludeTestsMatching '*CalcitePPLEvalMaxMinFunctionIT.testEvalMaxNumericAndString'

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.sql.legacy.TestsConstants.*;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.BIN_TIME_FIELD_BUCKETING;
+import static org.opensearch.sql.util.Capability.BIN_TIME_FIELD_BUCKETING;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -21,6 +21,7 @@ import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalciteBinCommandIT extends PPLIntegTestCase {
   @Override
@@ -870,10 +871,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(BIN_TIME_FIELD_BUCKETING)
   public void testStatsWithBinsOnTimeField_Count() throws IOException {
     // TODO: Remove this after addressing https://github.com/opensearch-project/sql/issues/4317
     enabledOnlyWhenPushdownIsEnabled();
-    assumeNotAnalytics(BIN_TIME_FIELD_BUCKETING);
 
     JSONObject result =
         executeQuery("source=events_null | bin @timestamp bins=3 | stats count() by @timestamp");
@@ -909,10 +910,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(BIN_TIME_FIELD_BUCKETING)
   public void testStatsWithBinsOnTimeField_Avg() throws IOException {
     // TODO: Remove this after addressing https://github.com/opensearch-project/sql/issues/4317
     enabledOnlyWhenPushdownIsEnabled();
-    assumeNotAnalytics(BIN_TIME_FIELD_BUCKETING);
 
     JSONObject result =
         executeQuery(
@@ -951,10 +952,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(BIN_TIME_FIELD_BUCKETING)
   public void testStatsWithBinsOnTimeAndTermField_Count() throws IOException {
     // TODO: Remove this after addressing https://github.com/opensearch-project/sql/issues/4317
     enabledOnlyWhenPushdownIsEnabled();
-    assumeNotAnalytics(BIN_TIME_FIELD_BUCKETING);
 
     JSONObject result =
         executeQuery(
@@ -975,10 +976,10 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(BIN_TIME_FIELD_BUCKETING)
   public void testStatsWithBinsOnTimeAndTermField_Avg() throws IOException {
     // TODO: Remove this after addressing https://github.com/opensearch-project/sql/issues/4317
     enabledOnlyWhenPushdownIsEnabled();
-    assumeNotAnalytics(BIN_TIME_FIELD_BUCKETING);
 
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExpandCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExpandCommandIT.java
@@ -7,7 +7,7 @@ package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ARRAY;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.DOC_MUTATION;
+import static org.opensearch.sql.util.Capability.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -20,6 +20,7 @@ import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalciteExpandCommandIT extends PPLIntegTestCase {
   @Override
@@ -295,8 +296,8 @@ public class CalciteExpandCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testExpandEmptyArray() throws Exception {
-    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 6;
     Request insertRequest =
         new Request(
@@ -325,8 +326,8 @@ public class CalciteExpandCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testExpandOnNullField() throws Exception {
-    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 6;
     Request insertRequest =
         new Request(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultisearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultisearchCommandIT.java
@@ -6,8 +6,8 @@
 package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.*;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.MULTISEARCH_COLUMN_ORDER;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.MULTISEARCH_SAME_INDEX_CONFLATION;
+import static org.opensearch.sql.util.Capability.MULTISEARCH_COLUMN_ORDER;
+import static org.opensearch.sql.util.Capability.MULTISEARCH_SAME_INDEX_CONFLATION;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -18,6 +18,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
 
@@ -66,8 +67,8 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(MULTISEARCH_SAME_INDEX_CONFLATION)
   public void testMultisearchWithThreeSubsearches() throws IOException {
-    assumeNotAnalytics(MULTISEARCH_SAME_INDEX_CONFLATION);
     JSONObject result =
         executeQuery(
             String.format(
@@ -83,8 +84,8 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(MULTISEARCH_SAME_INDEX_CONFLATION)
   public void testMultisearchWithComplexAggregation() throws IOException {
-    assumeNotAnalytics(MULTISEARCH_SAME_INDEX_CONFLATION);
     JSONObject result =
         executeQuery(
             String.format(
@@ -146,8 +147,8 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(MULTISEARCH_COLUMN_ORDER)
   public void testMultisearchWithTimestampInterleaving() throws IOException {
-    assumeNotAnalytics(MULTISEARCH_COLUMN_ORDER);
     JSONObject result =
         executeQuery(
             "| multisearch [search"
@@ -357,8 +358,8 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
 
   /** Reproduce #5145: multisearch without further processing should return all rows. */
   @Test
+  @RequiresCapability(MULTISEARCH_SAME_INDEX_CONFLATION)
   public void testMultisearchWithoutFurtherProcessing() throws IOException {
-    assumeNotAnalytics(MULTISEARCH_SAME_INDEX_CONFLATION);
     JSONObject result =
         executeQuery(
             "| multisearch [search source=opensearch-sql_test_index_time_data | where category ="

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLConditionBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLConditionBuiltinFunctionIT.java
@@ -7,10 +7,10 @@ package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
 import static org.opensearch.sql.legacy.TestsConstants.*;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.CONCAT_NULL_AS_EMPTY;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.EARLIEST_LATEST_NOW_CLOCK;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.NESTED_FIELDS;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.STRUCT_PARENT_FIELD;
+import static org.opensearch.sql.util.Capability.CONCAT_NULL_AS_EMPTY;
+import static org.opensearch.sql.util.Capability.EARLIEST_LATEST_NOW_CLOCK;
+import static org.opensearch.sql.util.Capability.NESTED_FIELDS;
+import static org.opensearch.sql.util.Capability.STRUCT_PARENT_FIELD;
 import static org.opensearch.sql.util.MatcherUtils.*;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 
@@ -20,6 +20,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
   @Override
@@ -65,18 +66,20 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = STRUCT_PARENT_FIELD,
+      note = "Queries the object/struct parent field 'aws' directly.")
   public void testIsNullWithStruct() throws IOException {
-    // Queries the object/struct parent field 'aws' directly.
-    assumeNotAnalytics(STRUCT_PARENT_FIELD);
     JSONObject actual = executeQuery("source=big5 | where isnull(aws) | fields aws");
     verifySchema(actual, schema("aws", "struct"));
     verifyNumOfRows(actual, 0);
   }
 
   @Test
+  @RequiresCapability(
+      value = NESTED_FIELDS,
+      note = "Queries a nested field; the route strips nested fields at index creation.")
   public void testIsNullWithNested() throws IOException {
-    // Queries a nested field; the route strips nested fields at index creation.
-    assumeNotAnalytics(NESTED_FIELDS);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -139,18 +142,20 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = STRUCT_PARENT_FIELD,
+      note = "Queries the object/struct parent field 'aws' directly.")
   public void testIsNotNullWithStruct() throws IOException {
-    // Queries the object/struct parent field 'aws' directly.
-    assumeNotAnalytics(STRUCT_PARENT_FIELD);
     JSONObject actual = executeQuery("source=big5 | where isnotnull(aws) | fields aws");
     verifySchema(actual, schema("aws", "struct"));
     verifyNumOfRows(actual, 3);
   }
 
   @Test
+  @RequiresCapability(
+      value = NESTED_FIELDS,
+      note = "Queries a nested field; the route strips nested fields at index creation.")
   public void testIsNotNullWithNested() throws IOException {
-    // Queries a nested field; the route strips nested fields at index creation.
-    assumeNotAnalytics(NESTED_FIELDS);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -184,9 +189,11 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = CONCAT_NULL_AS_EMPTY,
+      note =
+          "concat('H', name) over the null-name row diverges (NULL-as-empty vs NULL-propagating).")
   public void testNullIfWithExpression() throws IOException {
-    // concat('H', name) over the null-name row diverges (NULL-as-empty vs NULL-propagating).
-    assumeNotAnalytics(CONCAT_NULL_AS_EMPTY);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -375,9 +382,12 @@ public class CalcitePPLConditionBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = EARLIEST_LATEST_NOW_CLOCK,
+      note =
+          "earliest('now', utc_timestamp()) resolves true on the route but false on v2 (clock"
+              + " source).")
   public void testEarliestWithEval() throws IOException {
-    // earliest('now', utc_timestamp()) resolves true on the route but false on v2 (clock source).
-    assumeNotAnalytics(EARLIEST_LATEST_NOW_CLOCK);
     JSONObject actual =
         executeQuery(
             String.format(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEnhancedCoalesceIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEnhancedCoalesceIT.java
@@ -6,8 +6,8 @@
 package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.*;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.COALESCE_ALL_NULL_OPERANDS;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.HEAD_WITHOUT_STABLE_SORT;
+import static org.opensearch.sql.util.Capability.COALESCE_ALL_NULL_OPERANDS;
+import static org.opensearch.sql.util.Capability.HEAD_WITHOUT_STABLE_SORT;
 import static org.opensearch.sql.util.MatcherUtils.*;
 
 import java.io.IOException;
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
   @Override
@@ -38,8 +39,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(HEAD_WITHOUT_STABLE_SORT)
   public void testCoalesceBasic() throws IOException {
-    assumeNotAnalytics(HEAD_WITHOUT_STABLE_SORT);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -54,8 +55,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(HEAD_WITHOUT_STABLE_SORT)
   public void testCoalesceWithMixedTypes() throws IOException {
-    assumeNotAnalytics(HEAD_WITHOUT_STABLE_SORT);
     JSONObject actual =
         executeQuery(
             String.format(
@@ -164,8 +165,8 @@ public class CalcitePPLEnhancedCoalesceIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(COALESCE_ALL_NULL_OPERANDS)
   public void testCoalesceWithAllNonExistentFields() throws IOException {
-    assumeNotAnalytics(COALESCE_ALL_NULL_OPERANDS);
     JSONObject actual =
         executeQuery(
             String.format(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEvalMaxMinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEvalMaxMinFunctionIT.java
@@ -7,8 +7,8 @@ package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DOG;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NULL_MISSING;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.EVAL_MAX_MIN_INT_WIDENING;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.EVAL_MAX_MIN_MIXED_TYPES;
+import static org.opensearch.sql.util.Capability.EVAL_MAX_MIN_INT_WIDENING;
+import static org.opensearch.sql.util.Capability.EVAL_MAX_MIN_MIXED_TYPES;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -17,6 +17,7 @@ import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
   @Override
@@ -29,9 +30,10 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = EVAL_MAX_MIN_INT_WIDENING,
+      note = "max(1, 3, age) selects an int-valued result; the AE route reports it as bigint.")
   public void testEvalMaxNumeric() throws Exception {
-    // max(1, 3, age) selects an int-valued result; the AE route reports it as bigint.
-    assumeNotAnalytics(EVAL_MAX_MIN_INT_WIDENING);
     JSONObject result =
         executeQuery(
             String.format(
@@ -52,9 +54,12 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = EVAL_MAX_MIN_MIXED_TYPES,
+      note =
+          "Mixed numeric+string operands -> 'Cannot infer return type for GREATEST' on the AE"
+              + " route.")
   public void testEvalMaxNumericAndString() throws Exception {
-    // Mixed numeric+string operands -> 'Cannot infer return type for GREATEST' on the AE route.
-    assumeNotAnalytics(EVAL_MAX_MIN_MIXED_TYPES);
     JSONObject result =
         executeQuery(
             String.format(
@@ -88,9 +93,12 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = EVAL_MAX_MIN_MIXED_TYPES,
+      note =
+          "Mixed numeric+string operands -> 'Cannot infer return type for GREATEST' on the AE"
+              + " route.")
   public void testEvalMinNumericAndString() throws Exception {
-    // Mixed numeric+string operands -> 'Cannot infer return type for GREATEST' on the AE route.
-    assumeNotAnalytics(EVAL_MAX_MIN_MIXED_TYPES);
     JSONObject result =
         executeQuery(
             String.format(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLInSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLInSubqueryIT.java
@@ -9,8 +9,8 @@ import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_OCCUPATION;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORKER;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORK_INFORMATION;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.SUBSEARCH_MAXOUT_IN_SUBQUERY;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.TEXT_FIELD_EXACT_MATCH;
+import static org.opensearch.sql.util.Capability.SUBSEARCH_MAXOUT_IN_SUBQUERY;
+import static org.opensearch.sql.util.Capability.TEXT_FIELD_EXACT_MATCH;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLInSubqueryIT extends PPLIntegTestCase {
 
@@ -348,9 +349,10 @@ public class CalcitePPLInSubqueryIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = TEXT_FIELD_EXACT_MATCH,
+      note = "Subsearch filters a text-mapped field with exact equality (i.department = 'DATA').")
   public void testInSubqueryWithTableAlias() throws IOException {
-    // Subsearch filters a text-mapped field with exact equality (i.department = 'DATA').
-    assumeNotAnalytics(TEXT_FIELD_EXACT_MATCH);
     JSONObject result =
         executeQuery(
             String.format(
@@ -368,9 +370,10 @@ public class CalcitePPLInSubqueryIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = TEXT_FIELD_EXACT_MATCH,
+      note = "Subsearch filters a text-mapped field with exact equality (occupation = 'Engineer').")
   public void testInCorrelatedSubquery() throws IOException {
-    // Subsearch filters a text-mapped field with exact equality (occupation = 'Engineer').
-    assumeNotAnalytics(TEXT_FIELD_EXACT_MATCH);
     JSONObject result =
         executeQuery(
             String.format(
@@ -384,8 +387,8 @@ public class CalcitePPLInSubqueryIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(SUBSEARCH_MAXOUT_IN_SUBQUERY)
   public void testSubsearchMaxOut() throws IOException {
-    assumeNotAnalytics(SUBSEARCH_MAXOUT_IN_SUBQUERY);
     setSubsearchMaxOut(1);
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLScalarSubqueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLScalarSubqueryIT.java
@@ -9,7 +9,7 @@ import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_OCCUPATION;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORKER;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WORK_INFORMATION;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.TEXT_FIELD_EXACT_MATCH;
+import static org.opensearch.sql.util.Capability.TEXT_FIELD_EXACT_MATCH;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -21,6 +21,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLScalarSubqueryIT extends PPLIntegTestCase {
 
@@ -237,9 +238,10 @@ public class CalcitePPLScalarSubqueryIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = TEXT_FIELD_EXACT_MATCH,
+      note = "Subsearch filters a text-mapped field with exact equality (department = 'DATA').")
   public void testTwoUncorrelatedScalarSubqueriesInOr() throws IOException {
-    // Subsearch filters a text-mapped field with exact equality (department = 'DATA').
-    assumeNotAnalytics(TEXT_FIELD_EXACT_MATCH);
     JSONObject result =
         executeQuery(
             String.format(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteStreamstatsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteStreamstatsCommandIT.java
@@ -6,7 +6,7 @@
 package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.*;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.DOC_MUTATION;
+import static org.opensearch.sql.util.Capability.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.*;
 
 import java.io.IOException;
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
   @Override
@@ -507,8 +508,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testStreamstatsGlobal() throws IOException {
-    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 5;
     Request insertRequest =
         new Request(
@@ -667,8 +668,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testStreamstatsReset() throws IOException {
-    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 5;
     Request insertRequest =
         new Request(
@@ -936,8 +937,8 @@ public class CalciteStreamstatsCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testMultipleStreamstatsWithNull2() throws IOException {
-    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 5;
     Request insertRequest =
         new Request(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteWhereCommandIT.java
@@ -8,7 +8,7 @@ package org.opensearch.sql.calcite.remote;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_CASCADED_NESTED;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DEEP_NESTED;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_SIMPLE;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.NESTED_FIELDS;
+import static org.opensearch.sql.util.Capability.NESTED_FIELDS;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -22,6 +22,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.ppl.WhereCommandIT;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalciteWhereCommandIT extends WhereCommandIT {
 
@@ -41,8 +42,8 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   }
 
   @Test
+  @RequiresCapability(NESTED_FIELDS)
   public void testFilterOnComputedNestedFields() throws IOException {
-    assumeNotAnalytics(NESTED_FIELDS);
     JSONObject result =
         executeQuery(
             String.format(
@@ -54,8 +55,8 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   }
 
   @Test
+  @RequiresCapability(NESTED_FIELDS)
   public void testFilterOnNestedAndRootFields() throws IOException {
-    assumeNotAnalytics(NESTED_FIELDS);
     JSONObject result =
         executeQuery(
             String.format(
@@ -67,8 +68,8 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   }
 
   @Test
+  @RequiresCapability(NESTED_FIELDS)
   public void testFilterOnNestedFields() throws IOException {
-    assumeNotAnalytics(NESTED_FIELDS);
     // address is a nested object
     JSONObject result1 =
         executeQuery(
@@ -87,8 +88,8 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   }
 
   @Test
+  @RequiresCapability(NESTED_FIELDS)
   public void testFilterOnMultipleCascadedNestedFields() throws IOException {
-    assumeNotAnalytics(NESTED_FIELDS);
     // SQL's static type system does not allow returning list[int] in place of int
     enabledOnlyWhenPushdownIsEnabled();
     JSONObject result =
@@ -131,8 +132,8 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   }
 
   @Test
+  @RequiresCapability(NESTED_FIELDS)
   public void testScriptFilterOnDifferentNestedHierarchyShouldThrow() throws IOException {
-    assumeNotAnalytics(NESTED_FIELDS);
     enabledOnlyWhenPushdownIsEnabled();
     Throwable t =
         assertThrows(
@@ -150,8 +151,8 @@ public class CalciteWhereCommandIT extends WhereCommandIT {
   }
 
   @Test
+  @RequiresCapability(NESTED_FIELDS)
   public void testAggFilterOnNestedFields() throws IOException {
-    assumeNotAnalytics(NESTED_FIELDS);
     enabledOnlyWhenPushdownIsEnabled();
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/CapabilityRule.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/CapabilityRule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.legacy;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.opensearch.sql.util.BackendCapabilities;
+import org.opensearch.sql.util.Capability;
+import org.opensearch.sql.util.RequiresCapability;
+
+/**
+ * Enforces {@link RequiresCapability} on test methods and classes, delegating to {@link
+ * BackendCapabilities#requireCapability(Capability, String)}.
+ */
+public class CapabilityRule implements TestRule {
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        Class<?> testClass = description.getTestClass();
+        if (testClass != null) {
+          enforce(testClass.getAnnotation(RequiresCapability.class));
+        }
+        enforce(description.getAnnotation(RequiresCapability.class));
+        base.evaluate();
+      }
+    };
+  }
+
+  private static void enforce(RequiresCapability annotation) {
+    if (annotation == null) {
+      return;
+    }
+    String note = annotation.note().isBlank() ? null : annotation.note();
+    for (Capability capability : annotation.value()) {
+      BackendCapabilities.requireCapability(capability, note);
+    }
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
@@ -59,6 +60,8 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
   public boolean shouldResetQuerySizeLimit() {
     return true;
   }
+
+  @Rule public final CapabilityRule capabilityRule = new CapabilityRule();
 
   @Before
   public void setUpIndices() throws Exception {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DateTimeFunctionIT.java
@@ -7,7 +7,7 @@ package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.DOC_MUTATION;
+import static org.opensearch.sql.util.Capability.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -28,6 +28,7 @@ import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.util.RequiresCapability;
 
 @SuppressWarnings("unchecked")
 public class DateTimeFunctionIT extends PPLIntegTestCase {
@@ -1573,8 +1574,8 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testCompareAgainstUTCDate() throws IOException {
-    assumeNotAnalytics(DOC_MUTATION);
     LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
     String isoTimestamp = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
     String pplTimestamp = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/PPLIntegTestCase.java
@@ -38,7 +38,6 @@ import org.opensearch.sql.common.setting.Settings.Key;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.legacy.TestUtils;
 import org.opensearch.sql.protocol.response.format.Format;
-import org.opensearch.sql.util.AnalyticsRouteLimitation;
 import org.opensearch.sql.util.RetryProcessor;
 
 /** OpenSearch Rest integration test base for PPL testing. */
@@ -68,16 +67,6 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
    */
   public static boolean isAnalyticsParquetIndicesEnabled() {
     return TestUtils.AnalyticsIndexConfig.isEnabled();
-  }
-
-  /**
-   * Skip the current test on the analytics-engine route because of a known limitation of that route
-   * (no-op on the v2/Calcite path). The {@link AnalyticsRouteLimitation} registry holds the reason,
-   * so a skip reads as {@code assumeNotAnalytics(NESTED_FIELDS)} and every route gap stays
-   * greppable in one place.
-   */
-  public static void assumeNotAnalytics(AnalyticsRouteLimitation limitation) {
-    Assume.assumeFalse(limitation.reason(), isAnalyticsParquetIndicesEnabled());
   }
 
   protected JSONObject executeQuery(String query) throws IOException {

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SearchCommandIT.java
@@ -6,7 +6,7 @@
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.*;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.DOC_MUTATION;
+import static org.opensearch.sql.util.Capability.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.columnName;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.client.ResponseException;
 import org.opensearch.sql.common.utils.StringUtils;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class SearchCommandIT extends PPLIntegTestCase {
   private static final DateTimeFormatter PPL_TIMESTAMP_FORMATTER =
@@ -1053,8 +1054,8 @@ public class SearchCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testSearchTimeModifierWithSnappedWeek() throws IOException {
-    assumeNotAnalytics(DOC_MUTATION);
     // Test whether alignment to weekday works
 
     final int docId = 101;
@@ -1142,8 +1143,8 @@ public class SearchCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testSearchWithRelativeTimeModifiers() throws IOException {
-    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 101;
 
     LocalDateTime currentTime = LocalDateTime.now(ZoneOffset.UTC);
@@ -1191,8 +1192,8 @@ public class SearchCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testSearchWithTimeUnitSnapping() throws IOException {
-    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 101;
 
     LocalDateTime currentHour = LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
@@ -1240,8 +1241,8 @@ public class SearchCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DOC_MUTATION)
   public void testSearchWithQuarterlyModifiers() throws IOException {
-    assumeNotAnalytics(DOC_MUTATION);
     final int docId = 101;
 
     LocalDateTime currentQuarter =

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/WhereCommandIT.java
@@ -9,8 +9,8 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_TIME;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.DYNAMIC_STRING_NO_KEYWORD;
-import static org.opensearch.sql.util.AnalyticsRouteLimitation.ID_METADATA;
+import static org.opensearch.sql.util.Capability.DYNAMIC_STRING_NO_KEYWORD;
+import static org.opensearch.sql.util.Capability.ID_METADATA;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -22,6 +22,7 @@ import org.hamcrest.MatcherAssert;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class WhereCommandIT extends PPLIntegTestCase {
 
@@ -217,8 +218,8 @@ public class WhereCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(ID_METADATA)
   public void testWhereWithMetadataFields() throws IOException {
-    assumeNotAnalytics(ID_METADATA);
     JSONObject result =
         executeQuery(
             String.format("source=%s | where _id='1' | fields firstname", TEST_INDEX_ACCOUNT));
@@ -226,8 +227,8 @@ public class WhereCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(ID_METADATA)
   public void testWhereWithMetadataFields2() throws IOException {
-    assumeNotAnalytics(ID_METADATA);
     JSONObject result =
         executeQuery(String.format("source=%s | where _id='1'", TEST_INDEX_ACCOUNT));
     verifyDataRows(
@@ -534,8 +535,8 @@ public class WhereCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(DYNAMIC_STRING_NO_KEYWORD)
   public void testDoubleEqualWithSpecialCharacters() throws IOException {
-    assumeNotAnalytics(DYNAMIC_STRING_NO_KEYWORD);
     // Test == with strings containing special characters
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/util/BackendCapabilities.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/BackendCapabilities.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.util;
+
+import org.junit.Assume;
+import org.opensearch.sql.legacy.TestUtils;
+
+/** Skips integration tests that require a {@link Capability} the active backend lacks. */
+public final class BackendCapabilities {
+
+  public static void requireCapability(Capability capability) {
+    requireCapability(capability, null);
+  }
+
+  public static void requireCapability(Capability capability, String note) {
+    // Today analytics-engine supports none of the defined capabilities, so all are skipped on it.
+    Assume.assumeTrue(skipMessage(capability, note), !TestUtils.AnalyticsIndexConfig.isEnabled());
+  }
+
+  private static String skipMessage(Capability capability, String note) {
+    String base = capability.name() + ": " + capability.reason();
+    return (note == null || note.isBlank()) ? base : base + " — " + note;
+  }
+
+  private BackendCapabilities() {}
+}

--- a/integ-test/src/test/java/org/opensearch/sql/util/Capability.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/Capability.java
@@ -6,17 +6,17 @@
 package org.opensearch.sql.util;
 
 /**
- * Single registry of the known behavioral divergences of the analytics-engine route
- * (parquet/composite store + DataFusion backend, activated by {@code
- * -Dtests.analytics.parquet_indices=true}). Each constant carries the reason a test is skipped on
- * that route.
+ * Backend-agnostic registry of execution capabilities a test may require. Each constant names a
+ * behavior (nested fields, document mutation, stable head ordering, ...) and carries the reason it
+ * is unavailable on a backend that lacks it — currently the analytics-engine route. Tests declare
+ * the capability they need via {@code BackendCapabilities.requireCapability(...)} or the {@link
+ * RequiresCapability} annotation rather than naming a backend.
  *
- * <p>Pair it with {@code PPLIntegTestCase.assumeNotAnalytics(...)} so a skip reads as {@code
- * assumeNotAnalytics(NESTED_FIELDS)} instead of a copy-pasted string literal. Keeping every reason
- * here makes the full set of analytics-route gaps greppable in one place — both for humans tracking
- * what still needs fixing and as a single block of context to hand an agent for bulk triage.
+ * <p>Keeping every reason here makes the full set of route gaps greppable in one place — both for
+ * humans tracking what still needs fixing and as a single block of context to hand an agent for
+ * bulk triage.
  */
-public enum AnalyticsRouteLimitation {
+public enum Capability {
   /**
    * The parquet/composite store has no nested-document support, so nested fields are stripped from
    * the dataset at load (#5541) and queries that reference them resolve against fields that don't
@@ -196,7 +196,7 @@ public enum AnalyticsRouteLimitation {
 
   private final String reason;
 
-  AnalyticsRouteLimitation(String reason) {
+  Capability(String reason) {
     this.reason = reason;
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/util/RequiresCapability.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/RequiresCapability.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the {@link Capability} the annotated test method or test class requires. Enforced by
+ * {@code CapabilityRule}: when the active backend lacks any listed capability the test is skipped,
+ * with the capability's reason — plus the optional {@code note} — as the skip message. The note
+ * applies to every capability in {@code value()}.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiresCapability {
+  Capability[] value();
+
+  String note() default "";
+}


### PR DESCRIPTION
### Description
Make analytics-engine route test gating backend-agnostic and declarative, replacing the imperative, backend-named `assumeNotAnalytics(...)` calls. Test-only change.

- **Decouple ITs from the backend via a capability matrix:** rename `AnalyticsRouteLimitation` to a `Capability` registry and route skip decisions through `BackendCapabilities`, so tests declare the capability they need instead of naming a backend.
- **Make gating usable as an annotation:** add `@RequiresCapability` (method/class), enforced by `CapabilityRule`, and convert all existing call sites to it — keeping test bodies clean.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5246

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
