### PR TITLE
Migrate to Jackson 3.x APIs

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -53,10 +53,11 @@ dependencies {
     api group: 'org.apache.commons', name: 'commons-text', version: "${commons_text_version}"
     api group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-    api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    api "tools.jackson.core:jackson-core:${versions.jackson3}"
+    api "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
     api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
-    api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
+    api "tools.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson3}"
+    api "org.snakeyaml:snakeyaml-engine:${versions.snakeyaml_engine}"
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
     api group: 'com.tdunning', name: 't-digest', version: '3.3'
     api "net.minidev:json-smart:${versions.json_smart}"

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonAppendFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonAppendFunctionImpl.java
@@ -8,8 +8,6 @@ package org.opensearch.sql.expression.function.jsonUDF;
 import static org.opensearch.sql.calcite.utils.PPLReturnTypes.STRING_FORCE_NULLABLE;
 import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +23,8 @@ import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
 
 public class JsonAppendFunctionImpl extends ImplementorUDF {
   public JsonAppendFunctionImpl() {
@@ -53,7 +53,7 @@ public class JsonAppendFunctionImpl extends ImplementorUDF {
     }
   }
 
-  public static Object eval(Object... args) throws JsonProcessingException {
+  public static Object eval(Object... args) throws JacksonException {
     String jsonStr = (String) args[0];
     List<Object> keys = Arrays.asList(args).subList(1, args.length);
     if (keys.size() % 2 != 0) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonDeleteFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonDeleteFunctionImpl.java
@@ -9,7 +9,6 @@ import static org.apache.calcite.runtime.JsonFunctions.jsonRemove;
 import static org.opensearch.sql.calcite.utils.PPLReturnTypes.STRING_FORCE_NULLABLE;
 import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.adapter.enumerable.NotNullImplementor;
@@ -23,6 +22,7 @@ import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
+import tools.jackson.core.JacksonException;
 
 public class JsonDeleteFunctionImpl extends ImplementorUDF {
   public JsonDeleteFunctionImpl() {
@@ -51,7 +51,7 @@ public class JsonDeleteFunctionImpl extends ImplementorUDF {
     }
   }
 
-  public static Object eval(Object... args) throws JsonProcessingException {
+  public static Object eval(Object... args) throws JacksonException {
     List<Object> jsonPaths = Arrays.asList(args).subList(1, args.length);
     String[] pathSpecs =
         jsonPaths.stream()

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonExtendFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonExtendFunctionImpl.java
@@ -8,8 +8,6 @@ package org.opensearch.sql.expression.function.jsonUDF;
 import static org.opensearch.sql.calcite.utils.PPLReturnTypes.STRING_FORCE_NULLABLE;
 import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +23,8 @@ import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
 
 public class JsonExtendFunctionImpl extends ImplementorUDF {
   public JsonExtendFunctionImpl() {
@@ -53,7 +53,7 @@ public class JsonExtendFunctionImpl extends ImplementorUDF {
     }
   }
 
-  public static Object eval(Object... args) throws JsonProcessingException {
+  public static Object eval(Object... args) throws JacksonException {
     String jsonStr = (String) args[0];
     List<Object> keys = Arrays.asList(args).subList(1, args.length);
     if (keys.size() % 2 != 0) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonExtractAllFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonExtractAllFunctionImpl.java
@@ -8,10 +8,6 @@ package org.opensearch.sql.expression.function.jsonUDF;
 import static java.util.stream.Collectors.toMap;
 import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.TYPE_FACTORY;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -33,6 +29,11 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.json.JsonFactory;
 
 /**
  * UDF which extract all the fields from JSON to a MAP. Items are collected from input JSON and
@@ -106,7 +107,7 @@ public class JsonExtractAllFunctionImpl extends ImplementorUDF {
     Map<String, Object> resultMap = new HashMap<>();
     Stack<String> pathStack = new Stack<>();
 
-    try (JsonParser parser = JSON_FACTORY.createParser(jsonStr)) {
+    try (JsonParser parser = JSON_FACTORY.createParser(ObjectReadContext.empty(), jsonStr)) {
       JsonToken token;
 
       while ((token = parser.nextToken()) != null) {
@@ -131,7 +132,7 @@ public class JsonExtractAllFunctionImpl extends ImplementorUDF {
             }
             break;
 
-          case FIELD_NAME:
+          case PROPERTY_NAME:
             String fieldName = parser.currentName();
             pathStack.push(fieldName);
             break;
@@ -158,7 +159,7 @@ public class JsonExtractAllFunctionImpl extends ImplementorUDF {
             break;
         }
       }
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       // ignore exception, and current result will be returned
     }
     return resultMap;
@@ -188,7 +189,7 @@ public class JsonExtractAllFunctionImpl extends ImplementorUDF {
     return path.size() >= 1 && path.getLast().equals(ARRAY_SUFFIX);
   }
 
-  private static Object extractValue(JsonParser parser, JsonToken token) throws IOException {
+  private static Object extractValue(JsonParser parser, JsonToken token) throws JacksonException {
     switch (token) {
       case VALUE_STRING:
         return parser.getValueAsString();
@@ -207,7 +208,7 @@ public class JsonExtractAllFunctionImpl extends ImplementorUDF {
     }
   }
 
-  private static Object getIntValue(JsonParser parser) throws IOException {
+  private static Object getIntValue(JsonParser parser) throws JacksonException {
     if (parser.getNumberType() == JsonParser.NumberType.INT) {
       return parser.getIntValue();
     } else if (parser.getNumberType() == JsonParser.NumberType.LONG) {

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonSetFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonSetFunctionImpl.java
@@ -8,7 +8,6 @@ package org.opensearch.sql.expression.function.jsonUDF;
 import static org.opensearch.sql.calcite.utils.PPLReturnTypes.STRING_FORCE_NULLABLE;
 import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +23,7 @@ import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.opensearch.sql.expression.function.ImplementorUDF;
 import org.opensearch.sql.expression.function.UDFOperandMetadata;
+import tools.jackson.databind.JsonNode;
 
 public class JsonSetFunctionImpl extends ImplementorUDF {
   public JsonSetFunctionImpl() {

--- a/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonUtils.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/jsonUDF/JsonUtils.java
@@ -5,11 +5,11 @@
 
 package org.opensearch.sql.expression.function.jsonUDF;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.List;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class JsonUtils {
   static ObjectMapper objectMapper = new ObjectMapper();

--- a/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
+++ b/core/src/main/java/org/opensearch/sql/utils/JsonUtils.java
@@ -9,9 +9,6 @@ import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_FALSE;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_NULL;
 import static org.opensearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,6 +24,9 @@ import org.opensearch.sql.data.model.ExprTupleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.data.model.ExprValueUtils;
 import org.opensearch.sql.exception.SemanticCheckException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @UtilityClass
 public class JsonUtils {
@@ -46,7 +46,7 @@ public class JsonUtils {
     try {
       objectMapper.readTree(jsonExprValue.stringValue());
       return LITERAL_TRUE;
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return LITERAL_FALSE;
     }
   }
@@ -71,7 +71,7 @@ public class JsonUtils {
     JsonNode jsonNode;
     try {
       jsonNode = objectMapper.readTree(json.stringValue());
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       final String errorFormat = "JSON string '%s' is not valid. Error details: %s";
       throw new SemanticCheckException(String.format(errorFormat, json, e.getMessage()), e);
     }
@@ -90,13 +90,13 @@ public class JsonUtils {
         return new ExprCollectionValue(elements);
       case OBJECT:
         Map<String, ExprValue> values = new LinkedHashMap<>();
-        for (var iter = jsonNode.fields(); iter.hasNext(); ) {
+        for (var iter = jsonNode.properties().iterator(); iter.hasNext(); ) {
           Map.Entry<String, JsonNode> entry = iter.next();
           values.put(entry.getKey(), processJsonNode(entry.getValue()));
         }
         return ExprTupleValue.fromExprValueMap(values);
       case STRING:
-        return new ExprStringValue(jsonNode.asText());
+        return new ExprStringValue(jsonNode.asString());
       case NUMBER:
         if (jsonNode.isFloatingPointNumber()) {
           return new ExprDoubleValue(jsonNode.asDouble());

--- a/core/src/main/java/org/opensearch/sql/utils/YamlFormatter.java
+++ b/core/src/main/java/org/opensearch/sql/utils/YamlFormatter.java
@@ -6,11 +6,12 @@
 package org.opensearch.sql.utils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLFactoryBuilder;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 /**
  * YAML formatter utility class. Attributes are sorted alphabetically for consistent output. Check
@@ -21,18 +22,23 @@ public class YamlFormatter {
   private static final ObjectMapper YAML_MAPPER;
 
   static {
-    YAMLFactory yamlFactory = new YAMLFactory();
-    yamlFactory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
-    yamlFactory.enable(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS);
-    yamlFactory.enable(YAMLGenerator.Feature.LITERAL_BLOCK_STYLE);
-    yamlFactory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES); // Enable smart quoting
-    yamlFactory.enable(
-        YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS); // Quote numeric strings
-    yamlFactory.enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR);
-    YAML_MAPPER = new ObjectMapper(yamlFactory);
+    final YAMLFactoryBuilder builder = new YAMLFactoryBuilder(new YAMLFactory());
+    builder.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER);
+    builder.enable(YAMLWriteFeature.LITERAL_BLOCK_STYLE);
+    builder.enable(YAMLWriteFeature.MINIMIZE_QUOTES); // Enable smart quoting
+    builder.enable(YAMLWriteFeature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS); // Quote numeric strings
+    builder.enable(YAMLWriteFeature.INDENT_ARRAYS_WITH_INDICATOR);
 
-    YAML_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    YAML_MAPPER.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
+    YAML_MAPPER =
+        new ObjectMapper(builder.build())
+            .rebuild()
+            .accessorNaming(
+                new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+            .changeDefaultPropertyInclusion(
+                incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+            .changeDefaultPropertyInclusion(
+                incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL))
+            .build();
   }
 
   /**
@@ -44,7 +50,7 @@ public class YamlFormatter {
   public static String formatToYaml(Object object) {
     try {
       return YAML_MAPPER.writeValueAsString(object);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Failed to format object to YAML", e);
     }
   }

--- a/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
+++ b/core/src/test/java/org/opensearch/sql/expression/json/JsonFunctionsTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opensearch.sql.expression.function.jsonUDF.JsonUtils.*;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +21,7 @@ import org.opensearch.sql.expression.LiteralExpression;
 import org.opensearch.sql.expression.function.jsonUDF.JsonDeleteFunctionImpl;
 import org.opensearch.sql.expression.function.jsonUDF.JsonSetFunctionImpl;
 import org.opensearch.sql.expression.function.jsonUDF.JsonUtils;
+import tools.jackson.databind.JsonNode;
 
 @ExtendWith(MockitoExtension.class)
 public class JsonFunctionsTest {

--- a/core/src/test/java/org/opensearch/sql/utils/YamlFormatter.java
+++ b/core/src/test/java/org/opensearch/sql/utils/YamlFormatter.java
@@ -5,11 +5,13 @@
 
 package org.opensearch.sql.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLFactoryBuilder;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 /**
  * YAML formatter utility class. Attributes are sorted alphabetically for consistent output. Check
@@ -20,15 +22,19 @@ public class YamlFormatter {
   private static final ObjectMapper YAML_MAPPER = initObjectMapper();
 
   private static ObjectMapper initObjectMapper() {
-    YAMLFactory yamlFactory = new YAMLFactory();
-    yamlFactory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
-    yamlFactory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES); // Enable smart quoting
-    yamlFactory.enable(
-        YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS); // Quote numeric strings
-    yamlFactory.enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR);
+    final YAMLFactoryBuilder builder = new YAMLFactoryBuilder(new YAMLFactory());
+    builder.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER);
+    builder.enable(YAMLWriteFeature.MINIMIZE_QUOTES); // Enable smart quoting
+    builder.enable(YAMLWriteFeature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS); // Quote numeric strings
+    builder.enable(YAMLWriteFeature.INDENT_ARRAYS_WITH_INDICATOR);
 
-    ObjectMapper mapper = new ObjectMapper(yamlFactory);
-    mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+    ObjectMapper mapper =
+        new ObjectMapper(builder.build())
+            .rebuild()
+            .accessorNaming(
+                new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+            .build();
     return mapper;
   }
 
@@ -36,7 +42,7 @@ public class YamlFormatter {
   public static String formatToYaml(Object object) {
     try {
       return YAML_MAPPER.writer().withDefaultPrettyPrinter().writeValueAsString(object);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Failed to format object to YAML", e);
     }
   }

--- a/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/storage/OpenSearchDataSourceMetadataStorageTest.java
@@ -8,12 +8,13 @@ package org.opensearch.sql.datasources.storage;
 import static org.opensearch.sql.datasource.model.DataSourceStatus.ACTIVE;
 import static org.opensearch.sql.datasources.storage.OpenSearchDataSourceMetadataStorage.DATASOURCE_INDEX_NAME;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -701,7 +702,7 @@ public class OpenSearchDataSourceMetadataStorageTest {
         .hasIndex(DATASOURCE_INDEX_NAME);
   }
 
-  private String getBasicDataSourceMetadataString() throws JsonProcessingException {
+  private String getBasicDataSourceMetadataString() throws JacksonException {
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.type", "basicauth");
     properties.put("prometheus.auth.username", "username");
@@ -721,7 +722,7 @@ public class OpenSearchDataSourceMetadataStorageTest {
     return "{\"name\":\"testDS\",\"description\":\"\",\"connector\":\"PROMETHEUS\",\"allowedRoles\":[\"prometheus_access\"],\"properties\":{\"prometheus.auth.password\":\"password\",\"prometheus.auth.username\":\"username\",\"prometheus.auth.uri\":\"https://localhost:9090\",\"prometheus.auth.type\":\"basicauth\"},\"resultIndex\":\"query_execution_result_testds\"}";
   }
 
-  private String getAWSSigv4DataSourceMetadataString() throws JsonProcessingException {
+  private String getAWSSigv4DataSourceMetadataString() throws JacksonException {
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.type", "awssigv4");
     properties.put("prometheus.auth.secret_key", "secret_key");
@@ -738,7 +739,7 @@ public class OpenSearchDataSourceMetadataStorageTest {
   }
 
   private String getDataSourceMetadataStringWithBasicAuthentication()
-      throws JsonProcessingException {
+      throws JacksonException {
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.uri", "https://localhost:9090");
     properties.put("prometheus.auth.type", "basicauth");
@@ -754,7 +755,7 @@ public class OpenSearchDataSourceMetadataStorageTest {
     return serialize(dataSourceMetadata);
   }
 
-  private String getDataSourceMetadataStringWithNoAuthentication() throws JsonProcessingException {
+  private String getDataSourceMetadataStringWithNoAuthentication() throws JacksonException {
     Map<String, String> properties = new HashMap<>();
     properties.put("prometheus.auth.uri", "https://localhost:9090");
     DataSourceMetadata dataSourceMetadata =
@@ -781,29 +782,22 @@ public class OpenSearchDataSourceMetadataStorageTest {
         .build();
   }
 
-  private String serialize(DataSourceMetadata dataSourceMetadata) throws JsonProcessingException {
+  private String serialize(DataSourceMetadata dataSourceMetadata) throws JacksonException {
     return getObjectMapper().writeValueAsString(dataSourceMetadata);
   }
 
   private ObjectMapper getObjectMapper() {
-    ObjectMapper mapper = new ObjectMapper();
-    addSerializerForDataSourceType(mapper);
-    return mapper;
-  }
-
-  /** It is needed to serialize DataSourceType as string. */
-  private void addSerializerForDataSourceType(ObjectMapper mapper) {
     SimpleModule module = new SimpleModule();
     module.addSerializer(DataSourceType.class, getDataSourceTypeSerializer());
-    mapper.registerModule(module);
+    return JsonMapper.builder().addModule(module).build();
   }
 
   private StdSerializer<DataSourceType> getDataSourceTypeSerializer() {
     return new StdSerializer<>(DataSourceType.class) {
       @Override
       public void serialize(
-          DataSourceType dsType, JsonGenerator jsonGen, SerializerProvider provider)
-          throws IOException {
+          DataSourceType dsType, JsonGenerator jsonGen, SerializationContext ctxt)
+          throws JacksonException {
         jsonGen.writeString(dsType.name());
       }
     };

--- a/direct-query-core/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
+++ b/direct-query-core/src/main/java/org/opensearch/sql/prometheus/client/PrometheusClientImpl.java
@@ -5,9 +5,9 @@
 
 package org.opensearch.sql.prometheus.client;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;

--- a/direct-query-core/src/test/java/org/opensearch/sql/directquery/rest/model/WriteDirectQueryResourcesResponseTest.java
+++ b/direct-query-core/src/test/java/org/opensearch/sql/directquery/rest/model/WriteDirectQueryResourcesResponseTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;

--- a/direct-query-core/src/test/java/org/opensearch/sql/prometheus/model/MetricMetadataTest.java
+++ b/direct-query-core/src/test/java/org/opensearch/sql/prometheus/model/MetricMetadataTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 public class MetricMetadataTest {

--- a/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/ExecuteDirectQueryActionResponse.java
+++ b/direct-query/src/main/java/org/opensearch/sql/directquery/transport/model/ExecuteDirectQueryActionResponse.java
@@ -5,8 +5,11 @@
 
 package org.opensearch.sql.directquery.transport.model;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,8 +27,9 @@ import org.opensearch.sql.directquery.transport.model.datasource.PrometheusResul
 @RequiredArgsConstructor
 public class ExecuteDirectQueryActionResponse extends ActionResponse {
 
-  private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .build();
 
   @Getter private final String queryId;
   @Getter private final Map<String, DataSourceResult> results;
@@ -68,7 +72,7 @@ public class ExecuteDirectQueryActionResponse extends ActionResponse {
         case "prometheus":
           try {
             result = OBJECT_MAPPER.readValue(resultJson, PrometheusResult.class);
-          } catch (IOException e) {
+          } catch (JacksonException e) {
             throw new RuntimeException("Failed to deserialize Prometheus result", e);
           }
           break;
@@ -107,7 +111,7 @@ public class ExecuteDirectQueryActionResponse extends ActionResponse {
       final String serializedResult;
       try {
         serializedResult = OBJECT_MAPPER.writeValueAsString(result);
-      } catch (IOException e) {
+      } catch (JacksonException e) {
         throw new RuntimeException("Failed to serialize result", e);
       }
       streamOutput.writeString(serializedResult);

--- a/direct-query/src/test/java/org/opensearch/sql/directquery/rest/RestDirectQueryManagementActionTest.java
+++ b/direct-query/src/test/java/org/opensearch/sql/directquery/rest/RestDirectQueryManagementActionTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.util.HashMap;

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLExplainIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLExplainIT.java
@@ -7,7 +7,6 @@ package org.opensearch.sql.calcite.remote;
 
 import static org.opensearch.sql.util.MatcherUtils.assertJsonEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;
@@ -15,6 +14,7 @@ import org.opensearch.sql.ast.statement.ExplainMode;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 import org.opensearch.sql.ppl.PPLIntegTestCase.GlobalPushdownConfig;
 import org.opensearch.sql.protocol.response.format.Format;
+import tools.jackson.databind.ObjectMapper;
 
 public class CalcitePPLExplainIT extends PPLIntegTestCase {
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/IncludeMetadataIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/IncludeMetadataIT.java
@@ -15,7 +15,6 @@ import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyColumn;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,6 +27,7 @@ import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
 import org.opensearch.sql.legacy.TestUtils;
+import tools.jackson.databind.ObjectMapper;
 
 public class IncludeMetadataIT extends PPLIntegTestCase {
 

--- a/integ-test/src/test/java/org/opensearch/sql/util/MatcherUtils.java
+++ b/integ-test/src/test/java/org/opensearch/sql/util/MatcherUtils.java
@@ -18,7 +18,6 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.gson.JsonParser;
 import java.math.BigDecimal;
@@ -42,6 +41,7 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.sql.legacy.TestUtils;
 import org.opensearch.sql.utils.YamlFormatter;
+import tools.jackson.databind.ObjectMapper;
 
 public class MatcherUtils {
 

--- a/integ-test/src/test/resources/expectedOutput/calcite/explain_output_extended.yaml
+++ b/integ-test/src/test/resources/expectedOutput/calcite/explain_output_extended.yaml
@@ -1,25 +1,4 @@
 calcite:
-  logical: |
-    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
-      LogicalProject(age2=[$2])
-        LogicalSort(sort0=[$1], dir0=[ASC-nulls-first])
-          LogicalProject(avg_age=[$0], state=[$1], age2=[$2])
-            LogicalFilter(condition=[<=($3, 1)])
-              LogicalProject(avg_age=[$0], state=[$1], age2=[$2], _row_number_dedup_=[ROW_NUMBER() OVER (PARTITION BY $2 ORDER BY $1 NULLS FIRST)])
-                LogicalFilter(condition=[IS NOT NULL($2)])
-                  LogicalProject(avg_age=[$0], state=[$1], age2=[+($0, 2)])
-                    LogicalProject(avg_age=[$2], state=[$0], city=[$1])
-                      LogicalAggregate(group=[{0, 1}], avg_age=[AVG($2)])
-                        LogicalProject(state=[$7], city=[$5], age=[$8])
-                          LogicalFilter(condition=[>($8, 30)])
-                            CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])
-  physical: |
-    EnumerableCalc(expr#0..2=[{inputs}], age2=[$t1])
-      CalciteEnumerableTopK(sort0=[$0], dir0=[ASC-nulls-first], fetch=[10000])
-        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[1], expr#4=[<=($t2, $t3)], proj#0..2=[{exprs}], $condition=[$t4])
-          EnumerableWindow(window#0=[window(partition {1} order by [1 ASC-nulls-first] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])
-            EnumerableCalc(expr#0..1=[{inputs}], expr#2=[2], expr#3=[+($t1, $t2)], expr#4=[IS NOT NULL($t1)], state=[$t0], age2=[$t3], $condition=[$t4])
-              CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[FILTER->>($2, 30), AGGREGATION->rel#1776:LogicalAggregate.NONE.[](input=RelSubset#1744,group={0, 1},avg_age=AVG($2)), PROJECT->[state, avg_age]], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":0,"timeout":"1m","query":{"range":{"age":{"from":30,"to":null,"include_lower":false,"include_upper":true,"boost":1.0}}},"aggregations":{"composite_buckets":{"composite":{"size":1000,"sources":[{"city":{"terms":{"field":"city.keyword","missing_bucket":true,"missing_order":"first","order":"asc"}}},{"state":{"terms":{"field":"state.keyword","missing_bucket":true,"missing_order":"first","order":"asc"}}}]},"aggregations":{"avg_age":{"avg":{"field":"age"}}}}}}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])
   extended: |+
     public org.apache.calcite.linq4j.Enumerable bind(final org.apache.calcite.DataContext root) {
       final org.opensearch.sql.opensearch.storage.scan.CalciteEnumerableIndexScan v1stashed = (org.opensearch.sql.opensearch.storage.scan.CalciteEnumerableIndexScan) root.get("v1stashed");
@@ -187,3 +166,26 @@ calcite:
     public Class getElementType() {
       return java.lang.Double.class;
     }
+
+
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalProject(age2=[$2])
+        LogicalSort(sort0=[$1], dir0=[ASC-nulls-first])
+          LogicalProject(avg_age=[$0], state=[$1], age2=[$2])
+            LogicalFilter(condition=[<=($3, 1)])
+              LogicalProject(avg_age=[$0], state=[$1], age2=[$2], _row_number_dedup_=[ROW_NUMBER() OVER (PARTITION BY $2 ORDER BY $1 NULLS FIRST)])
+                LogicalFilter(condition=[IS NOT NULL($2)])
+                  LogicalProject(avg_age=[$0], state=[$1], age2=[+($0, 2)])
+                    LogicalProject(avg_age=[$2], state=[$0], city=[$1])
+                      LogicalAggregate(group=[{0, 1}], avg_age=[AVG($2)])
+                        LogicalProject(state=[$7], city=[$5], age=[$8])
+                          LogicalFilter(condition=[>($8, 30)])
+                            CalciteLogicalIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]])
+  physical: |
+    EnumerableCalc(expr#0..2=[{inputs}], age2=[$t1])
+      CalciteEnumerableTopK(sort0=[$0], dir0=[ASC-nulls-first], fetch=[10000])
+        EnumerableCalc(expr#0..2=[{inputs}], expr#3=[1], expr#4=[<=($t2, $t3)], proj#0..2=[{exprs}], $condition=[$t4])
+          EnumerableWindow(window#0=[window(partition {1} order by [1 ASC-nulls-first] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])
+            EnumerableCalc(expr#0..1=[{inputs}], expr#2=[2], expr#3=[+($t1, $t2)], expr#4=[IS NOT NULL($t1)], state=[$t0], age2=[$t3], $condition=[$t4])
+              CalciteEnumerableIndexScan(table=[[OpenSearch, opensearch-sql_test_index_account]], PushDownContext=[[FILTER->>($2, 30), AGGREGATION->rel#1776:LogicalAggregate.NONE.[](input=RelSubset#1744,group={0, 1},avg_age=AVG($2)), PROJECT->[state, avg_age]], OpenSearchRequestBuilder(sourceBuilder={"from":0,"size":0,"timeout":"1m","query":{"range":{"age":{"from":30,"to":null,"include_lower":false,"include_upper":true,"boost":1.0}}},"aggregations":{"composite_buckets":{"composite":{"size":1000,"sources":[{"city":{"terms":{"field":"city.keyword","missing_bucket":true,"missing_order":"first","order":"asc"}}},{"state":{"terms":{"field":"state.keyword","missing_bucket":true,"missing_order":"first","order":"asc"}}}]},"aggregations":{"avg_age":{"avg":{"field":"age"}}}}}}, requestedTotalSize=2147483647, pageSize=null, startFrom=0)])

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/asc_sort_timestamp.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/asc_sort_timestamp.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"agent\",\"process\"\
@@ -12,4 +8,9 @@ root:
           ,\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]},\"sort\"\
           :[{\"@timestamp\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator
+  

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/asc_sort_timestamp_can_match_shortcut.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/asc_sort_timestamp_can_match_shortcut.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"process.name:kernel\"\
@@ -16,4 +12,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]},\"sort\":[{\"@timestamp\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/asc_sort_timestamp_no_can_match_shortcut.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/asc_sort_timestamp_no_can_match_shortcut.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"process.name:kernel\"\
@@ -16,4 +12,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]},\"sort\":[{\"@timestamp\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/asc_sort_with_after_timestamp.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/asc_sort_with_after_timestamp.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"agent\",\"process\"\
@@ -12,4 +8,8 @@ root:
           ,\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]},\"sort\"\
           :[{\"@timestamp\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/cardinality_agg_high.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/cardinality_agg_high.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[dc(`agent.name`)]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":0,\"timeout\":\"1m\",\"aggregations\":{\"dc(`agent.name`)\":{\"cardinality\"\
           :{\"field\":\"agent.name\"}}}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[dc(`agent.name`)]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/cardinality_agg_high_2.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/cardinality_agg_high_2.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[dc(`event.id`)]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":0,\"timeout\":\"1m\",\"aggregations\":{\"dc(`event.id`)\":{\"cardinality\"\
           :{\"field\":\"event.id\"}}}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[dc(`event.id`)]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/cardinality_agg_low.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/cardinality_agg_low.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[dc(`cloud.region`)]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":0,\"timeout\":\"1m\",\"aggregations\":{\"dc(`cloud.region`)\":{\"\
           cardinality\":{\"field\":\"cloud.region\"}}}}, pitId=*, cursorKeepAlive=null,\
           \ searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[dc(`cloud.region`)]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/composite_date_histogram_daily.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/composite_date_histogram_daily.yaml
@@ -1,14 +1,7 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), span(`@timestamp`,1d)]"
   children:
-    - name: LimitOperator
-      description:
-        limit: 10
-        offset: 0
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\"\
               :0,\"size\":0,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"\
@@ -22,4 +15,11 @@ root:
               :\"1d\"}}}]},\"aggregations\":{\"count()\":{\"value_count\":{\"field\"\
               :\"_index\"}}}}}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
               \ searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        limit: 10
+        offset: 0
+      name: LimitOperator
+  description:
+    fields: "[count(), span(`@timestamp`,1d)]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/composite_terms.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/composite_terms.yaml
@@ -1,14 +1,7 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), process.name, cloud.region]"
   children:
-    - name: LimitOperator
-      description:
-        limit: 10
-        offset: 0
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\"\
               :0,\"size\":0,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"\
@@ -23,4 +16,11 @@ root:
               :true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\"\
               :{\"count()\":{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*,\
               \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        limit: 10
+        offset: 0
+      name: LimitOperator
+  description:
+    fields: "[count(), process.name, cloud.region]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/composite_terms_keyword.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/composite_terms_keyword.yaml
@@ -1,14 +1,7 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), process.name, cloud.region, aws.cloudwatch.log_stream]"
   children:
-    - name: LimitOperator
-      description:
-        limit: 10
-        offset: 0
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\"\
               :0,\"size\":0,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"\
@@ -25,4 +18,11 @@ root:
               :true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\"\
               :{\"count()\":{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*,\
               \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        limit: 10
+        offset: 0
+      name: LimitOperator
+  description:
+    fields: "[count(), process.name, cloud.region, aws.cloudwatch.log_stream]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/date_histogram_hourly_agg.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/date_histogram_hourly_agg.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), span(`@timestamp`,1h)]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":0,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\":{\"\
@@ -12,4 +9,7 @@ root:
           fixed_interval\":\"1h\"}}}]},\"aggregations\":{\"count()\":{\"value_count\"\
           :{\"field\":\"_index\"}}}}}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[count(), span(`@timestamp`,1h)]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/date_histogram_minute_agg.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/date_histogram_minute_agg.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), span(`@timestamp`,1m)]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":0,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\"\
@@ -16,4 +13,7 @@ root:
           order\":\"asc\",\"fixed_interval\":\"1m\"}}}]},\"aggregations\":{\"count()\"\
           :{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*, cursorKeepAlive=null,\
           \ searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[count(), span(`@timestamp`,1m)]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/default.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/default.yaml
@@ -1,14 +1,14 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"agent\",\"process\"\
           ,\"log\",\"message\",\"tags\",\"cloud\",\"input\",\"@timestamp\",\"ecs\"\
           ,\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]}}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/desc_sort_timestamp.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/desc_sort_timestamp.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"agent\",\"process\"\
@@ -12,4 +8,8 @@ root:
           ,\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]},\"sort\"\
           :[{\"@timestamp\":{\"order\":\"desc\",\"missing\":\"_last\"}}]}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/desc_sort_timestamp_can_match_shortcut.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/desc_sort_timestamp_can_match_shortcut.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"process.name:kernel\"\
@@ -16,4 +12,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]},\"sort\":[{\"@timestamp\":{\"order\":\"desc\",\"missing\"\
           :\"_last\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/desc_sort_timestamp_no_can_match_shortcut.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/desc_sort_timestamp_no_can_match_shortcut.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"process.name:kernel\"\
@@ -16,4 +12,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]},\"sort\":[{\"@timestamp\":{\"order\":\"desc\",\"missing\"\
           :\"_last\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/desc_sort_with_after_timestamp.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/desc_sort_with_after_timestamp.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"agent\",\"process\"\
@@ -12,4 +8,8 @@ root:
           ,\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]},\"sort\"\
           :[{\"@timestamp\":{\"order\":\"desc\",\"missing\":\"_last\"}}]}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/keyword_in_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/keyword_in_range.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"bool\"\
@@ -21,4 +17,8 @@ root:
           log\",\"message\",\"tags\",\"cloud\",\"input\",\"@timestamp\",\"ecs\",\"\
           data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]}}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/keyword_terms.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/keyword_terms.yaml
@@ -1,18 +1,7 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[station, aws.cloudwatch.log_stream]"
   children:
-    - name: TakeOrderedOperator
-      description:
-        limit: 500
-        offset: 0
-        sortList:
-          station:
-            sortOrder: DESC
-            nullOrder: NULL_LAST
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\"\
               :0,\"size\":0,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\"\
@@ -21,4 +10,15 @@ root:
               :true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\"\
               :{\"station\":{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*,\
               \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        limit: 500
+        offset: 0
+        sortList:
+          station:
+            sortOrder: DESC
+            nullOrder: NULL_LAST
+      name: TakeOrderedOperator
+  description:
+    fields: "[station, aws.cloudwatch.log_stream]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/keyword_terms_low_cardinality.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/keyword_terms_low_cardinality.yaml
@@ -1,18 +1,7 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[country, aws.cloudwatch.log_stream]"
   children:
-    - name: TakeOrderedOperator
-      description:
-        limit: 50
-        offset: 0
-        sortList:
-          country:
-            sortOrder: DESC
-            nullOrder: NULL_LAST
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\"\
               :0,\"size\":0,\"timeout\":\"1m\",\"aggregations\":{\"composite_buckets\"\
@@ -21,4 +10,15 @@ root:
               :true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\"\
               :{\"country\":{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*,\
               \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        limit: 50
+        offset: 0
+        sortList:
+          country:
+            sortOrder: DESC
+            nullOrder: NULL_LAST
+      name: TakeOrderedOperator
+  description:
+    fields: "[country, aws.cloudwatch.log_stream]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/multi_terms_keyword.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/multi_terms_keyword.yaml
@@ -1,18 +1,7 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), process.name, cloud.region]"
   children:
-    - name: TakeOrderedOperator
-      description:
-        limit: 10
-        offset: 0
-        sortList:
-          count():
-            sortOrder: DESC
-            nullOrder: NULL_LAST
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\"\
               :0,\"size\":0,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"\
@@ -27,4 +16,15 @@ root:
               :true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\"\
               :{\"count()\":{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*,\
               \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        limit: 10
+        offset: 0
+        sortList:
+          count():
+            sortOrder: DESC
+            nullOrder: NULL_LAST
+      name: TakeOrderedOperator
+  description:
+    fields: "[count(), process.name, cloud.region]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/query_string_on_message.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/query_string_on_message.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"((message:monkey\
@@ -17,4 +13,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/query_string_on_message_filtered.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/query_string_on_message_filtered.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"bool\"\
@@ -22,4 +18,8 @@ root:
           log\",\"message\",\"tags\",\"cloud\",\"input\",\"@timestamp\",\"ecs\",\"\
           data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]}}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/query_string_on_message_filtered_sorted_num.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/query_string_on_message_filtered_sorted_num.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"bool\"\
@@ -23,4 +19,8 @@ root:
           data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]},\"sort\"\
           :[{\"@timestamp\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\"\
@@ -16,4 +12,8 @@ root:
           ,\"input\",\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\"\
           ,\"aws\",\"event\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_agg_1.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_agg_1.yaml
@@ -1,14 +1,13 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), range_bucket]"
   children:
-    - name: AggregationOperator
-      description:
-        aggregators: "[count()]"
-        groupBy: "[range_bucket]"
-      children:
-        - name: OpenSearchEvalOperator
+    - children:
+        - children:
+            - children: []
+              description:
+                request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"\
+                  from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
+                  \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+              name: OpenSearchIndexScan
           description:
             expressions:
               range_bucket: "CaseClause(whenClauses=[WhenClause(condition=<(metrics.size,\
@@ -18,10 +17,11 @@ root:
                 \ 100), <(metrics.size, 1000)), result=\"range_4\"), WhenClause(condition=and(>=(metrics.size,\
                 \ 1000), <(metrics.size, 2000)), result=\"range_5\"), WhenClause(condition=>=(metrics.size,\
                 \ 2000), result=\"range_6\")], defaultResult=null)"
-          children:
-            - name: OpenSearchIndexScan
-              description:
-                request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"\
-                  from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
-                  \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+          name: OpenSearchEvalOperator
+      description:
+        aggregators: "[count()]"
+        groupBy: "[range_bucket]"
+      name: AggregationOperator
+  description:
+    fields: "[count(), range_bucket]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_agg_2.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_agg_2.yaml
@@ -1,14 +1,13 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), range_bucket]"
   children:
-    - name: AggregationOperator
-      description:
-        aggregators: "[count()]"
-        groupBy: "[range_bucket]"
-      children:
-        - name: OpenSearchEvalOperator
+    - children:
+        - children:
+            - children: []
+              description:
+                request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"\
+                  from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
+                  \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+              name: OpenSearchIndexScan
           description:
             expressions:
               range_bucket: "CaseClause(whenClauses=[WhenClause(condition=<(metrics.size,\
@@ -16,10 +15,11 @@ root:
                 \ 100), <(metrics.size, 1000)), result=\"range_2\"), WhenClause(condition=and(>=(metrics.size,\
                 \ 1000), <(metrics.size, 2000)), result=\"range_3\"), WhenClause(condition=>=(metrics.size,\
                 \ 2000), result=\"range_4\")], defaultResult=null)"
-          children:
-            - name: OpenSearchIndexScan
-              description:
-                request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"\
-                  from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
-                  \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+          name: OpenSearchEvalOperator
+      description:
+        aggregators: "[count()]"
+        groupBy: "[range_bucket]"
+      name: AggregationOperator
+  description:
+    fields: "[count(), range_bucket]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_auto_date_histo.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_auto_date_histo.yaml
@@ -1,24 +1,14 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), auto_span, range_bucket]"
   children:
