### PR TITLE
Fix SQL IT test queries, assertions, and data for engine-agnostic compatibility

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OrdinalAliasRewriterIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OrdinalAliasRewriterIT.java
@@ -25,13 +25,13 @@ public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
     String expected =
         executeQuery(
             StringUtils.format(
-                "SELECT lastname FROM %s AS b GROUP BY lastname LIMIT 3",
+                "SELECT lastname FROM %s AS b GROUP BY lastname ORDER BY lastname LIMIT 3",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     String actual =
         executeQuery(
             StringUtils.format(
-                "SELECT lastname FROM %s AS b GROUP BY 1 LIMIT 3",
+                "SELECT lastname FROM %s AS b GROUP BY 1 ORDER BY 1 LIMIT 3",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     assertThat(actual, equalTo(expected));
@@ -43,13 +43,14 @@ public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
         executeQuery(
             StringUtils.format(
                 "SELECT lastname, firstname, age FROM %s AS b GROUP BY firstname, age, lastname"
-                    + " LIMIT 3",
+                    + " ORDER BY lastname, firstname, age LIMIT 3",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     String actual =
         executeQuery(
             StringUtils.format(
-                "SELECT lastname, firstname, age FROM %s AS b GROUP BY 2, 3, 1 LIMIT 3",
+                "SELECT lastname, firstname, age FROM %s AS b GROUP BY 2, 3, 1"
+                    + " ORDER BY 1, 2, 3 LIMIT 3",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     assertThat(actual, equalTo(expected));
@@ -60,13 +61,13 @@ public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
     String expected =
         executeQuery(
             StringUtils.format(
-                "SELECT `lastname` FROM %s AS b GROUP BY `lastname` LIMIT 3",
+                "SELECT `lastname` FROM %s AS b GROUP BY `lastname` ORDER BY `lastname` LIMIT 3",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     String actual =
         executeQuery(
             StringUtils.format(
-                "SELECT `lastname` FROM %s AS b GROUP BY 1 LIMIT 3",
+                "SELECT `lastname` FROM %s AS b GROUP BY 1 ORDER BY 1 LIMIT 3",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     assertThat(actual, equalTo(expected));
@@ -78,13 +79,14 @@ public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
         executeQuery(
             StringUtils.format(
                 "SELECT `b`.`lastname`, `age`, firstname FROM %s AS b GROUP BY `age`,"
-                    + " `b`.`lastname` , firstname LIMIT 10",
+                    + " `b`.`lastname` , firstname ORDER BY `b`.`lastname`, `age` LIMIT 10",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     String actual =
         executeQuery(
             StringUtils.format(
-                "SELECT `b`.`lastname`, `age`, firstname  FROM %s AS b GROUP BY 2, 1, 3 LIMIT 10",
+                "SELECT `b`.`lastname`, `age`, firstname  FROM %s AS b GROUP BY 2, 1, 3 ORDER BY 1,"
+                    + " 2 LIMIT 10",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     assertThat(actual, equalTo(expected));
@@ -166,14 +168,14 @@ public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
         executeQuery(
             StringUtils.format(
                 "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY `b`.`lastname` IS NOT NULL DESC,"
-                    + " age is NULL LIMIT 3",
+                    + " age is NULL, `b`.`lastname` LIMIT 3",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     String actual =
         executeQuery(
             StringUtils.format(
-                "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY 1 IS NOT NULL DESC, 2 IS NULL"
-                    + " LIMIT 3",
+                "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY 1 IS NOT NULL DESC, 2 IS NULL,"
+                    + " 1 LIMIT 3",
                 TestsConstants.TEST_INDEX_ACCOUNT),
             "jdbc");
     assertThat(actual, equalTo(expected));

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatResponseIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/PrettyFormatResponseIT.java
@@ -80,7 +80,11 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     loadIndex(Index.ACCOUNT);
     loadIndex(Index.PHRASE);
     loadIndex(Index.GAME_OF_THRONES);
-    loadIndex(Index.NESTED);
+    // Skip on the analytics-engine route, where the parquet store rejects nested_objects'
+    // multi-value array in the scalar-mapped myNum field at bulk load.
+    if (!TestUtils.AnalyticsIndexConfig.isEnabled()) {
+      loadIndex(Index.NESTED);
+    }
   }
 
   @Override

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TypeInformationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TypeInformationIT.java
@@ -96,11 +96,11 @@ public class TypeInformationIT extends SQLIntegTestCase {
   public void testLengthWithGroupByExpr() {
     JSONObject response =
         executeJdbcRequest(
-            "SELECT Length(firstname) FROM "
+            "SELECT LENGTH(firstname) FROM "
                 + TestsConstants.TEST_INDEX_ACCOUNT
                 + " GROUP BY LENGTH(firstname) LIMIT 5");
 
-    verifySchema(response, schema("Length(firstname)", null, "integer"));
+    verifySchema(response, schema("LENGTH(firstname)", null, "integer"));
   }
 
   /*

--- a/integ-test/src/test/java/org/opensearch/sql/sql/ConditionalIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/ConditionalIT.java
@@ -105,9 +105,7 @@ public class ConditionalIT extends SQLIntegTestCase {
   public void nullifShouldPassJDBC() throws IOException {
     JSONObject response =
         executeJdbcRequest("SELECT NULLIF(lastname, 'unknown') AS name FROM " + TEST_INDEX_ACCOUNT);
-    assertEquals("NULLIF(lastname, 'unknown')", response.query("/schema/0/name"));
-    assertEquals("name", response.query("/schema/0/alias"));
-    assertEquals("keyword", response.query("/schema/0/type"));
+    verifySchema(response, schema("NULLIF(lastname, 'unknown')", "name", "keyword"));
   }
 
   @Test
@@ -148,9 +146,7 @@ public class ConditionalIT extends SQLIntegTestCase {
   public void isnullShouldPassJDBC() throws IOException {
     JSONObject response =
         executeJdbcRequest("SELECT ISNULL(lastname) AS name FROM " + TEST_INDEX_ACCOUNT);
-    assertEquals("ISNULL(lastname)", response.query("/schema/0/name"));
-    assertEquals("name", response.query("/schema/0/alias"));
-    assertEquals("boolean", response.query("/schema/0/type"));
+    verifySchema(response, schema("ISNULL(lastname)", "name", "boolean"));
   }
 
   @Ignore(
@@ -204,9 +200,7 @@ public class ConditionalIT extends SQLIntegTestCase {
   public void ifShouldPassJDBC() throws IOException {
     JSONObject response =
         executeJdbcRequest("SELECT IF(2 > 0, 'hello', 'world') AS name FROM " + TEST_INDEX_ACCOUNT);
-    assertEquals("IF(2 > 0, 'hello', 'world')", response.query("/schema/0/name"));
-    assertEquals("name", response.query("/schema/0/alias"));
-    assertEquals("keyword", response.query("/schema/0/type"));
+    verifySchema(response, schema("IF(2 > 0, 'hello', 'world')", "name", "keyword"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/sql/ConditionalIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/ConditionalIT.java
@@ -46,12 +46,8 @@ public class ConditionalIT extends SQLIntegTestCase {
   public void ifnullShouldPassJDBC() throws IOException {
     JSONObject response =
         executeJdbcRequest(
-            "SELECT IFNULL(lastname, 'unknown') AS name FROM "
-                + TEST_INDEX_ACCOUNT
-                + " GROUP BY name");
-    assertEquals("IFNULL(lastname, 'unknown')", response.query("/schema/0/name"));
-    assertEquals("name", response.query("/schema/0/alias"));
-    assertEquals("keyword", response.query("/schema/0/type"));
+            "SELECT IFNULL(lastname, 'unknown') FROM " + TEST_INDEX_ACCOUNT + " GROUP BY 1");
+    verifySchema(response, schema("IFNULL(lastname, 'unknown')", null, "keyword"));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/util/MatcherUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/MatcherUtils.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -39,6 +40,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.sql.legacy.TestUtils;
 import org.opensearch.sql.utils.YamlFormatter;
 
 public class MatcherUtils {
@@ -275,6 +277,9 @@ public class MatcherUtils {
   public static TypeSafeMatcher<JSONObject> schema(
       String expectedName, String expectedAlias, String expectedType) {
     return new TypeSafeMatcher<JSONObject>() {
+      private static final Set<String> NUMERIC_TYPES = Set.of("integer", "long", "float", "double");
+      private static final Set<String> STRING_TYPES = Set.of("keyword", "text", "string");
+
       @Override
       public void describeTo(Description description) {
         description.appendText(
@@ -287,9 +292,31 @@ public class MatcherUtils {
         String actualName = (String) jsonObject.query("/name");
         String actualAlias = (String) jsonObject.query("/alias");
         String actualType = (String) jsonObject.query("/type");
+
+        if (TestUtils.AnalyticsIndexConfig.isEnabled()) {
+          // The analytics-engine route promotes the alias to the name (SQL-standard) and unifies
+          // keyword/text/string and the numeric types, so relax name and type matching for it only.
+          boolean nameMatches =
+              expectedName.equals(actualName)
+                  || (!Strings.isNullOrEmpty(expectedAlias) && expectedAlias.equals(actualName));
+          boolean typeMatches =
+              expectedType.equals(actualType) || isCompatibleType(expectedType, actualType);
+          return nameMatches && typeMatches;
+        }
+
         return expectedName.equals(actualName)
             && (Strings.isNullOrEmpty(expectedAlias) || expectedAlias.equals(actualAlias))
             && expectedType.equals(actualType);
+      }
+
+      private boolean isCompatibleType(String expected, String actual) {
+        if (expected == null || actual == null) {
+          return false;
+        }
+        String e = expected.toLowerCase();
+        String a = actual.toLowerCase();
+        return (NUMERIC_TYPES.contains(e) && NUMERIC_TYPES.contains(a))
+            || (STRING_TYPES.contains(e) && STRING_TYPES.contains(a));
       }
     };
   }

--- a/integ-test/src/test/resources/game_of_thrones_complex.json
+++ b/integ-test/src/test/resources/game_of_thrones_complex.json
@@ -1,14 +1,14 @@
 {"index":{"_id":"1"}}
-{"name":{"firstname":"Daenerys","lastname":"Targaryen","ofHerName":1},"nickname":"Daenerys \"Stormborn\"","house":"Targaryen","gender":"F","parents":{"father":"Aerys" , "mother":"Rhaella"},"titles":["motherOfDragons","queenOfTheAndals","breakerOfChains","Khaleesi"]}
+{"name": {"firstname": "Daenerys", "lastname": "Targaryen", "ofHerName": 1}, "nickname": "Daenerys \"Stormborn\"", "house": "Targaryen", "gender": "F", "parents": {"father": "Aerys", "mother": "Rhaella"}}
 {"index":{"_id":"2"}}
-{"name":{"firstname":"Eddard","lastname":"Stark","ofHisName":1},"house":"Stark", "parents":{"father":"Rickard" , "mother":"Lyarra"} ,"gender":"M","titles":["lordOfWinterfell","wardenOfTheNorth","handOfTheKing"]}
+{"name": {"firstname": "Eddard", "lastname": "Stark", "ofHisName": 1}, "house": "Stark", "parents": {"father": "Rickard", "mother": "Lyarra"}, "gender": "M"}
 {"index":{"_id":"3"}}
-{"name":{"firstname":"Brandon","lastname":"Stark","ofHisName":4},"house":"Stark","parents":{"father":"Eddard","mother":"Catelyn"},"gender":"M","titles":["princeOfWinterfell"],"@wolf":"Summer"}
+{"name": {"firstname": "Brandon", "lastname": "Stark", "ofHisName": 4}, "house": "Stark", "parents": {"father": "Eddard", "mother": "Catelyn"}, "gender": "M", "@wolf": "Summer"}
 {"index":{"_id":"4"}}
-{"name":{"firstname":"Jaime","lastname":"Lannister","ofHisName":1},"gender":"M","house":"Lannister","parents":{"father":"Tywin","mother":"Joanna"},"titles":["kingSlayer","lordCommanderOfTheKingsguard","Ser"]}
+{"name": {"firstname": "Jaime", "lastname": "Lannister", "ofHisName": 1}, "gender": "M", "house": "Lannister", "parents": {"father": "Tywin", "mother": "Joanna"}}
 {"index":{"_id":"5"}}
-{"words":"fireAndBlood","hname":"Targaryen","sigil":"Dragon","seat":"Dragonstone"}
+{"words": "fireAndBlood", "hname": "Targaryen", "sigil": "Dragon", "seat": "Dragonstone"}
 {"index":{"_id":"6"}}
-{"words":"winterIsComing" , "hname":"Stark","sigil":"direwolf","seat":"Winterfell"}
+{"words": "winterIsComing", "hname": "Stark", "sigil": "direwolf", "seat": "Winterfell"}
 {"index":{"_id":"7"}}
-{"words":"hearMeRoar" , "hname":"Lannister","sigil":"lion","seat":"CasterlyRock"}
+{"words": "hearMeRoar", "hname": "Lannister", "sigil": "lion", "seat": "CasterlyRock"}


### PR DESCRIPTION
### Description

This PR fixed SQL integration tests so they behave consistently across query engines:

- **Test queries**: correct non-deterministic and non-standard-SQL queries, so the tests are stable and engine-independent.
- **Test assertions**: relax the shared schema matcher (column name and type) only on the analytics-engine route.
- **Test data**: remove unused array value from test data, because the bulk-load stripper only removes fields by unsupported type (but any field can hold an array value in OS, multi-value scalars can't be stripped generically per dataset).

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
