### PR TITLE
Stabilize PPL ITs on the analytics-engine route (case/string/full-text/like/appendpipe/datatype)

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1075,10 +1075,11 @@ task integTestRemote(type: RestIntegTestTask) {
             // GeoPointFormatsIT: EVERY test reads a geo_point field — whole class doomed.
             excludeTestsMatching 'org.opensearch.sql.ppl.GeoPointFormatsIT'
             // datatypes_index_mapping: nested_value=nested, geo_point_value=geo_point.
-            excludeTestsMatching 'org.opensearch.sql.ppl.DataTypeIT.test_nonnumeric_data_types'
-            excludeTestsMatching 'org.opensearch.sql.ppl.SystemFunctionIT.typeof_opensearch_types'
+            // Glob matches the Calcite subclasses too (CalciteDataTypeIT, CalciteSystemFunctionIT).
+            excludeTestsMatching '*DataTypeIT.test_nonnumeric_data_types'
+            excludeTestsMatching '*SystemFunctionIT.typeof_opensearch_types'
             // alias_index_mapping: alias_col is type=alias; query is `where alias_col > 1`.
-            excludeTestsMatching 'org.opensearch.sql.ppl.DataTypeIT.test_alias_data_type'
+            excludeTestsMatching '*DataTypeIT.test_alias_data_type'
             // CalciteAliasFieldAggregationIT: raw-PUT alias index can't be created on the AE route
             // and every test queries alias fields directly — whole class doomed.
             excludeTestsMatching 'org.opensearch.sql.calcite.remote.CalciteAliasFieldAggregationIT'
@@ -1176,6 +1177,33 @@ task integTestRemote(type: RestIntegTestTask) {
             //  - max() over int operands reports bigint on the AE route (DataFusion widens integers
             //    to Int64) where the v2/Calcite path reports int.
             excludeTestsMatching '*CalcitePPLEvalMaxMinFunctionIT.testEvalMaxNumeric'
+
+            // === Excludes: CalcitePPLCaseFunctionIT route divergences ===
+            // bin @timestamp then group by it: bucket column typed string (not timestamp) on AE.
+            excludeTestsMatching '*CalcitePPLCaseFunctionIT.testNestedCaseAggWithAutoDateHistogram'
+
+            // === Excludes: CalcitePPLStringBuiltinFunctionIT route divergences ===
+            // Re-PUT a shared _id with different data; the append-only AE store can't replace docs.
+            excludeTestsMatching '*CalcitePPLStringBuiltinFunctionIT.testConcatWithField'
+            excludeTestsMatching '*CalcitePPLStringBuiltinFunctionIT.testConcatWs'
+            excludeTestsMatching '*CalcitePPLStringBuiltinFunctionIT.testReverse'
+            excludeTestsMatching '*CalcitePPLStringBuiltinFunctionIT.testRight'
+            excludeTestsMatching '*CalcitePPLStringBuiltinFunctionIT.testTrim'
+            excludeTestsMatching '*CalcitePPLStringBuiltinFunctionIT.testRTrim'
+            excludeTestsMatching '*CalcitePPLStringBuiltinFunctionIT.testLTrim'
+
+            // === Excludes: full-text relevance functions (unsupported on DataFusion) ===
+            excludeTestsMatching '*MultiMatchIT.test_wildcard_multi_match'
+            excludeTestsMatching '*QueryStringIT.wildcard_test'
+            excludeTestsMatching '*SimpleQueryStringIT.test_wildcard_simple_query_string'
+
+            // === Excludes: CalciteLikeQueryIT route divergence ===
+            // LIKE is case-insensitive on AE (DataFusion); v2/Calcite treats LIKE as case-sensitive.
+            excludeTestsMatching '*CalciteLikeQueryIT.test_the_default_3rd_option'
+
+            // === Excludes: CalcitePPLAppendPipeCommandIT route divergence ===
+            // appendpipe drops the main pipeline's rows on AE (subpipe filter applied in place).
+            excludeTestsMatching '*CalcitePPLAppendPipeCommandIT.testDoubleAppendPipeWithFilter'
         }
     }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteLikeQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteLikeQueryIT.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WILDCARD;
