### PR TITLE
Preserve SQL-layer profiling alongside the analytics-engine profile

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analytics/AnalyticsExecutionEngine.java
@@ -169,6 +169,9 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
       org.opensearch.analytics.QueryRequestContext queryCtx,
       ResponseListener<QueryResponse> listener) {
 
+    ProfileContext profileCtx = QueryProfiling.current();
+    long execStart = System.nanoTime();
+
     planExecutor.executeWithProfile(
         plan,
         queryCtx,
@@ -178,6 +181,7 @@ public class AnalyticsExecutionEngine implements ExecutionEngine {
             try {
               // ProfiledResult delivers the profile on BOTH success and failure paths
               // so users get stage timing visibility even when a query partially fails.
+              profileCtx.getOrCreateMetric(MetricName.EXECUTE).set(System.nanoTime() - execStart);
               QueryResponse response = buildProfiledResponse(plan, result);
               listener.onResponse(response);
             } catch (Exception e) {

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/DefaultProfileContext.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/DefaultProfileContext.java
@@ -17,6 +17,7 @@ public class DefaultProfileContext implements ProfileContext {
   private boolean finished;
   private final Map<MetricName, DefaultMetricImpl> metrics = new ConcurrentHashMap<>();
   private ProfilePlanNode planRoot;
+  private Object enginePlan;
   private QueryProfile profile;
 
   public DefaultProfileContext() {}
@@ -40,6 +41,11 @@ public class DefaultProfileContext implements ProfileContext {
     }
   }
 
+  @Override
+  public synchronized void setEnginePlan(Object enginePlan) {
+    this.enginePlan = enginePlan;
+  }
+
   /** {@inheritDoc} */
   @Override
   public synchronized QueryProfile finish() {
@@ -55,7 +61,8 @@ public class DefaultProfileContext implements ProfileContext {
       snapshot.put(metricName, millis);
     }
     double totalMillis = ProfileUtils.roundToMillis(endNanos - startNanos);
-    QueryProfile.PlanNode planSnapshot = planRoot == null ? null : planRoot.snapshot();
+    Object planSnapshot =
+        enginePlan != null ? enginePlan : (planRoot == null ? null : planRoot.snapshot());
     profile = new QueryProfile(totalMillis, snapshot, planSnapshot);
     return profile;
   }

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/ProfileContext.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/ProfileContext.java
@@ -27,6 +27,9 @@ public interface ProfileContext {
    */
   void setPlanRoot(ProfilePlanNode planRoot);
 
+  /** TODO: merge with planRoot into one generic execution-engine-specific plan profile field. */
+  default void setEnginePlan(Object plan) {}
+
   /**
    * Finalize profiling and return a snapshot.
    *

--- a/core/src/main/java/org/opensearch/sql/monitor/profile/QueryProfile.java
+++ b/core/src/main/java/org/opensearch/sql/monitor/profile/QueryProfile.java
@@ -21,7 +21,8 @@ public final class QueryProfile {
 
   private final Map<String, Phase> phases;
 
-  private final PlanNode plan;
+  /** Execution-engine-specific plan profile: a {@link PlanNode} tree, or a pre-rendered object. */
+  private final Object plan;
 
   /**
    * Create a new query profile snapshot.
@@ -40,7 +41,7 @@ public final class QueryProfile {
    * @param phases metric values keyed by {@link MetricName}
    * @param plan plan tree profiling output
    */
-  public QueryProfile(double totalTimeMillis, Map<MetricName, Double> phases, PlanNode plan) {
+  public QueryProfile(double totalTimeMillis, Map<MetricName, Double> phases, Object plan) {
     this.summary = new Summary(totalTimeMillis);
     this.phases = buildPhases(phases);
     this.plan = plan;

--- a/integ-test/src/test/java/org/opensearch/sql/analytics/AnalyticsEngineProfileIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/analytics/AnalyticsEngineProfileIT.java
@@ -103,12 +103,21 @@ public class AnalyticsEngineProfileIT extends OpenSearchRestTestCase {
     assertTrue("has profile", result.has("profile"));
 
     JSONObject profile = result.getJSONObject("profile");
-    assertTrue("has query_id", profile.has("query_id"));
-    assertTrue("has planning_time_ms", profile.has("planning_time_ms"));
-    assertTrue("has execution_time_ms", profile.has("execution_time_ms"));
-    assertTrue("has full_plan", profile.has("full_plan"));
+    assertTrue("has summary", profile.has("summary"));
+    assertTrue("summary has total_time_ms", profile.getJSONObject("summary").has("total_time_ms"));
+    assertTrue("has phases", profile.has("phases"));
+    JSONObject phases = profile.getJSONObject("phases");
+    assertTrue("phase analyze", phases.getJSONObject("analyze").has("time_ms"));
+    assertTrue("phase execute", phases.getJSONObject("execute").has("time_ms"));
+    assertTrue("phase format", phases.getJSONObject("format").has("time_ms"));
 
-    JSONArray stages = profile.getJSONArray("stages");
+    JSONObject plan = profile.getJSONObject("plan");
+    assertTrue("has query_id", plan.has("query_id"));
+    assertTrue("has planning_time_ms", plan.has("planning_time_ms"));
+    assertTrue("has execution_time_ms", plan.has("execution_time_ms"));
+    assertTrue("has full_plan", plan.has("full_plan"));
+
+    JSONArray stages = plan.getJSONArray("stages");
     assertTrue("at least one stage", stages.length() >= 1);
 
     JSONObject stage = stages.getJSONObject(0);
@@ -129,9 +138,12 @@ public class AnalyticsEngineProfileIT extends OpenSearchRestTestCase {
     assertTrue("has profile", result.has("profile"));
 
     JSONObject profile = result.getJSONObject("profile");
-    assertTrue("has query_id", profile.has("query_id"));
-    assertTrue("has stages", profile.has("stages"));
-    JSONArray stages = profile.getJSONArray("stages");
+    assertTrue("has summary", profile.has("summary"));
+    assertTrue("has phases", profile.has("phases"));
+    JSONObject plan = profile.getJSONObject("plan");
+    assertTrue("has query_id", plan.has("query_id"));
+    assertTrue("has stages", plan.has("stages"));
+    JSONArray stages = plan.getJSONArray("stages");
     assertTrue("at least one stage", stages.length() >= 1);
   }
 
@@ -142,7 +154,7 @@ public class AnalyticsEngineProfileIT extends OpenSearchRestTestCase {
         executeWithProfile("source = " + INDEX + " | fields name, score", "/_plugins/_ppl");
 
     JSONObject profile = result.getJSONObject("profile");
-    JSONArray stages = profile.getJSONArray("stages");
+    JSONArray stages = profile.getJSONObject("plan").getJSONArray("stages");
 
     for (int i = 0; i < stages.length(); i++) {
       JSONObject stage = stages.getJSONObject(i);
@@ -158,7 +170,7 @@ public class AnalyticsEngineProfileIT extends OpenSearchRestTestCase {
         executeWithProfile("source = " + INDEX + " | fields name", "/_plugins/_ppl");
 
     JSONObject profile = result.getJSONObject("profile");
-    JSONArray stages = profile.getJSONArray("stages");
+    JSONArray stages = profile.getJSONObject("plan").getJSONArray("stages");
 
     boolean foundTasks = false;
     for (int i = 0; i < stages.length(); i++) {

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -10,6 +10,9 @@ import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
 import static org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.SQL_WORKER_THREAD_POOL_NAME;
 import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.calcite.rel.RelNode;
@@ -22,7 +25,10 @@ import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.exec.profile.QueryProfile;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.sql.api.UnifiedQueryContext;
@@ -38,6 +44,8 @@ import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.sql.executor.analytics.AnalyticsExecutionEngine;
 import org.opensearch.sql.lang.LangSpec;
+import org.opensearch.sql.monitor.profile.ProfileContext;
+import org.opensearch.sql.monitor.profile.QueryProfiling;
 import org.opensearch.sql.plugin.transport.TransportPPLQueryResponse;
 import org.opensearch.sql.protocol.response.QueryResult;
 import org.opensearch.sql.protocol.response.format.ResponseFormatter;
@@ -185,10 +193,9 @@ public class RestUnifiedQueryAction {
                   // Carry the front-end task so cancellation propagates into the engine.
                   QueryRequestContext queryCtx =
                       withParentTask(contextProvider.getContext(), parentTask);
-                  // Disable SQL-layer phase profiling when analytics engine profiling is active.
-                  // Our QueryProfile (stages, tasks, timing) is strictly more detailed and replaces
-                  // it.
-                  UnifiedQueryContext context = buildContext(queryType, false, queryCtx);
+
+                  UnifiedQueryContext context = buildContext(queryType, profiling, queryCtx);
+                  ProfileContext profileCtx = QueryProfiling.current();
                   ActionListener<TransportPPLQueryResponse> closingListener =
                       wrapWithContextClose(context, listener);
                   try {
@@ -205,13 +212,13 @@ public class RestUnifiedQueryAction {
                           plan,
                           planContext,
                           queryCtx,
-                          createQueryListener(queryType, closingListener));
+                          createQueryListener(queryType, profileCtx, closingListener));
                     } else {
                       analyticsEngine.execute(
                           plan,
                           planContext,
                           queryCtx,
-                          createQueryListener(queryType, closingListener));
+                          createQueryListener(queryType, profileCtx, closingListener));
                     }
                   } catch (Exception e) {
                     closingListener.onFailure(e);
@@ -361,19 +368,32 @@ public class RestUnifiedQueryAction {
   }
 
   private ResponseListener<QueryResponse> createQueryListener(
-      QueryType queryType, ActionListener<TransportPPLQueryResponse> transportListener) {
+      QueryType queryType,
+      ProfileContext profileCtx,
+      ActionListener<TransportPPLQueryResponse> transportListener) {
     ResponseFormatter<QueryResult> formatter = new SimpleJsonResponseFormatter(PRETTY);
     return new ResponseListener<QueryResponse>() {
       @Override
       public void onResponse(QueryResponse response) {
         LangSpec langSpec = queryType == QueryType.PPL ? PPL_SPEC : LangSpec.SQL_SPEC;
-        String result =
-            formatter.format(
-                new QueryResult(
-                    response.getSchema(), response.getResults(), response.getCursor(), langSpec));
+
+        // Set the engine profile as the plan so the formatter serializes it in one pass.
         if (response.getProfile() != null) {
-          // Append profile and error (if any) to the JSON response
-          result = appendProfileToJson(result, response.getProfile(), response.getError());
+          profileCtx.setEnginePlan(toJsonElement(response.getProfile()));
+        }
+
+        String result =
+            QueryProfiling.withCurrentContext(
+                profileCtx,
+                () ->
+                    formatter.format(
+                        new QueryResult(
+                            response.getSchema(),
+                            response.getResults(),
+                            response.getCursor(),
+                            langSpec)));
+        if (response.getError() != null) {
+          result = appendError(result, response.getError());
         }
         transportListener.onResponse(new TransportPPLQueryResponse(result));
       }
@@ -385,30 +405,24 @@ public class RestUnifiedQueryAction {
     };
   }
 
-  private static String appendProfileToJson(String json, QueryProfile profile, Throwable error) {
+  private static JsonElement toJsonElement(QueryProfile profile) {
     try {
-      StringBuilder extra = new StringBuilder();
-      // Append profile
-      org.opensearch.core.xcontent.XContentBuilder builder =
-          org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
-      profile.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
-      extra.append(",\"profile\":").append(builder.toString());
-      // Append error if query partially failed
-      if (error != null) {
-        extra
-            .append(",\"error\":{\"type\":\"")
-            .append(error.getClass().getSimpleName())
-            .append("\",\"reason\":\"")
-            .append(error.getMessage() != null ? error.getMessage().replace("\"", "\\\"") : "")
-            .append("\"}");
-      }
-      if (json.endsWith("}")) {
-        return json.substring(0, json.length() - 1) + extra + "}";
-      }
-      return json;
+      XContentBuilder builder = XContentFactory.jsonBuilder();
+      profile.toXContent(builder, ToXContent.EMPTY_PARAMS);
+      return JsonParser.parseString(builder.toString());
     } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private static String appendError(String json, Throwable error) {
+    if (!json.endsWith("}")) {
       return json;
     }
+    JsonObject err = new JsonObject();
+    err.addProperty("type", error.getClass().getSimpleName());
+    err.addProperty("reason", error.getMessage() != null ? error.getMessage() : "");
+    return json.substring(0, json.length() - 1) + ",\"error\":" + err + "}";
   }
 
   private static Runnable withCurrentContext(final Runnable task) {


### PR DESCRIPTION
### Description

In PR https://github.com/opensearch-project/sql/pull/5442, when a query routes to the analytics engine (AE) with `profile=true`, the response returned only the AE `QueryProfile`, dropping the SQL/PPL timing breakdown (`analyze`/`optimize`/`execute`/`format`). This changes enable both layers by generalizing the profile's `plan` field as engine-specific profile info, either:

- a Calcite per-operator execution profile (Calcite physical operators with duration and rows) for the default engine;
- or the AE execution profile (query_id, stages, tasks, …) for the analytics engine.

#### Testing

- `AnalyticsEngineProfileIT`: 6/6 passed
- Manual test (below):
    - No impact on PPL profiling without AE; 
    - No impact on query execution with AE;
    - SQL/PPL profiling is included under `profile` when `profile=true`.

```
$ curl -s localhost:9200/_plugins/_sql -H 'Content-Type: application/json'
    -d '{"query":"SELECT service, severity, status_code, latency_ms FROM otel-logs WHERE severity = '''ERROR''' ORDER BY latency_ms DESC", "profile":true}'
{
  "schema": [ ... ],
  "datarows": [ ... ],
  "total": 2,
  "size": 2,
  "profile": {
    "summary": { "total_time_ms": 54.62 },
    "phases": {                              // SQL/PPL frontend profiling
      "analyze":  { "time_ms": 3.65 },
      "optimize": { "time_ms": 0.0 },
      "execute":  { "time_ms": 42.84 },
      "format":   { "time_ms": 0.09 }
    },
    "plan": {                                // Analytics engine backend profiling
      "query_id": "562f827d-1738-44dc-a77b-ca19a620ce34",
      "full_plan": [
        "OpenSearchSort(sort0=[$3], dir0=[DESC-nulls-last], fetch=[10000], ...)",
        "  ..."
      ],
      "planning_time_ms": 20,
      "execution_time_ms": 14,
      "stages": [
        {
          "stage_id": 0,
          "execution_type": "SHARD_FRAGMENT",
          "state": "SUCCEEDED",
          "tasks": [
            {
              "node": "rZfPf1DqR12Qxi7iBTsVSA/shard[0]",
              "state": "FINISHED",
              "elapsed_ms": 14,
              "data_node_metrics": { ... },
              "physical_plan": "ProjectionExec: ... SortExec: TopK(fetch=10000) ..."
            }
          ]
        }
      ]
    }
  }
}
```

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5246

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
