### PR TITLE
[BugFix] Fix SQL window functions with `ORDER BY`/`LIMIT` on unified query path

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/parser/SqlV2QueryParser.java
+++ b/api/src/main/java/org/opensearch/sql/api/parser/SqlV2QueryParser.java
@@ -10,25 +10,36 @@ import static org.opensearch.sql.ast.dsl.AstDSL.inSubquery;
 import static org.opensearch.sql.ast.dsl.AstDSL.join;
 import static org.opensearch.sql.ast.dsl.AstDSL.union;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Not;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.statement.Query;
 import org.opensearch.sql.ast.statement.Statement;
 import org.opensearch.sql.ast.tree.Join.JoinType;
+import org.opensearch.sql.ast.tree.Project;
+import org.opensearch.sql.ast.tree.Sort;
+import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.ExistsSubqueryExpressionAtomContext;
+import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.FromClauseContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.InSubqueryPredicateContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.JoinClauseContext;
+import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.OrderByClauseContext;
+import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.QuerySpecificationContext;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.UnionSelectContext;
 import org.opensearch.sql.sql.parser.AstBuilder;
 import org.opensearch.sql.sql.parser.AstExpressionBuilder;
+import org.opensearch.sql.sql.parser.AstSortBuilder;
 import org.opensearch.sql.sql.parser.AstStatementBuilder;
