### PR TITLE
Lower frontend-private rel nodes before the analytics-engine handoff (fix dedup 500)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/CalciteToolsHelper.java
@@ -556,9 +556,27 @@ public class CalciteToolsHelper {
   private static final HepProgram HEP_PROGRAM =
       new HepProgramBuilder().addRuleCollection(hepRuleList).build();
 
+  // PPLSimplifyDedupRule collapses the ROW_NUMBER window form of dedup into a LogicalDedup so
+  // DedupPushdownRule can push it into a Lucene scan. The analytics engine has no such pushdown and
+  // cannot plan a LogicalDedup, so its optimization runs the standard window form directly.
+  private static final HepProgram ANALYTICS_HEP_PROGRAM =
+      new HepProgramBuilder()
+          .addRuleCollection(
+              hepRuleList.stream()
+                  .filter(rule -> rule != PPLSimplifyDedupRule.DEDUP_SIMPLIFY_RULE)
+                  .toList())
+          .build();
+
   public static RelNode optimize(RelNode plan, CalcitePlanContext context) {
     Util.discard(context);
     HepPlanner planner = new HepPlanner(HEP_PROGRAM);
+    planner.setRoot(plan);
+    return planner.findBestExp();
+  }
+
+  public static RelNode optimizeForAnalytics(RelNode plan, CalcitePlanContext context) {
+    Util.discard(context);
+    HepPlanner planner = new HepPlanner(ANALYTICS_HEP_PROGRAM);
     planner.setRoot(plan);
     return planner.findBestExp();
   }

--- a/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
+++ b/plugin/src/main/java/org/opensearch/sql/plugin/rest/RestUnifiedQueryAction.java
@@ -234,7 +234,7 @@ public class RestUnifiedQueryAction {
                     plan = addFetchSizeLimit(plan, planContext, fetchSize);
                     plan = addQuerySizeLimit(plan, planContext);
                     plan =
-                        org.opensearch.sql.calcite.utils.CalciteToolsHelper.optimize(
+                        org.opensearch.sql.calcite.utils.CalciteToolsHelper.optimizeForAnalytics(
                             plan, planContext);
                     RelNode finalPlan = plan;
                     Runnable executeTask =

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDedupTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLDedupTest.java
@@ -14,6 +14,7 @@ import org.apache.calcite.test.CalciteAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.sql.calcite.plan.rule.PPLSimplifyDedupRule;
+import org.opensearch.sql.calcite.utils.CalciteToolsHelper;
 
 public class CalcitePPLDedupTest extends CalcitePPLAbstractTest {
 
@@ -486,5 +487,39 @@ public class CalcitePPLDedupTest extends CalcitePPLAbstractTest {
     HepPlanner planner = new HepPlanner(program);
     planner.setRoot(root);
     return planner.findBestExp();
+  }
+
+  /**
+   * {@code optimize} collapses dedup into a {@code LogicalDedup} (for Lucene pushdown), which the
+   * analytics engine cannot plan. {@code optimizeForAnalytics} omits that rule so dedup keeps the
+   * {@code ROW_NUMBER() OVER (PARTITION BY ...)} window form the analytics engine can plan
+   * (#22671).
+   */
+  @Test
+  public void testOptimizeForAnalyticsKeepsRowNumberForm() {
+    RelNode raw = getRelNodeRaw("source=EMP | where SAL > 1000 | dedup DEPTNO");
+
+    Assert.assertTrue(
+        "optimize() should collapse dedup into a LogicalDedup:\n",
+        CalciteToolsHelper.optimize(raw, null).explain().contains("LogicalDedup"));
+
+    String analytics = CalciteToolsHelper.optimizeForAnalytics(raw, null).explain();
+    Assert.assertFalse(
+        "optimizeForAnalytics should not produce a LogicalDedup:\n" + analytics,
+        analytics.contains("LogicalDedup"));
+    Assert.assertTrue(
+        "optimizeForAnalytics should keep the ROW_NUMBER window form:\n" + analytics,
+        analytics.contains("ROW_NUMBER"));
+    Assert.assertTrue(
+        "where predicate should be preserved:\n" + analytics, analytics.contains(">($5, 1000)"));
+  }
+
+  /** A dedup-free plan is identical under both optimize variants. */
+  @Test
+  public void testOptimizeForAnalyticsMatchesOptimizeWithoutDedup() {
+    RelNode raw = getRelNodeRaw("source=EMP | where SAL > 1000 | fields DEPTNO");
+    Assert.assertEquals(
+        CalciteToolsHelper.optimize(raw, null).explain(),
+        CalciteToolsHelper.optimizeForAnalytics(raw, null).explain());
   }
 }


### PR DESCRIPTION
### Description

PPL `dedup` followed by any pipe stage fails with a 500 on the analytics-engine route:

```
source=idx | dedup category | fields category
→ 500 RuntimeException: There was internal problem at backend
```

Server-side: `IllegalStateException: Project rule encountered unmarked child [LogicalDedup]` at `OpenSearchProjectRule.onMatch`. Deterministic for every `dedup … | <anything>` shape.

Resolves #22671.

> **Supersedes [opensearch-project/OpenSearch#22675](https://github.com/opensearch-project/OpenSearch/pull/22675).** That PR fixed the same issue on the analytics-engine side by having the engine reflect over foreign rel nodes to discover and run their convert rules. Per review feedback, the frontend should own its own rules rather than the engine repairing plans it receives — this PR takes that direction. The companion QA IT (`DedupCommandIT`) will land as a small OpenSearch-core PR.

#### Root cause

`dedup` is planned as a `ROW_NUMBER() OVER (PARTITION BY keys)` + Filter composite. `CalciteToolsHelper.optimize` — run on both the Lucene and analytics routes — then collapses that composite into a `LogicalDedup` via `PPLSimplifyDedupRule`, so that `DedupPushdownRule` can push dedup into a Lucene scan.

On the **Lucene path**, physical planning (Volcano) lowers the `LogicalDedup` back (or pushes it into the scan), so it disappears. On the **analytics path**, the optimized `RelNode` goes straight to the analytics engine with no Volcano step, so the `LogicalDedup` survives to the engine's marking phase, which rejects it as an unmarked child.

`LogicalDedup` exists solely to enable the Lucene pushdown (`DedupPushdownRule` is its only consumer); the analytics engine has no equivalent pushdown and cannot plan the node.

#### Fix

Add `CalciteToolsHelper.optimizeForAnalytics`, which runs the same HEP rules as `optimize` **minus `PPLSimplifyDedupRule`**. `RestUnifiedQueryAction` calls it on the analytics route, so the dedup composite is never collapsed and the analytics engine receives the standard `ROW_NUMBER` window form it can plan directly.

- **No collapse-then-expand.** Rather than generate a `LogicalDedup` and convert it back, the analytics route simply doesn't generate it — the rule that creates it (only useful for the Lucene pushdown) is skipped.
- **Lucene path untouched.** `optimize` is unchanged; the Lucene route keeps `PPLSimplifyDedupRule` and its dedup pushdown.
- **Script-based thread-pool routing preserved.** Optimization still runs before dispatch (`ScriptDetector` inspects the optimized plan), so worker-pool routing is unaffected.

### Testing

| test | before | after |
|---|---|---|
| `CalcitePPLDedupTest.testOptimizeForAnalyticsKeepsRowNumberForm` (`optimize` produces `LogicalDedup`; `optimizeForAnalytics` keeps `ROW_NUMBER`, no `LogicalDedup`, predicate preserved) | — | pass |
| `CalcitePPLDedupTest.testOptimizeForAnalyticsMatchesOptimizeWithoutDedup` (dedup-free plan identical under both variants) | — | pass |
| `CalcitePPLDedupTest` (full class, regression) | 12/12 | 14/14 pass |
| Live analytics-engine cluster, parquet-backed index: `dedup category \| fields category`, `dedup category \| stats count()`, `dedup 2 category \| fields category` | 500 `unmarked child [LogicalDedup]` | 200, correct rows |

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented (method Javadoc + PR).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
