### PR TITLE
Fix SQL explain API rejecting ?format=json parameter

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/ExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/ExplainIT.java
@@ -13,11 +13,13 @@ import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_LOCATION;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NESTED_TYPE;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_PEOPLE;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_PHRASE;
+import static org.opensearch.sql.legacy.plugin.RestSqlAction.EXPLAIN_API_ENDPOINT;
 
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -252,5 +254,26 @@ public class ExplainIT extends SQLIntegTestCase {
     Response response = client().performRequest(request);
 
     assertEquals("application/json; charset=UTF-8", response.getHeader("content-type"));
+  }
+
+  /**
+   * Prior to OpenSearch 3.0, {@code ?format=json} was a valid way to request the explain plan.
+   * "json" was never a real {@code Format} value the query endpoint accepts (only
+   * jdbc/csv/raw/table are), so this depends on the explain endpoint specifically tolerating it.
+   * Regression test for https://github.com/opensearch-project/sql/issues/4373: this used to fail
+   * with "Failed to create executor due to unknown response format: json" before the explain
+   * endpoint reached any query-specific logic at all.
+   */
+  @Test
+  public void testExplainAcceptsJsonFormatForBackwardCompatibility() throws IOException {
+    String query = makeRequest("SELECT firstname FROM opensearch-sql_test_index_account");
+    Request request = new Request("POST", EXPLAIN_API_ENDPOINT + "?format=json");
+    request.setJsonEntity(query);
+
+    Response response = client().performRequest(request);
+
+    assertEquals(200, response.getStatusLine().getStatusCode());
+    JSONObject explanation = new JSONObject(TestUtils.getResponseBody(response));
+    Assert.assertFalse("explain response should not contain an error", explanation.has("error"));
   }
 }

