### PR TITLE
[Feature] `percentfield` and `showperc` with `top` and `rare` commands.

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/tree/RareTopN.java
+++ b/core/src/main/java/org/opensearch/sql/ast/tree/RareTopN.java
@@ -56,6 +56,8 @@ public class RareTopN extends UnresolvedPlan {
   public enum Option {
     countField,
     showCount,
+    percentField,
+    showPerc,
     useNull,
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -223,6 +223,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   private final MapPathPreMaterializer mapPathMaterializer;
   private final ForeachPlanner foreachPlanner;
 
+  private static final int PERCENT_DECIMAL_PLACES = 6;
+
   public CalciteRelNodeVisitor(DataSourceService dataSourceService) {
     this.rexVisitor = new CalciteRexNodeVisitor(this);
     this.aggVisitor = new CalciteAggCallVisitor(rexVisitor);
@@ -3264,6 +3266,39 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     orderKeys.add(countField);
     orderKeys.addAll(tieBreakKeys);
 
+    // 3. compute percentage if showperc=true
+    Boolean showPerc = (Boolean) argumentMap.get(RareTopN.Option.showPerc.name()).getValue();
+    if (showPerc) {
+      String percentFieldName =
+          (String) argumentMap.get(RareTopN.Option.percentField.name()).getValue();
+
+      RexNode totalWindowOver =
+          PlanUtils.makeOver(
+              context,
+              BuiltinFunctionName.SUM,
+              context.relBuilder.field(countFieldName),
+              List.of(),
+              partitionKeys,
+              List.of(),
+              WindowFrame.rowsUnbounded());
+
+      RexNode hundred = context.relBuilder.literal(new BigDecimal("100.0"));
+      RexNode countCast =
+          context.relBuilder.cast(context.relBuilder.field(countFieldName), SqlTypeName.DOUBLE);
+      RexNode totalCast = context.relBuilder.cast(totalWindowOver, SqlTypeName.DOUBLE);
+      RexNode numerator = context.relBuilder.call(SqlStdOperatorTable.MULTIPLY, hundred, countCast);
+      RexNode percValue = context.relBuilder.call(SqlStdOperatorTable.DIVIDE, numerator, totalCast);
+
+      // Round the percent value 6 decimal places
+      RexNode roundedPerc =
+          context.relBuilder.call(
+              SqlStdOperatorTable.ROUND,
+              percValue,
+              context.relBuilder.literal(PERCENT_DECIMAL_PLACES));
+
+      context.relBuilder.projectPlus(context.relBuilder.alias(roundedPerc, percentFieldName));
+    }
+
     RexNode rowNumberWindowOver =
         PlanUtils.makeOver(
             context,
@@ -3276,14 +3311,14 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     context.relBuilder.projectPlus(
         context.relBuilder.alias(rowNumberWindowOver, ROW_NUMBER_COLUMN_FOR_RARE_TOP));
 
-    // 3. filter row_number() <= k in each partition
+    // 4. filter row_number() <= k in each partition
     int k = node.getNoOfResults();
     context.relBuilder.filter(
         context.relBuilder.lessThanOrEqual(
             context.relBuilder.field(ROW_NUMBER_COLUMN_FOR_RARE_TOP),
             context.relBuilder.literal(k)));
 
-    // 4. project final output. the default output is group by list + field list
+    // 5. project final output: group by list + field list, optionally count and percent
     Boolean showCount = (Boolean) argumentMap.get(RareTopN.Option.showCount.name()).getValue();
     if (showCount) {
       context.relBuilder.projectExcept(context.relBuilder.field(ROW_NUMBER_COLUMN_FOR_RARE_TOP));

--- a/docs/user/ppl/cmd/rare.md
+++ b/docs/user/ppl/cmd/rare.md
@@ -23,7 +23,7 @@ The `rare` command supports the following parameters.
 | --- | --- | --- |
 | `<field-list>` | Required | A comma-delimited list of field names. |
 | `<by-clause>` | Optional | One or more fields to group the results by. |
-| `rare-options` | Optional | Additional options for controlling output: <br> - `showcount`: Whether to create a field in the output containing the frequency count for each combination of values. Default is `true`. <br> - `countfield`: The name of the field that contains the count. Default is `count`. <br> - `usenull`: Whether to output null values. Default is the value of `plugins.ppl.syntax.legacy.preferred`. |
+| `rare-options` | Optional | Additional options for controlling output: <br> - `showcount`: Whether to create a field in the output containing the frequency count for each combination of values. Default is `true`. <br> - `countfield`: The name of the field that contains the count. Default is `count`. <br> - `percentfield`: The name of the field that contains the percentage. Default is `percent`. <br> - `showperc`: Whether to create a field in the output containing the percentage of each value's count relative to the total. Default is `false`. <br> - `usenull`: Whether to output null values. Default is the value of `plugins.ppl.syntax.legacy.preferred`. |
 
 ## Example 1: Finding the least common values without showing counts
 
@@ -125,7 +125,52 @@ fetched rows / total rows = 4/4
 +--------------+-----+
 ```
 
-## Example 5: Specifying null value handling
+## Example 5: Displaying percentages
+
+   The following query finds the least common severity levels and shows what percentage each represents:
+
+```ppl
+source=otellogs
+| rare showperc=true severityText
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 4/4
++--------------+-------+---------+
+| severityText | count | percent |
+|--------------+-------+---------|
+| DEBUG        | 3     | 15.0    |
+| WARN         | 4     | 20.0    |
+| INFO         | 6     | 30.0    |
+| ERROR        | 7     | 35.0    |
++--------------+-------+---------+
+```
+
+## Example 6: Customizing the percent field name
+The following query uses `percentfield` to rename the percentage column from the default `percent` to `pct`:
+
+```ppl
+source=otellogs
+| rare showperc=true percentfield='pct' severityText
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 4/4
++--------------+-------+------+
+| severityText | count | pct  |
+|--------------+-------+------|
+| DEBUG        | 3     | 15.0 |
+| WARN         | 4     | 20.0 |
+| INFO         | 6     | 30.0 |
+| ERROR        | 7     | 35.0 |
++--------------+-------+------+
+```
+
+## Example 7: Specifying null value handling
 
 The following query uses `usenull=false` to exclude null values:
 

--- a/docs/user/ppl/cmd/top.md
+++ b/docs/user/ppl/cmd/top.md
@@ -20,7 +20,7 @@ The `top` command supports the following parameters.
 | Parameter | Required/Optional | Description |
 | --- | --- | --- |
 | `<N>` | Optional | The number of results to return. Default is `10`. |
-| `top-options` | Optional | `showcount`: Whether to create a field in the output that represents a count of the tuple of values. Default is `true`.<br>`countfield`: The name of the field that contains the count. Default is `count`.<br>`usenull`: Whether to output `null` values. Default is the value of `plugins.ppl.syntax.legacy.preferred`. |
+| `top-options` | Optional | `showcount`: Whether to create a field in the output that represents a count of the tuple of values. Default is `true`.<br>`countfield`: The name of the field that contains the count. Default is `count`.<br>`percentfield`: The name of the field that contains the percentage. Default is `percent`.<br>`showperc`: Whether to create a field in the output that represents the percentage of the count relative to the total. Default is `false`.<br>`usenull`: Whether to output `null` values. Default is the value of `plugins.ppl.syntax.legacy.preferred`. |
 | `<field-list>` | Required | A comma-delimited list of field names.  |
 | `<by-clause>` | Optional | One or more fields to group the results by. |
 
@@ -139,7 +139,52 @@ fetched rows / total rows = 7/7
 +----------------------------------+--------------+
 ```
 
-## Example 6: Specifying null value handling
+## Example 6: Displaying percentages
+
+The following query finds the most common severity levels and shows the percentage each represents:
+
+```ppl
+source=otellogs
+| top showperc=true severityText
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 4/4
++--------------+-------+---------+
+| severityText | count | percent |
+|--------------+-------+---------|
+| ERROR        | 7     | 35.0    |
+| INFO         | 6     | 30.0    |
+| WARN         | 4     | 20.0    |
+| DEBUG        | 3     | 15.0    |
++--------------+-------+---------+
+```
+
+## Example 7: Customizing the percent field name
+The following query uses `percentfield` to rename the percentage column from the default `percent` to `pct`:
+
+```ppl
+source=otellogs
+| top showperc=true percentfield='pct' severityText
+```
+
+The query returns the following results:
+
+```text
+fetched rows / total rows = 4/4
++--------------+-------+------+
+| severityText | count | pct  |
+|--------------+-------+------|
+| ERROR        | 7     | 35.0 |
+| INFO         | 6     | 30.0 |
+| WARN         | 4     | 20.0 |
+| DEBUG        | 3     | 15.0 |
++--------------+-------+------+
+```
+
+## Example 8: Specifying null value handling
 
 The following query specifies `usenull=false` to exclude null values:
 

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteTopCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteTopCommandIT.java
@@ -6,7 +6,9 @@
 package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_BANK_WITH_NULL_VALUES;
+import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifyNumOfRows;
 import static org.opensearch.sql.util.MatcherUtils.verifySchemaInOrder;
 
@@ -39,6 +41,43 @@ public class CalciteTopCommandIT extends TopCommandIT {
             String.format("source=%s | top usenull=false age", TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifySchemaInOrder(result, schema("age", "int"), schema("count", "bigint"));
     verifyNumOfRows(result, 5);
+  }
+
+  @Test
+  public void testTopCommandShowPerc() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format("source=%s | top showperc=true age", TEST_INDEX_BANK_WITH_NULL_VALUES));
+    verifySchemaInOrder(
+        result, schema("age", "int"), schema("count", "bigint"), schema("percent", "double"));
+    verifyNumOfRows(result, 6);
+    verifyDataRows(
+        result,
+        rows(36, 2, 28.571429),
+        rows(28, 1, 14.285714),
+        rows(32, 1, 14.285714),
+        rows(33, 1, 14.285714),
+        rows(34, 1, 14.285714),
+        rows(null, 1, 14.285714));
+  }
+
+  @Test
+  public void testTopCommandShowPercWithoutShowCount() throws IOException {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | top showperc=true showcount=false age",
+                TEST_INDEX_BANK_WITH_NULL_VALUES));
+    verifySchemaInOrder(result, schema("age", "int"), schema("percent", "double"));
+    verifyNumOfRows(result, 6);
+    verifyDataRows(
+        result,
+        rows(36, 28.571429),
+        rows(28, 14.285714),
+        rows(32, 14.285714),
+        rows(33, 14.285714),
+        rows(34, 14.285714),
+        rows(null, 14.285714));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/TopCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/TopCommandIT.java
@@ -58,4 +58,20 @@ public class TopCommandIT extends PPLIntegTestCase {
       verifyDataRows(result, rows("F", "TX"), rows("M", "MD"));
     }
   }
+
+  @Test
+  public void testTopWithShowPerc() throws IOException {
+    JSONObject result =
+        executeQuery(String.format("source=%s | top showperc=true gender", TEST_INDEX_ACCOUNT));
+    if (isCalciteEnabled()) {
+      verifySchemaInOrder(
+          result,
+          schema("gender", "string"),
+          schema("count", "bigint"),
+          schema("percent", "double"));
+      verifyDataRows(result, rows("M", 507, 50.7), rows("F", 493, 49.3));
+    } else {
+      verifyDataRows(result, rows("M"), rows("F"));
+    }
+  }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -188,6 +188,8 @@ UNION:                              'UNION';
 MAXOUT:                             'MAXOUT';
 COUNTFIELD:                         'COUNTFIELD';
 SHOWCOUNT:                          'SHOWCOUNT';
+PERCENTFIELD:                       'PERCENTFIELD';
+SHOWPERC:                           'SHOWPERC';
 LIMIT:                              'LIMIT';
 USEOTHER:                           'USEOTHER';
 OTHERSTR:                           'OTHERSTR';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -489,6 +489,8 @@ rareTopCommand
 rareTopOption
    : COUNTFIELD EQUAL countField = stringLiteral
    | SHOWCOUNT EQUAL showCount = booleanLiteral
+   | PERCENTFIELD EQUAL percentField = stringLiteral
+   | SHOWPERC EQUAL showPerc = booleanLiteral
    | USENULL EQUAL useNull = booleanLiteral
    ;
 
@@ -1806,6 +1808,8 @@ searchableKeyWord
    | ANOMALY_SCORE_THRESHOLD
    | COUNTFIELD
    | SHOWCOUNT
+   | PERCENTFIELD
+   | SHOWPERC
    | MAXOUT
    | PATH
    | INPUT

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/ArgumentFactory.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/ArgumentFactory.java
@@ -307,6 +307,18 @@ public class ArgumentFactory {
         new Argument(
             RareTopN.Option.showCount.name(),
             opt.isPresent() ? getArgumentValue(opt.get().showCount) : Literal.TRUE));
+    opt = ctx.rareTopOption().stream().filter(op -> op.percentField != null).findFirst();
+    list.add(
+        new Argument(
+            RareTopN.Option.percentField.name(),
+            opt.isPresent()
+                ? getArgumentValue(opt.get().percentField)
+                : new Literal("percent", DataType.STRING)));
+    opt = ctx.rareTopOption().stream().filter(op -> op.showPerc != null).findFirst();
+    list.add(
+        new Argument(
+            RareTopN.Option.showPerc.name(),
+            opt.isPresent() ? getArgumentValue(opt.get().showPerc) : Literal.FALSE));
     opt = ctx.rareTopOption().stream().filter(op -> op.useNull != null).findFirst();
     list.add(
         new Argument(

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -460,13 +460,16 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
     Integer noOfResults = node.getNoOfResults();
     String countField = (String) arguments.get(RareTopN.Option.countField.name()).getValue();
     Boolean showCount = (Boolean) arguments.get(RareTopN.Option.showCount.name()).getValue();
+    String percentField = (String) arguments.get(RareTopN.Option.percentField.name()).getValue();
+    Boolean showPerc = (Boolean) arguments.get(RareTopN.Option.showPerc.name()).getValue();
     Boolean useNull = (Boolean) arguments.get(RareTopN.Option.useNull.name()).getValue();
     String fields = visitFieldList(node.getFields());
     String group = visitExpressionList(node.getGroupExprList());
     String options =
         UnresolvedPlanHelper.isCalciteEnabled(settings)
             ? StringUtils.format(
-                "countield='%s' showcount=%s usenull=%s ", countField, showCount, useNull)
+                "countfield='%s' showcount=%s percentfield='%s' showperc=%s usenull=%s ",
+                countField, showCount, percentField, showPerc, useNull)
             : "";
     return StringUtils.format(
         "%s | %s %d %s%s",

--- a/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/antlr/PPLSyntaxParserTest.java
@@ -399,6 +399,25 @@ public class PPLSyntaxParserTest {
   }
 
   @Test
+  public void testRareCommandWithShowPercShouldPass() {
+    ParseTree tree = new PPLSyntaxParser().parse("source=t a=1 | rare showperc=true a");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
+  public void testRareCommandWithShowPercAndGroupByShouldPass() {
+    ParseTree tree = new PPLSyntaxParser().parse("source=t | rare showperc=true a by b");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
+  public void testRareCommandWithPercentFieldShouldPass() {
+    ParseTree tree =
+        new PPLSyntaxParser().parse("source=t | rare showperc=true percentfield='pct' a");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
   public void testTopCommandWithoutNShouldPass() {
     ParseTree tree = new PPLSyntaxParser().parse("source=t a=1 | top a");
     assertNotEquals(null, tree);
@@ -419,6 +438,25 @@ public class PPLSyntaxParserTest {
   @Test
   public void testTopCommandWithoutNAndGroupByShouldPass() {
     ParseTree tree = new PPLSyntaxParser().parse("source=t a=1 | top a by b");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
+  public void testTopCommandWithShowPercShouldPass() {
+    ParseTree tree = new PPLSyntaxParser().parse("source=t | top showperc=true a");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
+  public void testTopCommandWithShowPercAndGroupByShouldPass() {
+    ParseTree tree = new PPLSyntaxParser().parse("source=t | top showperc=true a by b");
+    assertNotEquals(null, tree);
+  }
+
+  @Test
+  public void testTopCommandWithPercentFieldShouldPass() {
+    ParseTree tree =
+        new PPLSyntaxParser().parse("source=t | top showperc=true percentfield='pct' a");
     assertNotEquals(null, tree);
   }
 

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLRareTopNTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLRareTopNTest.java
@@ -223,6 +223,206 @@ public class CalcitePPLRareTopNTest extends CalcitePPLAbstractTest {
   }
 
   @Test
+  public void testRareShowPerc() {
+    String ppl = "source=EMP | rare showperc=true JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(JOB=[$0], count=[$1], percent=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 10)])\n"
+            + "    LogicalProject(JOB=[$0], count=[$1], percent=[$2],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (ORDER BY $1, $0)])\n"
+            + "      LogicalProject(JOB=[$0], count=[$1],"
+            + " percent=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($1):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($1) OVER ()):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0}], count=[COUNT()])\n"
+            + "          LogicalProject(JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        ""
+            + "JOB=PRESIDENT; count=1; percent=7.142857\n"
+            + "JOB=ANALYST; count=2; percent=14.285714\n"
+            + "JOB=MANAGER; count=3; percent=21.428571\n"
+            + "JOB=CLERK; count=4; percent=28.571429\n"
+            + "JOB=SALESMAN; count=4; percent=28.571429\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `JOB`, `count`, `percent`\n"
+            + "FROM (SELECT `JOB`, `count`, `percent`, ROW_NUMBER() OVER (ORDER BY `count` NULLS"
+            + " LAST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS DOUBLE) /"
+            + " CAST(SUM(COUNT(*)) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+            + " FOLLOWING) AS DOUBLE), 6) `percent`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testRareShowPercWithGroupBy() {
+    String ppl = "source=EMP | rare showperc=true JOB by DEPTNO";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(DEPTNO=[$0], JOB=[$1], count=[$2], percent=[$3])\n"
+            + "  LogicalFilter(condition=[<=($4, 10)])\n"
+            + "    LogicalProject(DEPTNO=[$0], JOB=[$1], count=[$2], percent=[$3],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2, $1)])\n"
+            + "      LogicalProject(DEPTNO=[$0], JOB=[$1], count=[$2],"
+            + " percent=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($2):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($2) OVER (PARTITION BY $0)):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0, 1}], count=[COUNT()])\n"
+            + "          LogicalProject(DEPTNO=[$7], JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        ""
+            + "DEPTNO=20; JOB=MANAGER; count=1; percent=20.0\n"
+            + "DEPTNO=20; JOB=ANALYST; count=2; percent=40.0\n"
+            + "DEPTNO=20; JOB=CLERK; count=2; percent=40.0\n"
+            + "DEPTNO=10; JOB=CLERK; count=1; percent=33.333333\n"
+            + "DEPTNO=10; JOB=MANAGER; count=1; percent=33.333333\n"
+            + "DEPTNO=10; JOB=PRESIDENT; count=1; percent=33.333333\n"
+            + "DEPTNO=30; JOB=CLERK; count=1; percent=16.666667\n"
+            + "DEPTNO=30; JOB=MANAGER; count=1; percent=16.666667\n"
+            + "DEPTNO=30; JOB=SALESMAN; count=4; percent=66.666667\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `DEPTNO`, `JOB`, `count`, `percent`\n"
+            + "FROM (SELECT `DEPTNO`, `JOB`, `count`, `percent`, ROW_NUMBER() OVER (PARTITION BY"
+            + " `DEPTNO` ORDER BY `count` NULLS LAST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `DEPTNO`, `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS"
+            + " DOUBLE) / CAST(SUM(COUNT(*)) OVER (PARTITION BY `DEPTNO` RANGE BETWEEN UNBOUNDED"
+            + " PRECEDING AND UNBOUNDED FOLLOWING) AS DOUBLE), 6) `percent`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`, `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testRareShowPercWithoutShowCount() {
+    String ppl = "source=EMP | rare showcount=false showperc=true JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(JOB=[$0], percent=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 10)])\n"
+            + "    LogicalProject(JOB=[$0], count=[$1], percent=[$2],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (ORDER BY $1, $0)])\n"
+            + "      LogicalProject(JOB=[$0], count=[$1],"
+            + " percent=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($1):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($1) OVER ()):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0}], count=[COUNT()])\n"
+            + "          LogicalProject(JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        ""
+            + "JOB=PRESIDENT; percent=7.142857\n"
+            + "JOB=ANALYST; percent=14.285714\n"
+            + "JOB=MANAGER; percent=21.428571\n"
+            + "JOB=CLERK; percent=28.571429\n"
+            + "JOB=SALESMAN; percent=28.571429\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `JOB`, `percent`\n"
+            + "FROM (SELECT `JOB`, `count`, `percent`, ROW_NUMBER() OVER (ORDER BY `count` NULLS"
+            + " LAST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS DOUBLE) /"
+            + " CAST(SUM(COUNT(*)) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+            + " FOLLOWING) AS DOUBLE), 6) `percent`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testRareShowPercCustomField() {
+    String ppl = "source=EMP | rare percentfield='pct' showperc=true JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(JOB=[$0], count=[$1], pct=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 10)])\n"
+            + "    LogicalProject(JOB=[$0], count=[$1], pct=[$2],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (ORDER BY $1, $0)])\n"
+            + "      LogicalProject(JOB=[$0], count=[$1],"
+            + " pct=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($1):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($1) OVER ()):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0}], count=[COUNT()])\n"
+            + "          LogicalProject(JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        ""
+            + "JOB=PRESIDENT; count=1; pct=7.142857\n"
+            + "JOB=ANALYST; count=2; pct=14.285714\n"
+            + "JOB=MANAGER; count=3; pct=21.428571\n"
+            + "JOB=CLERK; count=4; pct=28.571429\n"
+            + "JOB=SALESMAN; count=4; pct=28.571429\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `JOB`, `count`, `pct`\n"
+            + "FROM (SELECT `JOB`, `count`, `pct`, ROW_NUMBER() OVER (ORDER BY `count` NULLS"
+            + " LAST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS DOUBLE) /"
+            + " CAST(SUM(COUNT(*)) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+            + " FOLLOWING) AS DOUBLE), 6) `pct`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testRareShowPercWithLimit() {
+    String ppl = "source=EMP | rare 1 showperc=true JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(JOB=[$0], count=[$1], percent=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 1)])\n"
+            + "    LogicalProject(JOB=[$0], count=[$1], percent=[$2],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (ORDER BY $1, $0)])\n"
+            + "      LogicalProject(JOB=[$0], count=[$1],"
+            + " percent=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($1):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($1) OVER ()):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0}], count=[COUNT()])\n"
+            + "          LogicalProject(JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    // Should show percentage relative to full dataset, not 100%
+    // PRESIDENT has 1 out of 14 total employees = 7.142857%
+    String expectedResult = "JOB=PRESIDENT; count=1; percent=7.142857\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `JOB`, `count`, `percent`\n"
+            + "FROM (SELECT `JOB`, `count`, `percent`, ROW_NUMBER() OVER (ORDER BY `count` NULLS"
+            + " LAST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS DOUBLE) /"
+            + " CAST(SUM(COUNT(*)) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+            + " FOLLOWING) AS DOUBLE), 6) `percent`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
   public void testTop() {
     String ppl = "source=EMP | top JOB";
     RelNode root = getRelNode(ppl);
@@ -406,6 +606,207 @@ public class CalcitePPLRareTopNTest extends CalcitePPLAbstractTest {
             + "WHERE `DEPTNO` IS NOT NULL AND `JOB` IS NOT NULL\n"
             + "GROUP BY `DEPTNO`, `JOB`) `t2`\n"
             + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testTopShowPerc() {
+    String ppl = "source=EMP | top showperc=true JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(JOB=[$0], count=[$1], percent=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 10)])\n"
+            + "    LogicalProject(JOB=[$0], count=[$1], percent=[$2],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (ORDER BY $1 DESC, $0)])\n"
+            + "      LogicalProject(JOB=[$0], count=[$1],"
+            + " percent=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($1):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($1) OVER ()):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0}], count=[COUNT()])\n"
+            + "          LogicalProject(JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        ""
+            + "JOB=CLERK; count=4; percent=28.571429\n"
+            + "JOB=SALESMAN; count=4; percent=28.571429\n"
+            + "JOB=MANAGER; count=3; percent=21.428571\n"
+            + "JOB=ANALYST; count=2; percent=14.285714\n"
+            + "JOB=PRESIDENT; count=1; percent=7.142857\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `JOB`, `count`, `percent`\n"
+            + "FROM (SELECT `JOB`, `count`, `percent`, ROW_NUMBER() OVER (ORDER BY `count` DESC"
+            + " NULLS FIRST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS DOUBLE) /"
+            + " CAST(SUM(COUNT(*)) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+            + " FOLLOWING) AS DOUBLE), 6) `percent`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testTopShowPercWithGroupBy() {
+    String ppl = "source=EMP | top showperc=true JOB by DEPTNO";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(DEPTNO=[$0], JOB=[$1], count=[$2], percent=[$3])\n"
+            + "  LogicalFilter(condition=[<=($4, 10)])\n"
+            + "    LogicalProject(DEPTNO=[$0], JOB=[$1], count=[$2], percent=[$3],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC, $1)])\n"
+            + "      LogicalProject(DEPTNO=[$0], JOB=[$1], count=[$2],"
+            + " percent=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($2):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($2) OVER (PARTITION BY $0)):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0, 1}], count=[COUNT()])\n"
+            + "          LogicalProject(DEPTNO=[$7], JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        ""
+            + "DEPTNO=20; JOB=ANALYST; count=2; percent=40.0\n"
+            + "DEPTNO=20; JOB=CLERK; count=2; percent=40.0\n"
+            + "DEPTNO=20; JOB=MANAGER; count=1; percent=20.0\n"
+            + "DEPTNO=10; JOB=CLERK; count=1; percent=33.333333\n"
+            + "DEPTNO=10; JOB=MANAGER; count=1; percent=33.333333\n"
+            + "DEPTNO=10; JOB=PRESIDENT; count=1; percent=33.333333\n"
+            + "DEPTNO=30; JOB=SALESMAN; count=4; percent=66.666667\n"
+            + "DEPTNO=30; JOB=CLERK; count=1; percent=16.666667\n"
+            + "DEPTNO=30; JOB=MANAGER; count=1; percent=16.666667\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `DEPTNO`, `JOB`, `count`, `percent`\n"
+            + "FROM (SELECT `DEPTNO`, `JOB`, `count`, `percent`, ROW_NUMBER() OVER (PARTITION BY"
+            + " `DEPTNO` ORDER BY `count` DESC NULLS FIRST, `JOB` NULLS LAST)"
+            + " `_row_number_rare_top_`\n"
+            + "FROM (SELECT `DEPTNO`, `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS"
+            + " DOUBLE) / CAST(SUM(COUNT(*)) OVER (PARTITION BY `DEPTNO` RANGE BETWEEN UNBOUNDED"
+            + " PRECEDING AND UNBOUNDED FOLLOWING) AS DOUBLE), 6) `percent`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `DEPTNO`, `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testTopShowPercWithoutShowCount() {
+    String ppl = "source=EMP | top showcount=false showperc=true JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(JOB=[$0], percent=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 10)])\n"
+            + "    LogicalProject(JOB=[$0], count=[$1], percent=[$2],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (ORDER BY $1 DESC, $0)])\n"
+            + "      LogicalProject(JOB=[$0], count=[$1],"
+            + " percent=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($1):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($1) OVER ()):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0}], count=[COUNT()])\n"
+            + "          LogicalProject(JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        ""
+            + "JOB=CLERK; percent=28.571429\n"
+            + "JOB=SALESMAN; percent=28.571429\n"
+            + "JOB=MANAGER; percent=21.428571\n"
+            + "JOB=ANALYST; percent=14.285714\n"
+            + "JOB=PRESIDENT; percent=7.142857\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `JOB`, `percent`\n"
+            + "FROM (SELECT `JOB`, `count`, `percent`, ROW_NUMBER() OVER (ORDER BY `count` DESC"
+            + " NULLS FIRST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS DOUBLE) /"
+            + " CAST(SUM(COUNT(*)) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+            + " FOLLOWING) AS DOUBLE), 6) `percent`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testTopShowPercCustomField() {
+    String ppl = "source=EMP | top percentfield='pct' showperc=true JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(JOB=[$0], count=[$1], pct=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 10)])\n"
+            + "    LogicalProject(JOB=[$0], count=[$1], pct=[$2],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (ORDER BY $1 DESC, $0)])\n"
+            + "      LogicalProject(JOB=[$0], count=[$1],"
+            + " pct=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($1):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($1) OVER ()):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0}], count=[COUNT()])\n"
+            + "          LogicalProject(JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult =
+        ""
+            + "JOB=CLERK; count=4; pct=28.571429\n"
+            + "JOB=SALESMAN; count=4; pct=28.571429\n"
+            + "JOB=MANAGER; count=3; pct=21.428571\n"
+            + "JOB=ANALYST; count=2; pct=14.285714\n"
+            + "JOB=PRESIDENT; count=1; pct=7.142857\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `JOB`, `count`, `pct`\n"
+            + "FROM (SELECT `JOB`, `count`, `pct`, ROW_NUMBER() OVER (ORDER BY `count` DESC"
+            + " NULLS FIRST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS DOUBLE) /"
+            + " CAST(SUM(COUNT(*)) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+            + " FOLLOWING) AS DOUBLE), 6) `pct`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 10";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
+  }
+
+  @Test
+  public void testTopShowPercWithLimit() {
+    String ppl = "source=EMP | top 1 showperc=true JOB";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(JOB=[$0], count=[$1], percent=[$2])\n"
+            + "  LogicalFilter(condition=[<=($3, 1)])\n"
+            + "    LogicalProject(JOB=[$0], count=[$1], percent=[$2],"
+            + " _row_number_rare_top_=[ROW_NUMBER() OVER (ORDER BY $1 DESC, $0)])\n"
+            + "      LogicalProject(JOB=[$0], count=[$1],"
+            + " percent=[ROUND(/(*(100.0:DECIMAL(4, 1), CAST($1):DOUBLE NOT NULL),"
+            + " CAST(CHECKED_LONG_SUM($1) OVER ()):DOUBLE NOT NULL), 6)])\n"
+            + "        LogicalAggregate(group=[{0}], count=[COUNT()])\n"
+            + "          LogicalProject(JOB=[$2])\n"
+            + "            LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    // Should show percentage relative to full dataset, not 100%
+    // CLERK has 4 out of 14 total employees = 28.571429%
+    String expectedResult = "JOB=CLERK; count=4; percent=28.571429\n";
+    verifyResult(root, expectedResult);
+
+    String expectedSparkSql =
+        "SELECT `JOB`, `count`, `percent`\n"
+            + "FROM (SELECT `JOB`, `count`, `percent`, ROW_NUMBER() OVER (ORDER BY `count` DESC"
+            + " NULLS FIRST, `JOB` NULLS LAST) `_row_number_rare_top_`\n"
+            + "FROM (SELECT `JOB`, COUNT(*) `count`, ROUND(100.0 * CAST(COUNT(*) AS DOUBLE) /"
+            + " CAST(SUM(COUNT(*)) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED"
+            + " FOLLOWING) AS DOUBLE), 6) `percent`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "GROUP BY `JOB`) `t1`) `t2`\n"
+            + "WHERE `_row_number_rare_top_` <= 1";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -741,6 +741,8 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(10)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(true))),
             emptyList(),
             field("a")));
