### PR TITLE
Remove reverted rest command from 3.8 release notes

### DIFF
--- a/release-notes/opensearch-sql.release-notes-3.8.0.0.md
+++ b/release-notes/opensearch-sql.release-notes-3.8.0.0.md
@@ -49,7 +49,6 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.8.0
 * Honor PPL `fetch_size` on the analytics-engine route ([#5567](https://github.com/opensearch-project/sql/pull/5567))
 * Strip analytics-engine-unsupported fields from test data and exclude affected ITs ([#5541](https://github.com/opensearch-project/sql/pull/5541))
 * Repair two pre-existing IT failures on main (error type assertion and explain flake) ([#5545](https://github.com/opensearch-project/sql/pull/5545))
-* Revert PPL `rest` command ([#5635](https://github.com/opensearch-project/sql/pull/5635))
 
 ### Infrastructure
 


### PR DESCRIPTION
### Description

Removes the `Revert PPL rest command (#5635)` line from the 3.8.0 release notes.

The PPL `rest` command was added (#5599) and fully reverted (#5635) within the same 3.8 release cycle, so it nets to zero for this release. The original feature is (correctly) not listed, so the standalone revert entry is noise and is best omitted rather than advertised as a change.

### Check List
- [x] All tests pass (docs-only change)
- [x] New functionality has been documented (n/a)
- [x] Commit changes are listed out in CHANGELOG.md (n/a — release notes)
- [x] Commits are signed per the DCO using `--signoff`
