### PR TITLE
[Enhancement] Forward cluster planning settings to the Analytics Engine unified query path

### DIFF
--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -10,9 +10,11 @@ import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
 import static org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.SQL_WORKER_THREAD_POOL_NAME;
 import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.calcite.rel.RelNode;
@@ -337,20 +339,33 @@ public class RestUnifiedQueryAction {
   }
 
   /**
+   * Cluster settings whose live values are forwarded into every {@link UnifiedQueryContext} so the
+   * Analytics Engine plans against the same configuration as the default pipeline. This list is the
+   * single source of truth for cluster fidelity on the unified path: any planning setting the AE
+   * path must honor belongs here, otherwise {@link UnifiedQueryContext.Builder}'s hardcoded default
+   * silently wins and the configured cluster value is ignored.
+   *
+   * <p>{@link org.opensearch.sql.common.setting.Settings.Key#CALCITE_ENGINE_ENABLED} is
+   * deliberately excluded — the unified path is Calcite-based by definition and forces it {@code
+   * true} regardless of the cluster value.
+   */
+  private static final List<org.opensearch.sql.common.setting.Settings.Key>
+      FORWARDED_CLUSTER_SETTINGS =
+          List.of(
+              org.opensearch.sql.common.setting.Settings.Key.QUERY_SIZE_LIMIT,
+              org.opensearch.sql.common.setting.Settings.Key.PPL_REX_MAX_MATCH_LIMIT,
+              org.opensearch.sql.common.setting.Settings.Key.PPL_SYNTAX_LEGACY_PREFERRED,
+              org.opensearch.sql.common.setting.Settings.Key.MAX_EXPRESSION_DEPTH);
+
+  /**
    * Routes operator-configured cluster overrides into the builder via the existing {@code
    * setting(String, Object)} API, keeping {@link UnifiedQueryContext} decoupled from any specific
-   * {@link org.opensearch.sql.common.setting.Settings} implementation.
-   *
-   * <p>Add keys here if a future PR / IT depends on cluster-side fidelity for one of the other
-   * planning settings.
+   * {@link org.opensearch.sql.common.setting.Settings} implementation. The forwarded keys are
+   * {@link #FORWARDED_CLUSTER_SETTINGS}.
    */
