### PR TITLE
Fix AE `isPluggableDataformatIndex` for multi index PPL queries

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -502,11 +502,11 @@ testClusters.analyticsEngineSecurityIT {
     plugin(getJobSchedulerPlugin())
     plugin(getArrowBasePlugin())
     plugin(getArrowFlightRpcPlugin())
+    plugin(getCompositeEnginePlugin())
     plugin(getAnalyticsEnginePlugin())
     plugin(getAnalyticsBackendLucenePlugin())
     plugin(getAnalyticsBackendDatafusionPlugin())
     plugin(getParquetDataFormatPlugin())
-    plugin(getCompositeEnginePlugin())
     plugin ":opensearch-sql-plugin"
     // Arrow Flight / streaming transport requirements
     jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'

--- a/integ-test/src/test/java/org/opensearch/sql/security/AnalyticsEngineSecurityIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/security/AnalyticsEngineSecurityIT.java
@@ -393,6 +393,94 @@ public class AnalyticsEngineSecurityIT extends SecurityTestBase {
     assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
   }
 
+  // --- Multi-index comma-separated source tests (FGAC bypass regression) ---
+
+  @Test
+  public void testPPLMultiIndexDeniedWhenSecondIndexUnauthorized() throws IOException {
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executePPLAsUser(
+                    "source = " + TEST_INDEX + ", " + FORBIDDEN_INDEX + " | fields name, age",
+                    ALLOWED_USER));
+    assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testPPLMultiIndexDeniedWithBackticksAuthorizedFirst() throws IOException {
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executePPLAsUser(
+                    "source = `" + TEST_INDEX + "`, `" + FORBIDDEN_INDEX + "` | fields name, age",
+                    ALLOWED_USER));
+    assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testPPLMultiIndexDeniedWithUnauthorizedFirst() throws IOException {
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executePPLAsUser(
+                    "source = " + FORBIDDEN_INDEX + ", " + TEST_INDEX + " | fields name, age",
+                    ALLOWED_USER));
+    assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testPPLMultiIndexAllowedWhenAllAuthorized() throws IOException {
+    try {
+      JSONObject result =
+          executePPLAsUser(
+              "source = " + TEST_INDEX + ", " + TEST_INDEX_2 + " | fields name, age",
+              WILDCARD_USER);
+      assertTrue("Expected datarows in response", result.has("datarows"));
+    } catch (ResponseException e) {
+      assertNotEquals(
+          "Expected auth to pass (not 403) when all indices are authorized",
+          403,
+          e.getResponse().getStatusLine().getStatusCode());
+    }
+  }
+
+  // --- Edge cases: malformed comma-separated source patterns ---
+
+  @Test
+  public void testPPLDoubleCommaRejected() throws IOException {
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executePPLAsUser(
+                    "source = " + TEST_INDEX + ",," + FORBIDDEN_INDEX + " | fields name, age",
+                    ALLOWED_USER));
+    assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testPPLLeadingCommaRejected() throws IOException {
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executePPLAsUser("source = ," + TEST_INDEX + " | fields name, age", ALLOWED_USER));
+    assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testPPLTrailingCommaRejected() throws IOException {
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executePPLAsUser("source = " + TEST_INDEX + ", | fields name, age", ALLOWED_USER));
+    assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+  }
+
   @Test
   public void testSQLQueryAllowedForAuthorizedUser() throws IOException {
     try {
@@ -439,6 +527,51 @@ public class AnalyticsEngineSecurityIT extends SecurityTestBase {
                 executeSQLAsUser(
                     "SELECT name, age FROM " + TEST_INDEX + " LIMIT 3", SEARCH_ONLY_USER));
     assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
+  }
+
+  // --- SQL multi-index syntax validation ---
+
+  @Test
+  public void testSQLMultiIndexCommaInFromRejected() throws IOException {
+    // SQL FROM "idx1,idx2" — comma inside identifier, should be rejected as syntax error
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executeSQLAsUser(
+                    "SELECT name, age FROM " + TEST_INDEX + "," + FORBIDDEN_INDEX + " LIMIT 3",
+                    ALLOWED_USER));
+    assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testSQLMultiIndexCrossJoinRejected() throws IOException {
+    // SQL cross join syntax — should not bypass FGAC
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executeSQLAsUser(
+                    "SELECT a.name FROM " + TEST_INDEX + " a, " + FORBIDDEN_INDEX + " b LIMIT 3",
+                    ALLOWED_USER));
+    assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testSQLMultiIndexJoinRejected() throws IOException {
+    // Explicit JOIN — should not bypass FGAC
+    ResponseException e =
+        assertThrows(
+            ResponseException.class,
+            () ->
+                executeSQLAsUser(
+                    "SELECT a.name FROM "
+                        + TEST_INDEX
+                        + " a JOIN "
+                        + FORBIDDEN_INDEX
+                        + " b ON a.name = b.name LIMIT 3",
+                    ALLOWED_USER));
+    assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
   }
 
   /** Executes a PPL query via the production SQL plugin endpoint (/_plugins/_ppl). */

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -122,11 +122,33 @@ public class RestUnifiedQueryAction {
     try (UnifiedQueryContext context = buildParsingContext(queryType)) {
       return extractIndexName(query, queryType, context)
           .map(this::stripSchemaPrefix)
-          .map(this::isPluggableDataformatIndex)
+          .map(this::allIndicesArePluggableDataformat)
           .orElse(false);
     } catch (Exception e) {
       return false;
     }
+  }
+
+  /**
+   * Checks if all indices in a (possibly comma-separated) index expression are pluggable
+   * dataformat. For multi-index queries (source=idx1,idx2), each index is checked independently.
+   * Returns true only if every index is composite — mixed or all-lucene returns false.
+   */
+  private boolean allIndicesArePluggableDataformat(String indexExpression) {
+    String[] indices = indexExpression.split(",");
+    if (indices.length == 0) {
+      return false;
+    }
+    for (String idx : indices) {
+      String trimmed = idx.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      if (!isPluggableDataformatIndex(trimmed)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private static boolean isSystemCatalog(String name) {


### PR DESCRIPTION
## Description

Related to https://github.com/opensearch-project/OpenSearch/pull/22314 where AE parsing of indices "index1, index2" would fail silently, subjecting the request to an FGAC check with no indices provided.

This PR adds the SQL side regression tests verifying that FGAC correctly evaluates permissions on **all** indices in comma-separated multi-source PPL queries.

Some cases covered here:

  - testPPLMultiIndexDeniedWhenSecondIndexUnauthorized — source = allowed, forbidden → 403
  - testPPLMultiIndexDeniedWithBackticksAuthorizedFirst — source = \allowed`, `forbidden`` → 403
  - testPPLMultiIndexDeniedWithUnauthorizedFirst — source = forbidden, allowed → 403
  - testPPLMultiIndexAllowedWhenAllAuthorized — source = allowed1, allowed2 → 200
  - testPPLDoubleCommaRejected — source = idx1,,idx2 → 400
  - testPPLLeadingCommaRejected — source = ,idx1 → 400
  - testPPLTrailingCommaRejected — source = idx1, → 400
  - testSQLMultiIndexCommaInFromRejected — SELECT name, age FROM idx1,idx2 LIMIT 3 → 400
  - testSQLMultiIndexCrossJoinRejected — SELECT a.name FROM idx1 a, idx2 b LIMIT 3 → 400
  - testSQLMultiIndexJoinRejected — SELECT a.name FROM idx1 a JOIN idx2 b ON a.name = b.name LIMIT 3 → 400

### Also fixes

Plugin install order in `analyticsEngineSecurityIT` cluster config — `composite-engine` must be installed before `analytics-backend-lucene` (dependency).