### PR TITLE
Fix ClassCastException in PPL multisearch on indexes with @timestamp alias field

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultisearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultisearchCommandIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.junit.Assume.assumeFalse;
 import static org.opensearch.sql.legacy.TestsConstants.*;
 import static org.opensearch.sql.util.Capability.MULTISEARCH_COLUMN_ORDER;
 import static org.opensearch.sql.util.Capability.MULTISEARCH_SAME_INDEX_CONFLATION;
@@ -12,6 +13,7 @@ import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+import static org.opensearch.sql.util.MatcherUtils.verifySchemaInOrder;
 
 import java.io.IOException;
 import org.json.JSONObject;
@@ -31,6 +33,7 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
     loadIndex(Index.TIME_TEST_DATA);
     loadIndex(Index.TIME_TEST_DATA2);
     loadIndex(Index.LOCATIONS_TYPE_CONFLICT);
+    loadIndex(Index.DATA_TYPE_ALIAS);
   }
 
   @Test
@@ -461,5 +464,43 @@ public class CalciteMultisearchCommandIT extends PPLIntegTestCase {
         exception
             .getMessage()
             .contains("Unable to process column 'age' due to incompatible types:"));
+  }
+
+  /**
+   * Regression test for GitHub issue #5533. When {@code @timestamp} is defined as a field-type
+   * alias in the index mapping, multisearch used to throw:
+   *
+   * <pre>ClassCastException: RelCompositeTrait cannot be cast to RelCollation</pre>
+   *
+   * <p>Root cause: {@code reIndexCollations()} and {@code pushDownSort()} both used {@code
+   * RelTraitSet.plus()} which composes collation traits into a {@link
+   * org.apache.calcite.rel.RelCompositeTrait} when a collation is already present. Calcite's {@code
+   * RelTraitSet.getCollation()} then fails with a ClassCastException. Fixed by using {@code
+   * RelTraitSet.replace()} instead to always replace the collation trait.
+   */
+  @Test
+  public void testMultisearchWithTimestampAliasFieldDoesNotThrow() throws IOException {
+    // alias-typed fields are stripped when loading indices in analytics-engine parquet mode,
+    // so @timestamp does not exist in TEST_INDEX_ALIAS on that route.
+    assumeFalse(
+        "alias-typed fields are stripped in analytics-engine parquet mode;"
+            + " @timestamp won't exist in TEST_INDEX_ALIAS on that route.",
+        isAnalyticsParquetIndicesEnabled());
+    // TEST_INDEX_ALIAS has @timestamp defined as an alias field pointing to original_date.
+    // Running multisearch on such an index used to crash with ClassCastException.
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "| multisearch "
+                    + "[search source=%s | where original_col > 1 | fields original_col,"
+                    + " @timestamp] "
+                    + "[search source=%s | where original_col = 1 | fields original_col,"
+                    + " @timestamp]",
+                TEST_INDEX_ALIAS, TEST_INDEX_ALIAS));
+
+    verifySchemaInOrder(
+        result, schema("original_col", null, "int"), schema("@timestamp", null, "timestamp"));
+    // 2 rows from original_col > 1, 1 row from original_col = 1
+    assertEquals(3, result.getInt("total"));
   }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/AbstractCalciteIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/AbstractCalciteIndexScan.java
@@ -323,7 +323,7 @@ public abstract class AbstractCalciteIndexScan extends TableScan implements Alia
         // aggregators.
         return null;
       }
-      RelTraitSet traitsWithCollations = getTraitSet().plus(RelCollations.of(collations));
+      RelTraitSet traitsWithCollations = getTraitSet().replace(RelCollations.of(collations));
       PushDownContext pushDownContextWithoutSort = this.pushDownContext.cloneWithoutSort();
       AbstractAction<?> action;
       Object digest;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteLogicalIndexScan.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/scan/CalciteLogicalIndexScan.java
@@ -321,7 +321,7 @@ public class CalciteLogicalIndexScan extends AbstractCalciteIndexScan implements
                   collation ->
                       collation.withFieldIndex(selectedColumns.indexOf(collation.getFieldIndex())))
               .collect(Collectors.toList());
-      newTraitSet = getTraitSet().plus(RelCollations.of(newCollations));
+      newTraitSet = getTraitSet().replace(RelCollations.of(newCollations));
     } else {
       newTraitSet = getTraitSet();
     }


### PR DESCRIPTION
## Summary

Fixes #5533.

When `@timestamp` is defined as a **field-type alias** in the index mapping (e.g. `"@timestamp": {"type": "alias", "path": "timestamp"}`), running a `| multisearch` command on that index throws:

```
java.lang.ClassCastException: class org.apache.calcite.rel.RelCompositeTrait
    cannot be cast to class org.apache.calcite.rel.RelCollation
```

### Root cause

`reIndexCollations()` (`CalciteLogicalIndexScan`) and `pushDownSort()` (`AbstractCalciteIndexScan`) both called `RelTraitSet.plus()` to set the collation trait on a scan node. `plus()` _composes_ traits — when the trait set already contains a `RelCollation`, it merges the old and new collations into a `RelCompositeTrait`. Calcite's `RelTraitSet.getCollation()` then does an unchecked cast `(RelCollation) getTrait(...)` which fails at runtime for `RelCompositeTrait`.

The `@timestamp` alias path specifically triggers this because `wrapProjectForAliasFields()` adds a `LogicalProject` on top of each sub-scan during multisearch plan building. Calcite's push-down rules later push this project back into the scan via `pushDownProject()` → `reIndexCollations()`, which uses `plus()` to remap an existing sort collation — producing the bad composite trait.

### Fix

Use `RelTraitSet.replace()` in both locations instead of `plus()`. `replace()` substitutes the collation trait in-place regardless of what was already there, which is the correct semantics for "this scan is sorted by these columns".

**Files changed (3):**
- `opensearch/.../AbstractCalciteIndexScan.java` — `pushDownSort()`: `plus` → `replace`
- `opensearch/.../CalciteLogicalIndexScan.java` — `reIndexCollations()`: `plus` → `replace`
- `integ-test/.../CalciteMultisearchCommandIT.java` — regression IT against `TEST_INDEX_ALIAS` (which maps `@timestamp` as a field-type alias to `original_date`)

## Test plan

- [x] Added `testMultisearchWithTimestampAliasFieldDoesNotThrow` IT — runs a multisearch against an index where `@timestamp` is a field-type alias; this would have crashed with `ClassCastException` before this fix
- [ ] All existing `CalciteMultisearchCommandIT` tests pass
- [ ] `OpenSearchIndexScanOptimizationTest` and related unit tests pass (`.replace()` is correct semantics here — a scan's collation is always a full replacement, never a union of multiple sort orders)

## Checklist
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed and DCO verification will pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.