-  private UnifiedQueryContext.Builder applyClusterOverrides(UnifiedQueryContext.Builder builder) {
-    forwardClusterSetting(
-        builder, org.opensearch.sql.common.setting.Settings.Key.PPL_REX_MAX_MATCH_LIMIT);
-    forwardClusterSetting(
-        builder, org.opensearch.sql.common.setting.Settings.Key.PPL_SYNTAX_LEGACY_PREFERRED);
-    forwardClusterSetting(
-        builder, org.opensearch.sql.common.setting.Settings.Key.MAX_EXPRESSION_DEPTH);
+  @VisibleForTesting
+  UnifiedQueryContext.Builder applyClusterOverrides(UnifiedQueryContext.Builder builder) {
+    FORWARDED_CLUSTER_SETTINGS.forEach(key -> forwardClusterSetting(builder, key));
     return builder;
   }
 

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -10,9 +10,11 @@ import static org.opensearch.sql.lang.PPLLangSpec.PPL_SPEC;
 import static org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.SQL_WORKER_THREAD_POOL_NAME;
 import static org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.calcite.rel.RelNode;
@@ -40,6 +42,7 @@ import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit;
 import org.opensearch.sql.common.response.ResponseListener;
+import org.opensearch.sql.common.setting.Settings.Key;
 import org.opensearch.sql.executor.ExecutionEngine.QueryResponse;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.sql.executor.analytics.AnalyticsExecutionEngine;
@@ -347,25 +350,51 @@ public class RestUnifiedQueryAction {
   }
 
   /**
+   * Cluster settings whose live values are forwarded into every {@link UnifiedQueryContext} so the
+   * Analytics Engine plans against the same configuration as the default pipeline. This list is the
+   * single source of truth for cluster fidelity on the unified path: any planning setting the AE
+   * path must honor belongs here, otherwise {@link UnifiedQueryContext.Builder}'s hardcoded default
+   * silently wins and the configured cluster value is ignored.
+   *
+   * <p>{@link Key#CALCITE_ENGINE_ENABLED} is deliberately excluded — the unified path is
+   * Calcite-based by definition and forces it {@code true} regardless of the cluster value. {@link
+   * Key#PPL_SUBSEARCH_MAXOUT} and {@link Key#PPL_JOIN_SUBSEARCH_MAXOUT} are excluded too: the
+   * builder seeds them to {@code 0} (unlimited) on purpose, to keep {@code LogicalSystemLimit} out
+   * of plans built by external consumers of the unified query API, and overriding that on the
+   * in-cluster path is a separate behavioral decision tracked by
+   * https://github.com/opensearch-project/sql/issues/5735.
+   *
+   * <p>{@code RestUnifiedQueryActionTest#everySeededPlanningSettingIsClassified} pins those three
+   * exclusions, so a key added to the builder's seed map cannot silently regress to its hardcoded
+   * default without failing a test.
+   */
+  @VisibleForTesting
+  static final List<Key> FORWARDED_CLUSTER_SETTINGS =
+      List.of(
+          Key.QUERY_SIZE_LIMIT,
+          Key.PPL_REX_MAX_MATCH_LIMIT,
+          Key.PPL_SYNTAX_LEGACY_PREFERRED,
+          Key.MAX_EXPRESSION_DEPTH,
+          Key.PPL_VALUES_MAX_LIMIT,
+          Key.PATTERN_METHOD,
+          Key.PATTERN_MODE,
+          Key.PATTERN_MAX_SAMPLE_COUNT,
+          Key.PATTERN_BUFFER_LIMIT,
+          Key.PATTERN_SHOW_NUMBERED_TOKEN);
+
+  /**
    * Routes operator-configured cluster overrides into the builder via the existing {@code
    * setting(String, Object)} API, keeping {@link UnifiedQueryContext} decoupled from any specific
-   * {@link org.opensearch.sql.common.setting.Settings} implementation.
-   *
-   * <p>Add keys here if a future PR / IT depends on cluster-side fidelity for one of the other
-   * planning settings.
+   * {@link org.opensearch.sql.common.setting.Settings} implementation. The forwarded keys are
+   * {@link #FORWARDED_CLUSTER_SETTINGS}.
    */
-  private UnifiedQueryContext.Builder applyClusterOverrides(UnifiedQueryContext.Builder builder) {
-    forwardClusterSetting(
-        builder, org.opensearch.sql.common.setting.Settings.Key.PPL_REX_MAX_MATCH_LIMIT);
-    forwardClusterSetting(
-        builder, org.opensearch.sql.common.setting.Settings.Key.PPL_SYNTAX_LEGACY_PREFERRED);
-    forwardClusterSetting(
-        builder, org.opensearch.sql.common.setting.Settings.Key.MAX_EXPRESSION_DEPTH);
+  @VisibleForTesting
+  UnifiedQueryContext.Builder applyClusterOverrides(UnifiedQueryContext.Builder builder) {
+    FORWARDED_CLUSTER_SETTINGS.forEach(key -> forwardClusterSetting(builder, key));
     return builder;
   }
 
-  private void forwardClusterSetting(
-      UnifiedQueryContext.Builder builder, org.opensearch.sql.common.setting.Settings.Key key) {
+  private void forwardClusterSetting(UnifiedQueryContext.Builder builder, Key key) {
     Object value = pluginSettings.getSettingValue(key);
     if (value != null) {
       builder.setting(key.getKeyValue(), value);

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -364,7 +364,16 @@ public class RestUnifiedQueryAction {
    * in-cluster path is a separate behavioral decision tracked by
    * https://github.com/opensearch-project/sql/issues/5735.
    *
-   * <p>{@code RestUnifiedQueryActionTest#everySeededPlanningSettingIsClassified} pins those three
+   * <p>{@link Key#PPL_VALUES_MAX_LIMIT} is excluded for a different reason: forwarding it makes
+   * things worse rather than better. The cap is applied by attaching a {@code limit} argument to
+   * the {@code values()} aggregate, which lowers to {@code array_agg(DISTINCT x, limit)} — a
+   * two-argument form the analytics-engine backend has no binding for. Verified against a live
+   * composite/parquet cluster: with the setting forwarded, {@code stats values(f)} fails with
+   * {@code UnsupportedOperationException: Unable to find binding for call array_agg(DISTINCT $0,
+   * $1)} (HTTP 500), where today it merely ignores the cap. Honoring the cap on this route needs
+   * backend support first — see {@code Capability.VALUES_LIMIT_NOT_HONORED}.
+   *
+   * <p>{@code RestUnifiedQueryActionTest#everySeededPlanningSettingIsClassified} pins the seeded
    * exclusions, so a key added to the builder's seed map cannot silently regress to its hardcoded
    * default without failing a test.
    */
@@ -375,7 +384,6 @@ public class RestUnifiedQueryAction {
           Key.PPL_REX_MAX_MATCH_LIMIT,
           Key.PPL_SYNTAX_LEGACY_PREFERRED,
           Key.MAX_EXPRESSION_DEPTH,
-          Key.PPL_VALUES_MAX_LIMIT,
           Key.PATTERN_METHOD,
           Key.PATTERN_MODE,
           Key.PATTERN_MAX_SAMPLE_COUNT,

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -350,32 +350,30 @@ public class RestUnifiedQueryAction {
   }
 
   /**
-   * Cluster settings whose live values are forwarded into every {@link UnifiedQueryContext} so the
-   * Analytics Engine plans against the same configuration as the default pipeline. This list is the
-   * single source of truth for cluster fidelity on the unified path: any planning setting the AE
-   * path must honor belongs here, otherwise {@link UnifiedQueryContext.Builder}'s hardcoded default
-   * silently wins and the configured cluster value is ignored.
+   * Cluster settings forwarded into every {@link UnifiedQueryContext}, so the Analytics Engine
+   * plans against the same configuration as the default pipeline. Any planning setting the AE path
+   * must honor belongs here; otherwise the value {@link UnifiedQueryContext.Builder} seeds silently
+   * wins and the configured cluster value is ignored.
    *
-   * <p>{@link Key#CALCITE_ENGINE_ENABLED} is deliberately excluded — the unified path is
-   * Calcite-based by definition and forces it {@code true} regardless of the cluster value. {@link
-   * Key#PPL_SUBSEARCH_MAXOUT} and {@link Key#PPL_JOIN_SUBSEARCH_MAXOUT} are excluded too: the
-   * builder seeds them to {@code 0} (unlimited) on purpose, to keep {@code LogicalSystemLimit} out
-   * of plans built by external consumers of the unified query API, and overriding that on the
-   * in-cluster path is a separate behavioral decision tracked by
-   * https://github.com/opensearch-project/sql/issues/5735.
+   * <p>The AE path reads exactly five other settings, each deliberately left out:
    *
-   * <p>{@link Key#PPL_VALUES_MAX_LIMIT} is excluded for a different reason: forwarding it makes
-   * things worse rather than better. The cap is applied by attaching a {@code limit} argument to
-   * the {@code values()} aggregate, which lowers to {@code array_agg(DISTINCT x, limit)} — a
-   * two-argument form the analytics-engine backend has no binding for. Verified against a live
-   * composite/parquet cluster: with the setting forwarded, {@code stats values(f)} fails with
-   * {@code UnsupportedOperationException: Unable to find binding for call array_agg(DISTINCT $0,
-   * $1)} (HTTP 500), where today it merely ignores the cap. Honoring the cap on this route needs
-   * backend support first — see {@code Capability.VALUES_LIMIT_NOT_HONORED}.
+   * <ul>
+   *   <li>{@link Key#CALCITE_ENGINE_ENABLED} — the unified path is Calcite-based by definition and
+   *       must force it on.
+   *   <li>{@link Key#PPL_SUBSEARCH_MAXOUT}, {@link Key#PPL_JOIN_SUBSEARCH_MAXOUT} — seeded to
+   *       {@code 0} (unlimited) on purpose, to keep {@code LogicalSystemLimit} out of plans built
+   *       by external consumers of the unified query API. Overriding that in-cluster is a separate
+   *       behavioral decision (issue #5735).
+   *   <li>{@link Key#PPL_VALUES_MAX_LIMIT} — forwarding it breaks the route rather than fixing it:
+   *       the cap lowers {@code values()} to {@code array_agg(DISTINCT x, limit)}, a form the
+   *       backend cannot bind, so the query 500s where today it merely ignores the cap (issue
+   *       #5736).
+   *   <li>{@link Key#CALCITE_SUPPORT_ALL_JOIN_TYPES} — never seeded, so {@code
+   *       AstBuilder.validateJoinType} reads {@code null} and skips the high-cost-join guard
+   *       entirely. Restoring it is a user-visible tightening (issue #5734).
+   * </ul>
    *
-   * <p>{@code RestUnifiedQueryActionTest#everySeededPlanningSettingIsClassified} pins the seeded
-   * exclusions, so a key added to the builder's seed map cannot silently regress to its hardcoded
-   * default without failing a test.
+   * <p>{@code RestUnifiedQueryActionTest} pins both this list and those exclusions.
    */
   @VisibleForTesting
   static final List<Key> FORWARDED_CLUSTER_SETTINGS =

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -351,29 +351,13 @@ public class RestUnifiedQueryAction {
 
   /**
    * Cluster settings forwarded into every {@link UnifiedQueryContext}, so the Analytics Engine
-   * plans against the same configuration as the default pipeline. Any planning setting the AE path
+   * plans against the same configuration as the default pipeline. A planning setting the AE path
    * must honor belongs here; otherwise the value {@link UnifiedQueryContext.Builder} seeds silently
    * wins and the configured cluster value is ignored.
    *
-   * <p>The AE path reads exactly five other settings, each deliberately left out:
-   *
-   * <ul>
-   *   <li>{@link Key#CALCITE_ENGINE_ENABLED} — the unified path is Calcite-based by definition and
-   *       must force it on.
-   *   <li>{@link Key#PPL_SUBSEARCH_MAXOUT}, {@link Key#PPL_JOIN_SUBSEARCH_MAXOUT} — seeded to
-   *       {@code 0} (unlimited) on purpose, to keep {@code LogicalSystemLimit} out of plans built
-   *       by external consumers of the unified query API. Overriding that in-cluster is a separate
-   *       behavioral decision (issue #5735).
-   *   <li>{@link Key#PPL_VALUES_MAX_LIMIT} — forwarding it breaks the route rather than fixing it:
-   *       the cap lowers {@code values()} to {@code array_agg(DISTINCT x, limit)}, a form the
-   *       backend cannot bind, so the query 500s where today it merely ignores the cap (issue
-   *       #5736).
-   *   <li>{@link Key#CALCITE_SUPPORT_ALL_JOIN_TYPES} — never seeded, so {@code
-   *       AstBuilder.validateJoinType} reads {@code null} and skips the high-cost-join guard
-   *       entirely. Restoring it is a user-visible tightening (issue #5734).
-   * </ul>
-   *
-   * <p>{@code RestUnifiedQueryActionTest} pins both this list and those exclusions.
+   * <p>The other settings the AE path reads are deliberately not forwarded; {@code
+   * RestUnifiedQueryActionTest#DELIBERATELY_NOT_FORWARDED} enumerates them with a reason each, and
+   * pins both lists.
    */
   @VisibleForTesting
   static final List<Key> FORWARDED_CLUSTER_SETTINGS =

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.plugin.rest;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -22,6 +23,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.sql.api.UnifiedQueryContext;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.transport.client.node.NodeClient;
 
@@ -33,6 +35,7 @@ public class RestUnifiedQueryActionTest {
 
   private ClusterService clusterService;
   private Metadata metadata;
+  private org.opensearch.sql.common.setting.Settings pluginSettings;
   private RestUnifiedQueryAction action;
 
   @Before
@@ -46,6 +49,7 @@ public class RestUnifiedQueryActionTest {
     // path is only exercised when this returns something other than "composite".
     when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
+    pluginSettings = mock(org.opensearch.sql.common.setting.Settings.class);
     @SuppressWarnings("unchecked")
     QueryPlanExecutor<RelNode, Iterable<Object[]>> executor = mock(QueryPlanExecutor.class);
     action =
@@ -54,7 +58,7 @@ public class RestUnifiedQueryActionTest {
             clusterService,
             executor,
             mock(EngineContextProvider.class),
-            mock(org.opensearch.sql.common.setting.Settings.class));
+            pluginSettings);
   }
 
   @Test
@@ -228,6 +232,44 @@ public class RestUnifiedQueryActionTest {
     enableClusterComposite();
     // malformed -> AE re-parses & reports
     assertTrue(action.isAnalyticsIndex("source = parquet_logs | | fields ts", QueryType.PPL));
+  }
+
+  @Test
+  public void clusterQuerySizeLimitReachesAnalyticsContext() {
+    // Regression: the AE path pinned QUERY_SIZE_LIMIT to the builder's hardcoded default (10000),
+    // silently ignoring the configured cluster value. Forwarding must carry the live value through
+    // to the plan context, since addQuerySizeLimit reads it from there.
+    when(pluginSettings.getSettingValue(
+            org.opensearch.sql.common.setting.Settings.Key.QUERY_SIZE_LIMIT))
+        .thenReturn(500);
+
+    UnifiedQueryContext context =
+        action.applyClusterOverrides(UnifiedQueryContext.builder().language(QueryType.PPL)).build();
+
+    assertEquals(
+        "Cluster plugins.query.size_limit must reach the AE plan context",
+        Integer.valueOf(500),
+        context.getPlanContext().sysLimit.querySizeLimit());
+  }
+
+  @Test
+  public void calciteEngineEnabledNotOverriddenByCluster() {
+    // CALCITE_ENGINE_ENABLED is deliberately excluded from forwarding: the unified path is
+    // Calcite-based by definition and must stay true even if the cluster disables it.
+    when(pluginSettings.getSettingValue(
+            org.opensearch.sql.common.setting.Settings.Key.CALCITE_ENGINE_ENABLED))
+        .thenReturn(false);
+
+    UnifiedQueryContext context =
+        action.applyClusterOverrides(UnifiedQueryContext.builder().language(QueryType.PPL)).build();
+
+    assertEquals(
+        "Unified path must force Calcite on regardless of the cluster setting",
+        Boolean.TRUE,
+        context
+            .getSettings()
+            .getSettingValue(
+                org.opensearch.sql.common.setting.Settings.Key.CALCITE_ENGINE_ENABLED));
   }
 
   private void enableClusterComposite() {

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -7,7 +7,7 @@ package org.opensearch.sql.plugin.rest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -272,19 +272,28 @@ public class RestUnifiedQueryActionTest {
   }
 
   /**
-   * Planning settings {@link UnifiedQueryContext.Builder} seeds that the REST handler deliberately
-   * does not forward, each with the reason it stays hardcoded on the unified path.
+   * Every setting the AE path reads that {@link RestUnifiedQueryAction} deliberately does not
+   * forward, with the reason it stays unforwarded. Derived from the call sites reachable from the
+   * unified context's {@code Settings}: {@code SysLimit.fromSettings}, {@code AstBuilder} /{@code
+   * AstExpressionBuilder} / {@code AstBuildGuard}, and {@code UnresolvedPlanHelper}.
    *
    * <ul>
    *   <li>{@link Key#CALCITE_ENGINE_ENABLED} — the unified path is Calcite-based by definition.
    *   <li>{@link Key#PPL_SUBSEARCH_MAXOUT} / {@link Key#PPL_JOIN_SUBSEARCH_MAXOUT} — seeded to
-   *       {@code 0} (unlimited) on purpose, to keep {@code LogicalSystemLimit} out of plans built
-   *       by external consumers of the unified query API. Whether the in-cluster path should
-   *       override that is tracked by https://github.com/opensearch-project/sql/issues/5735.
+   *       {@code 0} (unlimited) on purpose, for external consumers of the unified query API (issue
+   *       #5735).
+   *   <li>{@link Key#PPL_VALUES_MAX_LIMIT} — forwarding it 500s the route (issue #5736).
+   *   <li>{@link Key#CALCITE_SUPPORT_ALL_JOIN_TYPES} — never seeded; restoring the guard is a
+   *       user-visible tightening (issue #5734).
    * </ul>
    */
   private static final List<Key> DELIBERATELY_NOT_FORWARDED =
-      List.of(Key.CALCITE_ENGINE_ENABLED, Key.PPL_SUBSEARCH_MAXOUT, Key.PPL_JOIN_SUBSEARCH_MAXOUT);
+      List.of(
+          Key.CALCITE_ENGINE_ENABLED,
+          Key.PPL_SUBSEARCH_MAXOUT,
+          Key.PPL_JOIN_SUBSEARCH_MAXOUT,
+          Key.PPL_VALUES_MAX_LIMIT,
+          Key.CALCITE_SUPPORT_ALL_JOIN_TYPES);
 
   /**
    * Drift guard for the defect class this forwarding exists to prevent: the builder's seed map and
@@ -331,16 +340,27 @@ public class RestUnifiedQueryActionTest {
   }
 
   @Test
-  public void valuesMaxLimitIsNotForwarded() {
-    // Forwarding PPL_VALUES_MAX_LIMIT would attach a `limit` argument to values(), lowering to
-    // array_agg(DISTINCT x, limit) — a form the analytics-engine backend cannot bind, turning a
-    // silently-ignored cap into a 500. Verified against a live composite/parquet cluster.
-    when(pluginSettings.getSettingValue(Key.PPL_VALUES_MAX_LIMIT)).thenReturn(100);
+  public void documentedExclusionsAreNotForwarded() {
+    // Pins the exclusion list in RestUnifiedQueryAction's javadoc: each of these is a conscious
+    // decision, not an oversight, so a well-meaning "just forward everything" change fails here.
+    // PPL_VALUES_MAX_LIMIT in particular must stay out: forwarding it lowers values() to
+    // array_agg(DISTINCT x, limit), which the AE backend cannot bind, turning a silently-ignored
+    // cap into a 500 (verified on a live composite/parquet cluster).
+    DELIBERATELY_NOT_FORWARDED.forEach(
+        key -> when(pluginSettings.getSettingValue(key)).thenReturn(SENTINEL));
 
-    assertNull(
-        "Forwarding values.max.limit breaks values() on the AE route; it must stay unset",
-        buildAnalyticsContext().getSettings().getSettingValue(Key.PPL_VALUES_MAX_LIMIT));
+    org.opensearch.sql.common.setting.Settings forwarded = buildAnalyticsContext().getSettings();
+
+    for (Key key : DELIBERATELY_NOT_FORWARDED) {
+      assertNotEquals(
+          key.getKeyValue() + " must not be forwarded to the Analytics Engine context",
+          SENTINEL,
+          forwarded.getSettingValue(key));
+    }
   }
+
+  /** Value no seeded default uses, so "forwarded" is distinguishable from "seeded" or "absent". */
+  private static final Integer SENTINEL = -12345;
 
   /** Builds the context the AE path plans against, with the mocked cluster settings applied. */
   private UnifiedQueryContext buildAnalyticsContext() {

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -274,17 +274,20 @@ public class RestUnifiedQueryActionTest {
   /**
    * Every setting the AE path reads that {@link RestUnifiedQueryAction} deliberately does not
    * forward, with the reason it stays unforwarded. Derived from the call sites reachable from the
-   * unified context's {@code Settings}: {@code SysLimit.fromSettings}, {@code AstBuilder} /{@code
-   * AstExpressionBuilder} / {@code AstBuildGuard}, and {@code UnresolvedPlanHelper}.
+   * unified context's {@code Settings}: {@code SysLimit.fromSettings}, the {@code AstBuilder} /
+   * {@code AstExpressionBuilder} / {@code AstBuildGuard} behind its parser, and {@code
+   * UnresolvedPlanHelper}.
    *
    * <ul>
    *   <li>{@link Key#CALCITE_ENGINE_ENABLED} — the unified path is Calcite-based by definition.
    *   <li>{@link Key#PPL_SUBSEARCH_MAXOUT} / {@link Key#PPL_JOIN_SUBSEARCH_MAXOUT} — seeded to
-   *       {@code 0} (unlimited) on purpose, for external consumers of the unified query API (issue
-   *       #5735).
-   *   <li>{@link Key#PPL_VALUES_MAX_LIMIT} — forwarding it 500s the route (issue #5736).
-   *   <li>{@link Key#CALCITE_SUPPORT_ALL_JOIN_TYPES} — never seeded; restoring the guard is a
-   *       user-visible tightening (issue #5734).
+   *       {@code 0} (unlimited) on purpose, for external consumers of the unified query API.
+   *   <li>{@link Key#PPL_VALUES_MAX_LIMIT} — forwarding it lowers {@code values()} to {@code
+   *       array_agg(DISTINCT x, limit)}, which the backend cannot bind, so the query fails outright
+   *       where today it merely ignores the cap.
+   *   <li>{@link Key#CALCITE_SUPPORT_ALL_JOIN_TYPES} — never seeded, so {@code
+   *       AstBuilder.validateJoinType} reads {@code null} and skips the high-cost-join guard.
+   *       Restoring it is a user-visible tightening.
    * </ul>
    */
   private static final List<Key> DELIBERATELY_NOT_FORWARDED =

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.plugin.rest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -330,13 +331,14 @@ public class RestUnifiedQueryActionTest {
   }
 
   @Test
-  public void clusterValuesMaxLimitReachesAnalyticsContext() {
-    // PPL_VALUES_MAX_LIMIT is not seeded at all, so without forwarding AstExpressionBuilder reads
-    // null and falls back to unlimited — the configured cap on values() never applies.
+  public void valuesMaxLimitIsNotForwarded() {
+    // Forwarding PPL_VALUES_MAX_LIMIT would attach a `limit` argument to values(), lowering to
+    // array_agg(DISTINCT x, limit) — a form the analytics-engine backend cannot bind, turning a
+    // silently-ignored cap into a 500. Verified against a live composite/parquet cluster.
     when(pluginSettings.getSettingValue(Key.PPL_VALUES_MAX_LIMIT)).thenReturn(100);
 
-    assertEquals(
-        Integer.valueOf(100),
+    assertNull(
+        "Forwarding values.max.limit breaks values() on the AE route; it must stay unset",
         buildAnalyticsContext().getSettings().getSettingValue(Key.PPL_VALUES_MAX_LIMIT));
   }
 

--- a/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
+++ b/plugin/src/test/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryActionTest.java
@@ -5,11 +5,15 @@
 
 package org.opensearch.sql.plugin.rest;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.sql.plugin.rest.RestUnifiedQueryAction.FORWARDED_CLUSTER_SETTINGS;
 
+import java.util.List;
+import java.util.Map;
 import org.apache.calcite.rel.RelNode;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,6 +26,8 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.sql.api.UnifiedQueryContext;
+import org.opensearch.sql.common.setting.Settings.Key;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.transport.client.node.NodeClient;
 
@@ -33,6 +39,7 @@ public class RestUnifiedQueryActionTest {
 
   private ClusterService clusterService;
   private Metadata metadata;
+  private org.opensearch.sql.common.setting.Settings pluginSettings;
   private RestUnifiedQueryAction action;
 
   @Before
@@ -46,6 +53,7 @@ public class RestUnifiedQueryActionTest {
     // path is only exercised when this returns something other than "composite".
     when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
+    pluginSettings = mock(org.opensearch.sql.common.setting.Settings.class);
     @SuppressWarnings("unchecked")
     QueryPlanExecutor<RelNode, Iterable<Object[]>> executor = mock(QueryPlanExecutor.class);
     action =
@@ -54,7 +62,7 @@ public class RestUnifiedQueryActionTest {
             clusterService,
             executor,
             mock(EngineContextProvider.class),
-            mock(org.opensearch.sql.common.setting.Settings.class),
+            pluginSettings,
             new org.opensearch.sql.executor.DirectExecutionDispatcher());
   }
 
@@ -235,6 +243,108 @@ public class RestUnifiedQueryActionTest {
     enableClusterComposite();
     // malformed -> AE re-parses & reports
     assertTrue(action.isAnalyticsIndex("source = parquet_logs | | fields ts", QueryType.PPL));
+  }
+
+  @Test
+  public void clusterQuerySizeLimitReachesAnalyticsContext() {
+    // Regression: the AE path pinned QUERY_SIZE_LIMIT to the builder's hardcoded default (10000),
+    // silently ignoring the configured cluster value. Forwarding must carry the live value through
+    // to the plan context, since addQuerySizeLimit reads it from there.
+    when(pluginSettings.getSettingValue(Key.QUERY_SIZE_LIMIT)).thenReturn(500);
+
+    assertEquals(
+        "Cluster plugins.query.size_limit must reach the AE plan context",
+        Integer.valueOf(500),
+        buildAnalyticsContext().getPlanContext().sysLimit.querySizeLimit());
+  }
+
+  @Test
+  public void calciteEngineEnabledNotOverriddenByCluster() {
+    // CALCITE_ENGINE_ENABLED is deliberately excluded from forwarding: the unified path is
+    // Calcite-based by definition and must stay true even if the cluster disables it.
+    when(pluginSettings.getSettingValue(Key.CALCITE_ENGINE_ENABLED)).thenReturn(false);
+
+    assertEquals(
+        "Unified path must force Calcite on regardless of the cluster setting",
+        Boolean.TRUE,
+        buildAnalyticsContext().getSettings().getSettingValue(Key.CALCITE_ENGINE_ENABLED));
+  }
+
+  /**
+   * Planning settings {@link UnifiedQueryContext.Builder} seeds that the REST handler deliberately
+   * does not forward, each with the reason it stays hardcoded on the unified path.
+   *
+   * <ul>
+   *   <li>{@link Key#CALCITE_ENGINE_ENABLED} — the unified path is Calcite-based by definition.
+   *   <li>{@link Key#PPL_SUBSEARCH_MAXOUT} / {@link Key#PPL_JOIN_SUBSEARCH_MAXOUT} — seeded to
+   *       {@code 0} (unlimited) on purpose, to keep {@code LogicalSystemLimit} out of plans built
+   *       by external consumers of the unified query API. Whether the in-cluster path should
+   *       override that is tracked by https://github.com/opensearch-project/sql/issues/5735.
+   * </ul>
+   */
+  private static final List<Key> DELIBERATELY_NOT_FORWARDED =
+      List.of(Key.CALCITE_ENGINE_ENABLED, Key.PPL_SUBSEARCH_MAXOUT, Key.PPL_JOIN_SUBSEARCH_MAXOUT);
+
+  /**
+   * Drift guard for the defect class this forwarding exists to prevent: the builder's seed map and
+   * the handler's forward list are maintained independently, so a planning setting seeded but not
+   * forwarded silently regresses to its hardcoded default (this is how {@code
+   * plugins.query.size_limit} came to be ignored on the AE path). Every seeded key must therefore
+   * be classified — forwarded, or explicitly excluded with a reason.
+   */
+  @Test
+  public void everySeededPlanningSettingIsClassified() {
+    UnifiedQueryContext defaults = UnifiedQueryContext.builder().language(QueryType.PPL).build();
+
+    for (Object entry : defaults.getSettings().getSettings()) {
+      Key seeded = ((Map.Entry<Key, ?>) entry).getKey();
+      assertTrue(
+          "Setting "
+              + seeded.getKeyValue()
+              + " is seeded with a hardcoded default by UnifiedQueryContext.Builder but is neither"
+              + " forwarded from the cluster nor listed in DELIBERATELY_NOT_FORWARDED. Add it to"
+              + " RestUnifiedQueryAction.FORWARDED_CLUSTER_SETTINGS so the configured cluster value"
+              + " reaches the Analytics Engine, or document why it must stay hardcoded.",
+          FORWARDED_CLUSTER_SETTINGS.contains(seeded)
+              || DELIBERATELY_NOT_FORWARDED.contains(seeded));
+    }
+  }
+
+  @Test
+  public void clusterPatternSettingsReachAnalyticsContext() {
+    // patterns command defaults are read straight off the context's settings in AstBuilder, so a
+    // cluster-configured method/mode/limit must be visible there rather than the seeded default.
+    when(pluginSettings.getSettingValue(Key.PATTERN_METHOD)).thenReturn("BRAIN");
+    when(pluginSettings.getSettingValue(Key.PATTERN_MODE)).thenReturn("AGGREGATION");
+    when(pluginSettings.getSettingValue(Key.PATTERN_MAX_SAMPLE_COUNT)).thenReturn(42);
+    when(pluginSettings.getSettingValue(Key.PATTERN_BUFFER_LIMIT)).thenReturn(60000);
+    when(pluginSettings.getSettingValue(Key.PATTERN_SHOW_NUMBERED_TOKEN)).thenReturn(true);
+
+    org.opensearch.sql.common.setting.Settings forwarded = buildAnalyticsContext().getSettings();
+
+    assertEquals("BRAIN", forwarded.getSettingValue(Key.PATTERN_METHOD));
+    assertEquals("AGGREGATION", forwarded.getSettingValue(Key.PATTERN_MODE));
+    assertEquals(Integer.valueOf(42), forwarded.getSettingValue(Key.PATTERN_MAX_SAMPLE_COUNT));
+    assertEquals(Integer.valueOf(60000), forwarded.getSettingValue(Key.PATTERN_BUFFER_LIMIT));
+    assertEquals(Boolean.TRUE, forwarded.getSettingValue(Key.PATTERN_SHOW_NUMBERED_TOKEN));
+  }
+
+  @Test
+  public void clusterValuesMaxLimitReachesAnalyticsContext() {
+    // PPL_VALUES_MAX_LIMIT is not seeded at all, so without forwarding AstExpressionBuilder reads
+    // null and falls back to unlimited — the configured cap on values() never applies.
+    when(pluginSettings.getSettingValue(Key.PPL_VALUES_MAX_LIMIT)).thenReturn(100);
+
+    assertEquals(
+        Integer.valueOf(100),
+        buildAnalyticsContext().getSettings().getSettingValue(Key.PPL_VALUES_MAX_LIMIT));
+  }
+
+  /** Builds the context the AE path plans against, with the mocked cluster settings applied. */
+  private UnifiedQueryContext buildAnalyticsContext() {
+    return action
+        .applyClusterOverrides(UnifiedQueryContext.builder().language(QueryType.PPL))
+        .build();
   }
 
   private void enableClusterComposite() {


### PR DESCRIPTION
### Description

Several cluster settings were **silently ignored on the Analytics Engine (unified query) path** — the AE route always planned against `UnifiedQueryContext.Builder`'s hardcoded seed value regardless of the configured cluster value. The default (non-AE) pipeline honored them correctly.

**Root cause.** `RestUnifiedQueryAction.applyClusterOverrides()` forwarded only a hand-picked subset of cluster settings into the `UnifiedQueryContext`, while `UnifiedQueryContext.Builder` independently seeds a default settings map. Any planning setting present in the seed map but absent from the forward list silently regressed to its default. This is a *two-lists-drift* defect: the two lists are maintained independently, so the drift is invisible until someone configures the setting and it does nothing.

### Settings fixed

| Setting | Value the AE path actually used | Effect |
|---|---|---|
| `plugins.query.size_limit` | pinned to `10000` | configured result cap ignored |
| `plugins.ppl.pattern.method` | pinned to `SIMPLE_PATTERN` | configured `patterns` default ignored |
| `plugins.ppl.pattern.mode` | pinned to `LABEL` | ditto |
| `plugins.ppl.pattern.max.sample.count` | pinned to `10` | ditto |
| `plugins.ppl.pattern.buffer.limit` | pinned to `100000` | ditto |
| `plugins.ppl.pattern.show.numbered.token` | pinned to `false` | ditto |

Every one of these has a cluster-side default identical to the seeded value, so **behavior is unchanged unless an operator explicitly configured the setting** — at which point the configured value now takes effect. No query that works today changes behavior on defaults.

### Fix

- Replace the hand-maintained `forwardClusterSetting` calls with a single `FORWARDED_CLUSTER_SETTINGS` allow-list — one source of truth for which cluster settings the unified path honors. This matches the existing shape of the sibling handler `RestQuerySettingsAction`, which declares its own settings allow/deny lists the same way.
- Add a **drift guard** (`everySeededPlanningSettingIsClassified`) asserting that every key the builder seeds is either forwarded or explicitly listed as deliberately excluded, with a reason. Adding a key to the builder's seed map without classifying it now fails a test instead of silently regressing. The guard reads the seeded keys through the existing public `Settings#getSettings()` API — no reflection, no new production API.

### Verified end to end on a live Analytics Engine cluster

Single-node cluster with `composite-engine`, `parquet-data-format`, `analytics-engine`, `analytics-backend-datafusion`, `analytics-backend-lucene` + this plugin, querying parquet-backed composite indices. Same cluster, same data, **baseline build vs this PR's build** — every forwarded key this PR adds:

| Setting probed | Baseline (setting ignored) | This PR (setting honored) |
|---|---|---|
| `query.size_limit=2` | 6 rows | **2 rows** |
| `query.size_limit=4` | 6 rows | **4 rows** |
| `pattern.mode=AGGREGATION` | 6 rows, schema `[age, name, patterns_field]` | **1 row, schema `[patterns_field, pattern_count, sample_logs]`** |
| `pattern.method=BRAIN` | `<*> <*> <*> <*> <*> <*>.<*>.<*>.<*> <*> <*> <*>` | **`user <*> logged in from <*IP*> at port <*>`** |
| `pattern.show.numbered.token=true` | `<*> <*> <*> …` | **`<token1> <token2> <token3> …`** |
| `pattern.max.sample.count=2` / `=5` | n/a — `pattern_count` field absent, since `pattern.mode` was ignored too | **`len(sample_logs)` = 2 / 5 respectively** |

`plugins.ppl.pattern.buffer.limit` is forwarded by the same mechanism but is **not** covered by a live-cluster probe: its minimum is `50000`, so distinguishing values requires more buffered patterns than a probe dataset produces. It is covered only by the unit test asserting the value reaches the plan context.

### Deliberately not forwarded

- **`plugins.calcite.enabled`** — the unified path is Calcite-based by definition and must force it on regardless of the cluster value.
- **`plugins.ppl.values.max.limit`** — forwarding this one makes the AE route **strictly worse**. The cap is applied by attaching a `limit` argument to `values()`, which lowers to `array_agg(DISTINCT x, limit)`; the DataFusion backend has no binding for that two-argument form. Confirmed on the cluster above: with the key forwarded, `stats values(f)` fails with `UnsupportedOperationException: Unable to find binding for call array_agg(DISTINCT $0, $1)`, surfaced as HTTP 500 — where today it merely ignores the cap. Turning a silent no-op into a hard failure is a regression, so the key stays out until the backend can bind the limited form. Tracked in #5736; the gap is already recorded in-repo as `Capability.VALUES_LIMIT_NOT_HONORED`.
- **`plugins.ppl.subsearch.maxout` / `plugins.ppl.join.subsearch_maxout`** — the builder seeds these to `0` (unlimited) *on purpose*, to keep `LogicalSystemLimit` out of plans built by external consumers of the unified query API. Note these **do diverge from the cluster defaults (`10000` / `50000`) even when unconfigured**, so the AE path currently runs subsearches unbounded. Whether the in-cluster REST path should override that documented choice is a separate behavioral decision, tracked in #5735.

One further gap found during this work is also **out of scope here**, tracked in #5734: `plugins.calcite.all_join_types.allowed` is not seeded, so `AstBuilder.validateJoinType` reads `null` and its `config != null && !config` check skips validation entirely — the high-cost-join guardrail is inactive on the AE path. Restoring it is a user-visible tightening, so it belongs in its own PR.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented in code.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
