### PR TITLE
[Error Enhancement] Fix NPE when rex sits inside appendcol subsearch for Analytic Engine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/tree/Rex.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Rex.java
@@ -79,7 +79,7 @@ public class Rex extends UnresolvedPlan {
 
   @Override
   public List<UnresolvedPlan> getChild() {
-    return ImmutableList.of(child);
+    return this.child == null ? ImmutableList.of() : ImmutableList.of(this.child);
   }
 
   @Override

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAppendcolIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLAppendcolIT.java
@@ -81,4 +81,18 @@ public class CalcitePPLAppendcolIT extends PPLIntegTestCase {
         rows("F", "DE", 101, null),
         rows("F", "FL", 310, null));
   }
+
+  /** Verifies that rex can be used as the first command of an appendcol subsearch. */
+  @Test
+  public void testAppendColWithRexInSubsearch() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | stats count() as cnt by gender"
+                    + " | appendcol [ rex field=email '^(?<user>[^@]+)@.*' | fields user ]"
+                    + " | head 2",
+                TEST_INDEX_ACCOUNT));
+    verifySchema(
+        actual, schema("gender", "string"), schema("cnt", "bigint"), schema("user", "string"));
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLRexTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLRexTest.java
@@ -307,24 +307,13 @@ public class CalcitePPLRexTest extends CalcitePPLAbstractTest {
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
-  /**
-   * Regression for the rex-inside-appendcol NPE. The subsearch starts with rex (no upstream
-   * source), so the parsed Rex node has a null {@code child} until {@link
-   * org.opensearch.sql.calcite.utils.PlanUtils#transformPlanToAttachChild} walks the subsearch tree
-   * to attach the main relation. That walker calls {@code getChild()} on every node it crosses.
-   * {@code Rex.getChild()} previously returned {@code ImmutableList.of(child)} which throws NPE
-   * when {@code child} is null; sibling AST nodes (Project / Filter / Eval / Aggregation) all guard
-   * with {@code child == null ? ImmutableList.of() : ...}. This test ensures the rex-in-appendcol
-   * pipeline plans without NPE.
-   */
+  /** Verifies that rex plans correctly when it appears as the first command of a subsearch. */
   @Test
-  public void testRexInsideAppendCol() {
+  public void testRexInsideSubsearch() {
     String ppl =
         "source=EMP | stats count() as base_c by JOB"
             + " | appendcol [ rex field=ENAME '^(?<first>[A-Z])' | fields ENAME, first ]";
     RelNode root = getRelNode(ppl);
-    // Just verify planning succeeds (does not throw). Plan-shape assertions for AppendCol's join
-    // shape live in CalcitePPLAppendColumnsTest; this regression only covers the NPE.
     org.junit.Assert.assertNotNull(root);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLRexTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLRexTest.java
@@ -306,4 +306,25 @@ public class CalcitePPLRexTest extends CalcitePPLAbstractTest {
             + "FROM `scott`.`EMP`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
+
+  /**
+   * Regression for the rex-inside-appendcol NPE. The subsearch starts with rex (no upstream
+   * source), so the parsed Rex node has a null {@code child} until {@link
+   * org.opensearch.sql.calcite.utils.PlanUtils#transformPlanToAttachChild} walks the subsearch tree
+   * to attach the main relation. That walker calls {@code getChild()} on every node it crosses.
+   * {@code Rex.getChild()} previously returned {@code ImmutableList.of(child)} which throws NPE
+   * when {@code child} is null; sibling AST nodes (Project / Filter / Eval / Aggregation) all guard
+   * with {@code child == null ? ImmutableList.of() : ...}. This test ensures the rex-in-appendcol
+   * pipeline plans without NPE.
+   */
+  @Test
+  public void testRexInsideAppendCol() {
+    String ppl =
+        "source=EMP | stats count() as base_c by JOB"
+            + " | appendcol [ rex field=ENAME '^(?<first>[A-Z])' | fields ENAME, first ]";
+    RelNode root = getRelNode(ppl);
+    // Just verify planning succeeds (does not throw). Plan-shape assertions for AppendCol's join
+    // shape live in CalcitePPLAppendColumnsTest; this regression only covers the NPE.
+    org.junit.Assert.assertNotNull(root);
+  }
 }


### PR DESCRIPTION
### Description
The PPL query `... | appendcol [ rex field=X "..." | ... ]` (any pipeline that places `rex` as the *first* command of an `appendcol` body) crashes the backend with a `NullPointerException` ⇒ HTTP 500.

**Root cause** — `core/src/main/java/org/opensearch/sql/ast/tree/Rex.java:81-83`:

```java
@Override
public List<UnresolvedPlan> getChild() {
  return ImmutableList.of(child);   // ← NPE when child == null
}
```

Every sibling AST node (`Project`, `Filter`, `Eval`, `Aggregation`) uses the null-safe pattern:

```java
return this.child == null ? ImmutableList.of() : ImmutableList.of(this.child);
```

`Rex` is the only one missing the guard.

**Why only inside `appendcol`** — a top-level `... | rex ...` always has its `child` set by the parser (the upstream pipeline). But the `rex` inside `appendcol [ rex ... | ... ]` is the *leaf* of the subsearch as parsed; `child` stays null until `CalciteRelNodeVisitor.visitAppendCol` calls `PlanUtils.transformPlanToAttachChild` to wire the main relation in at the subsearch leaf. That walker (PlanUtils.java:457-471) recurses through every node's `getChild()` to find the attach point, so it hits `Rex.getChild()` before the attach has happened. `ImmutableList.of(null)` throws NPE.

**Reproducer (from the Mustang PPL sign-off sheet, Bug B):**

```ppl
source = signoff_events | stats count() as base_c by event_type
  | appendcol [ rex field=region "^(?<r1>[a-z]+)-.*$"
                | fields event_id, r1 ]
```

**Stack trace on unpatched main:**

```
java.lang.NullPointerException
    at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:902)
    at com.google.common.collect.SingletonImmutableList.<init>(SingletonImmutableList.java:41)
    at com.google.common.collect.ImmutableList.of(ImmutableList.java:99)
    at org.opensearch.sql.ast.tree.Rex.getChild(Rex.java:82)
    at org.opensearch.sql.calcite.utils.PlanUtils$5.visitChildren(PlanUtils.java:462)
    at org.opensearch.sql.calcite.utils.PlanUtils$5.visitChildren(PlanUtils.java:459)
    at org.opensearch.sql.ast.AbstractNodeVisitor.visitRex(AbstractNodeVisitor.java:309)
    at org.opensearch.sql.ast.tree.Rex.accept(Rex.java:87)
    ...
```

**Fix** — one-line change in `Rex.java` to mirror the sibling pattern.

**Test** — new `CalcitePPLRexTest.testRexInsideAppendCol` exercises the exact query shape from the bug report. Verified to fail with the stack above on unpatched main, and pass with the fix.

#### Out of scope
- `Search.java:40` has the same pattern (`return ImmutableList.of(child);` with no guard). In practice `search` is always a top-level command and its child is always set, so the bug isn't observable today — but it's a latent issue worth filing as a follow-up clean-up.

### Related Issues
Resolves Mustang PPL sign-off sheet Bug B (rex-inside-appendcol NPE). No public GitHub issue currently tracks this.
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing. (`CalcitePPLRexTest.testRexInsideAppendCol`)
- [ ] New functionality has been documented.
 - [x] New functionality has javadoc added. (Javadoc on the new test explains the regression scenario.)
 - [ ] New functionality has a user manual doc added. *(N/A — bug fix, not new behavior.)*
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed. *(N/A — bug fix to existing command.)*
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). *(N/A — no API surface change.)*
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose). *(N/A — no user-visible behavior change beyond removing the crash.)*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).