### PR TITLE
Support constant_keyword field type in PPL

### DIFF
--- a/docs/user/general/datatypes.rst
+++ b/docs/user/general/datatypes.rst
@@ -87,6 +87,8 @@ The table below list the mapping between OpenSearch Data Type, OpenSearch SQL Da
 +-----------------+---------------------+-----------+
 | keyword         | keyword             | VARCHAR   |
 +-----------------+---------------------+-----------+
+| constant_keyword| keyword             | VARCHAR   |
++-----------------+---------------------+-----------+
 | text            | text                | VARCHAR   |
 +-----------------+---------------------+-----------+
 | date*           | timestamp           | TIMESTAMP |

--- a/docs/user/ppl/general/datatypes.md
+++ b/docs/user/ppl/general/datatypes.md
@@ -42,6 +42,7 @@ The table below list the mapping between OpenSearch Data Type, PPL Data Type and
 | scaled_float | float | DOUBLE |
 | double | double | DOUBLE |
 | keyword | string | VARCHAR |
+| constant_keyword | string | VARCHAR |
 | text | string | VARCHAR |
 | match_only_text | string | VARCHAR |
 | date | timestamp | TIMESTAMP |

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
@@ -208,6 +208,35 @@ public class DataTypeIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void test_constant_keyword_data_type() throws Exception {
+    String index = "test_constant_keyword";
+    try {
+      Request createIndex = new Request("PUT", "/" + index);
+      createIndex.setJsonEntity(
+          "{\"mappings\":{\"properties\":{"
+              + "\"tenant\":{\"type\":\"constant_keyword\",\"value\":\"acme\"},"
+              + "\"message\":{\"type\":\"text\"}}}}");
+      client().performRequest(createIndex);
+
+      Request insertDoc = new Request("PUT", "/" + index + "/_doc/1?refresh=true");
+      insertDoc.setJsonEntity("{\"message\":\"hello\"}");
+      client().performRequest(insertDoc);
+
+      JSONObject result = executeQuery(String.format("source=%s | fields tenant, message", index));
+      verifySchema(result, schema("tenant", "string"), schema("message", "string"));
+      verifyDataRows(result, rows("acme", "hello"));
+
+      // constant_keyword should filter like a regular string.
+      JSONObject filtered =
+          executeQuery(
+              String.format("source=%s | where tenant='acme' | fields tenant, message", index));
+      verifyDataRows(filtered, rows("acme", "hello"));
+    } finally {
+      client().performRequest(new Request("DELETE", "/" + index));
+    }
+  }
+
+  @Test
   @RequiresCapability(
       value = DOC_MUTATION,
       note = "Seeds + deletes a doc; the AE store doesn't support DELETE.")

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/DataTypeIT.java
@@ -219,7 +219,7 @@ public class DataTypeIT extends PPLIntegTestCase {
       client().performRequest(createIndex);
 
       Request insertDoc = new Request("PUT", "/" + index + "/_doc/1?refresh=true");
-      insertDoc.setJsonEntity("{\"message\":\"hello\"}");
+      insertDoc.setJsonEntity("{\"tenant\":\"acme\",\"message\":\"hello\"}");
       client().performRequest(insertDoc);
 
       JSONObject result = executeQuery(String.format("source=%s | fields tenant, message", index));

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
@@ -31,6 +31,7 @@ public class OpenSearchDataType implements ExprType, Serializable {
     Text("text", ExprCoreType.UNKNOWN),
     MatchOnlyText("match_only_text", ExprCoreType.UNKNOWN),
     Keyword("keyword", ExprCoreType.STRING),
+    ConstantKeyword("constant_keyword", ExprCoreType.STRING),
     Ip("ip", ExprCoreType.IP),
     GeoPoint("geo_point", ExprCoreType.UNKNOWN),
     Binary("binary", ExprCoreType.UNKNOWN),

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataTypeTest.java
@@ -91,6 +91,7 @@ class OpenSearchDataTypeTest {
     assertEquals("DOUBLE", OpenSearchDataType.of(MappingType.Double).typeName());
     assertEquals("KEYWORD", OpenSearchDataType.of(MappingType.Keyword).typeName());
     assertEquals("KEYWORD", OpenSearchDataType.of(MappingType.Keyword).typeName());
+    assertEquals("CONSTANT_KEYWORD", OpenSearchDataType.of(MappingType.ConstantKeyword).typeName());
   }
 
   @Test
@@ -115,6 +116,7 @@ class OpenSearchDataTypeTest {
     return Stream.of(
         Arguments.of(MappingType.Text, "text", OpenSearchTextType.of()),
         Arguments.of(MappingType.Keyword, "keyword", STRING),
+        Arguments.of(MappingType.ConstantKeyword, "constant_keyword", STRING),
         Arguments.of(MappingType.Byte, "byte", BYTE),
         Arguments.of(MappingType.Short, "short", SHORT),
         Arguments.of(MappingType.Integer, "integer", INTEGER),


### PR DESCRIPTION
## Description
Registers `constant_keyword` in the OpenSearch mapping parser so PPL recognises the type and treats it as a string, matching the semantics of the OpenSearch [`constant_keyword`](https://docs.opensearch.org/latest/mappings/supported-field-types/constant-keyword/) field type — a single value shared by every document in an index (e.g., tenant / environment / source markers in shared indices).

Before this change, `constant_keyword` fields were silently dropped from the mapping (falling through the unknown-type filter in `OpenSearchDataType.parseMapping`) and were not selectable in PPL.

Resolves #3703

## Changes
- `OpenSearchDataType.MappingType`: add `ConstantKeyword("constant_keyword", ExprCoreType.STRING)`.
- `OpenSearchDataTypeTest`: parameterized case + `typeName` assertion covering the new type.
- `DataTypeIT`: integration test that creates an index with a `constant_keyword` field and verifies projection and filtering behave like a string (also exercised through Calcite via `CalciteDataTypeIT`).
- `docs/user/general/datatypes.rst` and `docs/user/ppl/general/datatypes.md`: add `constant_keyword` to the OpenSearch → SQL / PPL type mapping tables.

## Test plan
- [x] `./gradlew :opensearch:build -x integTest` — passes locally
- [x] Rebased on latest `opensearch-project/sql` `main`
- [ ] `:integ-test:integTest --tests "*DataTypeIT.test_constant_keyword_data_type"` on CI
- [ ] `:integ-test:integTest --tests "*CalciteDataTypeIT.test_constant_keyword_data_type"` on CI

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] New functionality has javadoc added.
- [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).