### PR TITLE
Emit list() for mvcombine so it runs on the analytics engine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -73,7 +73,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.rex.RexWindowBounds;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.fun.SqlTrimFunction;
 import org.apache.calcite.sql.type.ArraySqlType;
@@ -4498,13 +4497,10 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
       RelBuilder relBuilder, int targetIndex, String targetName, List<RexNode> groupExprs) {
 
     final RexNode targetRef = relBuilder.field(targetIndex);
-    final RexNode notNullTarget = relBuilder.isNotNull(targetRef);
-
+    // list() rather than Calcite ARRAY_AGG: list() carries the ARRAY<VARCHAR> contract the
+    // analytics-engine (DataFusion) route supports, and drops nulls itself (no filter needed).
     final RelBuilder.AggCall aggCall =
-        relBuilder
-            .aggregateCall(SqlLibraryOperators.ARRAY_AGG, targetRef)
-            .filter(notNullTarget)
-            .as(targetName);
+        relBuilder.aggregateCall(PPLBuiltinOperators.LIST, targetRef).as(targetName);
 
     relBuilder.aggregate(relBuilder.groupKey(groupExprs), aggCall);
   }

--- a/docs/user/ppl/cmd/mvcombine.md
+++ b/docs/user/ppl/cmd/mvcombine.md
@@ -108,6 +108,10 @@ Error: Query returned no data
 
 =======
 
+## Limitations
+
+Values are combined using the `list()` aggregation: the combined field is a multivalue array of **strings** (non-string values are rendered as strings), at most **100** values are retained per group, and the order of values within the array is not guaranteed.
+
 ## Related commands
 
 - [`nomv`](nomv.md) -- Converts a multivalue field into a single-value string

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_mvcombine.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_mvcombine.yaml
@@ -2,11 +2,10 @@ calcite:
   logical: |
     LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
       LogicalProject(state=[$0], city=[$1], age=[$2])
-        LogicalAggregate(group=[{0, 1}], age=[ARRAY_AGG($2) FILTER $3])
-          LogicalProject(state=[$7], city=[$5], age=[$8], $f3=[IS NOT NULL($8)])
+        LogicalAggregate(group=[{0, 1}], age=[LIST($2)])
+          LogicalProject(state=[$7], city=[$5], age=[$8])
             CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])
   physical: |
     EnumerableLimit(fetch=[10000])
-      EnumerableAggregate(group=[{0, 1}], age=[ARRAY_AGG($2) FILTER $3])
-        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[IS NOT NULL($t2)], proj#0..3=[{exprs}])
-          CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[PROJECT->[state, city, age]], OpenSearchRequestBuilder(sourceBuilder={"from":0,"timeout":"1m","_source":{"includes":["state","city","age"]}}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])
+      EnumerableAggregate(group=[{0, 1}], age=[LIST($2)])
+        CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[PROJECT->[state, city, age]], OpenSearchRequestBuilder(sourceBuilder={"from":0,"timeout":"1m","_source":{"includes":["state","city","age"]}}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_mvcombine.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite_no_pushdown/explain_mvcombine.yaml
@@ -2,11 +2,11 @@ calcite:
   logical: |
     LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
       LogicalProject(state=[$0], city=[$1], age=[$2])
-        LogicalAggregate(group=[{0, 1}], age=[ARRAY_AGG($2) FILTER $3])
-          LogicalProject(state=[$7], city=[$5], age=[$8], $f3=[IS NOT NULL($8)])
+        LogicalAggregate(group=[{0, 1}], age=[LIST($2)])
+          LogicalProject(state=[$7], city=[$5], age=[$8])
             CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])
   physical: |
     EnumerableLimit(fetch=[10000])
