### PR TITLE
allow partial pushdown for semi-scripted predicates

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePartialFilterPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePartialFilterPushdownIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_LOGS;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+/**
+ * Tests partial filter pushdown when some predicates can be pushed natively and others require
+ * script evaluation.
+ *
+ * <p>Regression test for issue where LIKE on text fields (without .keyword subfield) caused entire
+ * AND filter to fall back to script, preventing timestamp range pushdown.
+ */
+public class CalcitePartialFilterPushdownIT extends PPLIntegTestCase {
+
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+    loadIndex(Index.LOGS);
+  }
+
+  @Test
+  public void testTimestampRangePushesWithUnpushableLike() throws IOException {
+    // message is text field without .keyword — LIKE on it requires script evaluation
+    // @timestamp is date field — range should push natively despite LIKE failing
+    String query =
+        String.format(
+            "source=%s | where `@timestamp` >= '2023-01-01' and `@timestamp` < '2023-01-04' "
+                + "and LIKE(message, '%%failed%%') | stats count()",
+            TEST_INDEX_LOGS);
+
+    JSONObject result = executeQuery(query);
+
+    // Just verify query executes and returns reasonable results
+    // The key regression is that this doesn't do a full table scan
+    verifySchema(result, schema("count()", "bigint"));
+    // Should find "Database connection failed" in the date range
+    verifyDataRows(result, rows(1L));
+  }
+
+  @Test
+  public void testMultipleUnpushablePredicatesInAnd() throws IOException {
+    // Both LIKE conditions are on text field, but timestamp should still push
+    String query =
+        String.format(
+            "source=%s | where `@timestamp` >= '2023-01-01' and LIKE(message, '%%space%%') "
+                + "and LIKE(message, '%%low%%') | stats count()",
+            TEST_INDEX_LOGS);
+
+    JSONObject result = executeQuery(query);
+    verifySchema(result, schema("count()", "bigint"));
+    // Should find "Disk space low"
+    verifyDataRows(result, rows(1L));
+  }
+}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/PredicateAnalyzer.java
@@ -1394,7 +1394,7 @@ public class PredicateAnalyzer {
                 .caseInsensitive(!caseSensitive);
         return this;
       }
