### PR TITLE
Support PPL foreach command

### DIFF
--- a/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/org/opensearch/sql/analysis/Analyzer.java
@@ -74,6 +74,7 @@ import org.opensearch.sql.ast.tree.FetchCursor;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Flatten;
+import org.opensearch.sql.ast.tree.Foreach;
 import org.opensearch.sql.ast.tree.GraphLookup;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Join;
@@ -569,6 +570,11 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitGraphLookup(GraphLookup node, AnalysisContext context) {
     throw getOnlyForCalciteException("graphlookup");
+  }
+
+  @Override
+  public LogicalPlan visitForeach(Foreach node, AnalysisContext context) {
+    throw getOnlyForCalciteException("foreach");
   }
 
   /** Build {@link ParseExpression} to context and skip to child nodes. */

--- a/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/ast/AbstractNodeVisitor.java
@@ -18,6 +18,7 @@ import org.opensearch.sql.ast.expression.Cast;
 import org.opensearch.sql.ast.expression.Compare;
 import org.opensearch.sql.ast.expression.EqualTo;
 import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.ForeachPlaceholder;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.HighlightFunction;
 import org.opensearch.sql.ast.expression.In;
@@ -62,6 +63,7 @@ import org.opensearch.sql.ast.tree.FetchCursor;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Flatten;
+import org.opensearch.sql.ast.tree.Foreach;
 import org.opensearch.sql.ast.tree.GraphLookup;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Join;
@@ -174,6 +176,10 @@ public abstract class AbstractNodeVisitor<T, C> {
     return visitChildren(node, context);
   }
 
+  public T visitForeach(Foreach node, C context) {
+    return visitChildren(node, context);
+  }
+
   public T visitAggregation(Aggregation node, C context) {
     return visitChildren(node, context);
   }
