### PR TITLE
Grant BouncyCastle getProperty permission for datasource encryption

### DIFF
--- a/plugin/src/main/plugin-metadata/plugin-security.policy
+++ b/plugin/src/main/plugin-metadata/plugin-security.policy
@@ -27,4 +27,7 @@ grant {
 
   // Deserialization filter
   permission java.io.SerializablePermission "serialFilter";
+
+  // BouncyCastle reads org.bouncycastle.* security properties during datasource credential encryption
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.*";
 };


### PR DESCRIPTION
### Description

This PR fixed the 2.19.6 release IT failure (#5579) due to the BouncyCastle version bump in https://github.com/opensearch-project/OpenSearch/pull/22296.

Ref to opensearch-project/OpenSearch#17393 and opensearch-project/security#4266, #4270 for the same `getProperty.org.bouncycastle.*` grant.

### Related Issues
Resolves https://github.com/opensearch-project/sql/issues/5579

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