-    - name: SortOperator
-      description:
-        sortList:
-          range_bucket:
-            sortOrder: ASC
-            nullOrder: NULL_FIRST
-          auto_span:
-            sortOrder: ASC
-            nullOrder: NULL_FIRST
-      children:
-        - name: AggregationOperator
-          description:
-            aggregators: "[count()]"
-            groupBy: "[auto_span, range_bucket]"
-          children:
-            - name: OpenSearchEvalOperator
+    - children:
+        - children:
+            - children:
+                - children: []
+                  description:
+                    request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"\
+                      from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
+                      \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+                  name: OpenSearchIndexScan
               description:
                 expressions:
                   range_bucket: "CaseClause(whenClauses=[WhenClause(condition=<(metrics.size,\
@@ -28,10 +18,20 @@ root:
                     \ 100), <(metrics.size, 1000)), result=\"range_4\"), WhenClause(condition=and(>=(metrics.size,\
                     \ 1000), <(metrics.size, 2000)), result=\"range_5\"), WhenClause(condition=>=(metrics.size,\
                     \ 2000), result=\"range_6\")], defaultResult=null)"
-              children:
-                - name: OpenSearchIndexScan
-                  description:
-                    request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"\
-                      from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
-                      \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-                  children: []
+              name: OpenSearchEvalOperator
+          description:
+            aggregators: "[count()]"
+            groupBy: "[auto_span, range_bucket]"
+          name: AggregationOperator
+      description:
+        sortList:
+          range_bucket:
+            sortOrder: ASC
+            nullOrder: NULL_FIRST
+          auto_span:
+            sortOrder: ASC
+            nullOrder: NULL_FIRST
+      name: SortOperator
+  description:
+    fields: "[count(), auto_span, range_bucket]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_auto_date_histo_with_metrics.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_auto_date_histo_with_metrics.yaml
@@ -1,9 +1,26 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[tmin, tavg, tmax, auto_span, range_bucket]"
   children:
-    - name: SortOperator
+    - children:
+        - children:
+            - children:
+                - children: []
+                  description:
+                    request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"\
+                      from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
+                      \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
+                  name: OpenSearchIndexScan
+              description:
+                expressions:
+                  range_bucket: "CaseClause(whenClauses=[WhenClause(condition=<(metrics.size,\
+                    \ 100), result=\"range_1\"), WhenClause(condition=and(>=(metrics.size,\
+                    \ 100), <(metrics.size, 1000)), result=\"range_2\"), WhenClause(condition=and(>=(metrics.size,\
+                    \ 1000), <(metrics.size, 2000)), result=\"range_3\"), WhenClause(condition=>=(metrics.size,\
+                    \ 2000), result=\"range_4\")], defaultResult=null)"
+              name: OpenSearchEvalOperator
+          description:
+            aggregators: "[tmin, tavg, tmax]"
+            groupBy: "[auto_span, range_bucket]"
+          name: AggregationOperator
       description:
         sortList:
           range_bucket:
@@ -12,24 +29,7 @@ root:
           auto_span:
             sortOrder: ASC
             nullOrder: NULL_FIRST
-      children:
-        - name: AggregationOperator
-          description:
-            aggregators: "[tmin, tavg, tmax]"
-            groupBy: "[auto_span, range_bucket]"
-          children:
-            - name: OpenSearchEvalOperator
-              description:
-                expressions:
-                  range_bucket: "CaseClause(whenClauses=[WhenClause(condition=<(metrics.size,\
-                    \ 100), result=\"range_1\"), WhenClause(condition=and(>=(metrics.size,\
-                    \ 100), <(metrics.size, 1000)), result=\"range_2\"), WhenClause(condition=and(>=(metrics.size,\
-                    \ 1000), <(metrics.size, 2000)), result=\"range_3\"), WhenClause(condition=>=(metrics.size,\
-                    \ 2000), result=\"range_4\")], defaultResult=null)"
-              children:
-                - name: OpenSearchIndexScan
-                  description:
-                    request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"\
-                      from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
-                      \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-                  children: []
+      name: SortOperator
+  description:
+    fields: "[tmin, tavg, tmax, auto_span, range_bucket]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_field_conjunction_big_range_big_term_query.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_field_conjunction_big_range_big_term_query.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"bool\"\
@@ -17,4 +13,8 @@ root:
           agent\",\"process\",\"log\",\"message\",\"tags\",\"cloud\",\"input\",\"\
           @timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\"\
           ,\"event\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_field_conjunction_small_range_big_term_query.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_field_conjunction_small_range_big_term_query.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\"\
@@ -15,4 +11,8 @@ root:
           log\",\"message\",\"tags\",\"cloud\",\"input\",\"@timestamp\",\"ecs\",\"\
           data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]}}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_field_conjunction_small_range_small_term_query.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_field_conjunction_small_range_small_term_query.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"should\":[{\"term\"\
@@ -17,4 +13,8 @@ root:
           agent\",\"process\",\"log\",\"message\",\"tags\",\"cloud\",\"input\",\"\
           @timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\"\
           ,\"event\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_field_disjunction_big_range_small_term_query.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_field_disjunction_big_range_small_term_query.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"should\":[{\"term\"\
@@ -17,4 +13,8 @@ root:
           agent\",\"process\",\"log\",\"message\",\"tags\",\"cloud\",\"input\",\"\
           @timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\"\
           ,\"event\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_numeric.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_numeric.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\"\
@@ -15,4 +11,8 @@ root:
           agent\",\"process\",\"log\",\"message\",\"tags\",\"cloud\",\"input\",\"\
           @timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\"\
           ,\"event\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_with_asc_sort.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_with_asc_sort.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\"\
@@ -16,4 +12,8 @@ root:
           ,\"input\",\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\"\
           ,\"aws\",\"event\"]},\"sort\":[{\"@timestamp\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/range_with_desc_sort.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/range_with_desc_sort.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"range\"\
@@ -16,4 +12,8 @@ root:
           ,\"input\",\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\"\
           ,\"aws\",\"event\"]},\"sort\":[{\"@timestamp\":{\"order\":\"desc\",\"missing\"\
           :\"_last\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/scroll.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/scroll.yaml
