### PR TITLE
Add configurable expression depth limit during AST building

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryContext.java
@@ -262,7 +262,7 @@ public class UnifiedQueryContext implements AutoCloseable {
     private UnifiedQueryParser<?> createParser(CalcitePlanContext planContext, Settings settings) {
       return switch (queryType) {
         case PPL -> new PPLQueryParser(settings);
-        case SQL -> new SqlV2QueryParser();
+        case SQL -> new SqlV2QueryParser(settings);
       };
     }
 

--- a/api/src/main/java/org/opensearch/sql/api/parser/SqlV2QueryParser.java
+++ b/api/src/main/java/org/opensearch/sql/api/parser/SqlV2QueryParser.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Not;
@@ -26,6 +27,8 @@ import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.Sort;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.common.antlr.AstBuildGuard;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser.ExistsSubqueryExpressionAtomContext;
@@ -42,7 +45,11 @@ import org.opensearch.sql.sql.parser.AstStatementBuilder;
 import org.opensearch.sql.sql.parser.context.QuerySpecification;
 
 /** SQL query parser that produces {@link UnresolvedPlan} using the V2 ANTLR grammar. */
+@RequiredArgsConstructor
 public class SqlV2QueryParser implements UnifiedQueryParser<UnresolvedPlan> {
+
+  /** Settings containing execution limits and feature flags used by AST builders. */
+  private final Settings settings;
 
   /** Reusable ANTLR-based SQL syntax parser. Stateless and thread-safe. */
   private final SQLSyntaxParser syntaxParser = new SQLSyntaxParser();
@@ -52,7 +59,7 @@ public class SqlV2QueryParser implements UnifiedQueryParser<UnresolvedPlan> {
     ParseTree cst = syntaxParser.parse(query);
     AstStatementBuilder astStmtBuilder =
         new AstStatementBuilder(
-            new ExtendedAstBuilder(query),
+            new ExtendedAstBuilder(query, settings),
             AstStatementBuilder.StatementBuilderContext.builder().build());
     Statement statement = cst.accept(astStmtBuilder);
 
@@ -69,8 +76,8 @@ public class SqlV2QueryParser implements UnifiedQueryParser<UnresolvedPlan> {
    */
   private static class ExtendedAstBuilder extends AstBuilder {
 
-    ExtendedAstBuilder(String query) {
-      super(query);
+    ExtendedAstBuilder(String query, Settings settings) {
+      super(query, settings);
     }
 
     @Override
@@ -122,7 +129,7 @@ public class SqlV2QueryParser implements UnifiedQueryParser<UnresolvedPlan> {
 
     @Override
     protected AstExpressionBuilder createExpressionBuilder() {
-      return new ExtendedAstExpressionBuilder();
+      return new ExtendedAstExpressionBuilder(guard);
     }
 
     @Override
@@ -156,6 +163,10 @@ public class SqlV2QueryParser implements UnifiedQueryParser<UnresolvedPlan> {
      * enclosing {@code this} reference is not available during {@code super()} construction.
      */
     private class ExtendedAstExpressionBuilder extends AstExpressionBuilder {
+
+      ExtendedAstExpressionBuilder(AstBuildGuard guard) {
+        super(guard);
+      }
 
       @Override
       public UnresolvedExpression visitInSubqueryPredicate(InSubqueryPredicateContext ctx) {

--- a/api/src/test/java/org/opensearch/sql/api/parser/UnifiedQueryParserTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/parser/UnifiedQueryParserTest.java
@@ -26,9 +26,12 @@ import static org.opensearch.sql.ast.dsl.AstDSL.qualifiedName;
 import static org.opensearch.sql.ast.dsl.AstDSL.relation;
 
 import org.junit.Test;
+import org.opensearch.sql.api.UnifiedQueryContext;
 import org.opensearch.sql.api.UnifiedQueryTestBase;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.executor.QueryType;
 
 public class UnifiedQueryParserTest extends UnifiedQueryTestBase {
 
@@ -78,6 +81,38 @@ public class UnifiedQueryParserTest extends UnifiedQueryTestBase {
   @Test
   public void testSyntaxErrorThrows() {
     assertThrows(SyntaxCheckException.class, () -> context.getParser().parse("not a valid query"));
+  }
+
+  @Test
+  public void deeplyNestedExpressionShouldBeRejected() throws Exception {
+    String key = Settings.Key.MAX_EXPRESSION_DEPTH.getKeyValue();
+    try (UnifiedQueryContext ppl =
+            UnifiedQueryContext.builder()
+                .language(QueryType.PPL)
+                .catalog(DEFAULT_CATALOG, testSchema)
+                .setting(key, 20)
+                .build();
+        UnifiedQueryContext sql =
+            UnifiedQueryContext.builder()
+                .language(QueryType.SQL)
+                .catalog(DEFAULT_CATALOG, testSchema)
+                .setting(key, 20)
+                .build()) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> ppl.getParser().parse("source = catalog.employees | where " + orChain(30)));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> sql.getParser().parse("SELECT * FROM catalog.employees WHERE " + orChain(30)));
+    }
+  }
+
+  private String orChain(int terms) {
+    StringBuilder sb = new StringBuilder("age = 1");
+    for (int i = 2; i <= terms; i++) {
+      sb.append(" or age = ").append(i);
+    }
+    return sb.toString();
   }
 
   private void assertEqual(String query, UnresolvedPlan expected) {

--- a/common/src/main/java/org/opensearch/sql/common/antlr/AstBuildGuard.java
+++ b/common/src/main/java/org/opensearch/sql/common/antlr/AstBuildGuard.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.common.antlr;
+
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.sql.common.setting.Settings;
+import org.opensearch.sql.common.utils.StringUtils;
+
+/**
+ * Guards AST construction against pathological queries by bounding the depth of parse-tree visitor
+ * recursion, rejecting over-nested expressions with an {@link IllegalArgumentException} instead of
+ * letting a StackOverflowError crash the node.
+ *
+ * <p>Holds per-traversal state, so an instance must not be shared across threads.
+ */
+@RequiredArgsConstructor
+public final class AstBuildGuard {
+
+  public static final int DEFAULT_MAX_DEPTH = 1000;
+
+  /** Maximum nesting depth allowed; {@code 0} or less means unlimited. */
+  private final int maxDepth;
+
+  /** Live nesting depth of the in-progress traversal; resets to 0 between top-level visits. */
+  private int depth = 0;
+
+  public AstBuildGuard() {
+    this(DEFAULT_MAX_DEPTH);
+  }
+
+  /** Builds a guard from the configured {@code plugins.query.max_expression_depth} setting. */
+  public static AstBuildGuard fromSettings(Settings settings) {
+    Integer configured =
+        settings == null ? null : settings.getSettingValue(Settings.Key.MAX_EXPRESSION_DEPTH);
+    return new AstBuildGuard(configured == null ? DEFAULT_MAX_DEPTH : configured);
+  }
+
+  /**
+   * Runs a single AST-build descent under the configured guardrails.
+   *
+   * @param visit the visitor descent to execute
+   * @return the result of {@code visit}
+   * @throws IllegalArgumentException if a positive maximum depth is configured and would be
+   *     exceeded
+   */
+  public <T> T enforce(Supplier<T> visit) {
+    if (maxDepth > 0 && depth >= maxDepth) {
+      throw new IllegalArgumentException(
+          StringUtils.format(
+              "Expression nesting depth exceeds the maximum allowed [%d]; simplify the query or"
+                  + " reduce the number of chained conditions.",
+              maxDepth));
+    }
+    depth++;
+    try {
+      return visit.get();
+    } finally {
+      depth--;
+    }
+  }
+}

--- a/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
+++ b/common/src/main/java/org/opensearch/sql/common/setting/Settings.java
@@ -51,6 +51,7 @@ public abstract class Settings {
     /** Common Settings for SQL and PPL. */
     QUERY_MEMORY_LIMIT("plugins.query.memory_limit"),
     QUERY_SIZE_LIMIT("plugins.query.size_limit"),
+    MAX_EXPRESSION_DEPTH("plugins.query.max_expression_depth"),
     QUERY_BUCKET_SIZE("plugins.query.buckets"),
     SEARCH_MAX_BUCKETS("search.max_buckets"),
     ENCYRPTION_MASTER_KEY("plugins.query.datasources.encryption.masterkey"),

--- a/docs/user/admin/settings.rst
+++ b/docs/user/admin/settings.rst
@@ -204,6 +204,38 @@ Result set::
       }
     }
 
+plugins.query.max_expression_depth
+==================================
+
+Version
+-------
+3.8
+
+Description
+-----------
+
+This setting bounds the maximum nesting depth of an expression while a query is parsed into its abstract syntax tree, keeping parsing bounded for very large or deeply nested expressions. A query exceeding the limit is rejected with a 400 error. The default value is 1000. Set it to 0 to disable the limit (unlimited). Here is an example::
+
+	>> curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings -d '{
+	  "transient" : {
+	    "plugins.query.max_expression_depth" : 500
+	  }
+	}'
+
+Result set::
+
+    {
+      "acknowledged" : true,
+      "persistent" : { },
+      "transient" : {
+        "plugins" : {
+          "query" : {
+            "max_expression_depth" : "500"
+          }
+        }
+      }
+    }
+
 plugins.query.buckets
 =====================
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/QueryValidationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/QueryValidationIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.opensearch.client.ResponseException;
+import org.opensearch.sql.common.setting.Settings;
+
+/** PPL counterpart of the SQL {@code QueryValidationIT} for query-level rejection cases. */
+public class QueryValidationIT extends PPLIntegTestCase {
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.ACCOUNT);
+  }
+
+  @Test
+  public void deeplyNestedPredicateIsRejectedInsteadOfCrashingNode() throws IOException {
+    // Lower the limit so a small, safe-to-parse query triggers the guard (a query large enough
+    // to exhaust the default limit could overflow the ANTLR parser itself before the guard runs).
+    updateClusterSettings(
+        new ClusterSetting(TRANSIENT, Settings.Key.MAX_EXPRESSION_DEPTH.getKeyValue(), "20"));
+    try {
+      StringBuilder predicate = new StringBuilder("age = 1");
+      for (int i = 2; i <= 30; i++) {
+        predicate.append(" or age = ").append(i);
+      }
+      executeQuery("source=opensearch-sql_test_index_account | where " + predicate);
+      fail("Expected ResponseException for an over-nested predicate");
+    } catch (ResponseException e) {
+      assertTrue(e.getMessage().contains("Expression nesting depth exceeds the maximum allowed"));
+    } finally {
+      updateClusterSettings(
+          new ClusterSetting(TRANSIENT, Settings.Key.MAX_EXPRESSION_DEPTH.getKeyValue(), null));
+    }
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/QueryValidationIT.java
@@ -22,6 +22,7 @@ import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.ResponseException;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.util.RequiresCapability;
 
@@ -37,6 +38,27 @@ public class QueryValidationIT extends SQLIntegTestCase {
   @Override
   protected void init() throws Exception {
     loadIndex(Index.ACCOUNT);
+  }
+
+  @Test
+  public void testDeeplyNestedPredicateIsRejectedInsteadOfCrashingNode() throws IOException {
+    // Lower the limit so a small, safe-to-parse query triggers the guard (a query large enough
+    // to exhaust the default limit could overflow the ANTLR parser itself before the guard runs).
+    updateClusterSettings(
+        new ClusterSetting(TRANSIENT, Settings.Key.MAX_EXPRESSION_DEPTH.getKeyValue(), "20"));
+    try {
+      StringBuilder predicate = new StringBuilder("age = 1");
+      for (int i = 2; i <= 30; i++) {
+        predicate.append(" OR age = ").append(i);
+      }
+      expectResponseException()
+          .hasStatusCode(BAD_REQUEST)
+          .containsMessage("Expression nesting depth exceeds the maximum allowed")
+          .whenExecute("SELECT * FROM opensearch-sql_test_index_account WHERE " + predicate);
+    } finally {
+      updateClusterSettings(
+          new ClusterSetting(TRANSIENT, Settings.Key.MAX_EXPRESSION_DEPTH.getKeyValue(), null));
+    }
   }
 
   @Ignore(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/setting/OpenSearchSettings.java
@@ -29,6 +29,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.search.aggregations.MultiBucketConsumerService;
+import org.opensearch.sql.common.antlr.AstBuildGuard;
 import org.opensearch.sql.common.setting.Settings;
 
 /** Setting implementation on OpenSearch. */
@@ -197,6 +198,14 @@ public class OpenSearchSettings extends Settings {
       Setting.intSetting(
           Key.QUERY_SIZE_LIMIT.getKeyValue(),
           IndexSettings.MAX_RESULT_WINDOW_SETTING,
+          0,
+          Setting.Property.NodeScope,
+          Setting.Property.Dynamic);
+
+  public static final Setting<Integer> MAX_EXPRESSION_DEPTH_SETTING =
+      Setting.intSetting(
+          Key.MAX_EXPRESSION_DEPTH.getKeyValue(),
+          AstBuildGuard.DEFAULT_MAX_DEPTH,
           0,
           Setting.Property.NodeScope,
           Setting.Property.Dynamic);
@@ -482,6 +491,12 @@ public class OpenSearchSettings extends Settings {
     register(
         settingBuilder,
         clusterSettings,
+        Key.MAX_EXPRESSION_DEPTH,
+        MAX_EXPRESSION_DEPTH_SETTING,
+        new Updater(Key.MAX_EXPRESSION_DEPTH));
+    register(
+        settingBuilder,
+        clusterSettings,
         Key.QUERY_BUCKET_SIZE,
         QUERY_BUCKET_SIZE_SETTING,
         new Updater(Key.QUERY_BUCKET_SIZE));
@@ -650,6 +665,7 @@ public class OpenSearchSettings extends Settings {
         .add(SQL_ENABLED_SETTING)
         .add(SQL_SLOWLOG_SETTING)
         .add(SQL_CURSOR_KEEP_ALIVE_SETTING)
+        .add(MAX_EXPRESSION_DEPTH_SETTING)
         .add(PPL_ENABLED_SETTING)
         .add(PPL_QUERY_TIMEOUT_SETTING)
         .add(PPL_SYNTAX_LEGACY_PREFERRED_SETTING)

--- a/plugin/src/main/java/org/opensearch/sql/plugin/config/OpenSearchPluginModule.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/config/OpenSearchPluginModule.java
@@ -106,8 +106,9 @@ public class OpenSearchPluginModule extends AbstractModule {
   }
 
   @Provides
-  public SQLService sqlService(QueryManager queryManager, QueryPlanFactory queryPlanFactory) {
-    return new SQLService(new SQLSyntaxParser(), queryManager, queryPlanFactory);
+  public SQLService sqlService(
+      QueryManager queryManager, QueryPlanFactory queryPlanFactory, Settings settings) {
+    return new SQLService(new SQLSyntaxParser(), queryManager, queryPlanFactory, settings);
   }
 
   /** {@link QueryPlanFactory}. */

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -338,6 +338,8 @@ public class RestUnifiedQueryAction {
         builder, org.opensearch.sql.common.setting.Settings.Key.PPL_REX_MAX_MATCH_LIMIT);
     forwardClusterSetting(
         builder, org.opensearch.sql.common.setting.Settings.Key.PPL_SYNTAX_LEGACY_PREFERRED);
+    forwardClusterSetting(
+        builder, org.opensearch.sql.common.setting.Settings.Key.MAX_EXPRESSION_DEPTH);
     return builder;
   }
 

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -124,6 +124,7 @@ import org.opensearch.sql.ast.tree.Union;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Window;
 import org.opensearch.sql.calcite.plan.OpenSearchConstants;
+import org.opensearch.sql.common.antlr.AstBuildGuard;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.common.setting.Settings.Key;
@@ -159,7 +160,7 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   }
 
   public AstBuilder(String query, Settings settings) {
-    this.expressionBuilder = new AstExpressionBuilder(this);
+    this.expressionBuilder = new AstExpressionBuilder(this, AstBuildGuard.fromSettings(settings));
     this.query = query;
     this.settings = settings;
   }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.RuleNode;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.dsl.AstDSL;
@@ -31,6 +32,7 @@ import org.opensearch.sql.ast.expression.subquery.InSubquery;
 import org.opensearch.sql.ast.expression.subquery.ScalarSubquery;
 import org.opensearch.sql.ast.tree.Trendline;
 import org.opensearch.sql.calcite.plan.OpenSearchConstants;
+import org.opensearch.sql.common.antlr.AstBuildGuard;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.exception.SemanticCheckException;
@@ -95,8 +97,25 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
 
   private final AstBuilder astBuilder;
 
+  private final AstBuildGuard guard;
+
   public AstExpressionBuilder(AstBuilder astBuilder) {
+    this(astBuilder, new AstBuildGuard());
+  }
+
+  public AstExpressionBuilder(AstBuilder astBuilder, AstBuildGuard guard) {
     this.astBuilder = astBuilder;
+    this.guard = guard;
+  }
+
+  @Override
+  public UnresolvedExpression visit(ParseTree tree) {
+    return guard.enforce(() -> super.visit(tree));
+  }
+
+  @Override
+  public UnresolvedExpression visitChildren(RuleNode node) {
+    return guard.enforce(() -> super.visitChildren(node));
   }
 
   /** Eval clause. */

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -55,7 +55,9 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.sql.ast.Node;
@@ -65,10 +67,50 @@ import org.opensearch.sql.ast.expression.RelevanceFieldList;
 import org.opensearch.sql.ast.expression.SpanUnit;
 import org.opensearch.sql.ast.tree.Chart;
 import org.opensearch.sql.calcite.plan.OpenSearchConstants;
+import org.opensearch.sql.common.antlr.AstBuildGuard;
+import org.opensearch.sql.common.antlr.CaseInsensitiveCharStream;
+import org.opensearch.sql.common.antlr.SyntaxAnalysisErrorListener;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLLexer;
+import org.opensearch.sql.ppl.antlr.parser.OpenSearchPPLParser;
 
 public class AstExpressionBuilderTest extends AstBuilderTest {
+
+  @Test
+  public void deeplyNestedExpressionShouldBeRejected() {
+    for (String expr :
+        List.of(
+            nest(30, "a = 0", e -> "(" + e + " or a = 1)"),
+            nest(30, "a = 0", e -> "(" + e + " and a = 1)"),
+            nest(30, "a", e -> "abs(" + e + ")") + " = 1")) {
+      assertThrows(IllegalArgumentException.class, () -> parseWithGuard(expr, 20));
+    }
+  }
+
+  @Test
+  public void shallowExpressionWithinLimitIsAccepted() {
+    parseWithGuard("a = 0 or a = 1 or a = 2", 20);
+  }
+
+  private void parseWithGuard(String expr, int maxDepth) {
+    OpenSearchPPLParser parser =
+        new OpenSearchPPLParser(
+            new CommonTokenStream(new OpenSearchPPLLexer(new CaseInsensitiveCharStream(expr))));
+    parser.addErrorListener(new SyntaxAnalysisErrorListener());
+    parser
+        .logicalExpression()
+        .accept(new AstExpressionBuilder(new AstBuilder(expr), new AstBuildGuard(maxDepth)));
+  }
+
+  private static String nest(int depth, String base, UnaryOperator<String> wrap) {
+    String expr = base;
+    for (int i = 0; i < depth; i++) {
+      expr = wrap.apply(expr);
+    }
+    return expr;
+  }
+
   @Test
   public void testLogicalNotExpr() {
     assertEqual(

--- a/sql/src/main/java/org/opensearch/sql/sql/SQLService.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/SQLService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.opensearch.sql.ast.statement.Statement;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.executor.ExecutionEngine.ExplainResponse;
 import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
 import org.opensearch.sql.executor.QueryManager;
@@ -32,7 +33,14 @@ public class SQLService {
 
   private final QueryPlanFactory queryExecutionFactory;
 
+  private final Settings settings;
+
   private final QueryType SQL_QUERY = QueryType.SQL;
+
+  public SQLService(
+      SQLSyntaxParser parser, QueryManager queryManager, QueryPlanFactory queryExecutionFactory) {
+    this(parser, queryManager, queryExecutionFactory, null);
+  }
 
   /**
    * Given {@link SQLQueryRequest}, execute it. Using listener to listen result.
@@ -95,7 +103,7 @@ public class SQLService {
       Statement statement =
           cst.accept(
               new AstStatementBuilder(
-                  new AstBuilder(request.getQuery()),
+                  new AstBuilder(request.getQuery(), settings),
                   AstStatementBuilder.StatementBuilderContext.builder()
                       .isExplain(isExplainRequest)
                       .fetchSize(request.getFetchSize())

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstBuilder.java
@@ -39,7 +39,9 @@ import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
+import org.opensearch.sql.common.antlr.AstBuildGuard;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
@@ -62,8 +64,15 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
    */
   protected final String query;
 
+  protected final AstBuildGuard guard;
+
   public AstBuilder(String query) {
+    this(query, null);
+  }
+
+  public AstBuilder(String query, Settings settings) {
     this.query = query;
+    this.guard = AstBuildGuard.fromSettings(settings);
     this.expressionBuilder = createExpressionBuilder();
   }
 
@@ -290,7 +299,7 @@ public class AstBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedPlan> {
 
   /** Override to provide a custom expression builder (e.g., with subquery support). */
   protected AstExpressionBuilder createExpressionBuilder() {
-    return new AstExpressionBuilder();
+    return new AstExpressionBuilder(guard);
   }
 
   private UnresolvedExpression visitSelectItem(SelectElementContext ctx) {

--- a/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/parser/AstExpressionBuilder.java
@@ -79,11 +79,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.RuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.RuleNode;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.sql.ast.dsl.AstDSL;
 import org.opensearch.sql.ast.expression.*;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
+import org.opensearch.sql.common.antlr.AstBuildGuard;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
@@ -100,6 +103,26 @@ import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParserBaseVisitor;
 
 /** Expression builder to parse text to expression in AST. */
 public class AstExpressionBuilder extends OpenSearchSQLParserBaseVisitor<UnresolvedExpression> {
+
+  private final AstBuildGuard guard;
+
+  public AstExpressionBuilder() {
+    this(new AstBuildGuard());
+  }
+
+  public AstExpressionBuilder(AstBuildGuard guard) {
+    this.guard = guard;
+  }
+
+  @Override
+  public UnresolvedExpression visit(ParseTree tree) {
+    return guard.enforce(() -> super.visit(tree));
+  }
+
+  @Override
+  public UnresolvedExpression visitChildren(RuleNode node) {
+    return guard.enforce(() -> super.visitChildren(node));
+  }
 
   @Override
   public UnresolvedExpression visitTableName(TableNameContext ctx) {

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstBuilderTest.java
@@ -37,6 +37,7 @@ import static org.opensearch.sql.utils.SystemIndexUtils.mappingTable;
 
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -51,6 +52,7 @@ import org.opensearch.sql.ast.tree.SubqueryAlias;
 import org.opensearch.sql.ast.tree.TableFunction;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
+import org.opensearch.sql.common.setting.Settings;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.sql.antlr.SQLSyntaxParser;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLParser;
@@ -776,5 +778,29 @@ class AstBuilderTest extends AstBuilderTestBase {
     assertThrows(
         SyntaxCheckException.class,
         () -> buildAST("SELECT * FROM t WHERE EXISTS (SELECT 1 FROM t2)"));
+  }
+
+  @Test
+  public void configured_max_expression_depth_from_settings_is_applied() {
+    Settings settings =
+        new Settings() {
+          @Override
+          public <T> T getSettingValue(Key key) {
+            return (T) Integer.valueOf(5);
+          }
+
+          @Override
+          public List<?> getSettings() {
+            return List.of();
+          }
+        };
+    StringBuilder where = new StringBuilder("a = 1");
+    for (int i = 2; i <= 20; i++) {
+      where.append(" OR a = ").append(i);
+    }
+    String query = "SELECT * FROM t WHERE " + where;
+    AstBuilder builder = new AstBuilder(query, settings);
+    assertThrows(
+        IllegalArgumentException.class, () -> new SQLSyntaxParser().parse(query).accept(builder));
   }
 }

--- a/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.sql.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.sql.ast.dsl.AstDSL.aggregate;
 import static org.opensearch.sql.ast.dsl.AstDSL.and;
 import static org.opensearch.sql.ast.dsl.AstDSL.between;
@@ -35,6 +36,8 @@ import static org.opensearch.sql.ast.tree.Sort.SortOrder.DESC;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
+import java.util.List;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -47,6 +50,7 @@ import org.opensearch.sql.ast.expression.RelevanceFieldList;
 import org.opensearch.sql.ast.expression.WindowFrame;
 import org.opensearch.sql.ast.expression.WindowFunction;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
+import org.opensearch.sql.common.antlr.AstBuildGuard;
 import org.opensearch.sql.common.antlr.CaseInsensitiveCharStream;
 import org.opensearch.sql.common.antlr.SyntaxAnalysisErrorListener;
 import org.opensearch.sql.sql.antlr.parser.OpenSearchSQLLexer;
@@ -827,10 +831,43 @@ class AstExpressionBuilderTest {
         buildExprAst("age in (abs(20), abs(30))"));
   }
 
+  @Test
+  public void deeplyNestedExpressionShouldBeRejected() {
+    AstExpressionBuilder guarded = new AstExpressionBuilder(new AstBuildGuard(20));
+    for (String expr :
+        List.of(
+            nest(30, "a = 0", e -> "(" + e + " or a = 1)"),
+            nest(30, "a = 0", e -> "(" + e + " and a = 1)"),
+            nest(30, "a", e -> "abs(" + e + ")"),
+            nest(30, "a", e -> "case when " + e + " > 0 then 1 else 0 end"))) {
+      assertThrows(IllegalArgumentException.class, () -> buildExprAst(expr, guarded));
+    }
+  }
+
+  @Test
+  public void shallowExpressionWithinLimitIsAccepted() {
+    AstExpressionBuilder guarded = new AstExpressionBuilder(new AstBuildGuard(20));
+    assertEquals(
+        buildExprAst("a = 0 or a = 1 or a = 2", guarded),
+        buildExprAst("a = 0 or a = 1 or a = 2", guarded));
+  }
+
+  private static String nest(int depth, String base, UnaryOperator<String> wrap) {
+    String expr = base;
+    for (int i = 0; i < depth; i++) {
+      expr = wrap.apply(expr);
+    }
+    return expr;
+  }
+
   private Node buildExprAst(String expr) {
+    return buildExprAst(expr, astExprBuilder);
+  }
+
+  private Node buildExprAst(String expr, AstExpressionBuilder builder) {
     OpenSearchSQLLexer lexer = new OpenSearchSQLLexer(new CaseInsensitiveCharStream(expr));
     OpenSearchSQLParser parser = new OpenSearchSQLParser(new CommonTokenStream(lexer));
     parser.addErrorListener(new SyntaxAnalysisErrorListener());
-    return parser.expression().accept(astExprBuilder);
+    return parser.expression().accept(builder);
   }
 }


### PR DESCRIPTION
### Description

Adds a configurable safeguard on expression nesting depth during SQL/PPL parsing to improve robustness for very large or deeply nested queries. Introduces the dynamic setting `plugins.query.max_expression_depth` (default 1000; 0 to disable). Tested SQL/PPL both Lucene and composite index with default `-Xss 1m` as well as all ClickBench queries.

> **TODO**: Statement/command-level nesting — SQL subqueries (IN/EXISTS/scalar/FROM-derived, and JOINs onto subqueries) and PPL subsearches (in [...], scalar/exists [...], and subsearch-bearing commands like join/lookup/append/appendcol/multisearch) — recurses at the plan level and requires a separate guard.

#### Examples

With `plugins.query.max_expression_depth` (default `1000`), a query whose expression nesting exceeds the limit is rejected with `400 Bad Request` instead of triggering a `StackOverflowError` / node crash.

```
=== SQL ===
```bash
curl -s -XPOST localhost:9200/_plugins/_sql -H 'Content-Type: application/json' -d '{
  "query": "SELECT * FROM my_index WHERE n = 0 OR n = 1 OR ... OR n = 1023 LIMIT 1"
}'

{
  "error": {
    "reason": "Invalid SQL query",
    "details": "Expression nesting depth exceeds the maximum allowed [1000]; simplify the query or reduce the number of chained conditions.",
    "type": "IllegalArgumentException"
  },
  "status": 400
}

=== PPL ===
curl -s -XPOST localhost:9200/_plugins/_ppl -H 'Content-Type: application/json' -d '{
  "query": "source=my_index | where n = 0 OR n = 1 OR ... OR n = 1023 | head 1"
}'

{
  "error": {
    "reason": "Invalid Query",
    "details": "Expression nesting depth exceeds the maximum allowed [1000]; simplify the query or reduce the number of chained conditions.",
    "type": "IllegalArgumentException"
  },
  "status": 400
}
```

#### References

Bounding query/expression nesting to prevent parser or planner stack overflow is a well-established practice. Comparable safeguards in other engines:

| Engine | Setting / limit | Default | Bounds | Reference |
| --- | --- | --- | --- | --- |
| **SQLite** | `SQLITE_MAX_EXPR_DEPTH` (runtime `SQLITE_LIMIT_EXPR_DEPTH`) | **1000** | Expression-tree nesting depth (enforced in `sqlite3ExprCheckHeight()`) | https://www.sqlite.org/limits.html |
| **PostgreSQL** | `max_stack_depth` | ~2 MB | Physical stack depth for *all* recursion — parser, expression evaluation, nested subqueries, function calls (`check_stack_depth()`) | https://www.postgresql.org/docs/current/runtime-config-resource.html |
| **MySQL / MariaDB** | `thread_stack` (+ internal `check_stack_overrun()`); `max_sp_recursion_depth` | ~1 MB; 0 | Per-thread stack for parser/expression recursion; stored-procedure recursion depth | https://dev.mysql.com/doc/refman/en/server-system-variables.html#sysvar_thread_stack |
| **OpenSearch (core DSL)** | `index.query.max_nested_depth` | 20 | Nesting depth of compound/`bool` queries (query-structure depth) | https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/index-settings/ |
| **OpenSearch (core DSL)** | `indices.query.bool.max_clause_count` | 1024 | Total clause *count* in a boolean query (width, not depth) | https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/index-settings/ |
| **Apache Calcite** | `RexUtil.toCnf(maxCnfNodeCount, …)` → `PlanTooComplexError` | (caller-set) | Node-count guard during CNF/DNF expansion to prevent combinatorial/stack blowup | https://calcite.apache.org/javadocAggregate/org/apache/calcite/plan/PlanTooComplexError.html |

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5246

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