@@ -757,6 +759,8 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(10)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(true))),
             exprList(field("b")),
             field("a")));
@@ -773,10 +777,48 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(10)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(true))),
             exprList(field("c")),
             field("a"),
             field("b")));
+  }
+
+  @Test
+  public void testRareCommandWithShowPerc() {
+    assertEqual(
+        "source=t | rare showperc=true a",
+        rareTopN(
+            relation("t"),
+            CommandType.RARE,
+            exprList(
+                argument("noOfResults", intLiteral(10)),
+                argument("countField", stringLiteral("count")),
+                argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(true)),
+                argument("useNull", booleanLiteral(true))),
+            emptyList(),
+            field("a")));
+  }
+
+  @Test
+  public void testRareCommandWithShowPercAndGroupBy() {
+    assertEqual(
+        "source=t | rare showperc=true a by b",
+        rareTopN(
+            relation("t"),
+            CommandType.RARE,
+            exprList(
+                argument("noOfResults", intLiteral(10)),
+                argument("countField", stringLiteral("count")),
+                argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(true)),
+                argument("useNull", booleanLiteral(true))),
+            exprList(field("b")),
+            field("a")));
   }
 
   @Test
@@ -790,6 +832,8 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(1)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(true))),
             emptyList(),
             field("a")));
