### PR TITLE
test(ppl): remove invalid Spark SQL assertions from correlated-aggregate subquery tests

### DIFF
--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLScalarSubqueryTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLScalarSubqueryTest.java
@@ -135,15 +135,12 @@ public class CalcitePPLScalarSubqueryTest extends CalcitePPLAbstractTest {
             + "}))], variablesSet=[[$cor0]])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
-
-    String expectedSparkSql =
-        ""
-            + "SELECT *\n"
-            + "FROM `scott`.`EMP`\n"
-            + "WHERE `SAL` > (((SELECT AVG(`EMP`.`SAL`) `AVG(SAL)`\n"
-            + "FROM `scott`.`SALGRADE`\n"
-            + "WHERE `EMP`.`SAL` = `HISAL`)))";
-    verifyPPLToSparkSQL(root, expectedSparkSql);
+    // verifyPPLToSparkSQL is intentionally omitted: SALGRADE has no SAL column, so both SAL
+    // references in the subquery bind to the outer EMP.SAL (correlated outer reference). The
+    // SQL serializer emits AVG(`EMP`.`SAL`) in the subquery aggregate — outer-column references
+    // in aggregate functions are rejected by Spark with
+    // UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE. The logical plan above is
+    // the authoritative contract for this query; the Spark SQL string is not executable.
   }
 
   @Test
@@ -167,14 +164,11 @@ public class CalcitePPLScalarSubqueryTest extends CalcitePPLAbstractTest {
             + "})], SAL=[$5])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
-
-    String expectedSparkSql =
-        ""
-            + "SELECT (((SELECT MIN(`EMP`.`EMPNO`) `min(EMPNO)`\n"
-            + "FROM `scott`.`SALGRADE`\n"
-            + "WHERE `EMP`.`SAL` = `HISAL`))) `min_empno`, `SAL`\n"
-            + "FROM `scott`.`EMP`";
-    verifyPPLToSparkSQL(root, expectedSparkSql);
+    // verifyPPLToSparkSQL is intentionally omitted: SALGRADE has no EMPNO or SAL column, so
+    // both references in the subquery bind to outer EMP columns (correlated outer references).
+    // The SQL serializer emits MIN(`EMP`.`EMPNO`) inside a subquery aggregate — outer-column
+    // references in aggregate functions are rejected by Spark with
+    // UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE. See issue #5470.
   }
 
   @Test
