### PR TITLE
fix: cast mvindex index arithmetic to INTEGER type for Calcite ITEM compatibility (#5660)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/MVIndexFunctionImp.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/MVIndexFunctionImp.java
@@ -15,6 +15,7 @@ import java.math.BigDecimal;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.expression.function.PPLFuncImpTable;
 
 /**
@@ -64,12 +65,16 @@ public class MVIndexFunctionImp implements PPLFuncImpTable.FunctionImp {
 
   /** Non-widening integer addition for internal, int-domain array-index math. */
   private static RexNode add(RexBuilder builder, RexNode left, RexNode right) {
-    return builder.makeCall(SqlStdOperatorTable.PLUS, left, right);
+    RexNode result = builder.makeCall(SqlStdOperatorTable.PLUS, left, right);
+    return builder.makeCast(
+        builder.getTypeFactory().createSqlType(SqlTypeName.INTEGER), result);
   }
 
   /** Non-widening integer subtraction for internal, int-domain array-index math. */
   private static RexNode subtract(RexBuilder builder, RexNode left, RexNode right) {
-    return builder.makeCall(SqlStdOperatorTable.MINUS, left, right);
+    RexNode result = builder.makeCall(SqlStdOperatorTable.MINUS, left, right);
+    return builder.makeCast(
+        builder.getTypeFactory().createSqlType(SqlTypeName.INTEGER), result);
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #5660

When `mvindex()` is used in a PPL query with Calcite pushdown enabled, the index conversion `+(index, 1)` produces a `BIGINT` (long) value instead of `INTEGER` (int). The `INTERNAL_ITEM` operator expects `SqlTypeFamily.INTEGER` for the index parameter, causing a `CompileException`:

```
No applicable constructor/method found for actual parameters "java.util.List, long, int, boolean";
candidates are: "public static java.lang.Object org.apache.calcite.runtime.SqlFunctions.arrayItemOptional(java.util.List, int, int, boolean)"
```

### Root Cause

The `add` and `subtract` methods in `MVIndexFunctionImp.java` use Calcite's `SqlStdOperatorTable.PLUS`/`MINUS`, which widen the result type to `BIGINT` when both operands are `INTEGER`. The `INTERNAL_ITEM` operator's type checker expects `SqlTypeFamily.INTEGER`, but receives `BIGINT` (part of `SqlTypeFamily.NUMERIC`).

### Fix

Wrap the `PLUS`/`MINUS` results in a `CAST(INTEGER)` to ensure the index arithmetic always produces `INTEGER`-typed values for the `ITEM`/`ARRAY_SLICE` operators.

### Testing

- Existing `CalcitePPLArrayFunctionTest` covers `mvindex` with positive and negative indices
- The fix ensures the `+(1, 1)` expression is cast to `INTEGER` before being passed to `ITEM`
