### PR TITLE
Fix zero-offset limit skipping first deduplicated row

### DIFF
--- a/core/src/main/java/org/opensearch/sql/planner/physical/LimitOperator.java
+++ b/core/src/main/java/org/opensearch/sql/planner/physical/LimitOperator.java
@@ -39,7 +39,7 @@ public class LimitOperator extends PhysicalPlan {
     super.open();
 
     // skip the leading rows of offset size
-    while (input.hasNext() && count < offset) {
+    while (count < offset && input.hasNext()) {
       count++;
       input.next();
     }

--- a/core/src/test/java/org/opensearch/sql/planner/physical/LimitOperatorTest.java
+++ b/core/src/test/java/org/opensearch/sql/planner/physical/LimitOperatorTest.java
@@ -8,12 +8,14 @@ package org.opensearch.sql.planner.physical;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.opensearch.sql.data.type.ExprCoreType.INTEGER;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
+import org.opensearch.sql.expression.DSL;
 
 public class LimitOperatorTest extends PhysicalPlanTestBase {
 
@@ -62,5 +64,16 @@ public class LimitOperatorTest extends PhysicalPlanTestBase {
     PhysicalPlan plan = new LimitOperator(new TestScan(), 1, 6);
     List<ExprValue> result = execute(plan);
     assertEquals(0, result.size());
+  }
+
+  @Test
+  public void zero_offset_limit_does_not_skip_first_deduplicated_row() {
+    PhysicalPlan dedupe = new DedupeOperator(new TestScan(), List.of(DSL.ref("response", INTEGER)));
+    PhysicalPlan plan = new LimitOperator(dedupe, 500, 0);
+
+    List<ExprValue> result = execute(plan);
+
+    assertEquals(3, result.size());
+    assertEquals(200, result.get(0).tupleValue().get("response").integerValue());
   }
 }


### PR DESCRIPTION
### Description

Fix `LimitOperator.open()` so a zero offset does not probe its child iterator.

When PPL `fetch_size` adds a zero-offset limit around a stateful operator such as
`DedupeOperator`, the existing condition calls `input.hasNext()` even though no
rows need to be skipped. `DedupeOperator.hasNext()` consumes and caches the first
unique row, so the subsequent normal iteration replaces it with the second row
and omits the first result.

This change checks the offset before calling the child iterator and adds a
regression test covering a zero-offset limit around deduplication.

### Related Issues

Resolves #5699

Related: opensearch-project/OpenSearch-Dashboards#12606

### Testing

- Confirmed the new regression test fails on `main` with `expected: <3> but was: <2>`.
- `./gradlew :core:test`
- `./gradlew :core:spotlessCheck`
- `./gradlew :core:test --tests org.opensearch.sql.planner.physical.LimitOperatorTest`

### Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented. Not applicable; this restores expected iterator behavior.
 - [ ] New functionality has javadoc added. Not applicable.
 - [ ] New functionality has a user manual doc added. Not applicable.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed. Not applicable.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). Not applicable.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose). Not applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
