### PR TITLE
Preserve plugin-managed indices during integration test cleanup

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCase.java
@@ -77,6 +77,16 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
           + "}";
   private static final String SCRIPT_CONTEXT_MAX_COMPILATIONS_RATE_PATTERN =
       "script.context.*.max_compilations_rate";
+  // Per-class cleanup must not delete shared plugin state or force managed indices to be recreated.
+  private static final List<String> PLUGIN_MANAGED_INDEX_PREFIXES =
+      List.of(
+          ".opensearch",
+          ".opendistro",
+          ".ql",
+          ".plugins",
+          ".scheduler",
+          ".geospatial",
+          "security-auditlog-");
   private static RestClient remoteClient;
 
   /**
@@ -212,11 +222,7 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
         JSONObject jsonObject = (JSONObject) object;
         String indexName = jsonObject.getString("index");
         try {
-          // System index, mostly named .opensearch-xxx or .opendistro-xxx, are not allowed to
-          // delete
-          if (!indexName.startsWith(".opensearch")
-              && !indexName.startsWith(".opendistro")
-              && !indexName.startsWith(".ql")) {
+          if (!isPluginManagedIndex(indexName)) {
             client.performRequest(new Request("DELETE", "/" + indexName));
           }
         } catch (Exception e) {
@@ -228,6 +234,10 @@ public abstract class OpenSearchSQLRestTestCase extends OpenSearchRestTestCase {
     } catch (ParseException e) {
       throw new IOException(e);
     }
+  }
+
+  static boolean isPluginManagedIndex(String indexName) {
+    return PLUGIN_MANAGED_INDEX_PREFIXES.stream().anyMatch(indexName::startsWith);
   }
 
   /**

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCaseIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/OpenSearchSQLRestTestCaseIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.legacy;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class OpenSearchSQLRestTestCaseIT {
+
+  @Test
+  public void identifiesPluginManagedIndices() {
+    assertTrue(OpenSearchSQLRestTestCase.isPluginManagedIndex(".opensearch-observability"));
+    assertTrue(OpenSearchSQLRestTestCase.isPluginManagedIndex(".opendistro_security"));
+    assertTrue(OpenSearchSQLRestTestCase.isPluginManagedIndex(".ql-datasources"));
+    assertTrue(OpenSearchSQLRestTestCase.isPluginManagedIndex(".plugins-ml-config"));
+    assertTrue(
+        OpenSearchSQLRestTestCase.isPluginManagedIndex(".scheduler-geospatial-ip2geo-datasource"));
+    assertTrue(
+        OpenSearchSQLRestTestCase.isPluginManagedIndex(".geospatial-ip2geo-data.datasource"));
+    assertTrue(OpenSearchSQLRestTestCase.isPluginManagedIndex("security-auditlog-2026.07.15"));
+  }
+
+  @Test
+  public void leavesTestIndicesEligibleForCleanup() {
+    assertFalse(OpenSearchSQLRestTestCase.isPluginManagedIndex("opensearch-sql_test_index_bank"));
+    assertFalse(OpenSearchSQLRestTestCase.isPluginManagedIndex("security-test-index"));
+    assertFalse(OpenSearchSQLRestTestCase.isPluginManagedIndex(".test-hidden-index"));
+  }
+}


### PR DESCRIPTION
### Description

Prevents per-class integration test cleanup from deleting plugin-managed indices.

In release integration test run 11379, the secured SQL suite took 4h44m versus 41m without security. The secured cluster log shows cleanup deleting and forcing recreation of `security-auditlog-*` 358 times, once per test-class cleanup, along with 575 audit-indexing errors. Many of those errors were generated by attempted deletion of protected ML and geospatial indices.

This change extends the existing system-index filter to preserve the observed plugin-managed prefixes. Ordinary test indices, including unrelated hidden test indices, remain eligible for cleanup.

A representative secured A/B run of `SQLCursorPermissionsIT` showed:
- Unmodified `main`: audit index created, deleted by cleanup, then recreated.
- This branch: audit index created once and preserved; no audit-index deletion or recreation.

The next distribution integration run will provide the full-suite runtime measurement.

### Related Issues

Follow-up to #5620

### Testing

- `./gradlew :integ-test:spotlessJavaCheck :integ-test:compileTestJava --no-daemon`
- `./gradlew :integ-test:integTest --tests "org.opensearch.sql.legacy.OpenSearchSQLRestTestCaseIT" -DignorePrometheus=true --no-daemon`
- `./gradlew :integ-test:integTestWithSecurity --tests "org.opensearch.sql.security.SQLCursorPermissionsIT" --no-daemon`

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command checklist all confirmed.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.