@@ -338,37 +332,6 @@ public class CalcitePPLScalarSubqueryTest extends CalcitePPLAbstractTest {
             + "GROUP BY `JOB`)))\n"
             + "GROUP BY `GRADE`\n"
             + "LIMIT 1)))";
-    verifyPPLToSparkSQL(root, expectedSparkSql);
-  }
-
-  @Test
-  public void testCorrelatedScalarSubqueryInWhereMaxOut() {
-    String ppl =
-        """
-        source=EMP
-        | where SAL > [
-            source=SALGRADE | where SAL = HISAL | stats AVG(SAL)
-          ]
-        """;
-    RelNode root = getRelNode(ppl);
-    String expectedLogical =
-        ""
-            + "LogicalFilter(condition=[>($5, $SCALAR_QUERY({\n"
-            + "LogicalAggregate(group=[{}], AVG(SAL)=[AVG($0)])\n"
-            + "  LogicalProject($f0=[$cor0.SAL])\n"
-            + "    LogicalFilter(condition=[=($cor0.SAL, $2)])\n"
-            + "      LogicalTableScan(table=[[scott, SALGRADE]])\n"
-            + "}))], variablesSet=[[$cor0]])\n"
-            + "  LogicalTableScan(table=[[scott, EMP]])\n";
-    verifyLogical(root, expectedLogical);
-
-    String expectedSparkSql =
-        ""
-            + "SELECT *\n"
-            + "FROM `scott`.`EMP`\n"
-            + "WHERE `SAL` > (((SELECT AVG(`EMP`.`SAL`) `AVG(SAL)`\n"
-            + "FROM `scott`.`SALGRADE`\n"
-            + "WHERE `EMP`.`SAL` = `HISAL`)))";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLScalarSubqueryTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLScalarSubqueryTest.java
@@ -135,15 +135,12 @@ public class CalcitePPLScalarSubqueryTest extends CalcitePPLAbstractTest {
             + "}))], variablesSet=[[$cor0]])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
-
-    String expectedSparkSql =
-        ""
-            + "SELECT *\n"
-            + "FROM `scott`.`EMP`\n"
-            + "WHERE `SAL` > (SELECT AVG(`EMP`.`SAL`) `AVG(SAL)`\n"
-            + "FROM `scott`.`SALGRADE`\n"
-            + "WHERE `EMP`.`SAL` = `HISAL`)";
-    verifyPPLToSparkSQL(root, expectedSparkSql);
+    // verifyPPLToSparkSQL is intentionally omitted: SALGRADE has no SAL column, so both SAL
+    // references in the subquery bind to the outer EMP.SAL (correlated outer reference). The
+    // SQL serializer emits AVG(`EMP`.`SAL`) in the subquery aggregate — outer-column references
+    // in aggregate functions are rejected by Spark with
+    // UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE. The logical plan above is
+    // the authoritative contract for this query; the Spark SQL string is not executable.
   }
 
   @Test
@@ -167,14 +164,11 @@ public class CalcitePPLScalarSubqueryTest extends CalcitePPLAbstractTest {
             + "})], SAL=[$5])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
-
-    String expectedSparkSql =
-        ""
-            + "SELECT (SELECT MIN(`EMP`.`EMPNO`) `min(EMPNO)`\n"
-            + "FROM `scott`.`SALGRADE`\n"
-            + "WHERE `EMP`.`SAL` = `HISAL`) `min_empno`, `SAL`\n"
-            + "FROM `scott`.`EMP` `EMP`";
-    verifyPPLToSparkSQL(root, expectedSparkSql);
+    // verifyPPLToSparkSQL is intentionally omitted: SALGRADE has no EMPNO or SAL column, so
+    // both references in the subquery bind to outer EMP columns (correlated outer references).
+    // The SQL serializer emits MIN(`EMP`.`EMPNO`) inside a subquery aggregate — outer-column
+    // references in aggregate functions are rejected by Spark with
+    // UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE. See issue #5470.
   }
 
   @Test
@@ -361,14 +355,10 @@ public class CalcitePPLScalarSubqueryTest extends CalcitePPLAbstractTest {
             + "}))], variablesSet=[[$cor0]])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
-
-    String expectedSparkSql =
-        ""
-            + "SELECT *\n"
-            + "FROM `scott`.`EMP`\n"
-            + "WHERE `SAL` > (SELECT AVG(`EMP`.`SAL`) `AVG(SAL)`\n"
-            + "FROM `scott`.`SALGRADE`\n"
-            + "WHERE `EMP`.`SAL` = `HISAL`)";
-    verifyPPLToSparkSQL(root, expectedSparkSql);
+    // verifyPPLToSparkSQL is intentionally omitted: SALGRADE has no SAL column, so both SAL
+    // references in the subquery bind to the outer EMP.SAL (correlated outer reference). The
+    // SQL serializer emits AVG(`EMP`.`SAL`) in the subquery aggregate — outer-column references
+    // in aggregate functions are rejected by Spark with
+    // UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE. See issue #5470.
   }
 }


### PR DESCRIPTION
## Summary

Fixes #5470.

The `verifyPPLToSparkSQL` assertions in `testCorrelatedScalarSubqueryInWhere` and `testCorrelatedScalarSubqueryInSelect` pin SQL that Spark 4.1 rejects. `SALGRADE` has no `SAL` or `EMPNO` column, so those names bind to the outer `EMP` table as correlated outer references per SQL-92 scoping rules. The SQL serializer correctly emits `AVG(EMP.SAL)` and `MIN(EMP.EMPNO)` inside the subquery aggregates — but Spark refuses to execute them:

```
[UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE]
Unsupported subquery expression: Expressions referencing the outer query are not
supported outside of WHERE/HAVING clauses: "avg(SAL) AS AVG(SAL)". SQLSTATE: 0A000
```

The logical plans (verified by `verifyLogical`) are correct and match the correlated semantics. Only the `verifyPPLToSparkSQL` call is misleading — `verifyPPLToSparkSQL` only compares the serialized SQL string; it never executes against a real Spark engine, so the test passed while pinning invalid SQL.

**Changes:**

- `testCorrelatedScalarSubqueryInWhere`: remove `verifyPPLToSparkSQL`; keep `verifyLogical`; add comment explaining the omission
- `testCorrelatedScalarSubqueryInSelect`: same treatment — same root cause (`MIN(EMP.EMPNO)` in aggregate)
- Remove `testCorrelatedScalarSubqueryInWhereMaxOut`: it is an exact duplicate of `testCorrelatedScalarSubqueryInWhere` (same PPL, same expected logical plan, same invalid expected SQL)

**Tests not touched:** The disjunctive tests (`testDisjunctiveCorrelatedScalarSubqueryInWhere*`) use `COUNT()` which does not reference any outer column; their correlated reference lives only in the `WHERE` clause of the subquery. Spark supports correlated `WHERE`-clause references, so those `verifyPPLToSparkSQL` assertions remain valid and are untouched.

## Test plan

- [x] `./gradlew :ppl:test --tests "*CalcitePPLScalarSubqueryTest*"` — `BUILD SUCCESSFUL`; all remaining tests pass
- [x] `./gradlew spotlessApply` — no formatting violations
