### PR TITLE
fix: allow LIST/VALUES aggregates to accept DATE/TIMESTAMP/IP/BINARY field types

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -563,10 +563,9 @@ public interface PPLTypeChecker {
         && actual instanceof AbstractExprRelDataType<?> actUdt) {
       return expUdt.getUdt() == actUdt.getUdt();
     }
-    if (expected instanceof AbstractExprRelDataType<?>
-        || actual instanceof AbstractExprRelDataType<?>) {
-      return false;
-    }
+    // Fall back to SqlTypeName comparison when one operand is a UDT and the other is a plain
+    // RelDataType. This covers database-sourced fields (e.g. TIMESTAMP) that arrive as plain
+    // RelDataType against allowed signatures using UDT variants (e.g. TIMESTAMP_UDT).
     return expected.getSqlTypeName() == actual.getSqlTypeName();
   }
 


### PR DESCRIPTION
### Description

This PR fixes a type-matching bug in the PPL aggregate function validation that caused LIST and VALUES aggregate functions to reject DATE, TIMESTAMP, IP, and BINARY field types, even though these types were explicitly listed in the allowed signatures.

### Root Cause

The `typesMatch()` method in `PPLTypeChecker.java` was returning `false` when one operand was a UDT (via `AbstractExprRelDataType`) and the other was a plain `RelDataType`. Database-sourced fields (e.g., TIMESTAMP from a table) arrive as plain `RelDataType`, but the allowed `SCALAR_TYPES` list in `PPLOperandTypes.java` uses UDT variants for temporal/special types (e.g., `TIMESTAMP_UDT`, `DATE_UDT`, `IP_UDT`, `BINARY_UDT`).

This caused the validation to fail with:
```
Aggregation function LIST expects field type {[BYTE]|[SHORT]|[INTEGER]|[LONG]|[FLOAT]|[DOUBLE]|[STRING]|[BOOLEAN]|[DATE]|[TIME]|[TIMESTAMP]|[IP]|[BINARY]}, but got [TIMESTAMP]
```

### Fix

Changed `typesMatch()` to fall back to `SqlTypeName` comparison when one operand is a UDT and the other is a plain `RelDataType`, instead of returning `false`.

### Related Issues

Fixes opensearch-project/OpenSearch#22581