### PR TITLE
Propagate request-task cancellation into the analytics PPL route

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestPPLQueryAction.java
@@ -22,6 +22,7 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestCancellableNodeClient;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.error.ErrorReport;
 import org.opensearch.sql.datasources.exceptions.DataSourceClientException;
@@ -113,27 +114,32 @@ public class RestPPLQueryAction extends BaseRestHandler {
     TransportPPLQueryRequest transportPPLQueryRequest =
         new TransportPPLQueryRequest(PPLQueryRequestFactory.getPPLRequest(request));
 
-    return channel ->
-        nodeClient.execute(
-            PPLQueryAction.INSTANCE,
-            transportPPLQueryRequest,
-            new ActionListener<>() {
-              @Override
-              public void onResponse(TransportPPLQueryResponse response) {
-                sendResponse(channel, OK, response.getContentType(), response.getResult());
-              }
+    // RestCancellableNodeClient cancels the PPLQueryTask on client disconnect, which cascades to
+    // the analytics query + fragments.
+    return channel -> {
+      RestCancellableNodeClient cancellableClient =
+          new RestCancellableNodeClient(nodeClient, request.getHttpChannel());
+      cancellableClient.execute(
+          PPLQueryAction.INSTANCE,
+          transportPPLQueryRequest,
+          new ActionListener<>() {
+            @Override
+            public void onResponse(TransportPPLQueryResponse response) {
+              sendResponse(channel, OK, response.getContentType(), response.getResult());
+            }
 
-              @Override
-              public void onFailure(Exception e) {
-                RestStatus status = loggedErrorCode(e);
-                if (transportPPLQueryRequest.isExplainRequest()) {
-                  LOG.error("Error happened during explain (status {})", status, e);
-                } else {
-                  LOG.error("Error happened during query handling (status {})", status, e);
-                }
-                reportError(channel, e, status);
+            @Override
+            public void onFailure(Exception e) {
+              RestStatus status = loggedErrorCode(e);
+              if (transportPPLQueryRequest.isExplainRequest()) {
+                LOG.error("Error happened during explain (status {})", status, e);
+              } else {
+                LOG.error("Error happened during query handling (status {})", status, e);
               }
-            });
+              reportError(channel, e, status);
+            }
+          });
+    };
   }
 
   private void sendResponse(

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import org.opensearch.analytics.QueryRequestContext;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.cluster.service.ClusterService;
@@ -42,6 +43,7 @@ import org.opensearch.sql.protocol.response.QueryResult;
 import org.opensearch.sql.protocol.response.format.ResponseFormatter;
 import org.opensearch.sql.protocol.response.format.SimpleJsonResponseFormatter;
 import org.opensearch.sql.utils.SystemIndexUtils;
+import org.opensearch.tasks.Task;
 import org.opensearch.transport.client.node.NodeClient;
 
 /**
@@ -144,11 +146,31 @@ public class RestUnifiedQueryAction {
         && "composite".equals(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(settings));
   }
 
-  /** Execute a query through the unified query pipeline on the sql-worker thread pool. */
+  /** Execute with no parent task (SQL path): the analytics query runs detached, not cancellable. */
   public void execute(
       String query,
       QueryType queryType,
       boolean profiling,
+      ActionListener<TransportPPLQueryResponse> listener) {
+    doExecute(query, queryType, profiling, null, listener);
+  }
+
+  /** Execute linked to {@code parentTask} so a front-end cancel propagates into the engine. */
+  public void execute(
+      String query,
+      QueryType queryType,
+      boolean profiling,
+      Task parentTask,
+      ActionListener<TransportPPLQueryResponse> listener) {
+    assert parentTask != null : "parentTask required for cancellation propagation";
+    doExecute(query, queryType, profiling, parentTask, listener);
+  }
+
+  private void doExecute(
+      String query,
+      QueryType queryType,
+      boolean profiling,
+      Task parentTask,
       ActionListener<TransportPPLQueryResponse> listener) {
     client
         .threadPool()
@@ -158,8 +180,9 @@ public class RestUnifiedQueryAction {
                   // Ask the engine for a per-query context — it binds the snapshot
                   // (cluster state + schema built from it) and returns the pair, so the
                   // schema we plan against and the state the executor uses are the same view.
-                  org.opensearch.analytics.QueryRequestContext queryCtx =
-                      contextProvider.getContext();
+                  // Carry the front-end task so cancellation propagates into the engine.
+                  QueryRequestContext queryCtx =
+                      withParentTask(contextProvider.getContext(), parentTask);
                   // Disable SQL-layer phase profiling when analytics engine profiling is active.
                   // Our QueryProfile (stages, tasks, timing) is strictly more detailed and replaces
                   // it.
@@ -192,22 +215,39 @@ public class RestUnifiedQueryAction {
             SQL_WORKER_THREAD_POOL_NAME);
   }
 
-  /**
-   * Explain a query through the unified query pipeline on the sql-worker thread pool. Returns
-   * ExplainResponse via ResponseListener so the caller can format it.
-   */
+  /** Explain with no parent task (SQL path). */
   public void explain(
       String query,
       QueryType queryType,
       ExplainMode mode,
+      ResponseListener<ExplainResponse> listener) {
+    doExplain(query, queryType, mode, null, listener);
+  }
+
+  /** Explain linked to {@code parentTask} so a front-end cancel propagates into the engine. */
+  public void explain(
+      String query,
+      QueryType queryType,
+      ExplainMode mode,
+      Task parentTask,
+      ResponseListener<ExplainResponse> listener) {
+    assert parentTask != null : "parentTask required for cancellation propagation";
+    doExplain(query, queryType, mode, parentTask, listener);
+  }
+
+  private void doExplain(
+      String query,
+      QueryType queryType,
+      ExplainMode mode,
+      Task parentTask,
       ResponseListener<ExplainResponse> listener) {
     client
         .threadPool()
         .schedule(
             withCurrentContext(
                 () -> {
-                  org.opensearch.analytics.QueryRequestContext queryCtx =
-                      contextProvider.getContext();
+                  QueryRequestContext queryCtx =
+                      withParentTask(contextProvider.getContext(), parentTask);
                   try (UnifiedQueryContext context = buildContext(queryType, false, queryCtx)) {
                     UnifiedQueryPlanner planner = new UnifiedQueryPlanner(context);
                     RelNode plan = planner.plan(query);
@@ -231,9 +271,7 @@ public class RestUnifiedQueryAction {
   }
 
   private UnifiedQueryContext buildContext(
-      QueryType queryType,
-      boolean profiling,
-      org.opensearch.analytics.QueryRequestContext queryCtx) {
+      QueryType queryType, boolean profiling, QueryRequestContext queryCtx) {
     return applyClusterOverrides(
             UnifiedQueryContext.builder()
                 .language(queryType)
@@ -242,6 +280,14 @@ public class RestUnifiedQueryAction {
                 .defaultNamespace(SCHEMA_NAME)
                 .profiling(profiling))
         .build();
+  }
+
+  /** Returns {@code ctx} carrying {@code parentTask}, or unchanged when there is none. */
+  private static QueryRequestContext withParentTask(QueryRequestContext ctx, Task parentTask) {
+    if (parentTask == null) {
+      return ctx;
+    }
+    return new QueryRequestContext(ctx.clusterState(), ctx.schema(), ctx.querySource(), parentTask);
   }
 
   /**

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
@@ -176,17 +176,20 @@ public class TransportPPLQueryAction
     if (unifiedQueryHandler != null
         && unifiedQueryHandler.isAnalyticsIndex(transformedRequest.getRequest(), QueryType.PPL)) {
       LOG.info("[{}] Routing PPL query to analytics engine", QueryContext.getRequestId());
+      // Pass this PPL task so the analytics engine links its query task to it for cancellation.
       if (transformedRequest.isExplainRequest()) {
         unifiedQueryHandler.explain(
             transformedRequest.getRequest(),
             QueryType.PPL,
             transformedRequest.mode(),
+            task,
             createExplainResponseListener(transformedRequest, clearingListener));
       } else {
         unifiedQueryHandler.execute(
             transformedRequest.getRequest(),
             QueryType.PPL,
             transformedRequest.profile(),
+            task,
             clearingListener);
       }
       return;


### PR DESCRIPTION
### Description
PPL analytics queries ran detached from the request task, so client disconnects never cancelled them. Dispatch via RestCancellableNodeClient, thread the PPL task through QueryRequestContext on execute/explain (asserted non-null), and pass it from TransportPPLQueryAction. The analytics engine links it as the query-task parent so cancellation cascades to fragments.

core PR required before this can be merged - https://github.com/opensearch-project/OpenSearch/pull/22229

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