@@ -1,14 +1,14 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"agent\",\"process\"\
           ,\"log\",\"message\",\"tags\",\"cloud\",\"input\",\"@timestamp\",\"ecs\"\
           ,\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]}}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_keyword_can_match_shortcut.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_keyword_can_match_shortcut.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"process.name:kernel\"\
@@ -16,4 +12,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]},\"sort\":[{\"meta.file\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_keyword_no_can_match_shortcut.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_keyword_no_can_match_shortcut.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"process.name:kernel\"\
@@ -16,4 +12,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]},\"sort\":[{\"meta.file\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_numeric_asc.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_numeric_asc.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"agent\",\"process\"\
@@ -12,4 +8,8 @@ root:
           ,\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]},\"sort\"\
           :[{\"metrics.size\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_numeric_asc_with_match.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_numeric_asc_with_match.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"log.file.path:\\\
@@ -17,4 +13,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]},\"sort\":[{\"metrics.size\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_numeric_desc.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_numeric_desc.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"_source\":{\"includes\":[\"agent\",\"process\"\
@@ -12,4 +8,8 @@ root:
           ,\"data_stream\",\"meta\",\"host\",\"metrics\",\"aws\",\"event\"]},\"sort\"\
           :[{\"metrics.size\":{\"order\":\"desc\",\"missing\":\"_last\"}}]}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_numeric_desc_with_match.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/sort_numeric_desc_with_match.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"query_string\":{\"query\":\"log.file.path:\\\
@@ -17,4 +13,8 @@ root:
           ,\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\",\"\
           aws\",\"event\"]},\"sort\":[{\"metrics.size\":{\"order\":\"desc\",\"missing\"\
           :\"_last\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/term.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/term.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
