### PR TITLE
[BugFix] Bump get-ci-image-tag.yml ref to SHA-pinned opensearch-build commit to unblock CI

### DIFF
--- a/.github/workflows/analytics-engine-compat.yml
+++ b/.github/workflows/analytics-engine-compat.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     with:
       product: opensearch
 

--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     with:
       product: opensearch
 

--- a/.github/workflows/issue-dedupe.yml
+++ b/.github/workflows/issue-dedupe.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   detect:
     if: (github.event_name == 'issues' && github.event.issue.user.type != 'Bot') || (github.event_name == 'workflow_dispatch' && inputs.job == 'detect')
-    uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-detect.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-detect.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     permissions:
       contents: read
       issues: write
@@ -36,7 +36,7 @@ jobs:
 
   auto-close:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.job == 'auto-close')
-    uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-autoclose.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-autoclose.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     permissions:
       issues: write
     with:

--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Code-Diff-Analyzer:
-    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-analyzer.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-analyzer.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     if: github.repository == 'opensearch-project/sql'
     permissions:
       id-token: write  # github oidc to assume aws roles
@@ -18,7 +18,7 @@ jobs:
       update_pr_comment_with_analyzer_report: true
 
   Code-Diff-Reviewer:
-    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-reviewer.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/code-diff-reviewer.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     needs: Code-Diff-Analyzer
     if: github.repository == 'opensearch-project/sql'
     permissions:

--- a/.github/workflows/sql-pitest.yml
+++ b/.github/workflows/sql-pitest.yml
@@ -12,7 +12,7 @@ run-name:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     with:
       product: opensearch
 

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     with:
       product: opensearch
 

--- a/.github/workflows/sql-test-workflow.yml
+++ b/.github/workflows/sql-test-workflow.yml
@@ -12,7 +12,7 @@ run-name:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     with:
       product: opensearch
 


### PR DESCRIPTION
### Description

Several CI checks were blocked on `main` before any build or test could run, all with the same org-policy error:

> The actions ... are not allowed in opensearch-project/sql because all actions must be pinned to a full-length commit SHA.

The unpinned actions are not defined in this repository. They live in the `opensearch-build` reusable workflows that this repo's workflows pinned at the old ref `c2498b758c` (2026-05-21), which still referenced version tags (`crane-installer@v1`, `checkout@v6`, `setup-node@v6`, `configure-aws-credentials@v6`, `find-comment@v3`, `create-or-update-comment@v5`).

This bumps every `opensearch-build` reusable-workflow ref to `761e093b8c1349cc07f21c1d681d3b30bf9e1999` (`opensearch-build` PR #6253, "Update build repo all workflows to use SHA", 2026-06-12), where all of those actions are pinned to full-length SHAs, satisfying the policy. No product code is touched; this is a CI-infrastructure fix.

**Workflows updated (all to the new SHA):**
- `get-ci-image-tag.yml` consumers: `sql-test-and-build-workflow.yml`, `analytics-engine-compat.yml`, `integ-tests-with-security.yml`, `sql-pitest.yml`, `sql-test-workflow.yml`
- `pr_review.yml` (`code-diff-analyzer.yml`, `code-diff-reviewer.yml`)
- `issue-dedupe.yml` (`issue-dedupe-detect.yml`, `issue-dedupe-autoclose.yml`)

Verified that at the new SHA, each referenced `opensearch-build` workflow pins all of its actions to full SHAs. On this PR, the `get-ci-image-tag.yml`-gated checks (SQL Java CI, Analytics Engine Compatibility, Security Plugin IT, SQL PIT test) now pass.

Note: `pr_review.yml` triggers on `pull_request_target`, so it runs from the base branch. Its `Code-Diff-Analyzer` fix therefore takes effect for PRs opened after this merges, not retroactively on this PR.

### Related Issues
<!-- N/A -->

### Check List
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