--- a/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/plugin/RestSqlAction.java
@@ -143,7 +143,7 @@ public class RestSqlAction extends BaseRestHandler {
 
       LOG.info("[{}] Incoming request {}", QueryContext.getRequestId(), request.uri());
 
-      Format format = SqlRequestParam.getFormat(request.params());
+      Format format = resolveFormat(request);
 
       SQLQueryRequest newSqlRequest =
           new SQLQueryRequest(
@@ -318,6 +318,29 @@ public class RestSqlAction extends BaseRestHandler {
 
   private static boolean isExplainRequest(final RestRequest request) {
     return request.path().endsWith("/_explain");
+  }
+
+  /**
+   * Resolve the response {@link Format} for this request.
+   *
+   * <p>{@code format=json} is accepted for explain requests for backward compatibility: prior to
+   * OpenSearch 3.0, {@code ?format=json} was a valid way to request the explain plan (see #4373).
+   * It was never a real member of {@link Format} - {@code SqlRequestParam#getFormat} always
+   * rejected it - but the explain response body is JSON regardless of this parameter (see {@link
+   * #executeSqlRequest}, which calls {@code queryAction.explain().explain()} directly instead of
+   * going through a {@link Format}-specific executor), so the parameter can simply be ignored here
+   * for explain requests without changing any actual behavior.
+   */
+  private static Format resolveFormat(final RestRequest request) {
+    try {
+      return SqlRequestParam.getFormat(request.params());
+    } catch (IllegalArgumentException e) {
+      if (isExplainRequest(request)
+          && "json".equalsIgnoreCase(request.param(SqlRequestParam.QUERY_PARAMS_FORMAT))) {
+        return Format.JDBC;
+      }
+      throw e;
+    }
   }
 
   private static boolean isClientError(Exception e) {

--- a/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/org/opensearch/sql/sql/domain/SQLQueryRequest.java
@@ -159,7 +159,11 @@ public class SQLQueryRequest {
   }
 
   private boolean isSupportedExplainFormat() {
-    return Stream.of("simple", "standard", "extended", "cost").anyMatch(format::equalsIgnoreCase);
+    // "json" is accepted for backward compatibility: the explain endpoint always returns JSON
+    // regardless of this parameter, so treating it as valid avoids the 400 regression
+    // introduced in OpenSearch 3.0. See https://github.com/opensearch-project/sql/issues/4373
+    return Stream.of("simple", "standard", "extended", "cost", "json")
+        .anyMatch(format::equalsIgnoreCase);
   }
 
   private String getFormat(Map<String, String> params) {

--- a/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/org/opensearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -105,6 +105,22 @@ public class SQLQueryRequestTest {
   }
 
   @Test
+  public void should_support_explain_with_json_format() {
+    // Regression test for https://github.com/opensearch-project/sql/issues/4373.
+    // ?format=json was accepted before OpenSearch 3.0 and should continue to be valid.
+    // The explain endpoint always returns JSON regardless of this parameter.
+    SQLQueryRequest explainRequest =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .path("_plugins/_sql/_explain")
+            .params(Map.of("format", "json"))
+            .build();
+
+    assertAll(
+        () -> assertTrue(explainRequest.isExplainRequest()),
+        () -> assertTrue(explainRequest.isSupported()));
+  }
+
+  @Test
   public void should_not_support_explain_with_unsupported_explain_format() {
     SQLQueryRequest explainRequest =
         SQLQueryRequestBuilder.request("SELECT 1")


### PR DESCRIPTION
### Description

Fixes #4373

**Problem:** Since OpenSearch 3.0, calling `POST /_plugins/_sql/_explain?format=json` returns:
```json
{
  "error": {
    "reason": "Invalid SQL query",
    "details": "Failed to create executor due to unknown response format: json",
    "type": "IllegalArgumentException"
  },
  "status": 400
}
```

**Root cause (corrected):** My first attempt at this fix (still included below) only added `"json"` to `isSupportedExplainFormat()` in `SQLQueryRequest.java`, the V2/`sql`-module engine's own validation. That turned out to be insufficient - that method is never reached for this bug. `RestSqlAction#prepareRequest` calls `SqlRequestParam.getFormat(request.params())` **unconditionally, for every request**, before `SQLQueryRequest` is even constructed. That call throws `IllegalArgumentException` for any format outside the legacy `Format` enum (`jdbc`/`csv`/`raw`/`table`) - `"json"` included - which is exactly the error above. So the request was failing before either engine (legacy or V2) ever got a chance to look at it.

**Fix:**
1. `RestSqlAction#resolveFormat` (new): when `SqlRequestParam.getFormat` rejects the value AND the request is an explain request AND the rejected value is `"json"`, fall back to a default `Format` instead of throwing. The explain response body is JSON regardless of this parameter (`executeSqlRequest`'s explain branch calls `queryAction.explain().explain()` directly, never through a `Format`-specific executor), so ignoring it here changes nothing else about the response.
2. `SQLQueryRequest#isSupportedExplainFormat()` (kept from the original attempt): once a request gets past (1), this makes the V2 engine treat `format=json` as a supported explain format, so it handles the explain natively instead of always falling back to the legacy engine.

### Changes

- `legacy/src/main/java/.../plugin/RestSqlAction.java` — add `resolveFormat()`, the actual fix for the reported crash
- `sql/src/main/java/.../SQLQueryRequest.java` — add `"json"` to `isSupportedExplainFormat()` (keeps the V2 engine as the primary path once the format-parsing crash is fixed)
- `sql/src/test/java/.../SQLQueryRequestTest.java` — unit test for `isSupportedExplainFormat()`
- `integ-test/.../legacy/ExplainIT.java` — integration test hitting the real `/_explain?format=json` endpoint end-to-end (per review - a unit test of `isSupportedExplainFormat()` alone doesn't exercise `RestSqlAction`, so it wouldn't have caught that the real bug was one layer up)

### Testing

- `SQLQueryRequestTest`: unit coverage for the V2 engine's format validation.
- `ExplainIT#testExplainAcceptsJsonFormatForBackwardCompatibility`: hits `POST /_plugins/_sql/_explain?format=json` for real and asserts a 200 with no `error` key - this is the test that actually exercises the code path the bug lived in.

Note: I don't have a Java/Gradle toolchain available in my current environment, so I couldn't run these locally - would appreciate CI confirming.