### PR TITLE
Fix PPL search command ignoring wildcards and over-matching quoted values (#5682)

### DIFF
--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchAnd.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchAnd.java
@@ -7,10 +7,12 @@ package org.opensearch.sql.ast.expression;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.opensearch.sql.data.type.ExprType;
 
 /** Search expression for AND operator. */
 @Getter
@@ -23,8 +25,8 @@ public class SearchAnd extends SearchExpression {
   private final SearchExpression right;
 
   @Override
-  public String toQueryString() {
-    return left.toQueryString() + " AND " + right.toQueryString();
+  public String toQueryString(Function<String, ExprType> fieldTypeResolver) {
+    return left.toQueryString(fieldTypeResolver) + " AND " + right.toQueryString(fieldTypeResolver);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchComparison.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchComparison.java
@@ -9,10 +9,12 @@ import static org.opensearch.sql.utils.QueryStringUtils.maskField;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.utils.QueryStringUtils;
 
 /** Search expression for field comparisons. */
@@ -46,9 +48,11 @@ public class SearchComparison extends SearchExpression {
   private final SearchLiteral value;
 
   @Override
-  public String toQueryString() {
-    String fieldName = QueryStringUtils.escapeFieldName(field.getField().toString());
-    String valueStr = value.toQueryString();
+  public String toQueryString(Function<String, ExprType> fieldTypeResolver) {
+    String rawFieldName = field.getField().toString();
+    String fieldName = QueryStringUtils.escapeFieldName(rawFieldName);
+    ExprType resolvedType = fieldTypeResolver.apply(rawFieldName);
+    String valueStr = value.toQueryString(resolvedType);
     switch (operator) {
       case NOT_EQUALS:
         return "( _exists_:" + fieldName + " AND NOT " + fieldName + ":" + valueStr + " )";

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchExpression.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchExpression.java
@@ -5,17 +5,33 @@
 
 package org.opensearch.sql.ast.expression;
 
+import java.util.function.Function;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.data.type.ExprType;
 
 /** Base class for search expressions that get converted to query_string syntax. */
 public abstract class SearchExpression extends UnresolvedExpression {
 
   /**
-   * Convert this search expression to query_string syntax.
+   * Convert this search expression to query_string syntax without field-type awareness.
    *
    * @return the query string representation
    */
-  public abstract String toQueryString();
+  public String toQueryString() {
+    return toQueryString(f -> null);
+  }
+
+  /**
+   * Convert this search expression to query_string syntax, using {@code fieldTypeResolver} to
+   * resolve the OpenSearch type of a field when the emission depends on whether the field is
+   * keyword vs. text. When the resolver returns {@code null}, emission falls back to the
+   * field-type-agnostic form (same as {@link #toQueryString()}).
+   *
+   * @param fieldTypeResolver maps a field name to its resolved {@link ExprType}, or null when
+   *     unknown
+   * @return the query string representation
+   */
+  public abstract String toQueryString(Function<String, ExprType> fieldTypeResolver);
 
   /**
    * Convert the search expression to anonymized string

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchGroup.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchGroup.java
@@ -7,10 +7,12 @@ package org.opensearch.sql.ast.expression;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.opensearch.sql.data.type.ExprType;
 
 /** Search expression for grouped expressions (parentheses). */
 @Getter
@@ -22,8 +24,8 @@ public class SearchGroup extends SearchExpression {
   private final SearchExpression expression;
 
   @Override
-  public String toQueryString() {
-    return "(" + expression.toQueryString() + ")";
+  public String toQueryString(Function<String, ExprType> fieldTypeResolver) {
+    return "(" + expression.toQueryString(fieldTypeResolver) + ")";
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchIn.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchIn.java
@@ -7,11 +7,13 @@ package org.opensearch.sql.ast.expression;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.utils.QueryStringUtils;
 
 /** Search expression for IN operator. */
@@ -25,10 +27,12 @@ public class SearchIn extends SearchExpression {
   private final List<SearchLiteral> values;
 
   @Override
-  public String toQueryString() {
+  public String toQueryString(Function<String, ExprType> fieldTypeResolver) {
+    String rawFieldName = field.getField().toString();
     String fieldName = QueryStringUtils.escapeFieldName(field.getField().toString());
+    ExprType resolvedType = fieldTypeResolver.apply(rawFieldName);
     String valueList =
-        values.stream().map(SearchLiteral::toQueryString).collect(Collectors.joining(" OR "));
+        values.stream().map(v -> v.toQueryString(resolvedType)).collect(Collectors.joining(" OR "));
 
     return fieldName + ":( " + valueList + " )";
   }

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchLiteral.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchLiteral.java
@@ -42,16 +42,16 @@ public class SearchLiteral extends SearchExpression {
    * mapping decides whether the value gets analyzed:
    *
    * <ul>
+   *   <li><b>keyword family with a wildcard</b> — the analyzer is a no-op, so the value has to
+   *       reach Lucene as one term for the pattern to apply to the whole stored value. Emitted
+   *       unquoted with whitespace escaped.
    *   <li><b>text</b> — honor the user's quoting. Unquoted passes through, so {@code *} and {@code
    *       ?} stay query_string operators. Quoted becomes a phrase, which is how a user asks for
    *       "this whole value, in order" against the analyzed tokens.
-   *   <li><b>keyword family</b> — quoting is irrelevant, because the analyzer is a no-op and a
-   *       quoted phrase resolves to the same single term as a bare one. Emit whole-value semantics
-   *       instead: a wildcard pattern when the value holds an unescaped wildcard, otherwise an
-   *       exact term. Whitespace is escaped in the wildcard form so query_string keeps the value as
-   *       one clause rather than splitting at the space and dropping the field binding.
-   *   <li><b>anything else</b> (date, numeric, ip, boolean, or unresolved) — legacy behavior,
-   *       untouched. Those mappings do their own value parsing and are out of scope here.
+   *   <li><b>everything else</b> — keyword without a wildcard, plus date, numeric, ip, boolean and
+   *       unresolved fields. Legacy behavior. Note that quoting genuinely carries no information on
+   *       keyword: with a no-op analyzer a quoted phrase and a bare term both resolve to the same
+   *       single term, so there is nothing to gain by rewriting the emission here.
    * </ul>
    *
    * @param indexType the enclosing field's OpenSearch index-mapping type, or null if unresolved
@@ -70,6 +70,13 @@ public class SearchLiteral extends SearchExpression {
       if (val instanceof String) {
         String str = (String) val;
 
+        // A keyword-family field carries whole-value semantics, so a value holding a wildcard has
+        // to reach Lucene as a single term. Escaping the whitespace keeps query_string from
+        // splitting at the space and dropping the field binding on the tail.
+        if (isKeywordLike(indexType) && hasUnescapedWildcard(str)) {
+          return unquoted(str).replace(" ", "\\ ");
+        }
+
         if (isTextLike(indexType)) {
           // Quoting requests phrase semantics. One exception: a whitespace-free value carrying an
           // unescaped wildcard is emitted unquoted, because quoting would let the analyzer discard
@@ -80,11 +87,8 @@ public class SearchLiteral extends SearchExpression {
           return userQuoted && !wildcardTerm ? quoted(str) : unquoted(str);
         }
 
-        if (isKeywordLike(indexType)) {
-          return hasUnescapedWildcard(str) ? unquoted(str).replace(" ", "\\ ") : quoted(str);
-        }
-
-        // Other mappings (date, numeric, ip, boolean) and unresolved fields: legacy behavior.
+        // Everything else — keyword without a wildcard, plus date, numeric, ip, boolean and
+        // unresolved fields: legacy behavior, byte-identical to before this change.
         return str.contains(" ") ? quoted(str) : unquoted(str);
       }
     }

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchLiteral.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchLiteral.java
@@ -23,7 +23,12 @@ import org.opensearch.sql.utils.QueryStringUtils;
 public class SearchLiteral extends SearchExpression {
 
   private final UnresolvedExpression literal;
-  private final boolean isPhrase;
+
+  /**
+   * Whether the user wrote this value inside quotes in the PPL query. On a text field this is the
+   * user's explicit request for phrase semantics — see {@link #toQueryString(ExprType)}.
+   */
+  private final boolean userQuoted;
 
   @Override
   public String toQueryString(Function<String, ExprType> fieldTypeResolver) {
@@ -33,14 +38,23 @@ public class SearchLiteral extends SearchExpression {
 
   /**
    * Emits the query_string form for a literal on the RHS of {@link SearchComparison} or inside
-   * {@link SearchIn}. The decision tree is documented in {@code
-   * docs/dev/ppl-search-command-contract-empirical.md} — briefly: whitespace + wildcard on a
-   * non-text index escapes the space so the parser keeps the value as one whole-value pattern;
-   * everything else falls through to phrase (with whitespace) or unquoted-escaped (without).
+   * {@link SearchIn}. Emission is driven by the enclosing field's index mapping, because the
+   * mapping decides whether the value gets analyzed:
    *
-   * @param indexType the enclosing field's OpenSearch index-mapping type (text/keyword/...) — used
-   *     only to distinguish text-like from everything else; null means unknown, treated as
-   *     text-like so we don't regress the phrase form.
+   * <ul>
+   *   <li><b>text</b> — honor the user's quoting. Unquoted passes through, so {@code *} and {@code
+   *       ?} stay query_string operators. Quoted becomes a phrase, which is how a user asks for
+   *       "this whole value, in order" against the analyzed tokens.
+   *   <li><b>keyword family</b> — quoting is irrelevant, because the analyzer is a no-op and a
+   *       quoted phrase resolves to the same single term as a bare one. Emit whole-value semantics
+   *       instead: a wildcard pattern when the value holds an unescaped wildcard, otherwise an
+   *       exact term. Whitespace is escaped in the wildcard form so query_string keeps the value as
+   *       one clause rather than splitting at the space and dropping the field binding.
+   *   <li><b>anything else</b> (date, numeric, ip, boolean, or unresolved) — legacy behavior,
+   *       untouched. Those mappings do their own value parsing and are out of scope here.
+   * </ul>
+   *
+   * @param indexType the enclosing field's OpenSearch index-mapping type, or null if unresolved
    */
   public String toQueryString(ExprType indexType) {
     if (literal instanceof Literal) {
@@ -56,36 +70,51 @@ public class SearchLiteral extends SearchExpression {
       if (val instanceof String) {
         String str = (String) val;
 
-        // [D] whitespace + wildcard on a non-text index: single term with space escaped, so the
-        // query_string parser keeps the value as one whole-value pattern (a raw space would
-        // split it into two clauses and drop the field binding on the right half).
-        if (isPhrase && !isTextLike(indexType) && hasUnescapedWildcard(str)) {
-          return QueryStringUtils.escapeLuceneSpecialCharacters(str).replace(" ", "\\ ");
+        if (isTextLike(indexType)) {
+          // Quoting requests phrase semantics. One exception: a whitespace-free value carrying an
+          // unescaped wildcard is emitted unquoted, because quoting would let the analyzer discard
+          // the wildcard (`foo*` would stop matching `foobar`). That is only safe without
+          // whitespace — with a space, an unquoted value would be split into separate clauses and
+          // the tail would lose its field binding, so those stay phrases.
+          boolean wildcardTerm = hasUnescapedWildcard(str) && !str.contains(" ");
+          return userQuoted && !wildcardTerm ? quoted(str) : unquoted(str);
         }
 
-        // [B]/[C] quoted phrase.
-        if (isPhrase) {
-          str = QueryStringUtils.escapeLuceneSpecialCharacters(str);
-          return "\"" + str + "\"";
+        if (isKeywordLike(indexType)) {
+          return hasUnescapedWildcard(str) ? unquoted(str).replace(" ", "\\ ") : quoted(str);
         }
 
-        // [A] unquoted; escape Lucene specials, wildcards preserved.
-        return QueryStringUtils.escapeLuceneSpecialCharacters(str);
+        // Other mappings (date, numeric, ip, boolean) and unresolved fields: legacy behavior.
+        return str.contains(" ") ? quoted(str) : unquoted(str);
       }
     }
 
-    String text = literal.toString();
-    return QueryStringUtils.escapeLuceneSpecialCharacters(text);
+    return unquoted(literal.toString());
+  }
+
+  private static String quoted(String str) {
+    return "\"" + QueryStringUtils.escapeLuceneSpecialCharacters(str) + "\"";
+  }
+
+  private static String unquoted(String str) {
+    return QueryStringUtils.escapeLuceneSpecialCharacters(str);
   }
 
   private static boolean isTextLike(ExprType type) {
     if (type == null) {
-      // Unknown type → treat as text-like so we take the phrase branch and avoid a text
-      // regression when the resolver fails to identify the field.
-      return true;
+      return false;
     }
     String legacyName = type.getOriginalExprType().legacyTypeName();
     return "TEXT".equalsIgnoreCase(legacyName) || "MATCH_ONLY_TEXT".equalsIgnoreCase(legacyName);
+  }
+
+  private static boolean isKeywordLike(ExprType type) {
+    if (type == null) {
+      return false;
+    }
+    String legacyName = type.getOriginalExprType().legacyTypeName();
+    return "KEYWORD".equalsIgnoreCase(legacyName)
+        || "CONSTANT_KEYWORD".equalsIgnoreCase(legacyName);
   }
 
   private static boolean hasUnescapedWildcard(String s) {

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchLiteral.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchLiteral.java
@@ -7,10 +7,12 @@ package org.opensearch.sql.ast.expression;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.utils.QueryStringUtils;
 
 /** Search expression for standalone literals. */
@@ -24,7 +26,23 @@ public class SearchLiteral extends SearchExpression {
   private final boolean isPhrase;
 
   @Override
-  public String toQueryString() {
+  public String toQueryString(Function<String, ExprType> fieldTypeResolver) {
+    // Unfielded literal: no enclosing field, so no index type. Take the field-agnostic branch.
+    return toQueryString((ExprType) null);
+  }
+
+  /**
+   * Emits the query_string form for a literal on the RHS of {@link SearchComparison} or inside
+   * {@link SearchIn}. The decision tree is documented in {@code
+   * docs/dev/ppl-search-command-contract-empirical.md} — briefly: whitespace + wildcard on a
+   * non-text index escapes the space so the parser keeps the value as one whole-value pattern;
+   * everything else falls through to phrase (with whitespace) or unquoted-escaped (without).
+   *
+   * @param indexType the enclosing field's OpenSearch index-mapping type (text/keyword/...) — used
+   *     only to distinguish text-like from everything else; null means unknown, treated as
+   *     text-like so we don't regress the phrase form.
+   */
+  public String toQueryString(ExprType indexType) {
     if (literal instanceof Literal) {
       Literal lit = (Literal) literal;
       Object val = lit.getValue();
@@ -38,21 +56,50 @@ public class SearchLiteral extends SearchExpression {
       if (val instanceof String) {
         String str = (String) val;
 
-        // Phrase search - preserve quotes
+        // [D] whitespace + wildcard on a non-text index: single term with space escaped, so the
+        // query_string parser keeps the value as one whole-value pattern (a raw space would
+        // split it into two clauses and drop the field binding on the right half).
+        if (isPhrase && !isTextLike(indexType) && hasUnescapedWildcard(str)) {
+          return QueryStringUtils.escapeLuceneSpecialCharacters(str).replace(" ", "\\ ");
+        }
+
+        // [B]/[C] quoted phrase.
         if (isPhrase) {
-          // Escape special chars inside the phrase
           str = QueryStringUtils.escapeLuceneSpecialCharacters(str);
           return "\"" + str + "\"";
         }
 
-        // Regular string - escape special characters
+        // [A] unquoted; escape Lucene specials, wildcards preserved.
         return QueryStringUtils.escapeLuceneSpecialCharacters(str);
       }
     }
 
-    // Default: escape the text representation
     String text = literal.toString();
     return QueryStringUtils.escapeLuceneSpecialCharacters(text);
+  }
+
+  private static boolean isTextLike(ExprType type) {
+    if (type == null) {
+      // Unknown type → treat as text-like so we take the phrase branch and avoid a text
+      // regression when the resolver fails to identify the field.
+      return true;
+    }
+    String legacyName = type.getOriginalExprType().legacyTypeName();
+    return "TEXT".equalsIgnoreCase(legacyName) || "MATCH_ONLY_TEXT".equalsIgnoreCase(legacyName);
+  }
+
+  private static boolean hasUnescapedWildcard(String s) {
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      if (c == '\\' && i + 1 < s.length()) {
+        i++;
+        continue;
+      }
+      if (c == '*' || c == '?') {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchNot.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchNot.java
@@ -7,10 +7,12 @@ package org.opensearch.sql.ast.expression;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.opensearch.sql.data.type.ExprType;
 
 /** Search expression for NOT operator. */
 @Getter
@@ -22,8 +24,8 @@ public class SearchNot extends SearchExpression {
   private final SearchExpression expression;
 
   @Override
-  public String toQueryString() {
-    return "NOT(" + expression.toQueryString() + ")";
+  public String toQueryString(Function<String, ExprType> fieldTypeResolver) {
+    return "NOT(" + expression.toQueryString(fieldTypeResolver) + ")";
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/ast/expression/SearchOr.java
+++ b/core/src/main/java/org/opensearch/sql/ast/expression/SearchOr.java
@@ -7,10 +7,12 @@ package org.opensearch.sql.ast.expression;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.opensearch.sql.data.type.ExprType;
 
 /** Search expression for OR operator. */
 @Getter
@@ -23,8 +25,8 @@ public class SearchOr extends SearchExpression {
   private final SearchExpression right;
 
   @Override
-  public String toQueryString() {
-    return left.toQueryString() + " OR " + right.toQueryString();
+  public String toQueryString(Function<String, ExprType> fieldTypeResolver) {
+    return left.toQueryString(fieldTypeResolver) + " OR " + right.toQueryString(fieldTypeResolver);
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -173,6 +173,7 @@ import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.ast.tree.Values;
 import org.opensearch.sql.ast.tree.Window;
 import org.opensearch.sql.ast.tree.Xyseries;
+import org.opensearch.sql.calcite.plan.AbstractOpenSearchTable;
 import org.opensearch.sql.calcite.plan.AliasFieldsWrappable;
 import org.opensearch.sql.calcite.plan.HighlightPushDown;
 import org.opensearch.sql.calcite.plan.OpenSearchConstants;
@@ -192,6 +193,7 @@ import org.opensearch.sql.common.error.ErrorReport;
 import org.opensearch.sql.common.patterns.PatternUtils;
 import org.opensearch.sql.common.utils.StringUtils;
 import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
 import org.opensearch.sql.datasource.DataSourceService;
 import org.opensearch.sql.exception.CalciteUnsupportedException;
 import org.opensearch.sql.exception.SemanticCheckException;
@@ -297,11 +299,33 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   public RelNode visitSearch(Search node, CalcitePlanContext context) {
     // Visit the Relation child to get the scan
     node.getChild().get(0).accept(this, context);
+    // Resolve query_string from the structured expression when available so we can consult the
+    // OpenSearch table's field-type map for per-field text/keyword awareness (e.g. escape
+    // space + wildcard on keyword vs. quoted phrase on text). Falls back to the pre-computed
+    // string for callers that never populated the structured expression.
+    String queryString;
+    if (node.getOriginalExpression() != null) {
+      // TODO: index-mapping type (text/keyword) is storage metadata, not a data type — the right
+      // home is a field/scan annotation on RelDataType, but that needs a Calcite rule-pipeline
+      // audit (rules rebuild row types and can drop custom fields). For now, unwrap the table
+      // and read the ExprType map directly.
+      java.util.Map<String, ExprType> typesByName = new java.util.HashMap<>();
+      RelNode scan = context.relBuilder.peek();
+      RelOptTable relOptTable = scan.getTable();
+      if (relOptTable != null) {
+        AbstractOpenSearchTable osTable = relOptTable.unwrap(AbstractOpenSearchTable.class);
+        if (osTable != null) {
+          typesByName.putAll(osTable.getFieldTypes());
+        }
+      }
+      queryString = node.getOriginalExpression().toQueryString(typesByName::get);
+    } else {
+      queryString = node.getQueryString();
+    }
     // Create query_string function
     Function queryStringFunc =
         AstDSL.function(
-            "query_string",
-            AstDSL.unresolvedArg("query", AstDSL.stringLiteral(node.getQueryString())));
+            "query_string", AstDSL.unresolvedArg("query", AstDSL.stringLiteral(queryString)));
     RexNode queryStringRex = rexVisitor.analyze(queryStringFunc, context);
 
     context.relBuilder.filter(queryStringRex);

--- a/core/src/test/java/org/opensearch/sql/ast/expression/SearchLiteralTest.java
+++ b/core/src/test/java/org/opensearch/sql/ast/expression/SearchLiteralTest.java
@@ -118,9 +118,13 @@ class SearchLiteralTest {
   // -------------------------------------------------------------------------
 
   @Test
-  void keyword_no_wildcard_emits_exact_term_as_phrase() {
+  void keyword_no_wildcard_keeps_legacy_emission() {
+    // Quoting carries no information on keyword — a quoted phrase and a bare term both resolve to
+    // the same single term — so the emission is left exactly as it was.
+    assertEquals("foo", bare("foo").toQueryString(KEYWORD));
+    assertEquals("foo", q("foo").toQueryString(KEYWORD));
+    assertEquals("foo\\-bar", q("foo-bar").toQueryString(KEYWORD));
     assertEquals("\"foo bar\"", q("foo bar").toQueryString(KEYWORD));
-    assertEquals("\"foo\"", bare("foo").toQueryString(KEYWORD));
   }
 
   @Test

--- a/core/src/test/java/org/opensearch/sql/ast/expression/SearchLiteralTest.java
+++ b/core/src/test/java/org/opensearch/sql/ast/expression/SearchLiteralTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ast.expression;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.data.type.ExprType;
+
+/**
+ * Field-type-aware emission for {@link SearchLiteral} and {@link SearchComparison}.
+ *
+ * <p>Space + unescaped wildcard on a keyword field must not be phrase-quoted (the phrase form
+ * silently strips wildcard semantics inside quotes on keyword). On text (or when the type is
+ * unknown), the legacy phrase form is preserved to avoid regressing today's behavior — see the
+ * repro matrix in issue #5682.
+ */
+class SearchLiteralTest {
+
+  /** Stub {@link ExprType} that reports a given legacyTypeName — enough for isTextLike(). */
+  private static ExprType typeOf(String legacyName) {
+    return new ExprType() {
+      @Override
+      public String typeName() {
+        return legacyName;
+      }
+
+      @Override
+      public String legacyTypeName() {
+        return legacyName;
+      }
+    };
+  }
+
+  private static final ExprType KEYWORD = typeOf("KEYWORD");
+  private static final ExprType TEXT = typeOf("TEXT");
+  private static final ExprType MATCH_ONLY_TEXT = typeOf("MATCH_ONLY_TEXT");
+
+  private static SearchLiteral phrase(String value) {
+    return new SearchLiteral(new Literal(value, DataType.STRING), true);
+  }
+
+  private static SearchLiteral bare(String value) {
+    return new SearchLiteral(new Literal(value, DataType.STRING), false);
+  }
+
+  // -------------------------------------------------------------------------
+  // Phrase without wildcard: unchanged on both field types (regression guard).
+  // -------------------------------------------------------------------------
+
+  @Test
+  void phrase_no_wildcard_keyword_stays_quoted() {
+    assertEquals("\"foo bar\"", phrase("foo bar").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void phrase_no_wildcard_text_stays_quoted() {
+    assertEquals("\"foo bar\"", phrase("foo bar").toQueryString(TEXT));
+  }
+
+  // -------------------------------------------------------------------------
+  // Phrase with unescaped wildcard on keyword: emit escaped-space wildcard term.
+  // These are the D-family rows fixed by issue #5682.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void phrase_trailing_wildcard_keyword_emits_escaped_space_prefix() {
+    // P6-k: name="foo bar*" → PrefixQuery on whole keyword term
+    assertEquals("foo\\ bar*", phrase("foo bar*").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void phrase_leading_wildcard_keyword_emits_escaped_space_wildcard() {
+    // L3-k: name="*foo bar"
+    assertEquals("*foo\\ bar", phrase("*foo bar").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void phrase_interior_wildcard_keyword_emits_escaped_space_wildcard() {
+    // I3-k: name="foo *baz"
+    assertEquals("foo\\ *baz", phrase("foo *baz").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void phrase_question_wildcard_keyword_emits_escaped_space_wildcard() {
+    // Q5-k: name="foo b?r"
+    assertEquals("foo\\ b?r", phrase("foo b?r").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void phrase_with_special_chars_and_wildcard_keyword_escapes_all() {
+    // D3-k repro: name="POST /test-logs/_search*" → PrefixQuery, special chars still escaped.
+    assertEquals(
+        "POST\\ \\/test\\-logs\\/_search*",
+        phrase("POST /test-logs/_search*").toQueryString(KEYWORD));
+  }
+
+  // -------------------------------------------------------------------------
+  // Phrase with unescaped wildcard on text / match_only_text / unknown: keep
+  // legacy phrase form (no regression on text; wildcard silently ignored by
+  // Lucene inside phrase, same as today).
+  // -------------------------------------------------------------------------
+
+  @Test
+  void phrase_wildcard_text_keeps_phrase_form() {
+    assertEquals("\"foo bar*\"", phrase("foo bar*").toQueryString(TEXT));
+  }
+
+  @Test
+  void phrase_wildcard_match_only_text_keeps_phrase_form() {
+    assertEquals("\"foo bar*\"", phrase("foo bar*").toQueryString(MATCH_ONLY_TEXT));
+  }
+
+  @Test
+  void phrase_wildcard_unknown_type_keeps_phrase_form() {
+    // Unknown → treat as text-like so we never regress an unresolvable field.
+    assertEquals("\"foo bar*\"", phrase("foo bar*").toQueryString((ExprType) null));
+  }
+
+  // -------------------------------------------------------------------------
+  // Phrase with escaped wildcard: user asked for a LITERAL '*'/'?' — keep the
+  // phrase form even on keyword. The isPhrase flag was set for a reason.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void phrase_escaped_wildcard_keyword_keeps_phrase_form() {
+    // Input string literally contains `foo \*` (backslash + '*'). hasUnescapedWildcard() sees the
+    // backslash and skips '*', so we treat this as a phrase with a literal '*' — no emission
+    // change. QueryStringUtils.escapeLuceneSpecialCharacters keeps '\\' and '*' untouched.
+    assertEquals("\"foo \\*\"", phrase("foo \\*").toQueryString(KEYWORD));
+  }
+
+  // -------------------------------------------------------------------------
+  // Non-phrase (no space): field type does not matter — legacy code path.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void bare_wildcard_keyword_emits_unquoted() {
+    // P1: name="foo*" — never a phrase, works today.
+    assertEquals("foo*", bare("foo*").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void bare_wildcard_text_emits_unquoted() {
+    assertEquals("foo*", bare("foo*").toQueryString(TEXT));
+  }
+
+  // -------------------------------------------------------------------------
+  // Backwards-compat: arg-less toQueryString() must match the null-type branch
+  // (legacy phrase form) so callers that never wire the resolver see no change.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void argless_toQueryString_matches_null_type_branch() {
+    SearchLiteral lit = phrase("foo bar*");
+    assertEquals(lit.toQueryString((ExprType) null), lit.toQueryString());
+  }
+
+  // -------------------------------------------------------------------------
+  // End-to-end via SearchComparison + resolver — the actual planner call path.
+  // -------------------------------------------------------------------------
+
+  @Test
+  void comparison_resolves_field_type_and_emits_wildcard_on_keyword() {
+    // name="foo bar*" on a keyword field → name:foo\ bar*
+    SearchComparison cmp =
+        new SearchComparison(
+            new Field(new QualifiedName("name"), List.of()),
+            SearchComparison.Operator.EQUALS,
+            phrase("foo bar*"));
+    Function<String, ExprType> resolver = Map.of("name", KEYWORD)::get;
+    assertEquals("name:foo\\ bar*", cmp.toQueryString(resolver));
+  }
+
+  @Test
+  void comparison_resolves_field_type_and_keeps_phrase_on_text() {
+    SearchComparison cmp =
+        new SearchComparison(
+            new Field(new QualifiedName("name"), List.of()),
+            SearchComparison.Operator.EQUALS,
+            phrase("foo bar*"));
+    Function<String, ExprType> resolver = Map.of("name", TEXT)::get;
+    assertEquals("name:\"foo bar*\"", cmp.toQueryString(resolver));
+  }
+
+  @Test
+  void comparison_unknown_field_falls_back_to_phrase_form() {
+    SearchComparison cmp =
+        new SearchComparison(
+            new Field(new QualifiedName("unmapped"), List.of()),
+            SearchComparison.Operator.EQUALS,
+            phrase("foo bar*"));
+    // Resolver returns null for unknown fields.
+    Function<String, ExprType> resolver = f -> null;
+    assertEquals("unmapped:\"foo bar*\"", cmp.toQueryString(resolver));
+  }
+}

--- a/core/src/test/java/org/opensearch/sql/ast/expression/SearchLiteralTest.java
+++ b/core/src/test/java/org/opensearch/sql/ast/expression/SearchLiteralTest.java
@@ -14,16 +14,17 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.sql.data.type.ExprType;
 
 /**
- * Field-type-aware emission for {@link SearchLiteral} and {@link SearchComparison}.
+ * Index-mapping-aware emission for {@link SearchLiteral} and {@link SearchComparison}.
  *
- * <p>Space + unescaped wildcard on a keyword field must not be phrase-quoted (the phrase form
- * silently strips wildcard semantics inside quotes on keyword). On text (or when the type is
- * unknown), the legacy phrase form is preserved to avoid regressing today's behavior — see the
- * repro matrix in issue #5682.
+ * <p>On <b>text</b>, the user's quoting is honored: unquoted keeps {@code *}/{@code ?} as
+ * query_string operators, quoted becomes a phrase. On the <b>keyword family</b>, quoting is
+ * irrelevant (the analyzer is a no-op) so we emit whole-value semantics — a wildcard pattern when
+ * the value holds an unescaped wildcard, otherwise an exact term. Other mappings keep legacy
+ * behavior.
  */
 class SearchLiteralTest {
 
-  /** Stub {@link ExprType} that reports a given legacyTypeName — enough for isTextLike(). */
+  /** Stub {@link ExprType} reporting a given legacyTypeName — enough for the mapping checks. */
   private static ExprType typeOf(String legacyName) {
     return new ExprType() {
       @Override
@@ -39,126 +40,156 @@ class SearchLiteralTest {
   }
 
   private static final ExprType KEYWORD = typeOf("KEYWORD");
+  private static final ExprType CONSTANT_KEYWORD = typeOf("CONSTANT_KEYWORD");
   private static final ExprType TEXT = typeOf("TEXT");
   private static final ExprType MATCH_ONLY_TEXT = typeOf("MATCH_ONLY_TEXT");
+  private static final ExprType DATE = typeOf("TIMESTAMP");
+  private static final ExprType LONG = typeOf("LONG");
 
-  private static SearchLiteral phrase(String value) {
+  /** Value the user wrote inside quotes. */
+  private static SearchLiteral q(String value) {
     return new SearchLiteral(new Literal(value, DataType.STRING), true);
   }
 
+  /** Value the user wrote bare. */
   private static SearchLiteral bare(String value) {
     return new SearchLiteral(new Literal(value, DataType.STRING), false);
   }
 
   // -------------------------------------------------------------------------
-  // Phrase without wildcard: unchanged on both field types (regression guard).
+  // TEXT: honor the user's quoting.
   // -------------------------------------------------------------------------
 
   @Test
-  void phrase_no_wildcard_keyword_stays_quoted() {
-    assertEquals("\"foo bar\"", phrase("foo bar").toQueryString(KEYWORD));
+  void text_quoted_emits_phrase() {
+    assertEquals("\"foo bar\"", q("foo bar").toQueryString(TEXT));
   }
 
   @Test
-  void phrase_no_wildcard_text_stays_quoted() {
-    assertEquals("\"foo bar\"", phrase("foo bar").toQueryString(TEXT));
-  }
-
-  // -------------------------------------------------------------------------
-  // Phrase with unescaped wildcard on keyword: emit escaped-space wildcard term.
-  // These are the D-family rows fixed by issue #5682.
-  // -------------------------------------------------------------------------
-
-  @Test
-  void phrase_trailing_wildcard_keyword_emits_escaped_space_prefix() {
-    // P6-k: name="foo bar*" → PrefixQuery on whole keyword term
-    assertEquals("foo\\ bar*", phrase("foo bar*").toQueryString(KEYWORD));
+  void text_unquoted_emits_bare_term() {
+    assertEquals("foo", bare("foo").toQueryString(TEXT));
   }
 
   @Test
-  void phrase_leading_wildcard_keyword_emits_escaped_space_wildcard() {
-    // L3-k: name="*foo bar"
-    assertEquals("*foo\\ bar", phrase("*foo bar").toQueryString(KEYWORD));
+  void text_quoted_wildcard_term_stays_unquoted() {
+    // Whitespace-free value with a wildcard: emitted unquoted so '*' keeps operator meaning.
+    // Quoting it would let the analyzer discard the wildcard.
+    assertEquals("foo*", q("foo*").toQueryString(TEXT));
+    assertEquals("f?o", q("f?o").toQueryString(TEXT));
   }
 
   @Test
-  void phrase_interior_wildcard_keyword_emits_escaped_space_wildcard() {
-    // I3-k: name="foo *baz"
-    assertEquals("foo\\ *baz", phrase("foo *baz").toQueryString(KEYWORD));
+  void text_quoted_wildcard_with_whitespace_emits_phrase() {
+    // With whitespace, unquoted would split into separate clauses and the tail would lose its
+    // field binding, so the phrase form is kept.
+    assertEquals("\"foo bar*\"", q("foo bar*").toQueryString(TEXT));
+    assertEquals("\"*foo bar\"", q("*foo bar").toQueryString(TEXT));
   }
 
   @Test
-  void phrase_question_wildcard_keyword_emits_escaped_space_wildcard() {
-    // Q5-k: name="foo b?r"
-    assertEquals("foo\\ b?r", phrase("foo b?r").toQueryString(KEYWORD));
+  void text_escaped_wildcard_is_not_a_wildcard_term() {
+    // '*' is escaped, so it is a literal — the value has no unescaped wildcard and stays a phrase.
+    assertEquals("\"foo\\*\"", q("foo\\*").toQueryString(TEXT));
   }
 
   @Test
-  void phrase_with_special_chars_and_wildcard_keyword_escapes_all() {
-    // D3-k repro: name="POST /test-logs/_search*" → PrefixQuery, special chars still escaped.
-    assertEquals(
-        "POST\\ \\/test\\-logs\\/_search*",
-        phrase("POST /test-logs/_search*").toQueryString(KEYWORD));
-  }
-
-  // -------------------------------------------------------------------------
-  // Phrase with unescaped wildcard on text / match_only_text / unknown: keep
-  // legacy phrase form (no regression on text; wildcard silently ignored by
-  // Lucene inside phrase, same as today).
-  // -------------------------------------------------------------------------
-
-  @Test
-  void phrase_wildcard_text_keeps_phrase_form() {
-    assertEquals("\"foo bar*\"", phrase("foo bar*").toQueryString(TEXT));
+  void text_unquoted_wildcard_keeps_operator() {
+    assertEquals("foo*", bare("foo*").toQueryString(TEXT));
   }
 
   @Test
-  void phrase_wildcard_match_only_text_keeps_phrase_form() {
-    assertEquals("\"foo bar*\"", phrase("foo bar*").toQueryString(MATCH_ONLY_TEXT));
+  void text_match_only_text_behaves_like_text() {
+    assertEquals("\"foo bar\"", q("foo bar").toQueryString(MATCH_ONLY_TEXT));
+    assertEquals("foo*", bare("foo*").toQueryString(MATCH_ONLY_TEXT));
   }
 
+  /**
+   * A quoted value the analyzer splits must not become an OR of tokens. These values hold no
+   * whitespace, so before the mapping split they were emitted unquoted.
+   */
   @Test
-  void phrase_wildcard_unknown_type_keeps_phrase_form() {
-    // Unknown → treat as text-like so we never regress an unresolvable field.
-    assertEquals("\"foo bar*\"", phrase("foo bar*").toQueryString((ExprType) null));
+  void text_quoted_value_the_analyzer_splits_emits_phrase() {
+    assertEquals("\"foo\\-bar\"", q("foo-bar").toQueryString(TEXT));
+    assertEquals("\"foo=bar\"", q("foo=bar").toQueryString(TEXT));
   }
 
   // -------------------------------------------------------------------------
-  // Phrase with escaped wildcard: user asked for a LITERAL '*'/'?' — keep the
-  // phrase form even on keyword. The isPhrase flag was set for a reason.
+  // KEYWORD FAMILY: quoting is irrelevant; wildcard presence selects the form.
   // -------------------------------------------------------------------------
 
   @Test
-  void phrase_escaped_wildcard_keyword_keeps_phrase_form() {
-    // Input string literally contains `foo \*` (backslash + '*'). hasUnescapedWildcard() sees the
-    // backslash and skips '*', so we treat this as a phrase with a literal '*' — no emission
-    // change. QueryStringUtils.escapeLuceneSpecialCharacters keeps '\\' and '*' untouched.
-    assertEquals("\"foo \\*\"", phrase("foo \\*").toQueryString(KEYWORD));
+  void keyword_no_wildcard_emits_exact_term_as_phrase() {
+    assertEquals("\"foo bar\"", q("foo bar").toQueryString(KEYWORD));
+    assertEquals("\"foo\"", bare("foo").toQueryString(KEYWORD));
   }
 
-  // -------------------------------------------------------------------------
-  // Non-phrase (no space): field type does not matter — legacy code path.
-  // -------------------------------------------------------------------------
+  @Test
+  void keyword_no_wildcard_quoting_is_irrelevant() {
+    assertEquals(q("foo-bar").toQueryString(KEYWORD), bare("foo-bar").toQueryString(KEYWORD));
+  }
 
   @Test
-  void bare_wildcard_keyword_emits_unquoted() {
-    // P1: name="foo*" — never a phrase, works today.
+  void keyword_wildcard_with_space_escapes_the_space() {
+    // The reported bug (#5682): whole-value pattern, not a phrase with a literal '*'.
+    assertEquals("foo\\ bar*", q("foo bar*").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void keyword_wildcard_without_space_emits_bare_pattern() {
+    assertEquals("foo*", q("foo*").toQueryString(KEYWORD));
     assertEquals("foo*", bare("foo*").toQueryString(KEYWORD));
   }
 
   @Test
-  void bare_wildcard_text_emits_unquoted() {
-    assertEquals("foo*", bare("foo*").toQueryString(TEXT));
+  void keyword_leading_and_interior_wildcards_escape_spaces() {
+    assertEquals("*foo\\ bar", q("*foo bar").toQueryString(KEYWORD));
+    assertEquals("foo\\ *baz", q("foo *baz").toQueryString(KEYWORD));
+    assertEquals("foo\\ b?r", q("foo b?r").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void keyword_wildcard_with_special_chars_escapes_all() {
+    assertEquals(
+        "POST\\ \\/test\\-logs\\/_search*", q("POST /test-logs/_search*").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void keyword_escaped_wildcard_is_an_exact_term() {
+    // The user escaped '*', so it is a literal — no wildcard, so the exact-term form applies.
+    assertEquals("\"foo \\*\"", q("foo \\*").toQueryString(KEYWORD));
+  }
+
+  @Test
+  void constant_keyword_behaves_like_keyword() {
+    assertEquals("\"foo bar\"", q("foo bar").toQueryString(CONSTANT_KEYWORD));
+    assertEquals("foo\\ bar*", q("foo bar*").toQueryString(CONSTANT_KEYWORD));
   }
 
   // -------------------------------------------------------------------------
-  // Backwards-compat: arg-less toQueryString() must match the null-type branch
-  // (legacy phrase form) so callers that never wire the resolver see no change.
+  // OTHER MAPPINGS + unresolved: legacy behavior (space check), untouched.
   // -------------------------------------------------------------------------
 
   @Test
+  void date_field_keeps_legacy_unquoted_form() {
+    // Hyphens are escaped by the legacy path too — this is unchanged from before the mapping
+    // split, and query_string still parses the value as a date.
+    assertEquals("2024\\-01\\-15", q("2024-01-15").toQueryString(DATE));
+  }
+
+  @Test
+  void numeric_field_keeps_legacy_unquoted_form() {
+    assertEquals("not\\-a\\-number", q("not-a-number").toQueryString(LONG));
+  }
+
+  @Test
+  void unresolved_field_keeps_legacy_space_check() {
+    assertEquals("\"foo bar*\"", q("foo bar*").toQueryString((ExprType) null));
+    assertEquals("foo*", q("foo*").toQueryString((ExprType) null));
+  }
+
+  @Test
   void argless_toQueryString_matches_null_type_branch() {
-    SearchLiteral lit = phrase("foo bar*");
+    SearchLiteral lit = q("foo bar*");
     assertEquals(lit.toQueryString((ExprType) null), lit.toQueryString());
   }
 
@@ -166,38 +197,32 @@ class SearchLiteralTest {
   // End-to-end via SearchComparison + resolver — the actual planner call path.
   // -------------------------------------------------------------------------
 
+  private static SearchComparison cmp(String field, SearchLiteral value) {
+    return new SearchComparison(
+        new Field(new QualifiedName(field), List.of()), SearchComparison.Operator.EQUALS, value);
+  }
+
   @Test
-  void comparison_resolves_field_type_and_emits_wildcard_on_keyword() {
-    // name="foo bar*" on a keyword field → name:foo\ bar*
-    SearchComparison cmp =
-        new SearchComparison(
-            new Field(new QualifiedName("name"), List.of()),
-            SearchComparison.Operator.EQUALS,
-            phrase("foo bar*"));
+  void comparison_emits_wildcard_pattern_on_keyword() {
     Function<String, ExprType> resolver = Map.of("name", KEYWORD)::get;
-    assertEquals("name:foo\\ bar*", cmp.toQueryString(resolver));
+    assertEquals("name:foo\\ bar*", cmp("name", q("foo bar*")).toQueryString(resolver));
   }
 
   @Test
-  void comparison_resolves_field_type_and_keeps_phrase_on_text() {
-    SearchComparison cmp =
-        new SearchComparison(
-            new Field(new QualifiedName("name"), List.of()),
-            SearchComparison.Operator.EQUALS,
-            phrase("foo bar*"));
-    Function<String, ExprType> resolver = Map.of("name", TEXT)::get;
-    assertEquals("name:\"foo bar*\"", cmp.toQueryString(resolver));
+  void comparison_emits_phrase_on_text_when_quoted() {
+    Function<String, ExprType> resolver = Map.of("body", TEXT)::get;
+    assertEquals("body:\"foo=bar\"", cmp("body", q("foo=bar")).toQueryString(resolver));
   }
 
   @Test
-  void comparison_unknown_field_falls_back_to_phrase_form() {
-    SearchComparison cmp =
-        new SearchComparison(
-            new Field(new QualifiedName("unmapped"), List.of()),
-            SearchComparison.Operator.EQUALS,
-            phrase("foo bar*"));
-    // Resolver returns null for unknown fields.
+  void comparison_emits_bare_term_on_text_when_unquoted() {
+    Function<String, ExprType> resolver = Map.of("body", TEXT)::get;
+    assertEquals("body:foo*", cmp("body", bare("foo*")).toQueryString(resolver));
+  }
+
+  @Test
+  void comparison_unknown_field_falls_back_to_legacy_form() {
     Function<String, ExprType> resolver = f -> null;
-    assertEquals("unmapped:\"foo bar*\"", cmp.toQueryString(resolver));
+    assertEquals("unmapped:\"foo bar*\"", cmp("unmapped", q("foo bar*")).toQueryString(resolver));
   }
 }

--- a/docs/user/ppl/cmd/search.md
+++ b/docs/user/ppl/cmd/search.md
@@ -270,7 +270,7 @@ fetched rows / total rows = 11/11
 Combine conditions with `AND` to require all criteria to match:
 
 ```ppl
-search severityText="INFO" AND `resource.attributes.service.name`="cart-service" source=otellogs
+search severityText="INFO" AND `resource.attributes.service.name`="cart*" source=otellogs
 | fields body
 | head 1
 ```
@@ -330,12 +330,13 @@ search instrumentationScope.name!="@opentelemetry/instrumentation-http" source=o
 The query returns the following results:
 
 ```text
-fetched rows / total rows = 1/1
-+------------------------------+
-| instrumentationScope.name    |
-|------------------------------|
-| Microsoft.Extensions.Hosting |
-+------------------------------+
+fetched rows / total rows = 2/2
++-----------------------------------------------------------------------------+
+| instrumentationScope.name                                                   |
+|-----------------------------------------------------------------------------|
+| Microsoft.Extensions.Hosting                                                |
+| go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc |
++-----------------------------------------------------------------------------+
 ```
 
 **`NOT` operator**
@@ -352,15 +353,15 @@ The query returns the following results:
 
 ```text
 fetched rows / total rows = 5/5
-+------------------------------+
-| instrumentationScope.name    |
-|------------------------------|
-| Microsoft.Extensions.Hosting |
-| null                         |
-| null                         |
-| null                         |
-| null                         |
-+------------------------------+
++-----------------------------------------------------------------------------+
+| instrumentationScope.name                                                   |
+|-----------------------------------------------------------------------------|
+| Microsoft.Extensions.Hosting                                                |
+| go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc |
+| null                                                                        |
+| null                                                                        |
+| null                                                                        |
++-----------------------------------------------------------------------------+
 ```
 
 ## Example 5: Querying ranges

--- a/docs/user/ppl/cmd/search.md
+++ b/docs/user/ppl/cmd/search.md
@@ -270,7 +270,7 @@ fetched rows / total rows = 11/11
 Combine conditions with `AND` to require all criteria to match:
 
 ```ppl
-search severityText="INFO" AND `resource.attributes.service.name`="cart*" source=otellogs
+search severityText="INFO" AND `resource.attributes.service.name`="cart" source=otellogs
 | fields body
 | head 1
 ```

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSearchCommandIT.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.opensearch.sql.util.MatcherUtils.rows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
 import static org.opensearch.sql.util.MatcherUtils.verifyNumOfRows;
 
 import java.io.IOException;
@@ -19,6 +21,35 @@ public class CalciteSearchCommandIT extends SearchCommandIT {
   private static final String IDX_KEYWORD = "test_5682_keyword";
   private static final String IDX_TEXT = "test_5682_text";
 
+  /** Group 1-6 matrix: one value per wildcard-placement / special-character combination. */
+  private static final String MATRIX_DOCS =
+      "{\"index\":{}}\n{\"name\":\"foo\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foobar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"food\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"FOO\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo bar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo barbaz\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo-bar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo_bar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo.bar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo/bar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo@bar\"}\n";
+
+  private static final String IDX_SPLIT_KEYWORD = "test_5682_split_keyword";
+  private static final String IDX_SPLIT_TEXT = "test_5682_split_text";
+
+  /**
+   * Group 7 fixture. {@code foo=bar} holds no whitespace, yet the text analyzer still splits it
+   * into [foo, bar] — so the single-token {@code foo} and {@code bar} docs used to OR-match a
+   * search for {@code "foo=bar"}.
+   */
+  private static final String SPLIT_DOCS =
+      "{\"index\":{}}\n{\"name\":\"foo=bar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo bar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"foo\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"bar\"}\n"
+          + "{\"index\":{}}\n{\"name\":\"baz\"}\n";
+
   @Override
   public void init() throws Exception {
     super.init();
@@ -27,11 +58,13 @@ public class CalciteSearchCommandIT extends SearchCommandIT {
   }
 
   private void setupSpecIndices() throws IOException {
-    createSpecIndex(IDX_KEYWORD, "keyword");
-    createSpecIndex(IDX_TEXT, "text");
+    createSpecIndex(IDX_KEYWORD, "keyword", MATRIX_DOCS);
+    createSpecIndex(IDX_TEXT, "text", MATRIX_DOCS);
+    createSpecIndex(IDX_SPLIT_KEYWORD, "keyword", SPLIT_DOCS);
+    createSpecIndex(IDX_SPLIT_TEXT, "text", SPLIT_DOCS);
   }
 
-  private void createSpecIndex(String indexName, String fieldType) throws IOException {
+  private void createSpecIndex(String indexName, String fieldType, String docs) throws IOException {
     try {
       client().performRequest(new Request("DELETE", "/" + indexName));
     } catch (ResponseException ignore) {
@@ -53,18 +86,7 @@ public class CalciteSearchCommandIT extends SearchCommandIT {
     client().performRequest(createIndex);
 
     Request bulk = new Request("POST", "/" + indexName + "/_bulk?refresh=true");
-    bulk.setJsonEntity(
-        "{\"index\":{}}\n{\"name\":\"foo\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"foobar\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"food\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"FOO\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"foo bar\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"foo barbaz\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"foo-bar\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"foo_bar\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"foo.bar\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"foo/bar\"}\n"
-            + "{\"index\":{}}\n{\"name\":\"foo@bar\"}\n");
+    bulk.setJsonEntity(docs);
     client().performRequest(bulk);
   }
 
@@ -130,10 +152,9 @@ public class CalciteSearchCommandIT extends SearchCommandIT {
 
   @Test
   public void testGroup2_3_text_hyphen() throws IOException {
-    // Emitted: name:foo\-bar (unquoted, - escaped so parser treats as literal).
-    // Analyzer tokenizes to [foo, bar]; boolean OR matches 7 docs whose analyzed tokens
-    // contain foo or bar.
-    verifyNumOfRows(search(IDX_TEXT, "name=\"foo-bar\""), 7);
+    // Quoted with no wildcard -> phrase. Analyzer yields [foo, bar]; PhraseQuery requires them
+    // adjacent, so this no longer OR-matches every doc holding either token.
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo-bar\""), 4);
   }
 
   @Test
@@ -143,9 +164,8 @@ public class CalciteSearchCommandIT extends SearchCommandIT {
 
   @Test
   public void testGroup2_4_text_slash() throws IOException {
-    // Emitted: name:foo\/bar (unquoted, / escaped). Analyzer tokenizes to [foo, bar];
-    // boolean OR matches 7 docs.
-    verifyNumOfRows(search(IDX_TEXT, "name=\"foo/bar\""), 7);
+    // Quoted with no wildcard -> phrase over [foo, bar].
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo/bar\""), 4);
   }
 
   @Test
@@ -155,9 +175,9 @@ public class CalciteSearchCommandIT extends SearchCommandIT {
 
   @Test
   public void testGroup2_5_text_at() throws IOException {
-    // Emitted: name:foo@bar (unquoted; @ is not a Lucene special). Analyzer tokenizes
-    // to [foo, bar]; boolean OR matches 7 docs.
-    verifyNumOfRows(search(IDX_TEXT, "name=\"foo@bar\""), 7);
+    // Quoted with no wildcard -> phrase over [foo, bar]. '@' splits in the analyzer even though it
+    // is not a query_string reserved character.
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo@bar\""), 4);
   }
 
   @Test
@@ -382,5 +402,33 @@ public class CalciteSearchCommandIT extends SearchCommandIT {
   @Test
   public void testGroup6_5_text_foo_space_bqmarkr() throws IOException {
     verifyNumOfRows(search(IDX_TEXT, "name=\"foo b?r\""), 0);
+  }
+
+  // =============================================================================
+  // Group 7 — a quoted value must not OR-match its halves. Uses SPLIT_DOCS.
+  // =============================================================================
+
+  @Test
+  public void testGroup7_1_text_quoted_split_value_excludes_halves() throws IOException {
+    // The `foo` and `bar` docs hold one half each and must be absent.
+    verifyDataRows(search(IDX_SPLIT_TEXT, "name=\"foo=bar\""), rows("foo=bar"), rows("foo bar"));
+  }
+
+  @Test
+  public void testGroup7_2_keyword_quoted_split_value_is_exact() throws IOException {
+    verifyDataRows(search(IDX_SPLIT_KEYWORD, "name=\"foo=bar\""), rows("foo=bar"));
+  }
+
+  @Test
+  public void testGroup7_3_text_quoted_wildcard_term_keeps_wildcard() throws IOException {
+    // Exception to 7.1: a wildcard with no whitespace stays unquoted, so `foo*` still matches
+    // `foobar` and `food` rather than collapsing to the phrase [foo].
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo*\""), 11);
+  }
+
+  @Test
+  public void testGroup7_4_keyword_quoting_is_irrelevant() throws IOException {
+    verifyDataRows(search(IDX_KEYWORD, "name=foo-bar"), rows("foo-bar"));
+    verifyDataRows(search(IDX_KEYWORD, "name=\"foo-bar\""), rows("foo-bar"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSearchCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteSearchCommandIT.java
@@ -5,12 +5,382 @@
 
 package org.opensearch.sql.calcite.remote;
 
+import static org.opensearch.sql.util.MatcherUtils.verifyNumOfRows;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
 import org.opensearch.sql.ppl.SearchCommandIT;
 
 public class CalciteSearchCommandIT extends SearchCommandIT {
+
+  private static final String IDX_KEYWORD = "test_5682_keyword";
+  private static final String IDX_TEXT = "test_5682_text";
+
   @Override
   public void init() throws Exception {
     super.init();
     enableCalcite();
+    setupSpecIndices();
+  }
+
+  private void setupSpecIndices() throws IOException {
+    createSpecIndex(IDX_KEYWORD, "keyword");
+    createSpecIndex(IDX_TEXT, "text");
+  }
+
+  private void createSpecIndex(String indexName, String fieldType) throws IOException {
+    try {
+      client().performRequest(new Request("DELETE", "/" + indexName));
+    } catch (ResponseException ignore) {
+      // ok
+    }
+
+    Request createIndex = new Request("PUT", "/" + indexName);
+    createIndex.setJsonEntity(
+        "{\n"
+            + "  \"settings\": {\"number_of_shards\": 1, \"number_of_replicas\": 0},\n"
+            + "  \"mappings\": {\n"
+            + "    \"properties\": {\n"
+            + "      \"name\": {\"type\": \""
+            + fieldType
+            + "\"}\n"
+            + "    }\n"
+            + "  }\n"
+            + "}");
+    client().performRequest(createIndex);
+
+    Request bulk = new Request("POST", "/" + indexName + "/_bulk?refresh=true");
+    bulk.setJsonEntity(
+        "{\"index\":{}}\n{\"name\":\"foo\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"foobar\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"food\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"FOO\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"foo bar\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"foo barbaz\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"foo-bar\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"foo_bar\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"foo.bar\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"foo/bar\"}\n"
+            + "{\"index\":{}}\n{\"name\":\"foo@bar\"}\n");
+    client().performRequest(bulk);
+  }
+
+  private JSONObject search(String indexName, String predicate) throws IOException {
+    // Escape embedded quotes for JSON body wrapping done by executeQuery helper.
+    String query =
+        "search source=" + indexName + " " + predicate.replace("\"", "\\\"") + " | fields name";
+    return executeQuery(query);
+  }
+
+  // =============================================================================
+  // Group 1 — no special chars, no wildcards
+  // =============================================================================
+
+  @Test
+  public void testGroup1_1_keyword_foo() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=foo"), 1);
+  }
+
+  @Test
+  public void testGroup1_1_text_foo() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=foo"), 7);
+  }
+
+  @Test
+  public void testGroup1_2_keyword_quoted_foo() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo\""), 1);
+  }
+
+  @Test
+  public void testGroup1_2_text_quoted_foo() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo\""), 7);
+  }
+
+  // =============================================================================
+  // Group 2 — special chars, no wildcards
+  // =============================================================================
+
+  @Test
+  public void testGroup2_1_keyword_underscore() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo_bar\""), 1);
+  }
+
+  @Test
+  public void testGroup2_1_text_underscore() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo_bar\""), 1);
+  }
+
+  @Test
+  public void testGroup2_2_keyword_dot() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo.bar\""), 1);
+  }
+
+  @Test
+  public void testGroup2_2_text_dot() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo.bar\""), 1);
+  }
+
+  @Test
+  public void testGroup2_3_keyword_hyphen() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo-bar\""), 1);
+  }
+
+  @Test
+  public void testGroup2_3_text_hyphen() throws IOException {
+    // Emitted: name:foo\-bar (unquoted, - escaped so parser treats as literal).
+    // Analyzer tokenizes to [foo, bar]; boolean OR matches 7 docs whose analyzed tokens
+    // contain foo or bar.
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo-bar\""), 7);
+  }
+
+  @Test
+  public void testGroup2_4_keyword_slash() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo/bar\""), 1);
+  }
+
+  @Test
+  public void testGroup2_4_text_slash() throws IOException {
+    // Emitted: name:foo\/bar (unquoted, / escaped). Analyzer tokenizes to [foo, bar];
+    // boolean OR matches 7 docs.
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo/bar\""), 7);
+  }
+
+  @Test
+  public void testGroup2_5_keyword_at() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo@bar\""), 1);
+  }
+
+  @Test
+  public void testGroup2_5_text_at() throws IOException {
+    // Emitted: name:foo@bar (unquoted; @ is not a Lucene special). Analyzer tokenizes
+    // to [foo, bar]; boolean OR matches 7 docs.
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo@bar\""), 7);
+  }
+
+  @Test
+  public void testGroup2_6_keyword_space() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo bar\""), 1);
+  }
+
+  @Test
+  public void testGroup2_6_text_space() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo bar\""), 4);
+  }
+
+  // =============================================================================
+  // Group 3 — trailing wildcard (postfix)
+  // =============================================================================
+
+  @Test
+  public void testGroup3_1_keyword_unquoted_foostar() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=foo*"), 10);
+  }
+
+  @Test
+  public void testGroup3_1_text_unquoted_foostar() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=foo*"), 11);
+  }
+
+  @Test
+  public void testGroup3_2_keyword_quoted_foostar() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo*\""), 10);
+  }
+
+  @Test
+  public void testGroup3_2_text_quoted_foostar() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo*\""), 11);
+  }
+
+  @Test
+  public void testGroup3_3_keyword_foo_underscore_star() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo_*\""), 1);
+  }
+
+  @Test
+  public void testGroup3_3_text_foo_underscore_star() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo_*\""), 1);
+  }
+
+  @Test
+  public void testGroup3_4_keyword_foo_dot_star() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo.*\""), 1);
+  }
+
+  @Test
+  public void testGroup3_4_text_foo_dot_star() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo.*\""), 1);
+  }
+
+  @Test
+  public void testGroup3_5_keyword_foo_hyphen_star() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo-*\""), 1);
+  }
+
+  @Test
+  public void testGroup3_5_text_foo_hyphen_star() throws IOException {
+    // Emitted: name:foo\-* (unquoted, - escaped). This is a WildcardQuery over the analyzed
+    // token dictionary — text tokens don't contain '-'. 0 hits (accepted analyzer limit).
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo-*\""), 0);
+  }
+
+  @Test
+  public void testGroup3_6_keyword_foo_slash_star() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo/*\""), 1);
+  }
+
+  @Test
+  public void testGroup3_6_text_foo_slash_star() throws IOException {
+    // Emitted: name:foo\/* (unquoted, / escaped). WildcardQuery over analyzed tokens;
+    // text tokens don't contain '/'. 0 hits (accepted analyzer limit).
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo/*\""), 0);
+  }
+
+  @Test
+  public void testGroup3_7_keyword_foo_space_barstar() throws IOException {
+    // Reported bug row (#5682): keyword whole-value pattern "foo bar*" should match
+    // "foo bar" and "foo barbaz".
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo bar*\""), 2);
+  }
+
+  @Test
+  public void testGroup3_7_text_foo_space_barstar() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo bar*\""), 4);
+  }
+
+  // =============================================================================
+  // Group 4 — leading wildcard (prefix)
+  // =============================================================================
+
+  @Test
+  public void testGroup4_1_keyword_starfoo() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"*foo\""), 1);
+  }
+
+  @Test
+  public void testGroup4_1_text_starfoo() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"*foo\""), 7);
+  }
+
+  @Test
+  public void testGroup4_2_keyword_starbar() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"*bar\""), 7);
+  }
+
+  @Test
+  public void testGroup4_2_text_starbar() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"*bar\""), 7);
+  }
+
+  @Test
+  public void testGroup4_3_keyword_starfoo_bar() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"*foo bar\""), 1);
+  }
+
+  @Test
+  public void testGroup4_3_text_starfoo_bar() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"*foo bar\""), 4);
+  }
+
+  // =============================================================================
+  // Group 5 — interior wildcard (* in-between)
+  // =============================================================================
+
+  @Test
+  public void testGroup5_1_keyword_fstar_r() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"f*r\""), 7);
+  }
+
+  @Test
+  public void testGroup5_1_text_fstar_r() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"f*r\""), 3);
+  }
+
+  @Test
+  public void testGroup5_2_keyword_foostar_bar() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo*bar\""), 7);
+  }
+
+  @Test
+  public void testGroup5_2_text_foostar_bar() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo*bar\""), 3);
+  }
+
+  @Test
+  public void testGroup5_3_keyword_foo_space_starbaz() throws IOException {
+    // Keyword whole-value wildcard: "foo *baz" matches "foo barbaz".
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo *baz\""), 1);
+  }
+
+  @Test
+  public void testGroup5_3_text_foo_space_starbaz() throws IOException {
+    // Corpus-dependent 0 (no adjacent tokens foo→baz analyzed in this fixture).
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo *baz\""), 0);
+  }
+
+  @Test
+  public void testGroup5_4_keyword_starfoo_barstar() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"*foo bar*\""), 2);
+  }
+
+  @Test
+  public void testGroup5_4_text_starfoo_barstar() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"*foo bar*\""), 4);
+  }
+
+  // =============================================================================
+  // Group 6 — ? wildcard (exactly one character)
+  // =============================================================================
+
+  @Test
+  public void testGroup6_1_keyword_foo_qmark() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo?\""), 1);
+  }
+
+  @Test
+  public void testGroup6_1_text_foo_qmark() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo?\""), 1);
+  }
+
+  @Test
+  public void testGroup6_2_keyword_qmark_oo() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"?oo\""), 1);
+  }
+
+  @Test
+  public void testGroup6_2_text_qmark_oo() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"?oo\""), 7);
+  }
+
+  @Test
+  public void testGroup6_3_keyword_f_qmark_o() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"f?o\""), 1);
+  }
+
+  @Test
+  public void testGroup6_3_text_f_qmark_o() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"f?o\""), 7);
+  }
+
+  @Test
+  public void testGroup6_4_keyword_foo_qmark_bar() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo?bar\""), 6);
+  }
+
+  @Test
+  public void testGroup6_4_text_foo_qmark_bar() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo?bar\""), 2);
+  }
+
+  @Test
+  public void testGroup6_5_keyword_foo_space_bqmarkr() throws IOException {
+    verifyNumOfRows(search(IDX_KEYWORD, "name=\"foo b?r\""), 1);
+  }
+
+  @Test
+  public void testGroup6_5_text_foo_space_bqmarkr() throws IOException {
+    verifyNumOfRows(search(IDX_TEXT, "name=\"foo b?r\""), 0);
   }
 }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -1138,7 +1138,9 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
       // Use visit method to properly handle escaping
       Literal stringLit = (Literal) visit(ctx.stringLiteral());
       String content = (String) stringLit.getValue();
-      return new SearchLiteral(new Literal(content, DataType.STRING), content.contains(" "));
+      // The value came from a quoted literal. On a text field that is the user asking for phrase
+      // semantics; SearchLiteral decides what to emit per index mapping.
+      return new SearchLiteral(new Literal(content, DataType.STRING), true);
     } else if (ctx.numericLiteral() != null) {
       Literal numericLiteral = (Literal) visit(ctx.numericLiteral());
       return new SearchLiteral(numericLiteral, false);


### PR DESCRIPTION
### Description

Two ways the `search` command could return the wrong documents, both on the Calcite path.

#### 1. Wildcards were silently ignored when the value contained a space (#5682)

```
search source=logs name="foo bar*"
```

On a `keyword` field this returned **nothing**, instead of matching `foo bar` and `foo barbaz`. Any value containing whitespace was treated as a phrase, so the emitted filter was `name:"foo bar*"` — and inside a Lucene phrase `*` is an ordinary character, so the query went looking for documents with a literal asterisk in them.

#### 2. On text fields, a quoted value could match far too much

```
search source=logs body="foo=bar"
```

This matched any document containing **just** `foo`, or **just** `bar`. Reported from a real log search, where `body="isTombstone==false"` came back with lines whose only relevant content was `"endOfBatch":false`.

The cause is shared with the first bug. Whether to emit a phrase was decided by `SearchLiteral.isPhrase`, set at parse time as `value.contains(" ")` — a test for whitespace standing in for the real question: *will this field's analyzer split the value into multiple tokens?* Whitespace is a poor proxy for that. `foo=bar` has none, yet the standard analyzer splits it into `[foo, bar]`.

So the value went out unquoted, `query_string` kept it as a single field-scoped term, the analyzer split it, and `default_operator=OR` joined the halves.

### How emission is decided now

The parser keeps whether the user quoted the value, and emission is selected from the field's **index mapping** — the thing that actually determines whether a value gets analyzed. The mapping is read from `AbstractOpenSearchTable.getFieldTypes()`; the Calcite `RelDataType` round trip can't supply it, because `OpenSearchTypeFactory` collapses `text` to plain `VARCHAR` and erases the distinction. A `TODO` marks moving this onto a `RelDataType`/scan annotation once the Calcite rule pipeline has been audited.

```
keyword | constant_keyword, value holds an unescaped wildcard?
├── yes → unquoted, specials escaped INCLUDING whitespace
└── no  → field mapping?
          │
          ├── text | match_only_text
          │     └── quoted AND NOT (wildcard without whitespace)?
          │           ├── yes → quoted phrase
          │           └── no  → unquoted, specials escaped, * and ? preserved
          │
          └── everything else — keyword without a wildcard, date, numeric,
              ip, boolean, unresolved
                └── legacy, untouched: contains a space ? quoted phrase : unquoted
```

**keyword with a wildcard** — the keyword analyzer is a no-op, so the value has to arrive at Lucene as one term for the pattern to apply to the whole stored value. Escaping the whitespace stops `query_string` splitting at the space and dropping the field binding on the tail. This is fix #1.

**text** — honor the user's quoting. Unquoted passes straight through, so `*` and `?` keep working as operators. Quoted becomes a phrase, which is how a user asks for "this whole value, in order" against the analyzed tokens. This is fix #2.

There's one exception on text: a value with a wildcard and no whitespace stays unquoted. Quoting it would let the analyzer throw the wildcard away, so `body="foo*"` would stop matching `foobar`. The exception is gated on whitespace because with a space, an unquoted value splits into separate clauses and the tail loses its field binding.

**everything else** — left exactly as it was. Note that quoting genuinely carries no information on a keyword field: with a no-op analyzer, a quoted phrase and a bare term resolve to the same single term, because Lucene returns from `createFieldQuery` at `numTokens == 1` before it reads the `quoted` flag. That's a reason *not* to rewrite the emission — an earlier revision of this PR did, and broke ~12 expected-plan fixtures for no functional gain.

**The v2 engine is unaffected.** It reaches emission through the no-arg `SearchExpression.toQueryString()`, which passes a null-returning resolver and lands in the legacy branch.

### Measured behavior

Hit counts from `CalciteSearchCommandIT`, run against two indices holding identical documents — `name` mapped `keyword` in one, `text` (standard analyzer) in the other. 11 documents: `foo`, `foobar`, `food`, `FOO`, `foo bar`, `foo barbaz`, `foo-bar`, `foo_bar`, `foo.bar`, `foo/bar`, `foo@bar`.

| Row | PPL query | Text | Keyword |
|---|---|---|---|
| 1.1 | `name=foo` | 7 | 1 |
| 1.2 | `name="foo"` | 7 | 1 |
| 2.1 | `name="foo_bar"` | 1 | 1 |
| 2.2 | `name="foo.bar"` | 1 | 1 |
| 2.3 | `name="foo-bar"` | **4** ← was 7 | 1 |
| 2.4 | `name="foo/bar"` | **4** ← was 7 | 1 |
| 2.5 | `name="foo@bar"` | **4** ← was 7 | 1 |
| 2.6 | `name="foo bar"` | 4 | 1 |
| 3.1 | `name=foo*` | 11 | 10 |
| 3.2 | `name="foo*"` | 11 | 10 |
| 3.3 | `name="foo_*"` | 1 | 1 |
| 3.4 | `name="foo.*"` | 1 | 1 |
| 3.5 | `name="foo-*"` | 0 | 1 |
| 3.6 | `name="foo/*"` | 0 | 1 |
| 3.7 | `name="foo bar*"` | 4 | **2** ← was 0 (**#5682**) |
| 4.1 | `name="*foo"` | 7 | 1 |
| 4.2 | `name="*bar"` | 7 | 7 |
| 4.3 | `name="*foo bar"` | 4 | 1 |
| 5.1 | `name="f*r"` | 3 | 7 |
| 5.2 | `name="foo*bar"` | 3 | 7 |
| 5.3 | `name="foo *baz"` | 0 | 1 |
| 5.4 | `name="*foo bar*"` | 4 | 2 |
| 6.1 | `name="foo?"` | 1 | 1 |
| 6.2 | `name="?oo"` | 7 | 1 |
| 6.3 | `name="f?o"` | 7 | 1 |
| 6.4 | `name="foo?bar"` | 2 | 6 |
| 6.5 | `name="foo b?r"` | 0 | 1 |

Four cells move: the three Group 2 text rows stop over-matching, and 3.7 keyword is the reported bug. Every wildcard row on text is unchanged, and the keyword column is unchanged apart from 3.7.

A separate fixture — `foo=bar`, `foo bar`, `foo`, `bar`, `baz` — covers fix #2 with exact-row assertions rather than counts, so the regression is visible:

| Query | Field | Result |
|---|---|---|
| `name="foo=bar"` | text | `foo=bar`, `foo bar` — the single-token `foo` and `bar` documents are **absent**; they matched before |
| `name="foo=bar"` | keyword | `foo=bar` — exact whole value |
| `name="foo*"` | text | 11 — the wildcard survives quoting |
| `name=foo-bar` / `name="foo-bar"` | keyword | identical results; quoting is irrelevant |

### Known limitation

On a **text** field, a wildcard combined with a character the analyzer splits on cannot match under any emission — `body="foo=ba*"` returns 0.

Unquoted, `analyze_wildcard` defaults to `false`, so the pattern is matched against the token dictionary, where no token contains `=`. Quoted, the analyzer discards the `*` and the residual token has to match exactly. The indexed tokens for `foo=bar` are `[foo, bar]` — the original value isn't stored anywhere the query can reach. Keyword fields handle this correctly (3 hits on the same data), because the value is matched whole.

### Breaking change

**Text fields only.** A quoted value that the analyzer splits is now a phrase instead of an OR over its tokens, so queries relying on the wider behavior will return fewer rows.

Three examples in `docs/user/ppl/cmd/search.md` documented the over-matching and have been updated — one had `="cart-service"` matching a service actually named `cart`, which the fix correctly stops.

No expected-plan fixture is modified.

### Related Issues
Resolves #5682

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] New functionality has javadoc added.
- [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
