### PR TITLE
Accept plain Calcite types against UDT operand signatures

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -557,17 +557,49 @@ public interface PPLTypeChecker {
    * ExprUDT} tag — comparing {@code getClass()} is unsafe because addCharsetAndCollation collapses
    * ExprDateType/ExprTimeType/ExprTimeStampType/ExprBinaryType down to ExprSqlType, so different
    * UDTs would appear equal. Plain types match by SqlTypeName.
+   *
+   * <p>A UDT signature also accepts the equivalent plain Calcite type. Signatures such as {@code
+   * PPLOperandTypes.ANY_SCALAR} declare temporal/IP/BINARY operands as UDTs, but the analytics
+   * engine builds its row types from plain Calcite types plus its own markers, which extend
+   * Calcite's {@code AbstractSqlType} rather than {@link AbstractExprRelDataType}. Matching on
+   * class identity alone made {@code list(<date field>)} fail with an error that listed the very
+   * type it had just rejected.
    */
   private static boolean typesMatch(RelDataType expected, RelDataType actual) {
     if (expected instanceof AbstractExprRelDataType<?> expUdt
         && actual instanceof AbstractExprRelDataType<?> actUdt) {
       return expUdt.getUdt() == actUdt.getUdt();
     }
-    if (expected instanceof AbstractExprRelDataType<?>
-        || actual instanceof AbstractExprRelDataType<?>) {
-      return false;
+    if (expected instanceof AbstractExprRelDataType<?> expUdt) {
+      return matchesPlainType(expUdt.getUdt(), actual);
+    }
+    if (actual instanceof AbstractExprRelDataType<?> actUdt) {
+      return matchesPlainType(actUdt.getUdt(), expected);
     }
     return expected.getSqlTypeName() == actual.getSqlTypeName();
+  }
+
+  /**
+   * Whether a plain Calcite type is the non-UDT spelling of {@code udt}. The UDTs themselves are
+   * all VARCHAR-backed, so this maps the tag to the {@link SqlTypeName}s a backend would produce
+   * for the same logical type instead of comparing backing types.
+   */
+  private static boolean matchesPlainType(ExprUDT udt, RelDataType plain) {
+    return switch (udt) {
+      case EXPR_DATE -> plain.getSqlTypeName() == SqlTypeName.DATE;
+      case EXPR_TIME ->
+          switch (plain.getSqlTypeName()) {
+            case TIME, TIME_TZ, TIME_WITH_LOCAL_TIME_ZONE -> true;
+            default -> false;
+          };
+      case EXPR_TIMESTAMP ->
+          switch (plain.getSqlTypeName()) {
+            case TIMESTAMP, TIMESTAMP_TZ, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> true;
+            default -> false;
+          };
+      // ip and binary both land as VARBINARY.
+      case EXPR_IP, EXPR_BINARY -> SqlTypeName.BINARY_TYPES.contains(plain.getSqlTypeName());
+    };
   }
 
   // Util Functions

--- a/core/src/test/java/org/opensearch/sql/expression/function/PPLUdtSignatureMatchTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/PPLUdtSignatureMatchTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
+import org.opensearch.sql.calcite.utils.PPLOperandTypes;
+
+/**
+ * Exercises {@link PPLTypeChecker#wrapUDT} against plain Calcite types. Signatures declare
+ * temporal/IP/BINARY operands as UDTs, but the analytics engine builds row types from plain Calcite
+ * types, so a UDT signature must still accept the equivalent plain type.
+ */
+class PPLUdtSignatureMatchTest {
+
+  private static final OpenSearchTypeFactory TF = OpenSearchTypeFactory.TYPE_FACTORY;
+
+  /** The checker behind {@code list(<field>)}. */
+  private static final PPLTypeChecker ANY_SCALAR =
+      PPLTypeChecker.wrapUDT(
+          ((UDFOperandMetadata.UDTOperandMetadata) PPLOperandTypes.ANY_SCALAR).allowedParamTypes());
+
+  private static RelDataType nullable(RelDataType type) {
+    return TF.createTypeWithNullability(type, true);
+  }
+
+  private static boolean accepts(RelDataType type) {
+    return ANY_SCALAR.checkOperandTypes(List.of(type));
+  }
+
+  @Test
+  void plainTimestampMatchesTimestampUdt() {
+    // date -> TIMESTAMP(3), date_nanos -> TIMESTAMP(9) on the analytics route.
+    assertTrue(accepts(nullable(TF.createSqlType(SqlTypeName.TIMESTAMP, 3))));
+    assertTrue(accepts(nullable(TF.createSqlType(SqlTypeName.TIMESTAMP, 9))));
+  }
+
+  @Test
+  void plainDateAndTimeMatchTheirUdts() {
+    assertTrue(accepts(nullable(TF.createSqlType(SqlTypeName.DATE))));
+    assertTrue(accepts(nullable(TF.createSqlType(SqlTypeName.TIME))));
+  }
+
+  @Test
+  void plainVarbinaryMatchesBinaryUdt() {
+    // ip and binary both map to VARBINARY on the analytics route.
+    assertTrue(accepts(nullable(TF.createSqlType(SqlTypeName.VARBINARY))));
+  }
+
+  @Test
+  void udtOperandsStillMatch() {
+    assertTrue(accepts(TF.createUDT(ExprUDT.EXPR_TIMESTAMP)));
+    assertTrue(accepts(TF.createUDT(ExprUDT.EXPR_DATE)));
+    assertTrue(accepts(TF.createUDT(ExprUDT.EXPR_TIME)));
+    assertTrue(accepts(TF.createUDT(ExprUDT.EXPR_IP)));
+  }
+
+  @Test
+  void plainScalarsStillMatch() {
+    assertTrue(accepts(TF.createSqlType(SqlTypeName.INTEGER)));
+    assertTrue(accepts(TF.createSqlType(SqlTypeName.BIGINT)));
+    assertTrue(accepts(TF.createSqlType(SqlTypeName.VARCHAR)));
+    assertTrue(accepts(TF.createSqlType(SqlTypeName.BOOLEAN)));
+  }
+
+  @Test
+  void nonScalarsAreStillRejected() {
+    assertFalse(
+        accepts(TF.createArrayType(TF.createSqlType(SqlTypeName.INTEGER), -1)),
+        "ANY_SCALAR must not accept arrays");
+    assertFalse(
+        accepts(
+            TF.createMapType(
+                TF.createSqlType(SqlTypeName.VARCHAR), TF.createSqlType(SqlTypeName.INTEGER))),
+        "ANY_SCALAR must not accept maps");
+  }
+}


### PR DESCRIPTION
## Description

`PPLOperandTypes.SCALAR_TYPES` declares `DATE`/`TIME`/`TIMESTAMP`/`IP`/`BINARY` operands as UDTs, but `PPLTypeChecker.typesMatch` rejected a pair outright whenever only one side extended `AbstractExprRelDataType`:

```java
if (expected instanceof AbstractExprRelDataType<?>
    || actual instanceof AbstractExprRelDataType<?>) {
  return false;
}
```

The analytics engine builds its row types from plain Calcite types (`date` → `TIMESTAMP(3)`, `date_nanos` → `TIMESTAMP(9)`, `ip` and `binary` → `VARBINARY`) plus markers that extend Calcite's `AbstractSqlType`, not `AbstractExprRelDataType`. Every such operand therefore failed the check, so `list(<date field>)` and `values(<ip field>)` were rejected.

The resulting error contradicted itself, because `getAllowedSignatures()` renders via the UDT tag while `getActualSignature()` renders via `convertRelDataTypeToExprType` — both print `TIMESTAMP`:

```
Aggregation function LIST expects field type
{[BYTE]|...|[DATE]|[TIME]|[TIMESTAMP]|[IP]|[BINARY]}, but got [TIMESTAMP]
```

This maps the UDT tag to the `SqlTypeName`s a backend would emit for the same logical type. Comparing backing types would not work, since the UDTs are all VARCHAR-backed.

Note the mapping is expressed over `SqlTypeName` rather than by reusing `OpenSearchTypeFactory.convertAnalyticsEngineRelDataTypeToExprType`: `analytics-api` is a `compileOnly` dependency of `core`, so touching those marker classes throws `NoClassDefFoundError` on any runtime classpath that lacks them. An earlier revision of this fix did exactly that and broke 168 `:ppl:test` cases.

## Testing

New `PPLUdtSignatureMatchTest` covers the `ANY_SCALAR` checker behind `list(<field>)`:
- plain `TIMESTAMP(3)`/`TIMESTAMP(9)`, `DATE`, `TIME`, `VARBINARY` are accepted
- UDT operands still match (no behavior change on the existing path)
- plain scalars (`INTEGER`, `BIGINT`, `VARCHAR`, `BOOLEAN`) still match
- arrays and maps are still rejected, so `ANY_SCALAR` has not been widened into a catch-all

Verified the test fails without the production change (3 of 6 cases) and passes with it.

| Suite | Result |
|---|---|
| `:core:test` | pass (`--rerun-tasks`) |
| `:ppl:test` | pass (`--rerun-tasks`) |
| `:opensearch:test` | pass (`--rerun-tasks`) |
| `:core:spotlessCheck`, `:ppl:spotlessCheck` | pass |

### Downstream effect

This clears 11 pre-existing `sandbox-check` integration-test failures in `opensearch-project/OpenSearch`, which consumes `opensearch-sql-plugin:3.8.0.0-SNAPSHOT`:

- `ListAggregateMultiTypeIT` — `testListDate`, `testListDateNanos`, `testListIp`, `testListBinary`
- `ListAggregateMultiShardIT` — `testListDateTwoShards`, `testListIpTwoShards`, `testListBinaryTwoShards`
- `DatetimeCoverageIT` — `testListFunctionDateUsesSpace`, `testListFunctionTimestampUsesSpace`
- `TwoShardAggregationIT`, `TwoShardOversamplingAggregationIT` — `testReduceCorrectnessAcrossTwoShards`

Those failures reproduce identically on unrelated branches, confirming they are not caused by any single PR.

## Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR created — not applicable; this restores intended behavior with no user-facing API change.