### PR TITLE
fix: Don't push down bool filters recursively, append instead

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilder.java
@@ -198,6 +198,8 @@ public class OpenSearchRequestBuilder {
 
     if (current == null) {
       sourceBuilder.query(query);
+    } else if (isBoolFilterQuery(current)) {
+      ((BoolQueryBuilder) current).filter(query);
     } else {
       sourceBuilder.query(QueryBuilders.boolQuery().filter(current).filter(query));
     }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/request/OpenSearchRequestBuilderTest.java
@@ -341,13 +341,15 @@ class OpenSearchRequestBuilderTest {
 
     QueryBuilder newQuery = QueryBuilders.termQuery("intA", 1);
     requestBuilder.pushDownFilterForCalcite(newQuery);
-    initialBoolQuery.filter(newQuery);
     SearchSourceBuilder expectedSourceBuilder =
         new SearchSourceBuilder()
             .from(DEFAULT_OFFSET)
             .size(MAX_RESULT_WINDOW)
             .timeout(DEFAULT_QUERY_TIMEOUT)
-            .query(QueryBuilders.boolQuery().filter(initialBoolQuery).filter(newQuery));
+            .query(
+                QueryBuilders.boolQuery()
+                    .filter(QueryBuilders.termQuery("name", "John"))
+                    .filter(newQuery));
 
     assertSearchSourceBuilder(expectedSourceBuilder, requestBuilder);
   }


### PR DESCRIPTION
### Description
Some types of queries involving `where $timestamp_filter | ...` generate recursive filters for time ranges, e.g.

```json
{
  "query": {
    "bool": {
      "filter": [
        {
          "bool": {
            "must": [
              {
                "range": {
                  "@timestamp": {
                    "from": "2026-04-10T23:45:00.000Z",
                    "to": "2026-04-11T00:00:00.000Z",
                    "include_lower": true,
                    "include_upper": true,
                    "format": "date_time",
                    "boost": 1.0
                  }
                }
              },
              {
                "match_phrase": {
                  "body": {
                    "query": "logtype=ws:access",
                    "slop": 0,
                    "zero_terms_query": "NONE",
                    "boost": 1.0
                  }
                }
              }
            ],
            "adjust_pure_negative": true,
            "boost": 1.0
          }
        },
        {
          "exists": {
            "field": "@timestamp",
            "boost": 1.0
          }
        }
      ],
      "adjust_pure_negative": true,
      "boost": 1.0
    }
  }
}
```

This causes issues for `can_match` and causes elevated CPU on nodes that don't match the time range. Instead, we should nudge the optimizer to generate flattened ranges.

```json
{
  "query": {
    "bool": {
      "filter": [
        {
          "range": {
            "@timestamp": {
              "from": "2026-04-10T23:45:00.000Z",
              "to": "2026-04-11T00:00:00.000Z",
              "include_lower": true,
              "include_upper": true,
              "format": "date_time"
            }
          }
        },
        {
          "match_phrase": {
            "body": {
              "query": "logtype=ws:access"
            }
          }
        },
        {
          "exists": {
            "field": "@timestamp"
          }
        }
      ]
    }
  }
}
```

I don't fully understand why this is better and the repro is flaky at best, but experimentally it does seem to considerably reduce warm node CPU usage for some types of no-match queries.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
