### PR TITLE
Fix IllegalStateException in UnifiedQueryPlanner.preserveCollation on composite-collation plans

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -7,9 +7,10 @@ package org.opensearch.sql.api;
 
 import static org.opensearch.sql.monitor.profile.MetricName.ANALYZE;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.Sort;
@@ -154,9 +155,20 @@ public class UnifiedQueryPlanner {
     }
 
     private RelNode preserveCollation(RelNode logical) {
-      RelCollation collation = logical.getTraitSet().getCollation();
-      if (!(logical instanceof Sort) && collation != RelCollations.EMPTY) {
-        return LogicalSort.create(logical, collation, null, null);
+      if (logical instanceof Sort) {
+        return logical;
+      }
+      // Only a genuine single-sort collation is materialized. A literal-row plan (makeresults
+      // data=) carries several incidental derived collations kept as a RelCompositeTrait; those
+      // are not a user sort, so getTraits returns more than one and we leave the plan unwrapped.
+      // RelTraitSet.getCollation() would instead cast the composite to a single RelCollation and
+      // throw.
+      List<RelCollation> collations =
+          logical.getTraitSet().getTraits(RelCollationTraitDef.INSTANCE);
+      if (collations != null
+          && collations.size() == 1
+          && !collations.get(0).getFieldCollations().isEmpty()) {
+        return LogicalSort.create(logical, collations.get(0), null, null);
       }
       return logical;
     }

--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -158,11 +158,6 @@ public class UnifiedQueryPlanner {
       if (logical instanceof Sort) {
         return logical;
       }
-      // Only a genuine single-sort collation is materialized. A literal-row plan (makeresults
-      // data=) carries several incidental derived collations kept as a RelCompositeTrait; those
-      // are not a user sort, so getTraits returns more than one and we leave the plan unwrapped.
-      // RelTraitSet.getCollation() would instead cast the composite to a single RelCollation and
-      // throw.
       List<RelCollation> collations =
           logical.getTraitSet().getTraits(RelCollationTraitDef.INSTANCE);
       if (collations != null

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
@@ -5,11 +5,14 @@
 
 package org.opensearch.sql.api;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.runtime.CalciteException;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.impl.AbstractSchema;
@@ -197,5 +200,39 @@ public class UnifiedQueryPlannerTest extends UnifiedQueryTestBase {
     givenQuery("source = catalog.employees | patterns name")
         .assertPlanContains("REGEXP_REPLACE")
         .assertFields("id", "name", "age", "department", "patterns_field");
+  }
+
+  @Test
+  public void preserveCollationReturnsExistingSortUnchanged() {
+    var assertion = givenQuery("source = catalog.employees | sort age");
+    assertTrue("top node should be the user's Sort", assertion.plan() instanceof Sort);
+    assertion.assertPlan(
+        "LogicalSort(sort0=[$2], dir0=[ASC-nulls-first])\n"
+            + "  LogicalTableScan(table=[[catalog, employees]])\n");
+  }
+
+  @Test
+  public void preserveCollationLeavesCompositeCollationUnwrapped() {
+    var assertion = givenQuery("source = catalog.employees | sort age | eval x = age");
+    assertFalse(
+        "composite-collation plan must not be re-wrapped in a Sort",
+        assertion.plan() instanceof Sort);
+    assertion.assertFields("id", "name", "age", "department", "x");
+  }
+
+  @Test
+  public void preserveCollationMaterializesSingleDerivedCollation() {
+    givenQuery("makeresults format=csv data='name\nJohn\nSarah'")
+        .assertPlan(
+            "LogicalSort(sort0=[$0], dir0=[ASC])\n"
+                + "  LogicalProject(name=[CAST($0):VARCHAR NOT NULL])\n"
+                + "    LogicalValues(tuples=[[{ 'John' }, { 'Sarah' }]])\n");
+  }
+
+  @Test
+  public void preserveCollationLeavesUnsortedPlanUnwrapped() {
+    var assertion = givenQuery("source = catalog.employees");
+    assertFalse("unsorted plan must not be wrapped in a Sort", assertion.plan() instanceof Sort);
+    assertion.assertPlan("LogicalTableScan(table=[[catalog, employees]])\n");
   }
 }

--- a/api/src/test/java/org/opensearch/sql/api/compiler/UnifiedQueryCompilerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/compiler/UnifiedQueryCompilerTest.java
@@ -57,6 +57,27 @@ public class UnifiedQueryCompilerTest extends UnifiedQueryTestBase implements Re
     }
   }
 