-      throw new UnsupportedOperationException("Like query is not supported for text field");
+      throw new PredicateAnalyzerException("Like query is not supported for text field");
     }
 
     @Override

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/PredicateAnalyzerTest.java
@@ -1649,4 +1649,48 @@ public class PredicateAnalyzerTest {
         """,
         result.toString());
   }
+
+  @Test
+  void andWithUnpushableLike_partiallyPushesOtherPredicates()
+      throws ExpressionNotAnalyzableException {
+    // field3 (c) is text without .keyword → LIKE throws PredicateAnalyzerException
+    // field4 (d) is date → timestamp range should push as RangeQueryBuilder
+    final RelDataType rowType =
+        builder
+            .getTypeFactory()
+            .builder()
+            .kind(StructKind.FULLY_QUALIFIED)
+            .add("a", typeFactory.createSqlType(SqlTypeName.INTEGER))
+            .add("b", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+            .add("c", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+            .add("d", typeFactory.createUDT(ExprUDT.EXPR_TIMESTAMP))
+            .add("e", typeFactory.createSqlType(SqlTypeName.BOOLEAN))
+            .build();
+    Hook.CURRENT_TIME.addThread((Consumer<Holder<Long>>) h -> h.set(0L));
+
+    RexInputRef field3 = builder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 2);
+    RexNode likeCall =
+        builder.makeCall(
+            SqlStdOperatorTable.LIKE, field3, stringLiteral, builder.makeLiteral("\\"));
+    RexNode rangeCall =
+        builder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, field4, dateTimeLiteral);
+    RexNode andCall = builder.makeCall(SqlStdOperatorTable.AND, rangeCall, likeCall);
+
+    QueryBuilder result = PredicateAnalyzer.analyze(andCall, schema, fieldTypes, rowType, cluster);
+
+    // Should be a BoolQueryBuilder with range in must[] and LIKE as script
+    assertInstanceOf(BoolQueryBuilder.class, result);
+    BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
+    assertEquals(2, boolQuery.must().size());
+
+    // First must clause should be the range query (pushable)
+    QueryBuilder firstMust = boolQuery.must().get(0);
+    assertInstanceOf(RangeQueryBuilder.class, firstMust);
+    RangeQueryBuilder rangeQuery = (RangeQueryBuilder) firstMust;
+    assertEquals("d", rangeQuery.fieldName());
+
+    // Second must clause should be script query (unpushable LIKE)
+    QueryBuilder secondMust = boolQuery.must().get(1);
+    assertInstanceOf(ScriptQueryBuilder.class, secondMust);
+  }
 }


### PR DESCRIPTION
### Description
As `like` on text returns unsupported operation exceptions instead of predicate analyzer exceptions, this causes the entire expression pushdown to fail since UOE isn't caught in that process. This applies even if some parts of the expression are applicable. So a query like:
```kql
source=idx
| where `@timestamp` >= '2023-01-01' and `@timestamp` < '2023-01-04'
| where LIKE(message, '%failed%')
| stats count()
```
Compiles into a single script that filters documents on a full-table scan. With this fix, it's instead compiled into a script to evaluate the LIKE expression, but the `@timestamp` predicate is pushed down into DSL:

```bash
> echo 'source=logs | where `@timestamp` > "2026-05-22 00:00:00" | where like(raw_log, "nginx") | fields raw_log' | ppl --explain
= Calcite Plan =
== Logical ==
LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
  LogicalProject(raw_log=[$48])
    LogicalFilter(condition=[ILIKE($48, 'nginx', '\')])
      LogicalFilter(condition=[>($55, TIMESTAMP('2026-05-22 00:00:00':VARCHAR))])
        CalciteLogicalIndexScan(table=[[OpenSearch, logs]])


== Physical ==
CalciteEnumerableIndexScan(table=[[OpenSearch, logs]], PushDownContext=[[PROJECT->[raw_log, @timestamp], SCRIPT->AND(>($1, '2026-05-22 00:00:00'), ILIKE($0, 'nginx', '')), PROJECT->[raw_
  "_source": {
    "includes": [
      "raw_log"
    ]
  },
  "from": 0,
  "query": {
    "bool": {
      "adjust_pure_negative": true,
      "boost": 1.0,
      "must": [
        {
          "range": {
            "@timestamp": {
              "boost": 1.0,
              "format": "date_time",
              "from": "2026-05-22T00:00:00.000Z",
              "include_lower": false,
              "include_upper": true,
              "to": null
            }
          }
        },
        {
          "script": {
            "boost": 1.0,
            "script": {
              "lang": "opensearch_compounded_script",
              "params": {
                "DIGESTS": [
                  "raw_log",
                  "nginx",
                  "\\"
                ],
                "SOURCES": [
                  1,
                  2,
                  2
                ],
                "utcTimestamp": 1781818852859481509
              },
              "source": "{\"langType\":\"calcite\",\"script\":\"rO0ABXQCB3sKICAib3AiOiB7CiAgICAibmFtZSI6ICJJTElLRSIsCiAgICAia2luZCI6ICJMSUtFIiwKICAgICJzeW50YXgiOiAiU1BFQ0lBTCIKICB9LAogICJvcGVyYW5kcyI6IFsKICAgIHsKICAgICAgImR5bmFtaWNQYXJhbSI6IDAsCiAgICAgICJ0eXBlIjogewogICAgICAgICJ0eXBlIjogIlZBUkNIQVIiLAogICAgICAgICJudWxsYWJsZSI6IHRydWUsCiAgICAgICAgInByZWNpc2lvbiI6IC0xCiAgICAgIH0KICAgIH0sCiAgICB7CiAgICAgICJkeW5hbWljUGFyYW0iOiAxLAogICAgICAidHlwZSI6IHsKICAgICAgICAidHlwZSI6ICJWQVJDSEFSIiwKICAgICAgICAibnVsbGFibGUiOiB0cnVlLAogICAgICAgICJwcmVjaXNpb24iOiAtMQogICAgICB9CiAgICB9LAogICAgewogICAgICAiZHluYW1pY1BhcmFtIjogMiwKICAgICAgInR5cGUiOiB7CiAgICAgICAgInR5cGUiOiAiVkFSQ0hBUiIsCiAgICAgICAgIm51bGxhYmxlIjogdHJ1ZSwKICAgICAgICAicHJlY2lzaW9uIjogLTEKICAgICAgfQogICAgfQogIF0KfQ==\"}"
            }
          }
        }
      ]
    }
  },
  "size": 10000,
  "timeout": "1m"
}, requestedTotalSize=10000, pageSize=null, startFrom=0)])
```

### Related Issues
Related to issue 2 identified in #5491 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