-      \ meta, host, metrics, aws, event]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\":0,\"\
           size\":10,\"timeout\":\"1m\",\"query\":{\"term\":{\"log.file.path\":{\"\
@@ -13,4 +9,8 @@ root:
           ,\"input\",\"@timestamp\",\"ecs\",\"data_stream\",\"meta\",\"host\",\"metrics\"\
           ,\"aws\",\"event\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[agent, process, log, message, tags, cloud, input, @timestamp, ecs, data_stream,\
+      \ meta, host, metrics, aws, event]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/terms_significant_1.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/terms_significant_1.yaml
@@ -1,14 +1,7 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), aws.cloudwatch.log_stream, process.name]"
   children:
-    - name: LimitOperator
-      description:
-        limit: 10
-        offset: 0
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\"\
               :0,\"size\":0,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"\
@@ -23,4 +16,11 @@ root:
               :true,\"missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\"\
               :{\"count()\":{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*,\
               \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        limit: 10
+        offset: 0
+      name: LimitOperator
+  description:
+    fields: "[count(), aws.cloudwatch.log_stream, process.name]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/big5/terms_significant_2.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/big5/terms_significant_2.yaml
@@ -1,14 +1,7 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), process.name, aws.cloudwatch.log_stream]"
   children:
-    - name: LimitOperator
-      description:
-        limit: 10
-        offset: 0
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=big5, sourceBuilder={\"from\"\
               :0,\"size\":0,\"timeout\":\"1m\",\"query\":{\"bool\":{\"filter\":[{\"\
@@ -23,4 +16,11 @@ root:
               ,\"missing_bucket\":true,\"missing_order\":\"first\",\"order\":\"asc\"\
               }}}]},\"aggregations\":{\"count()\":{\"value_count\":{\"field\":\"_index\"\
               }}}}}}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        limit: 10
+        offset: 0
+      name: LimitOperator
+  description:
+    fields: "[count(), process.name, aws.cloudwatch.log_stream]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_agg_group_merge.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_agg_group_merge.yaml
@@ -1,24 +1,24 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), age1, age2, age3, age]"
   children:
-    - name: AggregationOperator
-      description:
-        aggregators: "[count()]"
-        groupBy: "[age1, age2, age3, age]"
-      children:
-        - name: OpenSearchEvalOperator
-          description:
-            expressions:
-              age3: "10"
-              age2: "+(age, 10)"
-              age1: "*(age, 10)"
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
                   \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\"},\
                   \ needClean=true, searchDone=false, pitId=*,\
                   \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            expressions:
+              age3: "10"
+              age2: "+(age, 10)"
+              age1: "*(age, 10)"
+          name: OpenSearchEvalOperator
+      description:
+        aggregators: "[count()]"
+        groupBy: "[age1, age2, age3, age]"
+      name: AggregationOperator
+  description:
+    fields: "[count(), age1, age2, age3, age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_agg_with_script.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_agg_with_script.yaml
@@ -1,22 +1,22 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[sum, len, gender]"
   children:
-    - name: AggregationOperator
-      description:
-        aggregators: "[sum]"
-        groupBy: "[len, gender]"
-      children:
-        - name: OpenSearchEvalOperator
-          description:
-            expressions:
-              len: length(gender)
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_bank,\
                   \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\"},\
                   \ needClean=true, searchDone=false, pitId=*,\
                   \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            expressions:
+              len: length(gender)
+          name: OpenSearchEvalOperator
+      description:
+        aggregators: "[sum]"
+        groupBy: "[len, gender]"
+      name: AggregationOperator
+  description:
+    fields: "[sum, len, gender]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_dedup_keepempty_false_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_dedup_keepempty_false_push.yaml
@@ -1,24 +1,24 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, gender, age]"
   children:
-    - name: DedupeOperator
-      description:
-        dedupeList: "[gender]"
-        allowedDuplication: 1
-        keepEmpty: false
-        consecutive: false
-      children:
-        - name: ProjectOperator
-          description:
-            fields: "[account_number, gender, age]"
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
                   \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"\
                   _source\":{\"includes\":[\"account_number\",\"gender\",\"age\"]}},\
                   \ pitId=*,\
                   \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            fields: "[account_number, gender, age]"
+          name: ProjectOperator
+      description:
+        dedupeList: "[gender]"
+        allowedDuplication: 1
+        keepEmpty: false
+        consecutive: false
+      name: DedupeOperator
+  description:
+    fields: "[account_number, gender, age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_dedup_keepempty_true_not_pushed.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_dedup_keepempty_true_not_pushed.yaml
@@ -1,24 +1,24 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, gender, age]"
   children:
-    - name: DedupeOperator
-      description:
-        dedupeList: "[gender]"
-        allowedDuplication: 1
-        keepEmpty: true
-        consecutive: false
-      children:
-        - name: ProjectOperator
-          description:
-            fields: "[account_number, gender, age]"
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
                   \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"\
                   _source\":{\"includes\":[\"account_number\",\"gender\",\"age\"]}},\
                   \ pitId=*,\
                   \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            fields: "[account_number, gender, age]"
+          name: ProjectOperator
+      description:
+        dedupeList: "[gender]"
+        allowedDuplication: 1
+        keepEmpty: true
+        consecutive: false
+      name: DedupeOperator
+  description:
+    fields: "[account_number, gender, age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_dedup_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_dedup_push.yaml
@@ -1,24 +1,24 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, gender, age]"
   children:
-    - name: DedupeOperator
-      description:
-        dedupeList: "[gender]"
-        allowedDuplication: 1
-        keepEmpty: false
-        consecutive: false
-      children:
-        - name: ProjectOperator
-          description:
-            fields: "[account_number, gender, age]"
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
                   \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"\
                   _source\":{\"includes\":[\"account_number\",\"gender\",\"age\"]}},\
                   \ pitId=*,\
                   \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            fields: "[account_number, gender, age]"