+  @Test
+  public void testCompositeCollationQueryExecutes() throws Exception {
+    RelNode plan = planner.plan("source = catalog.employees | sort age | eval x = age");
+    try (PreparedStatement statement = compiler.compile(plan)) {
+      ResultSet resultSet = statement.executeQuery();
+
+      verify(resultSet)
+          .expectSchema(
+              col("id", INTEGER),
+              col("name", VARCHAR),
+              col("age", INTEGER),
+              col("department", VARCHAR),
+              col("x", INTEGER))
+          .expectData(
+              row(1, "Alice", 25, "Engineering", 25),
+              row(2, "Bob", 35, "Sales", 35),
+              row(3, "Charlie", 45, "Engineering", 45),
+              row(4, "Diana", 28, "Marketing", 28));
+    }
+  }
+
   @Test(expected = IllegalStateException.class)
   public void testCompileFailure() {
     RelNode mockPlan = Mockito.mock(RelNode.class);

--- a/integ-test/src/test/java/org/opensearch/sql/api/UnifiedQueryOpenSearchIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/api/UnifiedQueryOpenSearchIT.java
@@ -104,6 +104,30 @@ public class UnifiedQueryOpenSearchIT extends PPLIntegTestCase implements Result
     }
   }
 
+  @Test
+  public void testSortThenEvalCopyExecutesEndToEnd() throws Exception {
+    String pplQuery =
+        String.format(
+            "source = opensearch.%s | sort age | eval age_copy = age"
+                + " | fields firstname, age, age_copy",
+            TEST_INDEX_ACCOUNT);
+
+    RelNode plan = planner.plan(pplQuery);
+    try (PreparedStatement statement = compiler.compile(plan)) {
+      ResultSet resultSet = statement.executeQuery();
+
+      verify(resultSet)
+          .expectSchema(col("firstname", VARCHAR), col("age", BIGINT), col("age_copy", BIGINT));
+
+      int rows = 0;
+      while (resultSet.next()) {
+        rows++;
+        assertEquals("age_copy must mirror age", resultSet.getObject(2), resultSet.getObject(3));
+      }
+      assertTrue("expected at least one row", rows > 0);
+    }
+  }
+
   /**
    * Creates a dynamic schema that creates OpenSearchIndex on-demand for any table name. This allows
    * querying any index without pre-registering it.


### PR DESCRIPTION
### Description

`UnifiedQueryPlanner.preserveCollation` fails to plan any query whose top `RelNode` carries more than one collation in its trait set. It surfaces as a 500 `Failed to plan query`.

**Root cause.** The method reads the collation via:

```java
RelCollation collation = logical.getTraitSet().getCollation();
```

`RelTraitSet.getCollation()` delegates to `getTrait(RelCollationTraitDef.INSTANCE)`, which assumes a single collation. When a plan derives several collations, Calcite stores them as a `RelCompositeTrait` and `getTrait` refuses to return it, throwing:

```
java.lang.IllegalStateException: Trait index 1 has multiple values in this trait set; use getTraits(RelTraitDef) instead of getTrait(RelTraitDef)
```

Such a composite arises whenever a non-`Sort` top node is ordered by more than one equivalent key — for example `... | sort age | eval x = age`: `x` mirrors `age`, so the top `LogicalProject` is sorted on both `age` and `x` and derives two collations. A plan with a single derived collation reads back fine, which is why this was not caught earlier. (A single multi-column literal-row plan such as `makeresults format=csv data=...` derives one multi-field collation, not a composite, so it does not trigger this.)

**Fix.** Read the collation through the composite-safe `getTraits(RelCollationTraitDef.INSTANCE)` and materialize a `LogicalSort` only when there is exactly one genuine (non-empty) sort collation. A composite (several incidental derived collations) is not a user sort, so the plan is left unwrapped instead of crashing. Behavior for the single-collation case is unchanged.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
