### PR TITLE
[Backport 2.19] Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/async-query-core/build.gradle
+++ b/async-query-core/build.gradle
@@ -13,6 +13,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/async-query/build.gradle
+++ b/async-query/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -9,6 +9,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }
@@ -79,6 +80,7 @@ apply plugin: 'opensearch.java'
 // Repository on root level is for dependencies that project code depends on. And this block must be placed after plugins{}
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral() // For Elastic Libs that you can use to get started coding until open OpenSearch libs are available
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url 'https://jitpack.io' }
@@ -130,6 +132,7 @@ allprojects {
 subprojects {
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/" }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'java'
 
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -29,6 +29,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -31,6 +31,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/datasources/build.gradle
+++ b/datasources/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -48,6 +48,7 @@ apply plugin: 'com.wiredforcode.spawn'
 
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url 'https://jitpack.io' }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -42,6 +42,7 @@ ext {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url 'https://jitpack.io' }
 }

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 repositories {
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
 
 rootProject.name = 'opensearch-sql'
 


### PR DESCRIPTION
### Description
Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins.

### Changes
* `build.gradle` — Add CI mirror before mavenCentral in repositories blocks
* `settings.gradle` — Add `pluginManagement` block with CI mirror

### Testing
Build verification