### PR TITLE
fix: [bug] PPL query with `mvindex()` fails when `plugins.calcite.pushdown.enabled=true` (#5660)

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
@@ -552,6 +552,35 @@ public class CalciteArrayFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testMvindexWithNonZeroIndexPushdown() throws IOException {
+    // Regression test for #5660: mvindex with non-zero literal index fails during pushdown
+    // because PLUS(1,1) gets widened to BIGINT but ITEM expects INTEGER.
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval arr = array('a', 'b', 'c'), result = mvindex(arr, 2)"
+                    + " | head 1 | fields result",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "string"));
+    verifyDataRows(actual, rows("c"));
+  }
+
+  @Test
+  public void testMvindexWithStatsAggregationPushdown() throws IOException {
+    // Regression test for #5660: mvindex with non-zero index in aggregation context
+    // triggers pushdown script compilation where BIGINT/INTEGER mismatch occurred.
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval arr = array('x', 'y', 'z'), e = mvindex(arr, 1)"
+                    + " | stats count() by e",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("count()", "bigint"), schema("e", "string"));
+  }
+
+  @Test
   public void testMvfindWithMatch() throws IOException {
     JSONObject actual =
         executeQuery(

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serde/RexStandardizer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serde/RexStandardizer.java
@@ -83,7 +83,19 @@ public class RexStandardizer extends RexBiVisitorImpl<RexNode, ScriptParameterHe
       // Do normalization before standardization
       Pair<SqlOperator, List<RexNode>> normalized = RexNormalize.normalize(call.op, call.operands);
       List<RexNode> standardizedOperands = visitList(normalized.right, helper, update);
-      return helper.rexBuilder.makeCall(call.getType(), normalized.left, standardizedOperands);
+      RexNode result =
+          helper.rexBuilder.makeCall(call.getType(), normalized.left, standardizedOperands);
+
+      if (allowNumericTypeWiden
+          && SqlTypeUtil.isExactNumeric(call.getType())
+          && !call.getType().getSqlTypeName().equals(SqlTypeName.BIGINT)) {
+        RelDataType targetType =
+            OpenSearchTypeFactory.TYPE_FACTORY.createTypeWithNullability(
+                call.getType(), call.getType().isNullable());
+        result = helper.rexBuilder.makeCast(targetType, result);
+      }
+
+      return result;
     } finally {
       helper.stack.pop();
     }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/serde/RelJsonSerializerTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/serde/RelJsonSerializerTest.java
@@ -351,6 +351,67 @@ public class RelJsonSerializerTest {
   }
 
   @Test
+  void testArithmeticInItemIndexPreservesIntegerType() {
+    // Simulates the mvindex(entity, 1) scenario where PLUS(1, 1) is used as an array index.
+    // The PLUS operands get widened to BIGINT during standardization (for doc-value compat),
+    // but the result must remain INTEGER since ITEM/arrayItemOptional expects int.
+    RelDataType intType = TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER);
+    RexNode plusCall =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            rexBuilder.makeLiteral(1, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER)),
+            rexBuilder.makeLiteral(1, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER)));
+
+    final ScriptParameterHelper helper =
+        new ScriptParameterHelper(rowType.getFieldList(), fieldTypes, rexBuilder);
+    String code = serializer.serialize(plusCall, helper);
+    RexNode deserialized = serializer.deserialize(code);
+
+    // After round-trip, the result should be wrapped in CAST(INTEGER) to preserve the type
+    assertEquals(SqlTypeName.INTEGER, deserialized.getType().getSqlTypeName());
+  }
+
+  @Test
+  void testArithmeticBigintNotWrappedInCast() {
+    // When the original arithmetic type is already BIGINT, no cast should be added.
+    RexNode plusCall =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            rexBuilder.makeLiteral(1L, TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT)),
+            rexBuilder.makeLiteral(1L, TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT)));
+
+    final ScriptParameterHelper helper =
+        new ScriptParameterHelper(rowType.getFieldList(), fieldTypes, rexBuilder);
+    String code = serializer.serialize(plusCall, helper);
+    RexNode deserialized = serializer.deserialize(code);
+
+    // BIGINT arithmetic should stay BIGINT without extra CAST
+    assertEquals(SqlTypeName.BIGINT, deserialized.getType().getSqlTypeName());
+  }
+
+  @Test
+  void testArithmeticWithFieldPreservesIntegerType() {
+    // Simulates arithmetic with a field reference: Number + 1
+    // The field gets widened to BIGINT, but the original PLUS type is INTEGER,
+    // so the result should be cast back to INTEGER.
+    RexNode plusCall =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            rexBuilder.makeInputRef(rowType.getFieldList().get(1).getType(), 1),
+            rexBuilder.makeLiteral(1, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER)));
+
+    Map<String, ExprType> fieldTypesWithNumber =
+        Map.of("Referer", ExprCoreType.STRING, "Number", ExprCoreType.INTEGER);
+    final ScriptParameterHelper helper =
+        new ScriptParameterHelper(rowType.getFieldList(), fieldTypesWithNumber, rexBuilder);
+    String code = serializer.serialize(plusCall, helper);
+    RexNode deserialized = serializer.deserialize(code);
+
+    // Result should be INTEGER after deserialization
+    assertEquals(SqlTypeName.INTEGER, deserialized.getType().getSqlTypeName());
+  }
+
+  @Test
   void deserialize_rejects_disallowed_class() throws Exception {
     java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
     java.io.ObjectOutputStream objectOutput = new java.io.ObjectOutputStream(output);


### PR DESCRIPTION
### Description
Fix Calcite pushdown `CompileException` where arithmetic in array index expressions (e.g., `mvindex(entity, 1)`) produces `long` instead of `int` at runtime.

`RexStandardizer` widens arithmetic operands to `BIGINT` for doc-value compatibility, but `PLUS` nodes do not have their type serialized in `JSON` (unlike `CAST/MINUS`). On deserialization the type is re-derived from `BIGINT` operands, breaking operators like `ITEM` that expect `int`.

**Fix**: Wrap arithmetic results in an explicit `CAST(INTEGER)` in `RexStandardizer.visitCall()` when the original type is narrower than `BIGINT`. `CAST` nodes always serialize their type, so `INTEGER` is preserved through serialization and deserialization.

Test Added:
* `testArithmeticInItemIndexPreservesIntegerType`: `PLUS(int, int)` preserves `INTEGER` type through serialization round-trip (the main bug fix) 
* `testArithmeticBigintNotWrappedInCast`: `PLUS(bigint, bigint)` stays `BIGINT` without unnecessary `CAST` (no regression)  
* `testArithmeticWithFieldPreservesIntegerType`: `field_ref + 1` where field is `INTEGER` preserves `INTEGER` (field-based index scenario)
* `testMvindexWithNonZeroIndexPushdown`:  `mvindex(arr, 2)` works, non-zero literal index with pushdown
* `testMvindexWithStatsAggregationPushdown`: `mvindex(arr, 1)` inside stats count() by e

### Related Issues
Resolves #5660
See also: #5670 (alternative plan-layer fix that is ineffective because the serialization layer overrides it)

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
