### PR TITLE
Decouple Calcite PPL planning from ExprType

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -87,7 +87,6 @@ import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBindingType;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit.SystemLimitType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
-import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.calcite.utils.SubsearchUtils;
 import org.opensearch.sql.common.utils.StringUtils;
@@ -320,12 +319,25 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
       lowerBound = context.rexBuilder.makeCast(commonType, lowerBound);
       upperBound = context.rexBuilder.makeCast(commonType, upperBound);
     } else {
-      throw new SemanticCheckException(
-          StringUtils.format(
-              "BETWEEN expression types are incompatible: [%s, %s, %s]",
-              OpenSearchTypeFactory.convertRelDataTypeToExprType(value.getType()),
-              OpenSearchTypeFactory.convertRelDataTypeToExprType(lowerBound.getType()),
-              OpenSearchTypeFactory.convertRelDataTypeToExprType(upperBound.getType())));
+      // leastRestrictive() has no common type for mixed temporal representations — e.g. a standard
+      // Calcite TIMESTAMP field compared against EXPR_DATE UDT bounds (`ts between date('...') and
+      // date('...')`). Comparison operators coerce these through CoercionUtils; BETWEEN calls
+      // leastRestrictive directly and would otherwise reject them. Fall back to the same temporal
+      // widening, scoped to all-temporal operands so genuinely incompatible mixes (e.g.
+      // `age between '35' and 38.5`) still raise SemanticCheckException.
+      List<RexNode> widened =
+          widenTemporalOperands(context, List.of(value, lowerBound, upperBound));
+      if (widened == null) {
+        throw new SemanticCheckException(
+            StringUtils.format(
+                "BETWEEN expression types are incompatible: [%s, %s, %s]",
+                OpenSearchTypeFactory.convertRelDataTypeToExprType(value.getType()),
+                OpenSearchTypeFactory.convertRelDataTypeToExprType(lowerBound.getType()),
+                OpenSearchTypeFactory.convertRelDataTypeToExprType(upperBound.getType())));
+      }
+      value = widened.get(0);
+      lowerBound = widened.get(1);
+      upperBound = widened.get(2);
     }
     return context.relBuilder.between(value, lowerBound, upperBound);
   }
@@ -913,26 +925,10 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   @Override
   public RexNode visitCast(Cast node, CalcitePlanContext context) {
     RexNode expr = analyze(node.getExpression(), context);
+    RelDataType type =
+        OpenSearchTypeFactory.convertExprTypeToRelDataType(node.getDataType().getCoreType());
     RelDataType nullableType =
-        switch (node.getDataType()) {
-          case TYPE_ERROR ->
-              throw new IllegalArgumentException("Unsupported AST DataType: " + node.getDataType());
-          case NULL -> TYPE_FACTORY.createSqlType(SqlTypeName.NULL, true);
-          case INTEGER -> TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER, true);
-          case LONG -> TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT, true);
-          case SHORT -> TYPE_FACTORY.createSqlType(SqlTypeName.SMALLINT, true);
-          case FLOAT -> TYPE_FACTORY.createSqlType(SqlTypeName.REAL, true);
-          case DOUBLE, DECIMAL -> TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE, true);
-          case STRING -> TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR, true);
-          case BOOLEAN -> TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN, true);
-          case DATE -> TYPE_FACTORY.createUDT(ExprUDT.EXPR_DATE, true);
-          case TIME -> TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME, true);
-          case TIMESTAMP -> TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
-          case INTERVAL ->
-              throw new IllegalArgumentException(
-                  "INTERVAL must carry a unit; cannot map to RelDataType directly.");
-          case IP -> TYPE_FACTORY.createUDT(ExprUDT.EXPR_IP, true);
-        };
+        context.rexBuilder.getTypeFactory().createTypeWithNullability(type, true);
     // call makeCast() instead of cast() because the saft parameter is true could avoid exception.
     return context.rexBuilder.makeCast(nullableType, expr, true, true);
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -87,6 +87,7 @@ import org.opensearch.sql.calcite.CalcitePlanContext.ForeachBindingType;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit;
 import org.opensearch.sql.calcite.plan.rel.LogicalSystemLimit.SystemLimitType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.calcite.utils.SubsearchUtils;
 import org.opensearch.sql.common.utils.StringUtils;
@@ -319,25 +320,12 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
       lowerBound = context.rexBuilder.makeCast(commonType, lowerBound);
       upperBound = context.rexBuilder.makeCast(commonType, upperBound);
     } else {
-      // leastRestrictive() has no common type for mixed temporal representations — e.g. a standard
-      // Calcite TIMESTAMP field compared against EXPR_DATE UDT bounds (`ts between date('...') and
-      // date('...')`). Comparison operators coerce these through CoercionUtils; BETWEEN calls
-      // leastRestrictive directly and would otherwise reject them. Fall back to the same temporal
-      // widening, scoped to all-temporal operands so genuinely incompatible mixes (e.g.
-      // `age between '35' and 38.5`) still raise SemanticCheckException.
-      List<RexNode> widened =
-          widenTemporalOperands(context, List.of(value, lowerBound, upperBound));
-      if (widened == null) {
-        throw new SemanticCheckException(
-            StringUtils.format(
-                "BETWEEN expression types are incompatible: [%s, %s, %s]",
-                OpenSearchTypeFactory.convertRelDataTypeToExprType(value.getType()),
-                OpenSearchTypeFactory.convertRelDataTypeToExprType(lowerBound.getType()),
-                OpenSearchTypeFactory.convertRelDataTypeToExprType(upperBound.getType())));
-      }
-      value = widened.get(0);
-      lowerBound = widened.get(1);
-      upperBound = widened.get(2);
+      throw new SemanticCheckException(
+          StringUtils.format(
+              "BETWEEN expression types are incompatible: [%s, %s, %s]",
+              OpenSearchTypeFactory.convertRelDataTypeToExprType(value.getType()),
+              OpenSearchTypeFactory.convertRelDataTypeToExprType(lowerBound.getType()),
+              OpenSearchTypeFactory.convertRelDataTypeToExprType(upperBound.getType())));
     }
     return context.relBuilder.between(value, lowerBound, upperBound);
   }
@@ -925,10 +913,26 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
   @Override
   public RexNode visitCast(Cast node, CalcitePlanContext context) {
     RexNode expr = analyze(node.getExpression(), context);
-    RelDataType type =
-        OpenSearchTypeFactory.convertExprTypeToRelDataType(node.getDataType().getCoreType());
     RelDataType nullableType =
-        context.rexBuilder.getTypeFactory().createTypeWithNullability(type, true);
+        switch (node.getDataType()) {
+          case TYPE_ERROR ->
+              throw new IllegalArgumentException("Unsupported AST DataType: " + node.getDataType());
+          case NULL -> TYPE_FACTORY.createSqlType(SqlTypeName.NULL, true);
+          case INTEGER -> TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER, true);
+          case LONG -> TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT, true);
+          case SHORT -> TYPE_FACTORY.createSqlType(SqlTypeName.SMALLINT, true);
+          case FLOAT -> TYPE_FACTORY.createSqlType(SqlTypeName.REAL, true);
+          case DOUBLE, DECIMAL -> TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE, true);
+          case STRING -> TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR, true);
+          case BOOLEAN -> TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN, true);
+          case DATE -> TYPE_FACTORY.createUDT(ExprUDT.EXPR_DATE, true);
+          case TIME -> TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME, true);
+          case TIMESTAMP -> TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
+          case INTERVAL ->
+              throw new IllegalArgumentException(
+                  "INTERVAL must carry a unit; cannot map to RelDataType directly.");
+          case IP -> TYPE_FACTORY.createUDT(ExprUDT.EXPR_IP, true);
+        };
     // call makeCast() instead of cast() because the saft parameter is true could avoid exception.
     return context.rexBuilder.makeCast(nullableType, expr, true, true);
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/PPLOperandTypes.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/PPLOperandTypes.java
@@ -5,10 +5,17 @@
 
 package org.opensearch.sql.calcite.utils;
 
+import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.TYPE_FACTORY;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.CompositeOperandTypeChecker;
 import org.apache.calcite.sql.type.FamilyOperandTypeChecker;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 
 /**
@@ -20,41 +27,51 @@ public class PPLOperandTypes {
   // This class is not meant to be instantiated.
   private PPLOperandTypes() {}
 
+  // Convenience RelDataType constants used to express UDF signatures via wrapUDT(...).
+  // UDT-backed scalar types:
+  public static final RelDataType DATE_UDT = TYPE_FACTORY.createUDT(ExprUDT.EXPR_DATE);
+  public static final RelDataType TIME_UDT = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME);
+  public static final RelDataType TIMESTAMP_UDT = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP);
+  public static final RelDataType IP_UDT = TYPE_FACTORY.createUDT(ExprUDT.EXPR_IP);
+  public static final RelDataType BINARY_UDT = TYPE_FACTORY.createUDT(ExprUDT.EXPR_BINARY);
+  // Plain SQL scalar types:
+  public static final RelDataType BYTE_T = TYPE_FACTORY.createSqlType(SqlTypeName.TINYINT);
+  public static final RelDataType SHORT_T = TYPE_FACTORY.createSqlType(SqlTypeName.SMALLINT);
+  public static final RelDataType INTEGER_T = TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER);
+  public static final RelDataType LONG_T = TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT);
+  public static final RelDataType FLOAT_T = TYPE_FACTORY.createSqlType(SqlTypeName.REAL);
+  public static final RelDataType DOUBLE_T = TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE);
+  public static final RelDataType STRING_T = TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
+  public static final RelDataType BOOLEAN_T = TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN);
+
   /** List of all scalar type signatures (single parameter each) */
-  private static final java.util.List<java.util.List<org.opensearch.sql.data.type.ExprType>>
-      SCALAR_TYPES =
-          java.util.List.of(
-              // Numeric types
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.BYTE),
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.SHORT),
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.INTEGER),
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.LONG),
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.FLOAT),
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.DOUBLE),
-              // String type
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.STRING),
-              // Boolean type
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.BOOLEAN),
-              // Temporal types
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.DATE),
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.TIME),
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP),
-              // Special scalar types
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.IP),
-              java.util.List.of(org.opensearch.sql.data.type.ExprCoreType.BINARY));
+  private static final List<List<RelDataType>> SCALAR_TYPES =
+      List.of(
+          // Numeric types
+          List.of(BYTE_T),
+          List.of(SHORT_T),
+          List.of(INTEGER_T),
+          List.of(LONG_T),
+          List.of(FLOAT_T),
+          List.of(DOUBLE_T),
+          // String type
+          List.of(STRING_T),
+          // Boolean type
+          List.of(BOOLEAN_T),
+          // Temporal types
+          List.of(DATE_UDT),
+          List.of(TIME_UDT),
+          List.of(TIMESTAMP_UDT),
+          // Special scalar types
+          List.of(IP_UDT),
+          List.of(BINARY_UDT));
 
   /** Helper method to create scalar types with optional integer parameter */