-      EnumerableAggregate(group=[{0, 1}], age=[ARRAY_AGG($2) FILTER $3])
-        EnumerableCalc(expr#0..16=[{inputs}], expr#17=[IS NOT NULL($t8)], state=[$t7], city=[$t5], age=[$t8], $f3=[$t17])
+      EnumerableAggregate(group=[{0, 1}], age=[LIST($2)])
+        EnumerableCalc(expr#0..16=[{inputs}], state=[$t7], city=[$t5], age=[$t8])
           CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMvCombineTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMvCombineTest.java
@@ -85,14 +85,13 @@ public class CalcitePPLMvCombineTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         "LogicalSort(sort0=[$1], dir0=[ASC-nulls-first])\n"
             + "  LogicalProject(case=[$0], ip=[$1], packets=[$2])\n"
-            + "    LogicalAggregate(group=[{0, 1}], packets=[ARRAY_AGG($2) FILTER $3])\n"
-            + "      LogicalProject(case=[$0], ip=[$1], packets=[$2], $f3=[IS NOT NULL($2)])\n"
-            + "        LogicalFilter(condition=[=($0, 'basic')])\n"
-            + "          LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
+            + "    LogicalAggregate(group=[{0, 1}], packets=[LIST($2)])\n"
+            + "      LogicalFilter(condition=[=($0, 'basic')])\n"
+            + "        LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
     verifyLogical(root, expectedLogical);
 
     String expectedSparkSql =
-        "SELECT `case`, `ip`, ARRAY_AGG(`packets`) FILTER (WHERE `packets` IS NOT NULL) `packets`\n"
+        "SELECT `case`, `ip`, `LIST`(`packets`) `packets`\n"
             + "FROM `scott`.`MVCOMBINE_DATA`\n"
             + "WHERE `case` = 'basic'\n"
             + "GROUP BY `case`, `ip`\n"
@@ -114,14 +113,13 @@ public class CalcitePPLMvCombineTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         "LogicalSort(sort0=[$1], dir0=[ASC-nulls-first])\n"
             + "  LogicalProject(case=[$0], ip=[$1], packets=[$2])\n"
-            + "    LogicalAggregate(group=[{0, 1}], packets=[ARRAY_AGG($2) FILTER $3])\n"
-            + "      LogicalProject(case=[$0], ip=[$1], packets=[$2], $f3=[IS NOT NULL($2)])\n"
-            + "        LogicalFilter(condition=[=($0, 'nulls')])\n"
-            + "          LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
+            + "    LogicalAggregate(group=[{0, 1}], packets=[LIST($2)])\n"
+            + "      LogicalFilter(condition=[=($0, 'nulls')])\n"
+            + "        LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
     verifyLogical(root, expectedLogical);
 
     String expectedSparkSql =
-        "SELECT `case`, `ip`, ARRAY_AGG(`packets`) FILTER (WHERE `packets` IS NOT NULL) `packets`\n"
+        "SELECT `case`, `ip`, `LIST`(`packets`) `packets`\n"
             + "FROM `scott`.`MVCOMBINE_DATA`\n"
             + "WHERE `case` = 'nulls'\n"
             + "GROUP BY `case`, `ip`\n"
@@ -143,14 +141,13 @@ public class CalcitePPLMvCombineTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         "LogicalSort(sort0=[$1], dir0=[ASC-nulls-first])\n"
             + "  LogicalProject(case=[$0], ip=[$1], packets=[$2])\n"
-            + "    LogicalAggregate(group=[{0, 1}], packets=[ARRAY_AGG($2) FILTER $3])\n"
-            + "      LogicalProject(case=[$0], ip=[$1], packets=[$2], $f3=[IS NOT NULL($2)])\n"
-            + "        LogicalFilter(condition=[=($0, 'basic')])\n"
-            + "          LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
+            + "    LogicalAggregate(group=[{0, 1}], packets=[LIST($2)])\n"
+            + "      LogicalFilter(condition=[=($0, 'basic')])\n"
+            + "        LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
     verifyLogical(root, expectedLogical);
 
     String expectedSparkSql =
-        "SELECT `case`, `ip`, ARRAY_AGG(`packets`) FILTER (WHERE `packets` IS NOT NULL) `packets`\n"
+        "SELECT `case`, `ip`, `LIST`(`packets`) `packets`\n"
             + "FROM `scott`.`MVCOMBINE_DATA`\n"
             + "WHERE `case` = 'basic'\n"
             + "GROUP BY `case`, `ip`\n"
@@ -188,10 +185,9 @@ public class CalcitePPLMvCombineTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         "LogicalSort(sort0=[$1], dir0=[ASC-nulls-first])\n"
             + "  LogicalProject(case=[$0], ip=[$1], packets=[$2])\n"
-            + "    LogicalAggregate(group=[{0, 1}], packets=[ARRAY_AGG($2) FILTER $3])\n"
-            + "      LogicalProject(case=[$0], ip=[$1], packets=[$2], $f3=[IS NOT NULL($2)])\n"
-            + "        LogicalFilter(condition=[=($0, 'single')])\n"
-            + "          LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
+            + "    LogicalAggregate(group=[{0, 1}], packets=[LIST($2)])\n"
+            + "      LogicalFilter(condition=[=($0, 'single')])\n"
+            + "        LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
     verifyLogical(root, expectedLogical);
   }
 
@@ -209,10 +205,9 @@ public class CalcitePPLMvCombineTest extends CalcitePPLAbstractTest {
     String expectedLogical =
         "LogicalSort(sort0=[$1], dir0=[ASC-nulls-first])\n"
             + "  LogicalProject(case=[$0], ip=[$1], packets=[$2])\n"
-            + "    LogicalAggregate(group=[{0, 1}], packets=[ARRAY_AGG($2) FILTER $3])\n"
-            + "      LogicalProject(case=[$0], ip=[$1], packets=[$2], $f3=[IS NOT NULL($2)])\n"
-            + "        LogicalFilter(condition=[=($0, 'no_such_case')])\n"
-            + "          LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
+            + "    LogicalAggregate(group=[{0, 1}], packets=[LIST($2)])\n"
+            + "      LogicalFilter(condition=[=($0, 'no_such_case')])\n"
+            + "        LogicalTableScan(table=[[scott, MVCOMBINE_DATA]])\n";
     verifyLogical(root, expectedLogical);
   }
 


### PR DESCRIPTION
### Description

`mvcombine` lowered to Calcite `ARRAY_AGG(<field>) FILTER (<field> IS NOT NULL)`, which the analytics-engine (DataFusion) route cannot execute: `ARRAY_AGG` is not in the engine's aggregate function set, so the plan is rejected during marking. Mapping it into the engine is not viable either — Calcite `ARRAY_AGG` infers a nullable-element `ARRAY` while the engine's `array_agg` infers a NOT NULL element, and the two cannot be reconciled during the aggregate rewrite.

The fix stays on the SQL side: `performArrayAggAggregation` now emits the existing PPL `list()` aggregate (`PPLBuiltinOperators.LIST`), which the analytics engine already supports end to end (it maps to the engine's `array_agg` / `list_merge` operators). `ListAggFunction` filters nulls internally, so the explicit `IS NOT NULL` filter is dropped. No analytics-engine (core) change is required.

**Behavior change (please review):** the combined field is now `ARRAY<VARCHAR>` — `list()` renders elements as strings and retains at most 100 values per group, per its documented contract. For string target fields (the documented `mvcombine` use) output is unchanged; numeric/other targets are now stringified and capped. On the Calcite/Lucene path this differs from the previous unbounded, type-preserving `ARRAY_AGG`, so flagging in case reviewers prefer to gate it.

### Bug reproduce (analytics-engine / DataFusion route)

Composite/parquet index, `analytics.planner.prefer_metadata_driver=false` (forces DataFusion):

```ppl
source=test_data | fields category, status | mvcombine status
```

#### Before (`ARRAY_AGG`) — rejected on the analytics engine

Logical plan:

```
LogicalProject(category=[$0], status=[$1])
  LogicalAggregate(group=[{0}], status=[ARRAY_AGG($1) FILTER $2])
    LogicalProject(category=[$0], status=[$7], $f2=[IS NOT NULL($7)])
      LogicalTableScan(table=[[opensearch, test_data]])
```

Physical plan: none — rejected during analytics-engine marking, before execution.

Output:

```json
{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "No enum constant org.opensearch.analytics.spi.AggregateFunction.ARRAY_AGG",
    "type": "IllegalArgumentException"
  },
  "status": 500
}
```

#### After (`LIST`) — runs on DataFusion

Logical plan:

```
LogicalProject(category=[$0], status=[$1])
  LogicalAggregate(group=[{0}], status=[LIST($1)])
    LogicalProject(category=[$0], status=[$7])
      LogicalTableScan(table=[[opensearch, test_data]])
```

Physical plan (`profile=true`; every node `viableBackends=[[datafusion]]`, stage `chosen_backend=datafusion`):

```
OpenSearchSort(fetch=[10000], viableBackends=[[datafusion]])
  OpenSearchProject(category=[$0], status=[$1], viableBackends=[[datafusion]])
    OpenSearchAggregate(group=[{0}], status=[LIST($1)], mode=[SINGLE], viableBackends=[[datafusion]])
      OpenSearchProject(category=[$0], status=[$7], viableBackends=[[datafusion]])
        OpenSearchTableScan(table=[[test_data]], viableBackends=[[datafusion]])
```

Output:

```
+----------+--------------------------+
| category | status                   |
|----------+--------------------------|
| A        | ["active", "active"]     |
| B        | ["inactive", "active"]   |
| C        | ["pending"]              |
+----------+--------------------------+
```

### Related Issues

Related to #4766 ([FEATURE] Add `mvcombine` command in PPL) — extends it to the analytics-engine (DataFusion) route.

### Check List

- [x] New functionality includes testing.
  - `CalcitePPLMvCombineTest` logical-plan + Spark SQL expectations updated for the `LIST` aggregate. `CalciteMvCombineCommandIT` is unchanged (it already asserts string-array output on a string field).
- [x] New functionality has been documented.
  - `docs/user/ppl/cmd/mvcombine.md` gains a Limitations note (string elements, 100-value cap, unordered).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
