### PR TITLE
[Backport 2.19-dev] Pin async-query-core publish actions to commit SHAs

### DIFF
--- a/.github/workflows/publish-async-query-core.yml
+++ b/.github/workflows/publish-async-query-core.yml
@@ -33,15 +33,15 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: temurin
           java-version: 17
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Load secret
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2
         with:
           # Export loaded secrets as environment variables
           export-env: true
@@ -56,7 +56,7 @@ jobs:
           echo "SNAPSHOT_REPO_URL=$snapshot_repo_url" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
           aws-region: us-east-1
@@ -80,7 +80,7 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           echo "Version: ${VERSION}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: 'opensearch-project/opensearch-build'
           path: 'build'


### PR DESCRIPTION
### Description

Pins all actions in `publish-async-query-core.yml` to full commit SHAs, matching the versions pinned on `main` by #5464.

The 2.19-dev pinning backport #5617 was based on #5573, whose source branch did not contain this workflow, so these five action references remained unpinned. This caused the July 10 async-query-core publication to fail during action preparation: https://github.com/opensearch-project/sql/actions/runs/29123519082

### Testing

- `git diff --check`
- Verified every `uses:` entry in the workflow is pinned to a full commit SHA

Related: #5464, #5573, #5617