-  private static java.util.List<java.util.List<org.opensearch.sql.data.type.ExprType>>
-      createScalarWithOptionalInteger() {
-    java.util.List<java.util.List<org.opensearch.sql.data.type.ExprType>> result =
-        new java.util.ArrayList<>(SCALAR_TYPES);
+  private static List<List<RelDataType>> createScalarWithOptionalInteger() {
+    List<List<RelDataType>> result = new ArrayList<>(SCALAR_TYPES);
 
     // Add scalar + integer combinations
-    SCALAR_TYPES.forEach(
-        scalarType ->
-            result.add(
-                java.util.List.of(
-                    scalarType.get(0), org.opensearch.sql.data.type.ExprCoreType.INTEGER)));
+    SCALAR_TYPES.forEach(scalarType -> result.add(List.of(scalarType.get(0), INTEGER_T)));
 
     return result;
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/CoercionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CoercionUtils.java
@@ -5,49 +5,61 @@
 
 package org.opensearch.sql.expression.function;
 
-import static org.opensearch.sql.data.type.ExprCoreType.UNKNOWN;
-
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.BinaryOperator;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
-import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 
+/**
+ * RelDataType-native widening, casting, and common-type resolution for PPL function dispatch.
+ *
+ * <p>This module models a small widening DAG over a tag space derived from {@link RelDataType}:
+ *
+ * <ul>
+ *   <li>numeric SQL types (BYTE → SHORT → INTEGER → LONG → FLOAT → DOUBLE)
+ *   <li>STRING (VARCHAR/CHAR)
+ *   <li>BOOLEAN
+ *   <li>OpenSearch UDTs (DATE, TIME, TIMESTAMP, IP, BINARY) detected via {@code instanceof}
+ * </ul>
+ *
+ * <p>The widening rules mirror prior behavior: {@code STRING + NUMERIC → DOUBLE}, {@code DATE +
+ * TIME → TIMESTAMP}, {@code STRING + BINARY → BINARY}; STRING widens to BOOLEAN/DATE/TIME/
+ * TIMESTAMP/IP; numerics widen along the integer/float chain; etc.
+ */
 public final class CoercionUtils {
+  private CoercionUtils() {}
+
   /**
-   * Casts the arguments to the types specified in the typeChecker. Returns null if no combination
-   * of parameter types matches the arguments or if casting fails.
-   *
-   * @param builder RexBuilder to create casts
-   * @param typeChecker PPLTypeChecker that provides the parameter types
-   * @param arguments List of RexNode arguments to be cast
-   * @return List of cast RexNode arguments or null if casting fails
+   * Casts the arguments to one of the typeChecker's allowed signatures. Returns null if no
+   * combination of parameter types matches the arguments or if casting fails.
    */
   public static @Nullable List<RexNode> castArguments(
       RexBuilder builder, PPLTypeChecker typeChecker, List<RexNode> arguments) {
-    List<List<ExprType>> paramTypeCombinations = typeChecker.getParameterTypes();
+    List<List<RelDataType>> paramTypeCombinations = typeChecker.getParameterTypes();
 
-    List<ExprType> sourceTypes =
-        arguments.stream()
-            .map(node -> OpenSearchTypeFactory.convertRelDataTypeToExprType(node.getType()))
-            .collect(Collectors.toList());
+    List<RelDataType> sourceTypes = arguments.stream().map(RexNode::getType).toList();
     // Candidate parameter signatures ordered by decreasing widening distance
-    PriorityQueue<Pair<List<ExprType>, Integer>> rankedSignatures =
+    PriorityQueue<Pair<List<RelDataType>, Integer>> rankedSignatures =
         new PriorityQueue<>((left, right) -> Integer.compare(right.getValue(), left.getValue()));
-    for (List<ExprType> paramTypes : paramTypeCombinations) {
-      int distance = distance(sourceTypes, paramTypes);
+    for (List<RelDataType> paramTypes : paramTypeCombinations) {
+      int distance = signatureDistance(sourceTypes, paramTypes);
       if (distance == TYPE_EQUAL) {
         return castArguments(builder, paramTypes, arguments);
       }
@@ -64,38 +76,43 @@ public final class CoercionUtils {
   /**
    * Widen the arguments to the widest type found among them. If no widest type can be determined,
    * returns null.
-   *
-   * @param builder RexBuilder to create casts
-   * @param arguments List of RexNode arguments to be widened
-   * @return List of widened RexNode arguments or null if no widest type can be determined
    */
   public static @Nullable List<RexNode> widenArguments(
       RexBuilder builder, List<RexNode> arguments) {
-    // TODO: Add test on e.g. IP
-    ExprType widestType = findWidestType(arguments);
+    RelDataType widestType = findWidestType(arguments);
     if (widestType == null) {
-      return null; // No widest type found, return null
+      return null;
     }
     return arguments.stream().map(arg -> cast(builder, widestType, arg)).toList();
   }
 
-  /**
-   * Casts the arguments to the types specified in paramTypes. Returns null if the number of
-   * parameters does not match or if casting fails.
-   */
-  private static @Nullable List<RexNode> castArguments(
-      RexBuilder builder, List<ExprType> paramTypes, List<RexNode> arguments) {
-    if (paramTypes.size() != arguments.size()) {
-      return null; // Skip if the number of parameters does not match
-    }
+  /** Returns true if any of the operands is a string-like (VARCHAR/CHAR) RexNode. */
+  public static boolean hasString(List<RexNode> rexNodeList) {
+    return rexNodeList.stream().map(RexNode::getType).anyMatch(SqlTypeUtil::isCharacter);
+  }
 
+  /**
+   * Resolves the widening common type for two {@link RelDataType}s using PPL coercion rules. Used
+   * primarily by tests to verify the rule set.
+   */
+  @VisibleForTesting
+  public static Optional<RelDataType> resolveCommonType(RelDataType left, RelDataType right) {
+    return COMMON_COERCION_RULES.stream()
+        .map(rule -> rule.apply(left, right))
+        .flatMap(Optional::stream)
+        .findFirst();
+  }
+
+  // -------- Internals --------
+
+  private static @Nullable List<RexNode> castArguments(
+      RexBuilder builder, List<RelDataType> paramTypes, List<RexNode> arguments) {
+    if (paramTypes.size() != arguments.size()) {
+      return null;
+    }
     List<RexNode> castedArguments = new ArrayList<>();
     for (int i = 0; i < paramTypes.size(); i++) {
-      ExprType toType = paramTypes.get(i);
-      RexNode arg = arguments.get(i);
-
-      RexNode castedArg = cast(builder, toType, arg);
-
+      RexNode castedArg = cast(builder, paramTypes.get(i), arguments.get(i));
       if (castedArg == null) {
         return null;
       }
@@ -104,180 +121,289 @@ public final class CoercionUtils {
     return castedArguments;
   }
 
-  private static @Nullable RexNode cast(RexBuilder builder, ExprType targetType, RexNode arg) {
-    ExprType argType = OpenSearchTypeFactory.convertRelDataTypeToExprType(arg.getType());
-    if (!argType.shouldCast(targetType)) {
+  private static @Nullable RexNode cast(RexBuilder builder, RelDataType targetType, RexNode arg) {
+    RelDataType argType = arg.getType();
+    if (!shouldCast(argType, targetType)) {
       return arg;
     }
+    // Always make the cast target nullable. Safe cast returns null on parse failure or on a null
+    // source, so a non-nullable declared target defeats null-propagation and leads to primitive
+    // unboxing NPEs in downstream aggregations.
     if (distance(argType, targetType) != IMPOSSIBLE_WIDENING) {
       return builder.makeCast(
-          OpenSearchTypeFactory.convertExprTypeToRelDataType(targetType), arg, true, true);
+          builder.getTypeFactory().createTypeWithNullability(targetType, true), arg, true, true);
     }
     return resolveCommonType(argType, targetType)
         .map(
-            exprType ->
+            common ->
                 builder.makeCast(
-                    OpenSearchTypeFactory.convertExprTypeToRelDataType(exprType), arg, true, true))
+                    builder.getTypeFactory().createTypeWithNullability(common, true),
+                    arg,
+                    true,
+                    true))
         .orElse(null);
   }
 
-  /**
-   * Finds the widest type among the given arguments. The widest type is determined by applying the
-   * widening type rule to each pair of types in the arguments.
-   *
-   * @param arguments List of RexNode arguments to find the widest type from
-   * @return the widest ExprType if found, otherwise null
-   */
-  private static @Nullable ExprType findWidestType(List<RexNode> arguments) {
+  private static @Nullable RelDataType findWidestType(List<RexNode> arguments) {
     if (arguments.isEmpty()) {
-      return null; // No arguments to process
+      return null;
     }
-    ExprType widestType =
-        OpenSearchTypeFactory.convertRelDataTypeToExprType(arguments.getFirst().getType());
+    RelDataType widest = arguments.getFirst().getType();
     if (arguments.size() == 1) {
-      return widestType;
+      return widest;
     }
-
-    // Iterate pairwise through the arguments and find the widest type
     for (int i = 1; i < arguments.size(); i++) {
-      var type = OpenSearchTypeFactory.convertRelDataTypeToExprType(arguments.get(i).getType());
+      RelDataType type = arguments.get(i).getType();
       try {
-        final ExprType tempType = widestType;
-        widestType = resolveCommonType(widestType, type).orElseGet(() -> max(tempType, type));
+        final RelDataType current = widest;
+        widest = resolveCommonType(widest, type).orElseGet(() -> max(current, type));
       } catch (ExpressionEvaluationException e) {
-        // the two types are not compatible, return null
         return null;
       }
     }
-    return widestType;
+    // Normalize standard temporal types to their UDT equivalents so downstream casts route through
+    // the ExtendedRexBuilder UDT path (producing TIMESTAMP/DATE/TIME function calls at runtime).
+    return normalizeTemporalToUdt(widest);
   }
 
-  private static boolean areDateAndTime(ExprType type1, ExprType type2) {
-    return (type1 == ExprCoreType.DATE && type2 == ExprCoreType.TIME)
-        || (type1 == ExprCoreType.TIME && type2 == ExprCoreType.DATE);
+  private static RelDataType normalizeTemporalToUdt(RelDataType type) {
+    if (type instanceof AbstractExprRelDataType<?>) {
+      return type;
+    }
+    SqlTypeName name = type.getSqlTypeName();
+    ExprUDT udt =
+        switch (name) {
+          case TIMESTAMP -> ExprUDT.EXPR_TIMESTAMP;
+          case DATE -> ExprUDT.EXPR_DATE;
+          case TIME -> ExprUDT.EXPR_TIME;
+          default -> null;
+        };
+    return udt == null
+        ? type
+        : OpenSearchTypeFactory.TYPE_FACTORY.createUDT(udt, type.isNullable());
   }
 
-  @VisibleForTesting
-  public static Optional<ExprType> resolveCommonType(ExprType left, ExprType right) {
-    return COMMON_COERCION_RULES.stream()
-        .map(rule -> rule.apply(left, right))
-        .flatMap(Optional::stream)
-        .findFirst();
+  // -------- Tag space + widening DAG --------
+
+  /**
+   * A small enum that tags every {@link RelDataType} the coercion rules need to reason about. Using
+   * an enum means the widening DAG is closed and self-contained.
+   */
+  private enum CoercionTag {
+    UNDEFINED, // Calcite NULL — compatible with anything
+    UNKNOWN, // Anything we can't classify
+    BYTE,
+    SHORT,
+    INTEGER,
+    LONG,
+    FLOAT,
+    DOUBLE,
+    STRING,
+    BOOLEAN,
+    DATE,
+    TIME,
+    TIMESTAMP,
+    IP,
+    BINARY,
+    INTERVAL,
+    ARRAY,
+    STRUCT,
+    GEOMETRY;
   }
 
-  public static boolean hasString(List<RexNode> rexNodeList) {
-    return rexNodeList.stream()
-        .map(RexNode::getType)
-        .map(OpenSearchTypeFactory::convertRelDataTypeToExprType)
-        .anyMatch(t -> t == ExprCoreType.STRING);
+  private static CoercionTag tagOf(RelDataType type) {
+    if (type instanceof AbstractExprRelDataType<?> udt) {
+      return switch (udt.getUdt()) {
+        case EXPR_DATE -> CoercionTag.DATE;
+        case EXPR_TIME -> CoercionTag.TIME;
+        case EXPR_TIMESTAMP -> CoercionTag.TIMESTAMP;
+        case EXPR_IP -> CoercionTag.IP;
+        case EXPR_BINARY -> CoercionTag.BINARY;
+      };
+    }
+    SqlTypeName name = type.getSqlTypeName();
+    if (name == null) return CoercionTag.UNKNOWN;
+    return switch (name) {
+      case TINYINT -> CoercionTag.BYTE;
+      case SMALLINT -> CoercionTag.SHORT;
+      case INTEGER -> CoercionTag.INTEGER;
+      case BIGINT -> CoercionTag.LONG;
+      case REAL, FLOAT -> CoercionTag.FLOAT;
+      case DOUBLE, DECIMAL -> CoercionTag.DOUBLE;
+      case CHAR, VARCHAR -> CoercionTag.STRING;
+      case BOOLEAN -> CoercionTag.BOOLEAN;
+      case BINARY, VARBINARY -> CoercionTag.BINARY;
+      case DATE -> CoercionTag.DATE;
+      case TIME, TIME_WITH_LOCAL_TIME_ZONE, TIME_TZ -> CoercionTag.TIME;
+      case TIMESTAMP, TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_TZ -> CoercionTag.TIMESTAMP;
+      case NULL -> CoercionTag.UNDEFINED;
+      case ARRAY, MULTISET -> CoercionTag.ARRAY;
+      case MAP, ROW, STRUCTURED -> CoercionTag.STRUCT;
+      case GEOMETRY -> CoercionTag.GEOMETRY;
+      default -> {
+        if (SqlTypeName.INTERVAL_TYPES.contains(name)) {
+          yield CoercionTag.INTERVAL;
+        }
+        yield CoercionTag.UNKNOWN;
+      }
+    };
   }
 
-  private static final Set<ExprType> NUMBER_TYPES = ExprCoreType.numberTypes();
+  /**
+   * Parents in the widening DAG. Mirrors {@code ExprCoreType} parent links. A type widens to its
+   * parent and (transitively) to grandparents.
+   */
+  private static final Map<CoercionTag, List<CoercionTag>> PARENTS = buildParents();
+
+  private static Map<CoercionTag, List<CoercionTag>> buildParents() {
+    Map<CoercionTag, List<CoercionTag>> p = new HashMap<>();
+    p.put(CoercionTag.BYTE, List.of(CoercionTag.SHORT));
+    p.put(CoercionTag.SHORT, List.of(CoercionTag.INTEGER));
+    p.put(CoercionTag.INTEGER, List.of(CoercionTag.LONG));
+    p.put(CoercionTag.LONG, List.of(CoercionTag.FLOAT));
+    p.put(CoercionTag.FLOAT, List.of(CoercionTag.DOUBLE));
+    // STRING has TIMESTAMP as a direct parent (in addition to DATE/TIME/BOOLEAN/IP) so the
+    // STRING→TIMESTAMP widening cost matches STRING→DOUBLE (1). This preserves baseline ranking
+    // when both NUMERIC and TIMESTAMP signatures are candidates for a STRING input.
+    p.put(
+        CoercionTag.STRING,
+        List.of(
+            CoercionTag.BOOLEAN,
+            CoercionTag.DATE,
+            CoercionTag.TIME,
+            CoercionTag.TIMESTAMP,
+            CoercionTag.IP));
+    p.put(CoercionTag.DATE, List.of(CoercionTag.TIMESTAMP));
+    p.put(CoercionTag.TIME, List.of(CoercionTag.TIMESTAMP));
+    return p;
+  }
+
+  private static List<CoercionTag> parentsOf(CoercionTag tag) {
+    return PARENTS.getOrDefault(tag, List.of());
+  }
+
+  private static final Set<CoercionTag> NUMBER_TAGS =
+      Set.of(
+          CoercionTag.BYTE,
+          CoercionTag.SHORT,
+          CoercionTag.INTEGER,
+          CoercionTag.LONG,
+          CoercionTag.FLOAT,
+          CoercionTag.DOUBLE);
+
+  // -------- Distance and "shouldCast" --------
+
+  private static final int IMPOSSIBLE_WIDENING = Integer.MAX_VALUE;
+  private static final int TYPE_EQUAL = 0;
+
+  private static int distance(RelDataType from, RelDataType to) {
+    return distance(tagOf(from), tagOf(to), TYPE_EQUAL);
+  }
+
+  private static int distance(CoercionTag from, CoercionTag to) {
+    return distance(from, to, TYPE_EQUAL);
+  }
+
+  private static int distance(CoercionTag from, CoercionTag to, int acc) {
+    if (from == to) return acc;
+    if (from == CoercionTag.UNKNOWN) return IMPOSSIBLE_WIDENING;
+    // UNDEFINED (NULL literal) widens to any concrete type at unit cost — mirrors v2 where every
+    // concrete ExprCoreType has UNDEFINED as a parent.
+    if (from == CoercionTag.UNDEFINED && to != CoercionTag.UNKNOWN) return acc + 1;
+    // STRING widens directly to DOUBLE (custom rule mirroring v2 behavior).
+    if (from == CoercionTag.STRING && to == CoercionTag.DOUBLE) return acc + 1;
+    List<CoercionTag> parents = parentsOf(from);
+    if (parents.isEmpty()) return IMPOSSIBLE_WIDENING;
+    int best = IMPOSSIBLE_WIDENING;
+    for (CoercionTag parent : parents) {
+      int d = distance(parent, to, acc + 1);
+      if (d < best) best = d;
+    }
+    return best;
+  }
+
+  /** The argument should be cast to the target type when their CoercionTags differ. */
+  private static boolean shouldCast(RelDataType source, RelDataType target) {
+    return tagOf(source) != tagOf(target);
+  }
+
+  /**
+   * The widest of two types: the one that the other can widen to. Throws if neither widens to the
+   * other.
+   */
+  static RelDataType max(RelDataType type1, RelDataType type2) {
+    int t1To2 = distance(type1, type2);
+    int t2To1 = distance(type2, type1);
+    if (t1To2 == IMPOSSIBLE_WIDENING && t2To1 == IMPOSSIBLE_WIDENING) {
+      throw new ExpressionEvaluationException(
+          String.format("no max type of %s and %s ", type1, type2));
+    }
+    return t1To2 == IMPOSSIBLE_WIDENING ? type1 : type2;
+  }
+
+  private static int signatureDistance(
+      List<RelDataType> sourceTypes, List<RelDataType> targetTypes) {
+    if (sourceTypes.size() != targetTypes.size()) {
+      return IMPOSSIBLE_WIDENING;
+    }
+    int total = 0;
+    for (int i = 0; i < sourceTypes.size(); i++) {
+      int d = distance(sourceTypes.get(i), targetTypes.get(i));
+      if (d == IMPOSSIBLE_WIDENING) {
+        return IMPOSSIBLE_WIDENING;
+      }
+      total += d;
+    }
+    return total;
+  }
+
+  // -------- Common-type rules --------
+
+  private static boolean hasString(RelDataType l, RelDataType r) {
+    return tagOf(l) == CoercionTag.STRING || tagOf(r) == CoercionTag.STRING;
+  }
+
+  private static boolean hasNumber(RelDataType l, RelDataType r) {
+    return NUMBER_TAGS.contains(tagOf(l)) || NUMBER_TAGS.contains(tagOf(r));
+  }
+
+  private static boolean hasBinary(RelDataType l, RelDataType r) {
+    return tagOf(l) == CoercionTag.BINARY || tagOf(r) == CoercionTag.BINARY;
+  }
+
+  private static boolean areDateAndTime(RelDataType l, RelDataType r) {
+    CoercionTag lt = tagOf(l);
+    CoercionTag rt = tagOf(r);
+    return (lt == CoercionTag.DATE && rt == CoercionTag.TIME)
+        || (lt == CoercionTag.TIME && rt == CoercionTag.DATE);
+  }
 
   private static final List<CoercionRule> COMMON_COERCION_RULES =
       List.of(
           CoercionRule.of(
-              (left, right) -> areDateAndTime(left, right),
-              (left, right) -> ExprCoreType.TIMESTAMP),
+              CoercionUtils::areDateAndTime,
+              (l, r) -> OpenSearchTypeFactory.TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP)),
           CoercionRule.of(
-              (left, right) -> hasString(left, right) && hasNumber(left, right),
-              (left, right) -> ExprCoreType.DOUBLE),
+              (l, r) -> hasString(l, r) && hasNumber(l, r),
+              (l, r) -> OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE)),
           // (BINARY, STRING) → BINARY: ip/binary columns compared with string literals.
-          // Triggers ExtendedRexBuilder.makeCast which wraps the literal with BINARY.
+          // ExtendedRexBuilder.makeCast wraps the literal into VARBINARY when it sees this.
           CoercionRule.of(
-              (left, right) -> hasString(left, right) && hasBinary(left, right),
-              (left, right) -> ExprCoreType.BINARY));
-
-  private static boolean hasString(ExprType left, ExprType right) {
-    return left == ExprCoreType.STRING || right == ExprCoreType.STRING;
-  }
-
-  private static boolean hasNumber(ExprType left, ExprType right) {
-    return NUMBER_TYPES.contains(left) || NUMBER_TYPES.contains(right);
-  }
-
-  private static boolean hasBoolean(ExprType left, ExprType right) {
-    return left == ExprCoreType.BOOLEAN || right == ExprCoreType.BOOLEAN;
-  }
-
-  private static boolean hasBinary(ExprType left, ExprType right) {
-    return left == ExprCoreType.BINARY || right == ExprCoreType.BINARY;
-  }
+              (l, r) -> hasString(l, r) && hasBinary(l, r),
+              (l, r) -> OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.VARBINARY)));
 
   private record CoercionRule(
-      BiPredicate<ExprType, ExprType> predicate, BinaryOperator<ExprType> resolver) {
+      BiPredicate<RelDataType, RelDataType> predicate, BinaryOperator<RelDataType> resolver) {
 
-    Optional<ExprType> apply(ExprType left, ExprType right) {
+    Optional<RelDataType> apply(RelDataType left, RelDataType right) {
       return predicate.test(left, right)
           ? Optional.of(resolver.apply(left, right))
           : Optional.empty();
     }
 
     static CoercionRule of(
-        BiPredicate<ExprType, ExprType> predicate, BinaryOperator<ExprType> resolver) {
+        BiPredicate<RelDataType, RelDataType> predicate, BinaryOperator<RelDataType> resolver) {
       return new CoercionRule(predicate, resolver);
     }
-  }
-
-  private static final int IMPOSSIBLE_WIDENING = Integer.MAX_VALUE;
-  private static final int TYPE_EQUAL = 0;
-
-  private static int distance(ExprType type1, ExprType type2) {
-    return distance(type1, type2, TYPE_EQUAL);
-  }
-
-  private static int distance(ExprType type1, ExprType type2, int distance) {
-    if (type1 == type2) {
-      return distance;
-    } else if (type1 == UNKNOWN) {
-      return IMPOSSIBLE_WIDENING;
-    } else if (type1 == ExprCoreType.STRING && type2 == ExprCoreType.DOUBLE) {
-      return 1;
-    } else {
-      return type1.getParent().stream()
-          .map(parentOfType1 -> distance(parentOfType1, type2, distance + 1))
-          .reduce(Math::min)
-          .get();
-    }
-  }
-
-  /**
-   * The max type among two types. The max is defined as follow if type1 could widen to type2, then
-   * max is type2, vice versa if type1 couldn't widen to type2 and type2 could't widen to type1,
-   * then throw {@link ExpressionEvaluationException}.
-   *
-   * @param type1 type1
-   * @param type2 type2
-   * @return the max type among two types.
-   */
-  public static ExprType max(ExprType type1, ExprType type2) {
-    int type1To2 = distance(type1, type2);
-    int type2To1 = distance(type2, type1);
-
-    if (type1To2 == Integer.MAX_VALUE && type2To1 == Integer.MAX_VALUE) {
-      throw new ExpressionEvaluationException(
-          String.format("no max type of %s and %s ", type1, type2));
-    } else {
-      return type1To2 == Integer.MAX_VALUE ? type1 : type2;
-    }
-  }
-
-  public static int distance(List<ExprType> sourceTypes, List<ExprType> targetTypes) {
-    if (sourceTypes.size() != targetTypes.size()) {
-      return IMPOSSIBLE_WIDENING;
-    }
-
-    int totalDistance = 0;
-    for (int i = 0; i < sourceTypes.size(); i++) {
-      ExprType source = sourceTypes.get(i);
-      ExprType target = targetTypes.get(i);
-      int distance = distance(source, target);
-      if (distance == IMPOSSIBLE_WIDENING) {
-        return IMPOSSIBLE_WIDENING;
-      } else {
-        totalDistance += distance;
-      }
-    }
-    return totalDistance;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/CoercionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CoercionUtils.java
@@ -15,8 +15,8 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.commons.lang3.tuple.Pair;
@@ -25,27 +25,32 @@ import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 
-/**
- * PPL function-dispatch widening. Signatures expose {@link RelDataType} at the public boundary, but
- * the widening lattice and common-type rules operate on {@link ExprType} — the source of truth for
- * OpenSearch's type hierarchy. RelDataType inputs are converted at the entry via {@link
- * OpenSearchTypeFactory#convertRelDataTypeToExprType}, and results are round-tripped back with
- * {@link OpenSearchTypeFactory#convertExprTypeToRelDataType} — which returns the UDT variant for
- * temporal / IP types so downstream casts route through the UDT path automatically.
- */
 public final class CoercionUtils {
-  private CoercionUtils() {}
-
   /**
-   * Casts the arguments to one of the typeChecker's allowed signatures. Returns null if no
-   * combination of parameter types matches the arguments or if casting fails.
+   * Casts the arguments to the types specified in the typeChecker. Returns null if no combination
+   * of parameter types matches the arguments or if casting fails.
+   *
+   * @param builder RexBuilder to create casts
+   * @param typeChecker PPLTypeChecker that provides the parameter types
+   * @param arguments List of RexNode arguments to be cast
+   * @return List of cast RexNode arguments or null if casting fails
    */
   public static @Nullable List<RexNode> castArguments(
       RexBuilder builder, PPLTypeChecker typeChecker, List<RexNode> arguments) {
     List<List<ExprType>> paramTypeCombinations =
-        typeChecker.getParameterTypes().stream().map(CoercionUtils::toExprTypes).toList();
+        typeChecker.getParameterTypes().stream()
+            .map(
+                types ->
+                    types.stream()
+                        .map(OpenSearchTypeFactory::convertRelDataTypeToExprType)
+                        .toList())
+            .toList();
 
-    List<ExprType> sourceTypes = arguments.stream().map(CoercionUtils::exprTypeOf).toList();
+    List<ExprType> sourceTypes =
+        arguments.stream()
+            .map(node -> OpenSearchTypeFactory.convertRelDataTypeToExprType(node.getType()))
+            .collect(Collectors.toList());
+    // Candidate parameter signatures ordered by decreasing widening distance
     PriorityQueue<Pair<List<ExprType>, Integer>> rankedSignatures =
         new PriorityQueue<>((left, right) -> Integer.compare(right.getValue(), left.getValue()));
     for (List<ExprType> paramTypes : paramTypeCombinations) {
@@ -64,55 +69,40 @@ public final class CoercionUtils {
   }
 
   /**
-   * Widen the arguments to the widest type found among them. Returns null if no widest type can be
-   * determined.
+   * Widen the arguments to the widest type found among them. If no widest type can be determined,
+   * returns null.
+   *
+   * @param builder RexBuilder to create casts
+   * @param arguments List of RexNode arguments to be widened
+   * @return List of widened RexNode arguments or null if no widest type can be determined
    */
   public static @Nullable List<RexNode> widenArguments(
       RexBuilder builder, List<RexNode> arguments) {
+    // TODO: Add test on e.g. IP
     ExprType widestType = findWidestType(arguments);
     if (widestType == null) {
-      return null;
+      return null; // No widest type found, return null
     }
     return arguments.stream().map(arg -> cast(builder, widestType, arg)).toList();
   }
 
-  /** Returns true if any of the operands has {@link ExprCoreType#STRING} type. */
-  public static boolean hasString(List<RexNode> rexNodeList) {
-    return rexNodeList.stream()
-        .map(CoercionUtils::exprTypeOf)
-        .anyMatch(t -> t == ExprCoreType.STRING);
-  }
-
   /**
-   * Resolves the widening common type for two {@link RelDataType}s using PPL coercion rules. Used
-   * primarily by tests to verify the rule set.
+   * Casts the arguments to the types specified in paramTypes. Returns null if the number of
+   * parameters does not match or if casting fails.
    */
-  @VisibleForTesting
-  public static Optional<RelDataType> resolveCommonType(RelDataType left, RelDataType right) {
-    return resolveCommonType(
-            OpenSearchTypeFactory.convertRelDataTypeToExprType(left),
-            OpenSearchTypeFactory.convertRelDataTypeToExprType(right))
-        .map(OpenSearchTypeFactory::convertExprTypeToRelDataType);
-  }
-
-  // -------- Internals --------
-
-  private static ExprType exprTypeOf(RexNode node) {
-    return OpenSearchTypeFactory.convertRelDataTypeToExprType(node.getType());
-  }
-
-  private static List<ExprType> toExprTypes(List<RelDataType> types) {
-    return types.stream().map(OpenSearchTypeFactory::convertRelDataTypeToExprType).toList();
-  }
-
   private static @Nullable List<RexNode> castArguments(
       RexBuilder builder, List<ExprType> paramTypes, List<RexNode> arguments) {
     if (paramTypes.size() != arguments.size()) {
-      return null;
+      return null; // Skip if the number of parameters does not match
     }
+
     List<RexNode> castedArguments = new ArrayList<>();
     for (int i = 0; i < paramTypes.size(); i++) {
-      RexNode castedArg = cast(builder, paramTypes.get(i), arguments.get(i));
+      ExprType toType = paramTypes.get(i);
+      RexNode arg = arguments.get(i);
+
+      RexNode castedArg = cast(builder, toType, arg);
+
       if (castedArg == null) {
         return null;
       }
@@ -122,61 +112,88 @@ public final class CoercionUtils {
   }
 
   private static @Nullable RexNode cast(RexBuilder builder, ExprType targetType, RexNode arg) {
-    ExprType argType = exprTypeOf(arg);
+    ExprType argType = OpenSearchTypeFactory.convertRelDataTypeToExprType(arg.getType());
     if (!argType.shouldCast(targetType)) {
       return arg;
     }
-    // Always make the cast target nullable. Safe cast returns null on parse failure or on a null
-    // source, so a non-nullable declared target defeats null-propagation and leads to primitive
-    // unboxing NPEs in downstream aggregations.
     if (distance(argType, targetType) != IMPOSSIBLE_WIDENING) {
       return builder.makeCast(
-          OpenSearchTypeFactory.convertExprTypeToRelDataType(targetType, true), arg, true, true);
+          OpenSearchTypeFactory.convertExprTypeToRelDataType(targetType), arg, true, true);
     }
     return resolveCommonType(argType, targetType)
         .map(
-            common ->
+            exprType ->
                 builder.makeCast(
-                    OpenSearchTypeFactory.convertExprTypeToRelDataType(common, true),
-                    arg,
-                    true,
-                    true))
+                    OpenSearchTypeFactory.convertExprTypeToRelDataType(exprType), arg, true, true))
         .orElse(null);
   }
 
+  /**
+   * Finds the widest type among the given arguments. The widest type is determined by applying the
+   * widening type rule to each pair of types in the arguments.
+   *
+   * @param arguments List of RexNode arguments to find the widest type from
+   * @return the widest ExprType if found, otherwise null
+   */
   private static @Nullable ExprType findWidestType(List<RexNode> arguments) {
     if (arguments.isEmpty()) {
-      return null;
+      return null; // No arguments to process
     }
-    ExprType widest = exprTypeOf(arguments.getFirst());
+    ExprType widestType =
+        OpenSearchTypeFactory.convertRelDataTypeToExprType(arguments.getFirst().getType());
     if (arguments.size() == 1) {
-      return widest;
+      return widestType;
     }
+
+    // Iterate pairwise through the arguments and find the widest type
     for (int i = 1; i < arguments.size(); i++) {
-      ExprType type = exprTypeOf(arguments.get(i));
+      var type = OpenSearchTypeFactory.convertRelDataTypeToExprType(arguments.get(i).getType());
       try {
-        final ExprType current = widest;
-        widest = resolveCommonType(widest, type).orElseGet(() -> max(current, type));
+        final ExprType tempType = widestType;
+        widestType = resolveCommonType(widestType, type).orElseGet(() -> max(tempType, type));
       } catch (ExpressionEvaluationException e) {
+        // the two types are not compatible, return null
         return null;
       }
     }
-    return widest;
+    return widestType;
   }
 
-  // -------- Common-type rules --------
+  private static boolean areDateAndTime(ExprType type1, ExprType type2) {
+    return (type1 == ExprCoreType.DATE && type2 == ExprCoreType.TIME)
+        || (type1 == ExprCoreType.TIME && type2 == ExprCoreType.DATE);
+  }
 
-  private static Optional<ExprType> resolveCommonType(ExprType left, ExprType right) {
+  @VisibleForTesting
+  public static Optional<ExprType> resolveCommonType(ExprType left, ExprType right) {
     return COMMON_COERCION_RULES.stream()
         .map(rule -> rule.apply(left, right))
         .flatMap(Optional::stream)
         .findFirst();
   }
 
-  private static boolean areDateAndTime(ExprType left, ExprType right) {
-    return (left == ExprCoreType.DATE && right == ExprCoreType.TIME)
-        || (left == ExprCoreType.TIME && right == ExprCoreType.DATE);
+  public static boolean hasString(List<RexNode> rexNodeList) {
+    return rexNodeList.stream()
+        .map(RexNode::getType)
+        .map(OpenSearchTypeFactory::convertRelDataTypeToExprType)
+        .anyMatch(t -> t == ExprCoreType.STRING);
   }
+
+  private static final Set<ExprType> NUMBER_TYPES = ExprCoreType.numberTypes();
+
+  private static final List<CoercionRule> COMMON_COERCION_RULES =
+      List.of(
+          CoercionRule.of(
+              (left, right) -> areDateAndTime(left, right),
+              (left, right) -> ExprCoreType.TIMESTAMP),
+          CoercionRule.of(
+              (left, right) -> hasString(left, right) && hasNumber(left, right),
+              (left, right) -> ExprCoreType.DOUBLE),
+          // (BINARY, STRING) → BINARY: ip/binary columns compared with string literals.
+          // Triggers ExtendedRexBuilder.makeCast which wraps the literal with BINARY.
+          CoercionRule.of(
+              (left, right) -> hasString(left, right) && hasBinary(left, right),
+              (left, right) -> ExprCoreType.BINARY));
 
   private static boolean hasString(ExprType left, ExprType right) {
     return left == ExprCoreType.STRING || right == ExprCoreType.STRING;
@@ -186,21 +203,13 @@ public final class CoercionUtils {
     return NUMBER_TYPES.contains(left) || NUMBER_TYPES.contains(right);
   }
 
+  private static boolean hasBoolean(ExprType left, ExprType right) {
+    return left == ExprCoreType.BOOLEAN || right == ExprCoreType.BOOLEAN;
+  }
+
   private static boolean hasBinary(ExprType left, ExprType right) {
     return left == ExprCoreType.BINARY || right == ExprCoreType.BINARY;
   }
-
-  private static final Set<ExprType> NUMBER_TYPES = ExprCoreType.numberTypes();
-
-  private static final List<CoercionRule> COMMON_COERCION_RULES =
-      List.of(
-          CoercionRule.of(CoercionUtils::areDateAndTime, (l, r) -> ExprCoreType.TIMESTAMP),
-          CoercionRule.of(
-              (l, r) -> hasString(l, r) && hasNumber(l, r), (l, r) -> ExprCoreType.DOUBLE),
-          // (BINARY, STRING) → BINARY: ip/binary columns compared with string literals.
-          // ExtendedRexBuilder.makeCast wraps the literal into VARBINARY when it sees this.
-          CoercionRule.of(
-              (l, r) -> hasString(l, r) && hasBinary(l, r), (l, r) -> ExprCoreType.BINARY));
 
   private record CoercionRule(
       BiPredicate<ExprType, ExprType> predicate, BinaryOperator<ExprType> resolver) {
@@ -217,8 +226,6 @@ public final class CoercionUtils {
     }
   }
 
-  // -------- Widening distance --------
-
   private static final int IMPOSSIBLE_WIDENING = Integer.MAX_VALUE;
   private static final int TYPE_EQUAL = 0;
 
@@ -232,41 +239,52 @@ public final class CoercionUtils {
     } else if (type1 == UNKNOWN) {
       return IMPOSSIBLE_WIDENING;
     } else if (type1 == ExprCoreType.STRING && type2 == ExprCoreType.DOUBLE) {
-      return distance + 1;
+      return 1;
     } else {
       return type1.getParent().stream()
           .map(parentOfType1 -> distance(parentOfType1, type2, distance + 1))
           .reduce(Math::min)
-          .orElse(IMPOSSIBLE_WIDENING);
+          .get();
     }
-  }
-
-  private static int distance(List<ExprType> sourceTypes, List<ExprType> targetTypes) {
-    if (sourceTypes.size() != targetTypes.size()) {
-      return IMPOSSIBLE_WIDENING;
-    }
-    int total = 0;
-    for (int i = 0; i < sourceTypes.size(); i++) {
-      int d = distance(sourceTypes.get(i), targetTypes.get(i));
-      if (d == IMPOSSIBLE_WIDENING) {
-        return IMPOSSIBLE_WIDENING;
-      }
-      total += d;
-    }
-    return total;
   }
 
   /**
-   * The widest of two types: the one that the other can widen to. Throws if neither widens to the
-   * other.
+   * The max type among two types. The max is defined as follow if type1 could widen to type2, then
+   * max is type2, vice versa if type1 couldn't widen to type2 and type2 could't widen to type1,
+   * then throw {@link ExpressionEvaluationException}.
+   *
+   * @param type1 type1
+   * @param type2 type2
+   * @return the max type among two types.
    */
-  static ExprType max(ExprType type1, ExprType type2) {
-    int t1To2 = distance(type1, type2);
-    int t2To1 = distance(type2, type1);
-    if (t1To2 == IMPOSSIBLE_WIDENING && t2To1 == IMPOSSIBLE_WIDENING) {
+  public static ExprType max(ExprType type1, ExprType type2) {
+    int type1To2 = distance(type1, type2);
+    int type2To1 = distance(type2, type1);
+
+    if (type1To2 == Integer.MAX_VALUE && type2To1 == Integer.MAX_VALUE) {
       throw new ExpressionEvaluationException(
           String.format("no max type of %s and %s ", type1, type2));
+    } else {
+      return type1To2 == Integer.MAX_VALUE ? type1 : type2;
     }
-    return t1To2 == IMPOSSIBLE_WIDENING ? type1 : type2;
+  }
+
+  public static int distance(List<ExprType> sourceTypes, List<ExprType> targetTypes) {
+    if (sourceTypes.size() != targetTypes.size()) {
+      return IMPOSSIBLE_WIDENING;
+    }
+
+    int totalDistance = 0;
+    for (int i = 0; i < sourceTypes.size(); i++) {
+      ExprType source = sourceTypes.get(i);
+      ExprType target = targetTypes.get(i);
+      int distance = distance(source, target);
+      if (distance == IMPOSSIBLE_WIDENING) {
+        return IMPOSSIBLE_WIDENING;
+      } else {
+        totalDistance += distance;
+      }
+    }
+    return totalDistance;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/CoercionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CoercionUtils.java
@@ -5,11 +5,11 @@
 
 package org.opensearch.sql.expression.function;
 
+import static org.opensearch.sql.data.type.ExprCoreType.UNKNOWN;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
@@ -19,29 +19,19 @@ import javax.annotation.Nullable;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.commons.lang3.tuple.Pair;
-import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
-import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 
 /**
- * RelDataType-native widening, casting, and common-type resolution for PPL function dispatch.
- *
- * <p>This module models a small widening DAG over a tag space derived from {@link RelDataType}:
- *
- * <ul>
- *   <li>numeric SQL types (BYTE → SHORT → INTEGER → LONG → FLOAT → DOUBLE)
- *   <li>STRING (VARCHAR/CHAR)
- *   <li>BOOLEAN
- *   <li>OpenSearch UDTs (DATE, TIME, TIMESTAMP, IP, BINARY) detected via {@code instanceof}
- * </ul>
- *
- * <p>The widening rules mirror prior behavior: {@code STRING + NUMERIC → DOUBLE}, {@code DATE +
- * TIME → TIMESTAMP}, {@code STRING + BINARY → BINARY}; STRING widens to BOOLEAN/DATE/TIME/
- * TIMESTAMP/IP; numerics widen along the integer/float chain; etc.
+ * PPL function-dispatch widening. Signatures expose {@link RelDataType} at the public boundary, but
+ * the widening lattice and common-type rules operate on {@link ExprType} — the source of truth for
+ * OpenSearch's type hierarchy. RelDataType inputs are converted at the entry via {@link
+ * OpenSearchTypeFactory#convertRelDataTypeToExprType}, and results are round-tripped back with
+ * {@link OpenSearchTypeFactory#convertExprTypeToRelDataType} — which returns the UDT variant for
+ * temporal / IP types so downstream casts route through the UDT path automatically.
  */
 public final class CoercionUtils {
   private CoercionUtils() {}
@@ -52,14 +42,14 @@ public final class CoercionUtils {
    */
   public static @Nullable List<RexNode> castArguments(
       RexBuilder builder, PPLTypeChecker typeChecker, List<RexNode> arguments) {
-    List<List<RelDataType>> paramTypeCombinations = typeChecker.getParameterTypes();
+    List<List<ExprType>> paramTypeCombinations =
+        typeChecker.getParameterTypes().stream().map(CoercionUtils::toExprTypes).toList();
 
-    List<RelDataType> sourceTypes = arguments.stream().map(RexNode::getType).toList();
-    // Candidate parameter signatures ordered by decreasing widening distance
-    PriorityQueue<Pair<List<RelDataType>, Integer>> rankedSignatures =
+    List<ExprType> sourceTypes = arguments.stream().map(CoercionUtils::exprTypeOf).toList();
+    PriorityQueue<Pair<List<ExprType>, Integer>> rankedSignatures =
         new PriorityQueue<>((left, right) -> Integer.compare(right.getValue(), left.getValue()));
-    for (List<RelDataType> paramTypes : paramTypeCombinations) {
-      int distance = signatureDistance(sourceTypes, paramTypes);
+    for (List<ExprType> paramTypes : paramTypeCombinations) {
+      int distance = distance(sourceTypes, paramTypes);
       if (distance == TYPE_EQUAL) {
         return castArguments(builder, paramTypes, arguments);
       }
@@ -74,21 +64,23 @@ public final class CoercionUtils {
   }
 
   /**
-   * Widen the arguments to the widest type found among them. If no widest type can be determined,
-   * returns null.
+   * Widen the arguments to the widest type found among them. Returns null if no widest type can be
+   * determined.
    */
   public static @Nullable List<RexNode> widenArguments(
       RexBuilder builder, List<RexNode> arguments) {
-    RelDataType widestType = findWidestType(arguments);
+    ExprType widestType = findWidestType(arguments);
     if (widestType == null) {
       return null;
     }
     return arguments.stream().map(arg -> cast(builder, widestType, arg)).toList();
   }
 
-  /** Returns true if any of the operands is a string-like (VARCHAR/CHAR) RexNode. */
+  /** Returns true if any of the operands has {@link ExprCoreType#STRING} type. */
   public static boolean hasString(List<RexNode> rexNodeList) {
-    return rexNodeList.stream().map(RexNode::getType).anyMatch(SqlTypeUtil::isCharacter);
+    return rexNodeList.stream()
+        .map(CoercionUtils::exprTypeOf)
+        .anyMatch(t -> t == ExprCoreType.STRING);
   }
 
   /**
@@ -97,16 +89,24 @@ public final class CoercionUtils {
    */
   @VisibleForTesting
   public static Optional<RelDataType> resolveCommonType(RelDataType left, RelDataType right) {
-    return COMMON_COERCION_RULES.stream()
-        .map(rule -> rule.apply(left, right))
-        .flatMap(Optional::stream)
-        .findFirst();
+    return resolveCommonType(
+            OpenSearchTypeFactory.convertRelDataTypeToExprType(left),
+            OpenSearchTypeFactory.convertRelDataTypeToExprType(right))
+        .map(OpenSearchTypeFactory::convertExprTypeToRelDataType);
   }
 
   // -------- Internals --------
 
+  private static ExprType exprTypeOf(RexNode node) {
+    return OpenSearchTypeFactory.convertRelDataTypeToExprType(node.getType());
+  }
+
+  private static List<ExprType> toExprTypes(List<RelDataType> types) {
+    return types.stream().map(OpenSearchTypeFactory::convertRelDataTypeToExprType).toList();
+  }
+
   private static @Nullable List<RexNode> castArguments(
-      RexBuilder builder, List<RelDataType> paramTypes, List<RexNode> arguments) {
+      RexBuilder builder, List<ExprType> paramTypes, List<RexNode> arguments) {
     if (paramTypes.size() != arguments.size()) {
       return null;
     }
@@ -121,9 +121,9 @@ public final class CoercionUtils {
     return castedArguments;
   }
 
-  private static @Nullable RexNode cast(RexBuilder builder, RelDataType targetType, RexNode arg) {
-    RelDataType argType = arg.getType();
-    if (!shouldCast(argType, targetType)) {
+  private static @Nullable RexNode cast(RexBuilder builder, ExprType targetType, RexNode arg) {
+    ExprType argType = exprTypeOf(arg);
+    if (!argType.shouldCast(targetType)) {
       return arg;
     }
     // Always make the cast target nullable. Safe cast returns null on parse failure or on a null
@@ -131,218 +131,117 @@ public final class CoercionUtils {
     // unboxing NPEs in downstream aggregations.
     if (distance(argType, targetType) != IMPOSSIBLE_WIDENING) {
       return builder.makeCast(
-          builder.getTypeFactory().createTypeWithNullability(targetType, true), arg, true, true);
+          OpenSearchTypeFactory.convertExprTypeToRelDataType(targetType, true), arg, true, true);
     }
     return resolveCommonType(argType, targetType)
         .map(
             common ->
                 builder.makeCast(
-                    builder.getTypeFactory().createTypeWithNullability(common, true),
+                    OpenSearchTypeFactory.convertExprTypeToRelDataType(common, true),
                     arg,
                     true,
                     true))
         .orElse(null);
   }
 
-  private static @Nullable RelDataType findWidestType(List<RexNode> arguments) {
+  private static @Nullable ExprType findWidestType(List<RexNode> arguments) {
     if (arguments.isEmpty()) {
       return null;
     }
-    RelDataType widest = arguments.getFirst().getType();
+    ExprType widest = exprTypeOf(arguments.getFirst());
     if (arguments.size() == 1) {
       return widest;
     }
     for (int i = 1; i < arguments.size(); i++) {
-      RelDataType type = arguments.get(i).getType();
+      ExprType type = exprTypeOf(arguments.get(i));
       try {
-        final RelDataType current = widest;
+        final ExprType current = widest;
         widest = resolveCommonType(widest, type).orElseGet(() -> max(current, type));
       } catch (ExpressionEvaluationException e) {
         return null;
       }
     }
-    // Normalize standard temporal types to their UDT equivalents so downstream casts route through
-    // the ExtendedRexBuilder UDT path (producing TIMESTAMP/DATE/TIME function calls at runtime).
-    return normalizeTemporalToUdt(widest);
+    return widest;
   }
 
-  private static RelDataType normalizeTemporalToUdt(RelDataType type) {
-    if (type instanceof AbstractExprRelDataType<?>) {
-      return type;
+  // -------- Common-type rules --------
+
+  private static Optional<ExprType> resolveCommonType(ExprType left, ExprType right) {
+    return COMMON_COERCION_RULES.stream()
+        .map(rule -> rule.apply(left, right))
+        .flatMap(Optional::stream)
+        .findFirst();
+  }
+
+  private static boolean areDateAndTime(ExprType left, ExprType right) {
+    return (left == ExprCoreType.DATE && right == ExprCoreType.TIME)
+        || (left == ExprCoreType.TIME && right == ExprCoreType.DATE);
+  }
+
+  private static boolean hasString(ExprType left, ExprType right) {
+    return left == ExprCoreType.STRING || right == ExprCoreType.STRING;
+  }
+
+  private static boolean hasNumber(ExprType left, ExprType right) {
+    return NUMBER_TYPES.contains(left) || NUMBER_TYPES.contains(right);
+  }
+
+  private static boolean hasBinary(ExprType left, ExprType right) {
+    return left == ExprCoreType.BINARY || right == ExprCoreType.BINARY;
+  }
+
+  private static final Set<ExprType> NUMBER_TYPES = ExprCoreType.numberTypes();
+
+  private static final List<CoercionRule> COMMON_COERCION_RULES =
+      List.of(
+          CoercionRule.of(CoercionUtils::areDateAndTime, (l, r) -> ExprCoreType.TIMESTAMP),
+          CoercionRule.of(
+              (l, r) -> hasString(l, r) && hasNumber(l, r), (l, r) -> ExprCoreType.DOUBLE),
+          // (BINARY, STRING) → BINARY: ip/binary columns compared with string literals.
+          // ExtendedRexBuilder.makeCast wraps the literal into VARBINARY when it sees this.
+          CoercionRule.of(
+              (l, r) -> hasString(l, r) && hasBinary(l, r), (l, r) -> ExprCoreType.BINARY));
+
+  private record CoercionRule(
+      BiPredicate<ExprType, ExprType> predicate, BinaryOperator<ExprType> resolver) {
+
+    Optional<ExprType> apply(ExprType left, ExprType right) {
+      return predicate.test(left, right)
+          ? Optional.of(resolver.apply(left, right))
+          : Optional.empty();
     }
-    SqlTypeName name = type.getSqlTypeName();
-    ExprUDT udt =
-        switch (name) {
-          case TIMESTAMP -> ExprUDT.EXPR_TIMESTAMP;
-          case DATE -> ExprUDT.EXPR_DATE;
-          case TIME -> ExprUDT.EXPR_TIME;
-          default -> null;
-        };
-    return udt == null
-        ? type
-        : OpenSearchTypeFactory.TYPE_FACTORY.createUDT(udt, type.isNullable());
-  }
 
-  // -------- Tag space + widening DAG --------
-
-  /**
-   * A small enum that tags every {@link RelDataType} the coercion rules need to reason about. Using
-   * an enum means the widening DAG is closed and self-contained.
-   */
-  private enum CoercionTag {
-    UNDEFINED, // Calcite NULL — compatible with anything
-    UNKNOWN, // Anything we can't classify
-    BYTE,
-    SHORT,
-    INTEGER,
-    LONG,
-    FLOAT,
-    DOUBLE,
-    STRING,
-    BOOLEAN,
-    DATE,
-    TIME,
-    TIMESTAMP,
-    IP,
-    BINARY,
-    INTERVAL,
-    ARRAY,
-    STRUCT,
-    GEOMETRY;
-  }
-
-  private static CoercionTag tagOf(RelDataType type) {
-    if (type instanceof AbstractExprRelDataType<?> udt) {
-      return switch (udt.getUdt()) {
-        case EXPR_DATE -> CoercionTag.DATE;
-        case EXPR_TIME -> CoercionTag.TIME;
-        case EXPR_TIMESTAMP -> CoercionTag.TIMESTAMP;
-        case EXPR_IP -> CoercionTag.IP;
-        case EXPR_BINARY -> CoercionTag.BINARY;
-      };
+    static CoercionRule of(
+        BiPredicate<ExprType, ExprType> predicate, BinaryOperator<ExprType> resolver) {
+      return new CoercionRule(predicate, resolver);
     }
-    SqlTypeName name = type.getSqlTypeName();
-    if (name == null) return CoercionTag.UNKNOWN;
-    return switch (name) {
-      case TINYINT -> CoercionTag.BYTE;
-      case SMALLINT -> CoercionTag.SHORT;
-      case INTEGER -> CoercionTag.INTEGER;
-      case BIGINT -> CoercionTag.LONG;
-      case REAL, FLOAT -> CoercionTag.FLOAT;
-      case DOUBLE, DECIMAL -> CoercionTag.DOUBLE;
-      case CHAR, VARCHAR -> CoercionTag.STRING;
-      case BOOLEAN -> CoercionTag.BOOLEAN;
-      case BINARY, VARBINARY -> CoercionTag.BINARY;
-      case DATE -> CoercionTag.DATE;
-      case TIME, TIME_WITH_LOCAL_TIME_ZONE, TIME_TZ -> CoercionTag.TIME;
-      case TIMESTAMP, TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_TZ -> CoercionTag.TIMESTAMP;
-      case NULL -> CoercionTag.UNDEFINED;
-      case ARRAY, MULTISET -> CoercionTag.ARRAY;
-      case MAP, ROW, STRUCTURED -> CoercionTag.STRUCT;
-      case GEOMETRY -> CoercionTag.GEOMETRY;
-      default -> {
-        if (SqlTypeName.INTERVAL_TYPES.contains(name)) {
-          yield CoercionTag.INTERVAL;
-        }
-        yield CoercionTag.UNKNOWN;
-      }
-    };
   }
 
-  /**
-   * Parents in the widening DAG. Mirrors {@code ExprCoreType} parent links. A type widens to its
-   * parent and (transitively) to grandparents.
-   */
-  private static final Map<CoercionTag, List<CoercionTag>> PARENTS = buildParents();
-
-  private static Map<CoercionTag, List<CoercionTag>> buildParents() {
-    Map<CoercionTag, List<CoercionTag>> p = new HashMap<>();
-    p.put(CoercionTag.BYTE, List.of(CoercionTag.SHORT));
-    p.put(CoercionTag.SHORT, List.of(CoercionTag.INTEGER));
-    p.put(CoercionTag.INTEGER, List.of(CoercionTag.LONG));
-    p.put(CoercionTag.LONG, List.of(CoercionTag.FLOAT));
-    p.put(CoercionTag.FLOAT, List.of(CoercionTag.DOUBLE));
-    // STRING has TIMESTAMP as a direct parent (in addition to DATE/TIME/BOOLEAN/IP) so the
-    // STRING→TIMESTAMP widening cost matches STRING→DOUBLE (1). This preserves baseline ranking
-    // when both NUMERIC and TIMESTAMP signatures are candidates for a STRING input.
-    p.put(
-        CoercionTag.STRING,
-        List.of(
-            CoercionTag.BOOLEAN,
-            CoercionTag.DATE,
-            CoercionTag.TIME,
-            CoercionTag.TIMESTAMP,
-            CoercionTag.IP));
-    p.put(CoercionTag.DATE, List.of(CoercionTag.TIMESTAMP));
-    p.put(CoercionTag.TIME, List.of(CoercionTag.TIMESTAMP));
-    return p;
-  }
-
-  private static List<CoercionTag> parentsOf(CoercionTag tag) {
-    return PARENTS.getOrDefault(tag, List.of());
-  }
-
-  private static final Set<CoercionTag> NUMBER_TAGS =
-      Set.of(
-          CoercionTag.BYTE,
-          CoercionTag.SHORT,
-          CoercionTag.INTEGER,
-          CoercionTag.LONG,
-          CoercionTag.FLOAT,
-          CoercionTag.DOUBLE);
-
-  // -------- Distance and "shouldCast" --------
+  // -------- Widening distance --------
 
   private static final int IMPOSSIBLE_WIDENING = Integer.MAX_VALUE;
   private static final int TYPE_EQUAL = 0;
 
-  private static int distance(RelDataType from, RelDataType to) {
-    return distance(tagOf(from), tagOf(to), TYPE_EQUAL);
+  private static int distance(ExprType type1, ExprType type2) {
+    return distance(type1, type2, TYPE_EQUAL);
   }
 
-  private static int distance(CoercionTag from, CoercionTag to) {
-    return distance(from, to, TYPE_EQUAL);
-  }
-
-  private static int distance(CoercionTag from, CoercionTag to, int acc) {
-    if (from == to) return acc;
-    if (from == CoercionTag.UNKNOWN) return IMPOSSIBLE_WIDENING;
-    // UNDEFINED (NULL literal) widens to any concrete type at unit cost — mirrors v2 where every
-    // concrete ExprCoreType has UNDEFINED as a parent.
-    if (from == CoercionTag.UNDEFINED && to != CoercionTag.UNKNOWN) return acc + 1;
-    // STRING widens directly to DOUBLE (custom rule mirroring v2 behavior).
-    if (from == CoercionTag.STRING && to == CoercionTag.DOUBLE) return acc + 1;
-    List<CoercionTag> parents = parentsOf(from);
-    if (parents.isEmpty()) return IMPOSSIBLE_WIDENING;
-    int best = IMPOSSIBLE_WIDENING;
-    for (CoercionTag parent : parents) {
-      int d = distance(parent, to, acc + 1);
-      if (d < best) best = d;
+  private static int distance(ExprType type1, ExprType type2, int distance) {
+    if (type1 == type2) {
+      return distance;
+    } else if (type1 == UNKNOWN) {
+      return IMPOSSIBLE_WIDENING;
+    } else if (type1 == ExprCoreType.STRING && type2 == ExprCoreType.DOUBLE) {
+      return distance + 1;
+    } else {
+      return type1.getParent().stream()
+          .map(parentOfType1 -> distance(parentOfType1, type2, distance + 1))
+          .reduce(Math::min)
+          .orElse(IMPOSSIBLE_WIDENING);
     }
-    return best;
   }
 
-  /** The argument should be cast to the target type when their CoercionTags differ. */
-  private static boolean shouldCast(RelDataType source, RelDataType target) {
-    return tagOf(source) != tagOf(target);
-  }
-
-  /**
-   * The widest of two types: the one that the other can widen to. Throws if neither widens to the
-   * other.
-   */
-  static RelDataType max(RelDataType type1, RelDataType type2) {
-    int t1To2 = distance(type1, type2);
-    int t2To1 = distance(type2, type1);
-    if (t1To2 == IMPOSSIBLE_WIDENING && t2To1 == IMPOSSIBLE_WIDENING) {
-      throw new ExpressionEvaluationException(
-          String.format("no max type of %s and %s ", type1, type2));
-    }
-    return t1To2 == IMPOSSIBLE_WIDENING ? type1 : type2;
-  }
-
-  private static int signatureDistance(
-      List<RelDataType> sourceTypes, List<RelDataType> targetTypes) {
+  private static int distance(List<ExprType> sourceTypes, List<ExprType> targetTypes) {
     if (sourceTypes.size() != targetTypes.size()) {
       return IMPOSSIBLE_WIDENING;
     }
@@ -357,53 +256,17 @@ public final class CoercionUtils {
     return total;
   }
 
-  // -------- Common-type rules --------
-
-  private static boolean hasString(RelDataType l, RelDataType r) {
-    return tagOf(l) == CoercionTag.STRING || tagOf(r) == CoercionTag.STRING;
-  }
-
-  private static boolean hasNumber(RelDataType l, RelDataType r) {
-    return NUMBER_TAGS.contains(tagOf(l)) || NUMBER_TAGS.contains(tagOf(r));
-  }
-
-  private static boolean hasBinary(RelDataType l, RelDataType r) {
-    return tagOf(l) == CoercionTag.BINARY || tagOf(r) == CoercionTag.BINARY;
-  }
-
-  private static boolean areDateAndTime(RelDataType l, RelDataType r) {
-    CoercionTag lt = tagOf(l);
-    CoercionTag rt = tagOf(r);
-    return (lt == CoercionTag.DATE && rt == CoercionTag.TIME)
-        || (lt == CoercionTag.TIME && rt == CoercionTag.DATE);
-  }
-
-  private static final List<CoercionRule> COMMON_COERCION_RULES =
-      List.of(
-          CoercionRule.of(
-              CoercionUtils::areDateAndTime,
-              (l, r) -> OpenSearchTypeFactory.TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP)),
-          CoercionRule.of(
-              (l, r) -> hasString(l, r) && hasNumber(l, r),
-              (l, r) -> OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE)),
-          // (BINARY, STRING) → BINARY: ip/binary columns compared with string literals.
-          // ExtendedRexBuilder.makeCast wraps the literal into VARBINARY when it sees this.
-          CoercionRule.of(
-              (l, r) -> hasString(l, r) && hasBinary(l, r),
-              (l, r) -> OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.VARBINARY)));
-
-  private record CoercionRule(
-      BiPredicate<RelDataType, RelDataType> predicate, BinaryOperator<RelDataType> resolver) {
-
-    Optional<RelDataType> apply(RelDataType left, RelDataType right) {
-      return predicate.test(left, right)
-          ? Optional.of(resolver.apply(left, right))
-          : Optional.empty();
+  /**
+   * The widest of two types: the one that the other can widen to. Throws if neither widens to the
+   * other.
+   */
+  static ExprType max(ExprType type1, ExprType type2) {
+    int t1To2 = distance(type1, type2);
+    int t2To1 = distance(type2, type1);
+    if (t1To2 == IMPOSSIBLE_WIDENING && t2To1 == IMPOSSIBLE_WIDENING) {
+      throw new ExpressionEvaluationException(
+          String.format("no max type of %s and %s ", type1, type2));
     }
-
-    static CoercionRule of(
-        BiPredicate<RelDataType, RelDataType> predicate, BinaryOperator<RelDataType> resolver) {
-      return new CoercionRule(predicate, resolver);
-    }
+    return t1To2 == IMPOSSIBLE_WIDENING ? type1 : type2;
   }
 }

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLBuiltinOperators.java
@@ -246,11 +246,12 @@ public class PPLBuiltinOperators extends ReflectiveSqlOperatorTable {
   public static final SqlOperator SECOND = new DatePartFunction(TimeUnit.SECOND).toUDF("SECOND");
   public static final SqlOperator MICROSECOND =
       new DatePartFunction(TimeUnit.MICROSECOND).toUDF("MICROSECOND");
-  public static final SqlOperator NOW = new CurrentFunction(ExprCoreType.TIMESTAMP).toUDF("NOW");
+  public static final SqlOperator NOW =
+      new CurrentFunction(CurrentFunction.Kind.TIMESTAMP).toUDF("NOW");
   public static final SqlOperator CURRENT_TIME =
-      new CurrentFunction(ExprCoreType.TIME).toUDF("CURRENT_TIME");
+      new CurrentFunction(CurrentFunction.Kind.TIME).toUDF("CURRENT_TIME");
   public static final SqlOperator CURRENT_DATE =
-      new CurrentFunction(ExprCoreType.DATE).toUDF("CURRENT_DATE");
+      new CurrentFunction(CurrentFunction.Kind.DATE).toUDF("CURRENT_DATE");
   public static final SqlOperator DATE_FORMAT =
       new FormatFunction(ExprCoreType.DATE).toUDF("DATE_FORMAT");
   public static final SqlOperator TIME_FORMAT =

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -309,6 +309,7 @@ import org.apache.calcite.sql.type.SameOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlUserDefinedAggFunction;
 import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
 import org.apache.calcite.tools.RelBuilder;
@@ -319,8 +320,6 @@ import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.calcite.utils.PlanUtils;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
-import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.executor.QueryType;
 import org.opensearch.sql.expression.function.CollectionUDF.MVIndexFunctionImp;
@@ -450,7 +449,7 @@ public class PPLFuncImpTable {
         return false;
       }
       try {
-        List<List<ExprType>> signatures =
+        List<List<RelDataType>> signatures =
             checker.getParameterTypes().stream()
                 .filter(parameters -> argumentIndex < parameters.size())
                 .toList();
@@ -458,12 +457,12 @@ public class PPLFuncImpTable {
           return false;
         }
         foundArgument = true;
-        List<ExprType> acceptedTypes =
+        List<RelDataType> acceptedTypes =
             signatures.stream().map(parameters -> parameters.get(argumentIndex)).toList();
-        if (acceptedTypes.stream().allMatch(ExprCoreType.numberTypes()::contains)) {
+        if (acceptedTypes.stream().allMatch(SqlTypeUtil::isNumeric)) {
           continue;
         }
-        if (acceptedTypes.stream().anyMatch(type -> type != ExprCoreType.UNKNOWN)
+        if (acceptedTypes.stream().anyMatch(type -> type.getSqlTypeName() != SqlTypeName.ANY)
             || !requiresNumericByValidation(checker, signatures, argumentIndex)) {
           return false;
         }
@@ -475,7 +474,7 @@ public class PPLFuncImpTable {
   }
 
   private boolean requiresNumericByValidation(
-      PPLTypeChecker checker, List<List<ExprType>> signatures, int argumentIndex) {
+      PPLTypeChecker checker, List<List<RelDataType>> signatures, int argumentIndex) {
     RelDataType numericType = TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE);
     RelDataType stringType = TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
     return signatures.stream()

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -572,10 +572,10 @@ public interface PPLTypeChecker {
   }
 
   /**
-   * Compares two RelDataTypes for signature matching. Two UDTs match if they share the same
-   * {@link ExprUDT} tag — comparing {@code getClass()} is unsafe because addCharsetAndCollation
-   * collapses ExprDateType/ExprTimeType/ExprTimeStampType/ExprBinaryType down to ExprSqlType, so
-   * different UDTs would appear equal. Plain types match by SqlTypeName.
+   * Compares two RelDataTypes for signature matching. Two UDTs match if they share the same {@link
+   * ExprUDT} tag — comparing {@code getClass()} is unsafe because addCharsetAndCollation collapses
+   * ExprDateType/ExprTimeType/ExprTimeStampType/ExprBinaryType down to ExprSqlType, so different
+   * UDTs would appear equal. Plain types match by SqlTypeName.
    */
   private static boolean typesMatch(RelDataType expected, RelDataType actual) {
     if (expected instanceof AbstractExprRelDataType<?> expUdt

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.expression.function;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import java.lang.reflect.Field;
 import java.lang.reflect.InaccessibleObjectException;
@@ -274,16 +273,13 @@ public interface PPLTypeChecker {
     }
 
     /**
-     * Modified from {@link SqlTypeUtil#isComparable(RelDataType, RelDataType)} to accommodate PPL
-     * semantics: comparability follows the ExprType lattice (via {@code shouldCast}), so a UDT
-     * temporal / IP / binary compares to any RelDataType that maps to the same {@link ExprType}.
+     * Modified from {@link SqlTypeUtil#isComparable(RelDataType, RelDataType)} to
      *
      * @param type1 first type
      * @param type2 second type
      * @return true if the two types are comparable, false otherwise
      */
-    @VisibleForTesting
-    static boolean isComparable(RelDataType type1, RelDataType type2) {
+    private static boolean isComparable(RelDataType type1, RelDataType type2) {
       if (type1.isStruct() != type2.isStruct()) {
         return false;
       }
@@ -302,13 +298,14 @@ public interface PPLTypeChecker {
         return true;
       }
 
-      // Numeric types are comparable without the need to cast.
+      // Numeric types are comparable without the need to cast
       if (SqlTypeUtil.isNumeric(type1) && SqlTypeUtil.isNumeric(type2)) {
         return true;
       }
 
       ExprType exprType1 = OpenSearchTypeFactory.convertRelDataTypeToExprType(type1);
       ExprType exprType2 = OpenSearchTypeFactory.convertRelDataTypeToExprType(type2);
+
       if (!exprType1.shouldCast(exprType2)) {
         return true;
       }

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.sql.expression.function;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import java.lang.reflect.Field;
 import java.lang.reflect.InaccessibleObjectException;
@@ -33,6 +34,7 @@ import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
 
 /**
  * A custom type checker interface for PPL (Piped Processing Language) functions.
@@ -272,13 +274,16 @@ public interface PPLTypeChecker {
     }
 
     /**
-     * Modified from {@link SqlTypeUtil#isComparable(RelDataType, RelDataType)} for PPL semantics.
+     * Modified from {@link SqlTypeUtil#isComparable(RelDataType, RelDataType)} to accommodate PPL
+     * semantics: comparability follows the ExprType lattice (via {@code shouldCast}), so a UDT
+     * temporal / IP / binary compares to any RelDataType that maps to the same {@link ExprType}.
      *
      * @param type1 first type
      * @param type2 second type
      * @return true if the two types are comparable, false otherwise
      */
-    private static boolean isComparable(RelDataType type1, RelDataType type2) {
+    @VisibleForTesting
+    static boolean isComparable(RelDataType type1, RelDataType type2) {
       if (type1.isStruct() != type2.isStruct()) {
         return false;
       }
@@ -302,31 +307,10 @@ public interface PPLTypeChecker {
         return true;
       }
 
-      // Same UDT kind is comparable. Compare via the ExprUDT tag (not the concrete Java class),
-      // because createTypeWithNullability on an AbstractExprRelDataType returns a plain ExprSqlType
-      // that loses the concrete subclass identity.
-      if (type1 instanceof AbstractExprRelDataType<?> udt1
-          && type2 instanceof AbstractExprRelDataType<?> udt2
-          && udt1.getUdt() == udt2.getUdt()) {
+      ExprType exprType1 = OpenSearchTypeFactory.convertRelDataTypeToExprType(type1);
+      ExprType exprType2 = OpenSearchTypeFactory.convertRelDataTypeToExprType(type2);
+      if (!exprType1.shouldCast(exprType2)) {
         return true;
-      }
-
-      // Temporal UDT vs standard temporal of the same kind is comparable (widening produced by
-      // findWidestType may leave a standard TIMESTAMP field alongside a UDT temporal literal).
-      if (temporalKind(type1) != null && temporalKind(type1) == temporalKind(type2)) {
-        return true;
-      }
-
-      // Plain types are comparable when their SqlTypeFamily matches (CHAR vs VARCHAR, INTEGER vs
-      // BIGINT, BOOLEAN vs BOOLEAN, etc.). UDTs are excluded since they share the underlying
-      // VARCHAR family but should not be transparently comparable to plain strings here.
-      if (!(type1 instanceof AbstractExprRelDataType<?>)
-          && !(type2 instanceof AbstractExprRelDataType<?>)) {
-        SqlTypeFamily family1 = type1.getSqlTypeName().getFamily();
-        SqlTypeFamily family2 = type2.getSqlTypeName().getFamily();
-        if (family1 != null && family1 == family2) {
-          return true;
-        }
       }
 
       // If one of the arguments is of type 'ANY', return true.
@@ -587,23 +571,6 @@ public interface PPLTypeChecker {
       return false;
     }
     return expected.getSqlTypeName() == actual.getSqlTypeName();
-  }
-
-  /** Returns DATE / TIME / TIMESTAMP for either UDT or standard temporal types; null otherwise. */
-  private static SqlTypeName temporalKind(RelDataType type) {
-    if (type instanceof AbstractExprRelDataType<?> udt) {
-      return switch (udt.getUdt()) {
-        case EXPR_DATE -> SqlTypeName.DATE;
-        case EXPR_TIME -> SqlTypeName.TIME;
-        case EXPR_TIMESTAMP -> SqlTypeName.TIMESTAMP;
-        default -> null;
-      };
-    }
-    SqlTypeName name = type.getSqlTypeName();
-    if (name == SqlTypeName.DATE || name == SqlTypeName.TIME || name == SqlTypeName.TIMESTAMP) {
-      return name;
-    }
-    return null;
   }
 
   // Util Functions

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -572,13 +572,19 @@ public interface PPLTypeChecker {
   }
 
   /**
-   * Compares two RelDataTypes for signature matching. Two UDTs match if they share the same UDT
-   * class. Plain types match by SqlTypeName.
+   * Compares two RelDataTypes for signature matching. Two UDTs match if they share the same
+   * {@link ExprUDT} tag — comparing {@code getClass()} is unsafe because addCharsetAndCollation
+   * collapses ExprDateType/ExprTimeType/ExprTimeStampType/ExprBinaryType down to ExprSqlType, so
+   * different UDTs would appear equal. Plain types match by SqlTypeName.
    */
   private static boolean typesMatch(RelDataType expected, RelDataType actual) {
+    if (expected instanceof AbstractExprRelDataType<?> expUdt
+        && actual instanceof AbstractExprRelDataType<?> actUdt) {
+      return expUdt.getUdt() == actUdt.getUdt();
+    }
     if (expected instanceof AbstractExprRelDataType<?>
         || actual instanceof AbstractExprRelDataType<?>) {
-      return expected.getClass() == actual.getClass();
+      return false;
     }
     return expected.getSqlTypeName() == actual.getSqlTypeName();
   }

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -27,11 +27,12 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.Pair;
+import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.calcite.type.ExprIPType;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
 
 /**
  * A custom type checker interface for PPL (Piped Processing Language) functions.
@@ -61,12 +62,9 @@ public interface PPLTypeChecker {
   /**
    * Get a list of all possible parameter type combinations for the function.
    *
-   * <p>This method is used to generate the allowed signatures for the function based on the
-   * parameter types.
-   *
    * @return a list of lists, where each inner list represents an allowed parameter type combination
    */
-  List<List<ExprType>> getParameterTypes();
+  List<List<RelDataType>> getParameterTypes();
 
   private static boolean validateOperands(
       List<SqlTypeFamily> funcTypeFamilies, List<RelDataType> operandTypes) {
@@ -111,8 +109,8 @@ public interface PPLTypeChecker {
     }
 
     @Override
-    public List<List<ExprType>> getParameterTypes() {
-      return PPLTypeChecker.getExprSignatures(families);
+    public List<List<RelDataType>> getParameterTypes() {
+      return PPLTypeChecker.getRelDataTypeSignatures(families);
     }
 
     @Override
@@ -150,17 +148,17 @@ public interface PPLTypeChecker {
     @Override
     public String getAllowedSignatures() {
       if (innerTypeChecker instanceof FamilyOperandTypeChecker familyOperandTypeChecker) {
-        var allowedExprSignatures = getExprSignatures(familyOperandTypeChecker);
-        return PPLTypeChecker.formatExprSignatures(allowedExprSignatures);
+        var allowedSignatures = getRelDataTypeSignatures(familyOperandTypeChecker);
+        return PPLTypeChecker.formatSignatures(allowedSignatures);
       } else {
         return "";
       }
     }
 
     @Override
-    public List<List<ExprType>> getParameterTypes() {
+    public List<List<RelDataType>> getParameterTypes() {
       if (innerTypeChecker instanceof FamilyOperandTypeChecker familyOperandTypeChecker) {
-        return getExprSignatures(familyOperandTypeChecker);
+        return getRelDataTypeSignatures(familyOperandTypeChecker);
       } else {
         // If the inner type checker is not a FamilyOperandTypeChecker, we cannot provide
         // parameter types.
@@ -232,11 +230,11 @@ public interface PPLTypeChecker {
     }
 
     @Override
-    public List<List<ExprType>> getParameterTypes() {
-      List<List<ExprType>> parameterTypes = new ArrayList<>();
+    public List<List<RelDataType>> getParameterTypes() {
+      List<List<RelDataType>> parameterTypes = new ArrayList<>();
       for (SqlOperandTypeChecker rule : allowedRules) {
         if (rule instanceof FamilyOperandTypeChecker familyOperandTypeChecker) {
-          parameterTypes.addAll(getExprSignatures(familyOperandTypeChecker));
+          parameterTypes.addAll(getRelDataTypeSignatures(familyOperandTypeChecker));
         } else {
           throw new IllegalArgumentException(
               "Currently only compositions of FamilyOperandTypeChecker are supported");
@@ -274,7 +272,7 @@ public interface PPLTypeChecker {
     }
 
     /**
-     * Modified from {@link SqlTypeUtil#isComparable(RelDataType, RelDataType)} to
+     * Modified from {@link SqlTypeUtil#isComparable(RelDataType, RelDataType)} for PPL semantics.
      *
      * @param type1 first type
      * @param type2 second type
@@ -299,16 +297,36 @@ public interface PPLTypeChecker {
         return true;
       }
 
-      // Numeric types are comparable without the need to cast
+      // Numeric types are comparable without the need to cast.
       if (SqlTypeUtil.isNumeric(type1) && SqlTypeUtil.isNumeric(type2)) {
         return true;
       }
 
-      ExprType exprType1 = OpenSearchTypeFactory.convertRelDataTypeToExprType(type1);
-      ExprType exprType2 = OpenSearchTypeFactory.convertRelDataTypeToExprType(type2);
-
-      if (!exprType1.shouldCast(exprType2)) {
+      // Same UDT kind is comparable. Compare via the ExprUDT tag (not the concrete Java class),
+      // because createTypeWithNullability on an AbstractExprRelDataType returns a plain ExprSqlType
+      // that loses the concrete subclass identity.
+      if (type1 instanceof AbstractExprRelDataType<?> udt1
+          && type2 instanceof AbstractExprRelDataType<?> udt2
+          && udt1.getUdt() == udt2.getUdt()) {
         return true;
+      }
+
+      // Temporal UDT vs standard temporal of the same kind is comparable (widening produced by
+      // findWidestType may leave a standard TIMESTAMP field alongside a UDT temporal literal).
+      if (temporalKind(type1) != null && temporalKind(type1) == temporalKind(type2)) {
+        return true;
+      }
+
+      // Plain types are comparable when their SqlTypeFamily matches (CHAR vs VARCHAR, INTEGER vs
+      // BIGINT, BOOLEAN vs BOOLEAN, etc.). UDTs are excluded since they share the underlying
+      // VARCHAR family but should not be transparently comparable to plain strings here.
+      if (!(type1 instanceof AbstractExprRelDataType<?>)
+          && !(type2 instanceof AbstractExprRelDataType<?>)) {
+        SqlTypeFamily family1 = type1.getSqlTypeName().getFamily();
+        SqlTypeFamily family2 = type2.getSqlTypeName().getFamily();
+        if (family1 != null && family1 == family2) {
+          return true;
+        }
       }
 
       // If one of the arguments is of type 'ANY', return true.
@@ -337,9 +355,10 @@ public interface PPLTypeChecker {
     }
 
     @Override
-    public List<List<ExprType>> getParameterTypes() {
-      // Should not be used
-      return List.of(List.of(ExprCoreType.UNKNOWN, ExprCoreType.UNKNOWN));
+    public List<List<RelDataType>> getParameterTypes() {
+      // Should not be used by coercion since comparable operators don't drive type widening here.
+      RelDataType anyType = OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.ANY);
+      return List.of(List.of(anyType, anyType));
     }
   }
 
@@ -397,23 +416,23 @@ public interface PPLTypeChecker {
     }
 
     @Override
-    public List<List<ExprType>> getParameterTypes() {
+    public List<List<RelDataType>> getParameterTypes() {
       if (internal instanceof FamilyOperandTypeChecker familyChecker) {
-        return getExprSignatures(familyChecker);
+        return getRelDataTypeSignatures(familyChecker);
       } else {
-        // For unknown type checkers, return UNKNOWN types
+        // For unknown type checkers, return ANY-typed signatures.
         int min = internal.getOperandCountRange().getMin();
         int max = internal.getOperandCountRange().getMax();
+        RelDataType anyType = OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.ANY);
 
         if (min == -1 || max == -1) {
-          // Variable arguments - return a single signature with UNKNOWN
-          return List.of(List.of(ExprCoreType.UNKNOWN));
+          return List.of(List.of(anyType));
         } else {
-          List<List<ExprType>> parameterTypes = new ArrayList<>();
+          List<List<RelDataType>> parameterTypes = new ArrayList<>();
           final int MAX_ARGS = 10;
           max = Math.min(MAX_ARGS, max);
           for (int i = min; i <= max; i++) {
-            parameterTypes.add(Collections.nCopies(i, ExprCoreType.UNKNOWN));
+            parameterTypes.add(Collections.nCopies(i, anyType));
           }
           return parameterTypes;
         }
@@ -513,28 +532,27 @@ public interface PPLTypeChecker {
   }
 
   /**
-   * Create a {@link PPLTypeChecker} from a list of allowed signatures consisted of {@link
-   * ExprType}. This is useful to validate arguments against user-defined types (UDT) that does not
-   * match any Calcite {@link SqlTypeFamily}.
+   * Create a {@link PPLTypeChecker} from a list of allowed signatures composed of {@link
+   * RelDataType}. This is used for functions whose argument types include user-defined types (UDTs)
+   * that don't fit any standard {@link SqlTypeFamily}.
    *
    * @param allowedSignatures a list of allowed signatures, where each signature is a list of {@link
-   *     ExprType} representing the expected types of the function arguments.
+   *     RelDataType} representing the expected types of the function arguments.
    * @return a {@link PPLTypeChecker} that checks if the operand types match any of the allowed
    *     signatures
    */
-  static PPLTypeChecker wrapUDT(List<List<ExprType>> allowedSignatures) {
+  static PPLTypeChecker wrapUDT(List<List<RelDataType>> allowedSignatures) {
     return new PPLTypeChecker() {
       @Override
       public boolean checkOperandTypes(List<RelDataType> types) {
-        List<ExprType> argExprTypes =
-            types.stream().map(OpenSearchTypeFactory::convertRelDataTypeToExprType).toList();
         for (var allowedSignature : allowedSignatures) {
           if (allowedSignature.size() != types.size()) {
             continue; // Skip signatures that do not match the operand count
           }
-          // Check if the argument types match the allowed signature
+          // Match each operand against the allowed signature using nullability-insensitive
+          // equality with UDT-class-aware comparison.
           if (IntStream.range(0, allowedSignature.size())
-              .allMatch(i -> allowedSignature.get(i).equals(argExprTypes.get(i)))) {
+              .allMatch(i -> typesMatch(allowedSignature.get(i), types.get(i)))) {
             return true;
           }
         }
@@ -543,17 +561,47 @@ public interface PPLTypeChecker {
 
       @Override
       public String getAllowedSignatures() {
-        return PPLTypeChecker.formatExprSignatures(allowedSignatures);
+        return PPLTypeChecker.formatSignatures(allowedSignatures);
       }
 
       @Override
-      public List<List<ExprType>> getParameterTypes() {
+      public List<List<RelDataType>> getParameterTypes() {
         return allowedSignatures;
       }
     };
   }
 
+  /**
+   * Compares two RelDataTypes for signature matching. Two UDTs match if they share the same UDT
+   * class. Plain types match by SqlTypeName.
+   */
+  private static boolean typesMatch(RelDataType expected, RelDataType actual) {
+    if (expected instanceof AbstractExprRelDataType<?>
+        || actual instanceof AbstractExprRelDataType<?>) {
+      return expected.getClass() == actual.getClass();
+    }
+    return expected.getSqlTypeName() == actual.getSqlTypeName();
+  }
+
+  /** Returns DATE / TIME / TIMESTAMP for either UDT or standard temporal types; null otherwise. */
+  private static SqlTypeName temporalKind(RelDataType type) {
+    if (type instanceof AbstractExprRelDataType<?> udt) {
+      return switch (udt.getUdt()) {
+        case EXPR_DATE -> SqlTypeName.DATE;
+        case EXPR_TIME -> SqlTypeName.TIME;
+        case EXPR_TIMESTAMP -> SqlTypeName.TIMESTAMP;
+        default -> null;
+      };
+    }
+    SqlTypeName name = type.getSqlTypeName();
+    if (name == SqlTypeName.DATE || name == SqlTypeName.TIME || name == SqlTypeName.TIMESTAMP) {
+      return name;
+    }
+    return null;
+  }
+
   // Util Functions
+
   /**
    * Generates a list of allowed function signatures based on the provided {@link
    * FamilyOperandTypeChecker}. The signatures are generated by iterating through the operand count
@@ -563,14 +611,15 @@ public interface PPLTypeChecker {
    * to 10 to avoid excessive enumeration.
    *
    * @param typeChecker the {@link FamilyOperandTypeChecker} to use for generating signatures
-   * @return a list of allowed function signatures
+   * @return a string representation of allowed function signatures
    */
   private static String getFamilySignatures(FamilyOperandTypeChecker typeChecker) {
-    var allowedExprSignatures = getExprSignatures(typeChecker);
-    return formatExprSignatures(allowedExprSignatures);
+    var allowedSignatures = getRelDataTypeSignatures(typeChecker);
+    return formatSignatures(allowedSignatures);
   }
 
-  private static List<List<ExprType>> getExprSignatures(FamilyOperandTypeChecker typeChecker) {
+  private static List<List<RelDataType>> getRelDataTypeSignatures(
+      FamilyOperandTypeChecker typeChecker) {
     var operandCountRange = typeChecker.getOperandCountRange();
     int min = operandCountRange.getMin();
     int max = operandCountRange.getMax();
@@ -578,91 +627,79 @@ public interface PPLTypeChecker {
     for (int i = 0; i < min; i++) {
       families.add(typeChecker.getOperandSqlTypeFamily(i));
     }
-    List<List<ExprType>> allowedSignatures = new ArrayList<>(getExprSignatures(families));
+    List<List<RelDataType>> allowedSignatures = new ArrayList<>(getRelDataTypeSignatures(families));
 
     // Avoid enumerating signatures for infinite args
     final int MAX_ARGS = 10;
     max = Math.min(max, MAX_ARGS);
     for (int i = min; i < max; i++) {
       families.add(typeChecker.getOperandSqlTypeFamily(i));
-      allowedSignatures.addAll(getExprSignatures(families));
+      allowedSignatures.addAll(getRelDataTypeSignatures(families));
     }
     return allowedSignatures;
   }
 
   /**
-   * Converts a {@link SqlTypeFamily} to a list of {@link ExprType}. This method is used to display
-   * the allowed signatures for functions based on their type families.
-   *
-   * @param family the {@link SqlTypeFamily} to convert
-   * @return a list of {@link ExprType} corresponding to the concrete types of the family
+   * Converts a {@link SqlTypeFamily} to a list of concrete {@link RelDataType} representatives.
+   * Used to enumerate allowed signatures and to drive widening in PPL coercion.
    */
-  private static List<ExprType> getExprTypes(SqlTypeFamily family) {
-    List<RelDataType> concreteTypes =
-        switch (family) {
-          case DATETIME ->
-              List.of(
-                  OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.TIMESTAMP),
-                  OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.DATE),
-                  OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.TIME));
-          case NUMERIC ->
-              List.of(
-                  OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER),
-                  OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE));
-          // Integer is mapped to BIGINT in family.getDefaultConcreteType
-          case INTEGER ->
-              List.of(OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER));
-          case ANY, IGNORE ->
-              List.of(OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.ANY));
-          case DATETIME_INTERVAL ->
-              SqlTypeName.INTERVAL_TYPES.stream()
-                  .map(
-                      type ->
-                          OpenSearchTypeFactory.TYPE_FACTORY.createSqlIntervalType(
+  private static List<RelDataType> getRelDataTypes(SqlTypeFamily family) {
+    OpenSearchTypeFactory tf = OpenSearchTypeFactory.TYPE_FACTORY;
+    return switch (family) {
+      case DATETIME ->
+          List.of(
+              tf.createUDT(ExprUDT.EXPR_TIMESTAMP),
+              tf.createUDT(ExprUDT.EXPR_DATE),
+              tf.createUDT(ExprUDT.EXPR_TIME));
+      case TIMESTAMP -> List.of(tf.createUDT(ExprUDT.EXPR_TIMESTAMP));
+      case DATE -> List.of(tf.createUDT(ExprUDT.EXPR_DATE));
+      case TIME -> List.of(tf.createUDT(ExprUDT.EXPR_TIME));
+      case NUMERIC ->
+          List.of(tf.createSqlType(SqlTypeName.INTEGER), tf.createSqlType(SqlTypeName.DOUBLE));
+      // Integer is mapped to BIGINT in family.getDefaultConcreteType
+      case INTEGER -> List.of(tf.createSqlType(SqlTypeName.INTEGER));
+      case ANY, IGNORE -> List.of(tf.createSqlType(SqlTypeName.ANY));
+      // ARRAY of nullable ANY, matching convertExprTypeToRelDataType(ARRAY, nullable=true).
+      // Calcite's default concrete type for ARRAY has a NOT NULL element, which diverges from
+      // PPL semantics (see #5175: null literals must remain nullable inside an array).
+      case ARRAY -> List.of(tf.createArrayType(tf.createSqlType(SqlTypeName.ANY, true), -1));
+      case BINARY -> List.of(tf.createUDT(ExprUDT.EXPR_BINARY));
+      case DATETIME_INTERVAL ->
+          SqlTypeName.INTERVAL_TYPES.stream()
+              .map(
+                  type ->
+                      (RelDataType)
+                          tf.createSqlIntervalType(
                               new SqlIntervalQualifier(
                                   type.getStartUnit(), type.getEndUnit(), SqlParserPos.ZERO)))
-                  .collect(Collectors.toList());
-          default -> {
-            RelDataType type = family.getDefaultConcreteType(OpenSearchTypeFactory.TYPE_FACTORY);
-            if (type == null) {
-              yield List.of(OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.OTHER));
-            }
-            yield List.of(type);
-          }
-        };
-    return concreteTypes.stream()
-        .map(OpenSearchTypeFactory::convertRelDataTypeToExprType)
-        .distinct()
-        .collect(Collectors.toList());
+              .collect(Collectors.toList());
+      default -> {
+        RelDataType type = family.getDefaultConcreteType(tf);
+        if (type == null) {
+          yield List.of(tf.createSqlType(SqlTypeName.OTHER));
+        }
+        yield List.of(type);
+      }
+    };
   }
 
   /**
-   * Generates a list of all possible {@link ExprType} signatures based on the provided {@link
-   * SqlTypeFamily} list.
-   *
-   * @param families the list of {@link SqlTypeFamily} to generate signatures for
-   * @return a list of lists, where each inner list contains {@link ExprType} signatures
+   * Generates a list of all possible {@link RelDataType} signatures based on the provided {@link
+   * SqlTypeFamily} list (cartesian product per-position).
    */
-  private static List<List<ExprType>> getExprSignatures(List<SqlTypeFamily> families) {
-    List<List<ExprType>> exprTypes =
-        families.stream().map(PPLTypeChecker::getExprTypes).collect(Collectors.toList());
-
-    // Do a cartesian product of all ExprTypes in the family
-    return Lists.cartesianProduct(exprTypes);
+  private static List<List<RelDataType>> getRelDataTypeSignatures(List<SqlTypeFamily> families) {
+    List<List<RelDataType>> perPosition =
+        families.stream().map(PPLTypeChecker::getRelDataTypes).collect(Collectors.toList());
+    return Lists.cartesianProduct(perPosition);
   }
 
   /**
    * Generates a string representation of the function signature based on the provided type
    * families. The format is a list of type families enclosed in square brackets, e.g.: "[INTEGER,
    * STRING]".
-   *
-   * @param families the list of type families to include in the signature
-   * @return a string representation of the function signature
    */
   private static String getFamilySignature(List<SqlTypeFamily> families) {
-    List<List<ExprType>> signatures = getExprSignatures(families);
-    // Convert each signature to a string representation and then concatenate them
-    return formatExprSignatures(signatures);
+    return formatSignatures(getRelDataTypeSignatures(families));
   }
 
   /**
@@ -686,13 +723,20 @@ public interface PPLTypeChecker {
     return composition == CompositeOperandTypeChecker.Composition.OR;
   }
 
-  private static String formatExprSignatures(List<List<ExprType>> signatures) {
+  /**
+   * Renders a list of {@link RelDataType} signatures as a pipe-separated string of bracketed
+   * signatures, e.g. {@code [INTEGER,STRING]|[DOUBLE,STRING]}. Each type is rendered through {@link
+   * OpenSearchTypeFactory#convertRelDataTypeToExprType} so plain SQL types come out as their PPL
+   * names ({@code STRING}, {@code LONG}, ...) and UDTs as their {@code ExprCoreType} names; {@code
+   * UNDEFINED} (Calcite {@code NULL}/{@code ANY}) is displayed as {@code ANY}.
+   */
+  static String formatSignatures(List<List<RelDataType>> signatures) {
     return signatures.stream()
         .map(
             types ->
                 "["
                     + types.stream()
-                        // Display ExprCoreType.UNDEFINED as "ANY" for better interpretability
+                        .map(OpenSearchTypeFactory::convertRelDataTypeToExprType)
                         .map(t -> t == ExprCoreType.UNDEFINED ? "ANY" : t.toString())
                         .collect(Collectors.joining(","))
                     + "]")

--- a/core/src/main/java/org/opensearch/sql/expression/function/UDFOperandMetadata.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/UDFOperandMetadata.java
@@ -17,7 +17,6 @@ import org.apache.calcite.sql.type.FamilyOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
-import org.opensearch.sql.data.type.ExprType;
 
 /**
  * This class is created for the compatibility with {@link SqlUserDefinedFunction} constructors when
@@ -106,11 +105,12 @@ public interface UDFOperandMetadata extends SqlOperandMetadata {
     };
   }
 
-  static UDFOperandMetadata wrapUDT(List<List<ExprType>> allowSignatures) {
+  static UDFOperandMetadata wrapUDT(List<List<RelDataType>> allowSignatures) {
     return new UDTOperandMetadata(allowSignatures);
   }
 
-  record UDTOperandMetadata(List<List<ExprType>> allowedParamTypes) implements UDFOperandMetadata {
+  record UDTOperandMetadata(List<List<RelDataType>> allowedParamTypes)
+      implements UDFOperandMetadata {
     @Override
     public SqlOperandTypeChecker getInnerTypeChecker() {
       return this;

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/CurrentFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/CurrentFunction.java
@@ -20,8 +20,6 @@ import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.model.ExprDateValue;
 import org.opensearch.sql.data.model.ExprTimeValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
-import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
 import org.opensearch.sql.expression.function.FunctionProperties;
 import org.opensearch.sql.expression.function.ImplementorUDF;
@@ -39,21 +37,28 @@ import org.opensearch.sql.expression.function.UDFOperandMetadata;
  * <p>It returns the current date, time, or timestamp based on the specified return type.
  */
 public class CurrentFunction extends ImplementorUDF {
-  private final ExprType returnType;
 
-  public CurrentFunction(ExprType returnType) {
-    super(new CurrentFunctionImplementor(returnType), NullPolicy.NONE);
-    this.returnType = returnType;
+  /** Discriminates the temporal flavour at registration time, decoupled from {@code ExprType}. */
+  public enum Kind {
+    DATE,
+    TIME,
+    TIMESTAMP
+  }
+
+  private final Kind kind;
+
+  public CurrentFunction(Kind kind) {
+    super(new CurrentFunctionImplementor(kind), NullPolicy.NONE);
+    this.kind = kind;
   }
 
   @Override
   public SqlReturnTypeInference getReturnTypeInference() {
     return opBinding ->
-        switch (returnType) {
-          case ExprCoreType.DATE -> UserDefinedFunctionUtils.NULLABLE_DATE_UDT;
-          case ExprCoreType.TIME -> UserDefinedFunctionUtils.NULLABLE_TIME_UDT;
-          case ExprCoreType.TIMESTAMP -> UserDefinedFunctionUtils.NULLABLE_TIMESTAMP_UDT;
-          default -> throw new IllegalArgumentException("Unsupported return type: " + returnType);
+        switch (kind) {
+          case DATE -> UserDefinedFunctionUtils.NULLABLE_DATE_UDT;
+          case TIME -> UserDefinedFunctionUtils.NULLABLE_TIME_UDT;
+          case TIMESTAMP -> UserDefinedFunctionUtils.NULLABLE_TIMESTAMP_UDT;
         };
   }
 
@@ -64,18 +69,17 @@ public class CurrentFunction extends ImplementorUDF {
 
   @RequiredArgsConstructor
   public static class CurrentFunctionImplementor implements NotNullImplementor {
-    private final ExprType returnType;
+    private final Kind kind;
 
     @Override
     public Expression implement(
         RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
 
       String functionName =
-          switch (returnType) {
-            case ExprCoreType.DATE -> "currentDate";
-            case ExprCoreType.TIME -> "currentTime";
-            case ExprCoreType.TIMESTAMP -> "currentTimestamp";
-            default -> throw new IllegalArgumentException("Unsupported return type: " + returnType);
+          switch (kind) {
+            case DATE -> "currentDate";
+            case TIME -> "currentTime";
+            case TIMESTAMP -> "currentTimestamp";
           };
 
       Expression properties =

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/PeriodNameFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/datetime/PeriodNameFunction.java
@@ -17,11 +17,9 @@ import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
-import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
 import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.calcite.utils.PPLReturnTypes;
 import org.opensearch.sql.data.model.ExprDateValue;
-import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 
@@ -65,9 +63,6 @@ public class PeriodNameFunction extends ImplementorUDF {
     @Override
     public Expression implement(
         RexToLixTranslator translator, RexCall call, List<Expression> translatedOperands) {
-      ExprType dateType =
-          OpenSearchTypeFactory.convertRelDataTypeToExprType(
-              call.getOperands().getFirst().getType());
       return Expressions.call(
           PeriodNameFunctionImplementor.class,
           "name",

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/CidrMatchFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/CidrMatchFunction.java
@@ -14,10 +14,10 @@ import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.data.model.ExprIpValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
-import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 import org.opensearch.sql.expression.ip.IPFunctions;
@@ -51,9 +51,9 @@ public class CidrMatchFunction extends ImplementorUDF {
     // We use a specific type checker to serve
     return UDFOperandMetadata.wrapUDT(
         List.of(
-            List.of(ExprCoreType.IP, ExprCoreType.STRING),
-            List.of(ExprCoreType.STRING, ExprCoreType.STRING),
-            List.of(ExprCoreType.BINARY, ExprCoreType.STRING)));
+            List.of(PPLOperandTypes.IP_UDT, PPLOperandTypes.STRING_T),
+            List.of(PPLOperandTypes.STRING_T, PPLOperandTypes.STRING_T),
+            List.of(PPLOperandTypes.BINARY_UDT, PPLOperandTypes.STRING_T)));
   }
 
   public static class CidrMatchImplementor implements NotNullImplementor {

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/CompareIpFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/CompareIpFunction.java
@@ -25,8 +25,8 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.data.model.ExprIpValue;
-import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.PPLBuiltinOperators;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
@@ -120,7 +120,8 @@ public class CompareIpFunction extends ImplementorUDF {
 
   @Override
   public UDFOperandMetadata getOperandMetadata() {
-    return UDFOperandMetadata.wrapUDT(List.of(List.of(ExprCoreType.IP, ExprCoreType.IP)));
+    return UDFOperandMetadata.wrapUDT(
+        List.of(List.of(PPLOperandTypes.IP_UDT, PPLOperandTypes.IP_UDT)));
   }
 
   public static class CompareImplementor implements NotNullImplementor {

--- a/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/IPFunction.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/udf/ip/IPFunction.java
@@ -11,13 +11,14 @@ import org.apache.calcite.adapter.enumerable.NullPolicy;
 import org.apache.calcite.adapter.enumerable.RexToLixTranslator;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
-import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.opensearch.sql.calcite.type.ExprIPType;
+import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.calcite.utils.PPLReturnTypes;
 import org.opensearch.sql.data.model.ExprIpValue;
-import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
@@ -41,7 +42,7 @@ public class IPFunction extends ImplementorUDF {
   @Override
   public UDFOperandMetadata getOperandMetadata() {
     return UDFOperandMetadata.wrapUDT(
-        List.of(List.of(ExprCoreType.IP), List.of(ExprCoreType.STRING)));
+        List.of(List.of(PPLOperandTypes.IP_UDT), List.of(PPLOperandTypes.STRING_T)));
   }
 
   @Override
@@ -57,12 +58,10 @@ public class IPFunction extends ImplementorUDF {
       if (call.getOperands().size() != 1) {
         throw new IllegalArgumentException("IP function requires exactly one operand");
       }
-      ExprType argType =
-          OpenSearchTypeFactory.convertRelDataTypeToExprType(
-              call.getOperands().getFirst().getType());
-      if (argType == ExprCoreType.IP) {
+      RelDataType argType = call.getOperands().getFirst().getType();
+      if (argType instanceof ExprIPType) {
         return translatedOperands.getFirst();
-      } else if (argType == ExprCoreType.STRING) {
+      } else if (SqlTypeUtil.isCharacter(argType)) {
         return Expressions.new_(ExprIpValue.class, translatedOperands);
       } else {
         throw new ExpressionEvaluationException(

--- a/core/src/test/java/org/opensearch/sql/expression/function/CoercionUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/CoercionUtilsTest.java
@@ -6,6 +6,11 @@
 package org.opensearch.sql.expression.function;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.opensearch.sql.data.type.ExprCoreType.BINARY;
+import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -18,51 +23,32 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
-import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
-import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.data.type.ExprCoreType;
 
 class CoercionUtilsTest {
 
-  private static final OpenSearchTypeFactory TF = OpenSearchTypeFactory.TYPE_FACTORY;
-  private static final RexBuilder REX_BUILDER = new RexBuilder(TF);
+  private static final RexBuilder REX_BUILDER = new RexBuilder(OpenSearchTypeFactory.TYPE_FACTORY);
 
-  private static RelDataType type(SqlTypeName name) {
-    return TF.createSqlType(name);
-  }
-
-  private static RexNode nullLiteral(RelDataType type) {
-    return REX_BUILDER.makeNullLiteral(type);
+  private static RexNode nullLiteral(ExprCoreType type) {
+    return REX_BUILDER.makeNullLiteral(OpenSearchTypeFactory.convertExprTypeToRelDataType(type));
   }
 
   private static Stream<Arguments> commonWidestTypeArguments() {
-    RelDataType string = type(SqlTypeName.VARCHAR);
-    RelDataType integer = type(SqlTypeName.INTEGER);
-    RelDataType doubleT = type(SqlTypeName.DOUBLE);
-    RelDataType bool = type(SqlTypeName.BOOLEAN);
-    RelDataType binary = TF.createUDT(ExprUDT.EXPR_BINARY);
-    RelDataType varbinary = type(SqlTypeName.VARBINARY);
     return Stream.of(
-        Arguments.of(string, integer, doubleT),
-        Arguments.of(integer, string, doubleT),
-        Arguments.of(string, doubleT, doubleT),
-        Arguments.of(integer, bool, null),
-        Arguments.of(binary, string, varbinary),
-        Arguments.of(string, binary, varbinary));
+        Arguments.of(STRING, INTEGER, DOUBLE),
+        Arguments.of(INTEGER, STRING, DOUBLE),
+        Arguments.of(STRING, DOUBLE, DOUBLE),
+        Arguments.of(INTEGER, BOOLEAN, null),
+        Arguments.of(BINARY, STRING, BINARY),
+        Arguments.of(STRING, BINARY, BINARY));
   }
 
   @ParameterizedTest
   @MethodSource("commonWidestTypeArguments")
-  public void findCommonWidestType(RelDataType left, RelDataType right, RelDataType expected) {
-    if (expected == null) {
-      assertTrue(CoercionUtils.resolveCommonType(left, right).isEmpty());
-    } else {
-      assertEquals(
-          expected.getSqlTypeName(),
-          CoercionUtils.resolveCommonType(left, right)
-              .map(RelDataType::getSqlTypeName)
-              .orElse(null));
-    }
+  public void findCommonWidestType(
+      ExprCoreType left, ExprCoreType right, ExprCoreType expectedCommonType) {
+    assertEquals(
+        expectedCommonType, CoercionUtils.resolveCommonType(left, right).orElseGet(() -> null));
   }
 
   @Test
@@ -102,47 +88,43 @@ class CoercionUtilsTest {
   @Test
   void castArgumentsReturnsExactMatchWhenAvailable() {
     PPLTypeChecker typeChecker =
-        new StubTypeChecker(
-            List.of(List.of(type(SqlTypeName.INTEGER)), List.of(type(SqlTypeName.DOUBLE))));
-    List<RexNode> arguments = List.of(nullLiteral(type(SqlTypeName.INTEGER)));
+        new StubTypeChecker(List.of(List.of(sqlType(INTEGER)), List.of(sqlType(DOUBLE))));
+    List<RexNode> arguments = List.of(nullLiteral(INTEGER));
 
     List<RexNode> result = CoercionUtils.castArguments(REX_BUILDER, typeChecker, arguments);
 
     assertNotNull(result);
     assertEquals(1, result.size());
-    assertEquals(SqlTypeName.INTEGER, result.getFirst().getType().getSqlTypeName());
+    assertEquals(
+        INTEGER, OpenSearchTypeFactory.convertRelDataTypeToExprType(result.getFirst().getType()));
   }
 
   @Test
   void castArgumentsFallsBackToWidestCandidate() {
     PPLTypeChecker typeChecker =
-        new StubTypeChecker(
-            List.of(List.of(type(SqlTypeName.BIGINT)), List.of(type(SqlTypeName.DOUBLE))));
-    List<RexNode> arguments = List.of(nullLiteral(type(SqlTypeName.VARCHAR)));
+        new StubTypeChecker(List.of(List.of(sqlType(ExprCoreType.LONG)), List.of(sqlType(DOUBLE))));
+    List<RexNode> arguments = List.of(nullLiteral(STRING));
 
     List<RexNode> result = CoercionUtils.castArguments(REX_BUILDER, typeChecker, arguments);
 
     assertNotNull(result);
-    assertEquals(SqlTypeName.DOUBLE, result.getFirst().getType().getSqlTypeName());
+    assertEquals(
+        DOUBLE, OpenSearchTypeFactory.convertRelDataTypeToExprType(result.getFirst().getType()));
   }
 
   @Test
   void castArgumentsReturnsNullWhenNoCompatibleSignatureExists() {
-    PPLTypeChecker typeChecker = new StubTypeChecker(List.of(List.of(type(SqlTypeName.GEOMETRY))));
-    List<RexNode> arguments = List.of(nullLiteral(type(SqlTypeName.INTEGER)));
+    PPLTypeChecker typeChecker =
+        new StubTypeChecker(
+            List.of(
+                List.of(OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.GEOMETRY))));
+    List<RexNode> arguments = List.of(nullLiteral(INTEGER));
 
     assertNull(CoercionUtils.castArguments(REX_BUILDER, typeChecker, arguments));
   }
 
-  @Test
-  void hasStringDetectsCharacterArguments() {
-    assertTrue(
-        CoercionUtils.hasString(
-            List.of(
-                nullLiteral(type(SqlTypeName.VARCHAR)), nullLiteral(type(SqlTypeName.INTEGER)))));
-    assertFalse(
-        CoercionUtils.hasString(
-            List.of(nullLiteral(type(SqlTypeName.INTEGER)), nullLiteral(PPLOperandTypes.IP_UDT))));
+  private static RelDataType sqlType(ExprCoreType type) {
+    return OpenSearchTypeFactory.convertExprTypeToRelDataType(type);
   }
 
   private static class StubTypeChecker implements PPLTypeChecker {

--- a/core/src/test/java/org/opensearch/sql/expression/function/CoercionUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/CoercionUtilsTest.java
@@ -6,11 +6,6 @@
 package org.opensearch.sql.expression.function;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.opensearch.sql.data.type.ExprCoreType.BINARY;
-import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
-import static org.opensearch.sql.data.type.ExprCoreType.DOUBLE;
-import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
-import static org.opensearch.sql.data.type.ExprCoreType.STRING;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -23,33 +18,51 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
+import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
 
 class CoercionUtilsTest {
 
-  private static final RexBuilder REX_BUILDER = new RexBuilder(OpenSearchTypeFactory.TYPE_FACTORY);
+  private static final OpenSearchTypeFactory TF = OpenSearchTypeFactory.TYPE_FACTORY;
+  private static final RexBuilder REX_BUILDER = new RexBuilder(TF);
 
-  private static RexNode nullLiteral(ExprCoreType type) {
-    return REX_BUILDER.makeNullLiteral(OpenSearchTypeFactory.convertExprTypeToRelDataType(type));
+  private static RelDataType type(SqlTypeName name) {
+    return TF.createSqlType(name);
+  }
+
+  private static RexNode nullLiteral(RelDataType type) {
+    return REX_BUILDER.makeNullLiteral(type);
   }
 
   private static Stream<Arguments> commonWidestTypeArguments() {
+    RelDataType string = type(SqlTypeName.VARCHAR);
+    RelDataType integer = type(SqlTypeName.INTEGER);
+    RelDataType doubleT = type(SqlTypeName.DOUBLE);
+    RelDataType bool = type(SqlTypeName.BOOLEAN);
+    RelDataType binary = TF.createUDT(ExprUDT.EXPR_BINARY);
+    RelDataType varbinary = type(SqlTypeName.VARBINARY);
     return Stream.of(
-        Arguments.of(STRING, INTEGER, DOUBLE),
-        Arguments.of(INTEGER, STRING, DOUBLE),
-        Arguments.of(STRING, DOUBLE, DOUBLE),
-        Arguments.of(INTEGER, BOOLEAN, null),
-        Arguments.of(BINARY, STRING, BINARY),
-        Arguments.of(STRING, BINARY, BINARY));
+        Arguments.of(string, integer, doubleT),
+        Arguments.of(integer, string, doubleT),
+        Arguments.of(string, doubleT, doubleT),
+        Arguments.of(integer, bool, null),
+        Arguments.of(binary, string, varbinary),
+        Arguments.of(string, binary, varbinary));
   }
 
   @ParameterizedTest
   @MethodSource("commonWidestTypeArguments")
-  public void findCommonWidestType(
-      ExprCoreType left, ExprCoreType right, ExprCoreType expectedCommonType) {
-    assertEquals(
-        expectedCommonType, CoercionUtils.resolveCommonType(left, right).orElseGet(() -> null));
+  public void findCommonWidestType(RelDataType left, RelDataType right, RelDataType expected) {
+    if (expected == null) {
+      assertTrue(CoercionUtils.resolveCommonType(left, right).isEmpty());
+    } else {
+      assertEquals(
+          expected.getSqlTypeName(),
+          CoercionUtils.resolveCommonType(left, right)
+              .map(RelDataType::getSqlTypeName)
+              .orElse(null));
+    }
   }
 
   @Test
@@ -88,42 +101,54 @@ class CoercionUtilsTest {
 
   @Test
   void castArgumentsReturnsExactMatchWhenAvailable() {
-    PPLTypeChecker typeChecker = new StubTypeChecker(List.of(List.of(INTEGER), List.of(DOUBLE)));
-    List<RexNode> arguments = List.of(nullLiteral(INTEGER));
+    PPLTypeChecker typeChecker =
+        new StubTypeChecker(
+            List.of(List.of(type(SqlTypeName.INTEGER)), List.of(type(SqlTypeName.DOUBLE))));
+    List<RexNode> arguments = List.of(nullLiteral(type(SqlTypeName.INTEGER)));
 
     List<RexNode> result = CoercionUtils.castArguments(REX_BUILDER, typeChecker, arguments);
 
     assertNotNull(result);
     assertEquals(1, result.size());
-    assertEquals(
-        INTEGER, OpenSearchTypeFactory.convertRelDataTypeToExprType(result.getFirst().getType()));
+    assertEquals(SqlTypeName.INTEGER, result.getFirst().getType().getSqlTypeName());
   }
 
   @Test
   void castArgumentsFallsBackToWidestCandidate() {
     PPLTypeChecker typeChecker =
-        new StubTypeChecker(List.of(List.of(ExprCoreType.LONG), List.of(DOUBLE)));
-    List<RexNode> arguments = List.of(nullLiteral(STRING));
+        new StubTypeChecker(
+            List.of(List.of(type(SqlTypeName.BIGINT)), List.of(type(SqlTypeName.DOUBLE))));
+    List<RexNode> arguments = List.of(nullLiteral(type(SqlTypeName.VARCHAR)));
 
     List<RexNode> result = CoercionUtils.castArguments(REX_BUILDER, typeChecker, arguments);
 
     assertNotNull(result);
-    assertEquals(
-        DOUBLE, OpenSearchTypeFactory.convertRelDataTypeToExprType(result.getFirst().getType()));
+    assertEquals(SqlTypeName.DOUBLE, result.getFirst().getType().getSqlTypeName());
   }
 
   @Test
   void castArgumentsReturnsNullWhenNoCompatibleSignatureExists() {
-    PPLTypeChecker typeChecker = new StubTypeChecker(List.of(List.of(ExprCoreType.GEO_POINT)));
-    List<RexNode> arguments = List.of(nullLiteral(INTEGER));
+    PPLTypeChecker typeChecker = new StubTypeChecker(List.of(List.of(type(SqlTypeName.GEOMETRY))));
+    List<RexNode> arguments = List.of(nullLiteral(type(SqlTypeName.INTEGER)));
 
     assertNull(CoercionUtils.castArguments(REX_BUILDER, typeChecker, arguments));
   }
 
-  private static class StubTypeChecker implements PPLTypeChecker {
-    private final List<List<ExprType>> signatures;
+  @Test
+  void hasStringDetectsCharacterArguments() {
+    assertTrue(
+        CoercionUtils.hasString(
+            List.of(
+                nullLiteral(type(SqlTypeName.VARCHAR)), nullLiteral(type(SqlTypeName.INTEGER)))));
+    assertFalse(
+        CoercionUtils.hasString(
+            List.of(nullLiteral(type(SqlTypeName.INTEGER)), nullLiteral(PPLOperandTypes.IP_UDT))));
+  }
 
-    private StubTypeChecker(List<List<ExprType>> signatures) {
+  private static class StubTypeChecker implements PPLTypeChecker {
+    private final List<List<RelDataType>> signatures;
+
+    private StubTypeChecker(List<List<RelDataType>> signatures) {
       this.signatures = signatures;
     }
 
@@ -138,7 +163,7 @@ class CoercionUtilsTest {
     }
 
     @Override
-    public List<List<ExprType>> getParameterTypes() {
+    public List<List<RelDataType>> getParameterTypes() {
       return signatures;
     }
   }

--- a/core/src/test/java/org/opensearch/sql/expression/function/PPLComparableTypeCheckerTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/PPLComparableTypeCheckerTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SameOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
+import org.opensearch.sql.expression.function.PPLTypeChecker.PPLComparableTypeChecker;
+
+class PPLComparableTypeCheckerTest {
+
+  private static final OpenSearchTypeFactory TF = OpenSearchTypeFactory.TYPE_FACTORY;
+
+  private static RelDataType sql(SqlTypeName name) {
+    return TF.createSqlType(name);
+  }
+
+  private static RelDataType udt(ExprUDT udt) {
+    return TF.createUDT(udt);
+  }
+
+  private static RelDataType udt(ExprUDT udt, boolean nullable) {
+    return TF.createUDT(udt, nullable);
+  }
+
+  private static RelDataType interval(TimeUnit unit) {
+    return TF.createSqlIntervalType(new SqlIntervalQualifier(unit, unit, SqlParserPos.ZERO));
+  }
+
+  @Test
+  void numericAndNumericAreComparable() {
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.INTEGER), sql(SqlTypeName.DOUBLE)));
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.TINYINT), sql(SqlTypeName.BIGINT)));
+  }
+
+  @Test
+  void sameUdtIsComparable() {
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_DATE)));
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(
+            udt(ExprUDT.EXPR_TIMESTAMP, true), udt(ExprUDT.EXPR_TIMESTAMP, false)));
+    assertTrue(PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_IP), udt(ExprUDT.EXPR_IP)));
+  }
+
+  @Test
+  void plainBinaryVsBinaryUdtAreComparable() {
+    // Regression: VARBINARY / BINARY both map to ExprCoreType.BINARY, as does EXPR_BINARY UDT.
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(
+            sql(SqlTypeName.VARBINARY), udt(ExprUDT.EXPR_BINARY)));
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(
+            udt(ExprUDT.EXPR_BINARY), sql(SqlTypeName.VARBINARY)));
+  }
+
+  @Test
+  void dayTimeAndYearMonthIntervalsAreComparable() {
+    // Regression: Calcite splits INTERVAL into day-time and year-month families, but
+    // convertRelDataTypeToExprType maps every interval SqlTypeName to ExprCoreType.INTERVAL, so
+    // shouldCast is false and both should be comparable in the PPL sense.
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(interval(TimeUnit.DAY), interval(TimeUnit.YEAR)));
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(interval(TimeUnit.HOUR), interval(TimeUnit.MONTH)));
+  }
+
+  @Test
+  void plainTemporalVsMatchingTemporalUdtIsComparable() {
+    // Plain TIMESTAMP and EXPR_TIMESTAMP both map to ExprCoreType.TIMESTAMP.
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(
+            sql(SqlTypeName.TIMESTAMP), udt(ExprUDT.EXPR_TIMESTAMP)));
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.DATE), udt(ExprUDT.EXPR_DATE)));
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.TIME), udt(ExprUDT.EXPR_TIME)));
+  }
+
+  @Test
+  void differentUdtsAreNotComparable() {
+    assertFalse(
+        PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_TIMESTAMP)));
+    assertFalse(
+        PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_BINARY)));
+  }
+
+  @Test
+  void udtVsUnrelatedPlainTypeIsNotComparable() {
+    // EXPR_DATE → DATE, VARCHAR → STRING. shouldCast returns true, ANY fallback doesn't fire.
+    assertFalse(
+        PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_DATE), sql(SqlTypeName.VARCHAR)));
+    assertFalse(
+        PPLComparableTypeChecker.isComparable(
+            udt(ExprUDT.EXPR_TIMESTAMP), sql(SqlTypeName.INTEGER)));
+  }
+
+  @Test
+  void stringVsNumericIsNotComparable() {
+    assertFalse(
+        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.VARCHAR), sql(SqlTypeName.INTEGER)));
+  }
+
+  @Test
+  void anyIsComparableWithAnything() {
+    assertTrue(
+        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.ANY), sql(SqlTypeName.INTEGER)));
+    assertTrue(PPLComparableTypeChecker.isComparable(sql(SqlTypeName.ANY), udt(ExprUDT.EXPR_DATE)));
+  }
+
+  @Test
+  void structVsNonStructIsNotComparable() {
+    RelDataType struct =
+        TF.createStructType(
+            List.of(sql(SqlTypeName.INTEGER), sql(SqlTypeName.VARCHAR)), List.of("a", "b"));
+    assertFalse(PPLComparableTypeChecker.isComparable(struct, sql(SqlTypeName.INTEGER)));
+  }
+
+  @Test
+  void structsWithMatchingFieldsAreComparable() {
+    RelDataType s1 =
+        TF.createStructType(
+            List.of(sql(SqlTypeName.INTEGER), sql(SqlTypeName.VARCHAR)), List.of("a", "b"));
+    RelDataType s2 =
+        TF.createStructType(
+            List.of(sql(SqlTypeName.BIGINT), sql(SqlTypeName.CHAR)), List.of("x", "y"));
+    assertTrue(PPLComparableTypeChecker.isComparable(s1, s2));
+  }
+
+  @Test
+  void structsWithMismatchedFieldCountsAreNotComparable() {
+    RelDataType s1 = TF.createStructType(List.of(sql(SqlTypeName.INTEGER)), List.of("a"));
+    RelDataType s2 =
+        TF.createStructType(
+            List.of(sql(SqlTypeName.INTEGER), sql(SqlTypeName.VARCHAR)), List.of("a", "b"));
+    assertFalse(PPLComparableTypeChecker.isComparable(s1, s2));
+  }
+
+  @Test
+  void ipTypesAreRejectedByOuterChecker() {
+    // Even though EXPR_IP vs EXPR_IP is comparable in isolation, PPLComparableTypeChecker
+    // filters IP UDTs out at the outer checkOperandTypes level.
+    PPLComparableTypeChecker checker =
+        new PPLComparableTypeChecker((SameOperandTypeChecker) OperandTypes.SAME_SAME);
+    assertFalse(checker.checkOperandTypes(List.of(udt(ExprUDT.EXPR_IP), udt(ExprUDT.EXPR_IP))));
+  }
+
+  @Test
+  void checkerAcceptsMixedTemporalOperands() {
+    // Regression: date_field = timestamp_field must NOT be rejected here — comparison operators
+    // rely on downstream coercion. Both DATE and TIMESTAMP map to their own ExprCoreType so
+    // shouldCast is true, but ExprCoreType.DATE has TIMESTAMP as a parent (widening lattice), so
+    // isCompatible-style checks pass. Confirm directly through the checker:
+    PPLComparableTypeChecker checker =
+        new PPLComparableTypeChecker((SameOperandTypeChecker) OperandTypes.SAME_SAME);
+    // Same-kind temporals go through fine.
+    assertTrue(checker.checkOperandTypes(List.of(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_DATE))));
+    assertTrue(
+        checker.checkOperandTypes(
+            List.of(udt(ExprUDT.EXPR_TIMESTAMP), sql(SqlTypeName.TIMESTAMP))));
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/expression/function/PPLComparableTypeCheckerTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/PPLComparableTypeCheckerTest.java
@@ -21,9 +21,14 @@ import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
 import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
 import org.opensearch.sql.expression.function.PPLTypeChecker.PPLComparableTypeChecker;
 
+/**
+ * Exercises {@link PPLComparableTypeChecker#checkOperandTypes} against representative type pairs.
+ */
 class PPLComparableTypeCheckerTest {
 
   private static final OpenSearchTypeFactory TF = OpenSearchTypeFactory.TYPE_FACTORY;
+  private static final PPLComparableTypeChecker CHECKER =
+      new PPLComparableTypeChecker((SameOperandTypeChecker) OperandTypes.SAME_SAME);
 
   private static RelDataType sql(SqlTypeName name) {
     return TF.createSqlType(name);
@@ -41,87 +46,60 @@ class PPLComparableTypeCheckerTest {
     return TF.createSqlIntervalType(new SqlIntervalQualifier(unit, unit, SqlParserPos.ZERO));
   }
 
+  private static boolean comparable(RelDataType a, RelDataType b) {
+    return CHECKER.checkOperandTypes(List.of(a, b));
+  }
+
   @Test
   void numericAndNumericAreComparable() {
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.INTEGER), sql(SqlTypeName.DOUBLE)));
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.TINYINT), sql(SqlTypeName.BIGINT)));
+    assertTrue(comparable(sql(SqlTypeName.INTEGER), sql(SqlTypeName.DOUBLE)));
+    assertTrue(comparable(sql(SqlTypeName.TINYINT), sql(SqlTypeName.BIGINT)));
   }
 
   @Test
   void sameUdtIsComparable() {
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_DATE)));
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(
-            udt(ExprUDT.EXPR_TIMESTAMP, true), udt(ExprUDT.EXPR_TIMESTAMP, false)));
-    assertTrue(PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_IP), udt(ExprUDT.EXPR_IP)));
+    assertTrue(comparable(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_DATE)));
+    assertTrue(comparable(udt(ExprUDT.EXPR_TIMESTAMP, true), udt(ExprUDT.EXPR_TIMESTAMP, false)));
   }
 
   @Test
   void plainBinaryVsBinaryUdtAreComparable() {
     // Regression: VARBINARY / BINARY both map to ExprCoreType.BINARY, as does EXPR_BINARY UDT.
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(
-            sql(SqlTypeName.VARBINARY), udt(ExprUDT.EXPR_BINARY)));
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(
-            udt(ExprUDT.EXPR_BINARY), sql(SqlTypeName.VARBINARY)));
+    assertTrue(comparable(sql(SqlTypeName.VARBINARY), udt(ExprUDT.EXPR_BINARY)));
+    assertTrue(comparable(udt(ExprUDT.EXPR_BINARY), sql(SqlTypeName.VARBINARY)));
   }
 
   @Test
   void dayTimeAndYearMonthIntervalsAreComparable() {
-    // Regression: Calcite splits INTERVAL into day-time and year-month families, but
-    // convertRelDataTypeToExprType maps every interval SqlTypeName to ExprCoreType.INTERVAL, so
-    // shouldCast is false and both should be comparable in the PPL sense.
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(interval(TimeUnit.DAY), interval(TimeUnit.YEAR)));
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(interval(TimeUnit.HOUR), interval(TimeUnit.MONTH)));
+    // Regression: Calcite splits INTERVAL into day-time and year-month SqlTypeFamilies, but
+    // convertRelDataTypeToExprType maps every interval SqlTypeName to ExprCoreType.INTERVAL,
+    // so shouldCast is false and both should be comparable in the PPL sense.
+    assertTrue(comparable(interval(TimeUnit.DAY), interval(TimeUnit.YEAR)));
+    assertTrue(comparable(interval(TimeUnit.HOUR), interval(TimeUnit.MONTH)));
   }
 
   @Test
   void plainTemporalVsMatchingTemporalUdtIsComparable() {
-    // Plain TIMESTAMP and EXPR_TIMESTAMP both map to ExprCoreType.TIMESTAMP.
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(
-            sql(SqlTypeName.TIMESTAMP), udt(ExprUDT.EXPR_TIMESTAMP)));
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.DATE), udt(ExprUDT.EXPR_DATE)));
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.TIME), udt(ExprUDT.EXPR_TIME)));
-  }
-
-  @Test
-  void differentUdtsAreNotComparable() {
-    assertFalse(
-        PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_TIMESTAMP)));
-    assertFalse(
-        PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_BINARY)));
+    assertTrue(comparable(sql(SqlTypeName.TIMESTAMP), udt(ExprUDT.EXPR_TIMESTAMP)));
+    assertTrue(comparable(sql(SqlTypeName.DATE), udt(ExprUDT.EXPR_DATE)));
+    assertTrue(comparable(sql(SqlTypeName.TIME), udt(ExprUDT.EXPR_TIME)));
   }
 
   @Test
   void udtVsUnrelatedPlainTypeIsNotComparable() {
-    // EXPR_DATE → DATE, VARCHAR → STRING. shouldCast returns true, ANY fallback doesn't fire.
-    assertFalse(
-        PPLComparableTypeChecker.isComparable(udt(ExprUDT.EXPR_DATE), sql(SqlTypeName.VARCHAR)));
-    assertFalse(
-        PPLComparableTypeChecker.isComparable(
-            udt(ExprUDT.EXPR_TIMESTAMP), sql(SqlTypeName.INTEGER)));
+    assertFalse(comparable(udt(ExprUDT.EXPR_DATE), sql(SqlTypeName.VARCHAR)));
+    assertFalse(comparable(udt(ExprUDT.EXPR_TIMESTAMP), sql(SqlTypeName.INTEGER)));
   }
 
   @Test
   void stringVsNumericIsNotComparable() {
-    assertFalse(
-        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.VARCHAR), sql(SqlTypeName.INTEGER)));
+    assertFalse(comparable(sql(SqlTypeName.VARCHAR), sql(SqlTypeName.INTEGER)));
   }
 
   @Test
   void anyIsComparableWithAnything() {
-    assertTrue(
-        PPLComparableTypeChecker.isComparable(sql(SqlTypeName.ANY), sql(SqlTypeName.INTEGER)));
-    assertTrue(PPLComparableTypeChecker.isComparable(sql(SqlTypeName.ANY), udt(ExprUDT.EXPR_DATE)));
+    assertTrue(comparable(sql(SqlTypeName.ANY), sql(SqlTypeName.INTEGER)));
+    assertTrue(comparable(sql(SqlTypeName.ANY), udt(ExprUDT.EXPR_DATE)));
   }
 
   @Test
@@ -129,7 +107,7 @@ class PPLComparableTypeCheckerTest {
     RelDataType struct =
         TF.createStructType(
             List.of(sql(SqlTypeName.INTEGER), sql(SqlTypeName.VARCHAR)), List.of("a", "b"));
-    assertFalse(PPLComparableTypeChecker.isComparable(struct, sql(SqlTypeName.INTEGER)));
+    assertFalse(comparable(struct, sql(SqlTypeName.INTEGER)));
   }
 
   @Test
@@ -140,7 +118,7 @@ class PPLComparableTypeCheckerTest {
     RelDataType s2 =
         TF.createStructType(
             List.of(sql(SqlTypeName.BIGINT), sql(SqlTypeName.CHAR)), List.of("x", "y"));
-    assertTrue(PPLComparableTypeChecker.isComparable(s1, s2));
+    assertTrue(comparable(s1, s2));
   }
 
   @Test
@@ -149,30 +127,13 @@ class PPLComparableTypeCheckerTest {
     RelDataType s2 =
         TF.createStructType(
             List.of(sql(SqlTypeName.INTEGER), sql(SqlTypeName.VARCHAR)), List.of("a", "b"));
-    assertFalse(PPLComparableTypeChecker.isComparable(s1, s2));
+    assertFalse(comparable(s1, s2));
   }
 
   @Test
   void ipTypesAreRejectedByOuterChecker() {
-    // Even though EXPR_IP vs EXPR_IP is comparable in isolation, PPLComparableTypeChecker
-    // filters IP UDTs out at the outer checkOperandTypes level.
-    PPLComparableTypeChecker checker =
-        new PPLComparableTypeChecker((SameOperandTypeChecker) OperandTypes.SAME_SAME);
-    assertFalse(checker.checkOperandTypes(List.of(udt(ExprUDT.EXPR_IP), udt(ExprUDT.EXPR_IP))));
-  }
-
-  @Test
-  void checkerAcceptsMixedTemporalOperands() {
-    // Regression: date_field = timestamp_field must NOT be rejected here — comparison operators
-    // rely on downstream coercion. Both DATE and TIMESTAMP map to their own ExprCoreType so
-    // shouldCast is true, but ExprCoreType.DATE has TIMESTAMP as a parent (widening lattice), so
-    // isCompatible-style checks pass. Confirm directly through the checker:
-    PPLComparableTypeChecker checker =
-        new PPLComparableTypeChecker((SameOperandTypeChecker) OperandTypes.SAME_SAME);
-    // Same-kind temporals go through fine.
-    assertTrue(checker.checkOperandTypes(List.of(udt(ExprUDT.EXPR_DATE), udt(ExprUDT.EXPR_DATE))));
-    assertTrue(
-        checker.checkOperandTypes(
-            List.of(udt(ExprUDT.EXPR_TIMESTAMP), sql(SqlTypeName.TIMESTAMP))));
+    // IP UDTs are explicitly filtered out in PPLComparableTypeChecker.checkOperandTypes so that
+    // built-in comparable functions (COALESCE, NULLIF, IFNULL, IF) cannot accept them.
+    assertFalse(comparable(udt(ExprUDT.EXPR_IP), udt(ExprUDT.EXPR_IP)));
   }
 }

--- a/core/src/test/java/org/opensearch/sql/expression/function/PPLComparableTypeCheckerTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/PPLComparableTypeCheckerTest.java
@@ -64,16 +64,18 @@ class PPLComparableTypeCheckerTest {
 
   @Test
   void plainBinaryVsBinaryUdtAreComparable() {
-    // Regression: VARBINARY / BINARY both map to ExprCoreType.BINARY, as does EXPR_BINARY UDT.
+    // Guardrail: any future refactor of isComparable that classifies via SqlTypeFamily or Java
+    // class would break this pair — VARBINARY (family=BINARY) and EXPR_BINARY (VARCHAR-backed
+    // UDT) look unrelated at that level, but both map to ExprCoreType.BINARY and must compare.
     assertTrue(comparable(sql(SqlTypeName.VARBINARY), udt(ExprUDT.EXPR_BINARY)));
     assertTrue(comparable(udt(ExprUDT.EXPR_BINARY), sql(SqlTypeName.VARBINARY)));
   }
 
   @Test
   void dayTimeAndYearMonthIntervalsAreComparable() {
-    // Regression: Calcite splits INTERVAL into day-time and year-month SqlTypeFamilies, but
-    // convertRelDataTypeToExprType maps every interval SqlTypeName to ExprCoreType.INTERVAL,
-    // so shouldCast is false and both should be comparable in the PPL sense.
+    // Guardrail: Calcite splits INTERVAL into day-time and year-month SqlTypeFamilies, so a
+    // family-based check would reject this pair. convertRelDataTypeToExprType collapses every
+    // interval SqlTypeName to ExprCoreType.INTERVAL, so shouldCast is false and both compare.
     assertTrue(comparable(interval(TimeUnit.DAY), interval(TimeUnit.YEAR)));
     assertTrue(comparable(interval(TimeUnit.HOUR), interval(TimeUnit.MONTH)));
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/functions/GeoIpFunction.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/functions/GeoIpFunction.java
@@ -19,12 +19,12 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.geospatial.action.IpEnrichmentActionClient;
+import org.opensearch.sql.calcite.utils.PPLOperandTypes;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.data.model.ExprIpValue;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
-import org.opensearch.sql.data.type.ExprCoreType;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
 import org.opensearch.transport.client.node.NodeClient;
@@ -60,8 +60,8 @@ public class GeoIpFunction extends ImplementorUDF {
   public UDFOperandMetadata getOperandMetadata() {
     return UDFOperandMetadata.wrapUDT(
         List.of(
-            List.of(ExprCoreType.STRING, ExprCoreType.IP),
-            List.of(ExprCoreType.STRING, ExprCoreType.IP, ExprCoreType.STRING)));
+            List.of(PPLOperandTypes.STRING_T, PPLOperandTypes.IP_UDT),
+            List.of(PPLOperandTypes.STRING_T, PPLOperandTypes.IP_UDT, PPLOperandTypes.STRING_T)));
   }
 
   public static class GeoIPImplementor implements NotNullImplementor {


### PR DESCRIPTION
### Summary

The Calcite planning surface for PPL currently round-trips every operand through the v2 `ExprType` enum: type checkers, coercion, UDF operand metadata, and cast targets all bounce between `RelDataType` and `ExprType`. This makes the planning layer coupled to the v2 type system and blocks future work that only needs `RelDataType`.

This PR decouples the planning surface: 
* `PPLTypeChecker` exposes signatures as `List<List<RelDataType>>`
* `PPLOperandTypes` publishes `RelDataType` constants 
* UDF metadata / IP / temporal functions branch on `RelDataType` directly. 

Out of scope
* UDTs (`ExprDateType`, `ExprTimeType`, `ExprTimeStampType`, `ExprIPType`, `ExprBinaryType`) still flow through logical plans unchanged; only the planning-time abstraction is affected. 
* `CoercionUtils` keeps main-branch behavior — only the entry to `castArguments` converts `RelDataType` back to `ExprType` at the boundary.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] New functionality has javadoc added.
- [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).