### PR TITLE
Fix unclear PPL error message for empty mapping on wildcard indices

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/ppl/IndexMappingErrorMessageIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/IndexMappingErrorMessageIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.json.JSONObject;
+import org.opensearch.client.ResponseException;
+
+/**
+ * Verifies that the improved empty-mapping error path is surfaced correctly end-to-end.
+ *
+ * <p>We exercise two shapes:
+ *
+ * <ol>
+ *   <li>A wildcard pattern that matches no indices — OpenSearch returns an empty mapping response;
+ *       the plugin must return HTTP 404, error.code=INDEX_NOT_FOUND, and details that name the
+ *       pattern and advise the user to check mapping compatibility.
+ *   <li>A plain exact index name that does not exist — also 404/INDEX_NOT_FOUND but the details
+ *       should NOT contain the "compatible mapping" hint (that hint is for wildcard patterns only).
+ * </ol>
+ *
+ * <p>Note: the third scenario from the original bug report — a wildcard that matches multiple
+ * existing indices with <em>incompatible</em> mappings — cannot be reliably reproduced in a unit
+ * test cluster because OpenSearch returns each index's mapping individually (not an empty combined
+ * response) for simple type conflicts. That scenario is covered by the {@link
+ * org.opensearch.sql.opensearch.client.OpenSearchClient#emptyMappingException} unit tests and the
+ * production logic path is identical to the "no matching indices" case tested here.
+ */
+public class IndexMappingErrorMessageIT extends PPLIntegTestCase {
+
+  // Deliberately unique names so they never collide with real test indices.
+  private static final String WILDCARD_PATTERN = "errmsg_it_no_such_idx_*";
+  private static final String EXACT_NAME = "errmsg_it_no_such_exact";
+
+  /**
+   * Querying a wildcard pattern that matches no indices triggers the empty-mapping path. The plugin
+   * must return HTTP 404 with INDEX_NOT_FOUND and a "compatible mapping" hint.
+   */
+  public void test_wildcard_pattern_with_no_matching_indices_returns_404_with_hint()
+      throws Exception {
+    ResponseException ex =
+        assertThrows(
+            ResponseException.class,
+            () -> executeQueryToString("source=" + WILDCARD_PATTERN + " | fields age"));
+
+    String body = EntityUtils.toString(ex.getResponse().getEntity());
+    JSONObject json = new JSONObject(body);
+
+    assertEquals(404, json.getInt("status"));
+    JSONObject error = json.getJSONObject("error");
+    assertEquals("INDEX_NOT_FOUND", error.getString("code"));
+    String details = error.getString("details");
+    assertTrue("details should contain the pattern", details.contains("errmsg_it_no_such_idx_"));
+    assertTrue(
+        "details should hint at incompatible mappings", details.contains("compatible mapping"));
+  }
+
+  /**
+   * Querying a plain non-wildcard index name that does not exist returns 404/INDEX_NOT_FOUND. The
+   * details should NOT contain the "compatible mapping" hint.
+   */
+  public void test_exact_nonexistent_index_returns_404_without_mapping_hint() throws Exception {
+    ResponseException ex =
+        assertThrows(
+            ResponseException.class,
+            () -> executeQueryToString("source=" + EXACT_NAME + " | fields age"));
+
+    String body = EntityUtils.toString(ex.getResponse().getEntity());
+    JSONObject json = new JSONObject(body);
+
+    assertEquals(404, json.getInt("status"));
+    JSONObject error = json.getJSONObject("error");
+    assertEquals("INDEX_NOT_FOUND", error.getString("code"));
+    assertFalse(
+        "details should NOT contain compatible mapping hint for exact index names",
+        error.getString("details").contains("compatible mapping"));
+  }
+}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/error_handling.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/error_handling.yml
@@ -114,3 +114,39 @@ teardown:
         body:
           query: source=test_error_agg | stats count(eval(age)) as cnt
   - match: {"$body": "/[Cc]ondition.*boolean|[Bb]oolean.*expected/"}
