### PR TITLE
[Error Enhancement] Fix NPE on case() with incompatible branch types

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -835,6 +835,7 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   @Override
   public RexNode visitCase(Case node, CalcitePlanContext context) {
     List<RexNode> caseOperands = new ArrayList<>();
+    List<RelDataType> resultTypes = new ArrayList<>();
     for (When when : node.getWhenClauses()) {
       RexNode condition = analyze(when.getCondition(), context);
       if (!SqlTypeUtil.isBoolean(condition.getType())) {
@@ -843,11 +844,22 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
                 "Condition expected a boolean type, but got %s", condition.getType()));
       }
       caseOperands.add(condition);
-      caseOperands.add(analyze(when.getResult(), context));
+      RexNode result = analyze(when.getResult(), context);
+      caseOperands.add(result);
+      resultTypes.add(result.getType());
     }
     RexNode elseExpr =
         node.getElseClause().map(e -> analyze(e, context)).orElse(context.relBuilder.literal(null));
     caseOperands.add(elseExpr);
+    resultTypes.add(elseExpr.getType());
+
+    // Pre-validate the THEN/ELSE result types so an unsupertyped mix surfaces as a clean
+    // 400 here instead of an opaque NPE deep in Calcite's makeCall return-type inference.
+    RelDataType commonType = context.rexBuilder.getTypeFactory().leastRestrictive(resultTypes);
+    if (commonType == null) {
+      throw new ExpressionEvaluationException(
+          StringUtils.format("case branches must have a common type, but got %s", resultTypes));
+    }
     return context.rexBuilder.makeCall(SqlStdOperatorTable.CASE, caseOperands);
   }
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLCaseFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLCaseFunctionIT.java
@@ -537,4 +537,21 @@ public class CalcitePPLCaseFunctionIT extends PPLIntegTestCase {
         schema("flags", "bigint"));
     verifyNumOfRows(actual2, 32);
   }
+
+  /** Case with no common branch supertype must return a clean 4xx, not a 500. */
+  @Test
+  public void testCaseWithIncompatibleBranchTypesRejectsCleanly() {
+    org.opensearch.client.ResponseException e =
+        org.junit.Assert.assertThrows(
+            org.opensearch.client.ResponseException.class,
+            () ->
+                executeQuery(
+                    String.format(
+                        "source=%s | eval x = case(age > 30, 'old', age > 20, 1 else 0.0) | fields"
+                            + " x",
+                        TEST_INDEX_BANK)));
+    org.junit.Assert.assertTrue(
+        "expected 400 status, got: " + e.getMessage(),
+        e.getMessage().contains("status line [HTTP/1.1 400"));
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLCaseFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLCaseFunctionTest.java
@@ -5,9 +5,13 @@
 
 package org.opensearch.sql.ppl.calcite;
 
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.test.CalciteAssert;
 import org.junit.Test;
+import org.opensearch.sql.exception.ExpressionEvaluationException;
 
 public class CalcitePPLCaseFunctionTest extends CalcitePPLAbstractTest {
 
@@ -100,5 +104,17 @@ public class CalcitePPLCaseFunctionTest extends CalcitePPLAbstractTest {
             + " (30, 31) THEN 30 ELSE 100 END `new_deptno`\n"
             + "FROM `scott`.`EMP`)";
     verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  /** Case branches with no common supertype must be rejected cleanly, not NPE. */
+  @Test
+  public void testCaseWithIncompatibleBranchTypesRejectsCleanly() {
+    String ppl =
+        "source=EMP | eval x = case(DEPTNO > 20, 'big'," + " DEPTNO > 10, 1 else 0.0) | fields x";
+    ExpressionEvaluationException e =
+        assertThrows(ExpressionEvaluationException.class, () -> getRelNode(ppl));
+    assertTrue(
+        "expected message to list incompatible types, got: " + e.getMessage(),
+        e.getMessage().contains("case branches must have a common type"));
   }
 }


### PR DESCRIPTION
### Description
A `case(...)` whose branches have no common supertype (e.g. mixing string + int + decimal) crashes with `NullPointerException` ⇒ HTTP 500. The rejection should be a clean validation error.

**Root cause** — `CalciteRexNodeVisitor.visitCase` at `core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java:851` passes the THEN/ELSE operands straight to `rexBuilder.makeCall(SqlStdOperatorTable.CASE, …)` without checking that the result types have a common supertype:

```java
return context.rexBuilder.makeCall(SqlStdOperatorTable.CASE, caseOperands);
```

Calcite's CASE return-type inference then calls `leastRestrictive` over the result types. When the types have no common supertype, `leastRestrictive` returns `null` and downstream code dereferences it — surfacing as an opaque NPE at HTTP 500.

The dev comment at `PPLFuncImpTable.java:1153-1155` anticipated this scenario for the 3-arg `IF(cond, a, b)` form (registered with a type checker), but the multi-arg `case(...)` syntax routes through a different path that bypasses the checker.

**Reproducer (from the Mustang PPL sign-off sheet, Bug K):**

```ppl
source = signoff_events
  | eval x = case(latency_ms > 1000, 'slow',
                  latency_ms > 100,  1,
                  true,              0.0)
  | fields event_id, x | head 5
```

**Behaviour before:**

```
HTTP 500
type:    NullPointerException
reason:  Can't find leastRestrictive type for [VARCHAR, INTEGER, DECIMAL(2, 1), NULL]
```

**Behaviour after:**

```
HTTP 400
type:    ExpressionEvaluationException
reason:  case branches must have a common type, but got [VARCHAR, INTEGER, DECIMAL(2, 1), NULL]
```

**Fix** — pre-validate the THEN/ELSE result types in `visitCase` before calling `makeCall`. If `leastRestrictive` returns `null`, throw a clean `ExpressionEvaluationException` with the offending type list. No behaviour change for any `case(...)` whose branches do unify.

**Workaround (if you cannot upgrade):** cast all branches to the same type explicitly, e.g.

```ppl
case(cond1, 'slow', cond2, cast(1 as string), true, cast(0.0 as string))
```

### Related Issues
Resolves Mustang PPL sign-off sheet Bug K (case incompatible branches → NPE instead of clean SemanticCheckException). No public GitHub issue currently tracks this.

### Check List
- [x] New functionality includes testing. Unit test `CalcitePPLCaseFunctionTest.testCaseWithIncompatibleBranchTypesRejectsCleanly` + IT `CalcitePPLCaseFunctionIT.testCaseWithIncompatibleBranchTypesRejectsCleanly`.
- [ ] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added. *(N/A — bug fix, not new behavior.)*
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed. *(N/A — bug fix to existing command.)*
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). *(N/A — no API surface change.)*
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose). *(N/A — error message change only, no user-visible product behavior change.)*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).