+import org.opensearch.sql.sql.parser.context.QuerySpecification;
 
 /** SQL query parser that produces {@link UnresolvedPlan} using the V2 ANTLR grammar. */
 public class SqlV2QueryParser implements UnifiedQueryParser<UnresolvedPlan> {
@@ -60,6 +71,53 @@ public class SqlV2QueryParser implements UnifiedQueryParser<UnresolvedPlan> {
 
     ExtendedAstBuilder(String query) {
       super(query);
+    }
+
+    @Override
+    public UnresolvedPlan visitQuerySpecification(QuerySpecificationContext queryContext) {
+      if (!hasWindowFunctionInProjectList(queryContext)) {
+        return super.visitQuerySpecification(queryContext);
+      }
+
+      context.push();
+      context.peek().collect(queryContext, query);
+      Project project = (Project) visit(queryContext.selectClause());
+      UnresolvedPlan result = project.attach(visit(queryContext.fromClause()));
+
+      // Window output must be computed before ORDER BY/LIMIT, so build Limit(Sort(Project(from)))
+      OrderByClauseContext orderByClause = queryContext.fromClause().orderByClause();
+      if (orderByClause != null) {
+        result = new ExtendedAstSortBuilder(context.peek()).visit(orderByClause).attach(result);
+      }
+      if (queryContext.limitClause() != null) {
+        result = visit(queryContext.limitClause()).attach(result);
+      }
+
+      context.pop();
+      return result;
+    }
+
+    @Override
+    public UnresolvedPlan visitFromClause(FromClauseContext ctx) {
+      UnresolvedPlan from = super.visitFromClause(ctx);
+      if (hasWindowFunctionInProjectList(context.peek()) && from instanceof Sort sort) {
+        // Drop the ORDER BY Sort for window queries; it is re-attached above the Project
+        return sort.getChild().get(0);
+      }
+      return from;
+    }
+
+    private boolean hasWindowFunctionInProjectList(QuerySpecificationContext queryContext) {
+      if (queryContext.fromClause() == null) {
+        return false;
+      }
+      QuerySpecification probe = new QuerySpecification();
+      probe.collect(queryContext, query);
+      return hasWindowFunctionInProjectList(probe);
+    }
+
+    private static boolean hasWindowFunctionInProjectList(QuerySpecification querySpec) {
+      return querySpec.getSelectItems().stream().anyMatch(item -> item instanceof WindowFunction);
     }
 
     @Override
@@ -112,6 +170,34 @@ public class SqlV2QueryParser implements UnifiedQueryParser<UnresolvedPlan> {
         UnresolvedPlan subquery = ExtendedAstBuilder.this.visit(ctx.querySpecification());
         return existsSubquery(subquery);
       }
+    }
+  }
+
+  /**
+   * Keeps an ORDER BY window-alias as a column reference (Sort is above the Project) to avoid a
+   * second RexOver.
+   */
+  private static class ExtendedAstSortBuilder extends AstSortBuilder {
+
+    ExtendedAstSortBuilder(QuerySpecification querySpec) {
+      super(querySpec);
+    }
+
+    @Override
+    public UnresolvedPlan visitOrderByClause(OrderByClauseContext ctx) {
+      List<Field> fields = new ArrayList<>();
+      List<UnresolvedExpression> items = querySpec.getOrderByItems();
+      List<SortOption> options = querySpec.getOrderByOptions();
+      for (int i = 0; i < items.size(); i++) {
+        UnresolvedExpression item = items.get(i);
+        UnresolvedExpression sortKey =
+            (querySpec.isSelectAlias(item)
+                    && querySpec.getSelectItemByAlias(item) instanceof WindowFunction)
+                ? item
+                : querySpec.replaceIfAliasOrOrdinal(item);
+        fields.add(new Field(sortKey, createSortArguments(options.get(i))));
+      }
+      return new Sort(fields);
     }
   }
 }

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlV2Test.java
@@ -547,4 +547,73 @@ public class UnifiedQueryPlannerSqlV2Test extends UnifiedQueryTestBase {
                   LogicalTableScan(table=[[catalog, employees]])
             """);
   }
+
+  @Test
+  public void testWindowOverGroupByWithLimit() {
+    givenQuery(
+            """
+            SELECT department, COUNT(*) AS cnt, ROW_NUMBER() OVER (ORDER BY COUNT(*) DESC) AS rn
+              FROM catalog.employees GROUP BY department LIMIT 3
+            """)
+        .assertPlan(
+            """
+            LogicalSort(fetch=[3])
+              LogicalProject(department=[$0], cnt=[$1], rn=[ROW_NUMBER() OVER (ORDER BY $1 DESC NULLS FIRST)])
+                LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+                  LogicalProject(department=[$3])
+                    LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testWindowOverGroupByOrderByWindowAlias() {
+    givenQuery(
+            """
+            SELECT department, COUNT(*) AS cnt, ROW_NUMBER() OVER (ORDER BY COUNT(*) DESC) AS rn
+              FROM catalog.employees GROUP BY department ORDER BY rn LIMIT 3
+            """)
+        .assertPlan(
+            """
+            LogicalSort(sort0=[$2], dir0=[ASC-nulls-first], fetch=[3])
+              LogicalProject(department=[$0], cnt=[$1], rn=[ROW_NUMBER() OVER (ORDER BY $1 DESC NULLS FIRST)])
+                LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+                  LogicalProject(department=[$3])
+                    LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testWindowOverGroupByOrderByWindowAliasWithoutLimit() {
+    givenQuery(
+            """
+            SELECT department, COUNT(*) AS cnt, ROW_NUMBER() OVER (ORDER BY COUNT(*) DESC) AS rn
+              FROM catalog.employees GROUP BY department ORDER BY rn
+            """)
+        .assertPlan(
+            """
+            LogicalSort(sort0=[$2], dir0=[ASC-nulls-first])
+              LogicalProject(department=[$0], cnt=[$1], rn=[ROW_NUMBER() OVER (ORDER BY $1 DESC NULLS FIRST)])
+                LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+                  LogicalProject(department=[$3])
+                    LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
+
+  @Test
+  public void testMultipleWindowFunctionsOrderByWindowAlias() {
+    givenQuery(
+            """
+            SELECT department, COUNT(*) AS cnt, ROW_NUMBER() OVER (ORDER BY COUNT(*) DESC) AS rn,
+                   ROW_NUMBER() OVER (ORDER BY department) AS rn2
+              FROM catalog.employees GROUP BY department ORDER BY rn LIMIT 3
+            """)
+        .assertPlan(
+            """
+            LogicalSort(sort0=[$2], dir0=[ASC-nulls-first], fetch=[3])
+              LogicalProject(department=[$0], cnt=[$1], rn=[ROW_NUMBER() OVER (ORDER BY $1 DESC NULLS FIRST)], rn2=[ROW_NUMBER() OVER (ORDER BY $0 NULLS FIRST)])
+                LogicalAggregate(group=[{0}], COUNT(*)=[COUNT()])
+                  LogicalProject(department=[$3])
+                    LogicalTableScan(table=[[catalog, employees]])
+            """);
+  }
 }

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
@@ -54,13 +54,13 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
   private final AstExpressionBuilder expressionBuilder;
 
   /** Parsing context stack that contains context for current query parsing. */
-  private final ParsingContext context = new ParsingContext();
+  protected final ParsingContext context = new ParsingContext();
 
   /**
    * SQL query to get original token text. This is necessary because token.getText() returns text
    * without whitespaces or other characters discarded by lexer.
    */
-  private final String query;
+  protected final String query;
 
   public AstBuilder(String query) {
     this.query = query;

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstSortBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstSortBuilder.java
@@ -33,7 +33,7 @@ import org.opensearch.sql.sql.parser.context.QuerySpecification;
 @RequiredArgsConstructor
 public class AstSortBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
 
-  private final QuerySpecification querySpec;
+  protected final QuerySpecification querySpec;
 
   @Override
   public UnresolvedPlan visitOrderByClause(OrderByClauseContext ctx) {
@@ -57,7 +57,7 @@ public class AstSortBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPla
    * Argument "asc" is required. Argument "nullFirst" is optional and determined by Analyzer later
    * if absent.
    */
-  private List<Argument> createSortArguments(SortOption option) {
+  protected List<Argument> createSortArguments(SortOption option) {
     SortOrder sortOrder = option.getSortOrder();
     NullOrder nullOrder = option.getNullOrder();
     ImmutableList.Builder<Argument> args = ImmutableList.builder();


### PR DESCRIPTION
### Description

This PR fixes SQL window functions used with `ORDER BY` / `LIMIT`, which produced wrong plans for Analytics Engine). Because fixing the shared `AstBuilder` directly would impact the SQL V2 engine (V2 requires the top operator to be a `Project`), the fix is implemented in the extended AST builder of the unified query API only.

> **Known limitation**: this change does NOT fix a window query with `ORDER BY` on a non-projected column plus `LIMIT` — e.g. `SELECT a, ROW_NUMBER() OVER (...) AS rn FROM t ORDER BY b LIMIT n`. Correctly supporting it requires Calcite-style ordering-column handling (`SqlToRelConverter.gatherOrderExprs`).

#### Case 1 — window over GROUP BY + bare LIMIT

```
SELECT region, COUNT(*) AS cnt, ROW_NUMBER() OVER (ORDER BY COUNT(*) DESC) AS rn
FROM clickbench
GROUP BY region
LIMIT 5

# BEFORE (base — buggy): Limit is below the window Project
Project[region, cnt, rn=WindowFunction(...)]
  Limit(5)
    Aggregation[group=region, COUNT(*)]
      Relation(clickbench)

→ window ranks only the 5 rows that survive LIMIT. Wrong / non-deterministic.

# AFTER (fix): Limit above the window Project
Limit(5)
  Project[region, cnt, rn=WindowFunction(...)]
    Aggregation[group=region, COUNT(*)]
      Relation(clickbench)

→ rn ranked over all groups, then top-5 taken.
```

#### Case 2 — ORDER BY on the window alias

```
SELECT region, COUNT(*) AS cnt, ROW_NUMBER() OVER (ORDER BY COUNT(*) DESC) AS rn
FROM clickbench
GROUP BY region
ORDER BY rn
LIMIT 5

# BEFORE (base — buggy): Sort below the Project, and rn re-expanded into a second window
Project[region, cnt, rn=WindowFunction(...)]          ← window #1
  Limit(5)
    Sort[ key = WindowFunction(ROW_NUMBER, ...) ]      ← window #2 (re-expanded from "rn")
      Aggregation[group=region, COUNT(*)]
        Relation(clickbench)

→ two RexOver ⇒ "duplicate unqualified field name" + RelCollation cast ⇒ HTTP 500.

# AFTER (fix): Limit(Sort(Project)), sort key is the column reference rn
Limit(5)
  Sort[ key = QualifiedName("rn"), asc ]               ← references projected column
    Project[region, cnt, rn=WindowFunction(...)]       ← single window
      Aggregation[group=region, COUNT(*)]
        Relation(clickbench)

→ one RexOver; Calcite resolves rn to the projected field. No crash; true top-5 by rn.
```

### Related Issues

Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
