### PR TITLE
Use ObjectInputFilter for deserialization (#5469)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,6 +81,7 @@ jacocoTestCoverageVerification {
             excludes = [
                     'org.opensearch.sql.utils.MLCommonsConstants',
                     'org.opensearch.sql.utils.Constants',
+                    'org.opensearch.sql.utils.DeserializationFilterUtil',
                     'org.opensearch.sql.datasource.model.DataSource',
                     'org.opensearch.sql.datasource.model.DataSourceStatus',
                     'org.opensearch.sql.datasource.model.DataSourceType'

--- a/core/src/main/java/org/opensearch/sql/executor/pagination/PlanSerializer.java
+++ b/core/src/main/java/org/opensearch/sql/executor/pagination/PlanSerializer.java
@@ -22,6 +22,7 @@ import org.opensearch.sql.exception.NoCursorException;
 import org.opensearch.sql.planner.SerializablePlan;
 import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.storage.StorageEngine;
+import org.opensearch.sql.utils.DeserializationFilterUtil;
 
 /**
  * This class is entry point to paged requests. It is responsible to cursor serialization and
@@ -88,6 +89,14 @@ public class PlanSerializer {
           new GZIPInputStream(new ByteArrayInputStream(HashCode.fromString(code).asBytes()));
       ObjectInputStream objectInput =
           new CursorDeserializationStream(new ByteArrayInputStream(gzip.readAllBytes()));
+      objectInput.setObjectInputFilter(
+          DeserializationFilterUtil.createFilter(
+              "org.opensearch.sql.planner.physical.*;"
+                  + "org.opensearch.sql.opensearch.storage.scan.*;"
+                  + "org.opensearch.sql.opensearch.data.type.*;"
+                  + "org.opensearch.sql.executor.pagination.*;"
+                  + "org.opensearch.sql.executor.QueryType;"
+                  + "org.opensearch.sql.utils.*;"));
       return (Serializable) objectInput.readObject();
     } catch (Exception e) {
       throw new IllegalStateException("Failed to deserialize object", e);

--- a/core/src/main/java/org/opensearch/sql/executor/pagination/PlanSerializer.java
+++ b/core/src/main/java/org/opensearch/sql/executor/pagination/PlanSerializer.java
@@ -89,14 +89,19 @@ public class PlanSerializer {
           new GZIPInputStream(new ByteArrayInputStream(HashCode.fromString(code).asBytes()));
       ObjectInputStream objectInput =
           new CursorDeserializationStream(new ByteArrayInputStream(gzip.readAllBytes()));
-      objectInput.setObjectInputFilter(
-          DeserializationFilterUtil.createFilter(
-              "org.opensearch.sql.planner.physical.*;"
-                  + "org.opensearch.sql.opensearch.storage.scan.*;"
-                  + "org.opensearch.sql.opensearch.data.type.*;"
-                  + "org.opensearch.sql.executor.pagination.*;"
-                  + "org.opensearch.sql.executor.QueryType;"
-                  + "org.opensearch.sql.utils.*;"));
+      java.security.AccessController.doPrivileged(
+          (java.security.PrivilegedAction<Void>)
+              () -> {
+                objectInput.setObjectInputFilter(
+                    DeserializationFilterUtil.createFilter(
+                        "org.opensearch.sql.planner.physical.*;"
+                            + "org.opensearch.sql.opensearch.storage.scan.*;"
+                            + "org.opensearch.sql.opensearch.data.type.*;"
+                            + "org.opensearch.sql.executor.pagination.*;"
+                            + "org.opensearch.sql.executor.QueryType;"
+                            + "org.opensearch.sql.utils.*;"));
+                return null;
+              });
       return (Serializable) objectInput.readObject();
     } catch (Exception e) {
       throw new IllegalStateException("Failed to deserialize object", e);

--- a/core/src/main/java/org/opensearch/sql/utils/DeserializationFilterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/utils/DeserializationFilterUtil.java
@@ -44,6 +44,7 @@ public class DeserializationFilterUtil {
           + "java.math.BigDecimal;"
           + "java.math.BigInteger;"
           + "java.time.**;"
+          + "java.util.regex.Pattern;"
           + "com.google.common.collect.**;";
 
   /**

--- a/core/src/main/java/org/opensearch/sql/utils/DeserializationFilterUtil.java
+++ b/core/src/main/java/org/opensearch/sql/utils/DeserializationFilterUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.utils;
+
+import java.io.ObjectInputFilter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** Utility class for creating deserialization filters with logging. */
+public class DeserializationFilterUtil {
+  private static final Logger LOG = LogManager.getLogger(DeserializationFilterUtil.class);
+
+  /** Base allowlist shared across all serializers. */
+  private static final String BASE_ALLOWLIST =
+      "org.opensearch.sql.expression.**;"
+          + "org.opensearch.sql.data.**;"
+          + "org.opensearch.sql.executor.QueryType;"
+          + "org.opensearch.sql.opensearch.data.type.*;"
+          + "java.lang.Object;"
+          + "java.lang.String;"
+          + "java.lang.Number;"
+          + "java.lang.Integer;"
+          + "java.lang.Long;"
+          + "java.lang.Double;"
+          + "java.lang.Float;"
+          + "java.lang.Short;"
+          + "java.lang.Byte;"
+          + "java.lang.Boolean;"
+          + "java.lang.Character;"
+          + "java.lang.Enum;"
+          + "java.util.ArrayList;"
+          + "java.util.Arrays$ArrayList;"
+          + "java.util.LinkedHashMap;"
+          + "java.util.HashMap;"
+          + "java.util.Collections$*;"
+          + "java.util.ImmutableCollections$*;"
+          + "java.util.CollSer;"
+          + "java.util.Map$Entry;"
+          + "java.io.Serializable;"
+          + "java.lang.invoke.SerializedLambda;"
+          + "java.math.BigDecimal;"
+          + "java.math.BigInteger;"
+          + "java.time.**;"
+          + "com.google.common.collect.**;";
+
+  /**
+   * Creates a logging filter that wraps the provided filter and logs rejected classes.
+   *
+   * @param filter The underlying filter to wrap.
+   * @return A filter that logs rejections.
+   */
+  public static ObjectInputFilter createLoggingFilter(ObjectInputFilter filter) {
+    return info -> {
+      ObjectInputFilter.Status status = filter.checkInput(info);
+      if (status == ObjectInputFilter.Status.REJECTED && info.serialClass() != null) {
+        LOG.warn("Deserialization filter rejected class: {}", info.serialClass().getName());
+      }
+      return status;
+    };
+  }
+
+  /**
+   * Creates a filter with the base allowlist plus additional patterns.
+   *
+   * @param additionalPatterns Additional patterns to append to the base allowlist.
+   * @return A logging filter with the combined allowlist.
+   */
+  public static ObjectInputFilter createFilter(String additionalPatterns) {
+    String fullPattern = BASE_ALLOWLIST + additionalPatterns + "!*";
+    return createLoggingFilter(ObjectInputFilter.Config.createFilter(fullPattern));
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/executor/pagination/PlanSerializerTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/pagination/PlanSerializerTest.java
@@ -168,6 +168,14 @@ public class PlanSerializerTest {
     assertSame(object, cds.resolveObject(object));
   }
 
+  @Test
+  @SneakyThrows
+  void deserialize_rejects_disallowed_class() {
+    String serialized = serialize(new java.net.URL("http://example.com"));
+    var exception = assertThrows(IllegalStateException.class, () -> deserialize(serialized));
+    assertTrue(exception.getMessage().contains("Failed to deserialize"));
+  }
+
   // Helpers and auxiliary classes section below
 
   @SneakyThrows

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serialization/DefaultExpressionSerializer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serialization/DefaultExpressionSerializer.java
@@ -12,6 +12,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Base64;
 import org.opensearch.sql.expression.Expression;
+import org.opensearch.sql.utils.DeserializationFilterUtil;
 
 /** Default serializer that (de-)serialize expressions by JDK serialization. */
 public class DefaultExpressionSerializer implements ExpressionSerializer {
@@ -34,6 +35,7 @@ public class DefaultExpressionSerializer implements ExpressionSerializer {
     try {
       ByteArrayInputStream input = new ByteArrayInputStream(Base64.getDecoder().decode(code));
       ObjectInputStream objectInput = new ObjectInputStream(input);
+      objectInput.setObjectInputFilter(DeserializationFilterUtil.createFilter(""));
       return (Expression) objectInput.readObject();
     } catch (Exception e) {
       throw new IllegalStateException("Failed to deserialize expression code: " + code, e);

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serialization/DefaultExpressionSerializer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serialization/DefaultExpressionSerializer.java
@@ -35,7 +35,12 @@ public class DefaultExpressionSerializer implements ExpressionSerializer {
     try {
       ByteArrayInputStream input = new ByteArrayInputStream(Base64.getDecoder().decode(code));
       ObjectInputStream objectInput = new ObjectInputStream(input);
-      objectInput.setObjectInputFilter(DeserializationFilterUtil.createFilter(""));
+      java.security.AccessController.doPrivileged(
+          (java.security.PrivilegedAction<Void>)
+              () -> {
+                objectInput.setObjectInputFilter(DeserializationFilterUtil.createFilter(""));
+                return null;
+              });
       return (Expression) objectInput.readObject();
     } catch (Exception e) {
       throw new IllegalStateException("Failed to deserialize expression code: " + code, e);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/serialization/DefaultExpressionSerializerTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/serialization/DefaultExpressionSerializerTest.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.opensearch.storage.serialization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 import static org.opensearch.sql.expression.DSL.literal;
 import static org.opensearch.sql.expression.DSL.ref;
@@ -81,5 +82,17 @@ class DefaultExpressionSerializerTest {
   @Test
   public void cannot_deserialize_illegal_expression_code() {
     assertThrows(IllegalStateException.class, () -> serializer.deserialize("hello world"));
+  }
+
+  @Test
+  public void deserialize_rejects_disallowed_class() throws Exception {
+    java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+    java.io.ObjectOutputStream objectOutput = new java.io.ObjectOutputStream(output);
+    objectOutput.writeObject(new java.net.URL("http://example.com"));
+    objectOutput.flush();
+    String encoded = java.util.Base64.getEncoder().encodeToString(output.toByteArray());
+    var exception =
+        assertThrows(IllegalStateException.class, () -> serializer.deserialize(encoded));
+    assertTrue(exception.getMessage().contains("Failed to deserialize"));
   }
 }

--- a/plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugin/src/main/plugin-metadata/plugin-security.policy
@@ -24,4 +24,7 @@ grant {
   permission javax.management.MBeanServerPermission "findMBeanServer";
   permission javax.management.MBeanPermission "com.amazonaws.metrics.*", "*";
   permission javax.management.MBeanTrustPermission "register";
+
+  // Deserialization filter
+  permission java.io.SerializablePermission "serialFilter";
 };


### PR DESCRIPTION
### Description

Adds ObjectInputFilter for deserialization in PlanSerializer, DefaultExpressionSerializer, and RelJsonSerializer by implementing a allowlist-based approach that only allows specific classes.

### Related Issues

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
