### PR TITLE
[Fix] Make HTTP status assertion protocol-independent

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLCaseFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLCaseFunctionIT.java
@@ -550,8 +550,9 @@ public class CalcitePPLCaseFunctionIT extends PPLIntegTestCase {
                         "source=%s | eval x = case(age > 30, 'old', age > 20, 1 else 0.0) | fields"
                             + " x",
                         TEST_INDEX_BANK)));
-    org.junit.Assert.assertTrue(
+    org.junit.Assert.assertEquals(
         "expected 400 status, got: " + e.getMessage(),
-        e.getMessage().contains("status line [HTTP/1.1 400"));
+        400,
+        e.getResponse().getStatusLine().getStatusCode());
   }
 }


### PR DESCRIPTION
### Description
Replace the protocol-specific `ResponseException` message check with an assertion on the numeric HTTP status code. Security-enabled clusters can negotiate HTTP/2, which caused this test to fail despite correctly receiving HTTP 400.

### Related Issues
Resolves #5620

### Testing
- `./gradlew :integ-test:spotlessJavaCheck :integ-test:compileTestJava`
- `./gradlew :integ-test:integTest -Dsecurity.enabled=true --tests org.opensearch.sql.calcite.remote.CalcitePPLCaseFunctionIT.testCaseWithIncompatibleBranchTypesRejectsCleanly`

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).