### PR TITLE
Fix flaky TPC-H Q15 floating-point assertion

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/tpch/CalcitePPLTpchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/tpch/CalcitePPLTpchIT.java
@@ -314,7 +314,7 @@ public class CalcitePPLTpchIT extends PPLIntegTestCase {
         schema("total_revenue", "double"));
     verifyDataRows(
         actual,
-        rows(10, "Supplier#000000010", "Saygah3gYWMp72i PY", "34-852-489-8585", 797313.3838));
+        closeTo(10, "Supplier#000000010", "Saygah3gYWMp72i PY", "34-852-489-8585", 797313.3838));
   }
 
   @Test


### PR DESCRIPTION
### Description
Updates the TPC-H Q15 integration test to use the existing ULP-aware `MatcherUtils.closeTo(...)` matcher for `total_revenue`.

The distributed `sum()` returned `797313.3838000001` in the failing release test instead of the exactly asserted `797313.3838`. These values differ by one ULP, but `rows(...)` requires exact numeric equality. `closeTo(...)` tolerates platform-dependent floating-point rounding while continuing to compare the supplier ID and string fields exactly.

### Related Issues
Resolves #5620

### Testing
- `./gradlew :integ-test:spotlessJavaCheck :integ-test:compileTestJava --no-daemon`
- `./gradlew :integ-test:integTest --tests "org.opensearch.sql.calcite.tpch.CalcitePPLTpchIT.testQ15" --no-daemon`

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.