### PR TITLE
fix: Honor PPL fetch_size on the analytics-engine route

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -346,13 +346,14 @@ public class RestUnifiedQueryAction {
   }
 
   /**
-   * Cap the result to {@code fetchSize} rows when {@code fetchSize > 0}, mirroring PPL's
-   * {@code fetch_size} (which the V2 path lowers to a top-level {@code head N} in
-   * AstStatementBuilder). {@code fetchSize <= 0} means "use system default", so no limit is added.
-   * Uses the same {@code relBuilder.limit} primitive that {@code head} lowers to, so the analytics
-   * backend sees an ordinary fetch limit.
+   * Cap the result to {@code fetchSize} rows when {@code fetchSize > 0}, mirroring PPL's {@code
+   * fetch_size} (which the V2 path lowers to a top-level {@code head N} in AstStatementBuilder).
+   * {@code fetchSize <= 0} means "use system default", so no limit is added. Uses the same {@code
+   * relBuilder.limit} primitive that {@code head} lowers to, so the analytics backend sees an
+   * ordinary fetch limit.
    */
-  private static RelNode addFetchSizeLimit(RelNode plan, CalcitePlanContext context, int fetchSize) {
+  private static RelNode addFetchSizeLimit(
+      RelNode plan, CalcitePlanContext context, int fetchSize) {
     if (fetchSize <= 0) {
       return plan;
     }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -152,7 +152,7 @@ public class RestUnifiedQueryAction {
       QueryType queryType,
       boolean profiling,
       ActionListener<TransportPPLQueryResponse> listener) {
-    doExecute(query, queryType, profiling, null, listener);
+    doExecute(query, queryType, profiling, 0, null, listener);
   }
 
   /** Execute linked to {@code parentTask} so a front-end cancel propagates into the engine. */
@@ -160,16 +160,18 @@ public class RestUnifiedQueryAction {
       String query,
       QueryType queryType,
       boolean profiling,
+      int fetchSize,
       Task parentTask,
       ActionListener<TransportPPLQueryResponse> listener) {
     assert parentTask != null : "parentTask required for cancellation propagation";
-    doExecute(query, queryType, profiling, parentTask, listener);
+    doExecute(query, queryType, profiling, fetchSize, parentTask, listener);
   }
 
   private void doExecute(
       String query,
       QueryType queryType,
       boolean profiling,
+      int fetchSize,
       Task parentTask,
       ActionListener<TransportPPLQueryResponse> listener) {
     client
@@ -193,6 +195,10 @@ public class RestUnifiedQueryAction {
                     UnifiedQueryPlanner planner = new UnifiedQueryPlanner(context);
                     RelNode plan = planner.plan(query);
                     CalcitePlanContext planContext = context.getPlanContext();
+                    // PPL fetch_size caps the response to N rows (no cursor) — the V2 path attaches
+                    // a `head N` in AstStatementBuilder; the unified path parses only the query
+                    // string, so apply the equivalent top-level limit here before the system cap.
+                    plan = addFetchSizeLimit(plan, planContext, fetchSize);
                     plan = addQuerySizeLimit(plan, planContext);
                     if (profiling) {
                       analyticsEngine.executeWithProfile(
@@ -337,6 +343,20 @@ public class RestUnifiedQueryAction {
         LogicalSystemLimit.SystemLimitType.QUERY_SIZE_LIMIT,
         plan,
         context.relBuilder.literal(context.sysLimit.querySizeLimit()));
+  }
+
+  /**
+   * Cap the result to {@code fetchSize} rows when {@code fetchSize > 0}, mirroring PPL's
+   * {@code fetch_size} (which the V2 path lowers to a top-level {@code head N} in
+   * AstStatementBuilder). {@code fetchSize <= 0} means "use system default", so no limit is added.
+   * Uses the same {@code relBuilder.limit} primitive that {@code head} lowers to, so the analytics
+   * backend sees an ordinary fetch limit.
+   */
+  private static RelNode addFetchSizeLimit(RelNode plan, CalcitePlanContext context, int fetchSize) {
+    if (fetchSize <= 0) {
+      return plan;
+    }
+    return context.relBuilder.push(plan).limit(0, fetchSize).build();
   }
 
   private ResponseListener<QueryResponse> createQueryListener(

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
@@ -189,6 +189,7 @@ public class TransportPPLQueryAction
             transformedRequest.getRequest(),
             QueryType.PPL,
             transformedRequest.profile(),
+            transformedRequest.getFetchSize(),
             task,
             clearingListener);
       }


### PR DESCRIPTION
## Problem
PPL's `fetch_size` caps a response to N rows (no cursor — distinct from SQL's cursor-based fetch_size). On the **V2 path** this is lowered to a top-level `head N` in `AstStatementBuilder.visitPplStatement` (`if (fetchSize > 0) rawPlan = new Head(fetchSize, 0).attach(rawPlan)`).

The **analytics-engine route bypasses that builder**: `TransportPPLQueryAction` forwards only the query *string* to `RestUnifiedQueryAction.execute(...)`, which re-parses it via the raw ANTLR→AST path. The `fetchSize` field never reaches the plan, so the engine returns the full result set.

Verified directly on a parquet-backed index:
```
source=idx | head 5      -> 5 rows   (head works on the analytics route)
source=idx + fetch_size:5 -> 20 rows  (fetch_size dropped before the analytics path)
```

## Fix
- Thread the request's `fetchSize` through the parent-task `execute(...)` overload into `doExecute`.
- After planning, apply an equivalent top-level limit on the `RelNode` via a new `addFetchSizeLimit(plan, ctx, fetchSize)` helper that uses the **same `relBuilder.limit` primitive that `head` lowers to** (`CalciteRelNodeVisitor.visitHead` → `relBuilder.limit(from, size)`), so the analytics backend sees an ordinary fetch limit it already supports.
- `fetchSize <= 0` preserves the prior "system default" behavior (no limit added). The SQL path (`SQLPlugin`, separate cursor-based fetch_size) is untouched — only the PPL parent-task overload gains the parameter.

No new engine capability needed: `head`/`limit` already works on the analytics route; this just routes `fetch_size` to it.

## Before / After
`FetchSizeIT` on the analytics-engine route (`-Dtests.analytics.parquet_indices=true -Dtests.analytics.force_routing=true`):

| | Pass | Fail |
|---|---:|---:|
| before | 9/19 | 10 |
| after | **19/19** | **0** |

The 10 previously-failing tests all returned the full set (e.g. `testFetchSizeOne` expected 1 got 1000); all now return the requested page.

## Test plan
- [x] `./gradlew :integ-test:integTestRemote --tests '*.FetchSizeIT'` against an analytics-engine cluster — 19/19.
- [x] Direct probe: `source=idx + fetch_size:5` → 5 rows (was 20).
- [x] V2 path unchanged (fetch_size still handled in AstStatementBuilder; SQL path overload untouched).