@@ -251,6 +257,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitField(Field node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitForeachPlaceholder(ForeachPlaceholder node, C context) {
     return visitChildren(node, context);
   }
 

--- a/core/src/main/java/org/opensearch/sql/ast/expression/ForeachPlaceholder.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/ForeachPlaceholder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.expression;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+
+/** Placeholder used by the PPL foreach command, such as {@code <<FIELD>>}. */
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class ForeachPlaceholder extends UnresolvedExpression {
+  private final String name;
+
+  @Override
+  public List<UnresolvedExpression> getChild() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
+    return nodeVisitor.visitForeachPlaceholder(this, context);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Foreach.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Foreach.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.tree;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+
+/** AST node representing the PPL foreach command. */
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class Foreach extends UnresolvedPlan {
+  private final String mode;
+  private final List<String> fieldPatterns;
+  private final List<ForeachEvalClause> evalClauses;
+  private UnresolvedPlan child;
+
+  @Override
+  public Foreach attach(UnresolvedPlan child) {
+    this.child = child;
+    return this;
+  }
+
+  @Override
+  public List<UnresolvedPlan> getChild() {
+    return child == null ? ImmutableList.of() : ImmutableList.of(child);
+  }
+
+  @Override
+  public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
+    return nodeVisitor.visitForeach(this, context);
+  }
+
+  @Getter
+  @ToString
+  @EqualsAndHashCode
+  @RequiredArgsConstructor
+  public static class ForeachEvalClause {
+    private final String targetTemplate;
+    private final UnresolvedExpression expression;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Foreach.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Foreach.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -21,7 +22,7 @@ import org.opensearch.sql.ast.expression.UnresolvedExpression;
 @EqualsAndHashCode(callSuper = false)
 @RequiredArgsConstructor
 public class Foreach extends UnresolvedPlan {
-  private final String mode;
+  private final Mode mode;
   private final Map<String, String> options;
   private final List<String> fieldPatterns;
   private final UnresolvedExpression collectionExpression;
@@ -42,6 +43,27 @@ public class Foreach extends UnresolvedPlan {
   @Override
   public <T, C> T accept(AbstractNodeVisitor<T, C> nodeVisitor, C context) {
     return nodeVisitor.visitForeach(this, context);
+  }
+
+  /** Iteration mode of the foreach command. */
+  public enum Mode {
+    MULTIFIELD,
+    MULTIVALUE,
+    JSON_ARRAY,
+    AUTO_COLLECTIONS;
+
+    public static Mode of(String name) {
+      try {
+        return valueOf(name.toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("foreach mode [" + name + "] is not supported");
+      }
+    }
+
+    @Override
+    public String toString() {
+      return name().toLowerCase(Locale.ROOT);
+    }
   }
 
   @Getter

--- a/core/src/main/java/org/opensearch/sql/ast/tree/Foreach.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/Foreach.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.ast.tree;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,9 @@ import org.opensearch.sql.ast.expression.UnresolvedExpression;
 @RequiredArgsConstructor
 public class Foreach extends UnresolvedPlan {
   private final String mode;
+  private final Map<String, String> options;
   private final List<String> fieldPatterns;
+  private final UnresolvedExpression collectionExpression;
   private final List<ForeachEvalClause> evalClauses;
   private UnresolvedPlan child;
 

--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -77,7 +77,7 @@ public class CalcitePlanContext {
   private final Stack<List<RexNode>> windowPartitions = new Stack<>();
 
   @Getter public Map<String, RexLambdaRef> rexLambdaRefMap;
-  @Getter private Map<String, String> foreachBindings = new HashMap<>();
+  @Getter private Map<String, ForeachBinding> foreachBindings = new HashMap<>();
 
   /**
    * Maps AggregateFunction AST nodes to their output field index for HAVING/post-aggregate
@@ -126,6 +126,7 @@ public class CalcitePlanContext {
     this.rexLambdaRefMap = new HashMap<>(); // New map for lambda variables
     this.capturedVariables = new ArrayList<>(); // New list for captured variables
     this.inLambdaContext = true; // Mark that we're inside a lambda
+    this.foreachBindings = new HashMap<>(parent.foreachBindings);
   }
 
   public RexNode resolveJoinCondition(
@@ -204,13 +205,23 @@ public class CalcitePlanContext {
     timewrapSeries.set(null);
   }
 
-  public void pushForeachBindings(Map<String, String> bindings) {
+  public void pushForeachBindings(Map<String, ForeachBinding> bindings) {
     foreachBindings = new HashMap<>(bindings);
   }
 
   public void clearForeachBindings() {
     foreachBindings.clear();
   }
+
+  public enum ForeachBindingType {
+    FIELD,
+    LITERAL,
+    LAMBDA,
+    PAIR_ITEM,
+    PAIR_ITER
+  }
+
+  public record ForeachBinding(String value, ForeachBindingType type) {}
 
   public void putRexLambdaRefMap(Map<String, RexLambdaRef> candidateMap) {
     this.rexLambdaRefMap.putAll(candidateMap);

--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -21,6 +21,7 @@ import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexLambdaRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.FrameworkConfig;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.UnresolvedExpression;
@@ -218,10 +219,20 @@ public class CalcitePlanContext {
     LITERAL,
     LAMBDA,
     PAIR_ITEM,
-    PAIR_ITER
+    PAIR_ITER,
+    PAIR_EXTRA
   }
 
-  public record ForeachBinding(String value, ForeachBindingType type) {}
+  public record ForeachBinding(
+      String value,
+      ForeachBindingType type,
+      int pairIndex,
+      String typeName,
+      @Nullable String componentTypeName) {
+    public ForeachBinding(String value, ForeachBindingType type) {
+      this(value, type, -1, null, null);
+    }
+  }
 
   public void putRexLambdaRefMap(Map<String, RexLambdaRef> candidateMap) {
     this.rexLambdaRefMap.putAll(candidateMap);

--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -17,6 +17,7 @@ import java.util.Stack;
 import java.util.function.BiFunction;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexLambdaRef;
 import org.apache.calcite.rex.RexNode;
@@ -78,7 +79,17 @@ public class CalcitePlanContext {
   private final Stack<List<RexNode>> windowPartitions = new Stack<>();
 
   @Getter public Map<String, RexLambdaRef> rexLambdaRefMap;
+
+  /**
+   * Foreach placeholder bindings active in this context, keyed by upper-cased placeholder name.
+   * Multifield mode activates bindings directly (placeholders resolve against the current row);
+   * collection modes stage bindings via {@link #stageForeachLambdaBindings} instead, so they only
+   * become active inside the lambda context cloned for the generated {@code reduce} call.
+   */
   @Getter private Map<String, ForeachBinding> foreachBindings = new HashMap<>();
+
+  /** Bindings that become active in lambda contexts cloned from this one. */
+  private Map<String, ForeachBinding> stagedForeachLambdaBindings = new HashMap<>();
 
   /**
    * Maps AggregateFunction AST nodes to their output field index for HAVING/post-aggregate
@@ -127,7 +138,9 @@ public class CalcitePlanContext {
     this.rexLambdaRefMap = new HashMap<>(); // New map for lambda variables
     this.capturedVariables = new ArrayList<>(); // New list for captured variables
     this.inLambdaContext = true; // Mark that we're inside a lambda
+    // Active bindings carry over; staged bindings become active inside the lambda.
     this.foreachBindings = new HashMap<>(parent.foreachBindings);
+    this.foreachBindings.putAll(parent.stagedForeachLambdaBindings);
   }
 
   public RexNode resolveJoinCondition(
@@ -210,28 +223,31 @@ public class CalcitePlanContext {
     foreachBindings = new HashMap<>(bindings);
   }
 
+  public void stageForeachLambdaBindings(Map<String, ForeachBinding> bindings) {
+    stagedForeachLambdaBindings = new HashMap<>(bindings);
+  }
+
   public void clearForeachBindings() {
     foreachBindings.clear();
+    stagedForeachLambdaBindings.clear();
+  }
+
+  /**
+   * A foreach placeholder binding. {@code FIELD} resolves to the named row field, {@code LITERAL}
+   * to a string literal, and {@code PAIR_SLOT} to slot {@code pairIndex} (typed {@code pairType})
+   * of the named lambda pair variable.
+   */
+  public record ForeachBinding(
+      String value, ForeachBindingType type, int pairIndex, @Nullable RelDataType pairType) {
+    public ForeachBinding(String value, ForeachBindingType type) {
+      this(value, type, -1, null);
+    }
   }
 
   public enum ForeachBindingType {
     FIELD,
     LITERAL,
-    LAMBDA,
-    PAIR_ITEM,
-    PAIR_ITER,
-    PAIR_EXTRA
-  }
-
-  public record ForeachBinding(
-      String value,
-      ForeachBindingType type,
-      int pairIndex,
-      String typeName,
-      @Nullable String componentTypeName) {
-    public ForeachBinding(String value, ForeachBindingType type) {
-      this(value, type, -1, null, null);
-    }
+    PAIR_SLOT
   }
 
   public void putRexLambdaRefMap(Map<String, RexLambdaRef> candidateMap) {

--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -88,8 +88,17 @@ public class CalcitePlanContext {
    */
   @Getter private Map<String, ForeachBinding> foreachBindings = new HashMap<>();
 
+  /** Bare identifiers enabled by explicit options such as {@code itemstr=ITEM}. */
+  @Getter private Map<String, ForeachBinding> foreachIdentifierBindings = new HashMap<>();
+
   /** Bindings that become active in lambda contexts cloned from this one. */
   private Map<String, ForeachBinding> stagedForeachLambdaBindings = new HashMap<>();
+
+  /** Bare identifier bindings staged for a generated foreach lambda. */
+  private Map<String, ForeachBinding> stagedForeachIdentifierBindings = new HashMap<>();
+
+  /** Expressions computed by earlier assignments in the same foreach eval iteration. */
+  @Getter private Map<String, RexNode> foreachComputedBindings = new HashMap<>();
 
   /**
    * Maps AggregateFunction AST nodes to their output field index for HAVING/post-aggregate
@@ -141,6 +150,9 @@ public class CalcitePlanContext {
     // Active bindings carry over; staged bindings become active inside the lambda.
     this.foreachBindings = new HashMap<>(parent.foreachBindings);
     this.foreachBindings.putAll(parent.stagedForeachLambdaBindings);
+    this.foreachIdentifierBindings = new HashMap<>(parent.foreachIdentifierBindings);
+    this.foreachIdentifierBindings.putAll(parent.stagedForeachIdentifierBindings);
+    this.foreachComputedBindings = new HashMap<>(parent.foreachComputedBindings);
   }
 
   public RexNode resolveJoinCondition(
@@ -219,17 +231,28 @@ public class CalcitePlanContext {
     timewrapSeries.set(null);
   }
 
-  public void pushForeachBindings(Map<String, ForeachBinding> bindings) {
+  public void pushForeachBindings(
+      Map<String, ForeachBinding> bindings, Map<String, ForeachBinding> identifierBindings) {
     foreachBindings = new HashMap<>(bindings);
+    foreachIdentifierBindings = new HashMap<>(identifierBindings);
   }
 
-  public void stageForeachLambdaBindings(Map<String, ForeachBinding> bindings) {
+  public void stageForeachLambdaBindings(
+      Map<String, ForeachBinding> bindings, Map<String, ForeachBinding> identifierBindings) {
     stagedForeachLambdaBindings = new HashMap<>(bindings);
+    stagedForeachIdentifierBindings = new HashMap<>(identifierBindings);
+  }
+
+  public void putForeachComputedBinding(String name, RexNode expression) {
+    foreachComputedBindings.put(name.toUpperCase(java.util.Locale.ROOT), expression);
   }
 
   public void clearForeachBindings() {
     foreachBindings.clear();
+    foreachIdentifierBindings.clear();
     stagedForeachLambdaBindings.clear();
+    stagedForeachIdentifierBindings.clear();
+    foreachComputedBindings.clear();
   }
 
   /**

--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -77,6 +77,7 @@ public class CalcitePlanContext {
   private final Stack<List<RexNode>> windowPartitions = new Stack<>();
 
   @Getter public Map<String, RexLambdaRef> rexLambdaRefMap;
+  @Getter private Map<String, String> foreachBindings = new HashMap<>();
 
   /**
    * Maps AggregateFunction AST nodes to their output field index for HAVING/post-aggregate
@@ -201,6 +202,14 @@ public class CalcitePlanContext {
     stripNullColumns.set(false);
     timewrapUnitName.set(null);
     timewrapSeries.set(null);
+  }
+
+  public void pushForeachBindings(Map<String, String> bindings) {
+    foreachBindings = new HashMap<>(bindings);
+  }
+
+  public void clearForeachBindings() {
+    foreachBindings.clear();
   }
 
   public void putRexLambdaRefMap(Map<String, RexLambdaRef> candidateMap) {

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -213,6 +214,25 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   /** Name of the right-side sequence column in the streamstats self-join plan. */
   private static final String RIGHT_SIDE_SEQ_COLUMN =
       RIGHT_SIDE_FIELD_PREFIX + "seq" + RIGHT_SIDE_FIELD_SUFFIX;
+
+  private static final String FOREACH_MODE_MULTIFIELD = "multifield";
+  private static final String FOREACH_MODE_MULTIVALUE = "multivalue";
+  private static final String FOREACH_MODE_JSON_ARRAY = "json_array";
+  private static final String FOREACH_MODE_AUTO_COLLECTIONS = "auto_collections";
+  private static final String FOREACH_OPTION_FIELDSTR = "fieldstr";
+  private static final String FOREACH_OPTION_MATCHSTR = "matchstr";
+  private static final String FOREACH_OPTION_MATCHSEG = "matchseg";
+  private static final String FOREACH_OPTION_ITEMSTR = "itemstr";
+  private static final String FOREACH_OPTION_ITERSTR = "iterstr";
+  private static final String FOREACH_PLACEHOLDER_FIELD = "FIELD";
+  private static final String FOREACH_PLACEHOLDER_MATCHSTR = "MATCHSTR";
+  private static final String FOREACH_PLACEHOLDER_MATCHSEG = "MATCHSEG";
+  private static final String FOREACH_PLACEHOLDER_ITEM = "ITEM";
+  private static final String FOREACH_PLACEHOLDER_ITER = "ITER";
+  private static final String FOREACH_TRANSFORM_ITEM = "__foreach_item";
+  private static final String FOREACH_TRANSFORM_ITER = "__foreach_iter";
+  private static final String FOREACH_PAIR = "__foreach_pair";
+  private static final String FOREACH_JSON_ARRAY_FUNCTION = "foreach_json_array";
 
   private final CalciteRexNodeVisitor rexVisitor;
   private final CalciteAggCallVisitor aggVisitor;
@@ -1250,13 +1270,13 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   @Override
   public RelNode visitForeach(Foreach node, CalcitePlanContext context) {
     visitChildren(node, context);
-    String mode = node.getMode().toLowerCase(java.util.Locale.ROOT);
+    String mode = node.getMode().toLowerCase(Locale.ROOT);
     switch (mode) {
-      case "multifield":
+      case FOREACH_MODE_MULTIFIELD:
         return visitForeachMultifield(node, context);
-      case "multivalue":
-      case "json_array":
-      case "auto_collections":
+      case FOREACH_MODE_MULTIVALUE:
+      case FOREACH_MODE_JSON_ARRAY:
+      case FOREACH_MODE_AUTO_COLLECTIONS:
         return visitForeachCollection(node, context, mode);
       default:
         throw new CalciteUnsupportedException(
@@ -1300,11 +1320,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     }
     UnresolvedExpression collectionExpression =
         collectionExpressionForMode(node.getCollectionExpression(), context, normalizedMode);
-    String itemName = option(node.getOptions(), "itemstr", "ITEM");
-    String iterName = option(node.getOptions(), "iterstr", "ITER");
-    String transformItemName = "__foreach_item";
-    String transformIterName = "__foreach_iter";
-    String pairName = "__foreach_pair";
+    String itemName = option(node.getOptions(), FOREACH_OPTION_ITEMSTR, FOREACH_PLACEHOLDER_ITEM);
+    String iterName = option(node.getOptions(), FOREACH_OPTION_ITERSTR, FOREACH_PLACEHOLDER_ITER);
     Function pairedCollection =
         new Function(
             BuiltinFunctionName.TRANSFORM.getName().getFunctionName(),
@@ -1314,16 +1331,16 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
                     new Function(
                         BuiltinFunctionName.ARRAY.getName().getFunctionName(),
                         List.of(
-                            new QualifiedName(transformItemName),
-                            new QualifiedName(transformIterName))),
+                            new QualifiedName(FOREACH_TRANSFORM_ITEM),
+                            new QualifiedName(FOREACH_TRANSFORM_ITER))),
                     List.of(
-                        new QualifiedName(transformItemName),
-                        new QualifiedName(transformIterName)))));
+                        new QualifiedName(FOREACH_TRANSFORM_ITEM),
+                        new QualifiedName(FOREACH_TRANSFORM_ITER)))));
     Map<String, ForeachBinding> bindings = new HashMap<>();
-    putBinding(bindings, itemName, pairName, ForeachBindingType.PAIR_ITEM);
-    putBinding(bindings, "ITEM", pairName, ForeachBindingType.PAIR_ITEM);
-    putBinding(bindings, iterName, pairName, ForeachBindingType.PAIR_ITER);
-    putBinding(bindings, "ITER", pairName, ForeachBindingType.PAIR_ITER);
+    putBinding(bindings, itemName, FOREACH_PAIR, ForeachBindingType.PAIR_ITEM);
+    putBinding(bindings, FOREACH_PLACEHOLDER_ITEM, FOREACH_PAIR, ForeachBindingType.PAIR_ITEM);
+    putBinding(bindings, iterName, FOREACH_PAIR, ForeachBindingType.PAIR_ITER);
+    putBinding(bindings, FOREACH_PLACEHOLDER_ITER, FOREACH_PAIR, ForeachBindingType.PAIR_ITER);
 
     context.pushForeachBindings(bindings);
     try {
@@ -1337,7 +1354,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
                     new Field(new QualifiedName(alias)),
                     new LambdaFunction(
                         clause.getExpression(),
-                        List.of(new QualifiedName(alias), new QualifiedName(pairName)))));
+                        List.of(new QualifiedName(alias), new QualifiedName(FOREACH_PAIR)))));
         RexNode expr = rexVisitor.analyze(reduce, context);
         projectPlusOverriding(
             List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
@@ -1352,39 +1369,43 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
       UnresolvedExpression collectionExpression,
       CalcitePlanContext context,
       String normalizedMode) {
-    if ("multivalue".equals(normalizedMode)) {
+    if (FOREACH_MODE_MULTIVALUE.equals(normalizedMode)) {
       return collectionExpression;
     }
-    if ("auto_collections".equals(normalizedMode)) {
+    if (FOREACH_MODE_AUTO_COLLECTIONS.equals(normalizedMode)) {
       RexNode rexNode = rexVisitor.analyze(collectionExpression, context);
       if (rexNode.getType() instanceof ArraySqlType) {
         return collectionExpression;
       }
     }
-    return new Function("foreach_json_array", List.of(collectionExpression));
+    return new Function(FOREACH_JSON_ARRAY_FUNCTION, List.of(collectionExpression));
   }
 
   private Map<String, ForeachBinding> buildForeachMultifieldBindings(
       List<String> patterns, String fieldName, Map<String, String> options) {
     Map<String, ForeachBinding> bindings = new HashMap<>();
-    putBinding(bindings, "FIELD", fieldName, ForeachBindingType.FIELD);
-    putBinding(bindings, option(options, "fieldstr", "FIELD"), fieldName, ForeachBindingType.FIELD);
+    putBinding(bindings, FOREACH_PLACEHOLDER_FIELD, fieldName, ForeachBindingType.FIELD);
+    putBinding(
+        bindings,
+        option(options, FOREACH_OPTION_FIELDSTR, FOREACH_PLACEHOLDER_FIELD),
+        fieldName,
+        ForeachBindingType.FIELD);
     for (String pattern : patterns) {
       List<String> segments = wildcardSegments(pattern, fieldName);
       if (segments != null) {
         String matchStr = String.join("", segments);
-        putBinding(bindings, "MATCHSTR", matchStr, ForeachBindingType.LITERAL);
+        putBinding(bindings, FOREACH_PLACEHOLDER_MATCHSTR, matchStr, ForeachBindingType.LITERAL);
         putBinding(
             bindings,
-            option(options, "matchstr", "MATCHSTR"),
+            option(options, FOREACH_OPTION_MATCHSTR, FOREACH_PLACEHOLDER_MATCHSTR),
             matchStr,
             ForeachBindingType.LITERAL);
         for (int i = 0; i < segments.size(); i++) {
-          String key = "MATCHSEG" + (i + 1);
+          String key = FOREACH_PLACEHOLDER_MATCHSEG + (i + 1);
           putBinding(bindings, key, segments.get(i), ForeachBindingType.LITERAL);
           putBinding(
               bindings,
-              option(options, "matchseg" + (i + 1), key),
+              option(options, FOREACH_OPTION_MATCHSEG + (i + 1), key),
               segments.get(i),
               ForeachBindingType.LITERAL);
         }
@@ -1420,7 +1441,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
 
   private void putBinding(
       Map<String, ForeachBinding> bindings, String name, String value, ForeachBindingType type) {
-    bindings.put(name.toUpperCase(java.util.Locale.ROOT), new ForeachBinding(value, type));
+    bindings.put(name.toUpperCase(Locale.ROOT), new ForeachBinding(value, type));
   }
 
   private String substituteForeachTemplate(String template, Map<String, ForeachBinding> bindings) {

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -99,6 +99,7 @@ import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Argument.ArgumentMap;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Function;
+import org.opensearch.sql.ast.expression.LambdaFunction;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.ParseMethod;
@@ -169,6 +170,8 @@ import org.opensearch.sql.ast.tree.Union;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
 import org.opensearch.sql.ast.tree.Window;
+import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBinding;
+import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBindingType;
 import org.opensearch.sql.calcite.plan.AliasFieldsWrappable;
 import org.opensearch.sql.calcite.plan.HighlightPushDown;
 import org.opensearch.sql.calcite.plan.OpenSearchConstants;
@@ -1247,11 +1250,21 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   @Override
   public RelNode visitForeach(Foreach node, CalcitePlanContext context) {
     visitChildren(node, context);
-    if (!"multifield".equalsIgnoreCase(node.getMode())) {
-      throw new CalciteUnsupportedException(
-          "foreach mode [" + node.getMode() + "] is not supported");
+    String mode = node.getMode().toLowerCase(java.util.Locale.ROOT);
+    switch (mode) {
+      case "multifield":
+        return visitForeachMultifield(node, context);
+      case "multivalue":
+      case "json_array":
+      case "auto_collections":
+        return visitForeachCollection(node, context, mode);
+      default:
+        throw new CalciteUnsupportedException(
+            "foreach mode [" + node.getMode() + "] is not supported");
     }
+  }
 
+  private RelNode visitForeachMultifield(Foreach node, CalcitePlanContext context) {
     List<String> currentFields = context.relBuilder.peek().getRowType().getFieldNames();
     LinkedHashSet<String> matchingFields = new LinkedHashSet<>();
     for (String pattern : node.getFieldPatterns()) {
@@ -1259,7 +1272,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     }
 
     for (String fieldName : matchingFields) {
-      Map<String, String> bindings = buildForeachBindings(node.getFieldPatterns(), fieldName);
+      Map<String, ForeachBinding> bindings =
+          buildForeachMultifieldBindings(node.getFieldPatterns(), fieldName, node.getOptions());
       context.pushForeachBindings(bindings);
       try {
         for (Foreach.ForeachEvalClause clause : node.getEvalClauses()) {
@@ -1275,15 +1289,104 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     return context.relBuilder.peek();
   }
 
-  private Map<String, String> buildForeachBindings(List<String> patterns, String fieldName) {
-    Map<String, String> bindings = new HashMap<>();
-    bindings.put("FIELD", fieldName);
+  private RelNode visitForeachCollection(
+      Foreach node, CalcitePlanContext context, String normalizedMode) {
+    if (node.getCollectionExpression() == null) {
+      throw new SemanticCheckException("foreach " + normalizedMode + " mode requires a field");
+    }
+    if (node.getFieldPatterns().size() != 1) {
+      throw new SemanticCheckException(
+          "foreach " + normalizedMode + " mode accepts exactly one field");
+    }
+    UnresolvedExpression collectionExpression =
+        collectionExpressionForMode(node.getCollectionExpression(), context, normalizedMode);
+    String itemName = option(node.getOptions(), "itemstr", "ITEM");
+    String iterName = option(node.getOptions(), "iterstr", "ITER");
+    String transformItemName = "__foreach_item";
+    String transformIterName = "__foreach_iter";
+    String pairName = "__foreach_pair";
+    Function pairedCollection =
+        new Function(
+            BuiltinFunctionName.TRANSFORM.getName().getFunctionName(),
+            List.of(
+                collectionExpression,
+                new LambdaFunction(
+                    new Function(
+                        BuiltinFunctionName.ARRAY.getName().getFunctionName(),
+                        List.of(
+                            new QualifiedName(transformItemName),
+                            new QualifiedName(transformIterName))),
+                    List.of(
+                        new QualifiedName(transformItemName),
+                        new QualifiedName(transformIterName)))));
+    Map<String, ForeachBinding> bindings = new HashMap<>();
+    putBinding(bindings, itemName, pairName, ForeachBindingType.PAIR_ITEM);
+    putBinding(bindings, "ITEM", pairName, ForeachBindingType.PAIR_ITEM);
+    putBinding(bindings, iterName, pairName, ForeachBindingType.PAIR_ITER);
+    putBinding(bindings, "ITER", pairName, ForeachBindingType.PAIR_ITER);
+
+    context.pushForeachBindings(bindings);
+    try {
+      for (Foreach.ForeachEvalClause clause : node.getEvalClauses()) {
+        String alias = substituteForeachTemplate(clause.getTargetTemplate(), bindings);
+        Function reduce =
+            new Function(
+                BuiltinFunctionName.REDUCE.getName().getFunctionName(),
+                List.of(
+                    pairedCollection,
+                    new Field(new QualifiedName(alias)),
+                    new LambdaFunction(
+                        clause.getExpression(),
+                        List.of(new QualifiedName(alias), new QualifiedName(pairName)))));
+        RexNode expr = rexVisitor.analyze(reduce, context);
+        projectPlusOverriding(
+            List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
+      }
+    } finally {
+      context.clearForeachBindings();
+    }
+    return context.relBuilder.peek();
+  }
+
+  private UnresolvedExpression collectionExpressionForMode(
+      UnresolvedExpression collectionExpression,
+      CalcitePlanContext context,
+      String normalizedMode) {
+    if ("multivalue".equals(normalizedMode)) {
+      return collectionExpression;
+    }
+    if ("auto_collections".equals(normalizedMode)) {
+      RexNode rexNode = rexVisitor.analyze(collectionExpression, context);
+      if (rexNode.getType() instanceof ArraySqlType) {
+        return collectionExpression;
+      }
+    }
+    return new Function("foreach_json_array", List.of(collectionExpression));
+  }
+
+  private Map<String, ForeachBinding> buildForeachMultifieldBindings(
+      List<String> patterns, String fieldName, Map<String, String> options) {
+    Map<String, ForeachBinding> bindings = new HashMap<>();
+    putBinding(bindings, "FIELD", fieldName, ForeachBindingType.FIELD);
+    putBinding(bindings, option(options, "fieldstr", "FIELD"), fieldName, ForeachBindingType.FIELD);
     for (String pattern : patterns) {
       List<String> segments = wildcardSegments(pattern, fieldName);
       if (segments != null) {
-        bindings.put("MATCHSTR", String.join("", segments));
+        String matchStr = String.join("", segments);
+        putBinding(bindings, "MATCHSTR", matchStr, ForeachBindingType.LITERAL);
+        putBinding(
+            bindings,
+            option(options, "matchstr", "MATCHSTR"),
+            matchStr,
+            ForeachBindingType.LITERAL);
         for (int i = 0; i < segments.size(); i++) {
-          bindings.put("MATCHSEG" + (i + 1), segments.get(i));
+          String key = "MATCHSEG" + (i + 1);
+          putBinding(bindings, key, segments.get(i), ForeachBindingType.LITERAL);
+          putBinding(
+              bindings,
+              option(options, "matchseg" + (i + 1), key),
+              segments.get(i),
+              ForeachBindingType.LITERAL);
         }
         break;
       }
@@ -1311,13 +1414,22 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     return segments;
   }
 
-  private String substituteForeachTemplate(String template, Map<String, String> bindings) {
+  private String option(Map<String, String> options, String name, String defaultValue) {
+    return options.getOrDefault(name, defaultValue);
+  }
+
+  private void putBinding(
+      Map<String, ForeachBinding> bindings, String name, String value, ForeachBindingType type) {
+    bindings.put(name.toUpperCase(java.util.Locale.ROOT), new ForeachBinding(value, type));
+  }
+
+  private String substituteForeachTemplate(String template, Map<String, ForeachBinding> bindings) {
     String result = template;
-    for (Map.Entry<String, String> entry : bindings.entrySet()) {
+    for (Map.Entry<String, ForeachBinding> entry : bindings.entrySet()) {
       result =
           result.replaceAll(
               "(?i)<<" + java.util.regex.Pattern.quote(entry.getKey()) + ">>",
-              java.util.regex.Matcher.quoteReplacement(entry.getValue()));
+              java.util.regex.Matcher.quoteReplacement(entry.getValue().value()));
     }
     return result;
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -130,6 +130,7 @@ import org.opensearch.sql.ast.tree.FetchCursor;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Flatten;
+import org.opensearch.sql.ast.tree.Foreach;
 import org.opensearch.sql.ast.tree.GraphLookup;
 import org.opensearch.sql.ast.tree.GraphLookup.Direction;
 import org.opensearch.sql.ast.tree.Head;
@@ -1241,6 +1242,84 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
               }
             });
     return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitForeach(Foreach node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    if (!"multifield".equalsIgnoreCase(node.getMode())) {
+      throw new CalciteUnsupportedException(
+          "foreach mode [" + node.getMode() + "] is not supported");
+    }
+
+    List<String> currentFields = context.relBuilder.peek().getRowType().getFieldNames();
+    LinkedHashSet<String> matchingFields = new LinkedHashSet<>();
+    for (String pattern : node.getFieldPatterns()) {
+      matchingFields.addAll(WildcardUtils.expandWildcardPattern(pattern, currentFields));
+    }
+
+    for (String fieldName : matchingFields) {
+      Map<String, String> bindings = buildForeachBindings(node.getFieldPatterns(), fieldName);
+      context.pushForeachBindings(bindings);
+      try {
+        for (Foreach.ForeachEvalClause clause : node.getEvalClauses()) {
+          RexNode expr = rexVisitor.analyze(clause.getExpression(), context);
+          String alias = substituteForeachTemplate(clause.getTargetTemplate(), bindings);
+          projectPlusOverriding(
+              List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
+        }
+      } finally {
+        context.clearForeachBindings();
+      }
+    }
+    return context.relBuilder.peek();
+  }
+
+  private Map<String, String> buildForeachBindings(List<String> patterns, String fieldName) {
+    Map<String, String> bindings = new HashMap<>();
+    bindings.put("FIELD", fieldName);
+    for (String pattern : patterns) {
+      List<String> segments = wildcardSegments(pattern, fieldName);
+      if (segments != null) {
+        bindings.put("MATCHSTR", String.join("", segments));
+        for (int i = 0; i < segments.size(); i++) {
+          bindings.put("MATCHSEG" + (i + 1), segments.get(i));
+        }
+        break;
+      }
+    }
+    return bindings;
+  }
+
+  private List<String> wildcardSegments(String pattern, String fieldName) {
+    if (!WildcardUtils.matchesWildcardPattern(pattern, fieldName)) {
+      return null;
+    }
+    if (!WildcardUtils.containsWildcard(pattern)) {
+      return List.of();
+    }
+    java.util.regex.Matcher matcher =
+        java.util.regex.Pattern.compile(WildcardUtils.convertWildcardPatternToRegex(pattern))
+            .matcher(fieldName);
+    if (!matcher.matches()) {
+      return null;
+    }
+    List<String> segments = new ArrayList<>();
+    for (int i = 1; i <= matcher.groupCount(); i++) {
+      segments.add(matcher.group(i));
+    }
+    return segments;
+  }
+
+  private String substituteForeachTemplate(String template, Map<String, String> bindings) {
+    String result = template;
+    for (Map.Entry<String, String> entry : bindings.entrySet()) {
+      result =
+          result.replaceAll(
+              "(?i)<<" + java.util.regex.Pattern.quote(entry.getKey()) + ">>",
+              java.util.regex.Matcher.quoteReplacement(entry.getValue()));
+    }
+    return result;
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -38,6 +38,7 @@ import java.util.BitSet;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -45,6 +46,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -98,7 +101,9 @@ import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.AllFieldsExcludeMeta;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Argument.ArgumentMap;
+import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.ForeachPlaceholder;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.LambdaFunction;
 import org.opensearch.sql.ast.expression.Let;
@@ -233,6 +238,9 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   private static final String FOREACH_TRANSFORM_ITER = "__foreach_iter";
   private static final String FOREACH_PAIR = "__foreach_pair";
   private static final String FOREACH_JSON_ARRAY_FUNCTION = "foreach_json_array";
+  private static final String FOREACH_PAIR_COLLECTION_FUNCTION = "foreach_pair_collection";
+  private static final String FOREACH_JSON_ARRAY_NUMERIC_TYPE = SqlTypeName.DOUBLE.name();
+  private static final String FOREACH_JSON_ARRAY_STRING_TYPE = SqlTypeName.VARCHAR.name();
 
   private final CalciteRexNodeVisitor rexVisitor;
   private final CalciteAggCallVisitor aggVisitor;
@@ -1311,36 +1319,64 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
 
   private RelNode visitForeachCollection(
       Foreach node, CalcitePlanContext context, String normalizedMode) {
-    if (node.getCollectionExpression() == null) {
+    UnresolvedExpression sourceCollection = node.getCollectionExpression();
+    if (sourceCollection == null && FOREACH_MODE_AUTO_COLLECTIONS.equals(normalizedMode)) {
+      sourceCollection = inferAutoCollectionExpression(context);
+    }
+    if (sourceCollection == null) {
       throw new SemanticCheckException("foreach " + normalizedMode + " mode requires a field");
     }
-    if (node.getFieldPatterns().size() != 1) {
+    if (node.getFieldPatterns().size() > 1) {
       throw new SemanticCheckException(
           "foreach " + normalizedMode + " mode accepts exactly one field");
     }
+    String itemName =
+        node.getOptions().getOrDefault(FOREACH_OPTION_ITEMSTR, FOREACH_PLACEHOLDER_ITEM);
+    String iterName =
+        node.getOptions().getOrDefault(FOREACH_OPTION_ITERSTR, FOREACH_PLACEHOLDER_ITER);
     UnresolvedExpression collectionExpression =
-        collectionExpressionForMode(node.getCollectionExpression(), context, normalizedMode);
-    String itemName = option(node.getOptions(), FOREACH_OPTION_ITEMSTR, FOREACH_PLACEHOLDER_ITEM);
-    String iterName = option(node.getOptions(), FOREACH_OPTION_ITERSTR, FOREACH_PLACEHOLDER_ITER);
-    Function pairedCollection =
-        new Function(
-            BuiltinFunctionName.TRANSFORM.getName().getFunctionName(),
-            List.of(
-                collectionExpression,
-                new LambdaFunction(
-                    new Function(
-                        BuiltinFunctionName.ARRAY.getName().getFunctionName(),
-                        List.of(
-                            new QualifiedName(FOREACH_TRANSFORM_ITEM),
-                            new QualifiedName(FOREACH_TRANSFORM_ITER))),
-                    List.of(
-                        new QualifiedName(FOREACH_TRANSFORM_ITEM),
-                        new QualifiedName(FOREACH_TRANSFORM_ITER)))));
+        collectionExpressionForMode(
+            sourceCollection, context, normalizedMode, node.getEvalClauses(), itemName);
+    RexNode collectionRex = rexVisitor.analyze(collectionExpression, context);
+    RelDataType itemType = ((ArraySqlType) collectionRex.getType()).getComponentType();
+    List<String> targetAliases =
+        node.getEvalClauses().stream().map(Foreach.ForeachEvalClause::getTargetTemplate).toList();
+    List<ForeachCapturedField> capturedFields =
+        collectForeachCapturedFields(
+            node.getEvalClauses(), context, itemName, iterName, targetAliases);
+    List<UnresolvedExpression> pairArguments = new ArrayList<>();
+    pairArguments.add(collectionExpression);
+    capturedFields.stream()
+        .map(field -> new Field(new QualifiedName(field.name())))
+        .forEach(pairArguments::add);
+    Function pairedCollection = new Function(FOREACH_PAIR_COLLECTION_FUNCTION, pairArguments);
     Map<String, ForeachBinding> bindings = new HashMap<>();
-    putBinding(bindings, itemName, FOREACH_PAIR, ForeachBindingType.PAIR_ITEM);
-    putBinding(bindings, FOREACH_PLACEHOLDER_ITEM, FOREACH_PAIR, ForeachBindingType.PAIR_ITEM);
-    putBinding(bindings, iterName, FOREACH_PAIR, ForeachBindingType.PAIR_ITER);
-    putBinding(bindings, FOREACH_PLACEHOLDER_ITER, FOREACH_PAIR, ForeachBindingType.PAIR_ITER);
+    bindings.put(
+        itemName.toUpperCase(Locale.ROOT),
+        newForeachPairBinding(FOREACH_PAIR, ForeachBindingType.PAIR_ITEM, 0, itemType));
+    bindings.put(
+        FOREACH_PLACEHOLDER_ITEM,
+        newForeachPairBinding(FOREACH_PAIR, ForeachBindingType.PAIR_ITEM, 0, itemType));
+    bindings.put(
+        iterName.toUpperCase(Locale.ROOT),
+        newForeachPairBinding(
+            FOREACH_PAIR,
+            ForeachBindingType.PAIR_ITER,
+            1,
+            context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER)));
+    bindings.put(
+        FOREACH_PLACEHOLDER_ITER,
+        newForeachPairBinding(
+            FOREACH_PAIR,
+            ForeachBindingType.PAIR_ITER,
+            1,
+            context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER)));
+    for (int i = 0; i < capturedFields.size(); i++) {
+      ForeachCapturedField field = capturedFields.get(i);
+      bindings.put(
+          field.name().toUpperCase(Locale.ROOT),
+          newForeachPairBinding(FOREACH_PAIR, ForeachBindingType.PAIR_EXTRA, i + 2, field.type()));
+    }
 
     context.pushForeachBindings(bindings);
     try {
@@ -1365,10 +1401,75 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     return context.relBuilder.peek();
   }
 
+  private List<ForeachCapturedField> collectForeachCapturedFields(
+      List<Foreach.ForeachEvalClause> evalClauses,
+      CalcitePlanContext context,
+      String itemName,
+      String iterName,
+      List<String> targetAliases) {
+    Set<String> excluded =
+        Stream.concat(
+                Stream.of(
+                    itemName,
+                    iterName,
+                    FOREACH_PLACEHOLDER_ITEM,
+                    FOREACH_PLACEHOLDER_ITER,
+                    FOREACH_PAIR),
+                targetAliases.stream())
+            .map(name -> name.toUpperCase(Locale.ROOT))
+            .collect(Collectors.toSet());
+    Map<String, RelDataType> rowTypes =
+        context.relBuilder.peek().getRowType().getFieldList().stream()
+            .collect(
+                Collectors.toMap(
+                    field -> field.getName().toUpperCase(Locale.ROOT),
+                    RelDataTypeField::getType,
+                    (left, right) -> left,
+                    LinkedHashMap::new));
+    Map<String, ForeachCapturedField> fields = new LinkedHashMap<>();
+    evalClauses.forEach(
+        clause -> collectForeachCapturedFields(clause.getExpression(), excluded, rowTypes, fields));
+    return new ArrayList<>(fields.values());
+  }
+
+  private void collectForeachCapturedFields(
+      Node node,
+      Set<String> excluded,
+      Map<String, RelDataType> rowTypes,
+      Map<String, ForeachCapturedField> fields) {
+    if (node instanceof QualifiedName qualifiedName) {
+      String key = qualifiedName.toString().toUpperCase(Locale.ROOT);
+      RelDataType type = rowTypes.get(key);
+      if (type != null && !excluded.contains(key)) {
+        fields.putIfAbsent(key, new ForeachCapturedField(qualifiedName.toString(), type));
+      }
+    }
+    node.getChild()
+        .forEach(child -> collectForeachCapturedFields(child, excluded, rowTypes, fields));
+  }
+
+  private ForeachBinding newForeachPairBinding(
+      String pairName, ForeachBindingType type, int index, RelDataType relDataType) {
+    return new ForeachBinding(
+        pairName, type, index, relDataType.getSqlTypeName().name(), componentTypeName(relDataType));
+  }
+
+  @Nullable
+  private String componentTypeName(RelDataType relDataType) {
+    if (relDataType instanceof ArraySqlType arrayType) {
+      return arrayType.getComponentType().getSqlTypeName().name();
+    }
+    return null;
+  }
+
+  private record ForeachCapturedField(String name, RelDataType type) {}
+
   private UnresolvedExpression collectionExpressionForMode(
       UnresolvedExpression collectionExpression,
       CalcitePlanContext context,
-      String normalizedMode) {
+      String normalizedMode,
+      List<Foreach.ForeachEvalClause> evalClauses,
+      String itemName) {
     if (FOREACH_MODE_MULTIVALUE.equals(normalizedMode)) {
       return collectionExpression;
     }
@@ -1378,36 +1479,158 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
         return collectionExpression;
       }
     }
-    return new Function(FOREACH_JSON_ARRAY_FUNCTION, List.of(collectionExpression));
+    if (isJsonArrayFunction(collectionExpression)) {
+      Function jsonArray = (Function) collectionExpression;
+      validateHomogeneousJsonArrayArguments(jsonArray);
+      return new Function(
+          FOREACH_JSON_ARRAY_FUNCTION,
+          List.of(
+              collectionExpression,
+              new Literal(
+                  inferForeachJsonArrayType(collectionExpression, evalClauses, itemName),
+                  DataType.STRING)));
+    }
+    return new Function(
+        FOREACH_JSON_ARRAY_FUNCTION,
+        List.of(
+            collectionExpression,
+            new Literal(
+                inferForeachJsonArrayType(collectionExpression, evalClauses, itemName),
+                DataType.STRING)));
+  }
+
+  private UnresolvedExpression inferAutoCollectionExpression(CalcitePlanContext context) {
+    return context.relBuilder.peek().getRowType().getFieldList().stream()
+        .filter(field -> field.getType() instanceof ArraySqlType)
+        .findFirst()
+        .map(field -> (UnresolvedExpression) new Field(new QualifiedName(field.getName())))
+        .orElseThrow(
+            () ->
+                new SemanticCheckException(
+                    "foreach auto_collections mode requires a multivalue field or JSON array"));
+  }
+
+  private boolean isJsonArrayFunction(UnresolvedExpression expression) {
+    return expression instanceof Function function
+        && BuiltinFunctionName.JSON_ARRAY
+            .getName()
+            .getFunctionName()
+            .equalsIgnoreCase(function.getFuncName());
+  }
+
+  private String inferForeachJsonArrayType(
+      UnresolvedExpression collectionExpression,
+      List<Foreach.ForeachEvalClause> evalClauses,
+      String itemName) {
+    if (isJsonArrayFunction(collectionExpression)) {
+      return jsonArrayTypeFromArguments((Function) collectionExpression)
+          .orElse(FOREACH_JSON_ARRAY_STRING_TYPE);
+    }
+    if (foreachItemUsedInArithmetic(evalClauses, itemName)) {
+      return FOREACH_JSON_ARRAY_NUMERIC_TYPE;
+    }
+    return FOREACH_JSON_ARRAY_STRING_TYPE;
+  }
+
+  private Optional<String> jsonArrayTypeFromArguments(Function jsonArray) {
+    boolean hasNumeric = false;
+    boolean hasString = false;
+    for (UnresolvedExpression argument : jsonArray.getFuncArgs()) {
+      if (argument instanceof Literal literal) {
+        switch (literal.getType()) {
+          case INTEGER, LONG, SHORT, FLOAT, DOUBLE, DECIMAL:
+            hasNumeric = true;
+            break;
+          case STRING:
+            hasString = true;
+            break;
+          case NULL:
+            break;
+          default:
+            return Optional.empty();
+        }
+      } else {
+        return Optional.empty();
+      }
+    }
+    if (hasNumeric && hasString) {
+      throw new SemanticCheckException(
+          "foreach json_array elements must be consistently strings or numbers");
+    }
+    if (hasNumeric) {
+      return Optional.of(FOREACH_JSON_ARRAY_NUMERIC_TYPE);
+    }
+    if (hasString) {
+      return Optional.of(FOREACH_JSON_ARRAY_STRING_TYPE);
+    }
+    return Optional.empty();
+  }
+
+  private void validateHomogeneousJsonArrayArguments(Function jsonArray) {
+    jsonArrayTypeFromArguments(jsonArray);
+  }
+
+  private boolean foreachItemUsedInArithmetic(
+      List<Foreach.ForeachEvalClause> evalClauses, String itemName) {
+    return evalClauses.stream()
+        .anyMatch(clause -> foreachItemUsedInArithmetic(clause.getExpression(), itemName, false));
+  }
+
+  private boolean foreachItemUsedInArithmetic(Node node, String itemName, boolean inArithmetic) {
+    if (node instanceof UnresolvedExpression expression
+        && isForeachItemReference(expression, itemName)) {
+      return inArithmetic;
+    }
+    boolean arithmetic =
+        inArithmetic
+            || (node instanceof UnresolvedExpression expression
+                && isArithmeticExpression(expression));
+    return node.getChild().stream()
+        .anyMatch(child -> foreachItemUsedInArithmetic(child, itemName, arithmetic));
+  }
+
+  private boolean isForeachItemReference(UnresolvedExpression expression, String itemName) {
+    if (expression instanceof ForeachPlaceholder placeholder) {
+      return FOREACH_PLACEHOLDER_ITEM.equalsIgnoreCase(placeholder.getName())
+          || itemName.equalsIgnoreCase(placeholder.getName());
+    }
+    return expression instanceof QualifiedName qualifiedName
+        && (FOREACH_PLACEHOLDER_ITEM.equalsIgnoreCase(qualifiedName.toString())
+            || itemName.equalsIgnoreCase(qualifiedName.toString()));
+  }
+
+  private boolean isArithmeticExpression(UnresolvedExpression expression) {
+    return expression instanceof Function function
+        && Set.of("+", "-", "*", "/", "%").contains(function.getFuncName());
   }
 
   private Map<String, ForeachBinding> buildForeachMultifieldBindings(
       List<String> patterns, String fieldName, Map<String, String> options) {
     Map<String, ForeachBinding> bindings = new HashMap<>();
-    putBinding(bindings, FOREACH_PLACEHOLDER_FIELD, fieldName, ForeachBindingType.FIELD);
-    putBinding(
-        bindings,
-        option(options, FOREACH_OPTION_FIELDSTR, FOREACH_PLACEHOLDER_FIELD),
-        fieldName,
-        ForeachBindingType.FIELD);
+    bindings.put(
+        FOREACH_PLACEHOLDER_FIELD, new ForeachBinding(fieldName, ForeachBindingType.FIELD));
+    bindings.put(
+        options
+            .getOrDefault(FOREACH_OPTION_FIELDSTR, FOREACH_PLACEHOLDER_FIELD)
+            .toUpperCase(Locale.ROOT),
+        new ForeachBinding(fieldName, ForeachBindingType.FIELD));
     for (String pattern : patterns) {
       List<String> segments = wildcardSegments(pattern, fieldName);
       if (segments != null) {
         String matchStr = String.join("", segments);
-        putBinding(bindings, FOREACH_PLACEHOLDER_MATCHSTR, matchStr, ForeachBindingType.LITERAL);
-        putBinding(
-            bindings,
-            option(options, FOREACH_OPTION_MATCHSTR, FOREACH_PLACEHOLDER_MATCHSTR),
-            matchStr,
-            ForeachBindingType.LITERAL);
+        bindings.put(
+            FOREACH_PLACEHOLDER_MATCHSTR, new ForeachBinding(matchStr, ForeachBindingType.LITERAL));
+        bindings.put(
+            options
+                .getOrDefault(FOREACH_OPTION_MATCHSTR, FOREACH_PLACEHOLDER_MATCHSTR)
+                .toUpperCase(Locale.ROOT),
+            new ForeachBinding(matchStr, ForeachBindingType.LITERAL));
         for (int i = 0; i < segments.size(); i++) {
           String key = FOREACH_PLACEHOLDER_MATCHSEG + (i + 1);
-          putBinding(bindings, key, segments.get(i), ForeachBindingType.LITERAL);
-          putBinding(
-              bindings,
-              option(options, FOREACH_OPTION_MATCHSEG + (i + 1), key),
-              segments.get(i),
-              ForeachBindingType.LITERAL);
+          bindings.put(key, new ForeachBinding(segments.get(i), ForeachBindingType.LITERAL));
+          bindings.put(
+              options.getOrDefault(FOREACH_OPTION_MATCHSEG + (i + 1), key).toUpperCase(Locale.ROOT),
+              new ForeachBinding(segments.get(i), ForeachBindingType.LITERAL));
         }
         break;
       }
@@ -1422,9 +1645,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     if (!WildcardUtils.containsWildcard(pattern)) {
       return List.of();
     }
-    java.util.regex.Matcher matcher =
-        java.util.regex.Pattern.compile(WildcardUtils.convertWildcardPatternToRegex(pattern))
-            .matcher(fieldName);
+    Matcher matcher =
+        Pattern.compile(WildcardUtils.convertWildcardPatternToRegex(pattern)).matcher(fieldName);
     if (!matcher.matches()) {
       return null;
     }
@@ -1433,15 +1655,6 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
       segments.add(matcher.group(i));
     }
     return segments;
-  }
-
-  private String option(Map<String, String> options, String name, String defaultValue) {
-    return options.getOrDefault(name, defaultValue);
-  }
-
-  private void putBinding(
-      Map<String, ForeachBinding> bindings, String name, String value, ForeachBindingType type) {
-    bindings.put(name.toUpperCase(Locale.ROOT), new ForeachBinding(value, type));
   }
 
   private String substituteForeachTemplate(String template, Map<String, ForeachBinding> bindings) {

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -38,16 +38,12 @@ import java.util.BitSet;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -101,11 +97,8 @@ import org.opensearch.sql.ast.expression.AllFields;
 import org.opensearch.sql.ast.expression.AllFieldsExcludeMeta;
 import org.opensearch.sql.ast.expression.Argument;
 import org.opensearch.sql.ast.expression.Argument.ArgumentMap;
-import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Field;
-import org.opensearch.sql.ast.expression.ForeachPlaceholder;
 import org.opensearch.sql.ast.expression.Function;
-import org.opensearch.sql.ast.expression.LambdaFunction;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.ParseMethod;
@@ -176,8 +169,6 @@ import org.opensearch.sql.ast.tree.Union;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
 import org.opensearch.sql.ast.tree.Window;
-import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBinding;
-import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBindingType;
 import org.opensearch.sql.calcite.plan.AliasFieldsWrappable;
 import org.opensearch.sql.calcite.plan.HighlightPushDown;
 import org.opensearch.sql.calcite.plan.OpenSearchConstants;
@@ -220,38 +211,18 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   private static final String RIGHT_SIDE_SEQ_COLUMN =
       RIGHT_SIDE_FIELD_PREFIX + "seq" + RIGHT_SIDE_FIELD_SUFFIX;
 
-  private static final String FOREACH_MODE_MULTIFIELD = "multifield";
-  private static final String FOREACH_MODE_MULTIVALUE = "multivalue";
-  private static final String FOREACH_MODE_JSON_ARRAY = "json_array";
-  private static final String FOREACH_MODE_AUTO_COLLECTIONS = "auto_collections";
-  private static final String FOREACH_OPTION_FIELDSTR = "fieldstr";
-  private static final String FOREACH_OPTION_MATCHSTR = "matchstr";
-  private static final String FOREACH_OPTION_MATCHSEG = "matchseg";
-  private static final String FOREACH_OPTION_ITEMSTR = "itemstr";
-  private static final String FOREACH_OPTION_ITERSTR = "iterstr";
-  private static final String FOREACH_PLACEHOLDER_FIELD = "FIELD";
-  private static final String FOREACH_PLACEHOLDER_MATCHSTR = "MATCHSTR";
-  private static final String FOREACH_PLACEHOLDER_MATCHSEG = "MATCHSEG";
-  private static final String FOREACH_PLACEHOLDER_ITEM = "ITEM";
-  private static final String FOREACH_PLACEHOLDER_ITER = "ITER";
-  private static final String FOREACH_TRANSFORM_ITEM = "__foreach_item";
-  private static final String FOREACH_TRANSFORM_ITER = "__foreach_iter";
-  private static final String FOREACH_PAIR = "__foreach_pair";
-  private static final String FOREACH_JSON_ARRAY_FUNCTION = "foreach_json_array";
-  private static final String FOREACH_PAIR_COLLECTION_FUNCTION = "foreach_pair_collection";
-  private static final String FOREACH_JSON_ARRAY_NUMERIC_TYPE = SqlTypeName.DOUBLE.name();
-  private static final String FOREACH_JSON_ARRAY_STRING_TYPE = SqlTypeName.VARCHAR.name();
-
   private final CalciteRexNodeVisitor rexVisitor;
   private final CalciteAggCallVisitor aggVisitor;
   private final DataSourceService dataSourceService;
   private final MapPathPreMaterializer mapPathMaterializer;
+  private final ForeachPlanner foreachPlanner;
 
   public CalciteRelNodeVisitor(DataSourceService dataSourceService) {
     this.rexVisitor = new CalciteRexNodeVisitor(this);
     this.aggVisitor = new CalciteAggCallVisitor(rexVisitor);
     this.dataSourceService = dataSourceService;
     this.mapPathMaterializer = new MapPathPreMaterializer(rexVisitor);
+    this.foreachPlanner = new ForeachPlanner(this, rexVisitor);
   }
 
   public RelNode analyze(UnresolvedPlan unresolved, CalcitePlanContext context) {
@@ -1278,394 +1249,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   @Override
   public RelNode visitForeach(Foreach node, CalcitePlanContext context) {
     visitChildren(node, context);
-    String mode = node.getMode().toLowerCase(Locale.ROOT);
-    switch (mode) {
-      case FOREACH_MODE_MULTIFIELD:
-        return visitForeachMultifield(node, context);
-      case FOREACH_MODE_MULTIVALUE:
-      case FOREACH_MODE_JSON_ARRAY:
-      case FOREACH_MODE_AUTO_COLLECTIONS:
-        return visitForeachCollection(node, context, mode);
-      default:
-        throw new CalciteUnsupportedException(
-            "foreach mode [" + node.getMode() + "] is not supported");
-    }
-  }
-
-  private RelNode visitForeachMultifield(Foreach node, CalcitePlanContext context) {
-    List<String> currentFields = context.relBuilder.peek().getRowType().getFieldNames();
-    LinkedHashSet<String> matchingFields = new LinkedHashSet<>();
-    for (String pattern : node.getFieldPatterns()) {
-      matchingFields.addAll(WildcardUtils.expandWildcardPattern(pattern, currentFields));
-    }
-
-    for (String fieldName : matchingFields) {
-      Map<String, ForeachBinding> bindings =
-          buildForeachMultifieldBindings(node.getFieldPatterns(), fieldName, node.getOptions());
-      context.pushForeachBindings(bindings);
-      try {
-        for (Foreach.ForeachEvalClause clause : node.getEvalClauses()) {
-          RexNode expr = rexVisitor.analyze(clause.getExpression(), context);
-          String alias = substituteForeachTemplate(clause.getTargetTemplate(), bindings);
-          projectPlusOverriding(
-              List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
-        }
-      } finally {
-        context.clearForeachBindings();
-      }
-    }
-    return context.relBuilder.peek();
-  }
-
-  private RelNode visitForeachCollection(
-      Foreach node, CalcitePlanContext context, String normalizedMode) {
-    UnresolvedExpression sourceCollection = node.getCollectionExpression();
-    if (sourceCollection == null && FOREACH_MODE_AUTO_COLLECTIONS.equals(normalizedMode)) {
-      sourceCollection = inferAutoCollectionExpression(context);
-    }
-    if (sourceCollection == null) {
-      throw new SemanticCheckException("foreach " + normalizedMode + " mode requires a field");
-    }
-    if (node.getFieldPatterns().size() > 1) {
-      throw new SemanticCheckException(
-          "foreach " + normalizedMode + " mode accepts exactly one field");
-    }
-    String itemName =
-        node.getOptions().getOrDefault(FOREACH_OPTION_ITEMSTR, FOREACH_PLACEHOLDER_ITEM);
-    String iterName =
-        node.getOptions().getOrDefault(FOREACH_OPTION_ITERSTR, FOREACH_PLACEHOLDER_ITER);
-    UnresolvedExpression collectionExpression =
-        collectionExpressionForMode(
-            sourceCollection, context, normalizedMode, node.getEvalClauses(), itemName);
-    RexNode collectionRex = rexVisitor.analyze(collectionExpression, context);
-    RelDataType itemType = ((ArraySqlType) collectionRex.getType()).getComponentType();
-    List<String> targetAliases =
-        node.getEvalClauses().stream().map(Foreach.ForeachEvalClause::getTargetTemplate).toList();
-    List<ForeachCapturedField> capturedFields =
-        collectForeachCapturedFields(
-            node.getEvalClauses(), context, itemName, iterName, targetAliases);
-    List<UnresolvedExpression> pairArguments = new ArrayList<>();
-    pairArguments.add(collectionExpression);
-    capturedFields.stream()
-        .map(field -> new Field(new QualifiedName(field.name())))
-        .forEach(pairArguments::add);
-    Function pairedCollection = new Function(FOREACH_PAIR_COLLECTION_FUNCTION, pairArguments);
-    Map<String, ForeachBinding> bindings = new HashMap<>();
-    bindings.put(
-        itemName.toUpperCase(Locale.ROOT),
-        newForeachPairBinding(FOREACH_PAIR, ForeachBindingType.PAIR_ITEM, 0, itemType));
-    bindings.put(
-        FOREACH_PLACEHOLDER_ITEM,
-        newForeachPairBinding(FOREACH_PAIR, ForeachBindingType.PAIR_ITEM, 0, itemType));
-    bindings.put(
-        iterName.toUpperCase(Locale.ROOT),
-        newForeachPairBinding(
-            FOREACH_PAIR,
-            ForeachBindingType.PAIR_ITER,
-            1,
-            context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER)));
-    bindings.put(
-        FOREACH_PLACEHOLDER_ITER,
-        newForeachPairBinding(
-            FOREACH_PAIR,
-            ForeachBindingType.PAIR_ITER,
-            1,
-            context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER)));
-    for (int i = 0; i < capturedFields.size(); i++) {
-      ForeachCapturedField field = capturedFields.get(i);
-      bindings.put(
-          field.name().toUpperCase(Locale.ROOT),
-          newForeachPairBinding(FOREACH_PAIR, ForeachBindingType.PAIR_EXTRA, i + 2, field.type()));
-    }
-
-    context.pushForeachBindings(bindings);
-    try {
-      for (Foreach.ForeachEvalClause clause : node.getEvalClauses()) {
-        String alias = substituteForeachTemplate(clause.getTargetTemplate(), bindings);
-        Function reduce =
-            new Function(
-                BuiltinFunctionName.REDUCE.getName().getFunctionName(),
-                List.of(
-                    pairedCollection,
-                    new Field(new QualifiedName(alias)),
-                    new LambdaFunction(
-                        clause.getExpression(),
-                        List.of(new QualifiedName(alias), new QualifiedName(FOREACH_PAIR)))));
-        RexNode expr = rexVisitor.analyze(reduce, context);
-        projectPlusOverriding(
-            List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
-      }
-    } finally {
-      context.clearForeachBindings();
-    }
-    return context.relBuilder.peek();
-  }
-
-  private List<ForeachCapturedField> collectForeachCapturedFields(
-      List<Foreach.ForeachEvalClause> evalClauses,
-      CalcitePlanContext context,
-      String itemName,
-      String iterName,
-      List<String> targetAliases) {
-    Set<String> excluded =
-        Stream.concat(
-                Stream.of(
-                    itemName,
-                    iterName,
-                    FOREACH_PLACEHOLDER_ITEM,
-                    FOREACH_PLACEHOLDER_ITER,
-                    FOREACH_PAIR),
-                targetAliases.stream())
-            .map(name -> name.toUpperCase(Locale.ROOT))
-            .collect(Collectors.toSet());
-    Map<String, RelDataType> rowTypes =
-        context.relBuilder.peek().getRowType().getFieldList().stream()
-            .collect(
-                Collectors.toMap(
-                    field -> field.getName().toUpperCase(Locale.ROOT),
-                    RelDataTypeField::getType,
-                    (left, right) -> left,
-                    LinkedHashMap::new));
-    Map<String, ForeachCapturedField> fields = new LinkedHashMap<>();
-    evalClauses.forEach(
-        clause -> collectForeachCapturedFields(clause.getExpression(), excluded, rowTypes, fields));
-    return new ArrayList<>(fields.values());
-  }
-
-  private void collectForeachCapturedFields(
-      Node node,
-      Set<String> excluded,
-      Map<String, RelDataType> rowTypes,
-      Map<String, ForeachCapturedField> fields) {
-    if (node instanceof QualifiedName qualifiedName) {
-      String key = qualifiedName.toString().toUpperCase(Locale.ROOT);
-      RelDataType type = rowTypes.get(key);
-      if (type != null && !excluded.contains(key)) {
-        fields.putIfAbsent(key, new ForeachCapturedField(qualifiedName.toString(), type));
-      }
-    }
-    node.getChild()
-        .forEach(child -> collectForeachCapturedFields(child, excluded, rowTypes, fields));
-  }
-
-  private ForeachBinding newForeachPairBinding(
-      String pairName, ForeachBindingType type, int index, RelDataType relDataType) {
-    return new ForeachBinding(
-        pairName, type, index, relDataType.getSqlTypeName().name(), componentTypeName(relDataType));
-  }
-
-  @Nullable
-  private String componentTypeName(RelDataType relDataType) {
-    if (relDataType instanceof ArraySqlType arrayType) {
-      return arrayType.getComponentType().getSqlTypeName().name();
-    }
-    return null;
-  }
-
-  private record ForeachCapturedField(String name, RelDataType type) {}
-
-  private UnresolvedExpression collectionExpressionForMode(
-      UnresolvedExpression collectionExpression,
-      CalcitePlanContext context,
-      String normalizedMode,
-      List<Foreach.ForeachEvalClause> evalClauses,
-      String itemName) {
-    if (FOREACH_MODE_MULTIVALUE.equals(normalizedMode)) {
-      return collectionExpression;
-    }
-    if (FOREACH_MODE_AUTO_COLLECTIONS.equals(normalizedMode)) {
-      RexNode rexNode = rexVisitor.analyze(collectionExpression, context);
-      if (rexNode.getType() instanceof ArraySqlType) {
-        return collectionExpression;
-      }
-    }
-    if (isJsonArrayFunction(collectionExpression)) {
-      Function jsonArray = (Function) collectionExpression;
-      validateHomogeneousJsonArrayArguments(jsonArray);
-      return new Function(
-          FOREACH_JSON_ARRAY_FUNCTION,
-          List.of(
-              collectionExpression,
-              new Literal(
-                  inferForeachJsonArrayType(collectionExpression, evalClauses, itemName),
-                  DataType.STRING)));
-    }
-    return new Function(
-        FOREACH_JSON_ARRAY_FUNCTION,
-        List.of(
-            collectionExpression,
-            new Literal(
-                inferForeachJsonArrayType(collectionExpression, evalClauses, itemName),
-                DataType.STRING)));
-  }
-
-  private UnresolvedExpression inferAutoCollectionExpression(CalcitePlanContext context) {
-    return context.relBuilder.peek().getRowType().getFieldList().stream()
-        .filter(field -> field.getType() instanceof ArraySqlType)
-        .findFirst()
-        .map(field -> (UnresolvedExpression) new Field(new QualifiedName(field.getName())))
-        .orElseThrow(
-            () ->
-                new SemanticCheckException(
-                    "foreach auto_collections mode requires a multivalue field or JSON array"));
-  }
-
-  private boolean isJsonArrayFunction(UnresolvedExpression expression) {
-    return expression instanceof Function function
-        && BuiltinFunctionName.JSON_ARRAY
-            .getName()
-            .getFunctionName()
-            .equalsIgnoreCase(function.getFuncName());
-  }
-
-  private String inferForeachJsonArrayType(
-      UnresolvedExpression collectionExpression,
-      List<Foreach.ForeachEvalClause> evalClauses,
-      String itemName) {
-    if (isJsonArrayFunction(collectionExpression)) {
-      return jsonArrayTypeFromArguments((Function) collectionExpression)
-          .orElse(FOREACH_JSON_ARRAY_STRING_TYPE);
-    }
-    if (foreachItemUsedInArithmetic(evalClauses, itemName)) {
-      return FOREACH_JSON_ARRAY_NUMERIC_TYPE;
-    }
-    return FOREACH_JSON_ARRAY_STRING_TYPE;
-  }
-
-  private Optional<String> jsonArrayTypeFromArguments(Function jsonArray) {
-    boolean hasNumeric = false;
-    boolean hasString = false;
-    for (UnresolvedExpression argument : jsonArray.getFuncArgs()) {
-      if (argument instanceof Literal literal) {
-        switch (literal.getType()) {
-          case INTEGER, LONG, SHORT, FLOAT, DOUBLE, DECIMAL:
-            hasNumeric = true;
-            break;
-          case STRING:
-            hasString = true;
-            break;
-          case NULL:
-            break;
-          default:
-            return Optional.empty();
-        }
-      } else {
-        return Optional.empty();
-      }
-    }
-    if (hasNumeric && hasString) {
-      throw new SemanticCheckException(
-          "foreach json_array elements must be consistently strings or numbers");
-    }
-    if (hasNumeric) {
-      return Optional.of(FOREACH_JSON_ARRAY_NUMERIC_TYPE);
-    }
-    if (hasString) {
-      return Optional.of(FOREACH_JSON_ARRAY_STRING_TYPE);
-    }
-    return Optional.empty();
-  }
-
-  private void validateHomogeneousJsonArrayArguments(Function jsonArray) {
-    jsonArrayTypeFromArguments(jsonArray);
-  }
-
-  private boolean foreachItemUsedInArithmetic(
-      List<Foreach.ForeachEvalClause> evalClauses, String itemName) {
-    return evalClauses.stream()
-        .anyMatch(clause -> foreachItemUsedInArithmetic(clause.getExpression(), itemName, false));
-  }
-
-  private boolean foreachItemUsedInArithmetic(Node node, String itemName, boolean inArithmetic) {
-    if (node instanceof UnresolvedExpression expression
-        && isForeachItemReference(expression, itemName)) {
-      return inArithmetic;
-    }
-    boolean arithmetic =
-        inArithmetic
-            || (node instanceof UnresolvedExpression expression
-                && isArithmeticExpression(expression));
-    return node.getChild().stream()
-        .anyMatch(child -> foreachItemUsedInArithmetic(child, itemName, arithmetic));
-  }
-
-  private boolean isForeachItemReference(UnresolvedExpression expression, String itemName) {
-    if (expression instanceof ForeachPlaceholder placeholder) {
-      return FOREACH_PLACEHOLDER_ITEM.equalsIgnoreCase(placeholder.getName())
-          || itemName.equalsIgnoreCase(placeholder.getName());
-    }
-    return expression instanceof QualifiedName qualifiedName
-        && (FOREACH_PLACEHOLDER_ITEM.equalsIgnoreCase(qualifiedName.toString())
-            || itemName.equalsIgnoreCase(qualifiedName.toString()));
-  }
-
-  private boolean isArithmeticExpression(UnresolvedExpression expression) {
-    return expression instanceof Function function
-        && Set.of("+", "-", "*", "/", "%").contains(function.getFuncName());
-  }
-
-  private Map<String, ForeachBinding> buildForeachMultifieldBindings(
-      List<String> patterns, String fieldName, Map<String, String> options) {
-    Map<String, ForeachBinding> bindings = new HashMap<>();
-    bindings.put(
-        FOREACH_PLACEHOLDER_FIELD, new ForeachBinding(fieldName, ForeachBindingType.FIELD));
-    bindings.put(
-        options
-            .getOrDefault(FOREACH_OPTION_FIELDSTR, FOREACH_PLACEHOLDER_FIELD)
-            .toUpperCase(Locale.ROOT),
-        new ForeachBinding(fieldName, ForeachBindingType.FIELD));
-    for (String pattern : patterns) {
-      List<String> segments = wildcardSegments(pattern, fieldName);
-      if (segments != null) {
-        String matchStr = String.join("", segments);
-        bindings.put(
-            FOREACH_PLACEHOLDER_MATCHSTR, new ForeachBinding(matchStr, ForeachBindingType.LITERAL));
-        bindings.put(
-            options
-                .getOrDefault(FOREACH_OPTION_MATCHSTR, FOREACH_PLACEHOLDER_MATCHSTR)
-                .toUpperCase(Locale.ROOT),
-            new ForeachBinding(matchStr, ForeachBindingType.LITERAL));
-        for (int i = 0; i < segments.size(); i++) {
-          String key = FOREACH_PLACEHOLDER_MATCHSEG + (i + 1);
-          bindings.put(key, new ForeachBinding(segments.get(i), ForeachBindingType.LITERAL));
-          bindings.put(
-              options.getOrDefault(FOREACH_OPTION_MATCHSEG + (i + 1), key).toUpperCase(Locale.ROOT),
-              new ForeachBinding(segments.get(i), ForeachBindingType.LITERAL));
-        }
-        break;
-      }
-    }
-    return bindings;
-  }
-
-  private List<String> wildcardSegments(String pattern, String fieldName) {
-    if (!WildcardUtils.matchesWildcardPattern(pattern, fieldName)) {
-      return null;
-    }
-    if (!WildcardUtils.containsWildcard(pattern)) {
-      return List.of();
-    }
-    Matcher matcher =
-        Pattern.compile(WildcardUtils.convertWildcardPatternToRegex(pattern)).matcher(fieldName);
-    if (!matcher.matches()) {
-      return null;
-    }
-    List<String> segments = new ArrayList<>();
-    for (int i = 1; i <= matcher.groupCount(); i++) {
-      segments.add(matcher.group(i));
-    }
-    return segments;
-  }
-
-  private String substituteForeachTemplate(String template, Map<String, ForeachBinding> bindings) {
-    String result = template;
-    for (Map.Entry<String, ForeachBinding> entry : bindings.entrySet()) {
-      result =
-          result.replaceAll(
-              "(?i)<<" + java.util.regex.Pattern.quote(entry.getKey()) + ">>",
-              java.util.regex.Matcher.quoteReplacement(entry.getValue().value()));
-    }
-    return result;
+    return foreachPlanner.plan(node, context);
   }
 
   @Override
@@ -1799,7 +1383,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     return context.relBuilder.peek();
   }
 
-  private void projectPlusOverriding(
+  void projectPlusOverriding(
       List<RexNode> newFields, List<String> newNames, CalcitePlanContext context) {
     Set<String> originalFieldNameSet =
         new HashSet<>(context.relBuilder.peek().getRowType().getFieldNames());

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -53,6 +53,7 @@ import org.opensearch.sql.ast.expression.Case;
 import org.opensearch.sql.ast.expression.Cast;
 import org.opensearch.sql.ast.expression.Compare;
 import org.opensearch.sql.ast.expression.EqualTo;
+import org.opensearch.sql.ast.expression.ForeachPlaceholder;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.HighlightFunction;
 import org.opensearch.sql.ast.expression.In;
@@ -400,6 +401,19 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   @Override
   public RexNode visitQualifiedName(QualifiedName node, CalcitePlanContext context) {
     return QualifiedNameResolver.resolve(node, context);
+  }
+
+  @Override
+  public RexNode visitForeachPlaceholder(ForeachPlaceholder node, CalcitePlanContext context) {
+    String name = node.getName().toUpperCase(Locale.ROOT);
+    String value = context.getForeachBindings().get(name);
+    if (value == null) {
+      throw new SemanticCheckException("Unresolved foreach placeholder <<" + node.getName() + ">>");
+    }
+    if ("FIELD".equals(name)) {
+      return context.relBuilder.field(value);
+    }
+    return context.rexBuilder.makeLiteral(value);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -433,9 +433,10 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
         }
         return lambdaRef;
       case PAIR_ITEM:
-        return foreachPairItem(binding.value(), 0, name, context);
+      case PAIR_EXTRA:
+        return foreachPairItem(binding, name, context);
       case PAIR_ITER:
-        return foreachPairItem(binding.value(), 1, name, context);
+        return foreachPairItem(binding, name, context);
       case LITERAL:
       default:
         return context.rexBuilder.makeLiteral(binding.value());
@@ -443,16 +444,21 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   }
 
   private RexNode foreachPairItem(
-      String pairName, int index, String placeholderName, CalcitePlanContext context) {
-    RexLambdaRef pair = context.getRexLambdaRefMap().get(pairName);
+      ForeachBinding binding, String placeholderName, CalcitePlanContext context) {
+    RexLambdaRef pair = context.getRexLambdaRefMap().get(binding.value());
     if (pair == null) {
       throw new SemanticCheckException("Unresolved foreach lambda placeholder " + placeholderName);
     }
     return PPLFuncImpTable.INSTANCE.resolve(
         context.rexBuilder,
-        BuiltinFunctionName.MVINDEX,
+        BuiltinFunctionName.FOREACH_PAIR_ITEM,
         pair,
-        context.rexBuilder.makeExactLiteral(BigDecimal.valueOf(index)));
+        context.rexBuilder.makeExactLiteral(BigDecimal.valueOf(binding.pairIndex())),
+        context.rexBuilder.makeLiteral(binding.typeName()),
+        binding.componentTypeName() == null
+            ? context.rexBuilder.makeNullLiteral(
+                context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.NULL))
+            : context.rexBuilder.makeLiteral(binding.componentTypeName()));
   }
 
   @Override
@@ -631,7 +637,8 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
 
     List<RexNode> capturedVars = null;
     try {
-      for (UnresolvedExpression arg : args) {
+      for (int argIndex = 0; argIndex < args.size(); argIndex++) {
+        UnresolvedExpression arg = args.get(argIndex);
         if (arg instanceof LambdaFunction) {
           CalcitePlanContext lambdaContext =
               prepareLambdaContext(
@@ -650,6 +657,14 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
           arguments.add(lambdaNode);
           // Capture any external variables that were referenced in the lambda
           capturedVars = lambdaContext.getCapturedVariables();
+        } else if (node.getFuncName().equalsIgnoreCase("reduce") && argIndex == 0) {
+          Map<String, ForeachBinding> foreachBindings = new HashMap<>(context.getForeachBindings());
+          context.clearForeachBindings();
+          try {
+            arguments.add(analyze(arg, context));
+          } finally {
+            context.pushForeachBindings(foreachBindings);
+          }
         } else {
           arguments.add(analyze(arg, context));
         }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -94,6 +94,7 @@ import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
 import org.opensearch.sql.expression.function.CoercionUtils;
+import org.opensearch.sql.expression.function.PPLBuiltinOperators;
 import org.opensearch.sql.expression.function.PPLFuncImpTable;
 
 @RequiredArgsConstructor
@@ -426,39 +427,24 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
     switch (binding.type()) {
       case FIELD:
         return context.relBuilder.field(binding.value());
-      case LAMBDA:
-        RexLambdaRef lambdaRef = context.getRexLambdaRefMap().get(binding.value());
-        if (lambdaRef == null) {
+      case PAIR_SLOT:
+        RexLambdaRef pair = context.getRexLambdaRefMap().get(binding.value());
+        if (pair == null) {
           throw new SemanticCheckException("Unresolved foreach lambda placeholder " + name);
         }
-        return lambdaRef;
-      case PAIR_ITEM:
-      case PAIR_EXTRA:
-        return foreachPairItem(binding, name, context);
-      case PAIR_ITER:
-        return foreachPairItem(binding, name, context);
+        // The slot's type is known at plan time but the extraction UDF infers ANY, so build the
+        // call with the type set explicitly. LambdaUtils' re-inference preserves it (a CAST would
+        // not survive the enumerable backend for complex types like arrays).
+        return context.rexBuilder.makeCall(
+            binding.pairType(),
+            PPLBuiltinOperators.FOREACH_PAIR_ITEM,
+            List.of(
+                pair,
+                context.rexBuilder.makeExactLiteral(BigDecimal.valueOf(binding.pairIndex()))));
       case LITERAL:
       default:
         return context.rexBuilder.makeLiteral(binding.value());
     }
-  }
-
-  private RexNode foreachPairItem(
-      ForeachBinding binding, String placeholderName, CalcitePlanContext context) {
-    RexLambdaRef pair = context.getRexLambdaRefMap().get(binding.value());
-    if (pair == null) {
-      throw new SemanticCheckException("Unresolved foreach lambda placeholder " + placeholderName);
-    }
-    return PPLFuncImpTable.INSTANCE.resolve(
-        context.rexBuilder,
-        BuiltinFunctionName.FOREACH_PAIR_ITEM,
-        pair,
-        context.rexBuilder.makeExactLiteral(BigDecimal.valueOf(binding.pairIndex())),
-        context.rexBuilder.makeLiteral(binding.typeName()),
-        binding.componentTypeName() == null
-            ? context.rexBuilder.makeNullLiteral(
-                context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.NULL))
-            : context.rexBuilder.makeLiteral(binding.componentTypeName()));
   }
 
   @Override
@@ -637,8 +623,7 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
 
     List<RexNode> capturedVars = null;
     try {
-      for (int argIndex = 0; argIndex < args.size(); argIndex++) {
-        UnresolvedExpression arg = args.get(argIndex);
+      for (UnresolvedExpression arg : args) {
         if (arg instanceof LambdaFunction) {
           CalcitePlanContext lambdaContext =
               prepareLambdaContext(
@@ -657,14 +642,6 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
           arguments.add(lambdaNode);
           // Capture any external variables that were referenced in the lambda
           capturedVars = lambdaContext.getCapturedVariables();
-        } else if (node.getFuncName().equalsIgnoreCase("reduce") && argIndex == 0) {
-          Map<String, ForeachBinding> foreachBindings = new HashMap<>(context.getForeachBindings());
-          context.clearForeachBindings();
-          try {
-            arguments.add(analyze(arg, context));
-          } finally {
-            context.pushForeachBindings(foreachBindings);
-          }
         } else {
           arguments.add(analyze(arg, context));
         }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
@@ -81,6 +83,7 @@ import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.Sort.SortOrder;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBinding;
+import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBindingType;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit.SystemLimitType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
@@ -99,6 +102,8 @@ import org.opensearch.sql.expression.function.PPLFuncImpTable;
 
 @RequiredArgsConstructor
 public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalcitePlanContext> {
+  private static final Pattern FOREACH_TEMPLATE = Pattern.compile("<<([A-Za-z0-9_]+)>>");
+
   private final CalciteRelNodeVisitor planVisitor;
 
   public RexNode analyze(UnresolvedExpression unresolved, CalcitePlanContext context) {
@@ -137,6 +142,10 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
       case NULL:
         return rexBuilder.makeNullLiteral(typeFactory.createSqlType(SqlTypeName.NULL));
       case STRING:
+        RexNode foreachTemplate = foreachTemplateLiteral(value.toString(), context);
+        if (foreachTemplate != null) {
+          return foreachTemplate;
+        }
         if (value.toString().length() == 1) {
           // To align Spark/PostgreSQL, Char(1) is useful, such as cast('1' to boolean) should
           // return true
@@ -402,7 +411,13 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   /** Resolve qualified name. Note, the name should be case-sensitive. */
   @Override
   public RexNode visitQualifiedName(QualifiedName node, CalcitePlanContext context) {
-    ForeachBinding binding = foreachBinding(node.toString(), context);
+    String name = node.toString();
+    RexNode computed = context.getForeachComputedBindings().get(name.toUpperCase(Locale.ROOT));
+    if (computed != null) {
+      return computed;
+    }
+    ForeachBinding binding =
+        context.getForeachIdentifierBindings().get(name.toUpperCase(Locale.ROOT));
     if (binding != null) {
       return foreachBindingToRexNode(node.toString(), binding, context);
     }
@@ -422,6 +437,47 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
     return context.getForeachBindings().get(name.toUpperCase(Locale.ROOT));
   }
 
+  private RexNode foreachTemplateLiteral(String value, CalcitePlanContext context) {
+    Matcher matcher = FOREACH_TEMPLATE.matcher(value);
+    List<RexNode> parts = new ArrayList<>();
+    int start = 0;
+    boolean replaced = false;
+    while (matcher.find()) {
+      ForeachBinding binding = foreachBinding(matcher.group(1), context);
+      if (binding == null) {
+        continue;
+      }
+      if (matcher.start() > start) {
+        parts.add(context.rexBuilder.makeLiteral(value.substring(start, matcher.start())));
+      }
+      if (binding.type() == ForeachBindingType.PAIR_SLOT) {
+        RelDataType varchar =
+            context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR);
+        parts.add(
+            context.rexBuilder.makeCast(
+                varchar, foreachBindingToRexNode(matcher.group(1), binding, context), true, true));
+      } else {
+        parts.add(context.rexBuilder.makeLiteral(binding.value()));
+      }
+      start = matcher.end();
+      replaced = true;
+    }
+    if (!replaced) {
+      return null;
+    }
+    if (start < value.length()) {
+      parts.add(context.rexBuilder.makeLiteral(value.substring(start)));
+    }
+    if (parts.isEmpty()) {
+      return context.rexBuilder.makeLiteral("");
+    }
+    RexNode result = parts.getFirst();
+    for (int i = 1; i < parts.size(); i++) {
+      result = context.rexBuilder.makeCall(SqlStdOperatorTable.CONCAT, result, parts.get(i));
+    }
+    return result;
+  }
+
   private RexNode foreachBindingToRexNode(
       String name, ForeachBinding binding, CalcitePlanContext context) {
     switch (binding.type()) {
@@ -432,9 +488,9 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
         if (pair == null) {
           throw new SemanticCheckException("Unresolved foreach lambda placeholder " + name);
         }
-        // The slot's type is known at plan time but the extraction UDF infers ANY, so build the
-        // call with the type set explicitly. LambdaUtils' re-inference preserves it (a CAST would
-        // not survive the enumerable backend for complex types like arrays).
+        // The slot's type is known at plan time, so assign it directly to the opaque extraction
+        // call. LambdaUtils' re-inference preserves it (a CAST would not survive the enumerable
+        // backend for complex types like arrays).
         return context.rexBuilder.makeCall(
             binding.pairType(),
             PPLBuiltinOperators.FOREACH_PAIR_ITEM,

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -80,6 +80,7 @@ import org.opensearch.sql.ast.expression.subquery.SubqueryExpression;
 import org.opensearch.sql.ast.tree.Sort.SortOption;
 import org.opensearch.sql.ast.tree.Sort.SortOrder;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
+import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBinding;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit.SystemLimitType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
@@ -400,20 +401,58 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   /** Resolve qualified name. Note, the name should be case-sensitive. */
   @Override
   public RexNode visitQualifiedName(QualifiedName node, CalcitePlanContext context) {
+    ForeachBinding binding = foreachBinding(node.toString(), context);
+    if (binding != null) {
+      return foreachBindingToRexNode(node.toString(), binding, context);
+    }
     return QualifiedNameResolver.resolve(node, context);
   }
 
   @Override
   public RexNode visitForeachPlaceholder(ForeachPlaceholder node, CalcitePlanContext context) {
-    String name = node.getName().toUpperCase(Locale.ROOT);
-    String value = context.getForeachBindings().get(name);
-    if (value == null) {
+    ForeachBinding binding = foreachBinding(node.getName(), context);
+    if (binding == null) {
       throw new SemanticCheckException("Unresolved foreach placeholder <<" + node.getName() + ">>");
     }
-    if ("FIELD".equals(name)) {
-      return context.relBuilder.field(value);
+    return foreachBindingToRexNode(node.getName(), binding, context);
+  }
+
+  private ForeachBinding foreachBinding(String name, CalcitePlanContext context) {
+    return context.getForeachBindings().get(name.toUpperCase(Locale.ROOT));
+  }
+
+  private RexNode foreachBindingToRexNode(
+      String name, ForeachBinding binding, CalcitePlanContext context) {
+    switch (binding.type()) {
+      case FIELD:
+        return context.relBuilder.field(binding.value());
+      case LAMBDA:
+        RexLambdaRef lambdaRef = context.getRexLambdaRefMap().get(binding.value());
+        if (lambdaRef == null) {
+          throw new SemanticCheckException("Unresolved foreach lambda placeholder " + name);
+        }
+        return lambdaRef;
+      case PAIR_ITEM:
+        return foreachPairItem(binding.value(), 0, name, context);
+      case PAIR_ITER:
+        return foreachPairItem(binding.value(), 1, name, context);
+      case LITERAL:
+      default:
+        return context.rexBuilder.makeLiteral(binding.value());
     }
-    return context.rexBuilder.makeLiteral(value);
+  }
+
+  private RexNode foreachPairItem(
+      String pairName, int index, String placeholderName, CalcitePlanContext context) {
+    RexLambdaRef pair = context.getRexLambdaRefMap().get(pairName);
+    if (pair == null) {
+      throw new SemanticCheckException("Unresolved foreach lambda placeholder " + placeholderName);
+    }
+    return PPLFuncImpTable.INSTANCE.resolve(
+        context.rexBuilder,
+        BuiltinFunctionName.MVINDEX,
+        pair,
+        context.rexBuilder.makeExactLiteral(BigDecimal.valueOf(index)));
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/ForeachPlanner.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ForeachPlanner.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.ForeachPlaceholder;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.LambdaFunction;
 import org.opensearch.sql.ast.expression.Literal;
@@ -70,6 +71,8 @@ class ForeachPlanner {
 
   /** Name of the lambda variable holding the internal pair inside generated reduce calls. */
   private static final String PAIR_VAR = "__foreach_pair";
+
+  private static final Set<String> ARITHMETIC_OPERATORS = Set.of("+", "-", "*", "/", "%");
 
   private final CalciteRelNodeVisitor relVisitor;
   private final CalciteRexNodeVisitor rexVisitor;
@@ -177,16 +180,15 @@ class ForeachPlanner {
     if (collection == null) {
       throw new SemanticCheckException("foreach " + mode + " mode requires a field");
     }
-    collection = asArrayExpression(collection, mode, context);
+    String itemName = node.getOptions().getOrDefault(OPTION_ITEMSTR, PLACEHOLDER_ITEM);
+    String iterName = node.getOptions().getOrDefault(OPTION_ITERSTR, PLACEHOLDER_ITER);
+    collection = asArrayExpression(collection, mode, context, node.getEvalClauses(), itemName);
     RexNode collectionRex = rexVisitor.analyze(collection, context);
     if (!(collectionRex.getType() instanceof ArraySqlType arrayType)) {
       throw new SemanticCheckException("foreach " + mode + " mode requires a multivalue field");
     }
     RelDataType itemType = arrayType.getComponentType();
     RelDataType iterType = context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER);
-
-    String itemName = node.getOptions().getOrDefault(OPTION_ITEMSTR, PLACEHOLDER_ITEM);
-    String iterName = node.getOptions().getOrDefault(OPTION_ITERSTR, PLACEHOLDER_ITER);
     List<String> targetAliases =
         node.getEvalClauses().stream().map(ForeachEvalClause::getTargetTemplate).toList();
     List<RelDataTypeField> capturedFields =
@@ -260,7 +262,11 @@ class ForeachPlanner {
    * parses the JSON and casts every element to one inferred type.
    */
   private UnresolvedExpression asArrayExpression(
-      UnresolvedExpression collection, Foreach.Mode mode, CalcitePlanContext context) {
+      UnresolvedExpression collection,
+      Foreach.Mode mode,
+      CalcitePlanContext context,
+      List<ForeachEvalClause> evalClauses,
+      String itemName) {
     if (mode == Foreach.Mode.MULTIVALUE
         || (mode == Foreach.Mode.AUTO_COLLECTIONS
             && rexVisitor.analyze(collection, context).getType() instanceof ArraySqlType)) {
@@ -269,16 +275,27 @@ class ForeachPlanner {
     return new Function(
         BuiltinFunctionName.FOREACH_JSON_ARRAY.getName().getFunctionName(),
         List.of(
-            collection, new Literal(jsonElementType(collection, context).name(), DataType.STRING)));
+            collection,
+            new Literal(
+                jsonElementType(collection, context, evalClauses, itemName).name(),
+                DataType.STRING)));
   }
 
   /**
    * Infers the element type a JSON array collection should be read as. JSON only distinguishes
    * numbers and strings here, so the answer is DOUBLE (gson parses JSON numbers as doubles) or
-   * VARCHAR. Mixed content is rejected; expressions whose content is unknowable at plan time (e.g.
-   * a field holding a JSON string) default to VARCHAR.
+   * VARCHAR.
+   *
+   * <p>For {@code json_array()} calls and string literals the content is visible at plan time;
+   * mixed content is rejected. For opaque expressions — typically a field holding JSON text, the
+   * primary Splunk use of json_array mode — content is unknowable, so infer from usage: an item
+   * placeholder consumed by arithmetic means numeric elements, anything else means strings.
    */
-  private SqlTypeName jsonElementType(UnresolvedExpression collection, CalcitePlanContext context) {
+  private SqlTypeName jsonElementType(
+      UnresolvedExpression collection,
+      CalcitePlanContext context,
+      List<ForeachEvalClause> evalClauses,
+      String itemName) {
     if (collection instanceof Function function
         && BuiltinFunctionName.JSON_ARRAY
             .getName()
@@ -303,8 +320,38 @@ class ForeachPlanner {
       } catch (JsonSyntaxException ignored) {
         // Malformed JSON literals return null at runtime; type choice is irrelevant.
       }
+      return SqlTypeName.VARCHAR;
     }
-    return SqlTypeName.VARCHAR;
+    return itemUsedInArithmetic(evalClauses, itemName) ? SqlTypeName.DOUBLE : SqlTypeName.VARCHAR;
+  }
+
+  private boolean itemUsedInArithmetic(List<ForeachEvalClause> evalClauses, String itemName) {
+    return evalClauses.stream()
+        .anyMatch(clause -> itemUsedInArithmetic(clause.getExpression(), itemName, false));
+  }
+
+  private boolean itemUsedInArithmetic(Node node, String itemName, boolean inArithmetic) {
+    if (isItemReference(node, itemName)) {
+      return inArithmetic;
+    }
+    boolean arithmetic =
+        inArithmetic
+            || (node instanceof Function function
+                && ARITHMETIC_OPERATORS.contains(function.getFuncName()));
+    return node.getChild().stream()
+        .anyMatch(child -> itemUsedInArithmetic(child, itemName, arithmetic));
+  }
+
+  private boolean isItemReference(Node node, String itemName) {
+    String name;
+    if (node instanceof ForeachPlaceholder placeholder) {
+      name = placeholder.getName();
+    } else if (node instanceof QualifiedName qualifiedName) {
+      name = qualifiedName.toString();
+    } else {
+      return false;
+    }
+    return PLACEHOLDER_ITEM.equalsIgnoreCase(name) || itemName.equalsIgnoreCase(name);
   }
 
   private SqlTypeName elementTypeOf(Set<?> families) {

--- a/core/src/main/java/org/opensearch/sql/calcite/ForeachPlanner.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ForeachPlanner.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.calcite;
 import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.gson;
 
 import com.google.gson.JsonSyntaxException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -28,6 +29,7 @@ import org.apache.calcite.sql.type.ArraySqlType;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.expression.Compare;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.ForeachPlaceholder;
@@ -43,6 +45,8 @@ import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBindingType;
 import org.opensearch.sql.calcite.utils.WildcardUtils;
 import org.opensearch.sql.exception.SemanticCheckException;
 import org.opensearch.sql.expression.function.BuiltinFunctionName;
+import org.opensearch.sql.expression.function.PPLBuiltinOperators;
+import org.opensearch.sql.expression.function.PPLFuncImpTable;
 
 /**
  * Plans the PPL {@code foreach} command.
@@ -72,6 +76,8 @@ class ForeachPlanner {
   /** Name of the lambda variable holding the internal pair inside generated reduce calls. */
   private static final String PAIR_VAR = "__foreach_pair";
 
+  private static final String STATE_VAR = "__foreach_state";
+
   private static final Set<String> ARITHMETIC_OPERATORS = Set.of("+", "-", "*", "/", "%");
 
   private final CalciteRelNodeVisitor relVisitor;
@@ -98,13 +104,13 @@ class ForeachPlanner {
     }
 
     for (String fieldName : matchingFields) {
-      Map<String, ForeachBinding> bindings =
+      ForeachBindings bindings =
           multifieldBindings(node.getFieldPatterns(), fieldName, node.getOptions());
-      context.pushForeachBindings(bindings);
+      context.pushForeachBindings(bindings.values(), bindings.identifiers());
       try {
         for (ForeachEvalClause clause : node.getEvalClauses()) {
           RexNode expr = rexVisitor.analyze(clause.getExpression(), context);
-          String alias = substituteTemplate(clause.getTargetTemplate(), bindings);
+          String alias = substituteTemplate(clause.getTargetTemplate(), bindings.values());
           relVisitor.projectPlusOverriding(
               List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
         }
@@ -115,35 +121,49 @@ class ForeachPlanner {
     return context.relBuilder.peek();
   }
 
-  private Map<String, ForeachBinding> multifieldBindings(
+  private ForeachBindings multifieldBindings(
       List<String> patterns, String fieldName, Map<String, String> options) {
     Map<String, ForeachBinding> bindings = new LinkedHashMap<>();
-    bind(
+    Map<String, ForeachBinding> identifiers = new LinkedHashMap<>();
+    bindOption(
         bindings,
+        identifiers,
         new ForeachBinding(fieldName, ForeachBindingType.FIELD),
         PLACEHOLDER_FIELD,
-        options.getOrDefault(OPTION_FIELDSTR, PLACEHOLDER_FIELD));
-    for (String pattern : patterns) {
+        OPTION_FIELDSTR,
+        options);
+    List<String> orderedPatterns =
+        Stream.concat(
+                patterns.stream()
+                    .filter(pattern -> !WildcardUtils.containsWildcard(pattern))
+                    .filter(pattern -> WildcardUtils.matchesWildcardPattern(pattern, fieldName)),
+                patterns.stream().filter(WildcardUtils::containsWildcard))
+            .toList();
+    for (String pattern : orderedPatterns) {
       List<String> segments = wildcardSegments(pattern, fieldName);
       if (segments == null) {
         continue;
       }
-      bind(
+      bindOption(
           bindings,
+          identifiers,
           new ForeachBinding(String.join("", segments), ForeachBindingType.LITERAL),
           PLACEHOLDER_MATCHSTR,
-          options.getOrDefault(OPTION_MATCHSTR, PLACEHOLDER_MATCHSTR));
+          OPTION_MATCHSTR,
+          options);
       for (int i = 0; i < segments.size(); i++) {
         String defaultName = PLACEHOLDER_MATCHSEG + (i + 1);
-        bind(
+        bindOption(
             bindings,
+            identifiers,
             new ForeachBinding(segments.get(i), ForeachBindingType.LITERAL),
             defaultName,
-            options.getOrDefault(OPTION_MATCHSEG + (i + 1), defaultName));
+            OPTION_MATCHSEG + (i + 1),
+            options);
       }
       break;
     }
-    return bindings;
+    return new ForeachBindings(bindings, identifiers);
   }
 
   /**
@@ -180,19 +200,27 @@ class ForeachPlanner {
     if (collection == null) {
       throw new SemanticCheckException("foreach " + mode + " mode requires a field");
     }
-    String itemName = node.getOptions().getOrDefault(OPTION_ITEMSTR, PLACEHOLDER_ITEM);
-    String iterName = node.getOptions().getOrDefault(OPTION_ITERSTR, PLACEHOLDER_ITER);
-    collection = asArrayExpression(collection, mode, context, node.getEvalClauses(), itemName);
+    RexNode rawCollection = rexVisitor.analyze(collection, context);
+    boolean nativeArray = rawCollection.getType() instanceof ArraySqlType;
+    if ((mode == Foreach.Mode.MULTIVALUE && !nativeArray)
+        || (mode == Foreach.Mode.JSON_ARRAY && nativeArray)) {
+      return context.relBuilder.peek();
+    }
+    collection = asArrayExpression(collection, nativeArray, context, node);
     RexNode collectionRex = rexVisitor.analyze(collection, context);
     if (!(collectionRex.getType() instanceof ArraySqlType arrayType)) {
-      throw new SemanticCheckException("foreach " + mode + " mode requires a multivalue field");
+      return context.relBuilder.peek();
     }
     RelDataType itemType = arrayType.getComponentType();
     RelDataType iterType = context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER);
     List<String> targetAliases =
         node.getEvalClauses().stream().map(ForeachEvalClause::getTargetTemplate).toList();
+    List<RexNode> initialTargets =
+        targetAliases.stream()
+            .map(alias -> rexVisitor.analyze(new Field(new QualifiedName(alias)), context))
+            .toList();
     List<RelDataTypeField> capturedFields =
-        capturedFields(node.getEvalClauses(), context, itemName, iterName, targetAliases);
+        capturedFields(node.getEvalClauses(), context, node.getOptions(), targetAliases);
 
     // Pack [item, iter, captured...] so the reduce lambda can reach everything through one var.
     List<UnresolvedExpression> pairArgs = new ArrayList<>();
@@ -203,46 +231,168 @@ class ForeachPlanner {
     Function pairedCollection =
         new Function(
             BuiltinFunctionName.FOREACH_PAIR_COLLECTION.getName().getFunctionName(), pairArgs);
+    RexNode pairedCollectionRex = rexVisitor.analyze(pairedCollection, context);
 
-    Map<String, ForeachBinding> bindings = new LinkedHashMap<>();
-    bindPairSlot(bindings, 0, itemType, itemName, PLACEHOLDER_ITEM);
-    bindPairSlot(bindings, 1, iterType, iterName, PLACEHOLDER_ITER);
-    for (int i = 0; i < capturedFields.size(); i++) {
-      RelDataTypeField field = capturedFields.get(i);
-      bindPairSlot(bindings, i + 2, field.getType(), field.getName());
+    List<RelDataType> targetTypes = initialTargets.stream().map(RexNode::getType).toList();
+    List<RexNode> probedExpressions =
+        analyzeCollectionEval(
+            node,
+            context,
+            pairedCollectionRex,
+            state(initialTargets, context),
+            itemType,
+            iterType,
+            capturedFields,
+            targetAliases,
+            targetTypes);
+    targetTypes = probedExpressions.stream().map(RexNode::getType).toList();
+    List<RexNode> castInitialTargets = new ArrayList<>();
+    for (int i = 0; i < initialTargets.size(); i++) {
+      castInitialTargets.add(
+          context.rexBuilder.makeCast(targetTypes.get(i), initialTargets.get(i), true, true));
     }
+    RexNode initialState = state(castInitialTargets, context);
 
-    // Stage rather than activate: the pair collection and the accumulator's initial value are
-    // resolved against the row; only the lambda body sees the placeholder bindings.
-    context.stageForeachLambdaBindings(bindings);
+    ForeachBindings bindings =
+        collectionBindings(node, itemType, iterType, capturedFields, targetAliases, targetTypes);
+    context.stageForeachLambdaBindings(bindings.values(), bindings.identifiers());
     try {
-      for (ForeachEvalClause clause : node.getEvalClauses()) {
-        String alias = substituteTemplate(clause.getTargetTemplate(), bindings);
-        Function reduce =
-            new Function(
-                BuiltinFunctionName.REDUCE.getName().getFunctionName(),
-                List.of(
-                    pairedCollection,
-                    new Field(new QualifiedName(alias)),
-                    new LambdaFunction(
-                        clause.getExpression(),
-                        List.of(new QualifiedName(alias), new QualifiedName(PAIR_VAR)))));
-        RexNode expr = rexVisitor.analyze(reduce, context);
-        relVisitor.projectPlusOverriding(
-            List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
+      CalcitePlanContext lambdaContext =
+          prepareStateLambdaContext(context, pairedCollectionRex, initialState);
+      List<RexNode> updatedTargets = analyzeClauses(node.getEvalClauses(), lambdaContext);
+      RexNode updatedState = state(updatedTargets, lambdaContext);
+      RexNode lambda =
+          context.rexBuilder.makeLambdaCall(
+              updatedState,
+              List.of(
+                  lambdaContext.getRexLambdaRefMap().get(STATE_VAR),
+                  lambdaContext.getRexLambdaRefMap().get(PAIR_VAR)));
+      RexNode reducedState =
+          PPLFuncImpTable.INSTANCE.resolve(
+              context.rexBuilder,
+              BuiltinFunctionName.REDUCE,
+              pairedCollectionRex,
+              initialState,
+              lambda);
+      List<RexNode> outputs = new ArrayList<>();
+      for (int i = 0; i < targetAliases.size(); i++) {
+        RexNode value = stateSlot(reducedState, i, targetTypes.get(i), context);
+        outputs.add(context.relBuilder.alias(value, targetAliases.get(i)));
       }
+      relVisitor.projectPlusOverriding(outputs, targetAliases, context);
     } finally {
       context.clearForeachBindings();
     }
     return context.relBuilder.peek();
   }
 
-  private void bindPairSlot(
-      Map<String, ForeachBinding> bindings, int slot, RelDataType type, String... names) {
-    ForeachBinding binding = new ForeachBinding(PAIR_VAR, ForeachBindingType.PAIR_SLOT, slot, type);
-    for (String name : names) {
-      bindings.put(name.toUpperCase(Locale.ROOT), binding);
+  private List<RexNode> analyzeCollectionEval(
+      Foreach node,
+      CalcitePlanContext context,
+      RexNode pairedCollection,
+      RexNode initialState,
+      RelDataType itemType,
+      RelDataType iterType,
+      List<RelDataTypeField> capturedFields,
+      List<String> targetAliases,
+      List<RelDataType> targetTypes) {
+    ForeachBindings bindings =
+        collectionBindings(node, itemType, iterType, capturedFields, targetAliases, targetTypes);
+    context.stageForeachLambdaBindings(bindings.values(), bindings.identifiers());
+    try {
+      return analyzeClauses(
+          node.getEvalClauses(),
+          prepareStateLambdaContext(context, pairedCollection, initialState));
+    } finally {
+      context.clearForeachBindings();
     }
+  }
+
+  private CalcitePlanContext prepareStateLambdaContext(
+      CalcitePlanContext context, RexNode pairedCollection, RexNode initialState) {
+    LambdaFunction template =
+        new LambdaFunction(
+            new Literal(0, DataType.INTEGER),
+            List.of(new QualifiedName(STATE_VAR), new QualifiedName(PAIR_VAR)));
+    return rexVisitor.prepareLambdaContext(
+        context,
+        template,
+        List.of(pairedCollection, initialState),
+        BuiltinFunctionName.REDUCE.getName().getFunctionName(),
+        initialState.getType());
+  }
+
+  private List<RexNode> analyzeClauses(
+      List<ForeachEvalClause> clauses, CalcitePlanContext lambdaContext) {
+    List<RexNode> expressions = new ArrayList<>();
+    for (ForeachEvalClause clause : clauses) {
+      RexNode expression = rexVisitor.analyze(clause.getExpression(), lambdaContext);
+      expressions.add(expression);
+      lambdaContext.putForeachComputedBinding(clause.getTargetTemplate(), expression);
+    }
+    return expressions;
+  }
+
+  private RexNode state(List<RexNode> values, CalcitePlanContext context) {
+    return PPLFuncImpTable.INSTANCE.resolve(
+        context.rexBuilder, BuiltinFunctionName.FOREACH_STATE, values.toArray(RexNode[]::new));
+  }
+
+  private RexNode stateSlot(RexNode state, int slot, RelDataType type, CalcitePlanContext context) {
+    return context.rexBuilder.makeCall(
+        type,
+        PPLBuiltinOperators.FOREACH_PAIR_ITEM,
+        List.of(state, context.rexBuilder.makeExactLiteral(BigDecimal.valueOf(slot))));
+  }
+
+  private ForeachBindings collectionBindings(
+      Foreach node,
+      RelDataType itemType,
+      RelDataType iterType,
+      List<RelDataTypeField> capturedFields,
+      List<String> targetAliases,
+      List<RelDataType> targetTypes) {
+    Map<String, ForeachBinding> bindings = new LinkedHashMap<>();
+    Map<String, ForeachBinding> identifiers = new LinkedHashMap<>();
+    bindPairPlaceholder(
+        bindings, identifiers, 0, itemType, PLACEHOLDER_ITEM, OPTION_ITEMSTR, node.getOptions());
+    bindPairPlaceholder(
+        bindings, identifiers, 1, iterType, PLACEHOLDER_ITER, OPTION_ITERSTR, node.getOptions());
+    for (int i = 0; i < capturedFields.size(); i++) {
+      RelDataTypeField field = capturedFields.get(i);
+      bindIdentifier(identifiers, field.getName(), PAIR_VAR, i + 2, field.getType());
+    }
+    for (int i = 0; i < targetAliases.size(); i++) {
+      bindIdentifier(identifiers, targetAliases.get(i), STATE_VAR, i, targetTypes.get(i));
+    }
+    return new ForeachBindings(bindings, identifiers);
+  }
+
+  private void bindPairPlaceholder(
+      Map<String, ForeachBinding> bindings,
+      Map<String, ForeachBinding> identifiers,
+      int slot,
+      RelDataType type,
+      String placeholder,
+      String option,
+      Map<String, String> options) {
+    ForeachBinding binding = new ForeachBinding(PAIR_VAR, ForeachBindingType.PAIR_SLOT, slot, type);
+    bindings.put(placeholder, binding);
+    if (options.containsKey(option)) {
+      String customName = options.get(option).toUpperCase(Locale.ROOT);
+      bindings.put(customName, binding);
+      identifiers.put(customName, binding);
+    }
+  }
+
+  private void bindIdentifier(
+      Map<String, ForeachBinding> identifiers,
+      String name,
+      String variable,
+      int slot,
+      RelDataType type) {
+    String key = name.toUpperCase(Locale.ROOT);
+    identifiers.put(key, new ForeachBinding(variable, ForeachBindingType.PAIR_SLOT, slot, type));
   }
 
   private UnresolvedExpression firstArrayField(CalcitePlanContext context) {
@@ -263,22 +413,17 @@ class ForeachPlanner {
    */
   private UnresolvedExpression asArrayExpression(
       UnresolvedExpression collection,
-      Foreach.Mode mode,
+      boolean nativeArray,
       CalcitePlanContext context,
-      List<ForeachEvalClause> evalClauses,
-      String itemName) {
-    if (mode == Foreach.Mode.MULTIVALUE
-        || (mode == Foreach.Mode.AUTO_COLLECTIONS
-            && rexVisitor.analyze(collection, context).getType() instanceof ArraySqlType)) {
+      Foreach node) {
+    if (nativeArray) {
       return collection;
     }
     return new Function(
         BuiltinFunctionName.FOREACH_JSON_ARRAY.getName().getFunctionName(),
         List.of(
             collection,
-            new Literal(
-                jsonElementType(collection, context, evalClauses, itemName).name(),
-                DataType.STRING)));
+            new Literal(jsonElementType(collection, context, node).name(), DataType.STRING)));
   }
 
   /**
@@ -292,10 +437,7 @@ class ForeachPlanner {
    * placeholder consumed by arithmetic means numeric elements, anything else means strings.
    */
   private SqlTypeName jsonElementType(
-      UnresolvedExpression collection,
-      CalcitePlanContext context,
-      List<ForeachEvalClause> evalClauses,
-      String itemName) {
+      UnresolvedExpression collection, CalcitePlanContext context, Foreach node) {
     if (collection instanceof Function function
         && BuiltinFunctionName.JSON_ARRAY
             .getName()
@@ -322,36 +464,82 @@ class ForeachPlanner {
       }
       return SqlTypeName.VARCHAR;
     }
-    return itemUsedInArithmetic(evalClauses, itemName) ? SqlTypeName.DOUBLE : SqlTypeName.VARCHAR;
+    return itemRequiresNumericType(node, context) ? SqlTypeName.DOUBLE : SqlTypeName.VARCHAR;
   }
 
-  private boolean itemUsedInArithmetic(List<ForeachEvalClause> evalClauses, String itemName) {
-    return evalClauses.stream()
-        .anyMatch(clause -> itemUsedInArithmetic(clause.getExpression(), itemName, false));
+  private boolean itemRequiresNumericType(Foreach node, CalcitePlanContext context) {
+    String itemName = node.getOptions().getOrDefault(OPTION_ITEMSTR, PLACEHOLDER_ITEM);
+    boolean customIdentifier = node.getOptions().containsKey(OPTION_ITEMSTR);
+    return node.getEvalClauses().stream()
+        .anyMatch(
+            clause ->
+                itemRequiresNumericType(
+                    clause.getExpression(), itemName, customIdentifier, context));
   }
 
-  private boolean itemUsedInArithmetic(Node node, String itemName, boolean inArithmetic) {
-    if (isItemReference(node, itemName)) {
-      return inArithmetic;
+  private boolean itemRequiresNumericType(
+      Node node, String itemName, boolean customIdentifier, CalcitePlanContext context) {
+    if (node instanceof Compare compare) {
+      if ((containsItem(compare.getLeft(), itemName, customIdentifier)
+              && isNumericExpression(compare.getRight(), context))
+          || (containsItem(compare.getRight(), itemName, customIdentifier)
+              && isNumericExpression(compare.getLeft(), context))) {
+        return true;
+      }
     }
-    boolean arithmetic =
-        inArithmetic
-            || (node instanceof Function function
-                && ARITHMETIC_OPERATORS.contains(function.getFuncName()));
+    if (node instanceof Function function) {
+      for (int i = 0; i < function.getFuncArgs().size(); i++) {
+        if (containsItem(function.getFuncArgs().get(i), itemName, customIdentifier)
+            && (ARITHMETIC_OPERATORS.contains(function.getFuncName())
+                || PPLFuncImpTable.INSTANCE.requiresNumericArgument(function.getFuncName(), i))) {
+          return true;
+        }
+      }
+    }
     return node.getChild().stream()
-        .anyMatch(child -> itemUsedInArithmetic(child, itemName, arithmetic));
+        .anyMatch(child -> itemRequiresNumericType(child, itemName, customIdentifier, context));
   }
 
-  private boolean isItemReference(Node node, String itemName) {
+  private boolean containsItem(Node node, String itemName, boolean customIdentifier) {
+    if (isItemReference(node, itemName, customIdentifier)) {
+      return true;
+    }
+    return node.getChild().stream()
+        .anyMatch(child -> containsItem(child, itemName, customIdentifier));
+  }
+
+  private boolean isItemReference(Node node, String itemName, boolean customIdentifier) {
     String name;
     if (node instanceof ForeachPlaceholder placeholder) {
       name = placeholder.getName();
     } else if (node instanceof QualifiedName qualifiedName) {
+      if (!customIdentifier) {
+        return false;
+      }
       name = qualifiedName.toString();
     } else {
       return false;
     }
     return PLACEHOLDER_ITEM.equalsIgnoreCase(name) || itemName.equalsIgnoreCase(name);
+  }
+
+  private boolean isNumericExpression(Node node, CalcitePlanContext context) {
+    if (node instanceof Literal literal) {
+      return Set.of(
+              DataType.SHORT,
+              DataType.INTEGER,
+              DataType.LONG,
+              DataType.FLOAT,
+              DataType.DOUBLE,
+              DataType.DECIMAL)
+          .contains(literal.getType());
+    }
+    try {
+      return rexVisitor.analyze((UnresolvedExpression) node, context).getType().getFamily()
+          == SqlTypeFamily.NUMERIC;
+    } catch (RuntimeException e) {
+      return false;
+    }
   }
 
   private SqlTypeName elementTypeOf(Set<?> families) {
@@ -368,15 +556,18 @@ class ForeachPlanner {
   private List<RelDataTypeField> capturedFields(
       List<ForeachEvalClause> evalClauses,
       CalcitePlanContext context,
-      String itemName,
-      String iterName,
+      Map<String, String> options,
       List<String> targetAliases) {
     Set<String> excluded =
-        Stream.concat(
-                Stream.of(itemName, iterName, PLACEHOLDER_ITEM, PLACEHOLDER_ITER, PAIR_VAR),
-                targetAliases.stream())
+        Stream.concat(Stream.of(PAIR_VAR), targetAliases.stream())
             .map(name -> name.toUpperCase(Locale.ROOT))
             .collect(Collectors.toSet());
+    if (options.containsKey(OPTION_ITEMSTR)) {
+      excluded.add(options.get(OPTION_ITEMSTR).toUpperCase(Locale.ROOT));
+    }
+    if (options.containsKey(OPTION_ITERSTR)) {
+      excluded.add(options.get(OPTION_ITERSTR).toUpperCase(Locale.ROOT));
+    }
     Map<String, RelDataTypeField> rowFields =
         context.relBuilder.peek().getRowType().getFieldList().stream()
             .collect(
@@ -408,13 +599,19 @@ class ForeachPlanner {
 
   // ---------------------------------------------------------------------- shared
 
-  private void bind(
+  private void bindOption(
       Map<String, ForeachBinding> bindings,
+      Map<String, ForeachBinding> identifiers,
       ForeachBinding binding,
       String defaultName,
-      String customName) {
+      String option,
+      Map<String, String> options) {
     bindings.put(defaultName.toUpperCase(Locale.ROOT), binding);
-    bindings.put(customName.toUpperCase(Locale.ROOT), binding);
+    if (options.containsKey(option)) {
+      String customName = options.get(option).toUpperCase(Locale.ROOT);
+      bindings.put(customName, binding);
+      identifiers.put(customName, binding);
+    }
   }
 
   private String substituteTemplate(String template, Map<String, ForeachBinding> bindings) {
@@ -427,4 +624,7 @@ class ForeachPlanner {
     }
     return result;
   }
+
+  private record ForeachBindings(
+      Map<String, ForeachBinding> values, Map<String, ForeachBinding> identifiers) {}
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/ForeachPlanner.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/ForeachPlanner.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite;
+
+import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.gson;
+
+import com.google.gson.JsonSyntaxException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.ArraySqlType;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.sql.ast.Node;
+import org.opensearch.sql.ast.expression.DataType;
+import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.Function;
+import org.opensearch.sql.ast.expression.LambdaFunction;
+import org.opensearch.sql.ast.expression.Literal;
+import org.opensearch.sql.ast.expression.QualifiedName;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
+import org.opensearch.sql.ast.tree.Foreach;
+import org.opensearch.sql.ast.tree.Foreach.ForeachEvalClause;
+import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBinding;
+import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBindingType;
+import org.opensearch.sql.calcite.utils.WildcardUtils;
+import org.opensearch.sql.exception.SemanticCheckException;
+import org.opensearch.sql.expression.function.BuiltinFunctionName;
+
+/**
+ * Plans the PPL {@code foreach} command.
+ *
+ * <p>Multifield mode expands each eval clause once per matching field, binding {@code <<FIELD>>}
+ * (and match placeholders) so the clause expression resolves against the current field.
+ *
+ * <p>Collection modes (multivalue / json_array / auto_collections) rewrite each eval clause into a
+ * {@code reduce} over the collection: elements are packed into internal pairs {@code [item, iter,
+ * captured-field...]} so the lambda can reference the loop item, the loop index, and any row fields
+ * the clause mentions. Placeholder bindings are staged on the context and only become active inside
+ * the lambda; the reduce call's other arguments resolve against the row as usual.
+ */
+class ForeachPlanner {
+
+  private static final String OPTION_FIELDSTR = "fieldstr";
+  private static final String OPTION_MATCHSTR = "matchstr";
+  private static final String OPTION_MATCHSEG = "matchseg";
+  private static final String OPTION_ITEMSTR = "itemstr";
+  private static final String OPTION_ITERSTR = "iterstr";
+  private static final String PLACEHOLDER_FIELD = "FIELD";
+  private static final String PLACEHOLDER_MATCHSTR = "MATCHSTR";
+  private static final String PLACEHOLDER_MATCHSEG = "MATCHSEG";
+  private static final String PLACEHOLDER_ITEM = "ITEM";
+  private static final String PLACEHOLDER_ITER = "ITER";
+
+  /** Name of the lambda variable holding the internal pair inside generated reduce calls. */
+  private static final String PAIR_VAR = "__foreach_pair";
+
+  private final CalciteRelNodeVisitor relVisitor;
+  private final CalciteRexNodeVisitor rexVisitor;
+
+  ForeachPlanner(CalciteRelNodeVisitor relVisitor, CalciteRexNodeVisitor rexVisitor) {
+    this.relVisitor = relVisitor;
+    this.rexVisitor = rexVisitor;
+  }
+
+  RelNode plan(Foreach node, CalcitePlanContext context) {
+    return node.getMode() == Foreach.Mode.MULTIFIELD
+        ? planMultifield(node, context)
+        : planCollection(node, context);
+  }
+
+  // ---------------------------------------------------------------------- multifield
+
+  private RelNode planMultifield(Foreach node, CalcitePlanContext context) {
+    List<String> currentFields = context.relBuilder.peek().getRowType().getFieldNames();
+    Set<String> matchingFields = new LinkedHashSet<>();
+    for (String pattern : node.getFieldPatterns()) {
+      matchingFields.addAll(WildcardUtils.expandWildcardPattern(pattern, currentFields));
+    }
+
+    for (String fieldName : matchingFields) {
+      Map<String, ForeachBinding> bindings =
+          multifieldBindings(node.getFieldPatterns(), fieldName, node.getOptions());
+      context.pushForeachBindings(bindings);
+      try {
+        for (ForeachEvalClause clause : node.getEvalClauses()) {
+          RexNode expr = rexVisitor.analyze(clause.getExpression(), context);
+          String alias = substituteTemplate(clause.getTargetTemplate(), bindings);
+          relVisitor.projectPlusOverriding(
+              List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
+        }
+      } finally {
+        context.clearForeachBindings();
+      }
+    }
+    return context.relBuilder.peek();
+  }
+
+  private Map<String, ForeachBinding> multifieldBindings(
+      List<String> patterns, String fieldName, Map<String, String> options) {
+    Map<String, ForeachBinding> bindings = new LinkedHashMap<>();
+    bind(
+        bindings,
+        new ForeachBinding(fieldName, ForeachBindingType.FIELD),
+        PLACEHOLDER_FIELD,
+        options.getOrDefault(OPTION_FIELDSTR, PLACEHOLDER_FIELD));
+    for (String pattern : patterns) {
+      List<String> segments = wildcardSegments(pattern, fieldName);
+      if (segments == null) {
+        continue;
+      }
+      bind(
+          bindings,
+          new ForeachBinding(String.join("", segments), ForeachBindingType.LITERAL),
+          PLACEHOLDER_MATCHSTR,
+          options.getOrDefault(OPTION_MATCHSTR, PLACEHOLDER_MATCHSTR));
+      for (int i = 0; i < segments.size(); i++) {
+        String defaultName = PLACEHOLDER_MATCHSEG + (i + 1);
+        bind(
+            bindings,
+            new ForeachBinding(segments.get(i), ForeachBindingType.LITERAL),
+            defaultName,
+            options.getOrDefault(OPTION_MATCHSEG + (i + 1), defaultName));
+      }
+      break;
+    }
+    return bindings;
+  }
+
+  /**
+   * Returns the substrings of {@code fieldName} captured by the wildcards in {@code pattern}, an
+   * empty list if the pattern matches without wildcards, or null if it does not match.
+   */
+  private List<String> wildcardSegments(String pattern, String fieldName) {
+    if (!WildcardUtils.matchesWildcardPattern(pattern, fieldName)) {
+      return null;
+    }
+    if (!WildcardUtils.containsWildcard(pattern)) {
+      return List.of();
+    }
+    Matcher matcher =
+        Pattern.compile(WildcardUtils.convertWildcardPatternToRegex(pattern)).matcher(fieldName);
+    if (!matcher.matches()) {
+      return null;
+    }
+    List<String> segments = new ArrayList<>();
+    for (int i = 1; i <= matcher.groupCount(); i++) {
+      segments.add(matcher.group(i));
+    }
+    return segments;
+  }
+
+  // ---------------------------------------------------------------------- collection modes
+
+  private RelNode planCollection(Foreach node, CalcitePlanContext context) {
+    Foreach.Mode mode = node.getMode();
+    UnresolvedExpression collection = node.getCollectionExpression();
+    if (collection == null && mode == Foreach.Mode.AUTO_COLLECTIONS) {
+      collection = firstArrayField(context);
+    }
+    if (collection == null) {
+      throw new SemanticCheckException("foreach " + mode + " mode requires a field");
+    }
+    collection = asArrayExpression(collection, mode, context);
+    RexNode collectionRex = rexVisitor.analyze(collection, context);
+    if (!(collectionRex.getType() instanceof ArraySqlType arrayType)) {
+      throw new SemanticCheckException("foreach " + mode + " mode requires a multivalue field");
+    }
+    RelDataType itemType = arrayType.getComponentType();
+    RelDataType iterType = context.rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER);
+
+    String itemName = node.getOptions().getOrDefault(OPTION_ITEMSTR, PLACEHOLDER_ITEM);
+    String iterName = node.getOptions().getOrDefault(OPTION_ITERSTR, PLACEHOLDER_ITER);
+    List<String> targetAliases =
+        node.getEvalClauses().stream().map(ForeachEvalClause::getTargetTemplate).toList();
+    List<RelDataTypeField> capturedFields =
+        capturedFields(node.getEvalClauses(), context, itemName, iterName, targetAliases);
+
+    // Pack [item, iter, captured...] so the reduce lambda can reach everything through one var.
+    List<UnresolvedExpression> pairArgs = new ArrayList<>();
+    pairArgs.add(collection);
+    capturedFields.stream()
+        .map(field -> new Field(new QualifiedName(field.getName())))
+        .forEach(pairArgs::add);
+    Function pairedCollection =
+        new Function(
+            BuiltinFunctionName.FOREACH_PAIR_COLLECTION.getName().getFunctionName(), pairArgs);
+
+    Map<String, ForeachBinding> bindings = new LinkedHashMap<>();
+    bindPairSlot(bindings, 0, itemType, itemName, PLACEHOLDER_ITEM);
+    bindPairSlot(bindings, 1, iterType, iterName, PLACEHOLDER_ITER);
+    for (int i = 0; i < capturedFields.size(); i++) {
+      RelDataTypeField field = capturedFields.get(i);
+      bindPairSlot(bindings, i + 2, field.getType(), field.getName());
+    }
+
+    // Stage rather than activate: the pair collection and the accumulator's initial value are
+    // resolved against the row; only the lambda body sees the placeholder bindings.
+    context.stageForeachLambdaBindings(bindings);
+    try {
+      for (ForeachEvalClause clause : node.getEvalClauses()) {
+        String alias = substituteTemplate(clause.getTargetTemplate(), bindings);
+        Function reduce =
+            new Function(
+                BuiltinFunctionName.REDUCE.getName().getFunctionName(),
+                List.of(
+                    pairedCollection,
+                    new Field(new QualifiedName(alias)),
+                    new LambdaFunction(
+                        clause.getExpression(),
+                        List.of(new QualifiedName(alias), new QualifiedName(PAIR_VAR)))));
+        RexNode expr = rexVisitor.analyze(reduce, context);
+        relVisitor.projectPlusOverriding(
+            List.of(context.relBuilder.alias(expr, alias)), List.of(alias), context);
+      }
+    } finally {
+      context.clearForeachBindings();
+    }
+    return context.relBuilder.peek();
+  }
+
+  private void bindPairSlot(
+      Map<String, ForeachBinding> bindings, int slot, RelDataType type, String... names) {
+    ForeachBinding binding = new ForeachBinding(PAIR_VAR, ForeachBindingType.PAIR_SLOT, slot, type);
+    for (String name : names) {
+      bindings.put(name.toUpperCase(Locale.ROOT), binding);
+    }
+  }
+
+  private UnresolvedExpression firstArrayField(CalcitePlanContext context) {
+    return context.relBuilder.peek().getRowType().getFieldList().stream()
+        .filter(field -> field.getType() instanceof ArraySqlType)
+        .findFirst()
+        .map(field -> (UnresolvedExpression) new Field(new QualifiedName(field.getName())))
+        .orElseThrow(
+            () ->
+                new SemanticCheckException(
+                    "foreach auto_collections mode requires a multivalue field or JSON array"));
+  }
+
+  /**
+   * Ensures the collection expression evaluates to a Calcite array. Non-array expressions (JSON
+   * array strings or {@code json_array()} calls) are wrapped in {@code foreach_json_array}, which
+   * parses the JSON and casts every element to one inferred type.
+   */
+  private UnresolvedExpression asArrayExpression(
+      UnresolvedExpression collection, Foreach.Mode mode, CalcitePlanContext context) {
+    if (mode == Foreach.Mode.MULTIVALUE
+        || (mode == Foreach.Mode.AUTO_COLLECTIONS
+            && rexVisitor.analyze(collection, context).getType() instanceof ArraySqlType)) {
+      return collection;
+    }
+    return new Function(
+        BuiltinFunctionName.FOREACH_JSON_ARRAY.getName().getFunctionName(),
+        List.of(
+            collection, new Literal(jsonElementType(collection, context).name(), DataType.STRING)));
+  }
+
+  /**
+   * Infers the element type a JSON array collection should be read as. JSON only distinguishes
+   * numbers and strings here, so the answer is DOUBLE (gson parses JSON numbers as doubles) or
+   * VARCHAR. Mixed content is rejected; expressions whose content is unknowable at plan time (e.g.
+   * a field holding a JSON string) default to VARCHAR.
+   */
+  private SqlTypeName jsonElementType(UnresolvedExpression collection, CalcitePlanContext context) {
+    if (collection instanceof Function function
+        && BuiltinFunctionName.JSON_ARRAY
+            .getName()
+            .getFunctionName()
+            .equalsIgnoreCase(function.getFuncName())) {
+      return elementTypeOf(
+          function.getFuncArgs().stream()
+              .map(arg -> rexVisitor.analyze(arg, context).getType())
+              .map(RelDataType::getFamily)
+              .collect(Collectors.toSet()));
+    }
+    if (collection instanceof Literal literal && literal.getType() == DataType.STRING) {
+      try {
+        List<?> values = gson.fromJson(String.valueOf(literal.getValue()), List.class);
+        if (values != null) {
+          return elementTypeOf(
+              values.stream()
+                  .filter(Objects::nonNull)
+                  .map(v -> v instanceof Number ? SqlTypeFamily.NUMERIC : SqlTypeFamily.CHARACTER)
+                  .collect(Collectors.toSet()));
+        }
+      } catch (JsonSyntaxException ignored) {
+        // Malformed JSON literals return null at runtime; type choice is irrelevant.
+      }
+    }
+    return SqlTypeName.VARCHAR;
+  }
+
+  private SqlTypeName elementTypeOf(Set<?> families) {
+    boolean numeric = families.contains(SqlTypeFamily.NUMERIC);
+    boolean character = families.contains(SqlTypeFamily.CHARACTER);
+    if (numeric && character) {
+      throw new SemanticCheckException(
+          "foreach json_array elements must be consistently strings or numbers");
+    }
+    return numeric ? SqlTypeName.DOUBLE : SqlTypeName.VARCHAR;
+  }
+
+  /** Row fields referenced by the eval clauses that must ride along inside the pairs. */
+  private List<RelDataTypeField> capturedFields(
+      List<ForeachEvalClause> evalClauses,
+      CalcitePlanContext context,
+      String itemName,
+      String iterName,
+      List<String> targetAliases) {
+    Set<String> excluded =
+        Stream.concat(
+                Stream.of(itemName, iterName, PLACEHOLDER_ITEM, PLACEHOLDER_ITER, PAIR_VAR),
+                targetAliases.stream())
+            .map(name -> name.toUpperCase(Locale.ROOT))
+            .collect(Collectors.toSet());
+    Map<String, RelDataTypeField> rowFields =
+        context.relBuilder.peek().getRowType().getFieldList().stream()
+            .collect(
+                Collectors.toMap(
+                    field -> field.getName().toUpperCase(Locale.ROOT),
+                    field -> field,
+                    (left, right) -> left,
+                    LinkedHashMap::new));
+    Map<String, RelDataTypeField> captured = new LinkedHashMap<>();
+    evalClauses.forEach(
+        clause -> collectFieldReferences(clause.getExpression(), excluded, rowFields, captured));
+    return new ArrayList<>(captured.values());
+  }
+
+  private void collectFieldReferences(
+      Node node,
+      Set<String> excluded,
+      Map<String, RelDataTypeField> rowFields,
+      Map<String, RelDataTypeField> captured) {
+    if (node instanceof QualifiedName qualifiedName) {
+      String key = qualifiedName.toString().toUpperCase(Locale.ROOT);
+      RelDataTypeField field = rowFields.get(key);
+      if (field != null && !excluded.contains(key)) {
+        captured.putIfAbsent(key, field);
+      }
+    }
+    node.getChild().forEach(child -> collectFieldReferences(child, excluded, rowFields, captured));
+  }
+
+  // ---------------------------------------------------------------------- shared
+
+  private void bind(
+      Map<String, ForeachBinding> bindings,
+      ForeachBinding binding,
+      String defaultName,
+      String customName) {
+    bindings.put(defaultName.toUpperCase(Locale.ROOT), binding);
+    bindings.put(customName.toUpperCase(Locale.ROOT), binding);
+  }
+
+  private String substituteTemplate(String template, Map<String, ForeachBinding> bindings) {
+    String result = template;
+    for (Map.Entry<String, ForeachBinding> entry : bindings.entrySet()) {
+      result =
+          result.replaceAll(
+              "(?i)<<" + Pattern.quote(entry.getKey()) + ">>",
+              Matcher.quoteReplacement(entry.getValue().value()));
+    }
+    return result;
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -71,6 +71,7 @@ public enum BuiltinFunctionName {
   ARRAY(FunctionName.of("array")),
   FOREACH_JSON_ARRAY(FunctionName.of("foreach_json_array"), true),
   FOREACH_PAIR_COLLECTION(FunctionName.of("foreach_pair_collection"), true),
+  FOREACH_STATE(FunctionName.of("foreach_state"), true),
   ARRAY_LENGTH(FunctionName.of("array_length")),
   ARRAY_SLICE(FunctionName.of("array_slice"), true),
   ARRAY_COMPACT(FunctionName.of("array_compact")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -70,6 +70,8 @@ public enum BuiltinFunctionName {
   /** Collection functions */
   ARRAY(FunctionName.of("array")),
   FOREACH_JSON_ARRAY(FunctionName.of("foreach_json_array"), true),
+  FOREACH_PAIR_COLLECTION(FunctionName.of("foreach_pair_collection"), true),
+  FOREACH_PAIR_ITEM(FunctionName.of("foreach_pair_item"), true),
   ARRAY_LENGTH(FunctionName.of("array_length")),
   ARRAY_SLICE(FunctionName.of("array_slice"), true),
   ARRAY_COMPACT(FunctionName.of("array_compact")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -69,6 +69,7 @@ public enum BuiltinFunctionName {
 
   /** Collection functions */
   ARRAY(FunctionName.of("array")),
+  FOREACH_JSON_ARRAY(FunctionName.of("foreach_json_array"), true),
   ARRAY_LENGTH(FunctionName.of("array_length")),
   ARRAY_SLICE(FunctionName.of("array_slice"), true),
   ARRAY_COMPACT(FunctionName.of("array_compact")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -71,7 +71,6 @@ public enum BuiltinFunctionName {
   ARRAY(FunctionName.of("array")),
   FOREACH_JSON_ARRAY(FunctionName.of("foreach_json_array"), true),
   FOREACH_PAIR_COLLECTION(FunctionName.of("foreach_pair_collection"), true),
-  FOREACH_PAIR_ITEM(FunctionName.of("foreach_pair_item"), true),
   ARRAY_LENGTH(FunctionName.of("array_length")),
   ARRAY_SLICE(FunctionName.of("array_slice"), true),
   ARRAY_COMPACT(FunctionName.of("array_compact")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachPairCollectionFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachPairCollectionFunctionImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function.CollectionUDF;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.adapter.enumerable.NotNullImplementor;
+import org.apache.calcite.adapter.enumerable.NullPolicy;
+import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.linq4j.tree.Types;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.opensearch.sql.expression.function.ImplementorUDF;
+import org.opensearch.sql.expression.function.UDFOperandMetadata;
+
+/** Builds the internal foreach pair array: [item, iter, captured-field...]. */
+public class ForeachPairCollectionFunctionImpl extends ImplementorUDF {
+  public ForeachPairCollectionFunctionImpl() {
+    super(new ForeachPairCollectionImplementor(), NullPolicy.NONE);
+  }
+
+  @Override
+  public SqlReturnTypeInference getReturnTypeInference() {
+    return opBinding -> {
+      RelDataType pair =
+          opBinding
+              .getTypeFactory()
+              .createTypeWithNullability(
+                  opBinding.getTypeFactory().createSqlType(SqlTypeName.OTHER), true);
+      return SqlTypeUtil.createArrayType(opBinding.getTypeFactory(), pair, true);
+    };
+  }
+
+  @Override
+  public UDFOperandMetadata getOperandMetadata() {
+    return null;
+  }
+
+  public static class ForeachPairCollectionImplementor implements NotNullImplementor {
+    @Override
+    public Expression implement(
+        RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
+      return Expressions.call(
+          Types.lookupMethod(ForeachPairCollectionFunctionImpl.class, "eval", Object[].class),
+          translatedOperands);
+    }
+  }
+
+  public static Object eval(Object... args) {
+    if (args.length == 0 || args[0] == null) {
+      return null;
+    }
+    List<?> source = toList(args[0]);
+    List<Object[]> pairs = new ArrayList<>();
+    for (int i = 0; i < source.size(); i++) {
+      Object[] pair = new Object[args.length + 1];
+      pair[0] = source.get(i);
+      pair[1] = i;
+      for (int j = 1; j < args.length; j++) {
+        pair[j + 1] = args[j];
+      }
+      pairs.add(pair);
+    }
+    return pairs;
+  }
+
+  private static List<?> toList(Object value) {
+    if (value instanceof List<?> list) {
+      return list;
+    }
+    if (value instanceof Object[] array) {
+      return List.of(array);
+    }
+    throw new IllegalArgumentException("foreach pair collection requires an array input");
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachPairCollectionFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachPairCollectionFunctionImpl.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.expression.function.CollectionUDF;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.adapter.enumerable.NotNullImplementor;
 import org.apache.calcite.adapter.enumerable.NullPolicy;
@@ -77,7 +78,7 @@ public class ForeachPairCollectionFunctionImpl extends ImplementorUDF {
       return list;
     }
     if (value instanceof Object[] array) {
-      return List.of(array);
+      return Arrays.asList(array);
     }
     throw new IllegalArgumentException("foreach pair collection requires an array input");
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachPairItemFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachPairItemFunctionImpl.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.expression.function.CollectionUDF;
 
+import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.adapter.enumerable.NotNullImplementor;
 import org.apache.calcite.adapter.enumerable.NullPolicy;
@@ -12,15 +13,16 @@ import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.Types;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 
-/** Extracts an internal foreach pair slot while preserving the slot's inferred Calcite type. */
+/**
+ * Extracts one slot of an internal foreach pair: {@code foreach_pair_item(pair, index)}. Returns
+ * ANY; the foreach planner wraps every call in a CAST to the slot's plan-time type.
+ */
 public class ForeachPairItemFunctionImpl extends ImplementorUDF {
   public ForeachPairItemFunctionImpl() {
     super(new ForeachPairItemImplementor(), NullPolicy.NONE);
@@ -28,25 +30,11 @@ public class ForeachPairItemFunctionImpl extends ImplementorUDF {
 
   @Override
   public SqlReturnTypeInference getReturnTypeInference() {
-    return opBinding -> {
-      SqlTypeName typeName = SqlTypeName.valueOf(opBinding.getOperandLiteralValue(2, String.class));
-      RelDataType type;
-      if (typeName == SqlTypeName.ARRAY) {
-        SqlTypeName componentTypeName =
-            SqlTypeName.valueOf(opBinding.getOperandLiteralValue(3, String.class));
-        type =
-            SqlTypeUtil.createArrayType(
-                opBinding.getTypeFactory(),
-                opBinding
-                    .getTypeFactory()
-                    .createTypeWithNullability(
-                        opBinding.getTypeFactory().createSqlType(componentTypeName), true),
-                true);
-      } else {
-        type = opBinding.getTypeFactory().createSqlType(typeName);
-      }
-      return opBinding.getTypeFactory().createTypeWithNullability(type, true);
-    };
+    return opBinding ->
+        opBinding
+            .getTypeFactory()
+            .createTypeWithNullability(
+                opBinding.getTypeFactory().createSqlType(SqlTypeName.ANY), true);
   }
 
   @Override
@@ -69,13 +57,7 @@ public class ForeachPairItemFunctionImpl extends ImplementorUDF {
       return null;
     }
     int index = ((Number) args[1]).intValue();
-    if (args[0] instanceof Object[] pair) {
-      return index < 0 || index >= pair.length ? null : pair[index];
-    }
-    List<?> pair = (List<?>) args[0];
-    if (index < 0 || index >= pair.size()) {
-      return null;
-    }
-    return pair.get(index);
+    List<?> pair = args[0] instanceof Object[] array ? Arrays.asList(array) : (List<?>) args[0];
+    return index < 0 || index >= pair.size() ? null : pair.get(index);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachPairItemFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachPairItemFunctionImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function.CollectionUDF;
+
+import java.util.List;
+import org.apache.calcite.adapter.enumerable.NotNullImplementor;
+import org.apache.calcite.adapter.enumerable.NullPolicy;
+import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.linq4j.tree.Types;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.opensearch.sql.expression.function.ImplementorUDF;
+import org.opensearch.sql.expression.function.UDFOperandMetadata;
+
+/** Extracts an internal foreach pair slot while preserving the slot's inferred Calcite type. */
+public class ForeachPairItemFunctionImpl extends ImplementorUDF {
+  public ForeachPairItemFunctionImpl() {
+    super(new ForeachPairItemImplementor(), NullPolicy.NONE);
+  }
+
+  @Override
+  public SqlReturnTypeInference getReturnTypeInference() {
+    return opBinding -> {
+      SqlTypeName typeName = SqlTypeName.valueOf(opBinding.getOperandLiteralValue(2, String.class));
+      RelDataType type;
+      if (typeName == SqlTypeName.ARRAY) {
+        SqlTypeName componentTypeName =
+            SqlTypeName.valueOf(opBinding.getOperandLiteralValue(3, String.class));
+        type =
+            SqlTypeUtil.createArrayType(
+                opBinding.getTypeFactory(),
+                opBinding
+                    .getTypeFactory()
+                    .createTypeWithNullability(
+                        opBinding.getTypeFactory().createSqlType(componentTypeName), true),
+                true);
+      } else {
+        type = opBinding.getTypeFactory().createSqlType(typeName);
+      }
+      return opBinding.getTypeFactory().createTypeWithNullability(type, true);
+    };
+  }
+
+  @Override
+  public UDFOperandMetadata getOperandMetadata() {
+    return null;
+  }
+
+  public static class ForeachPairItemImplementor implements NotNullImplementor {
+    @Override
+    public Expression implement(
+        RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
+      return Expressions.call(
+          Types.lookupMethod(ForeachPairItemFunctionImpl.class, "eval", Object[].class),
+          translatedOperands);
+    }
+  }
+
+  public static Object eval(Object... args) {
+    if (args.length < 2 || args[0] == null || args[1] == null) {
+      return null;
+    }
+    int index = ((Number) args[1]).intValue();
+    if (args[0] instanceof Object[] pair) {
+      return index < 0 || index >= pair.length ? null : pair[index];
+    }
+    List<?> pair = (List<?>) args[0];
+    if (index < 0 || index >= pair.size()) {
+      return null;
+    }
+    return pair.get(index);
+  }
+}

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachStateFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachStateFunctionImpl.java
@@ -13,28 +13,30 @@ import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.Types;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 
-/**
- * Extracts one slot of an internal foreach pair: {@code foreach_pair_item(pair, index)}. Returns
- * OTHER by default; the foreach planner assigns every call its inferred slot type explicitly.
- */
-public class ForeachPairItemFunctionImpl extends ImplementorUDF {
-  public ForeachPairItemFunctionImpl() {
-    super(new ForeachPairItemImplementor(), NullPolicy.NONE);
+/** Packs the typed accumulator slots used by a collection-mode foreach eval. */
+public class ForeachStateFunctionImpl extends ImplementorUDF {
+  public ForeachStateFunctionImpl() {
+    super(new ForeachStateImplementor(), NullPolicy.NONE);
   }
 
   @Override
   public SqlReturnTypeInference getReturnTypeInference() {
-    return opBinding ->
-        opBinding
-            .getTypeFactory()
-            .createTypeWithNullability(
-                opBinding.getTypeFactory().createSqlType(SqlTypeName.OTHER), true);
+    return opBinding -> {
+      RelDataType slot =
+          opBinding
+              .getTypeFactory()
+              .createTypeWithNullability(
+                  opBinding.getTypeFactory().createSqlType(SqlTypeName.OTHER), true);
+      return SqlTypeUtil.createArrayType(opBinding.getTypeFactory(), slot, true);
+    };
   }
 
   @Override
@@ -42,22 +44,17 @@ public class ForeachPairItemFunctionImpl extends ImplementorUDF {
     return null;
   }
 
-  public static class ForeachPairItemImplementor implements NotNullImplementor {
+  public static class ForeachStateImplementor implements NotNullImplementor {
     @Override
     public Expression implement(
         RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
       return Expressions.call(
-          Types.lookupMethod(ForeachPairItemFunctionImpl.class, "eval", Object[].class),
+          Types.lookupMethod(ForeachStateFunctionImpl.class, "eval", Object[].class),
           translatedOperands);
     }
   }
 
   public static Object eval(Object... args) {
-    if (args.length < 2 || args[0] == null || args[1] == null) {
-      return null;
-    }
-    int index = ((Number) args[1]).intValue();
-    List<?> pair = args[0] instanceof Object[] array ? Arrays.asList(array) : (List<?>) args[0];
-    return index < 0 || index >= pair.size() ? null : pair.get(index);
+    return Arrays.asList(args);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/LambdaUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/LambdaUtils.java
@@ -16,6 +16,7 @@ import org.apache.calcite.rex.RexCallBinding;
 import org.apache.calcite.rex.RexLambda;
 import org.apache.calcite.rex.RexLambdaRef;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -68,6 +69,10 @@ public class LambdaUtils {
 
   public static RexCall reInferReturnTypeForRexCallInsideLambda(
       RexCall rexCall, Map<String, RelDataType> argTypes, RelDataTypeFactory typeFactory) {
+    if (rexCall.getKind() == SqlKind.CAST
+        || "CAST".equalsIgnoreCase(rexCall.getOperator().getName())) {
+      return rexCall;
+    }
     List<RexNode> filledOperands = new ArrayList<>();
     List<RexNode> rexCallOperands = rexCall.getOperands();
     for (RexNode rexNode : rexCallOperands) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/LambdaUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/LambdaUtils.java
@@ -69,8 +69,9 @@ public class LambdaUtils {
 
   public static RexCall reInferReturnTypeForRexCallInsideLambda(
       RexCall rexCall, Map<String, RelDataType> argTypes, RelDataTypeFactory typeFactory) {
-    if (rexCall.getKind() == SqlKind.CAST
-        || "CAST".equalsIgnoreCase(rexCall.getOperator().getName())) {
+    // A CAST's target type lives on the call itself and cannot be re-derived from its operands;
+    // re-inferring it trips SqlCastFunction's assertion. Keep the call as-is.
+    if (rexCall.getKind() == SqlKind.CAST) {
       return rexCall;
     }
     List<RexNode> filledOperands = new ArrayList<>();
@@ -94,6 +95,12 @@ public class LambdaUtils {
             .getOperator()
             .inferReturnType(
                 new RexCallBinding(typeFactory, rexCall.getOperator(), filledOperands, List.of()));
+    // A call whose operator can only infer ANY may carry a more precise type assigned when the
+    // call was built (e.g. foreach pair slot extraction); re-inference must not erase it.
+    if (returnType.getSqlTypeName() == SqlTypeName.ANY
+        && rexCall.getType().getSqlTypeName() != SqlTypeName.ANY) {
+      returnType = rexCall.getType();
+    }
     return rexCall.clone(returnType, filledOperands);
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/LambdaUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/LambdaUtils.java
@@ -17,6 +17,7 @@ import org.apache.calcite.rex.RexLambda;
 import org.apache.calcite.rex.RexLambdaRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlCastFunction;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -71,7 +72,7 @@ public class LambdaUtils {
       RexCall rexCall, Map<String, RelDataType> argTypes, RelDataTypeFactory typeFactory) {
     // A CAST's target type lives on the call itself and cannot be re-derived from its operands;
     // re-inferring it trips SqlCastFunction's assertion. Keep the call as-is.
-    if (rexCall.getKind() == SqlKind.CAST) {
+    if (rexCall.getKind() == SqlKind.CAST || rexCall.getOperator() instanceof SqlCastFunction) {
       return rexCall;
     }
     List<RexNode> filledOperands = new ArrayList<>();
@@ -95,10 +96,12 @@ public class LambdaUtils {
             .getOperator()
             .inferReturnType(
                 new RexCallBinding(typeFactory, rexCall.getOperator(), filledOperands, List.of()));
-    // A call whose operator can only infer ANY may carry a more precise type assigned when the
-    // call was built (e.g. foreach pair slot extraction); re-inference must not erase it.
-    if (returnType.getSqlTypeName() == SqlTypeName.ANY
-        && rexCall.getType().getSqlTypeName() != SqlTypeName.ANY) {
+    // An opaque helper call may carry a more precise type assigned when the call was built (e.g.
+    // foreach pair slot extraction); re-inference must not erase it.
+    if ((returnType.getSqlTypeName() == SqlTypeName.ANY
+            || returnType.getSqlTypeName() == SqlTypeName.OTHER)
+        && rexCall.getType().getSqlTypeName() != SqlTypeName.ANY
+        && rexCall.getType().getSqlTypeName() != SqlTypeName.OTHER) {
       returnType = rexCall.getType();
     }
     return rexCall.clone(returnType, filledOperands);

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -54,6 +54,7 @@ import org.opensearch.sql.expression.function.CollectionUDF.MapAppendFunctionImp
 import org.opensearch.sql.expression.function.CollectionUDF.MapRemoveFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.ReduceFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.TransformFunctionImpl;
+import org.opensearch.sql.expression.function.jsonUDF.ForeachJsonArrayFunctionImpl;
 import org.opensearch.sql.expression.function.jsonUDF.JsonAppendFunctionImpl;
 import org.opensearch.sql.expression.function.jsonUDF.JsonArrayLengthFunctionImpl;
 import org.opensearch.sql.expression.function.jsonUDF.JsonDeleteFunctionImpl;
@@ -405,6 +406,8 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
   public static final SqlOperator FORALL = new ForallFunctionImpl().toUDF("forall");
   public static final SqlOperator EXISTS = new ExistsFunctionImpl().toUDF("exists");
   public static final SqlOperator ARRAY = new ArrayFunctionImpl().toUDF("array");
+  public static final SqlOperator FOREACH_JSON_ARRAY =
+      new ForeachJsonArrayFunctionImpl().toUDF("foreach_json_array");
   public static final SqlOperator MAP_APPEND = new MapAppendFunctionImpl().toUDF("map_append");
   public static final SqlOperator MAP_REMOVE = new MapRemoveFunctionImpl().toUDF("MAP_REMOVE");
   public static final SqlOperator MVAPPEND = new MVAppendFunctionImpl().toUDF("mvappend");

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -49,6 +49,7 @@ import org.opensearch.sql.expression.function.CollectionUDF.FilterFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.ForallFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.ForeachPairCollectionFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.ForeachPairItemFunctionImpl;
+import org.opensearch.sql.expression.function.CollectionUDF.ForeachStateFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.MVAppendFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.MVFindFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.MVZipFunctionImpl;
@@ -414,6 +415,8 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
       new ForeachPairCollectionFunctionImpl().toUDF("foreach_pair_collection");
   public static final SqlOperator FOREACH_PAIR_ITEM =
       new ForeachPairItemFunctionImpl().toUDF("foreach_pair_item");
+  public static final SqlOperator FOREACH_STATE =
+      new ForeachStateFunctionImpl().toUDF("foreach_state");
   public static final SqlOperator MAP_APPEND = new MapAppendFunctionImpl().toUDF("map_append");
   public static final SqlOperator MAP_REMOVE = new MapRemoveFunctionImpl().toUDF("MAP_REMOVE");
   public static final SqlOperator MVAPPEND = new MVAppendFunctionImpl().toUDF("mvappend");

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -47,6 +47,8 @@ import org.opensearch.sql.expression.function.CollectionUDF.ArrayFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.ExistsFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.FilterFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.ForallFunctionImpl;
+import org.opensearch.sql.expression.function.CollectionUDF.ForeachPairCollectionFunctionImpl;
+import org.opensearch.sql.expression.function.CollectionUDF.ForeachPairItemFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.MVAppendFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.MVFindFunctionImpl;
 import org.opensearch.sql.expression.function.CollectionUDF.MVZipFunctionImpl;
@@ -408,6 +410,10 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
   public static final SqlOperator ARRAY = new ArrayFunctionImpl().toUDF("array");
   public static final SqlOperator FOREACH_JSON_ARRAY =
       new ForeachJsonArrayFunctionImpl().toUDF("foreach_json_array");
+  public static final SqlOperator FOREACH_PAIR_COLLECTION =
+      new ForeachPairCollectionFunctionImpl().toUDF("foreach_pair_collection");
+  public static final SqlOperator FOREACH_PAIR_ITEM =
+      new ForeachPairItemFunctionImpl().toUDF("foreach_pair_item");
   public static final SqlOperator MAP_APPEND = new MapAppendFunctionImpl().toUDF("map_append");
   public static final SqlOperator MAP_REMOVE = new MapRemoveFunctionImpl().toUDF("MAP_REMOVE");
   public static final SqlOperator MVAPPEND = new MVAppendFunctionImpl().toUDF("mvappend");

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -76,6 +76,8 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.FIRST;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FLOOR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FORALL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_JSON_ARRAY;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_PAIR_COLLECTION;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_PAIR_ITEM;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FROM_DAYS;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FROM_UNIXTIME;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.GET_FORMAT;
@@ -1237,6 +1239,8 @@ public class PPLFuncImpTable {
       registerOperator(TRANSFORM, PPLBuiltinOperators.TRANSFORM);
       registerOperator(REDUCE, PPLBuiltinOperators.REDUCE);
       registerOperator(FOREACH_JSON_ARRAY, PPLBuiltinOperators.FOREACH_JSON_ARRAY);
+      registerOperator(FOREACH_PAIR_COLLECTION, PPLBuiltinOperators.FOREACH_PAIR_COLLECTION);
+      registerOperator(FOREACH_PAIR_ITEM, PPLBuiltinOperators.FOREACH_PAIR_ITEM);
 
       // Register Json function
       register(

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -77,7 +77,6 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.FLOOR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FORALL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_JSON_ARRAY;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_PAIR_COLLECTION;
-import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_PAIR_ITEM;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FROM_DAYS;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FROM_UNIXTIME;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.GET_FORMAT;
@@ -1240,7 +1239,6 @@ public class PPLFuncImpTable {
       registerOperator(REDUCE, PPLBuiltinOperators.REDUCE);
       registerOperator(FOREACH_JSON_ARRAY, PPLBuiltinOperators.FOREACH_JSON_ARRAY);
       registerOperator(FOREACH_PAIR_COLLECTION, PPLBuiltinOperators.FOREACH_PAIR_COLLECTION);
-      registerOperator(FOREACH_PAIR_ITEM, PPLBuiltinOperators.FOREACH_PAIR_ITEM);
 
       // Register Json function
       register(

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -75,6 +75,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.FILTER;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FIRST;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FLOOR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FORALL;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_JSON_ARRAY;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FROM_DAYS;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FROM_UNIXTIME;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.GET_FORMAT;
@@ -1235,6 +1236,7 @@ public class PPLFuncImpTable {
       registerOperator(FILTER, PPLBuiltinOperators.FILTER);
       registerOperator(TRANSFORM, PPLBuiltinOperators.TRANSFORM);
       registerOperator(REDUCE, PPLBuiltinOperators.REDUCE);
+      registerOperator(FOREACH_JSON_ARRAY, PPLBuiltinOperators.FOREACH_JSON_ARRAY);
 
       // Register Json function
       register(

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -77,6 +77,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.FLOOR;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FORALL;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_JSON_ARRAY;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_PAIR_COLLECTION;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.FOREACH_STATE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FROM_DAYS;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.FROM_UNIXTIME;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.GET_FORMAT;
@@ -275,6 +276,7 @@ import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -317,6 +319,8 @@ import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.sql.expression.function.CollectionUDF.MVIndexFunctionImp;
@@ -428,6 +432,63 @@ public class PPLFuncImpTable {
     aggBuilder.map.forEach(aggMapBuilder::put);
     this.aggFunctionRegistry = ImmutableMap.copyOf(aggMapBuilder.build());
     this.aggExternalFunctionRegistry = new ConcurrentHashMap<>();
+  }
+
+  /** Returns whether every known signature requires a numeric value at the given argument. */
+  public boolean requiresNumericArgument(String functionName, int argumentIndex) {
+    Optional<BuiltinFunctionName> builtin = BuiltinFunctionName.of(functionName);
+    if (builtin.isEmpty()) {
+      return false;
+    }
+    List<Pair<CalciteFuncSignature, FunctionImp>> implementations =
+        new ArrayList<>(functionRegistry.getOrDefault(builtin.get(), List.of()));
+    implementations.addAll(externalFunctionRegistry.getOrDefault(builtin.get(), List.of()));
+    boolean foundArgument = false;
+    for (Pair<CalciteFuncSignature, FunctionImp> implementation : implementations) {
+      PPLTypeChecker checker = implementation.getKey().typeChecker();
+      if (checker == null) {
+        return false;
+      }
+      try {
+        List<List<ExprType>> signatures =
+            checker.getParameterTypes().stream()
+                .filter(parameters -> argumentIndex < parameters.size())
+                .toList();
+        if (signatures.isEmpty()) {
+          return false;
+        }
+        foundArgument = true;
+        List<ExprType> acceptedTypes =
+            signatures.stream().map(parameters -> parameters.get(argumentIndex)).toList();
+        if (acceptedTypes.stream().allMatch(ExprCoreType.numberTypes()::contains)) {
+          continue;
+        }
+        if (acceptedTypes.stream().anyMatch(type -> type != ExprCoreType.UNKNOWN)
+            || !requiresNumericByValidation(checker, signatures, argumentIndex)) {
+          return false;
+        }
+      } catch (RuntimeException e) {
+        return false;
+      }
+    }
+    return foundArgument;
+  }
+
+  private boolean requiresNumericByValidation(
+      PPLTypeChecker checker, List<List<ExprType>> signatures, int argumentIndex) {
+    RelDataType numericType = TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE);
+    RelDataType stringType = TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
+    return signatures.stream()
+        .anyMatch(
+            signature -> {
+              List<RelDataType> numericArguments =
+                  new ArrayList<>(Collections.nCopies(signature.size(), numericType));
+              if (!checker.checkOperandTypes(numericArguments)) {
+                return false;
+              }
+              numericArguments.set(argumentIndex, stringType);
+              return !checker.checkOperandTypes(numericArguments);
+            });
   }
 
   /**
@@ -958,11 +1019,17 @@ public class PPLFuncImpTable {
           wrapSqlOperandTypeChecker(
               SqlLibraryOperators.REGEXP_REPLACE_3.getOperandTypeChecker(), REPLACE.name(), false));
       registerOperator(UPPER, SqlStdOperatorTable.UPPER);
-      registerOperator(ABS, SqlStdOperatorTable.ABS);
-      registerOperator(ACOS, SqlStdOperatorTable.ACOS);
-      registerOperator(ASIN, SqlStdOperatorTable.ASIN);
-      registerOperator(ATAN, SqlStdOperatorTable.ATAN);
-      registerOperator(ATAN2, SqlStdOperatorTable.ATAN2);
+      registerOperator(ABS, SqlStdOperatorTable.ABS, PPLTypeChecker.family(SqlTypeFamily.NUMERIC));
+      registerOperator(
+          ACOS, SqlStdOperatorTable.ACOS, PPLTypeChecker.family(SqlTypeFamily.NUMERIC));
+      registerOperator(
+          ASIN, SqlStdOperatorTable.ASIN, PPLTypeChecker.family(SqlTypeFamily.NUMERIC));
+      registerOperator(
+          ATAN, SqlStdOperatorTable.ATAN, PPLTypeChecker.family(SqlTypeFamily.NUMERIC));
+      registerOperator(
+          ATAN2,
+          SqlStdOperatorTable.ATAN2,
+          PPLTypeChecker.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC));
       // TODO, workaround to support sequence CompositeOperandTypeChecker.
       registerOperator(
           CEIL,
@@ -1239,6 +1306,7 @@ public class PPLFuncImpTable {
       registerOperator(REDUCE, PPLBuiltinOperators.REDUCE);
       registerOperator(FOREACH_JSON_ARRAY, PPLBuiltinOperators.FOREACH_JSON_ARRAY);
       registerOperator(FOREACH_PAIR_COLLECTION, PPLBuiltinOperators.FOREACH_PAIR_COLLECTION);
+      registerOperator(FOREACH_STATE, PPLBuiltinOperators.FOREACH_STATE);
 
       // Register Json function
       register(

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/ForeachJsonArrayFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/ForeachJsonArrayFunctionImpl.java
@@ -7,9 +7,12 @@ package org.opensearch.sql.expression.function.jsonUDF;
 
 import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.gson;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.stream.StreamSupport;
 import org.apache.calcite.adapter.enumerable.NotNullImplementor;
 import org.apache.calcite.adapter.enumerable.NullPolicy;
 import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
@@ -65,25 +68,41 @@ public class ForeachJsonArrayFunctionImpl extends ImplementorUDF {
     }
     SqlTypeName elementType = SqlTypeName.valueOf(String.valueOf(args[1]));
     try {
-      List<?> values =
-          args[0] instanceof List<?> list
-              ? list
-              : gson.fromJson(String.valueOf(args[0]), List.class);
-      return values == null
-          ? null
-          : values.stream().map(value -> cast(value, elementType)).toList();
+      if (args[0] instanceof List<?> values) {
+        return values.stream().map(value -> cast(value, elementType)).toList();
+      }
+      JsonArray values = gson.fromJson(String.valueOf(args[0]), JsonArray.class);
+      if (values == null) {
+        return List.of();
+      }
+      return StreamSupport.stream(values.spliterator(), false)
+          .map(value -> cast(value, elementType))
+          .toList();
     } catch (JsonSyntaxException e) {
-      return null;
+      return List.of();
     }
   }
 
   private static Object cast(Object value, SqlTypeName elementType) {
+    if (value instanceof JsonElement element) {
+      if (element.isJsonNull()) {
+        return elementType == SqlTypeName.VARCHAR ? "null" : null;
+      }
+      if (element.isJsonArray() || element.isJsonObject()) {
+        return element.toString();
+      }
+      value =
+          element.getAsJsonPrimitive().isNumber() ? element.getAsNumber() : element.getAsString();
+    }
     if (value == null) {
       return null;
     }
     return switch (elementType) {
       case DOUBLE -> ((Number) value).doubleValue();
-      case VARCHAR -> String.valueOf(value);
+      case VARCHAR ->
+          value instanceof List<?> || value instanceof java.util.Map<?, ?>
+              ? gson.toJson(value)
+              : String.valueOf(value);
       case DECIMAL -> BigDecimal.valueOf(((Number) value).doubleValue());
       default -> value;
     };

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/ForeachJsonArrayFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/ForeachJsonArrayFunctionImpl.java
@@ -8,18 +8,16 @@ package org.opensearch.sql.expression.function.jsonUDF;
 import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.gson;
 
 import com.google.gson.JsonSyntaxException;
+import java.math.BigDecimal;
 import java.util.List;
 import org.apache.calcite.adapter.enumerable.NotNullImplementor;
 import org.apache.calcite.adapter.enumerable.NullPolicy;
-import org.apache.calcite.adapter.enumerable.RexImpTable;
 import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
 import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.schema.impl.ScalarFunctionImpl;
-import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
-import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.opensearch.sql.expression.function.ImplementorUDF;
@@ -28,49 +26,66 @@ import org.opensearch.sql.expression.function.UDFOperandMetadata;
 /** Converts a JSON array string to a Calcite enumerable array for foreach collection modes. */
 public class ForeachJsonArrayFunctionImpl extends ImplementorUDF {
   public ForeachJsonArrayFunctionImpl() {
-    super(new ForeachJsonArrayImplementor(), NullPolicy.ANY);
+    super(new ForeachJsonArrayImplementor(), NullPolicy.NONE);
   }
 
   @Override
   public SqlReturnTypeInference getReturnTypeInference() {
-    return opBinding ->
-        SqlTypeUtil.createArrayType(
-            opBinding.getTypeFactory(),
-            opBinding
-                .getTypeFactory()
-                .createTypeWithNullability(
-                    opBinding.getTypeFactory().createSqlType(SqlTypeName.DOUBLE), true),
-            true);
+    return opBinding -> {
+      SqlTypeName elementTypeName =
+          SqlTypeName.valueOf(opBinding.getOperandLiteralValue(1, String.class));
+      return SqlTypeUtil.createArrayType(
+          opBinding.getTypeFactory(),
+          opBinding
+              .getTypeFactory()
+              .createTypeWithNullability(
+                  opBinding.getTypeFactory().createSqlType(elementTypeName), true),
+          true);
+    };
   }
 
   @Override
   public UDFOperandMetadata getOperandMetadata() {
-    return UDFOperandMetadata.wrap(OperandTypes.family(SqlTypeFamily.ANY));
+    return null;
   }
 
   public static class ForeachJsonArrayImplementor implements NotNullImplementor {
     @Override
     public Expression implement(
         RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
-      ScalarFunctionImpl function =
-          (ScalarFunctionImpl)
-              ScalarFunctionImpl.create(
-                  Types.lookupMethod(ForeachJsonArrayFunctionImpl.class, "eval", Object[].class));
-      return function.getImplementor().implement(translator, call, RexImpTable.NullAs.NULL);
+      return Expressions.call(
+          Types.lookupMethod(ForeachJsonArrayFunctionImpl.class, "eval", Object[].class),
+          translatedOperands);
     }
   }
 
   public static Object eval(Object... args) {
-    if (args.length != 1 || args[0] == null) {
+    if (args.length != 2 || args[0] == null) {
       return null;
     }
-    if (args[0] instanceof List<?>) {
-      return args[0];
-    }
+    SqlTypeName elementType = SqlTypeName.valueOf(String.valueOf(args[1]));
     try {
-      return gson.fromJson(String.valueOf(args[0]), List.class);
+      List<?> values =
+          args[0] instanceof List<?> list
+              ? list
+              : gson.fromJson(String.valueOf(args[0]), List.class);
+      return values == null
+          ? null
+          : values.stream().map(value -> cast(value, elementType)).toList();
     } catch (JsonSyntaxException e) {
       return null;
     }
+  }
+
+  private static Object cast(Object value, SqlTypeName elementType) {
+    if (value == null) {
+      return null;
+    }
+    return switch (elementType) {
+      case DOUBLE -> ((Number) value).doubleValue();
+      case VARCHAR -> String.valueOf(value);
+      case DECIMAL -> BigDecimal.valueOf(((Number) value).doubleValue());
+      default -> value;
+    };
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/ForeachJsonArrayFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/ForeachJsonArrayFunctionImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function.jsonUDF;
+
+import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.gson;
+
+import com.google.gson.JsonSyntaxException;
+import java.util.List;
+import org.apache.calcite.adapter.enumerable.NotNullImplementor;
+import org.apache.calcite.adapter.enumerable.NullPolicy;
+import org.apache.calcite.adapter.enumerable.RexImpTable;
+import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Types;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.schema.impl.ScalarFunctionImpl;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.opensearch.sql.expression.function.ImplementorUDF;
+import org.opensearch.sql.expression.function.UDFOperandMetadata;
+
+/** Converts a JSON array string to a Calcite enumerable array for foreach collection modes. */
+public class ForeachJsonArrayFunctionImpl extends ImplementorUDF {
+  public ForeachJsonArrayFunctionImpl() {
+    super(new ForeachJsonArrayImplementor(), NullPolicy.ANY);
+  }
+
+  @Override
+  public SqlReturnTypeInference getReturnTypeInference() {
+    return opBinding ->
+        SqlTypeUtil.createArrayType(
+            opBinding.getTypeFactory(),
+            opBinding
+                .getTypeFactory()
+                .createTypeWithNullability(
+                    opBinding.getTypeFactory().createSqlType(SqlTypeName.DOUBLE), true),
+            true);
+  }
+
+  @Override
+  public UDFOperandMetadata getOperandMetadata() {
+    return UDFOperandMetadata.wrap(OperandTypes.family(SqlTypeFamily.ANY));
+  }
+
+  public static class ForeachJsonArrayImplementor implements NotNullImplementor {
+    @Override
+    public Expression implement(
+        RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
+      ScalarFunctionImpl function =
+          (ScalarFunctionImpl)
+              ScalarFunctionImpl.create(
+                  Types.lookupMethod(ForeachJsonArrayFunctionImpl.class, "eval", Object[].class));
+      return function.getImplementor().implement(translator, call, RexImpTable.NullAs.NULL);
+    }
+  }
+
+  public static Object eval(Object... args) {
+    if (args.length != 1 || args[0] == null) {
+      return null;
+    }
+    if (args[0] instanceof List<?>) {
+      return args[0];
+    }
+    try {
+      return gson.fromJson(String.valueOf(args[0]), List.class);
+    } catch (JsonSyntaxException e) {
+      return null;
+    }
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/org/opensearch/sql/analysis/AnalyzerTest.java
@@ -1944,6 +1944,24 @@ class AnalyzerTest extends AnalyzerTestBase {
   }
 
   @Test
+  public void foreach_command_throws_unsupported_exception_with_legacy_engine() {
+    UnsupportedOperationException exception =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                analyze(
+                    new org.opensearch.sql.ast.tree.Foreach(
+                            org.opensearch.sql.ast.tree.Foreach.Mode.MULTIFIELD,
+                            ImmutableMap.of(),
+                            ImmutableList.of("integer_value"),
+                            null,
+                            ImmutableList.of())
+                        .attach(relation("schema"))));
+    assertEquals(
+        "foreach is supported only when plugins.calcite.enabled=true", exception.getMessage());
+  }
+
+  @Test
   public void rex_command_throws_unsupported_operation_exception_in_legacy_engine() {
     UnsupportedOperationException exception =
         assertThrows(

--- a/core/src/test/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachFunctionImplTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/CollectionUDF/ForeachFunctionImplTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function.CollectionUDF;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.expression.function.jsonUDF.ForeachJsonArrayFunctionImpl;
+
+public class ForeachFunctionImplTest {
+
+  @Test
+  public void testPairCollectionPreservesNullElements() {
+    List<?> pairs =
+        (List<?>)
+            ForeachPairCollectionFunctionImpl.eval(
+                new Object[] {new Object[] {1, null, 3}, "captured"});
+
+    assertEquals(3, pairs.size());
+    assertArrayEquals(new Object[] {1, 0, "captured"}, (Object[]) pairs.get(0));
+    assertArrayEquals(new Object[] {null, 1, "captured"}, (Object[]) pairs.get(1));
+    assertArrayEquals(new Object[] {3, 2, "captured"}, (Object[]) pairs.get(2));
+  }
+
+  @Test
+  public void testJsonArrayPreservesTopLevelNestedValuesAndNull() {
+    Object values = ForeachJsonArrayFunctionImpl.eval("[[1,2],{\"a\":1},null]", "VARCHAR");
+
+    assertEquals(List.of("[1,2]", "{\"a\":1}", "null"), values);
+  }
+
+  @Test
+  public void testMalformedJsonArrayIsEmpty() {
+    assertEquals(List.of(), ForeachJsonArrayFunctionImpl.eval("not-json", "VARCHAR"));
+  }
+
+  @Test
+  public void testStatePreservesHeterogeneousAndNullSlots() {
+    assertEquals(
+        Arrays.asList(3, null, "seen"),
+        ForeachStateFunctionImpl.eval(new Object[] {3, null, "seen"}));
+  }
+}

--- a/docs/category.json
+++ b/docs/category.json
@@ -20,6 +20,7 @@
     "user/ppl/cmd/fieldformat.md",
     "user/ppl/cmd/fields.md",
     "user/ppl/cmd/fillnull.md",
+    "user/ppl/cmd/foreach.md",
     "user/ppl/cmd/grok.md",
     "user/ppl/cmd/head.md",
     "user/ppl/cmd/join.md",

--- a/docs/user/ppl/cmd/foreach.md
+++ b/docs/user/ppl/cmd/foreach.md
@@ -1,0 +1,190 @@
+# foreach
+
+The `foreach` command runs a templated `eval` expression for each field in a field list, each element of a multivalue (array) field, or each element of a JSON array. It eliminates repetitive `eval` statements when the same computation applies to many fields or to every element of a collection.
+
+## Syntax
+
+The `foreach` command has the following syntax:
+
+```syntax
+foreach [mode=<mode>] [<option>=<value>]... <target>... "[" eval <field-template> = <expression> ["," <field-template> = <expression>]... "]"
+```
+
+## Parameters
+
+The `foreach` command supports the following parameters.
+
+| Parameter | Required/Optional | Description |
+| --- | --- | --- |
+| `mode` | Optional | How the target is interpreted: `multifield` (iterate over matching fields), `multivalue` (iterate over the elements of an array field), `json_array` (parse a JSON array string and iterate over its elements), or `auto_collections` (detect `multivalue` or `json_array` automatically). Defaults to `multifield`, or `json_array` when the target is a `json_array(...)` function call. |
+| `<target>` | Required for most modes | In `multifield` mode, one or more field names or wildcard patterns (for example, `value_*`). In collection modes, exactly one array field, JSON array string, or `json_array(...)` call. May be omitted in `auto_collections` mode, which then picks the first array field. |
+| `fieldstr` | Optional | Renames the `<<FIELD>>` placeholder in `multifield` mode. |
+| `matchstr` | Optional | Renames the `<<MATCHSTR>>` placeholder in `multifield` mode. |
+| `itemstr` | Optional | Renames the `<<ITEM>>` placeholder in collection modes. |
+| `iterstr` | Optional | Renames the `<<ITER>>` placeholder in collection modes. |
+
+### Placeholders
+
+Inside the bracketed `eval`, placeholders refer to the current iteration:
+
+| Placeholder | Mode | Meaning |
+| --- | --- | --- |
+| `<<FIELD>>` | `multifield` | The name of the current field. Usable in both the target field template and the expression. |
+| `<<MATCHSTR>>` | `multifield` | The part of the field name matched by wildcards in the pattern. |
+| `<<ITEM>>` | collection modes | The current element of the collection. |
+| `<<ITER>>` | collection modes | The zero-based index of the current element. |
+
+Placeholders renamed via `itemstr`/`iterstr` may be written without the `<<...>>` markers in the expression.
+
+## Notes
+
+The following considerations apply when using the `foreach` command:
+
+* In collection modes, the bracketed `eval` acts as an accumulator: the target field must already exist (typically initialized with a preceding `eval`), and the expression is applied once per element, folding into the target field.
+* In `json_array` mode the element type is inferred: a `json_array(...)` call or JSON string literal is inspected at plan time; for a field holding JSON text, elements are treated as numbers when `<<ITEM>>` is used in arithmetic and as strings otherwise. Mixed string/number JSON arrays are rejected.
+* A field whose mapping is a scalar type (for example, `long`) is not accepted by `multivalue` mode even if documents store arrays in it, because the mapping does not declare the field as an array.
+
+## Example 1: Apply the same calculation to multiple fields
+
+The following query doubles two fields using one templated eval:
+
+```ppl
+source=accounts
+| foreach age balance [ eval <<FIELD>>_double = <<FIELD>> * 2 ]
+| fields age, age_double, balance, balance_double
+| head 2
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 2/2
++-----+------------+---------+----------------+
+| age | age_double | balance | balance_double |
+|-----+------------+---------+----------------|
+| 32  | 64         | 39225   | 78450          |
+| 36  | 72         | 5686    | 11372          |
++-----+------------+---------+----------------+
+```
+
+## Example 2: Wildcard field patterns with `<<MATCHSTR>>`
+
+The following query copies every field ending in `name`, naming each copy after the wildcard match:
+
+```ppl
+source=accounts
+| foreach *name [ eval copy_<<MATCHSTR>> = <<FIELD>> ]
+| fields firstname, copy_first, lastname, copy_last
+| head 2
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 2/2
++-----------+------------+----------+-----------+
+| firstname | copy_first | lastname | copy_last |
+|-----------+------------+----------+-----------|
+| Amber     | Amber      | Duke     | Duke      |
+| Hattie    | Hattie     | Bond     | Bond      |
++-----------+------------+----------+-----------+
+```
+
+## Example 3: Sum the elements of an array field
+
+The following query iterates over an array and accumulates a total:
+
+```ppl
+source=accounts
+| eval nums = array(1, 2, 3), total = 0
+| foreach mode=multivalue nums [ eval total = total + <<ITEM>> ]
+| fields total
+| head 1
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 1/1
++-------+
+| total |
+|-------|
+| 6     |
++-------+
+```
+
+## Example 4: Use the element index with a custom placeholder name
+
+The following query sums the indexes (0 + 1 + 2) instead of the values, renaming `<<ITER>>` to `IDX`:
+
+```ppl
+source=accounts
+| eval nums = array(10, 20, 30), total = 0
+| foreach mode=multivalue iterstr=IDX nums [ eval total = total + IDX ]
+| fields total
+| head 1
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 1/1
++-------+
+| total |
+|-------|
+| 3     |
++-------+
+```
+
+## Example 5: Iterate over a JSON array string
+
+The following query parses a JSON array literal and accumulates its elements:
+
+```ppl
+source=accounts
+| eval total = 0
+| foreach mode=json_array '[1,2,3]' [ eval total = total + <<ITEM>> ]
+| fields total
+| head 1
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 1/1
++-------+
+| total |
+|-------|
+| 6.0   |
++-------+
+```
+
+`json_array` mode also accepts a field whose value is JSON array text, which is the common case for raw logs that embed JSON.
+
+## Example 6: Automatic collection detection
+
+The following query lets `auto_collections` mode detect that the target is an array field:
+
+```ppl
+source=accounts
+| eval nums = array(1, 2, 3), total = 0
+| foreach mode=auto_collections nums [ eval total = total + <<ITEM>> ]
+| fields total
+| head 1
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 1/1
++-------+
+| total |
+|-------|
+| 6     |
++-------+
+```
+
+## Related commands
+
+- [eval](eval.md) --- evaluate an expression and append the result to search results
+- [fieldformat](fieldformat.md) --- format field values for display

--- a/docs/user/ppl/cmd/foreach.md
+++ b/docs/user/ppl/cmd/foreach.md
@@ -40,9 +40,10 @@ Placeholders renamed via `itemstr`/`iterstr` may be written without the `<<...>>
 
 The following considerations apply when using the `foreach` command:
 
-* In collection modes, the bracketed `eval` acts as an accumulator: the target field must already exist (typically initialized with a preceding `eval`), and the expression is applied once per element, folding into the target field.
+* In collection modes, the bracketed `eval` acts as an accumulator: each target field must already exist (typically initialized with a preceding `eval`), and the expressions are applied once per element. Multiple assignments run from left to right, so a later assignment in the same iteration sees an earlier assignment's updated value.
 * In `json_array` mode the element type is inferred: a `json_array(...)` call or JSON string literal is inspected at plan time; for a field holding JSON text, elements are treated as numbers when `<<ITEM>>` is used in arithmetic and as strings otherwise. Mixed string/number JSON arrays are rejected.
-* A field whose mapping is a scalar type (for example, `long`) is not accepted by `multivalue` mode even if documents store arrays in it, because the mapping does not declare the field as an array.
+* Placeholders are also substituted inside string literals. For example, `eval <<FIELD>> = '<<FIELD>>'` replaces each selected field value with that field's name.
+* As in Splunk, `multivalue` mode applied to a non-array value and `json_array` mode applied to a native array are no-ops. A field whose mapping is scalar cannot be identified as multivalue at plan time even when a document stores several values, so `multivalue` mode also no-ops for that mapping.
 
 ## Example 1: Apply the same calculation to multiple fields
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteNoPushdownIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteNoPushdownIT.java
@@ -37,6 +37,7 @@ import org.opensearch.sql.ppl.PPLIntegTestCase;
   CalciteDescribeCommandIT.class,
   CalciteExpandCommandIT.class,
   CalciteFieldFormatCommandIT.class,
+  CalciteForeachCommandIT.class,
   CalciteFieldsCommandIT.class,
   CalciteFillNullCommandIT.class,
   CalciteFlattenCommandIT.class,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -2920,7 +2920,7 @@ public class CalciteExplainIT extends ExplainIT {
     String logical = logicalPlan(explainQueryYaml(query));
     Assert.assertTrue(
         "Expected logical plan to contain ARRAY_JOIN function",
-        logical.toLowerCase().contains("array_join"));
+        logical.toLowerCase(java.util.Locale.ROOT).contains("array_join"));
   }
 
   @Test
@@ -2930,7 +2930,7 @@ public class CalciteExplainIT extends ExplainIT {
             "source=%s | eval full_name = concat(firstname, ' J.') | eval name_array ="
                 + " array(full_name) | nomv name_array | fields name_array",
             TEST_INDEX_BANK);
-    String logical = logicalPlan(explainQueryYaml(query)).toLowerCase();
+    String logical = logicalPlan(explainQueryYaml(query)).toLowerCase(java.util.Locale.ROOT);
     Assert.assertTrue(
         "Expected logical plan to contain both CONCAT and ARRAY_JOIN",
         logical.contains("concat") && logical.contains("array_join"));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteExplainIT.java
@@ -2936,6 +2936,22 @@ public class CalciteExplainIT extends ExplainIT {
         logical.contains("concat") && logical.contains("array_join"));
   }
 
+  @Test
+  public void testForeachExplain() throws IOException {
+    String query =
+        StringUtils.format(
+            "source=%s | foreach age balance [ eval <<FIELD>>_double = <<FIELD>> * 2 ] | fields"
+                + " age_double, balance_double",
+            TEST_INDEX_BANK);
+    String logical = logicalPlan(explainQueryYaml(query));
+    Assert.assertTrue(
+        "Expected logical plan to contain foreach-expanded eval fields",
+        logical.contains("age_double")
+            && logical.contains("balance_double")
+            && logical.contains("*($")
+            && logical.contains(", 2)"));
+  }
+
   /**
    * Return just the {@code logical:} section of a YAML explain result (everything before the {@code
    * physical:} key). The logical plan is deterministic across pushdown on/off, whereas the physical

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteForeachCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteForeachCommandIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.sql.legacy.TestUtils;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+public class CalciteForeachCommandIT extends PPLIntegTestCase {
+
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+
+    if (!TestUtils.isIndexExist(client(), "test_foreach")) {
+      String mapping =
+          "{\"mappings\":{\"properties\":{"
+              + "\"a\":{\"type\":\"long\"},"
+              + "\"b\":{\"type\":\"long\"},"
+              + "\"value_cpu\":{\"type\":\"long\"},"
+              + "\"value_mem\":{\"type\":\"long\"}}}}";
+      TestUtils.createIndexByRestClient(client(), "test_foreach", mapping);
+
+      Request request1 = new Request("PUT", "/test_foreach/_doc/1?refresh=true");
+      request1.setJsonEntity("{\"a\": 1, \"b\": 2, \"value_cpu\": 10, \"value_mem\": 20}");
+      client().performRequest(request1);
+
+      Request request2 = new Request("PUT", "/test_foreach/_doc/2?refresh=true");
+      request2.setJsonEntity("{\"a\": 3, \"b\": 4, \"value_cpu\": 30, \"value_mem\": 40}");
+      client().performRequest(request2);
+    }
+  }
+
+  @Test
+  public void testForeachExplicitFields() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | foreach a b [ eval <<FIELD>>_double = <<FIELD>> * 2 ] |"
+                + " fields a_double, b_double");
+    verifySchema(result, schema("a_double", "bigint"), schema("b_double", "bigint"));
+    verifyDataRows(result, rows(2, 4), rows(6, 8));
+  }
+
+  @Test
+  public void testForeachWildcardMatchstr() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | foreach value_* [ eval copy_<<MATCHSTR>> = <<FIELD>> ] |"
+                + " fields copy_cpu, copy_mem");
+    verifySchema(result, schema("copy_cpu", "bigint"), schema("copy_mem", "bigint"));
+    verifyDataRows(result, rows(10, 20), rows(30, 40));
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteForeachCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteForeachCommandIT.java
@@ -62,4 +62,54 @@ public class CalciteForeachCommandIT extends PPLIntegTestCase {
     verifySchema(result, schema("copy_cpu", "bigint"), schema("copy_mem", "bigint"));
     verifyDataRows(result, rows(10, 20), rows(30, 40));
   }
+
+  @Test
+  public void testForeachCustomPlaceholders() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | foreach fieldstr=F matchstr=M value_* [ eval copy_<<M>> = F ] |"
+                + " fields copy_cpu, copy_mem");
+    verifySchema(result, schema("copy_cpu", "bigint"), schema("copy_mem", "bigint"));
+    verifyDataRows(result, rows(10, 20), rows(30, 40));
+  }
+
+  @Test
+  public void testForeachMultivalueMode() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval nums = array(1, 2, 3), total = 0 | foreach mode=multivalue"
+                + " itemstr=NUMBER nums [ eval total = total + NUMBER ] | fields total");
+    verifySchema(result, schema("total", "int"));
+    verifyDataRows(result, rows(6), rows(6));
+  }
+
+  @Test
+  public void testForeachMultivalueIterPlaceholder() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval nums = array(10, 20, 30), total = 0 | foreach"
+                + " mode=multivalue iterstr=IDX nums [ eval total = total + IDX ] | fields total");
+    verifySchema(result, schema("total", "int"));
+    verifyDataRows(result, rows(3), rows(3));
+  }
+
+  @Test
+  public void testForeachJsonArrayMode() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval total = 0 | foreach mode=json_array '[1,2,3]' [ eval total"
+                + " = total + <<ITEM>> ] | fields total");
+    verifySchema(result, schema("total", "double"));
+    verifyDataRows(result, rows(6.0), rows(6.0));
+  }
+
+  @Test
+  public void testForeachAutoCollectionsMode() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval nums = array(1, 2, 3), total = 0 | foreach"
+                + " mode=auto_collections nums [ eval total = total + <<ITEM>> ] | fields total");
+    verifySchema(result, schema("total", "int"));
+    verifyDataRows(result, rows(6), rows(6));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteForeachCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteForeachCommandIT.java
@@ -75,6 +75,15 @@ public class CalciteForeachCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testForeachSubstitutesPlaceholderInsideStringLiteral() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | foreach a b [ eval <<FIELD>> = '<<FIELD>>' ] | fields a, b");
+    verifySchema(result, schema("a", "string"), schema("b", "string"));
+    verifyDataRows(result, rows("a", "b"), rows("a", "b"));
+  }
+
+  @Test
   public void testForeachMultivalueMode() throws IOException {
     JSONObject result =
         executeQuery(
@@ -92,6 +101,17 @@ public class CalciteForeachCommandIT extends PPLIntegTestCase {
                 + " mode=multivalue iterstr=IDX nums [ eval total = total + IDX ] | fields total");
     verifySchema(result, schema("total", "int"));
     verifyDataRows(result, rows(3), rows(3));
+  }
+
+  @Test
+  public void testForeachAssignmentsUseUpdatedStateInOrder() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval nums=array(1,2), sum=0, seen=0 | foreach"
+                + " mode=multivalue itemstr=ITEM nums [ eval sum=sum+ITEM, seen=seen+sum ] |"
+                + " fields sum, seen");
+    verifySchema(result, schema("sum", "int"), schema("seen", "int"));
+    verifyDataRows(result, rows(3, 4), rows(3, 4));
   }
 
   @Test
@@ -157,5 +177,17 @@ public class CalciteForeachCommandIT extends PPLIntegTestCase {
                 + " mode=auto_collections [ eval total = total + <<ITEM>> ] | fields total");
     verifySchema(result, schema("total", "int"));
     verifyDataRows(result, rows(6), rows(6));
+  }
+
+  @Test
+  public void testCollectionModeMismatchIsNoOp() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval nums=array(1,2), first=0, second=0 | foreach"
+                + " mode=json_array nums [ eval first=first+<<ITEM>> ] | foreach"
+                + " mode=multivalue '[1,2]' [ eval second=second+<<ITEM>> ] | fields first,"
+                + " second");
+    verifySchema(result, schema("first", "int"), schema("second", "int"));
+    verifyDataRows(result, rows(0, 0), rows(0, 0));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteForeachCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteForeachCommandIT.java
@@ -11,6 +11,7 @@ import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
 import java.io.IOException;
+import java.util.List;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
@@ -94,6 +95,21 @@ public class CalciteForeachCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testForeachStringItemWithNumericIter() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval word = split('ABCDE', ''), nums = array('1', '2', '3',"
+                + " '4', '5'), word_and_num = array() | foreach word mode=multivalue [ eval"
+                + " word_and_num = mvappend(word_and_num, concat(<<ITEM>>, mvindex(nums,"
+                + " <<ITER>>))) ] | fields word_and_num");
+    verifySchema(result, schema("word_and_num", "array"));
+    verifyDataRows(
+        result,
+        rows(List.of("A1", "B2", "C3", "D4", "E5")),
+        rows(List.of("A1", "B2", "C3", "D4", "E5")));
+  }
+
+  @Test
   public void testForeachJsonArrayMode() throws IOException {
     JSONObject result =
         executeQuery(
@@ -104,11 +120,41 @@ public class CalciteForeachCommandIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testForeachJsonArrayFunctionWithoutMode() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval total = 0 | foreach json_array(1, 2, 3) [ eval total ="
+                + " total + <<ITEM>> ] | fields total");
+    verifySchema(result, schema("total", "double"));
+    verifyDataRows(result, rows(6.0), rows(6.0));
+  }
+
+  @Test
+  public void testForeachJsonArrayStringElements() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval result = '' | foreach json_array('a', 'b', 'c') [ eval"
+                + " result = concat(result, <<ITEM>>) ] | fields result");
+    verifySchema(result, schema("result", "string"));
+    verifyDataRows(result, rows("abc"), rows("abc"));
+  }
+
+  @Test
   public void testForeachAutoCollectionsMode() throws IOException {
     JSONObject result =
         executeQuery(
             "source=test_foreach | eval nums = array(1, 2, 3), total = 0 | foreach"
                 + " mode=auto_collections nums [ eval total = total + <<ITEM>> ] | fields total");
+    verifySchema(result, schema("total", "int"));
+    verifyDataRows(result, rows(6), rows(6));
+  }
+
+  @Test
+  public void testForeachAutoCollectionsWithoutTarget() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach | eval nums = array(1, 2, 3), total = 0 | foreach"
+                + " mode=auto_collections [ eval total = total + <<ITEM>> ] | fields total");
     verifySchema(result, schema("total", "int"));
     verifyDataRows(result, rows(6), rows(6));
   }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.calcite.remote;
+
+import static org.junit.Assert.assertThrows;
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+import org.opensearch.sql.legacy.TestUtils;
+import org.opensearch.sql.ppl.PPLIntegTestCase;
+
+/** Foreach collection modes over index fields (Splunk-parity scenarios). */
+public class ForeachFieldJsonIT extends PPLIntegTestCase {
+
+  @Override
+  public void init() throws Exception {
+    super.init();
+    enableCalcite();
+
+    if (!TestUtils.isIndexExist(client(), "test_foreach_field")) {
+      String mapping =
+          "{\"mappings\":{\"properties\":{"
+              + "\"jsonfield\":{\"type\":\"keyword\"},"
+              + "\"jsonstrs\":{\"type\":\"keyword\"},"
+              + "\"nativenums\":{\"type\":\"long\"}}}}";
+      TestUtils.createIndexByRestClient(client(), "test_foreach_field", mapping);
+
+      Request r = new Request("PUT", "/test_foreach_field/_doc/1?refresh=true");
+      r.setJsonEntity(
+          "{\"jsonfield\": \"[10,20,30]\", \"jsonstrs\": \"[\\\"a\\\",\\\"b\\\"]\","
+              + " \"nativenums\": [1, 2, 3]}");
+      client().performRequest(r);
+    }
+  }
+
+  @Test
+  public void testJsonArrayModeOnFieldWithNumericContent() throws IOException {
+    // Splunk: field holding "[10,20,30]" with foreach mode=json_array sums to 60.
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach_field | eval total = 0 | foreach mode=json_array jsonfield ["
+                + " eval total = total + <<ITEM>> ] | fields total");
+    verifySchema(result, schema("total", "double"));
+    verifyDataRows(result, rows(60.0));
+  }
+
+  @Test
+  public void testJsonArrayModeOnFieldWithStringContent() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach_field | eval r = '' | foreach mode=json_array jsonstrs ["
+                + " eval r = concat(r, <<ITEM>>) ] | fields r");
+    verifySchema(result, schema("r", "string"));
+    verifyDataRows(result, rows("ab"));
+  }
+
+  /**
+   * Native OpenSearch array fields (a long field holding [1,2,3]) are typed as scalar BIGINT at
+   * plan time because OpenSearch mappings do not distinguish scalars from arrays. foreach
+   * multivalue mode therefore rejects them; documents the current known limitation rather than the
+   * desired behavior.
+   */
+  @Test
+  public void testNativeArrayFieldIsRejected() {
+    assertThrows(
+        ResponseException.class,
+        () ->
+            executeQuery(
+                "source=test_foreach_field | eval total = 0 | foreach mode=multivalue nativenums"
+                    + " [ eval total = total + <<ITEM>> ] | fields total"));
+  }
+}

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
@@ -52,6 +52,26 @@ public class ForeachFieldJsonIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testJsonArrayFieldInfersNumericItemForAbs() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach_field2 | eval result = 0 | foreach mode=json_array jsonfield ["
+                + " eval result = abs(<<ITEM>>) ] | fields result");
+    verifySchema(result, schema("result", "double"));
+    verifyDataRows(result, rows(30.0));
+  }
+
+  @Test
+  public void testJsonArrayFieldInfersNumericItemForComparison() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach_field2 | eval count = 0 | foreach mode=json_array jsonfield ["
+                + " eval count = count + if(<<ITEM>> > 9, 1, 0) ] | fields count");
+    verifySchema(result, schema("count", "int"));
+    verifyDataRows(result, rows(3));
+  }
+
+  @Test
   public void testJsonArrayModeOnFieldWithStringContent() throws IOException {
     JSONObject result =
         executeQuery(

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
@@ -27,18 +27,17 @@ public class ForeachFieldJsonIT extends PPLIntegTestCase {
     super.init();
     enableCalcite();
 
-    if (!TestUtils.isIndexExist(client(), "test_foreach_field")) {
+    if (!TestUtils.isIndexExist(client(), "test_foreach_field2")) {
       String mapping =
-          "{\"mappings\":{\"properties\":{"
-              + "\"jsonfield\":{\"type\":\"keyword\"},"
-              + "\"jsonstrs\":{\"type\":\"keyword\"},"
-              + "\"nativenums\":{\"type\":\"long\"}}}}";
-      TestUtils.createIndexByRestClient(client(), "test_foreach_field", mapping);
+          "{\"mappings\":{\"properties\":{\"jsonfield\":{\"type\":\"keyword\"},"
+              + "\"jsonstrs\":{\"type\":\"keyword\"},\"nativenums\":{\"type\":\"long\"},"
+              + "\"nested_objs\":{\"type\":\"nested\",\"properties\":{\"a\":{\"type\":\"long\"}}}}}}";
+      TestUtils.createIndexByRestClient(client(), "test_foreach_field2", mapping);
 
-      Request r = new Request("PUT", "/test_foreach_field/_doc/1?refresh=true");
+      Request r = new Request("PUT", "/test_foreach_field2/_doc/1?refresh=true");
       r.setJsonEntity(
           "{\"jsonfield\": \"[10,20,30]\", \"jsonstrs\": \"[\\\"a\\\",\\\"b\\\"]\","
-              + " \"nativenums\": [1, 2, 3]}");
+              + " \"nativenums\": [1, 2, 3], \"nested_objs\": [{\"a\": 1}, {\"a\": 2}]}");
       client().performRequest(r);
     }
   }
@@ -48,7 +47,7 @@ public class ForeachFieldJsonIT extends PPLIntegTestCase {
     // Splunk: field holding "[10,20,30]" with foreach mode=json_array sums to 60.
     JSONObject result =
         executeQuery(
-            "source=test_foreach_field | eval total = 0 | foreach mode=json_array jsonfield ["
+            "source=test_foreach_field2 | eval total = 0 | foreach mode=json_array jsonfield ["
                 + " eval total = total + <<ITEM>> ] | fields total");
     verifySchema(result, schema("total", "double"));
     verifyDataRows(result, rows(60.0));
@@ -58,7 +57,7 @@ public class ForeachFieldJsonIT extends PPLIntegTestCase {
   public void testJsonArrayModeOnFieldWithStringContent() throws IOException {
     JSONObject result =
         executeQuery(
-            "source=test_foreach_field | eval r = '' | foreach mode=json_array jsonstrs ["
+            "source=test_foreach_field2 | eval r = '' | foreach mode=json_array jsonstrs ["
                 + " eval r = concat(r, <<ITEM>>) ] | fields r");
     verifySchema(result, schema("r", "string"));
     verifyDataRows(result, rows("ab"));
@@ -76,7 +75,21 @@ public class ForeachFieldJsonIT extends PPLIntegTestCase {
         ResponseException.class,
         () ->
             executeQuery(
-                "source=test_foreach_field | eval total = 0 | foreach mode=multivalue nativenums"
+                "source=test_foreach_field2 | eval total = 0 | foreach mode=multivalue nativenums"
                     + " [ eval total = total + <<ITEM>> ] | fields total"));
+  }
+
+  /**
+   * Nested-typed fields map to ARRAY&lt;ANY&gt; at plan time, so multivalue mode iterates them. The
+   * lambda here only counts elements; it does not dereference the object item.
+   */
+  @Test
+  public void testNestedFieldMultivalueIterates() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach_field2 | eval total = 0 | foreach mode=multivalue nested_objs ["
+                + " eval total = total + 1 ] | fields total");
+    verifySchema(result, schema("total", "int"));
+    verifyDataRows(result, rows(2));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import static org.junit.Assert.assertThrows;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
@@ -15,7 +14,6 @@ import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
-import org.opensearch.client.ResponseException;
 import org.opensearch.sql.legacy.TestUtils;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
@@ -70,13 +68,13 @@ public class ForeachFieldJsonIT extends PPLIntegTestCase {
    * desired behavior.
    */
   @Test
-  public void testNativeArrayFieldIsRejected() {
-    assertThrows(
-        ResponseException.class,
-        () ->
-            executeQuery(
-                "source=test_foreach_field2 | eval total = 0 | foreach mode=multivalue nativenums"
-                    + " [ eval total = total + <<ITEM>> ] | fields total"));
+  public void testNativeArrayFieldMappingMismatchIsNoOp() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach_field2 | eval total = 0 | foreach mode=multivalue nativenums"
+                + " [ eval total = total + <<ITEM>> ] | fields total");
+    verifySchema(result, schema("total", "int"));
+    verifyDataRows(result, rows(0));
   }
 
   /**
@@ -93,29 +91,25 @@ public class ForeachFieldJsonIT extends PPLIntegTestCase {
     verifyDataRows(result, rows(2));
   }
 
-  /**
-   * Cross-feed behavior differs from Splunk by design. Splunk silently no-ops when a mode is fed
-   * the wrong collection shape; we either still work (json_array mode on a real array iterates it -
-   * more permissive) or fail loudly at plan time (multivalue mode on a JSON-text field).
-   */
+  /** Splunk silently no-ops when a mode is fed the wrong collection shape. */
   @Test
-  public void testJsonArrayModeOnRealArrayIterates() throws IOException {
+  public void testJsonArrayModeOnRealArrayIsNoOp() throws IOException {
     JSONObject result =
         executeQuery(
             "source=test_foreach_field2 | eval nums = array(1, 2, 3), total = 0 | foreach"
                 + " mode=json_array nums [ eval total = total + <<ITEM>> ] | fields total | head"
                 + " 1");
-    verifySchema(result, schema("total", "double"));
-    verifyDataRows(result, rows(6.0));
+    verifySchema(result, schema("total", "int"));
+    verifyDataRows(result, rows(0));
   }
 
   @Test
-  public void testMultivalueModeOnJsonTextFieldIsRejected() {
-    assertThrows(
-        ResponseException.class,
-        () ->
-            executeQuery(
-                "source=test_foreach_field2 | eval total = 0 | foreach mode=multivalue jsonfield"
-                    + " [ eval total = total + <<ITEM>> ] | fields total"));
+  public void testMultivalueModeOnJsonTextFieldIsNoOp() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach_field2 | eval total = 0 | foreach mode=multivalue jsonfield"
+                + " [ eval total = total + <<ITEM>> ] | fields total");
+    verifySchema(result, schema("total", "int"));
+    verifyDataRows(result, rows(0));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/ForeachFieldJsonIT.java
@@ -92,4 +92,30 @@ public class ForeachFieldJsonIT extends PPLIntegTestCase {
     verifySchema(result, schema("total", "int"));
     verifyDataRows(result, rows(2));
   }
+
+  /**
+   * Cross-feed behavior differs from Splunk by design. Splunk silently no-ops when a mode is fed
+   * the wrong collection shape; we either still work (json_array mode on a real array iterates it -
+   * more permissive) or fail loudly at plan time (multivalue mode on a JSON-text field).
+   */
+  @Test
+  public void testJsonArrayModeOnRealArrayIterates() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_foreach_field2 | eval nums = array(1, 2, 3), total = 0 | foreach"
+                + " mode=json_array nums [ eval total = total + <<ITEM>> ] | fields total | head"
+                + " 1");
+    verifySchema(result, schema("total", "double"));
+    verifyDataRows(result, rows(6.0));
+  }
+
+  @Test
+  public void testMultivalueModeOnJsonTextFieldIsRejected() {
+    assertThrows(
+        ResponseException.class,
+        () ->
+            executeQuery(
+                "source=test_foreach_field2 | eval total = 0 | foreach mode=multivalue jsonfield"
+                    + " [ eval total = total + <<ITEM>> ] | fields total"));
+  }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -26,6 +26,7 @@ STREAMSTATS:                        'STREAMSTATS';
 DEDUP:                              'DEDUP';
 SORT:                               'SORT';
 EVAL:                               'EVAL';
+FOREACH:                            'FOREACH';
 FIELDFORMAT:                        'FIELDFORMAT';
 HEAD:                               'HEAD';
 BIN:                                'BIN';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -410,9 +410,10 @@ foreachArgument
    ;
 
 foreachTarget
-   : wcFieldExpression
+   : functionCall
+   | stringLiteral
+   | wcFieldExpression
    | STAR
-   | logicalExpression
    ;
 
 foreachOption

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -64,6 +64,7 @@ commands
    | dedupCommand
    | sortCommand
    | evalCommand
+   | foreachCommand
    | headCommand
    | binCommand
    | rareTopCommand
@@ -116,6 +117,7 @@ commandName
    | DEDUP
    | SORT
    | EVAL
+   | FOREACH
    | FIELDFORMAT
    | HEAD
    | BIN
@@ -396,6 +398,31 @@ spanLiteral
 
 evalCommand
    : EVAL evalClause (COMMA evalClause)*
+   ;
+
+foreachCommand
+   : FOREACH foreachOption* foreachFieldPattern (COMMA? foreachFieldPattern)* LT_SQR_PRTHS foreachEvalCommand RT_SQR_PRTHS
+   ;
+
+foreachFieldPattern
+   : wcFieldExpression
+   | STAR
+   ;
+
+foreachOption
+   : ident EQUAL ident
+   ;
+
+foreachEvalCommand
+   : EVAL foreachEvalClause (COMMA foreachEvalClause)*
+   ;
+
+foreachEvalClause
+   : target = foreachEvalTarget EQUAL logicalExpression
+   ;
+
+foreachEvalTarget
+   : (foreachPlaceholder | ident | DOT | MODULE)+
    ;
 
 fieldformatCommand
@@ -965,6 +992,7 @@ valueExpression
    | literalValue                                                                                               # literalValueExpr
    | functionCall                                                                                               # functionCallExpr
    | lambda                                                                                                     # lambdaExpr
+   | foreachPlaceholder                                                                                         # foreachPlaceholderExpr
    | LT_SQR_PRTHS subSearch RT_SQR_PRTHS                                                                        # scalarSubqueryExpr
    | valueExpression NOT? IN LT_SQR_PRTHS subSearch RT_SQR_PRTHS                                                # inSubqueryExpr
    | LT_PRTHS valueExpression (COMMA valueExpression)* RT_PRTHS NOT? IN LT_SQR_PRTHS subSearch RT_SQR_PRTHS     # inSubqueryExpr
@@ -1065,6 +1093,16 @@ fieldExpression
 
 wcFieldExpression
    : wcQualifiedName
+   ;
+
+foreachPlaceholder
+   : LESS LESS foreachPlaceholderName GREATER GREATER
+   ;
+
+foreachPlaceholderName
+   : FIELD
+   | ID
+   | NUMERIC_ID
    ;
 
 selectFieldExpression

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -401,16 +401,17 @@ evalCommand
    ;
 
 foreachCommand
-   : FOREACH foreachOption* foreachFieldPattern (COMMA? foreachFieldPattern)* LT_SQR_PRTHS foreachEvalCommand RT_SQR_PRTHS
+   : FOREACH foreachOption* foreachTarget (COMMA? foreachTarget)* LT_SQR_PRTHS foreachEvalCommand RT_SQR_PRTHS
    ;
 
-foreachFieldPattern
+foreachTarget
    : wcFieldExpression
    | STAR
+   | logicalExpression
    ;
 
 foreachOption
-   : ident EQUAL ident
+   : ident EQUAL (ident | foreachPlaceholder)
    ;
 
 foreachEvalCommand

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -401,7 +401,12 @@ evalCommand
    ;
 
 foreachCommand
-   : FOREACH foreachOption* foreachTarget (COMMA? foreachTarget)* LT_SQR_PRTHS foreachEvalCommand RT_SQR_PRTHS
+   : FOREACH foreachArgument* LT_SQR_PRTHS foreachEvalCommand RT_SQR_PRTHS
+   ;
+
+foreachArgument
+   : foreachOption
+   | foreachTarget
    ;
 
 foreachTarget

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -54,6 +54,7 @@ import org.opensearch.sql.ast.expression.Argument.ArgumentMap;
 import org.opensearch.sql.ast.expression.DataType;
 import org.opensearch.sql.ast.expression.EqualTo;
 import org.opensearch.sql.ast.expression.Field;
+import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Map;
@@ -872,19 +873,28 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitForeachCommand(OpenSearchPPLParser.ForeachCommandContext ctx) {
     java.util.Map<String, String> options = new LinkedHashMap<>();
-    ctx.foreachOption()
-        .forEach(
-            option ->
-                options.put(
-                    option.ident(0).getText().toLowerCase(Locale.ROOT),
-                    normalizeForeachOptionValue(option.getChild(2).getText())));
-    String mode = options.getOrDefault("mode", "multifield");
+    List<OpenSearchPPLParser.ForeachOptionContext> optionContexts =
+        ctx.foreachArgument().stream()
+            .map(OpenSearchPPLParser.ForeachArgumentContext::foreachOption)
+            .filter(java.util.Objects::nonNull)
+            .collect(Collectors.toList());
+    List<OpenSearchPPLParser.ForeachTargetContext> targetContexts =
+        ctx.foreachArgument().stream()
+            .map(OpenSearchPPLParser.ForeachArgumentContext::foreachTarget)
+            .filter(java.util.Objects::nonNull)
+            .collect(Collectors.toList());
+    optionContexts.forEach(
+        option ->
+            options.put(
+                option.ident(0).getText().toLowerCase(Locale.ROOT),
+                normalizeForeachOptionValue(option.getChild(2).getText())));
+    String mode = options.getOrDefault("mode", inferForeachMode(targetContexts));
     List<String> patterns =
-        ctx.foreachTarget().stream().map(this::getTextInQuery).collect(Collectors.toList());
+        targetContexts.stream().map(this::getTextInQuery).collect(Collectors.toList());
     UnresolvedExpression collectionExpression =
         "multifield".equalsIgnoreCase(mode)
             ? null
-            : buildForeachCollectionExpression(ctx.foreachTarget());
+            : buildForeachCollectionExpression(targetContexts, mode);
     List<ForeachEvalClause> evalClauses =
         ctx.foreachEvalCommand().foreachEvalClause().stream()
             .map(
@@ -903,8 +913,21 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     return value;
   }
 
+  private String inferForeachMode(List<OpenSearchPPLParser.ForeachTargetContext> targets) {
+    if (targets.size() == 1
+        && targets.get(0).logicalExpression() != null
+        && expressionBuilder.visit(targets.get(0).logicalExpression()) instanceof Function function
+        && "json_array".equalsIgnoreCase(function.getFuncName())) {
+      return "json_array";
+    }
+    return "multifield";
+  }
+
   private UnresolvedExpression buildForeachCollectionExpression(
-      List<OpenSearchPPLParser.ForeachTargetContext> targets) {
+      List<OpenSearchPPLParser.ForeachTargetContext> targets, String mode) {
+    if (targets.isEmpty() && "auto_collections".equalsIgnoreCase(mode)) {
+      return null;
+    }
     if (targets.size() != 1) {
       throw new IllegalArgumentException("foreach collection modes accept exactly one field");
     }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -884,10 +884,13 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
       } else {
         OpenSearchPPLParser.ForeachTargetContext target = argument.foreachTarget();
         patterns.add(getTextInQuery(target));
-        targets.add(
-            target.logicalExpression() != null
-                ? expressionBuilder.visit(target.logicalExpression())
-                : new Field(new QualifiedName(getTextInQuery(target))));
+        if (target.functionCall() != null) {
+          targets.add(expressionBuilder.visit(target.functionCall()));
+        } else if (target.stringLiteral() != null) {
+          targets.add(expressionBuilder.visit(target.stringLiteral()));
+        } else {
+          targets.add(new Field(new QualifiedName(getTextInQuery(target))));
+        }
       }
     }
     Foreach.Mode mode =

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -87,6 +87,8 @@ import org.opensearch.sql.ast.tree.Expand;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Flatten;
+import org.opensearch.sql.ast.tree.Foreach;
+import org.opensearch.sql.ast.tree.Foreach.ForeachEvalClause;
 import org.opensearch.sql.ast.tree.GraphLookup;
 import org.opensearch.sql.ast.tree.GraphLookup.Direction;
 import org.opensearch.sql.ast.tree.Head;
@@ -865,6 +867,27 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
         ctx.evalClause().stream()
             .map(ct -> (Let) internalVisitExpression(ct))
             .collect(Collectors.toList()));
+  }
+
+  @Override
+  public UnresolvedPlan visitForeachCommand(OpenSearchPPLParser.ForeachCommandContext ctx) {
+    String mode =
+        ctx.foreachOption().stream()
+            .filter(option -> "mode".equalsIgnoreCase(option.ident(0).getText()))
+            .map(option -> option.ident(1).getText())
+            .findFirst()
+            .orElse("multifield");
+    List<String> patterns =
+        ctx.foreachFieldPattern().stream().map(this::getTextInQuery).collect(Collectors.toList());
+    List<ForeachEvalClause> evalClauses =
+        ctx.foreachEvalCommand().foreachEvalClause().stream()
+            .map(
+                clause ->
+                    new ForeachEvalClause(
+                        getTextInQuery(clause.target),
+                        expressionBuilder.visit(clause.logicalExpression())))
+            .collect(Collectors.toList());
+    return new Foreach(mode, patterns, evalClauses);
   }
 
   @Override

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -871,14 +871,20 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
 
   @Override
   public UnresolvedPlan visitForeachCommand(OpenSearchPPLParser.ForeachCommandContext ctx) {
-    String mode =
-        ctx.foreachOption().stream()
-            .filter(option -> "mode".equalsIgnoreCase(option.ident(0).getText()))
-            .map(option -> option.ident(1).getText())
-            .findFirst()
-            .orElse("multifield");
+    java.util.Map<String, String> options = new LinkedHashMap<>();
+    ctx.foreachOption()
+        .forEach(
+            option ->
+                options.put(
+                    option.ident(0).getText().toLowerCase(Locale.ROOT),
+                    normalizeForeachOptionValue(option.getChild(2).getText())));
+    String mode = options.getOrDefault("mode", "multifield");
     List<String> patterns =
-        ctx.foreachFieldPattern().stream().map(this::getTextInQuery).collect(Collectors.toList());
+        ctx.foreachTarget().stream().map(this::getTextInQuery).collect(Collectors.toList());
+    UnresolvedExpression collectionExpression =
+        "multifield".equalsIgnoreCase(mode)
+            ? null
+            : buildForeachCollectionExpression(ctx.foreachTarget());
     List<ForeachEvalClause> evalClauses =
         ctx.foreachEvalCommand().foreachEvalClause().stream()
             .map(
@@ -887,7 +893,27 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
                         getTextInQuery(clause.target),
                         expressionBuilder.visit(clause.logicalExpression())))
             .collect(Collectors.toList());
-    return new Foreach(mode, patterns, evalClauses);
+    return new Foreach(mode, options, patterns, collectionExpression, evalClauses);
+  }
+
+  private String normalizeForeachOptionValue(String value) {
+    if (value.startsWith("<<") && value.endsWith(">>")) {
+      return value.substring(2, value.length() - 2);
+    }
+    return value;
+  }
+
+  private UnresolvedExpression buildForeachCollectionExpression(
+      List<OpenSearchPPLParser.ForeachTargetContext> targets) {
+    if (targets.size() != 1) {
+      throw new IllegalArgumentException("foreach collection modes accept exactly one field");
+    }
+    OpenSearchPPLParser.ForeachTargetContext target = targets.get(0);
+    if (target.logicalExpression() != null) {
+      return expressionBuilder.visit(target.logicalExpression());
+    }
+    String fieldName = getTextInQuery(target);
+    return new Field(new QualifiedName(fieldName));
   }
 
   @Override

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstBuilder.java
@@ -873,28 +873,34 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitForeachCommand(OpenSearchPPLParser.ForeachCommandContext ctx) {
     java.util.Map<String, String> options = new LinkedHashMap<>();
-    List<OpenSearchPPLParser.ForeachOptionContext> optionContexts =
-        ctx.foreachArgument().stream()
-            .map(OpenSearchPPLParser.ForeachArgumentContext::foreachOption)
-            .filter(java.util.Objects::nonNull)
-            .collect(Collectors.toList());
-    List<OpenSearchPPLParser.ForeachTargetContext> targetContexts =
-        ctx.foreachArgument().stream()
-            .map(OpenSearchPPLParser.ForeachArgumentContext::foreachTarget)
-            .filter(java.util.Objects::nonNull)
-            .collect(Collectors.toList());
-    optionContexts.forEach(
-        option ->
-            options.put(
-                option.ident(0).getText().toLowerCase(Locale.ROOT),
-                normalizeForeachOptionValue(option.getChild(2).getText())));
-    String mode = options.getOrDefault("mode", inferForeachMode(targetContexts));
-    List<String> patterns =
-        targetContexts.stream().map(this::getTextInQuery).collect(Collectors.toList());
-    UnresolvedExpression collectionExpression =
-        "multifield".equalsIgnoreCase(mode)
-            ? null
-            : buildForeachCollectionExpression(targetContexts, mode);
+    List<UnresolvedExpression> targets = new ArrayList<>();
+    List<String> patterns = new ArrayList<>();
+    for (OpenSearchPPLParser.ForeachArgumentContext argument : ctx.foreachArgument()) {
+      OpenSearchPPLParser.ForeachOptionContext option = argument.foreachOption();
+      if (option != null) {
+        options.put(
+            option.ident(0).getText().toLowerCase(Locale.ROOT),
+            stripForeachPlaceholderMarkers(option.getChild(2).getText()));
+      } else {
+        OpenSearchPPLParser.ForeachTargetContext target = argument.foreachTarget();
+        patterns.add(getTextInQuery(target));
+        targets.add(
+            target.logicalExpression() != null
+                ? expressionBuilder.visit(target.logicalExpression())
+                : new Field(new QualifiedName(getTextInQuery(target))));
+      }
+    }
+    Foreach.Mode mode =
+        options.containsKey("mode")
+            ? Foreach.Mode.of(options.get("mode"))
+            : inferForeachMode(targets);
+    UnresolvedExpression collectionExpression = null;
+    if (mode != Foreach.Mode.MULTIFIELD) {
+      if (targets.size() > 1 || (targets.isEmpty() && mode != Foreach.Mode.AUTO_COLLECTIONS)) {
+        throw new IllegalArgumentException("foreach collection modes accept exactly one field");
+      }
+      collectionExpression = targets.isEmpty() ? null : targets.get(0);
+    }
     List<ForeachEvalClause> evalClauses =
         ctx.foreachEvalCommand().foreachEvalClause().stream()
             .map(
@@ -906,37 +912,19 @@ public class AstBuilder extends OpenSearchPPLParserBaseVisitor<UnresolvedPlan> {
     return new Foreach(mode, options, patterns, collectionExpression, evalClauses);
   }
 
-  private String normalizeForeachOptionValue(String value) {
-    if (value.startsWith("<<") && value.endsWith(">>")) {
-      return value.substring(2, value.length() - 2);
-    }
-    return value;
+  private String stripForeachPlaceholderMarkers(String value) {
+    return value.startsWith("<<") && value.endsWith(">>")
+        ? value.substring(2, value.length() - 2)
+        : value;
   }
 
-  private String inferForeachMode(List<OpenSearchPPLParser.ForeachTargetContext> targets) {
-    if (targets.size() == 1
-        && targets.get(0).logicalExpression() != null
-        && expressionBuilder.visit(targets.get(0).logicalExpression()) instanceof Function function
-        && "json_array".equalsIgnoreCase(function.getFuncName())) {
-      return "json_array";
-    }
-    return "multifield";
-  }
-
-  private UnresolvedExpression buildForeachCollectionExpression(
-      List<OpenSearchPPLParser.ForeachTargetContext> targets, String mode) {
-    if (targets.isEmpty() && "auto_collections".equalsIgnoreCase(mode)) {
-      return null;
-    }
-    if (targets.size() != 1) {
-      throw new IllegalArgumentException("foreach collection modes accept exactly one field");
-    }
-    OpenSearchPPLParser.ForeachTargetContext target = targets.get(0);
-    if (target.logicalExpression() != null) {
-      return expressionBuilder.visit(target.logicalExpression());
-    }
-    String fieldName = getTextInQuery(target);
-    return new Field(new QualifiedName(fieldName));
+  /** A bare json_array(...) target implies json_array mode; anything else is multifield. */
+  private Foreach.Mode inferForeachMode(List<UnresolvedExpression> targets) {
+    return targets.size() == 1
+            && targets.get(0) instanceof Function function
+            && "json_array".equalsIgnoreCase(function.getFuncName())
+        ? Foreach.Mode.JSON_ARRAY
+        : Foreach.Mode.MULTIFIELD;
   }
 
   @Override

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -124,6 +124,18 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
     return new Let((Field) visit(ctx.fieldExpression()), visit(ctx.logicalExpression()));
   }
 
+  @Override
+  public UnresolvedExpression visitForeachPlaceholderExpr(
+      OpenSearchPPLParser.ForeachPlaceholderExprContext ctx) {
+    return visit(ctx.foreachPlaceholder());
+  }
+
+  @Override
+  public UnresolvedExpression visitForeachPlaceholder(
+      OpenSearchPPLParser.ForeachPlaceholderContext ctx) {
+    return new ForeachPlaceholder(ctx.foreachPlaceholderName().getText());
+  }
+
   /** Field format eval clause - similar to evalClause but for fieldformat command. */
   @Override
   public UnresolvedExpression visitFieldFormatEvalClause(

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -78,6 +78,7 @@ import org.opensearch.sql.ast.tree.Expand;
 import org.opensearch.sql.ast.tree.FillNull;
 import org.opensearch.sql.ast.tree.Filter;
 import org.opensearch.sql.ast.tree.Flatten;
+import org.opensearch.sql.ast.tree.Foreach;
 import org.opensearch.sql.ast.tree.GraphLookup;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Join;
@@ -583,6 +584,31 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
       return StringUtils.format("%s | mvexpand %s limit=%s", child, field, MASK_LITERAL);
     }
     return StringUtils.format("%s | mvexpand %s", child, field);
+  }
+
+  @Override
+  public String visitForeach(Foreach node, String context) {
+    String child = node.getChild().get(0).accept(this, context);
+    StringBuilder command = new StringBuilder(child).append(" | foreach");
+    if (node.getMode() != Foreach.Mode.MULTIFIELD) {
+      command.append(" mode=").append(node.getMode());
+    }
+    // Placeholder rename options (itemstr=X etc.) carry user-chosen identifiers, not data; the
+    // mode key is already rendered above.
+    node.getOptions().keySet().stream()
+        .filter(key -> !"mode".equals(key))
+        .forEach(key -> command.append(' ').append(key).append('=').append(MASK_COLUMN));
+    // Targets are field names or patterns in multifield mode; collection targets may embed
+    // literals (e.g. a JSON array string), so mask them all.
+    node.getFieldPatterns().forEach(pattern -> command.append(' ').append(MASK_COLUMN));
+    String evalClauses =
+        node.getEvalClauses().stream()
+            .map(
+                clause ->
+                    StringUtils.format(
+                        "%s = %s", MASK_COLUMN, visitExpression(clause.getExpression())))
+            .collect(Collectors.joining(", "));
+    return command.append(" [ eval ").append(evalClauses).append(" ]").toString();
   }
 
   /** Build {@link LogicalSort}. */
@@ -1225,6 +1251,13 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
     @Override
     public String visitQualifiedName(
         org.opensearch.sql.ast.expression.QualifiedName node, String context) {
+      return MASK_COLUMN;
+    }
+
+    @Override
+    public String visitForeachPlaceholder(
+        org.opensearch.sql.ast.expression.ForeachPlaceholder node, String context) {
+      // Placeholder names are user-chosen identifiers; mask like any other column reference.
       return MASK_COLUMN;
     }
   }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -90,6 +90,24 @@ public class PPLSyntaxParserTest {
   }
 
   @Test
+  public void testForeachCommandShouldPass() {
+    ParseTree tree =
+        new PPLSyntaxParser()
+            .parse("source=t | foreach a* b [ eval <<FIELD>>_double = <<FIELD>> * 2 ]");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
+  public void testForeachCommandWithModeShouldPass() {
+    ParseTree tree =
+        new PPLSyntaxParser()
+            .parse(
+                "source=t | foreach mode=multifield value_* [ eval"
+                    + " total_<<MATCHSTR>> = <<FIELD>> + 1 ]");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
   public void testSearchFieldsCommandCrossClusterShouldPass() {
     ParseTree tree = new PPLSyntaxParser().parse("search source=c:t a=1 b=2 | fields a,b");
     assertNotEquals(null, tree);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -127,6 +127,14 @@ public class PPLSyntaxParserTest {
     assertNotEquals(
         null,
         new PPLSyntaxParser()
+            .parse("source=t | foreach mode=auto_collections [ eval total = total + <<ITEM>> ]"));
+    assertNotEquals(
+        null,
+        new PPLSyntaxParser()
+            .parse("source=t | foreach json_array(1, 2, 3) [ eval total = total + <<ITEM>> ]"));
+    assertNotEquals(
+        null,
+        new PPLSyntaxParser()
             .parse(
                 "source=t | foreach mode=multivalue iterstr=IDX nums [ eval total = total + IDX"
                     + " ]"));

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -108,6 +108,31 @@ public class PPLSyntaxParserTest {
   }
 
   @Test
+  public void testForeachCollectionModesShouldPass() {
+    assertNotEquals(
+        null,
+        new PPLSyntaxParser()
+            .parse(
+                "source=t | foreach mode=multivalue itemstr=<<NUMBER>> nums [ eval total = total +"
+                    + " <<NUMBER>> ]"));
+    assertNotEquals(
+        null,
+        new PPLSyntaxParser()
+            .parse(
+                "source=t | foreach mode=json_array '[1,2,3]' [ eval total = total + <<ITEM>> ]"));
+    assertNotEquals(
+        null,
+        new PPLSyntaxParser()
+            .parse("source=t | foreach mode=auto_collections nums [ eval total = total + ITEM ]"));
+    assertNotEquals(
+        null,
+        new PPLSyntaxParser()
+            .parse(
+                "source=t | foreach mode=multivalue iterstr=IDX nums [ eval total = total + IDX"
+                    + " ]"));
+  }
+
+  @Test
   public void testSearchFieldsCommandCrossClusterShouldPass() {
     ParseTree tree = new PPLSyntaxParser().parse("search source=c:t a=1 b=2 | fields a,b");
     assertNotEquals(null, tree);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.test.CalciteAssert;
+import org.junit.Test;
+
+public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLForeachTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Test
+  public void testForeachExpandsExplicitFields() {
+    String ppl =
+        "source=EMP | foreach SAL COMM [ eval <<FIELD>>_double = <<FIELD>> * 2 ] | fields"
+            + " EMPNO, SAL_double, COMM_double";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(EMPNO=[$0], SAL_double=[*($5, 2)], COMM_double=[*($6, 2)])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT `EMPNO`, `SAL` * 2 `SAL_double`, `COMM` * 2 `COMM_double`\n" + "FROM `scott`.`EMP`";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testForeachWildcardAndMatchstr() {
+    String ppl =
+        "source=EMP | foreach *NO [ eval copy_<<MATCHSTR>> = <<FIELD>> ] | fields copy_EMP,"
+            + " copy_DEPT";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(copy_EMP=[$0], copy_DEPT=[$7])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.ppl.calcite;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.test.CalciteAssert;
 import org.junit.Test;
@@ -43,5 +45,58 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
         "LogicalProject(copy_EMP=[$0], copy_DEPT=[$7])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testForeachCustomMultifieldPlaceholders() {
+    String ppl =
+        "source=EMP | foreach fieldstr=F matchstr=M *NO [ eval copy_<<M>> = F ] | fields"
+            + " copy_EMP, copy_DEPT";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(copy_EMP=[$0], copy_DEPT=[$7])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testForeachMultivaluePlansReduce() {
+    String ppl =
+        "source=EMP | eval nums = array(1, 2, 3), total = 0 | foreach mode=multivalue"
+            + " itemstr=NUMBER nums [ eval total = total + NUMBER ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    assertNotNull(root);
+  }
+
+  @Test
+  public void testForeachJsonArrayPlansReduce() {
+    String ppl =
+        "source=EMP | eval total = 0 | foreach mode=json_array '[1,2,3]' [ eval total = total +"
+            + " <<ITEM>> ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    assertNotNull(root);
+  }
+
+  @Test
+  public void testForeachAutoCollectionsPlansReduce() {
+    String ppl =
+        "source=EMP | eval nums = array(1, 2, 3), total = 0 | foreach mode=auto_collections nums ["
+            + " eval total = total + <<ITEM>> ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    assertNotNull(root);
+  }
+
+  @Test
+  public void testForeachIterPlaceholderPlansReduce() {
+    String ppl =
+        "source=EMP | eval nums = array(10, 20, 30), total = 0 | foreach mode=multivalue"
+            + " iterstr=IDX nums [ eval total = total + IDX ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    assertNotNull(root);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
@@ -6,6 +6,7 @@
 package org.opensearch.sql.ppl.calcite;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.test.CalciteAssert;
@@ -69,8 +70,10 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
 
     String expectedLogical =
-        "LogicalProject(total=[reduce(foreach_pair_collection(array(1, 2, 3)), 0, (total,"
-            + " __foreach_pair) -> +(total, foreach_pair_item(__foreach_pair, 0)))])\n"
+        "LogicalProject(total=[foreach_pair_item(reduce(foreach_pair_collection(array(1, 2, 3)),"
+            + " foreach_state(0), (__foreach_state, __foreach_pair) ->"
+            + " foreach_state(+(foreach_pair_item(__foreach_state, 0),"
+            + " foreach_pair_item(__foreach_pair, 0)))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
@@ -83,8 +86,10 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
 
     String expectedLogical =
-        "LogicalProject(total=[reduce(foreach_pair_collection(array(10, 20, 30)), 0, (total,"
-            + " __foreach_pair) -> +(total, foreach_pair_item(__foreach_pair, 1)))])\n"
+        "LogicalProject(total=[foreach_pair_item(reduce(foreach_pair_collection(array(10, 20, 30)),"
+            + " foreach_state(0), (__foreach_state, __foreach_pair) ->"
+            + " foreach_state(+(foreach_pair_item(__foreach_state, 0),"
+            + " foreach_pair_item(__foreach_pair, 1)))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
@@ -97,9 +102,10 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
 
     String expectedLogical =
-        "LogicalProject(total=[reduce(foreach_pair_collection(foreach_json_array('[1,2,3]':VARCHAR,"
-            + " 'DOUBLE':VARCHAR)), 0.0E0:DOUBLE, (total, __foreach_pair) -> +(total,"
-            + " foreach_pair_item(__foreach_pair, 0)))])\n"
+        "LogicalProject(total=[foreach_pair_item(reduce(foreach_pair_collection(foreach_json_array('[1,2,3]':VARCHAR,"
+            + " 'DOUBLE':VARCHAR)), foreach_state(0.0E0:DOUBLE), (__foreach_state, __foreach_pair)"
+            + " -> foreach_state(+(foreach_pair_item(__foreach_state, 0),"
+            + " foreach_pair_item(__foreach_pair, 0)))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
@@ -112,9 +118,10 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
 
     String expectedLogical =
-        "LogicalProject(total=[reduce(foreach_pair_collection(foreach_json_array(JSON_ARRAY(FLAG(NULL_ON_NULL),"
-            + " 1, 2, 3), 'DOUBLE':VARCHAR)), 0.0E0:DOUBLE, (total, __foreach_pair) -> +(total,"
-            + " foreach_pair_item(__foreach_pair, 0)))])\n"
+        "LogicalProject(total=[foreach_pair_item(reduce(foreach_pair_collection(foreach_json_array(JSON_ARRAY(FLAG(NULL_ON_NULL),"
+            + " 1, 2, 3), 'DOUBLE':VARCHAR)), foreach_state(0.0E0:DOUBLE), (__foreach_state,"
+            + " __foreach_pair) -> foreach_state(+(foreach_pair_item(__foreach_state, 0),"
+            + " foreach_pair_item(__foreach_pair, 0)))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
@@ -136,8 +143,10 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
 
     String expectedLogical =
-        "LogicalProject(total=[reduce(foreach_pair_collection(array(1, 2, 3)), 0, (total,"
-            + " __foreach_pair) -> +(total, foreach_pair_item(__foreach_pair, 0)))])\n"
+        "LogicalProject(total=[foreach_pair_item(reduce(foreach_pair_collection(array(1, 2, 3)),"
+            + " foreach_state(0), (__foreach_state, __foreach_pair) ->"
+            + " foreach_state(+(foreach_pair_item(__foreach_state, 0),"
+            + " foreach_pair_item(__foreach_pair, 0)))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
@@ -150,8 +159,10 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
 
     String expectedLogical =
-        "LogicalProject(total=[reduce(foreach_pair_collection(array(1, 2, 3)), 0, (total,"
-            + " __foreach_pair) -> +(total, foreach_pair_item(__foreach_pair, 0)))])\n"
+        "LogicalProject(total=[foreach_pair_item(reduce(foreach_pair_collection(array(1, 2, 3)),"
+            + " foreach_state(0), (__foreach_state, __foreach_pair) ->"
+            + " foreach_state(+(foreach_pair_item(__foreach_state, 0),"
+            + " foreach_pair_item(__foreach_pair, 0)))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
@@ -167,15 +178,15 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
 
     // The captured field `nums` rides in pair slot 2; ITEM is slot 0 and ITER slot 1.
     String expectedLogical =
-        "LogicalProject(word_and_num=[reduce(foreach_pair_collection(CASE(=('':VARCHAR, ''),"
-            + " REGEXP_EXTRACT_ALL('ABCDE':VARCHAR, '.'), SPLIT('ABCDE':VARCHAR, '':VARCHAR)),"
-            + " array('1', '2', '3', '4', '5')), array(), (word_and_num, __foreach_pair) ->"
-            + " mvappend(word_and_num, CONCAT(foreach_pair_item(__foreach_pair, 0),"
-            + " ITEM(foreach_pair_item(__foreach_pair, 2),"
-            + " CASE(<(foreach_pair_item(__foreach_pair, 1), 0),"
+        "LogicalProject(word_and_num=[foreach_pair_item(reduce(foreach_pair_collection(CASE(=('':VARCHAR,"
+            + " ''), REGEXP_EXTRACT_ALL('ABCDE':VARCHAR, '.'), SPLIT('ABCDE':VARCHAR, '':VARCHAR)),"
+            + " array('1', '2', '3', '4', '5')), foreach_state(array()), (__foreach_state,"
+            + " __foreach_pair) -> foreach_state(mvappend(foreach_pair_item(__foreach_state, 0),"
+            + " CONCAT(foreach_pair_item(__foreach_pair, 0), ITEM(foreach_pair_item(__foreach_pair,"
+            + " 2), CASE(<(foreach_pair_item(__foreach_pair, 1), 0),"
             + " +(+(ARRAY_LENGTH(foreach_pair_item(__foreach_pair, 2)),"
             + " foreach_pair_item(__foreach_pair, 1)), 1), +(foreach_pair_item(__foreach_pair, 1),"
-            + " 1))))))])\n"
+            + " 1))))))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
@@ -189,9 +200,10 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
 
     String expectedLogical =
-        "LogicalProject(total=[reduce(foreach_pair_collection(foreach_json_array($1,"
-            + " 'DOUBLE':VARCHAR)), 0.0E0:DOUBLE, (total, __foreach_pair) -> +(total,"
-            + " foreach_pair_item(__foreach_pair, 0)))])\n"
+        "LogicalProject(total=[foreach_pair_item(reduce(foreach_pair_collection(foreach_json_array($1,"
+            + " 'DOUBLE':VARCHAR)), foreach_state(0.0E0:DOUBLE), (__foreach_state, __foreach_pair)"
+            + " -> foreach_state(+(foreach_pair_item(__foreach_state, 0),"
+            + " foreach_pair_item(__foreach_pair, 0)))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
@@ -205,10 +217,112 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
     RelNode root = getRelNode(ppl);
 
     String expectedLogical =
-        "LogicalProject(r=[reduce(foreach_pair_collection(foreach_json_array($1,"
-            + " 'VARCHAR':VARCHAR)), '':VARCHAR, (r, __foreach_pair) -> CONCAT(r,"
-            + " foreach_pair_item(__foreach_pair, 0)))])\n"
+        "LogicalProject(r=[foreach_pair_item(reduce(foreach_pair_collection(foreach_json_array($1,"
+            + " 'VARCHAR':VARCHAR)), foreach_state('':VARCHAR), (__foreach_state, __foreach_pair)"
+            + " -> foreach_state(CONCAT(foreach_pair_item(__foreach_state, 0),"
+            + " foreach_pair_item(__foreach_pair, 0)))), 0)])\n"
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testForeachSubstitutesTemplateInsideStringLiteral() {
+    RelNode root =
+        getRelNode("source=EMP | foreach ENAME [ eval copy = '<<FIELD>>' ] | fields copy");
+
+    verifyLogical(
+        root, "LogicalProject(copy=['ENAME'])\n" + "  LogicalTableScan(table=[[scott, EMP]])\n");
+  }
+
+  @Test
+  public void testDefaultItemNameDoesNotShadowRowField() {
+    RelNode root =
+        getRelNode(
+            "source=EMP | eval ITEM=100, nums=array(1,2), total=0 | foreach mode=multivalue"
+                + " nums [ eval total=total+ITEM ] | fields total");
+
+    String logical = org.apache.calcite.plan.RelOptUtil.toString(root);
+    assertTrue(logical.contains("foreach_pair_collection(array(1, 2), 100)"));
+    assertTrue(logical.contains("foreach_pair_item(__foreach_pair, 2)"));
+  }
+
+  @Test
+  public void testCustomItemNameShadowsRowField() {
+    RelNode root =
+        getRelNode(
+            "source=EMP | eval ITEM=100, nums=array(1,2), total=0 | foreach mode=multivalue"
+                + " itemstr=ITEM nums [ eval total=total+ITEM ] | fields total");
+
+    String logical = org.apache.calcite.plan.RelOptUtil.toString(root);
+    assertTrue(logical.contains("foreach_pair_collection(array(1, 2))"));
+    assertTrue(logical.contains("foreach_pair_item(__foreach_pair, 0)"));
+  }
+
+  @Test
+  public void testJsonFieldNumericFunctionInfersDoubleItem() {
+    RelNode root =
+        getRelNode(
+            "source=EMP | eval result=0 | foreach mode=json_array ENAME [ eval"
+                + " result=abs(<<ITEM>>) ] | fields result");
+
+    String logical = org.apache.calcite.plan.RelOptUtil.toString(root);
+    assertTrue(logical, logical.contains("foreach_json_array($1, 'DOUBLE':VARCHAR)"));
+  }
+
+  @Test
+  public void testJsonFieldNumericComparisonInfersDoubleItem() {
+    RelNode root =
+        getRelNode(
+            "source=EMP | eval count=0 | foreach mode=json_array ENAME [ eval"
+                + " count=count+if(<<ITEM>> > 9, 1, 0) ] | fields count");
+
+    assertTrue(
+        org.apache.calcite.plan.RelOptUtil.toString(root)
+            .contains("foreach_json_array($1, 'DOUBLE':VARCHAR)"));
+  }
+
+  @Test
+  public void testCollectionModeMismatchIsNoOp() {
+    RelNode multivalue =
+        getRelNode(
+            "source=EMP | eval total=0 | foreach mode=multivalue ENAME [ eval"
+                + " total=total+<<ITEM>> ] | fields total");
+    RelNode jsonArray =
+        getRelNode(
+            "source=EMP | eval nums=array(1,2), total=0 | foreach mode=json_array nums [ eval"
+                + " total=total+<<ITEM>> ] | fields total");
+
+    String expected = "LogicalProject(total=[0])\n" + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(multivalue, expected);
+    verifyLogical(jsonArray, expected);
+  }
+
+  @Test
+  public void testExactPatternTakesPrecedenceForMatchstr() {
+    RelNode root =
+        getRelNode(
+            "source=EMP | foreach *NO EMPNO [ eval copy_<<MATCHSTR>> = '<<MATCHSTR>>' ] |"
+                + " fields copy_");
+
+    verifyLogical(
+        root, "LogicalProject(copy_=[''])\n" + "  LogicalTableScan(table=[[scott, EMP]])\n");
+  }
+
+  @Test
+  public void testCollectionAssignmentsSharePerIterationState() {
+    RelNode root =
+        getRelNode(
+            "source=EMP | eval nums=array(1,2), sum=0, seen=0 | foreach mode=multivalue nums"
+                + " [ eval sum=sum+<<ITEM>>, seen=seen+sum ] | fields sum, seen");
+
+    String logical = org.apache.calcite.plan.RelOptUtil.toString(root);
+    assertTrue(logical.contains("foreach_state(0, 0)"));
+    assertTrue(
+        logical.contains(
+            "foreach_state(+(foreach_pair_item(__foreach_state, 0),"
+                + " foreach_pair_item(__foreach_pair, 0)),"
+                + " +(foreach_pair_item(__foreach_state, 1),"
+                + " +(foreach_pair_item(__foreach_state, 0),"
+                + " foreach_pair_item(__foreach_pair, 0))))"));
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
@@ -179,4 +179,36 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
             + "  LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
   }
+
+  @Test
+  public void testForeachJsonArrayFieldNumericUsage() {
+    // Field content is opaque at plan time; arithmetic on <<ITEM>> selects DOUBLE elements.
+    String ppl =
+        "source=EMP | eval total = 0 | foreach mode=json_array ENAME [ eval total = total +"
+            + " <<ITEM>> ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(total=[reduce(foreach_pair_collection(foreach_json_array($1,"
+            + " 'DOUBLE':VARCHAR)), 0.0E0:DOUBLE, (total, __foreach_pair) -> +(total,"
+            + " foreach_pair_item(__foreach_pair, 0)))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testForeachJsonArrayFieldStringUsage() {
+    // No arithmetic on <<ITEM>> keeps field-backed JSON array elements as VARCHAR.
+    String ppl =
+        "source=EMP | eval r = '' | foreach mode=json_array ENAME [ eval r = concat(r, <<ITEM>>)"
+            + " ] | fields r";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(r=[reduce(foreach_pair_collection(foreach_json_array($1,"
+            + " 'VARCHAR':VARCHAR)), '':VARCHAR, (r, __foreach_pair) -> CONCAT(r,"
+            + " foreach_pair_item(__foreach_pair, 0)))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
@@ -6,10 +6,12 @@
 package org.opensearch.sql.ppl.calcite;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.test.CalciteAssert;
 import org.junit.Test;
+import org.opensearch.sql.exception.SemanticCheckException;
 
 public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
 
@@ -81,10 +83,51 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
   }
 
   @Test
+  public void testForeachJsonArrayFunctionWithoutModePlansReduce() {
+    String ppl =
+        "source=EMP | eval total = 0 | foreach json_array(1, 2, 3) [ eval total = total +"
+            + " <<ITEM>> ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    assertNotNull(root);
+  }
+
+  @Test
+  public void testForeachJsonArrayMixedStringAndNumberFails() {
+    String ppl =
+        "source=EMP | eval total = 0 | foreach json_array(1, 2, 'hello') [ eval total = total +"
+            + " <<ITEM>> ] | fields total";
+
+    assertThrows(SemanticCheckException.class, () -> getRelNode(ppl));
+  }
+
+  @Test
   public void testForeachAutoCollectionsPlansReduce() {
     String ppl =
         "source=EMP | eval nums = array(1, 2, 3), total = 0 | foreach mode=auto_collections nums ["
             + " eval total = total + <<ITEM>> ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    assertNotNull(root);
+  }
+
+  @Test
+  public void testForeachAutoCollectionsWithoutTargetPlansReduce() {
+    String ppl =
+        "source=EMP | eval nums = array(1, 2, 3), total = 0 | foreach mode=auto_collections ["
+            + " eval total = total + <<ITEM>> ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    assertNotNull(root);
+  }
+
+  @Test
+  public void testForeachStringItemWithNumericIterPlansReduce() {
+    String ppl =
+        "source=EMP | eval word = split('ABCDE', ''), nums = array('1', '2', '3', '4', '5'),"
+            + " word_and_num = array() | foreach word mode=multivalue [ eval word_and_num ="
+            + " mvappend(word_and_num, concat(<<ITEM>>, mvindex(nums, <<ITER>>))) ] | fields"
+            + " word_and_num";
     RelNode root = getRelNode(ppl);
 
     assertNotNull(root);

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLForeachTest.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.ppl.calcite;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 import org.apache.calcite.rel.RelNode;
@@ -69,7 +68,25 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
             + " itemstr=NUMBER nums [ eval total = total + NUMBER ] | fields total";
     RelNode root = getRelNode(ppl);
 
-    assertNotNull(root);
+    String expectedLogical =
+        "LogicalProject(total=[reduce(foreach_pair_collection(array(1, 2, 3)), 0, (total,"
+            + " __foreach_pair) -> +(total, foreach_pair_item(__foreach_pair, 0)))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+  }
+
+  @Test
+  public void testForeachIterPlaceholderPlansReduce() {
+    String ppl =
+        "source=EMP | eval nums = array(10, 20, 30), total = 0 | foreach mode=multivalue"
+            + " iterstr=IDX nums [ eval total = total + IDX ] | fields total";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(total=[reduce(foreach_pair_collection(array(10, 20, 30)), 0, (total,"
+            + " __foreach_pair) -> +(total, foreach_pair_item(__foreach_pair, 1)))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
   }
 
   @Test
@@ -79,7 +96,12 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
             + " <<ITEM>> ] | fields total";
     RelNode root = getRelNode(ppl);
 
-    assertNotNull(root);
+    String expectedLogical =
+        "LogicalProject(total=[reduce(foreach_pair_collection(foreach_json_array('[1,2,3]':VARCHAR,"
+            + " 'DOUBLE':VARCHAR)), 0.0E0:DOUBLE, (total, __foreach_pair) -> +(total,"
+            + " foreach_pair_item(__foreach_pair, 0)))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
   }
 
   @Test
@@ -89,7 +111,12 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
             + " <<ITEM>> ] | fields total";
     RelNode root = getRelNode(ppl);
 
-    assertNotNull(root);
+    String expectedLogical =
+        "LogicalProject(total=[reduce(foreach_pair_collection(foreach_json_array(JSON_ARRAY(FLAG(NULL_ON_NULL),"
+            + " 1, 2, 3), 'DOUBLE':VARCHAR)), 0.0E0:DOUBLE, (total, __foreach_pair) -> +(total,"
+            + " foreach_pair_item(__foreach_pair, 0)))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
   }
 
   @Test
@@ -108,7 +135,11 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
             + " eval total = total + <<ITEM>> ] | fields total";
     RelNode root = getRelNode(ppl);
 
-    assertNotNull(root);
+    String expectedLogical =
+        "LogicalProject(total=[reduce(foreach_pair_collection(array(1, 2, 3)), 0, (total,"
+            + " __foreach_pair) -> +(total, foreach_pair_item(__foreach_pair, 0)))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
   }
 
   @Test
@@ -118,7 +149,11 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
             + " eval total = total + <<ITEM>> ] | fields total";
     RelNode root = getRelNode(ppl);
 
-    assertNotNull(root);
+    String expectedLogical =
+        "LogicalProject(total=[reduce(foreach_pair_collection(array(1, 2, 3)), 0, (total,"
+            + " __foreach_pair) -> +(total, foreach_pair_item(__foreach_pair, 0)))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
   }
 
   @Test
@@ -130,16 +165,18 @@ public class CalcitePPLForeachTest extends CalcitePPLAbstractTest {
             + " word_and_num";
     RelNode root = getRelNode(ppl);
 
-    assertNotNull(root);
-  }
-
-  @Test
-  public void testForeachIterPlaceholderPlansReduce() {
-    String ppl =
-        "source=EMP | eval nums = array(10, 20, 30), total = 0 | foreach mode=multivalue"
-            + " iterstr=IDX nums [ eval total = total + IDX ] | fields total";
-    RelNode root = getRelNode(ppl);
-
-    assertNotNull(root);
+    // The captured field `nums` rides in pair slot 2; ITEM is slot 0 and ITER slot 1.
+    String expectedLogical =
+        "LogicalProject(word_and_num=[reduce(foreach_pair_collection(CASE(=('':VARCHAR, ''),"
+            + " REGEXP_EXTRACT_ALL('ABCDE':VARCHAR, '.'), SPLIT('ABCDE':VARCHAR, '':VARCHAR)),"
+            + " array('1', '2', '3', '4', '5')), array(), (word_and_num, __foreach_pair) ->"
+            + " mvappend(word_and_num, CONCAT(foreach_pair_item(__foreach_pair, 0),"
+            + " ITEM(foreach_pair_item(__foreach_pair, 2),"
+            + " CASE(<(foreach_pair_item(__foreach_pair, 1), 0),"
+            + " +(+(ARRAY_LENGTH(foreach_pair_item(__foreach_pair, 2)),"
+            + " foreach_pair_item(__foreach_pair, 1)), 1), +(foreach_pair_item(__foreach_pair, 1),"
+            + " 1))))))])\n"
+            + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -1215,6 +1215,32 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testForeachMultifieldCommand() {
+    assertEquals(
+        "source=table | foreach identifier identifier [ eval identifier = *(identifier,***) ]",
+        anonymize("source=t | foreach a b [ eval <<FIELD>>_double = <<FIELD>> * 2 ]"));
+  }
+
+  @Test
+  public void testForeachMultivalueCommandWithOptions() {
+    assertEquals(
+        "source=table | foreach mode=multivalue itemstr=identifier identifier"
+            + " [ eval identifier = +(identifier,identifier) ]",
+        anonymize(
+            "source=t | foreach mode=multivalue itemstr=NUMBER nums"
+                + " [ eval total = total + NUMBER ]"));
+  }
+
+  @Test
+  public void testForeachJsonArrayCommandMasksLiteralTarget() {
+    assertEquals(
+        "source=table | foreach mode=json_array identifier [ eval identifier ="
+            + " +(identifier,identifier) ]",
+        anonymize(
+            "source=t | foreach mode=json_array '[1,2,3]' [ eval total = total + <<ITEM>> ]"));
+  }
+
+  @Test
   public void testUnion() {
     assertEquals(
         "| union [search source=table | where identifier < ***] [search source=table |"


### PR DESCRIPTION
### Description

Adds the PPL `foreach` command (Splunk-compatible), which runs a templated `eval` for each field in a field list, each element of a multivalue (array) field, or each element of a JSON array.

```
# multifield: double every matching field
source=idx | foreach value_* [ eval <<FIELD>>_double = <<FIELD>> * 2 ]

# multivalue: fold array elements into an accumulator
source=idx | eval nums = array(1,2,3), total = 0
           | foreach mode=multivalue nums [ eval total = total + <<ITEM>> ]

# json_array: parse JSON array text (literal or field) and iterate
source=idx | eval total = 0
           | foreach mode=json_array '[1,2,3]' [ eval total = total + <<ITEM>> ]
```

All four Splunk modes are supported: `multifield` (default), `multivalue`, `json_array`, and `auto_collections` (runtime detection). Placeholders `<<FIELD>>`/`<<MATCHSTR>>` (multifield) and `<<ITEM>>`/`<<ITER>>` (collection modes) are supported, with `fieldstr`/`matchstr`/`itemstr`/`iterstr` rename options.

#### Design

- **Multifield mode** expands each eval clause once per matching field via placeholder bindings on `CalcitePlanContext`; `<<FIELD>>` resolves to the current row field, `<<MATCHSTR>>` to the wildcard-captured segment.
- **Collection modes** rewrite each eval clause into a `reduce` call over the collection. Elements are packed into internal pairs `[item, iter, captured-field...]` by a `foreach_pair_collection` UDF so the two-parameter reduce lambda can reach the loop item, the loop index, and any referenced row fields; `foreach_pair_item(pair, slot)` extracts a slot with its plan-time type attached. Bindings are staged on the context and only activate inside the cloned lambda context, so the reduce call's own arguments resolve against the row normally.
- **json_array element typing**: `json_array(...)` calls and string literals are inspected at plan time (mixed string/number arrays rejected); for opaque expressions (a field holding JSON text — the primary Splunk use), the type is inferred from usage: arithmetic on `<<ITEM>>` selects DOUBLE, otherwise VARCHAR.
- Planning lives in a dedicated `ForeachPlanner` class rather than growing `CalciteRelNodeVisitor`.

#### Behavior verified against Splunk 10.4.0

| Scenario | Splunk | This PR |
| --- | --- | --- |
| mv field + multivalue | 6 | 6 ✓ |
| JSON-text field + json_array (sum of `"[10,20,30]"`) | 60 | 60 ✓ |
| json_array mode fed a real array | silent no-op | iterates (more permissive, pinned in IT) |
| multivalue mode fed JSON text | silent no-op | plan-time error (louder, pinned in IT) |

Known limitation (documented in tests and user doc): fields whose mapping is a scalar type (e.g. `long`) holding arrays are rejected by multivalue mode, because OpenSearch mappings do not declare array-ness and the plan-time type is scalar. Nested-typed fields map to `ARRAY<ANY>` and iterate correctly.

### Related Issues
N/A (new PPL command)

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [x] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