+
+---
+"Test wildcard pattern with no matching indices returns 404 with incompatible mapping hint":
+  - skip:
+      features:
+        - headers
+  # Query a wildcard pattern that matches no indices. The plugin should return HTTP 404
+  # with error.code=INDEX_NOT_FOUND and a details message that mentions the pattern and
+  # advises the user to check mapping compatibility.
+  - do:
+      catch: missing
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=no_such_index_errmsg_test_* | fields age
+  - match: { error.code: "INDEX_NOT_FOUND" }
+  - match: { "$body": "/no_such_index_errmsg_test_/" }
+  - match: { "$body": "/compatible mapping/" }
+
+---
+"Test exact index name not found returns 404 without compatible mapping hint":
+  - skip:
+      features:
+        - headers
+  # A plain non-wildcard name that doesn't exist should also return 404/INDEX_NOT_FOUND
+  # but the details should NOT mention "compatible mapping" (that hint is for patterns only).
+  - do:
+      catch: missing
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: source=no_such_index_errmsg_exact | fields age
+  - match: { error.code: "INDEX_NOT_FOUND" }
+  - match: { "$body": "/no_such_index_errmsg_exact/" }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchClient.java
@@ -133,17 +133,25 @@ public interface OpenSearchClient {
   static ErrorReport emptyMappingException(String... indexExpression) {
     String[] exprs = indexExpression != null ? indexExpression : new String[0];
     String joined = String.join(",", exprs);
+    if (joined.isEmpty()) {
+      return ErrorReport.wrap(new IndexNotFoundException("(none)"))
+          .code(ErrorCode.INDEX_NOT_FOUND)
+          .location("while fetching index mappings")
+          .context("index_pattern", "(none)")
+          .details("No index expression was provided.")
+          .build();
+    }
     boolean isPattern =
-        Arrays.stream(exprs)
-            .filter(e -> e != null)
-            .anyMatch(
-                e ->
-                    e.contains("*")
-                        || e.contains("?")
-                        || e.contains(",")
-                        || e.startsWith("<")
-                        || e.startsWith("-")
-                        || e.equals("_all"));
+        exprs.length > 1
+            || Arrays.stream(exprs)
+                .filter(e -> e != null)
+                .anyMatch(
+                    e ->
+                        e.contains("*")
+                            || e.contains("?")
+                            || e.startsWith("<")
+                            || e.startsWith("-")
+                            || e.equals("_all"));
     String details =
         isPattern
             ? String.format(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchClient.java
@@ -131,14 +131,16 @@ public interface OpenSearchClient {
    * @return an {@link ErrorReport} with {@link ErrorCode#INDEX_NOT_FOUND}
    */
   static ErrorReport emptyMappingException(String... indexExpression) {
-    String joined = String.join(",", indexExpression);
+    String[] exprs = indexExpression != null ? indexExpression : new String[0];
+    String joined = String.join(",", exprs);
     boolean isPattern =
-        Arrays.stream(indexExpression)
+        Arrays.stream(exprs)
             .filter(e -> e != null)
             .anyMatch(
                 e ->
                     e.contains("*")
                         || e.contains("?")
+                        || e.contains(",")
                         || e.startsWith("<")
                         || e.startsWith("-")
                         || e.equals("_all"));

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchClient.java
@@ -5,11 +5,15 @@
 
 package org.opensearch.sql.opensearch.client;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.opensearch.action.search.CreatePitRequest;
 import org.opensearch.action.search.DeletePitRequest;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.sql.common.error.ErrorCode;
+import org.opensearch.sql.common.error.ErrorReport;
 import org.opensearch.sql.opensearch.mapping.IndexMapping;
 import org.opensearch.sql.opensearch.request.OpenSearchRequest;
 import org.opensearch.sql.opensearch.response.OpenSearchResponse;
@@ -44,6 +48,8 @@ public interface OpenSearchClient {
    *
    * @param indexExpression index expression
    * @return index mapping(s) from index name to its mapping
+   * @throws ErrorReport with {@link ErrorCode#INDEX_NOT_FOUND} if no index matched or the pattern
+   *     returned an empty mapping response
    */
   Map<String, IndexMapping> getIndexMappings(String... indexExpression);
 
@@ -114,4 +120,40 @@ public interface OpenSearchClient {
    * @param deletePitRequest Delete Point In Time request
    */
   void deletePit(DeletePitRequest deletePitRequest);
+
+  /**
+   * Build a structured {@link ErrorReport} for the case where {@code getIndexMappings} receives an
+   * empty response. When the expression contains pattern syntax (wildcards, date-math, exclusions,
+   * etc.) the message guides the user to check mapping compatibility; otherwise it reports a plain
+   * "not found" for the named index.
+   *
+   * @param indexExpression the expressions passed to {@code getIndexMappings}
+   * @return an {@link ErrorReport} with {@link ErrorCode#INDEX_NOT_FOUND}
+   */
+  static ErrorReport emptyMappingException(String... indexExpression) {
+    String joined = String.join(",", indexExpression);
+    boolean isPattern =
+        Arrays.stream(indexExpression)
+            .filter(e -> e != null)
+            .anyMatch(
+                e ->
+                    e.contains("*")
+                        || e.contains("?")
+                        || e.startsWith("<")
+                        || e.startsWith("-")
+                        || e.equals("_all"));
+    String details =
+        isPattern
+            ? String.format(
+                "No indices matched '%s', or the matching indices have incompatible mappings."
+                    + " Ensure all indices matching the pattern share a compatible mapping.",
+                joined)
+            : String.format("No index found for '%s'.", joined);
+    return ErrorReport.wrap(new IndexNotFoundException(joined))
+        .code(ErrorCode.INDEX_NOT_FOUND)
+        .location("while fetching index mappings")
+        .context("index_pattern", joined)
+        .details(details)
+        .build();
+  }
 }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClient.java
@@ -84,8 +84,9 @@ public class OpenSearchNodeClient implements OpenSearchClient {
    * mapping cache, cluster state listener (mainly for performance and debugging).
    *
    * @param indexExpression index name expression
-   * @return index mapping(s) in our class to isolate OpenSearch API. IndexNotFoundException is
-   *     thrown if no index matched.
+   * @return index mapping(s) in our class to isolate OpenSearch API
+   * @throws ErrorReport with {@link org.opensearch.sql.common.error.ErrorCode#INDEX_NOT_FOUND} if
+   *     no index matched or the pattern returned an empty mapping response
    */
   @Override
   public Map<String, IndexMapping> getIndexMappings(String... indexExpression) {
@@ -93,7 +94,7 @@ public class OpenSearchNodeClient implements OpenSearchClient {
       GetMappingsResponse mappingsResponse =
           client.admin().indices().prepareGetMappings(indexExpression).setLocal(true).get();
       if (mappingsResponse.mappings().isEmpty()) {
-        throw new IndexNotFoundException(indexExpression[0]);
+        throw OpenSearchClient.emptyMappingException(indexExpression);
       }
       return mappingsResponse.mappings().entrySet().stream()
           .collect(
@@ -113,6 +114,8 @@ public class OpenSearchNodeClient implements OpenSearchClient {
           .location("while fetching index mappings")
           .context("index_name", indexExpression[0])
           .build();
+    } catch (ErrorReport e) {
+      throw e;
     } catch (Exception e) {
       throw new IllegalStateException(
           "Failed to read mapping for index pattern ["

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchRestClient.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/client/OpenSearchRestClient.java
@@ -30,7 +30,6 @@ import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.client.indices.GetMappingsResponse;
 import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.sql.opensearch.mapping.IndexMapping;
 import org.opensearch.sql.opensearch.request.OpenSearchRequest;
 import org.opensearch.sql.opensearch.request.OpenSearchScrollRequest;
@@ -74,7 +73,7 @@ public class OpenSearchRestClient implements OpenSearchClient {
     try {
       GetMappingsResponse response = client.indices().getMapping(request, RequestOptions.DEFAULT);
       if (response.mappings().isEmpty()) {
-        throw new IndexNotFoundException(indexExpression[0]);
+        throw OpenSearchClient.emptyMappingException(indexExpression);
       }
       return response.mappings().entrySet().stream()
           .collect(Collectors.toMap(Map.Entry::getKey, e -> new IndexMapping(e.getValue())));

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -301,6 +301,20 @@ class OpenSearchNodeClientTest {
   }
 
   @Test
+  void empty_mapping_exception_null_array_does_not_throw() {
+    ErrorReport report = OpenSearchClient.emptyMappingException((String[]) null);
+    assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode());
+  }
+
+  @Test
+  void empty_mapping_exception_comma_separated_single_string_produces_compatible_mapping_hint() {
+    ErrorReport report = OpenSearchClient.emptyMappingException("index1,index2");
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("compatible mapping")));
+  }
+
+  @Test
   void get_index_mappings_with_non_pattern_single_name_returns_index_not_found_error() {
     mockNodeClientIndicesMappings("", null);
     ErrorReport report =

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -66,6 +66,7 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.sql.common.error.ErrorCode;
 import org.opensearch.sql.common.error.ErrorReport;
 import org.opensearch.sql.data.model.ExprIntegerValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
@@ -246,11 +247,67 @@ class OpenSearchNodeClientTest {
   void get_index_mappings_with_index_patterns() {
     mockNodeClientIndicesMappings("", null);
     ErrorReport report = assertThrows(ErrorReport.class, () -> client.getIndexMappings("test*"));
-    assertTrue(
-        report.getMessage().contains("test*") && report.getMessage().contains("no such index"),
-        "expected index-not-found error message \""
-            + report.getMessage()
-            + "\" to resemble \"no such index [index]\"");
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("test*")),
+        () -> assertTrue(report.getDetails().contains("compatible mapping")));
+  }
+
+  @Test
+  void get_index_mappings_with_question_wildcard_returns_index_not_found_error() {
+    mockNodeClientIndicesMappings("", null);
+    ErrorReport report = assertThrows(ErrorReport.class, () -> client.getIndexMappings("test-?"));
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("test-?")),
+        () -> assertTrue(report.getDetails().contains("compatible mapping")));
+  }
+
+  // emptyMappingException is tested directly to avoid Mockito varargs-matching limitations
+  // that prevent the deep-stub from matching multi-argument prepareGetMappings calls.
+  @Test
+  void empty_mapping_exception_star_wildcard_produces_compatible_mapping_message() {
+    ErrorReport report = OpenSearchClient.emptyMappingException("ocsf-1.1.0*");
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("ocsf-1.1.0*")),
+        () -> assertTrue(report.getDetails().contains("compatible mapping")));
+  }
+
+  @Test
+  void empty_mapping_exception_question_wildcard_produces_compatible_mapping_message() {
+    ErrorReport report = OpenSearchClient.emptyMappingException("test-?");
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("compatible mapping")));
+  }
+
+  @Test
+  void empty_mapping_exception_multi_arg_literals_produces_index_not_found_message() {
+    ErrorReport report = OpenSearchClient.emptyMappingException("index-a", "index-b");
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("index-a")),
+        () -> assertTrue(report.getDetails().contains("index-b")));
+  }
+
+  @Test
+  void empty_mapping_exception_non_pattern_produces_no_index_found_message() {
+    ErrorReport report = OpenSearchClient.emptyMappingException("exact-index");
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("exact-index")),
+        () -> assertFalse(report.getDetails().contains("compatible mapping")));
+  }
+
+  @Test
+  void get_index_mappings_with_non_pattern_single_name_returns_index_not_found_error() {
+    mockNodeClientIndicesMappings("", null);
+    ErrorReport report =
+        assertThrows(ErrorReport.class, () -> client.getIndexMappings("exact-index"));
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("exact-index")));
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchNodeClientTest.java
@@ -307,11 +307,21 @@ class OpenSearchNodeClientTest {
   }
 
   @Test
-  void empty_mapping_exception_comma_separated_single_string_produces_compatible_mapping_hint() {
+  void empty_mapping_exception_comma_separated_single_string_produces_no_index_found_message() {
+    // A comma inside a single string element is not a wildcard pattern — report plain not-found
     ErrorReport report = OpenSearchClient.emptyMappingException("index1,index2");
     assertAll(
         () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
-        () -> assertTrue(report.getDetails().contains("compatible mapping")));
+        () -> assertFalse(report.getDetails().contains("compatible mapping")),
+        () -> assertTrue(report.getDetails().contains("index1,index2")));
+  }
+
+  @Test
+  void empty_mapping_exception_empty_array_produces_no_index_expression_message() {
+    ErrorReport report = OpenSearchClient.emptyMappingException(new String[0]);
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("No index expression was provided")));
   }
 
   @Test

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/client/OpenSearchRestClientTest.java
@@ -63,10 +63,11 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.sql.common.error.ErrorCode;
+import org.opensearch.sql.common.error.ErrorReport;
 import org.opensearch.sql.data.model.ExprIntegerValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
@@ -233,7 +234,37 @@ class OpenSearchRestClientTest {
     when(response.mappings()).thenReturn(Map.of());
     when(restClient.indices().getMapping(any(GetMappingsRequest.class), any()))
         .thenReturn(response);
-    assertThrows(IndexNotFoundException.class, () -> client.getIndexMappings("test*"));
+    ErrorReport report = assertThrows(ErrorReport.class, () -> client.getIndexMappings("test*"));
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("test*")),
+        () -> assertTrue(report.getDetails().contains("compatible mapping")));
+  }
+
+  @Test
+  void get_index_mappings_with_question_wildcard_returns_index_not_found_error()
+      throws IOException {
+    GetMappingsResponse response = mock(GetMappingsResponse.class);
+    when(response.mappings()).thenReturn(Map.of());
+    when(restClient.indices().getMapping(any(GetMappingsRequest.class), any()))
+        .thenReturn(response);
+    ErrorReport report = assertThrows(ErrorReport.class, () -> client.getIndexMappings("test-?"));
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("compatible mapping")));
+  }
+
+  @Test
+  void get_index_mappings_with_non_pattern_name_returns_index_not_found_error() throws IOException {
+    GetMappingsResponse response = mock(GetMappingsResponse.class);
+    when(response.mappings()).thenReturn(Map.of());
+    when(restClient.indices().getMapping(any(GetMappingsRequest.class), any()))
+        .thenReturn(response);
+    ErrorReport report =
+        assertThrows(ErrorReport.class, () -> client.getIndexMappings("exact-index"));
+    assertAll(
+        () -> assertEquals(ErrorCode.INDEX_NOT_FOUND, report.getCode()),
+        () -> assertTrue(report.getDetails().contains("exact-index")));
   }
 
   @Test


### PR DESCRIPTION
### Description
Improves the error message returned when an index has an empty mapping. This change makes the error clearer and more actionable for users while preserving the existing behavior. Unit tests have been updated to verify the new error message.


### Related Issues
Resolves #[4872]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
