### PR TITLE
[Enhancement] Reject unsupported output formats on the analytics-engine route with a 4xx

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -107,6 +107,7 @@ import org.opensearch.sql.opensearch.storage.OpenSearchDataSourceFactory;
 import org.opensearch.sql.opensearch.storage.script.CompoundedScriptEngine;
 import org.opensearch.sql.plugin.config.EngineExtensionsHolder;
 import org.opensearch.sql.plugin.config.OpenSearchPluginModule;
+import org.opensearch.sql.plugin.rest.AnalyticsEngineFormatSupport;
 import org.opensearch.sql.plugin.rest.AnalyticsExecutorHolder;
 import org.opensearch.sql.plugin.rest.RestPPLGrammarAction;
 import org.opensearch.sql.plugin.rest.RestPPLQueryAction;
@@ -271,6 +272,14 @@ public class SQLPlugin extends Plugin
               }
             });
       } else {
+        // The analytics route only emits JSON. Reject an unsupported output format (e.g.
+        // format=csv) up front with a clean 4xx instead of silently returning JSON.
+        try {
+          AnalyticsEngineFormatSupport.validateFormat(sqlRequest.format());
+        } catch (Exception e) {
+          RestSqlAction.handleException(channel, e);
+          return true;
+        }
         unifiedQueryHandler.execute(
             sqlRequest.getQuery(),
             QueryType.SQL,

--- a/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/SQLPlugin.java
@@ -272,8 +272,7 @@ public class SQLPlugin extends Plugin
               }
             });
       } else {
-        // The analytics route only emits JSON. Reject an unsupported output format (e.g.
-        // format=csv) up front with a clean 4xx instead of silently returning JSON.
+        // Analytics route only emits JSON; reject unsupported formats (e.g. csv) with a 4xx.
         try {
           AnalyticsEngineFormatSupport.validateFormat(sqlRequest.format());
         } catch (Exception e) {

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/AnalyticsEngineFormatSupport.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/AnalyticsEngineFormatSupport.java
@@ -12,33 +12,19 @@ import org.opensearch.sql.common.error.QueryProcessingStage;
 import org.opensearch.sql.protocol.response.format.Format;
 
 /**
- * Guards the analytics-engine (Calcite/DataFusion) query route, which only produces JSON output.
- *
- * <p>The unified analytics route formats every response with {@code SimpleJsonResponseFormatter}
- * and does not implement the alternate response formats (csv/raw/viz) that the classic SQL/PPL
- * engines support. Previously a {@code format=csv} request on an analytics index was silently
- * answered with JSON, which is misleading: the client asked for one content type and received
- * another with no indication the parameter was dropped.
- *
- * <p>This guard rejects an unsupported output format up front with a structured {@link ErrorReport}
- * coded {@link ErrorCode#UNSUPPORTED_OPERATION}, so the REST layer returns a clean client error
- * (4xx) with an actionable message instead of silently ignoring the request.
+ * Guards the analytics-engine query route, which only produces JSON. Rejects the alternate output
+ * formats (csv/raw/viz) the route does not implement, instead of silently answering with JSON.
  */
 public final class AnalyticsEngineFormatSupport {
 
   private AnalyticsEngineFormatSupport() {}
 
   /**
-   * Throw an {@link ErrorReport} if the requested output format is not supported on the analytics
+   * Throw an {@link ErrorReport} if the requested output format is unsupported on the analytics
    * engine. JSON/JDBC (the default) is supported; csv/raw/viz are not.
-   *
-   * @param format the resolved response format requested by the client
-   * @throws ErrorReport (coded {@link ErrorCode#UNSUPPORTED_OPERATION}) when the format is
-   *     unsupported on the analytics route
    */
   public static void validateFormat(Format format) {
-    // JDBC (the default) is the JSON contract the analytics route emits. Anything else is an
-    // alternate output format that the analytics route does not implement.
+    // JDBC (the default) is the JSON contract the analytics route emits.
     if (format == Format.JDBC) {
       return;
     }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/AnalyticsEngineFormatSupport.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/AnalyticsEngineFormatSupport.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.plugin.rest;
+
+import java.util.Locale;
+import org.opensearch.sql.common.error.ErrorCode;
+import org.opensearch.sql.common.error.ErrorReport;
+import org.opensearch.sql.common.error.QueryProcessingStage;
+import org.opensearch.sql.protocol.response.format.Format;
+
+/**
+ * Guards the analytics-engine (Calcite/DataFusion) query route, which only produces JSON output.
+ *
+ * <p>The unified analytics route formats every response with {@code SimpleJsonResponseFormatter}
+ * and does not implement the alternate response formats (csv/raw/viz) that the classic SQL/PPL
+ * engines support. Previously a {@code format=csv} request on an analytics index was silently
+ * answered with JSON, which is misleading: the client asked for one content type and received
+ * another with no indication the parameter was dropped.
+ *
+ * <p>This guard rejects an unsupported output format up front with a structured {@link ErrorReport}
+ * coded {@link ErrorCode#UNSUPPORTED_OPERATION}, so the REST layer returns a clean client error
+ * (4xx) with an actionable message instead of silently ignoring the request.
+ */
+public final class AnalyticsEngineFormatSupport {
+
+  private AnalyticsEngineFormatSupport() {}
+
+  /**
+   * Throw an {@link ErrorReport} if the requested output format is not supported on the analytics
+   * engine. JSON/JDBC (the default) is supported; csv/raw/viz are not.
+   *
+   * @param format the resolved response format requested by the client
+   * @throws ErrorReport (coded {@link ErrorCode#UNSUPPORTED_OPERATION}) when the format is
+   *     unsupported on the analytics route
+   */
+  public static void validateFormat(Format format) {
+    // JDBC (the default) is the JSON contract the analytics route emits. Anything else is an
+    // alternate output format that the analytics route does not implement.
+    if (format == Format.JDBC) {
+      return;
+    }
+    throw ErrorReport.wrap(
+            new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "response in %s format is not supported on the analytics engine",
+                    format.getFormatName())))
+        .code(ErrorCode.UNSUPPORTED_OPERATION)
+        .stage(QueryProcessingStage.ANALYZING)
+        .location("while selecting the response format for the analytics engine")
+        .suggestion(
+            "The analytics engine only returns JSON. Remove the 'format' parameter, or run this"
+                + " query against a non-analytics index to use the requested format.")
+        .build();
+  }
+}

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
@@ -40,6 +40,7 @@ import org.opensearch.sql.opensearch.executor.OpenSearchQueryManager;
 import org.opensearch.sql.opensearch.setting.OpenSearchSettings;
 import org.opensearch.sql.plugin.config.EngineExtensionsHolder;
 import org.opensearch.sql.plugin.config.OpenSearchPluginModule;
+import org.opensearch.sql.plugin.rest.AnalyticsEngineFormatSupport;
 import org.opensearch.sql.plugin.rest.AnalyticsExecutorHolder;
 import org.opensearch.sql.plugin.rest.RestUnifiedQueryAction;
 import org.opensearch.sql.ppl.PPLService;
@@ -185,6 +186,14 @@ public class TransportPPLQueryAction
             task,
             createExplainResponseListener(transformedRequest, clearingListener));
       } else {
+        // The analytics route only emits JSON. Reject an unsupported output format (e.g.
+        // format=csv) up front with a clean 4xx instead of silently returning JSON.
+        try {
+          AnalyticsEngineFormatSupport.validateFormat(format(transformedRequest));
+        } catch (Exception e) {
+          clearingListener.onFailure(e);
+          return;
+        }
         unifiedQueryHandler.execute(
             transformedRequest.getRequest(),
             QueryType.PPL,

--- a/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryAction.java
@@ -186,8 +186,7 @@ public class TransportPPLQueryAction
             task,
             createExplainResponseListener(transformedRequest, clearingListener));
       } else {
-        // The analytics route only emits JSON. Reject an unsupported output format (e.g.
-        // format=csv) up front with a clean 4xx instead of silently returning JSON.
+        // Analytics route only emits JSON; reject unsupported formats (e.g. csv) with a 4xx.
         try {
           AnalyticsEngineFormatSupport.validateFormat(format(transformedRequest));
         } catch (Exception e) {

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/AnalyticsEngineFormatSupportTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/AnalyticsEngineFormatSupportTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.plugin.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.opensearch.sql.common.error.ErrorCode;
+import org.opensearch.sql.common.error.ErrorReport;
+import org.opensearch.sql.protocol.response.format.Format;
+
+/**
+ * Verifies {@link AnalyticsEngineFormatSupport#validateFormat(Format)} accepts the JSON/JDBC
+ * default the analytics route emits and rejects unsupported output formats (csv/raw/viz) with a
+ * structured {@link ErrorReport} so the REST layer returns a clean 4xx instead of silently
+ * returning JSON.
+ */
+public class AnalyticsEngineFormatSupportTest {
+
+  @Test
+  public void jdbcFormatIsAccepted() {
+    // No exception expected — JDBC is the JSON contract the analytics route emits.
+    AnalyticsEngineFormatSupport.validateFormat(Format.JDBC);
+  }
+
+  @Test
+  public void csvFormatIsRejectedAsUnsupportedOperation() {
+    ErrorReport report =
+        assertThrows(() -> AnalyticsEngineFormatSupport.validateFormat(Format.CSV));
+    assertEquals(ErrorCode.UNSUPPORTED_OPERATION, report.getCode());
+    assertTrue(report.getMessage().toLowerCase().contains("csv"));
+    assertTrue(report.getMessage().contains("analytics engine"));
+    assertNotNull(report.getSuggestion());
+  }
+
+  @Test
+  public void rawFormatIsRejected() {
+    ErrorReport report =
+        assertThrows(() -> AnalyticsEngineFormatSupport.validateFormat(Format.RAW));
+    assertEquals(ErrorCode.UNSUPPORTED_OPERATION, report.getCode());
+    assertTrue(report.getMessage().toLowerCase().contains("raw"));
+  }
+
+  @Test
+  public void vizFormatIsRejected() {
+    ErrorReport report =
+        assertThrows(() -> AnalyticsEngineFormatSupport.validateFormat(Format.VIZ));
+    assertEquals(ErrorCode.UNSUPPORTED_OPERATION, report.getCode());
+  }
+
+  private static ErrorReport assertThrows(Runnable runnable) {
+    try {
+      runnable.run();
+    } catch (ErrorReport e) {
+      return e;
+    }
+    throw new AssertionError("Expected ErrorReport to be thrown, but nothing was thrown");
+  }
+}


### PR DESCRIPTION
### Description
The analytics-engine (Calcite/DataFusion) route formats every response with `SimpleJsonResponseFormatter` and does **not** implement the alternate response formats (csv/raw/viz) that the classic SQL/PPL engines support. A request such as `format=csv` against an analytics index was **silently answered with JSON**: the client asked for one content type and received another, with no signal that the parameter was dropped.

This PR adds an up-front guard on the analytics route that rejects an unsupported output format with a structured `ErrorReport` coded `UNSUPPORTED_OPERATION`, so the client gets a clean **4xx** with an actionable message instead of silent JSON. JSON/JDBC (the default) is unaffected.

**Changes**
- New `AnalyticsEngineFormatSupport.validateFormat(Format)`: accepts `JDBC` (the JSON contract the route emits); throws an `ErrorReport(UNSUPPORTED_OPERATION, ANALYZING)` with a suggestion for `csv`/`raw`/`viz`.
- Wire the guard into both analytics entry points:
  - `SQLPlugin#createSqlAnalyticsRouter` (SQL `_sql` route)
  - `TransportPPLQueryAction#doExecute` (PPL `_ppl` route)
- The thrown `ErrorReport` flows through the existing REST error handling (`RestSqlAction`/`RestPPLQueryAction`), which classifies its `IllegalArgumentException` cause as a client error → 400.

### Related Issues
<!-- No tracking issue; surfaced while validating analytics-engine output-format handling. -->
N/A

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command checklist all confirmed.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