@@ -806,6 +850,8 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(10)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(true))),
             emptyList(),
             field("a")));
@@ -822,6 +868,8 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(1)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(true))),
             exprList(field("b")),
             field("a")));
@@ -838,6 +886,8 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(1)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(true))),
             exprList(field("c")),
             field("a"),
@@ -855,7 +905,45 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(1)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(false))),
+            exprList(field("b")),
+            field("a")));
+  }
+
+  @Test
+  public void testTopCommandWithShowPerc() {
+    assertEqual(
+        "source=t | top showperc=true a",
+        rareTopN(
+            relation("t"),
+            CommandType.TOP,
+            exprList(
+                argument("noOfResults", intLiteral(10)),
+                argument("countField", stringLiteral("count")),
+                argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(true)),
+                argument("useNull", booleanLiteral(true))),
+            emptyList(),
+            field("a")));
+  }
+
+  @Test
+  public void testTopCommandWithShowPercAndGroupBy() {
+    assertEqual(
+        "source=t | top showperc=true a by b",
+        rareTopN(
+            relation("t"),
+            CommandType.TOP,
+            exprList(
+                argument("noOfResults", intLiteral(10)),
+                argument("countField", stringLiteral("count")),
+                argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(true)),
+                argument("useNull", booleanLiteral(true))),
             exprList(field("b")),
             field("a")));
   }