+import static org.opensearch.sql.util.Capability.LIKE_CASE_SENSITIVITY;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifyNumOfRows;
@@ -15,6 +16,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.ppl.LikeQueryIT;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalciteLikeQueryIT extends LikeQueryIT {
   @Override
@@ -49,6 +51,9 @@ public class CalciteLikeQueryIT extends LikeQueryIT {
   }
 
   @Test
+  @RequiresCapability(
+      value = LIKE_CASE_SENSITIVITY,
+      note = "case-sensitive LIKE (legacy=false) expects 0 rows; AE LIKE is case-insensitive.")
   public void test_the_default_3rd_option() throws IOException {
     // only work in v3
     String query =

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAppendPipeCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAppendPipeCommandIT.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.opensearch.sql.util.Capability.APPENDPIPE_MAIN_RESULT_DROPPED;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -17,6 +18,7 @@ import java.util.Locale;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLAppendPipeCommandIT extends PPLIntegTestCase {
   @Override
@@ -145,6 +147,9 @@ public class CalcitePPLAppendPipeCommandIT extends PPLIntegTestCase {
 
   /** Regression test: double appendpipe with non-aggregation (filter) subpipeline. */
   @Test
+  @RequiresCapability(
+      value = APPENDPIPE_MAIN_RESULT_DROPPED,
+      note = "appendpipe drops the main pipeline's rows on the AE route (filter applied in place).")
   public void testDoubleAppendPipeWithFilter() throws IOException {
     JSONObject actual =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLCaseFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLCaseFunctionIT.java
@@ -5,10 +5,12 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.opensearch.sql.legacy.TestUtils.isIndexExist;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_OTEL_LOGS;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_STATE_COUNTRY_WITH_NULL;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_WEBLOGS;
+import static org.opensearch.sql.util.Capability.BIN_TIME_FIELD_BUCKETING;
 import static org.opensearch.sql.util.MatcherUtils.closeTo;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.legacy.TestsConstants;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLCaseFunctionIT extends PPLIntegTestCase {
 
@@ -31,12 +34,20 @@ public class CalcitePPLCaseFunctionIT extends PPLIntegTestCase {
     super.init();
     enableCalcite();
 
+    // Seed only on first creation: the AE parquet store is append-only on same-_id PUT.
+    boolean weblogsExisted = isIndexExist(client(), TEST_INDEX_WEBLOGS);
     loadIndex(Index.WEBLOG);
     loadIndex(Index.TIME_TEST_DATA);
     loadIndex(Index.STATE_COUNTRY_WITH_NULL);
     loadIndex(Index.BANK);
-    loadIndex(Index.OTELLOGS);
-    appendDataForBadResponse();
+    // otel_logs has a multi-value keyword the AE store rejects at load; only the (AE-skipped)
+    // testNestedCaseAggWithAutoDateHistogram needs it.
+    if (!isAnalyticsParquetIndicesEnabled()) {
+      loadIndex(Index.OTELLOGS);
+    }
+    if (!weblogsExisted) {
+      appendDataForBadResponse();
+    }
   }
 
   private void appendDataForBadResponse() throws IOException {
@@ -478,6 +489,9 @@ public class CalcitePPLCaseFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = BIN_TIME_FIELD_BUCKETING,
+      note = "bin @timestamp then group by it: bucket column typed string (not timestamp) on AE.")
   public void testNestedCaseAggWithAutoDateHistogram() throws IOException {
     // TODO: Remove after resolving: https://github.com/opensearch-project/sql/issues/4578
     Assume.assumeFalse(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLStringBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLStringBuiltinFunctionIT.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.calcite.remote;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_STATE_COUNTRY;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_STATE_COUNTRY_WITH_NULL;
+import static org.opensearch.sql.util.Capability.DOC_MUTATION;
 import static org.opensearch.sql.util.MatcherUtils.*;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 
@@ -17,6 +18,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLStringBuiltinFunctionIT extends PPLIntegTestCase {
   @Override
@@ -60,6 +62,9 @@ public class CalcitePPLStringBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = DOC_MUTATION,
+      note = "Re-PUTs a shared _id with different data; the append-only AE store can't replace it.")
   public void testConcatWithField() throws IOException {
     Request request1 =
         new Request("PUT", "/opensearch-sql_test_index_state_country/_doc/5?refresh=true");
@@ -78,6 +83,9 @@ public class CalcitePPLStringBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = DOC_MUTATION,
+      note = "Re-PUTs a shared _id with different data; the append-only AE store can't replace it.")
   public void testConcatWs() throws IOException {
     Request request1 =
         new Request("PUT", "/opensearch-sql_test_index_state_country/_doc/5?refresh=true");
@@ -212,6 +220,9 @@ public class CalcitePPLStringBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = DOC_MUTATION,
+      note = "Re-PUTs a shared _id with different data; the append-only AE store can't replace it.")
   public void testTrim() throws IOException {
     prepareTrim();
     JSONObject actual =
@@ -226,6 +237,9 @@ public class CalcitePPLStringBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = DOC_MUTATION,
+      note = "Re-PUTs a shared _id with different data; the append-only AE store can't replace it.")
   public void testRTrim() throws IOException {
     prepareTrim();
     JSONObject actual =
@@ -240,6 +254,9 @@ public class CalcitePPLStringBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = DOC_MUTATION,
+      note = "Re-PUTs a shared _id with different data; the append-only AE store can't replace it.")
   public void testLTrim() throws IOException {
     prepareTrim();
     JSONObject actual =
@@ -254,6 +271,9 @@ public class CalcitePPLStringBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = DOC_MUTATION,
+      note = "Re-PUTs a shared _id with different data; the append-only AE store can't replace it.")
   public void testReverse() throws IOException {
     Request request1 =
         new Request("PUT", "/opensearch-sql_test_index_state_country/_doc/5?refresh=true");
@@ -272,6 +292,9 @@ public class CalcitePPLStringBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = DOC_MUTATION,
+      note = "Re-PUTs a shared _id with different data; the append-only AE store can't replace it.")
   public void testRight() throws IOException {
     Request request1 =
         new Request("PUT", "/opensearch-sql_test_index_state_country/_doc/5?refresh=true");

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/MultiMatchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/MultiMatchIT.java
@@ -6,10 +6,12 @@
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
+import static org.opensearch.sql.util.Capability.FULLTEXT_RELEVANCE_FUNC;
 
 import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class MultiMatchIT extends PPLIntegTestCase {
 
@@ -45,6 +47,9 @@ public class MultiMatchIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = FULLTEXT_RELEVANCE_FUNC,
+      note = "multi_match/query_string/simple_query_string are full-text relevance funcs.")
   public void test_wildcard_multi_match() throws IOException {
     String query1 =
         "SOURCE=" + TEST_INDEX_BEER + " | WHERE multi_match(['Tags'], 'taste') | fields Id";

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/QueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/QueryStringIT.java
@@ -6,10 +6,12 @@
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
+import static org.opensearch.sql.util.Capability.FULLTEXT_RELEVANCE_FUNC;
 
 import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class QueryStringIT extends PPLIntegTestCase {
 
@@ -56,6 +58,9 @@ public class QueryStringIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = FULLTEXT_RELEVANCE_FUNC,
+      note = "multi_match/query_string/simple_query_string are full-text relevance funcs.")
   public void wildcard_test() throws IOException {
 
     String query1 = "source=" + TEST_INDEX_BEER + " | where query_string(['Tags'], 'taste')";

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/SimpleQueryStringIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/SimpleQueryStringIT.java
@@ -6,10 +6,12 @@
 package org.opensearch.sql.ppl;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BEER;
+import static org.opensearch.sql.util.Capability.FULLTEXT_RELEVANCE_FUNC;
 
 import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.opensearch.sql.util.RequiresCapability;
 
 public class SimpleQueryStringIT extends PPLIntegTestCase {
   @Override
@@ -45,6 +47,9 @@ public class SimpleQueryStringIT extends PPLIntegTestCase {
   }
 
   @Test
+  @RequiresCapability(
+      value = FULLTEXT_RELEVANCE_FUNC,
+      note = "multi_match/query_string/simple_query_string are full-text relevance funcs.")
   public void test_wildcard_simple_query_string() throws IOException {
     String query1 =
         "SOURCE=" + TEST_INDEX_BEER + " | WHERE simple_query_string(['Tags'], 'taste') | fields Id";

--- a/integ-test/src/test/java/org/opensearch/sql/util/Capability.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/Capability.java
@@ -192,7 +192,35 @@ public enum Capability {
   EVAL_MAX_MIN_INT_WIDENING(
       "eval max()/min() over integer operands reports the result column as bigint on the"
           + " analytics-engine route (DataFusion widens integers to Int64), whereas the v2/Calcite"
-          + " path reports int.");
+          + " path reports int."),
+
+  /**
+   * Lucene full-text relevance functions ({@code match}, {@code multi_match}, {@code query_string},
+   * {@code simple_query_string}, …) are unsupported on the analytics-engine route — DataFusion has
+   * no relevance scorer, so a query that filters on one returns no rows.
+   */
+  FULLTEXT_RELEVANCE_FUNC(
+      "Full-text relevance functions (match/multi_match/query_string/simple_query_string) are"
+          + " unsupported on the analytics-engine route: DataFusion has no relevance scorer, so the"
+          + " filter returns no rows."),
+
+  /**
+   * LIKE is case-insensitive on the analytics-engine route (DataFusion), whereas the v2/Calcite
+   * path treats {@code LIKE} as case-sensitive (only {@code ILIKE} is case-insensitive).
+   */
+  LIKE_CASE_SENSITIVITY(
+      "LIKE is case-insensitive on the analytics-engine route (DataFusion), whereas the v2/Calcite"
+          + " path treats LIKE as case-sensitive."),
+
+  /**
+   * {@code appendpipe [subpipe]} drops the main pipeline's rows on the analytics-engine route: the
+   * subpipe's filter is applied to the main result instead of its output being appended to it, so
+   * the original rows are lost (e.g. {@code stats ... | appendpipe [where gender='F']} returns only
+   * the filtered F rows, not the originals plus the filtered copy).
+   */
+  APPENDPIPE_MAIN_RESULT_DROPPED(
+      "appendpipe drops the main pipeline's rows on the analytics-engine route: the subpipe filter"
+          + " is applied to the main result instead of appended, so the originals are lost.");
 
   private final String reason;
 


### PR DESCRIPTION
### Description

Analytics-engine route (`-Dtests.analytics.parquet_indices=true`) parity pass across several PPL IT classes. All changes are test-only; the v2/Calcite route is unchanged (every gated test still runs there — the `assumeNotAnalytics(...)` guards are no-ops off-route and the gradle excludes apply only to `integTestRemote`).

#### CalcitePPLCaseFunctionIT (3/9 → 8/9 pass, 1 excluded)
- **Accumulation:** `appendDataForBadResponse()` raw-PUTs 4 weblogs docs unconditionally in `init()`; the append-only AE store can't replace on same-`_id` PUT, so they accumulated per method. Guarded on a pre-`loadIndex` `isIndexExist` check.
- **otel_logs multi-value reject:** the dataset has a multi-value `attributes.email.invalid_recipients` array the parquet store rejects (`Cannot accept multiple values for field ... of type keyword`), aborting `init()`. Only `testNestedCaseAggWithAutoDateHistogram` uses it, so the load is skipped on the AE route.
- **`BIN_TIME_FIELD_BUCKETING`** (existing): `bin @timestamp | stats by @timestamp` returns the bucket column typed `string` not `timestamp`. Skips `testNestedCaseAggWithAutoDateHistogram`.

#### CalcitePPLStringBuiltinFunctionIT (7 tests skipped — `DOC_MUTATION`)
`testConcatWithField/ConcatWs/Reverse/Right/Trim/RTrim/LTrim` re-PUT a shared `_id` (5/6/7) with **different** data, relying on PUT-replace. On the AE store same-`_id` PUT **appends** and **DELETE is unsupported**, so these accumulate and cross-contaminate (counts are order-dependent). Skipped via the existing `DOC_MUTATION` limitation.

#### Full-text relevance functions (3 tests skipped — new `FULLTEXT_RELEVANCE_FUNC`)
`MultiMatchIT.test_wildcard_multi_match`, `QueryStringIT.wildcard_test`, `SimpleQueryStringIT.test_wildcard_simple_query_string` use `multi_match` / `query_string` / `simple_query_string` — Lucene relevance functions with no DataFusion equivalent (they return no rows).

#### CalciteLikeQueryIT.test_the_default_3rd_option (skipped — new `LIKE_CASE_SENSITIVITY`)
The v3 branch expects case-sensitive `LIKE` (0 rows for `'test Wildcard%'` vs lowercase data); the AE route's `LIKE` is case-insensitive (DataFusion) and returns 7.

#### CalcitePPLAppendPipeCommandIT.testDoubleAppendPipeWithFilter (skipped — new `APPENDPIPE_MAIN_RESULT_DROPPED`)
`appendpipe [subpipe]` drops the main pipeline's rows on the AE route: the subpipe's filter is applied to the main result instead of being appended, so the originals are lost (verified: `stats ... | appendpipe [where gender='F']` returns only the F rows, not the originals plus the filtered copy).

#### DataTypeIT exclude globs (coverage fix)
`test_nonnumeric_data_types`, `test_alias_data_type`, and `SystemFunctionIT.typeof_opensearch_types` were excluded with `org.opensearch.sql.ppl.*` globs that did **not** match the Calcite subclasses. Broadened to `*` so `CalciteDataTypeIT` / `CalciteSystemFunctionIT` are covered too.

### Results (analytics route, per-listed-test)

| Test | Before | After |
|---|---|---|
| CalcitePPLCaseFunctionIT.testCaseWhen{InFilter,InSubquery,WithCast,WithIn} | fail (accumulation) | pass |
| CalcitePPLStringBuiltinFunctionIT.test{LTrim,Reverse,Trim} | fail (accumulation) | excluded (DOC_MUTATION) |
| CalciteMultiMatchIT.test_wildcard_multi_match | fail | excluded |
| CalciteQueryStringIT.wildcard_test | fail | excluded |
| CalciteSimpleQueryStringIT.test_wildcard_simple_query_string | fail | excluded |
| CalciteLikeQueryIT.test_the_default_3rd_option | fail | excluded |
| CalcitePPLAppendPipeCommandIT.testDoubleAppendPipeWithFilter | fail | excluded |
| CalciteDataTypeIT.test_nonnumeric_data_types | fail | excluded (glob fix) |

v2/Calcite route: all edited classes 100% pass, 0 skips.

> **Not included** (deferred — investigated but not cleanly fixable here): `CalciteChartCommandIT` has 5 analytics-route failures (its own multi-bucket triage, partly the known otel_logs ip-scan defect), and `NfwPplDashboardIT.testTopLongLivedTCPFlows` returns 0 rows via the IT harness but the identical query returns the correct 2 rows in a direct probe — its cause isn't reproducible/classifiable from outside the harness, so it's left for separate investigation rather than shipping a mislabeled skip.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