+          name: ProjectOperator
+      description:
+        dedupeList: "[gender]"
+        allowedDuplication: 1
+        keepEmpty: false
+        consecutive: false
+      name: DedupeOperator
+  description:
+    fields: "[account_number, gender, age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_agg_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_agg_push.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[avg_age, state, city]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":0,\"timeout\":\"1m\",\"query\":{\"\
@@ -15,4 +12,7 @@ root:
           missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\":{\"avg_age\"\
           :{\"avg\":{\"field\":\"age\"}}}}}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[avg_age, state, city]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -15,4 +12,7 @@ root:
           :false,\"include_upper\":true,\"boost\":1.0}}}],\"adjust_pure_negative\"\
           :true,\"boost\":1.0}},\"_source\":{\"includes\":[\"age\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push_compare_date_string.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push_compare_date_string.yaml
@@ -1,21 +1,21 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[yyyy-MM-dd]"
   children:
-    - name: FilterOperator
-      description:
-        conditions: "and(<(yyyy-MM-dd, cast_to_date(\"2018-11-09 00:00:00.000000000\"\
-          )), >(yyyy-MM-dd, cast_to_date(\"2016-12-08 00:00:00.123456789\")))"
-      children:
-        - name: ProjectOperator
-          description:
-            fields: "[yyyy-MM-dd]"
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_date_formats,\
                   \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"\
                   _source\":{\"includes\":[\"yyyy-MM-dd\"]}}, pitId=*,\
                   \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            fields: "[yyyy-MM-dd]"
+          name: ProjectOperator
+      description:
+        conditions: "and(<(yyyy-MM-dd, cast_to_date(\"2018-11-09 00:00:00.000000000\"\
+          )), >(yyyy-MM-dd, cast_to_date(\"2016-12-08 00:00:00.123456789\")))"
+      name: FilterOperator
+  description:
+    fields: "[yyyy-MM-dd]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push_compare_time_string.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push_compare_time_string.yaml
@@ -1,21 +1,21 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[custom_time]"
   children:
-    - name: FilterOperator
-      description:
-        conditions: "and(<(custom_time, cast_to_time(\"2018-11-09 19:00:00.123456789\"\
-          )), >(custom_time, cast_to_time(\"2016-12-08 12:00:00.123456789\")))"
-      children:
-        - name: ProjectOperator
-          description:
-            fields: "[custom_time]"
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_date_formats,\
                   \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"\
                   _source\":{\"includes\":[\"custom_time\"]}}, pitId=*,\
                   \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            fields: "[custom_time]"
+          name: ProjectOperator
+      description:
+        conditions: "and(<(custom_time, cast_to_time(\"2018-11-09 19:00:00.123456789\"\
+          )), >(custom_time, cast_to_time(\"2016-12-08 12:00:00.123456789\")))"
+      name: FilterOperator
+  description:
+    fields: "[custom_time]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push_compare_timestamp_string.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_push_compare_timestamp_string.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, firstname, address, birthdate, gender, city, lastname,\
-      \ balance, employer, state, age, email, male]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_bank,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -16,4 +12,8 @@ root:
           ,\"address\",\"birthdate\",\"gender\",\"city\",\"lastname\",\"balance\"\
           ,\"employer\",\"state\",\"age\",\"email\",\"male\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[account_number, firstname, address, birthdate, gender, city, lastname,\
+      \ balance, employer, state, age, email, male]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_then_limit_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_filter_then_limit_push.yaml
@@ -1,13 +1,13 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"query\":{\"\
           range\":{\"age\":{\"from\":30,\"to\":null,\"include_lower\":false,\"include_upper\"\
           :true,\"boost\":1.0}}},\"_source\":{\"includes\":[\"age\"]}}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_keyword_like_function.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_keyword_like_function.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, firstname, address, balance, gender, city, employer,\
-      \ state, age, email, lastname]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -13,4 +9,8 @@ root:
           ,\"balance\",\"gender\",\"city\",\"employer\",\"state\",\"age\",\"email\"\
           ,\"lastname\"]}}, needClean=true, searchDone=false, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[account_number, firstname, address, balance, gender, city, employer,\
+      \ state, age, email, lastname]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_keyword_like_function_case_insensitive.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_keyword_like_function_case_insensitive.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, firstname, address, balance, gender, city, employer,\
-      \ state, age, email, lastname]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -13,4 +9,8 @@ root:
           firstname\",\"address\",\"balance\",\"gender\",\"city\",\"employer\",\"\
           state\",\"age\",\"email\",\"lastname\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[account_number, firstname, address, balance, gender, city, employer,\
+      \ state, age, email, lastname]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_10_5_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_10_5_push.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"_source\":{\"\
           includes\":[\"age\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_10_filter_5_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_10_filter_5_push.yaml
@@ -1,20 +1,20 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: LimitOperator
-      description:
-        limit: 5
-        offset: 0
-      children:
-        - name: FilterOperator
-          description:
-            conditions: ">(age, 30)"
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
                   \ sourceBuilder={\"from\":0,\"size\":10,\"timeout\":\"1m\"}, pitId=*,\
                   \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            conditions: ">(age, 30)"
+          name: FilterOperator
+      description:
+        limit: 5
+        offset: 0
+      name: LimitOperator
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_10from1_10from2_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_10from1_10from2_push.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":3,\"size\":8,\"timeout\":\"1m\",\"_source\":{\"\
           includes\":[\"age\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_5_10_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_5_10_push.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"_source\":{\"\
           includes\":[\"age\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_offsets_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_offsets_push.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":3,\"size\":5,\"timeout\":\"1m\",\"_source\":{\"\
           includes\":[\"age\"]}}, pitId=*, cursorKeepAlive=null, searchAfter=null,\
           \ searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_push.yaml
@@ -1,16 +1,16 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[ageMinus]"
   children:
-    - name: OpenSearchEvalOperator
-      description:
-        expressions:
-          ageMinus: "-(age, 30)"
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
               \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\"}, pitId=*,\
               \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        expressions:
+          ageMinus: "-(age, 30)"
+      name: OpenSearchEvalOperator
+  description:
+    fields: "[ageMinus]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_then_filter_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_then_filter_push.yaml
@@ -1,15 +1,15 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: FilterOperator
-      description:
-        conditions: ">(age, 30)"
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
               \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\"}, pitId=*,\
               \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        conditions: ">(age, 30)"
+      name: FilterOperator
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_then_sort_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_limit_then_sort_push.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"_source\":{\"\
           includes\":[\"age\"]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_output.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_output.yaml
@@ -1,25 +1,9 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age2]"
   children:
-    - name: DedupeOperator
-      description:
-        dedupeList: "[age2]"
-        allowedDuplication: 1
-        keepEmpty: false
-        consecutive: false
-      children:
-        - name: OpenSearchEvalOperator
-          description:
-            expressions:
-              age2: "+(avg_age, 2)"
-          children:
-            - name: RemoveOperator
-              description:
-                removeList: "[city]"
-              children:
-                - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children:
+                - children: []
                   description:
                     request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
                       \ sourceBuilder={\"from\":0,\"size\":0,\"timeout\":\"1m\",\"\
@@ -32,4 +16,20 @@ root:
                       missing_order\":\"first\",\"order\":\"asc\"}}}]},\"aggregations\"\
                       :{\"avg_age\":{\"avg\":{\"field\":\"age\"}}}}}}, pitId=*,\
                       \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-                  children: []
+                  name: OpenSearchIndexScan
+              description:
+                removeList: "[city]"
+              name: RemoveOperator
+          description:
+            expressions:
+              age2: "+(avg_age, 2)"
+          name: OpenSearchEvalOperator
+      description:
+        dedupeList: "[age2]"
+        allowedDuplication: 1
+        keepEmpty: false
+        consecutive: false
+      name: DedupeOperator
+  description:
+    fields: "[age2]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_patterns_brain_agg_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_patterns_brain_agg_push.yaml
@@ -1,24 +1,24 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[pattern_count, sample_logs, patterns_field]"
   children:
-    - name: AggregationOperator
-      description:
-        aggregators: "[pattern_count, sample_logs]"
-        groupBy: "[patterns_field]"
-      children:
-        - name: WindowOperator
-          description:
-            function: patterns_field
-            definition:
-              partitionBy: "[]"
-              sortList: {}
-          children:
-            - name: OpenSearchIndexScan
+    - children:
+        - children:
+            - children: []
               description:
                 request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
                   \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\"},\
                   \ needClean=true, searchDone=false, pitId=*,\
                   \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-              children: []
+              name: OpenSearchIndexScan
+          description:
+            function: patterns_field
+            definition:
+              partitionBy: "[]"
+              sortList: {}
+          name: WindowOperator
+      description:
+        aggregators: "[pattern_count, sample_logs]"
+        groupBy: "[patterns_field]"
+      name: AggregationOperator
+  description:
+    fields: "[pattern_count, sample_logs, patterns_field]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_patterns_simple_pattern.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_patterns_simple_pattern.yaml
@@ -1,10 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, firstname, address, balance, gender, city, employer,\
-      \ state, age, email, lastname, patterns_field]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"_source\"\
@@ -12,4 +8,8 @@ root:
           ,\"gender\",\"city\",\"employer\",\"state\",\"age\",\"email\",\"lastname\"\
           ,\"patterns_field\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[account_number, firstname, address, balance, gender, city, employer,\
+      \ state, age, email, lastname, patterns_field]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_patterns_simple_pattern_agg_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_patterns_simple_pattern_agg_push.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[pattern_count, sample_logs, patterns_field]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":0,\"timeout\":\"1m\",\"aggregations\"\
@@ -16,4 +13,7 @@ root:
           :{\"from\":0,\"size\":10,\"version\":false,\"seq_no_primary_term\":false,\"\
           explain\":false,\"_source\":{\"includes\":[\"email\"]}}}}}}}, pitId=*,\
           \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[pattern_count, sample_logs, patterns_field]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_sort_count_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_sort_count_push.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"_source\":{\"\
           includes\":[\"age\"]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_sort_then_limit_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_sort_then_limit_push.yaml
@@ -1,12 +1,12 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[age]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"_source\":{\"\
           includes\":[\"age\"]},\"sort\":[{\"age\":{\"order\":\"asc\",\"missing\"\
           :\"_first\"}}]}, pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[age]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_stats_by_timespan.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_stats_by_timespan.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), span(birthdate,1m)]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_bank,\
           \ sourceBuilder={\"from\":0,\"size\":0,\"timeout\":\"1m\",\"aggregations\"\
@@ -12,4 +9,7 @@ root:
           order\":\"asc\",\"fixed_interval\":\"1m\"}}}]},\"aggregations\":{\"count()\"\
           :{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*, cursorKeepAlive=null,\
           \ searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[count(), span(birthdate,1m)]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_stats_by_timespan2.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_stats_by_timespan2.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[count(), span(birthdate,1M)]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_bank,\
           \ sourceBuilder={\"from\":0,\"size\":0,\"timeout\":\"1m\",\"aggregations\"\
@@ -12,4 +9,7 @@ root:
           order\":\"asc\",\"calendar_interval\":\"1M\"}}}]},\"aggregations\":{\"count()\"\
           :{\"value_count\":{\"field\":\"_index\"}}}}}}, pitId=*, cursorKeepAlive=null,\
           \ searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[count(), span(birthdate,1M)]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_take.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_take.yaml
@@ -1,13 +1,13 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[take]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
           \ sourceBuilder={\"from\":0,\"size\":0,\"timeout\":\"1m\",\"aggregations\"\
           :{\"take\":{\"top_hits\":{\"from\":0,\"size\":2,\"version\":false,\"seq_no_primary_term\"\
           :false,\"explain\":false,\"_source\":{\"includes\":[\"firstname\"]}}}}},\
           \ pitId=*, cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[take]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_text_like_function.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_text_like_function.yaml
@@ -1,16 +1,16 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, firstname, address, balance, gender, city, employer,\
-      \ state, age, email, lastname]"
   children:
-    - name: FilterOperator
-      description:
-        conditions: "like(address, \"%Holmes%\", true)"
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
               \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
               \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        conditions: "like(address, \"%Holmes%\", true)"
+      name: FilterOperator
+  description:
+    fields: "[account_number, firstname, address, balance, gender, city, employer,\
+      \ state, age, email, lastname]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_text_like_function_case_insensitive.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_text_like_function_case_insensitive.yaml
@@ -1,16 +1,16 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[account_number, firstname, address, balance, gender, city, employer,\
-      \ state, age, email, lastname]"
   children:
-    - name: FilterOperator
-      description:
-        conditions: "like(address, \"%Holmes%\", false)"
-      children:
-        - name: OpenSearchIndexScan
+    - children:
+        - children: []
           description:
             request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
               \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\"}, pitId=*,\
               \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-          children: []
+          name: OpenSearchIndexScan
+      description:
+        conditions: "like(address, \"%Holmes%\", false)"
+      name: FilterOperator
+  description:
+    fields: "[account_number, firstname, address, balance, gender, city, employer,\
+      \ state, age, email, lastname]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_trendline_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_trendline_push.yaml
@@ -1,19 +1,19 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[ageTrend]"
   children:
-    - name: TrendlineOperator
+    - children:
+        - children: []
+          description:
+            request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
+              \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\"}, pitId=*,\
+              \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
+          name: OpenSearchIndexScan
       description:
         computations:
           - computationType: sma
             numberOfDataPoints: "2"
             dataField: age
             alias: ageTrend
-      children:
-        - name: OpenSearchIndexScan
-          description:
-            request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
-              \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\"}, pitId=*,\
-              \ cursorKeepAlive=null, searchAfter=null, searchResponse=null)"
-          children: []
+      name: TrendlineOperator
+  description:
+    fields: "[ageTrend]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/explain_trendline_sort_push.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/explain_trendline_sort_push.yaml
@@ -1,20 +1,20 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[ageTrend]"
   children:
-    - name: TrendlineOperator
+    - children:
+        - children: []
+          description:
+            request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
+              \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"sort\":[{\"\
+              age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, pitId=*, cursorKeepAlive=null,\
+              \ searchAfter=null, searchResponse=null)"
+          name: OpenSearchIndexScan
       description:
         computations:
           - computationType: sma
             numberOfDataPoints: "2"
             dataField: age
             alias: ageTrend
-      children:
-        - name: OpenSearchIndexScan
-          description:
-            request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_account,\
-              \ sourceBuilder={\"from\":0,\"size\":5,\"timeout\":\"1m\",\"sort\":[{\"\
-              age\":{\"order\":\"asc\",\"missing\":\"_first\"}}]}, pitId=*, cursorKeepAlive=null,\
-              \ searchAfter=null, searchResponse=null)"
-          children: []
+      name: TrendlineOperator
+  description:
+    fields: "[ageTrend]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_absolute_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_absolute_time_range.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[@timestamp, category, value, timestamp]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -15,4 +12,7 @@ root:
           :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
           :[\"@timestamp\",\"category\",\"value\",\"timestamp\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_chained_time_modifier.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_chained_time_modifier.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[@timestamp, category, value, timestamp]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -15,4 +12,7 @@ root:
           :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
           :[\"@timestamp\",\"category\",\"value\",\"timestamp\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_numeric_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_numeric_time_range.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[@timestamp, category, value, timestamp]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -14,4 +11,7 @@ root:
           :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
           :[\"@timestamp\",\"category\",\"value\",\"timestamp\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_relative_time_range.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_relative_time_range.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[@timestamp, category, value, timestamp]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -15,4 +12,7 @@ root:
           :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
           :[\"@timestamp\",\"category\",\"value\",\"timestamp\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  name: ProjectOperator

--- a/integ-test/src/test/resources/expectedOutput/ppl/search_with_relative_time_snap.yaml
+++ b/integ-test/src/test/resources/expectedOutput/ppl/search_with_relative_time_snap.yaml
@@ -1,9 +1,6 @@
 root:
-  name: ProjectOperator
-  description:
-    fields: "[@timestamp, category, value, timestamp]"
   children:
-    - name: OpenSearchIndexScan
+    - children: []
       description:
         request: "OpenSearchQueryRequest(indexName=opensearch-sql_test_index_time_data,\
           \ sourceBuilder={\"from\":0,\"size\":10000,\"timeout\":\"1m\",\"query\"\
@@ -14,4 +11,7 @@ root:
           :true,\"fuzzy_transpositions\":true,\"boost\":1.0}},\"_source\":{\"includes\"\
           :[\"@timestamp\",\"category\",\"value\",\"timestamp\"]}}, pitId=*,\
           \ cursorKeepAlive=1m, searchAfter=null, searchResponse=null)"
-      children: []
+      name: OpenSearchIndexScan
+  description:
+    fields: "[@timestamp, category, value, timestamp]"
+  name: ProjectOperator

--- a/legacy/src/main/java/org/opensearch/sql/legacy/cursor/DefaultCursor.java
+++ b/legacy/src/main/java/org/opensearch/sql/legacy/cursor/DefaultCursor.java
@@ -7,8 +7,6 @@ package org.opensearch.sql.legacy.cursor;
 
 import static org.opensearch.core.xcontent.DeprecationHandler.IGNORE_DEPRECATIONS;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -36,6 +34,8 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.SearchModule;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.sql.legacy.executor.format.Schema;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Minimum metdata that will be serialized for generating cursorId for<br>
@@ -141,7 +141,7 @@ public class DefaultCursor implements Cursor {
     String sortFieldValue;
     try {
       sortFieldValue = objectMapper.writeValueAsString(sortFields);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Failed to serialize sort fields to JSON string.", e);
     }
     json.put(SORT_FIELDS, sortFieldValue);
@@ -223,7 +223,7 @@ public class DefaultCursor implements Cursor {
   private static Object[] getSortFieldsFromJson(JSONObject json) {
     try {
       return objectMapper.readValue(json.getString(SORT_FIELDS), Object[].class);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Failed to parse sort fields from JSON string.", e);
     }
   }

--- a/opensearch/build.gradle
+++ b/opensearch/build.gradle
@@ -35,9 +35,9 @@ dependencies {
     api project(':ppl-rest-spi')
     api group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "io.github.resilience4j:resilience4j-retry:${resilience4j_version}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
+    implementation group: 'tools.jackson.core', name: 'jackson-core', version: "${versions.jackson3}"
+    implementation group: 'tools.jackson.core', name: 'jackson-databind', version: "${versions.jackson3_databind}"
+    implementation group: 'tools.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson3}"
     implementation group: 'org.json', name: 'json', version:'20231013'
     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
     implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/ObjectContent.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.opensearch.data.utils;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.AbstractMap;
 import java.util.Iterator;
 import java.util.List;
@@ -13,6 +12,7 @@ import java.util.Map;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
+import tools.jackson.databind.node.ArrayNode;
 
 /** The Implementation of Content to represent {@link Object}. */
 @RequiredArgsConstructor

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContent.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.opensearch.data.utils;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterators;
 import java.io.IOException;
 import java.util.Iterator;
@@ -23,6 +22,7 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import tools.jackson.databind.JsonNode;
 
 /** The Implementation of Content to represent {@link JsonNode}. */
 @RequiredArgsConstructor
@@ -62,7 +62,7 @@ public class OpenSearchJsonContent implements Content {
 
   @Override
   public String stringValue() {
-    return value().asText();
+    return value().asString();
   }
 
   @Override
@@ -75,14 +75,14 @@ public class OpenSearchJsonContent implements Content {
     LinkedHashMap<String, Content> map = new LinkedHashMap<>();
     final JsonNode mapValue = value();
     mapValue
-        .fieldNames()
-        .forEachRemaining(field -> map.put(field, new OpenSearchJsonContent(mapValue.get(field))));
+        .propertyNames()
+        .forEach(field -> map.put(field, new OpenSearchJsonContent(mapValue.get(field))));
     return map.entrySet().iterator();
   }
 
   @Override
   public Iterator<? extends Content> array() {
-    return Iterators.transform(value.elements(), OpenSearchJsonContent::new);
+    return Iterators.transform(value.values().iterator(), OpenSearchJsonContent::new);
   }
 
   @Override
@@ -127,7 +127,7 @@ public class OpenSearchJsonContent implements Content {
 
   @Override
   public boolean isString() {
-    return value().isTextual();
+    return value().isString();
   }
 
   @Override

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -20,9 +20,6 @@ import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 import static org.opensearch.sql.utils.DateTimeFormatters.STRICT_HOUR_MINUTE_SECOND_FORMATTER;
 import static org.opensearch.sql.utils.DateTimeFormatters.STRICT_YEAR_MONTH_DAY_FORMATTER;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -69,6 +66,11 @@ import org.opensearch.sql.opensearch.data.utils.Content;
 import org.opensearch.sql.opensearch.data.utils.ObjectContent;
 import org.opensearch.sql.opensearch.data.utils.OpenSearchJsonContent;
 import org.opensearch.sql.opensearch.response.agg.OpenSearchAggregationResponseParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 /** Construct ExprValue from OpenSearch response. */
 public class OpenSearchExprValueFactory {
@@ -100,7 +102,8 @@ public class OpenSearchExprValueFactory {
 
   private static final String TOP_PATH = "";
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER =
+      JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS).build();
 
   private static final Map<ExprType, BiFunction<Content, ExprType, ExprValue>> typeActionMap =
       new ImmutableMap.Builder<ExprType, BiFunction<Content, ExprType, ExprValue>>()
@@ -171,7 +174,7 @@ public class OpenSearchExprValueFactory {
           TOP_PATH,
           Optional.of(STRUCT),
           fieldTypeTolerance || supportArrays);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new IllegalStateException(String.format("invalid json: %s.", jsonString), e);
     }
   }

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/executor/OpenSearchExecutionEngine.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.opensearch.executor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Suppliers;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -75,6 +74,7 @@ import org.opensearch.sql.planner.physical.PhysicalPlan;
 import org.opensearch.sql.protocol.response.format.Format;
 import org.opensearch.sql.storage.TableScanOperator;
 import org.opensearch.transport.client.node.NodeClient;
+import tools.jackson.databind.ObjectMapper;
 
 /** OpenSearch execution engine implementation. */
 public class OpenSearchExecutionEngine implements ExecutionEngine {

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serde/RelJsonSerializer.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serde/RelJsonSerializer.java
@@ -5,9 +5,6 @@
 
 package org.opensearch.sql.opensearch.storage.serde;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -30,6 +27,10 @@ import org.opensearch.sql.calcite.CalcitePlanContext;
 import org.opensearch.sql.expression.function.PPLBuiltinOperators;
 import org.opensearch.sql.opensearch.executor.OpenSearchExecutionEngine.OperatorTable;
 import org.opensearch.sql.utils.DeserializationFilterUtil;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * A serializer that (de-)serializes Calcite RexNode, RelDataType and OpenSearch field mapping.
@@ -43,14 +44,13 @@ import org.opensearch.sql.utils.DeserializationFilterUtil;
 public class RelJsonSerializer {
 
   private final RelOptCluster cluster;
-  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final ObjectMapper mapper =
+      JsonMapper.builder()
+          .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
+          .build();
   private static final TypeReference<LinkedHashMap<String, Object>> TYPE_REF =
       new TypeReference<>() {};
   private static volatile SqlOperatorTable pplSqlOperatorTable;
-
-  static {
-    mapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
-  }
 
   public RelJsonSerializer(RelOptCluster cluster) {
     this.cluster = cluster;

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serde/SerializationWrapper.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/serde/SerializationWrapper.java
@@ -5,13 +5,13 @@
 
 package org.opensearch.sql.opensearch.storage.serde;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.sql.opensearch.storage.script.CompoundedScriptEngine.ScriptEngineType;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 /** Serialization wrapper that wraps the script language type with encoded script by JSON. */
 public class SerializationWrapper {
@@ -30,7 +30,7 @@ public class SerializationWrapper {
   public static String wrapWithLangType(ScriptEngineType langType, String script) {
     try {
       return mapper.writeValueAsString(new LangScriptWrapper(langType, script));
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Failed to wrap script with langType: " + langType, e);
     }
   }
@@ -48,7 +48,7 @@ public class SerializationWrapper {
         throw new IllegalArgumentException("Missing required fields in language script wrapper.");
       }
       return unwrapped;
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException("Failed to unwrap script with langType.", e);
     }
   }

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContentTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/utils/OpenSearchJsonContentTest.java
@@ -10,19 +10,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.opensearch.OpenSearchParseException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.JsonNode;
 
 public class OpenSearchJsonContentTest {
   @Test
-  public void testGetValueWithIOException() throws IOException {
+  public void testGetValueWithIOException() {
     JsonNode jsonNode = mock(JsonNode.class);
     JsonParser jsonParser = mock(JsonParser.class);
-    when(jsonNode.traverse()).thenReturn(jsonParser);
-    when(jsonParser.nextToken()).thenThrow(new IOException());
+    when(jsonNode.traverse(ObjectReadContext.empty())).thenReturn(jsonParser);
+    when(jsonParser.nextToken()).thenThrow(new StreamReadException("Simulated"));
     OpenSearchJsonContent content = new OpenSearchJsonContent(jsonNode);
     OpenSearchParseException exception =
         assertThrows(OpenSearchParseException.class, content::geoValue);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -35,8 +35,6 @@ import static org.opensearch.sql.data.type.ExprCoreType.STRUCT;
 import static org.opensearch.sql.data.type.ExprCoreType.TIME;
 import static org.opensearch.sql.data.type.ExprCoreType.TIMESTAMP;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -62,6 +60,8 @@ import org.opensearch.sql.opensearch.data.type.OpenSearchDateType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.data.utils.OpenSearchJsonContent;
 import org.opensearch.sql.opensearch.data.value.OpenSearchExprValueFactory.JsonPath;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 class OpenSearchExprValueFactoryTest {
 
@@ -137,7 +137,7 @@ class OpenSearchExprValueFactoryTest {
   }
 
   @Test
-  public void iterateArrayValue() throws JsonProcessingException {
+  public void iterateArrayValue() throws JacksonException {
     ObjectMapper mapper = new ObjectMapper();
     var arrayIt = new OpenSearchJsonContent(mapper.readTree("[\"zz\",\"bb\"]")).array();
     assertAll(
@@ -147,7 +147,7 @@ class OpenSearchExprValueFactoryTest {
   }
 
   @Test
-  public void iterateArrayValueWithOneElement() throws JsonProcessingException {
+  public void iterateArrayValueWithOneElement() throws JacksonException {
     ObjectMapper mapper = new ObjectMapper();
     var arrayIt = new OpenSearchJsonContent(mapper.readTree("[\"zz\"]")).array();
     assertAll(

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/AggregationQueryBuilderTest.java
@@ -27,7 +27,6 @@ import static org.opensearch.sql.opensearch.utils.Utils.avg;
 import static org.opensearch.sql.opensearch.utils.Utils.group;
 import static org.opensearch.sql.opensearch.utils.Utils.sort;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,6 +54,7 @@ import org.opensearch.sql.opensearch.data.type.OpenSearchDataType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchDateType;
 import org.opensearch.sql.opensearch.data.type.OpenSearchTextType;
 import org.opensearch.sql.opensearch.storage.serde.ExpressionSerializer;
+import tools.jackson.databind.ObjectMapper;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/MetricAggregationBuilderTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/storage/script/aggregation/dsl/MetricAggregationBuilderTest.java
@@ -21,7 +21,6 @@ import static org.opensearch.sql.expression.aggregation.StdDevAggregator.stddevS
 import static org.opensearch.sql.expression.aggregation.VarianceAggregator.variancePopulation;
 import static org.opensearch.sql.expression.aggregation.VarianceAggregator.varianceSample;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,6 +44,7 @@ import org.opensearch.sql.expression.aggregation.SumAggregator;
 import org.opensearch.sql.expression.aggregation.TakeAggregator;
 import org.opensearch.sql.expression.function.FunctionName;
 import org.opensearch.sql.opensearch.storage.serde.ExpressionSerializer;
+import tools.jackson.databind.ObjectMapper;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -155,8 +155,8 @@ spotless {
 dependencies {
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
 
-    api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-    api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    api "tools.jackson.core:jackson-core:${versions.jackson3}"
+    api "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
     api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
 
     api project(":ppl")

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/MakeResultsDataParser.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/MakeResultsDataParser.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.sql.ppl.utils;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -20,6 +18,8 @@ import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.tree.Values;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.data.type.ExprCoreType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Parses the inline {@code makeresults format=csv|json data="..."} literal into a shared {@link
@@ -129,7 +129,8 @@ public final class MakeResultsDataParser {
         throw new SyntaxCheckException("makeresults JSON data must be an array of objects");
       }
       Map<String, Object> row = new LinkedHashMap<>();
-      for (Iterator<Map.Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
+      for (Iterator<Map.Entry<String, JsonNode>> it = node.properties().iterator();
+          it.hasNext(); ) {
         Map.Entry<String, JsonNode> f = it.next();
         String name = f.getKey();
         JsonNode v = f.getValue();

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -22,9 +22,9 @@ dependencies {
 
     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     implementation "io.github.resilience4j:resilience4j-retry:${resilience4j_version}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
+    implementation group: 'tools.jackson.core', name: 'jackson-core', version: "${versions.jackson3}"
+    implementation group: 'tools.jackson.core', name: 'jackson-databind', version: "${versions.jackson3_databind}"
+    implementation group: 'tools.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson3}"
     implementation group: 'org.json', name: 'json', version: '20231013'
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.3')

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -31,9 +31,9 @@ plugins {
 
 dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: "${guava_version}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
+    implementation group: 'tools.jackson.core', name: 'jackson-core', version: "${versions.jackson3}"
+    implementation group: 'tools.jackson.core', name: 'jackson-databind', version: "${versions.jackson3_databind}"
+    implementation group: 'tools.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson3}"
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation project(':core')
     implementation project(':opensearch')
@@ -46,7 +46,7 @@ dependencies {
 }
 
 configurations.all {
-    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    resolutionStrategy.force "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
 }
 
 test {


### PR DESCRIPTION
### Description
Migrate to Jackson 3.x APIs. The OpenSearch Core will stop bundling Jackson 2.x (planned for 3.9.0), and it does not prevent plugins from using Jackson 2.x if needed, however all plugins have been migrated to Jackson 3.x APIs.

### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/22197, fixes the migration gap after https://github.com/opensearch-project/sql/pull/5361

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
