### PR TITLE
Return 4xx instead of 500 for unsupported window functions

### DIFF
--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
@@ -160,6 +160,18 @@ public class UnifiedQueryPlannerTest extends UnifiedQueryTestBase {
   }
 
   @Test
+  public void unsupportedWindowFunctionIsRethrownAsSemanticCheckException() {
+    // Window functions outside WINDOW_FUNC_MAPPING reach
+    // CalciteRexNodeVisitor#visitWindowFunction's
+    // orElseThrow. The throw site emits CalciteUnsupportedException so this path normalizes to a
+    // 4xx SemanticCheckException rather than escaping as a 500.
+    givenInvalidQuery("source = catalog.employees | eventstats rank()")
+        .assertErrorType(SemanticCheckException.class)
+        .assertCauseType(CalciteUnsupportedException.class)
+        .assertErrorMessageContains("Unexpected window function: rank");
+  }
+
+  @Test
   public void assertionErrorIsWrappedAsSemanticCheckException() {
     // Remove when the underlying Calcite assertion is fixed.
     givenInvalidQuery(

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -705,7 +705,7 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
                       node.getWindowFrame());
             })
         .orElseThrow(
-            () -> new UnsupportedOperationException("Unexpected window function: " + funcName));
+            () -> new CalciteUnsupportedException("Unexpected window function: " + funcName));
   }
 
   private List<RexNode> translateOrderKeys(


### PR DESCRIPTION
### Description

Window functions outside `WINDOW_FUNC_MAPPING` (e.g. `RANK`) were escaping the analytics-engine route as HTTP 500. The throw site in `CalciteRexNodeVisitor#visitWindowFunction` emitted a raw `UnsupportedOperationException`, which `UnifiedQueryPlanner.plan` rethrows unchanged, so it never got reclassified as a client error.

Switching the throw to `CalciteUnsupportedException` lets the 4xx wrapper from #5569 take over and normalize it to `SemanticCheckException`.

Repro:
```sql
SELECT RegionID, COUNT(*) AS cnt,
       RANK() OVER (ORDER BY COUNT(*) DESC) AS rnk
FROM clickbench GROUP BY RegionID LIMIT 5
```

### Test plan
- [x] New `UnifiedQueryPlannerTest#unsupportedWindowFunctionIsRethrownAsSemanticCheckException`: fails on `main`, passes with the fix
- [x] Existing `CalcitePPLEventstatsIT#testUnsupportedWindowFunctions` still green
- [x] Manual repro on a local cluster:
```
mikeovi@80a997164b98 ~ % curl -sS -w "\nHTTP %{http_code}\n" -X POST "http://localhost:9200/_plugins/_ppl" \
    -H 'Content-Type: application/json' \
    -d '{"query":"source=demo | eventstats rank() | head 5"}'
{
  "error": {
    "context": {
      "stage": "analyzing",
      "stage_description": "Parsing and validating the query"
    },
    "reason": "Unexpected window function: rank",
    "details": "Unexpected window function: rank",
    "location": ["while preparing and validating the query plan"],
    "code": "UNKNOWN",
    "type": "CalciteUnsupportedException"
  },
  "status": 400
}
HTTP 400
mikeovi@80a997164b98 ~ %
```

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).