### PR TITLE
Equality on an ARRAY-typed field means CONTAINS

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -936,8 +936,66 @@ public class PPLFuncImpTable {
       return needsLong ? SqlTypeName.BIGINT : SqlTypeName.INTEGER;
     }
 
+    /**
+     * Matches {@code [ARRAY<T>, scalar]} where the scalar is comparable with the array's element
+     * type. Drives the multi-valued-field comparison overloads: equality on an ARRAY-typed field
+     * is CONTAINS (any element equals the value), mirroring Lucene's term-match semantics on
+     * multi-valued fields. The scalar side must not itself be an ARRAY — array-to-array equality
+     * stays unsupported rather than silently meaning overlap.
+     */
+    private static final PPLTypeChecker ARRAY_ELEMENT_COMPARABLE =
+        new PPLTypeChecker() {
+          @Override
+          public boolean checkOperandTypes(List<RelDataType> types) {
+            if (types.size() != 2) {
+              return false;
+            }
+            RelDataType arrayType = types.get(0);
+            RelDataType valueType = types.get(1);
+            if (arrayType.getSqlTypeName() != SqlTypeName.ARRAY
+                || valueType.getSqlTypeName() == SqlTypeName.ARRAY) {
+              return false;
+            }
+            RelDataType elementType = arrayType.getComponentType();
+            return elementType != null
+                && PPLTypeChecker.PPLComparableTypeChecker.isComparable(elementType, valueType);
+          }
+
+          @Override
+          public String getAllowedSignatures() {
+            return "[ARRAY,ELEMENT_TYPE]";
+          }
+
+          @Override
+          public List<List<RelDataType>> getParameterTypes() {
+            RelDataType anyType = TYPE_FACTORY.createSqlType(SqlTypeName.ANY);
+            return List.of(List.of(anyType, anyType));
+          }
+        };
+
     void populate() {
       // register operators for comparison
+      //
+      // Equality against a multi-valued (ARRAY-typed) field means CONTAINS, matching
+      // OpenSearch/Lucene semantics where a term query on a multi-valued field matches a
+      // document if ANY value equals the term (SortedSetDocValues / inverted-index behavior).
+      // Registered BEFORE the scalar overloads so an [ARRAY<T>, T] argument pair resolves here;
+      // scalar comparisons are untouched. array_contains uses element equality (not regex),
+      // exactly mirroring a Lucene term match.
+      register(
+          EQUAL,
+          (FunctionImp2)
+              (builder, array, value) ->
+                  builder.makeCall(SqlLibraryOperators.ARRAY_CONTAINS, array, value),
+          ARRAY_ELEMENT_COMPARABLE);
+      register(
+          NOTEQUAL,
+          (FunctionImp2)
+              (builder, array, value) ->
+                  builder.makeCall(
+                      SqlStdOperatorTable.NOT,
+                      builder.makeCall(SqlLibraryOperators.ARRAY_CONTAINS, array, value)),
+          ARRAY_ELEMENT_COMPARABLE);
       registerOperator(NOTEQUAL, PPLBuiltinOperators.NOT_EQUALS_IP, SqlStdOperatorTable.NOT_EQUALS);
       registerOperator(EQUAL, PPLBuiltinOperators.EQUALS_IP, SqlStdOperatorTable.EQUALS);
       registerOperator(GREATER, PPLBuiltinOperators.GREATER_IP, SqlStdOperatorTable.GREATER_THAN);

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLTypeChecker.java
@@ -275,11 +275,14 @@ public interface PPLTypeChecker {
     /**
      * Modified from {@link SqlTypeUtil#isComparable(RelDataType, RelDataType)} to
      *
+     * <p>Package-private so the multi-valued-field comparison overloads in {@code
+     * PPLFuncImpTable} can reuse the same comparability rules for an array's element type.
+     *
      * @param type1 first type
      * @param type2 second type
      * @return true if the two types are comparable, false otherwise
      */
-    private static boolean isComparable(RelDataType type1, RelDataType type2) {
+    static boolean isComparable(RelDataType type1, RelDataType type2) {
       if (type1.isStruct() != type2.isStruct()) {
         return false;
       }

--- a/core/src/test/java/org/opensearch/sql/expression/function/ArrayEqualsResolutionTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/function/ArrayEqualsResolutionTest.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.expression.function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+
+class ArrayEqualsResolutionTest {
+
+  @Test
+  void equalsOnArrayColumnResolvesToArrayContains() {
+    RexBuilder builder = new RexBuilder(OpenSearchTypeFactory.TYPE_FACTORY);
+    RelDataType varchar =
+        OpenSearchTypeFactory.TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
+    RelDataType arrayOfVarchar =
+        OpenSearchTypeFactory.TYPE_FACTORY.createTypeWithNullability(
+            OpenSearchTypeFactory.TYPE_FACTORY.createArrayType(varchar, -1), true);
+
+    RexNode arrayRef = builder.makeInputRef(arrayOfVarchar, 0);
+    RexNode literal = builder.makeLiteral("alpha");
+    System.out.println("array type = " + arrayRef.getType().getSqlTypeName());
+    System.out.println("literal type = " + literal.getType().getSqlTypeName());
+
+    RexNode resolved =
+        PPLFuncImpTable.INSTANCE.resolve(builder, BuiltinFunctionName.EQUAL, arrayRef, literal);
+    System.out.println("resolved = " + resolved);
+    assertEquals("ARRAY_CONTAINS", ((org.apache.calcite.rex.RexCall) resolved).getOperator().getName());
+  }
+}


### PR DESCRIPTION
### Description

Registers `EQUAL`/`NOTEQUAL` overloads for `[ARRAY<T>, scalar]` argument pairs in `PPLFuncImpTable`: `tags = 'x'` on an ARRAY-typed column now resolves to Calcite's `ARRAY_CONTAINS(tags, 'x')` (element equality), and `!=` to `NOT(ARRAY_CONTAINS(...))`.

**Why.** This gives PPL the same semantics a Lucene term query has on a multi-valued field: a document matches when *any* value equals the term. Columnar storage engines surface multi-valued fields as ARRAY-typed columns — e.g. the OpenSearch composite engine's Parquet format, where a keyword field mapped `multi_value: true` is stored as a `LIST<element>` column ([opensearch-project/OpenSearch#22685](https://github.com/opensearch-project/OpenSearch/pull/22685)). Previously the analyzer rejected the comparison outright:

```
EQUAL function expects {[IP,IP],[COMPARABLE_TYPE,COMPARABLE_TYPE]}, but got [ARRAY,STRING]
```

**Design notes.**
- The overloads are registered *before* the scalar comparison overloads so an `[ARRAY, scalar]` pair resolves to contains; all scalar comparisons are untouched.
- The new `ARRAY_ELEMENT_COMPARABLE` type checker matches only when arg0 is ARRAY, arg1 is **not** an ARRAY (array-to-array equality stays unsupported rather than silently meaning overlap), and the element type is comparable with the value under the same rules scalar comparisons use — `PPLComparableTypeChecker.isComparable`, widened from private to package-private rather than duplicated.
- `ARRAY_CONTAINS` is element equality, not regex — `mvfind` (unanchored regex) is not a substitute for term equality.
- Engine-executability: DataFusion executes this natively as `array_has`; the Calcite Enumerable path uses Calcite's own `ARRAY_CONTAINS` implementation.

**Verification.** Unit test asserts `resolve(EQUAL, ARRAY<VARCHAR> ref, 'alpha')` produces `ARRAY_CONTAINS($0, 'alpha')`. Verified end-to-end against a live OpenSearch composite-engine cluster (Parquet LIST column → PPL `where tags = 'alpha'` → DataFusion `array_has`): contains-match, exact element equality (no substring match), and `!=` as NOT(contains) with three-valued-logic null exclusion. The consuming integration test lives in the OpenSearch PR above (`MultiValueFieldIT.testEqualsOnMultiValueColumnMeansContains`) and is muted there until this change ships in the published snapshot.

### Related Issues
Companion to opensearch-project/OpenSearch#22685 (multi-value keyword fields in the composite engine).

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
