### PR TITLE
[BUG] PPL `LIKE` function: no way to escape the escape character (`\`)

### DIFF
--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/StringUtils.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/StringUtils.java
@@ -43,8 +43,14 @@ public class StringUtils {
     for (char currentChar : text.toCharArray()) {
       switch (currentChar) {
         case DEFAULT_ESCAPE:
-          escaped = true;
-          convertedString.append(currentChar);
+          if (escaped) {
+            convertedString.deleteCharAt(convertedString.length() - 1);
+            convertedString.append(currentChar);
+            escaped = false;
+          } else {
+            escaped = true;
+            convertedString.append(currentChar);
+          }
           break;
         case '%':
           if (escaped) {

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/StringUtilsTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/StringUtilsTest.java
@@ -47,4 +47,22 @@ public class StringUtilsTest {
     assertEquals("foo\\*bar", StringUtils.convertSqlWildcardToLuceneSafe("foo*bar"));
     assertEquals("foo\\?bar", StringUtils.convertSqlWildcardToLuceneSafe("foo?bar"));
   }
+
+  @Test
+  public void test_escaping_backslash_itself() {
+    assertEquals("\\", StringUtils.convertSqlWildcardToLucene("\\\\"));
+    assertEquals("\\", StringUtils.convertSqlWildcardToLuceneSafe("\\\\"));
+    assertEquals("*\\*", StringUtils.convertSqlWildcardToLucene("%\\\\%"));
+    assertEquals("*\\*", StringUtils.convertSqlWildcardToLuceneSafe("%\\\\%"));
+    assertEquals("\\*", StringUtils.convertSqlWildcardToLucene("\\\\%"));
+    assertEquals("\\*", StringUtils.convertSqlWildcardToLuceneSafe("\\\\%"));
+    assertEquals("*\\", StringUtils.convertSqlWildcardToLucene("%\\\\"));
+    assertEquals("*\\", StringUtils.convertSqlWildcardToLuceneSafe("%\\\\"));
+    assertEquals("\\\\", StringUtils.convertSqlWildcardToLucene("\\\\\\\\"));
+    assertEquals("\\\\", StringUtils.convertSqlWildcardToLuceneSafe("\\\\\\\\"));
+    assertEquals("\\\\*", StringUtils.convertSqlWildcardToLucene("\\\\\\\\%"));
+    assertEquals("\\\\*", StringUtils.convertSqlWildcardToLuceneSafe("\\\\\\\\%"));
+    assertEquals("\\%", StringUtils.convertSqlWildcardToLucene("\\\\\\%"));
+    assertEquals("\\%", StringUtils.convertSqlWildcardToLuceneSafe("\\\\\\%"));
+  }
 }


### PR DESCRIPTION
### Description
 When the `DEFAULT_ESCAPE` (`\`) case is hit, the code  sets `escaped = true` without checking whether escaped is already `true`. This means a sequence of two backslashes (`\\`, which represents a literal backslash in `LIKE` syntax) sets `escaped = true` twice, the second backslash does not consume the escape state from the first. As a result, escaped remains true after both backslashes, causing the *next* character (e.g., `%`) to be incorrectly treated as escaped (literal) instead of as a wildcard.
 
The fix adds a check: if escaped is already true when we encounter another backslash, we know this backslash is being escaped by the previous one. We treat it as a literal backslash (removing the escape prefix from the output) and reset escaped to false.

### Related Issues
Resolves #5627 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
