### PR TITLE
Publish the ppl-rest-spi snapshot artifact

### DIFF
--- a/.github/workflows/maven-publish-modules.yml
+++ b/.github/workflows/maven-publish-modules.yml
@@ -44,4 +44,5 @@ jobs:
           aws-region: us-east-1
       - name: publish snapshots to maven
         run: |
-          ./gradlew publishUnifiedQueryPublicationToSnapshotsRepository
+          ./gradlew publishUnifiedQueryPublicationToSnapshotsRepository \
+                    publishRestSpiPublicationToSnapshotsRepository


### PR DESCRIPTION
## Description

#5656 added the `ppl-rest-spi` module and made `opensearch` depend on it (`opensearch/build.gradle`: `api project(':ppl-rest-spi')`). The published `unified-query-opensearch` POM therefore carries a compile-scope dependency on `org.opensearch.query:ppl-rest-spi` — but that artifact was never published.

The publish workflow runs only:

```
./gradlew publishUnifiedQueryPublicationToSnapshotsRepository
```

which matches publications named `unifiedQuery`. `ppl-rest-spi` deliberately names its publication `restSpi` so it keeps the plain `ppl-rest-spi` artifactId rather than the `unified-query-` prefix (see the comment in `ppl-rest-spi/build.gradle`), so its publish task never runs.

Result: every external consumer of `unified-query-opensearch` — opensearch-spark, opensearch-cli, and the OpenSearch sandbox — fails to resolve dependencies.

`ppl-rest-spi/build.gradle` already configures the publication and the Snapshots repository correctly, so this just runs its publish task alongside the existing one. No build-logic change.

## Verification

The dangling reference, in the currently published POM (`unified-query-opensearch-3.8.0.0-20260804.211640-79.pom`):

```xml
<dependency>
  <groupId>org.opensearch.query</groupId>
  <artifactId>ppl-rest-spi</artifactId>
  <version>3.8.0.0-SNAPSHOT</version>
  <scope>compile</scope>
</dependency>
```

And the artifact is absent from every configured repository:

| Repository | `ppl-rest-spi` metadata |
|---|---|
| `ci.opensearch.org/ci/dbc/snapshots/maven` | 404 |
| `ci.opensearch.org/maven2` | 404 |
| `repo.maven.apache.org/maven2` | 404 |

Confirmed the task produces exactly the coordinates the resolver searches for, via `:ppl-rest-spi:publishRestSpiPublicationToMavenLocal`:

```
org/opensearch/query/ppl-rest-spi/3.8.0.0-SNAPSHOT/ppl-rest-spi-3.8.0.0-SNAPSHOT.pom
org/opensearch/query/ppl-rest-spi/3.8.0.0-SNAPSHOT/ppl-rest-spi-3.8.0.0-SNAPSHOT.jar
org/opensearch/query/ppl-rest-spi/3.8.0.0-SNAPSHOT/ppl-rest-spi-3.8.0.0-SNAPSHOT.module
```

### Downstream failure this fixes

`sandbox-check` in `opensearch-project/OpenSearch` (e.g. [run 30951657273](https://github.com/opensearch-project/OpenSearch/actions/runs/30951657273), failing in under 2 minutes at dependency resolution):

```
Could not determine the dependencies of task
':sandbox:plugins:test-ppl-frontend:forbiddenApisMain'.
> Could not resolve all dependencies for configuration
  ':sandbox:plugins:test-ppl-frontend:runtimeClasspath'
   > Could not find org.opensearch.query:ppl-rest-spi:3.8.0.0-SNAPSHOT
     Required by:
       test-ppl-frontend > unified-query-ppl > unified-query-protocol
                         > unified-query-opensearch
```

Note this needs a merge to `main` to take effect, since the publish workflow only triggers on push to a release branch.

## Check List
- [x] Commits are signed per the DCO using `--signoff`.
- [x] New functionality includes testing — not applicable; CI workflow change, verified via `publishRestSpiPublicationToMavenLocal`.
- [x] Public documentation issue/PR created — not applicable; no user-facing change.