@@ -872,6 +960,8 @@ public class AstBuilderTest extends AstPlanningTestBase {
                 argument("noOfResults", intLiteral(1)),
                 argument("countField", stringLiteral("count")),
                 argument("showCount", booleanLiteral(true)),
+                argument("percentField", stringLiteral("percent")),
+                argument("showPerc", booleanLiteral(false)),
                 argument("useNull", booleanLiteral(false))),
             exprList(field("b")),
             field("a")));

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -429,18 +429,36 @@ public class PPLQueryDataAnonymizerTest {
   public void testRareCommandWithGroupByWithCalcite() {
     when(settings.getSettingValue(Key.CALCITE_ENGINE_ENABLED)).thenReturn(true);
     assertEquals(
-        "source=table | rare 10 countield='count' showcount=true usenull=true identifier by"
-            + " identifier",
+        "source=table | rare 10 countfield='count' showcount=true percentfield='percent'"
+            + " showperc=false usenull=true identifier by identifier",
         anonymize("source=t | rare a by b"));
+  }
+
+  @Test
+  public void testRareCommandWithShowPercWithCalCite() {
+    when(settings.getSettingValue(Key.CALCITE_ENGINE_ENABLED)).thenReturn(true);
+    assertEquals(
+        "source=table | rare 10 countfield='count' showcount=true percentfield='percent'"
+            + " showperc=true usenull=true identifier",
+        anonymize("source=t | rare showperc=true a "));
   }
 
   @Test
   public void testTopCommandWithNAndGroupByWithCalcite() {
     when(settings.getSettingValue(Key.CALCITE_ENGINE_ENABLED)).thenReturn(true);
     assertEquals(
-        "source=table | top 1 countield='count' showcount=true usenull=true identifier by"
-            + " identifier",
+        "source=table | top 1 countfield='count' showcount=true percentfield='percent'"
+            + " showperc=false usenull=true identifier by identifier",
         anonymize("source=t | top 1 a by b"));
+  }
+
+  @Test
+  public void testTopCommandWithShowPercWithCalcite() {
+    when(settings.getSettingValue(Key.CALCITE_ENGINE_ENABLED)).thenReturn(true);
+    assertEquals(
+        "source=table | top 1 countfield='count' showcount=true percentfield='percent'"
+            + " showperc=true usenull=true identifier by identifier",
+        anonymize("source=t | top 1 showperc=true a by b"));
   }
 
   @Test


### PR DESCRIPTION
### Description
Add `percentfield` and `showperc` options to the `top` and `rare` PPL commands. When `showperc=true` is specified, a percent column is added to the output showing each value's percentage of the total count within its partition (group-by clause). The `percentfield` option allows customizing the name of the percentage column (default: percent).

The percentage is computed as `ROUND(100.0 * count / SUM(count) OVER (PARTITION BY group_fields), 6)` and is rounded to 6 decimal places. When used with a by clause, percentages are calculated within each partition (summing to 100% per group).

#### Syntax
`source=index | top [percentfield='<name>'] showperc=true field_name [by group_field]`
`source=index | rare [percentfield='<name>'] showperc=true field_name [by group_field]`

#### `Top` Example
`source=otellogs | top showperc=true severityText`

Returns:

| severityText | count | percent |
| :---         | :---: |    ---: |
| ERROR        | 7     | 35.0    |
| INFO         | 6     | 30.0    |
| WARN         | 4     | 20.0    |
| DEBUG        | 3     | 15.0    |


#### `Rare` Example
`source=otellogs | rare showperc=true severityText`

Returns:

| severityText | count | percent |
| :---         | :---: |    ---: |
| DEBUG        | 3     | 15.0    |
| WARN         | 4     | 20.0    |
| INFO         | 6     | 30.0    |
| ERROR        | 7     | 35.0    |

### Custom Percentage Field Name Example
`source=otellogs | top percentfield='pct' showperc=true severityText`

Returns:

| severityText | count | pct |
| :---         | :---: |    ---: |
| ERROR        | 7     | 35.0    |
| INFO         | 6     | 30.0    |
| WARN         | 4     | 20.0    |
| DEBUG        | 3     | 15.0    |

### Related Issues
Resolves #5530 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
