### PR TITLE
fix: Prevent InvalidTypeIdException when Prometheus metric has 'type'…

### DIFF
--- a/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/ExecuteDirectQueryActionResponse.java
+++ b/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/ExecuteDirectQueryActionResponse.java
@@ -131,19 +131,11 @@ public class ExecuteDirectQueryActionResponse extends ActionResponse {
     Map<String, DataSourceResult> parsedResults = new HashMap<>();
 
     try {
-      // Add type to JSON if it doesn't already have it
-      final String resultWithType;
-      if (!rawResult.contains("\"type\":")) {
-        resultWithType = addTypeFieldToJson(rawResult, dataSourceType);
-      } else {
-        resultWithType = rawResult;
-      }
-
       DataSourceResult result;
       // Parse based on the determined data source type
       switch (dataSourceType.toLowerCase()) {
         case "prometheus":
-          result = OBJECT_MAPPER.readValue(resultWithType, PrometheusResult.class);
+          result = OBJECT_MAPPER.readValue(rawResult, PrometheusResult.class);
           break;
           // Add cases for other data source types as they're implemented
         default:
@@ -162,16 +154,5 @@ public class ExecuteDirectQueryActionResponse extends ActionResponse {
     }
 
     return parsedResults;
-  }
-
-  /**
-   * Adds a type field to the JSON string for proper polymorphic deserialization.
-   *
-   * @param rawJson The raw JSON string without a type field
-   * @param type The type to add
-   * @return Modified JSON string with type field
-   */
-  private String addTypeFieldToJson(String rawJson, String type) {
-    return rawJson.replaceFirst("\\{", "{\"type\":\"" + type + "\",");
   }
 }

--- a/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/datasource/DataSourceResult.java
+++ b/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/datasource/DataSourceResult.java
@@ -5,15 +5,14 @@
 
 package org.opensearch.sql.directquery.transport.model.datasource;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 /**
  *
  * @opensearch.experimental
  *
  * Interface for results from various data sources.
+ *
+ * <p>Concrete result types are dispatched by the {@code dataSourceType} string carried alongside
+ * the serialized payload in the transport protocol (see {@code ExecuteDirectQueryActionResponse}),
+ * so no in-JSON Jackson type discriminator is used here.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@JsonSubTypes({@JsonSubTypes.Type(value = PrometheusResult.class, name = "prometheus")})
 public interface DataSourceResult {}

--- a/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/datasource/PrometheusResult.java
+++ b/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/datasource/PrometheusResult.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.directquery.transport.model.datasource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @JsonTypeName("prometheus")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PrometheusResult implements DataSourceResult {
 

--- a/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/datasource/PrometheusResult.java
+++ b/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/datasource/PrometheusResult.java
@@ -7,8 +7,6 @@ package org.opensearch.sql.directquery.transport.model.datasource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
@@ -22,8 +20,6 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@JsonTypeName("prometheus")
-@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PrometheusResult implements DataSourceResult {
 

--- a/direct-query/src/test/java/org/opensearch/sql/directquery/transport/model/ExecuteDirectQueryActionResponseTest.java
+++ b/direct-query/src/test/java/org/opensearch/sql/directquery/transport/model/ExecuteDirectQueryActionResponseTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opensearch.core.common.io.stream.InputStreamStreamInput;
@@ -145,6 +146,43 @@ public class ExecuteDirectQueryActionResponseTest {
     assertEquals(1, deserializedResponse.getResults().size());
     assertTrue(deserializedResponse.getResults().containsKey("prom-ds-1"));
     assertInstanceOf(PrometheusResult.class, deserializedResponse.getResults().get("prom-ds-1"));
+  }
+
+  @Test
+  public void testStreamSerializationPreservesTypeMetricLabel() throws IOException {
+    // Regression for #5684: a metric label literally named "type" must survive the
+    // writeTo() -> StreamInput round-trip (the transport path), not only parseResult().
+    Map<String, DataSourceResult> results = new HashMap<>();
+    PrometheusResult prometheusResult = new PrometheusResult();
+    prometheusResult.setResultType("vector");
+    PrometheusResult.PrometheusResultItem item = new PrometheusResult.PrometheusResultItem();
+    Map<String, String> metric = new HashMap<>();
+    metric.put("type", "counter");
+    metric.put("__name__", "http_requests_total");
+    item.setMetric(metric);
+    prometheusResult.setResult(List.of(item));
+    results.put("prom-ds-1", prometheusResult);
+
+    ExecuteDirectQueryActionResponse response =
+        new ExecuteDirectQueryActionResponse("query-type-label", results, "session-type-label");
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    StreamOutput streamOutput = new OutputStreamStreamOutput(outputStream);
+    response.writeTo(streamOutput);
+    streamOutput.close();
+
+    StreamInput streamInput =
+        new InputStreamStreamInput(new ByteArrayInputStream(outputStream.toByteArray()));
+    ExecuteDirectQueryActionResponse deserialized =
+        new ExecuteDirectQueryActionResponse(streamInput);
+    streamInput.close();
+
+    PrometheusResult out = (PrometheusResult) deserialized.getResults().get("prom-ds-1");
+    assertInstanceOf(PrometheusResult.class, out);
+    assertEquals("vector", out.getResultType());
+    assertEquals(1, out.getResult().size());
+    assertEquals("counter", out.getResult().get(0).getMetric().get("type"));
+    assertEquals("http_requests_total", out.getResult().get(0).getMetric().get("__name__"));
   }
 
   @Test

--- a/direct-query/src/test/java/org/opensearch/sql/directquery/transport/model/ExecuteDirectQueryActionResponseTest.java
+++ b/direct-query/src/test/java/org/opensearch/sql/directquery/transport/model/ExecuteDirectQueryActionResponseTest.java
@@ -287,4 +287,30 @@ public class ExecuteDirectQueryActionResponseTest {
     PrometheusResult result = (PrometheusResult) response.getResults().get(dataSourceName);
     assertNotNull(result);
   }
+
+  @Test
+  public void testPrometheusResultWithTypeLabelInMetric() throws IOException {
+    // Regression test: metrics containing a label named "type" should not cause
+    // InvalidTypeIdException during deserialization (GitHub #5684)
+    String queryId = "query-type-label";
+    String sessionId = "session-type-label";
+    String rawResult =
+        "{\"resultType\":\"vector\",\"result\":[{\"metric\":"
+            + "{\"__name__\":\"cpu_usage\",\"type\":\"gauge\",\"instance\":\"localhost:9090\"},"
+            + "\"value\":[1625000000,\"0.5\"]}]}";
+    String dataSourceName = "prom-with-type-label";
+    String dataSourceType = "prometheus";
+
+    ExecuteDirectQueryActionResponse response =
+        new ExecuteDirectQueryActionResponse(
+            queryId, rawResult, sessionId, dataSourceName, dataSourceType);
+
+    assertEquals(queryId, response.getQueryId());
+    assertEquals(1, response.getResults().size());
+    assertInstanceOf(PrometheusResult.class, response.getResults().get(dataSourceName));
+    PrometheusResult result = (PrometheusResult) response.getResults().get(dataSourceName);
+    assertNotNull(result.getResult());
+    assertEquals(1, result.getResult().size());
+    assertEquals("gauge", result.getResult().get(0).getMetric().get("type"));
+  }
 }


### PR DESCRIPTION
… label

Add @JsonTypeInfo(use = JsonTypeInfo.Id.NONE) on PrometheusResult to override the parent DataSourceResult interface's polymorphic type handling. This prevents Jackson from interpreting a metric label named 'type' as the polymorphic type discriminator, which caused InvalidTypeIdException during deserialization.

The type dispatch is already handled explicitly via switch statement in ExecuteDirectQueryActionResponse, so polymorphic type annotations are not needed on the concrete class.

Resolves opensearch-project#5684

### Description
  PromQL queries fail with `InvalidTypeIdException` when a metric contains a label named `type`. This happens because the `DataSourceResult`
  interface uses `@JsonTypeInfo(property = "type")` for polymorphic deserialization, and Jackson interprets the metric's `type` label as the
  type discriminator.
  
  **Fix:** Add `@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)` on `PrometheusResult` to override the parent's polymorphic type handling. The type
  dispatch is already handled explicitly via switch statement in `ExecuteDirectQueryActionResponse`, so annotation-based polymorphism is unnecessary on the concrete class.
  
 Includes a regression test with a metric containing `"type": "gauge"` label.
  
  ### Related Issues
  Resolves #5684
  
  ### Check List
  - [x] New functionality includes testing.
  - [ ] New functionality has been documented.
   - [ ] New functionality has javadoc added.
   - [ ] New functionality has a user manual doc added.
  - [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
  - [ ] API changes companion pull request
  [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
  - [x] Commits are signed per the DCO using `--signoff` or `-s`.
  - [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
  
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
  For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
