### PR TITLE
test(integ-test): exclude suites integTestRemote cannot support

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1354,6 +1354,20 @@ task integTestRemote(type: RestIntegTestTask) {
             //  - STREAMSTATS_SORT_NOT_HONORED: streamstats computes its window over the backend scan
             //    order, ignoring a preceding `| sort` (the OVER clause has no explicit ORDER BY).
             excludeTestsMatching '*CalciteStreamstatsCommandIT.testStreamstatsAndSort'
+        } else {
+            // Suites that require the analytics-engine plugin stack. They create composite
+            // (parquet-backed) indices and depend on the node-level settings
+            // opensearch.experimental.feature.pluggable.dataformat.enabled and
+            // opensearch.experimental.feature.transport.stream.enabled. Each already has a
+            // dedicated task whose testClusters block provisions that stack --
+            // :analyticsEngineCompatIT, :analyticsEngineSecurityIT and :analyticsEngineProfileIT --
+            // whereas integTestRemote runs against an externally provided cluster and can neither
+            // install plugins nor set node settings, so they fail during setup instead of being
+            // skipped. Gated here rather than listed with the exclusions below so that all
+            // analytics-engine filtering for this task stays in one place.
+            excludeTestsMatching 'org.opensearch.sql.plugin.AnalyticsEngineCompatIT'
+            excludeTestsMatching 'org.opensearch.sql.security.AnalyticsEngineSecurityIT'
+            excludeTestsMatching 'org.opensearch.sql.analytics.AnalyticsEngineProfileIT'
         }
     }
 
@@ -1366,4 +1380,23 @@ task integTestRemote(type: RestIntegTestTask) {
     exclude 'org/opensearch/sql/legacy/QueryAnalysisIT.class'
     exclude 'org/opensearch/sql/legacy/OrderIT.class'
     exclude 'org/opensearch/sql/jdbc/**'
+
+    // Suites that query a Prometheus datasource and therefore need a running Prometheus
+    // instance. `integTest` starts one itself (dependsOn startPrometheus) so it only skips
+    // these when the caller passes -DignorePrometheus; integTestRemote has no such dependency
+    // and runs against an externally provided cluster, so it can never supply Prometheus and
+    // these suites always fail in setup here. Same reasoning as the analytics-engine
+    // exclusions, which integTest also applies unconditionally.
+    exclude 'org/opensearch/sql/ppl/PrometheusDataSourceCommandsIT.class'
+    exclude 'org/opensearch/sql/ppl/ShowDataSourcesCommandIT.class'
+    exclude 'org/opensearch/sql/ppl/InformationSchemaCommandIT.class'
+
+    // Suites that create or update a datasource. That requires
+    // plugins.query.datasources.encryption.masterkey, which EncryptorImpl validates as "a required
+    // config for using create and update datasource APIs" and which must be present in
+    // opensearch.yml on every node. testClusters supplies it for integTest and yamlRestTest;
+    // integTestRemote sets no cluster settings at all and cannot add a node config to an
+    // externally provided cluster, so these suites cannot pass here. integTest still covers them.
+    exclude 'org/opensearch/sql/datasource/DataSourceAPIsIT.class'
+    exclude 'org/opensearch/sql/datasource/DataSourceEnabledIT.class'
 }


### PR DESCRIPTION
### Description

`integTestRemote` runs against an externally provided cluster (`-Dtests.rest.cluster`). It cannot install plugins, cannot set node-level settings, and — unlike `integTest` — does not start Prometheus. Three groups of suites need one of those, so instead of being skipped they are selected and fail during setup.

| Group | Suites | What this task cannot provide |
|---|---|---|
| analytics-engine | `AnalyticsEngineCompatIT`, `AnalyticsEngineSecurityIT`, `AnalyticsEngineProfileIT` | the analytics-engine plugin stack, and the node settings `opensearch.experimental.feature.pluggable.dataformat.enabled` / `...transport.stream.enabled` |
| Prometheus | `PrometheusDataSourceCommandsIT`, `ShowDataSourcesCommandIT`, `InformationSchemaCommandIT` | a running Prometheus instance — `integTest` starts one via `dependsOn startPrometheus`, this task has no such dependency |
| datasource | `DataSourceAPIsIT`, `DataSourceEnabledIT` | `plugins.query.datasources.encryption.masterkey`, which `EncryptorImpl` validates as *"a required config for using create and update datasource APIs"* and which must be in `opensearch.yml` on every node |

Each group already has a task that provisions what it needs: the dedicated `analyticsEngine*IT` tasks, and `integTest`/`yamlRestTest` whose `testClusters` blocks start Prometheus and set the masterkey. Those are untouched, so no coverage is lost.

### Change

The analytics-engine group is added as an `else` on the existing `analyticsEnabled` gate, so those suites still run when the analytics-engine route is active and all analytics-engine filtering for this task stays in one place.

The Prometheus and datasource groups are excluded unconditionally, as `integTest` already does for the analytics-engine suites it cannot provision. Class-level exclusion is needed rather than method filtering because these suites also fail in `@After` / `@AfterClass` cleanup, which a test filter cannot suppress.

Verified by inspecting the task's resolved filter state at configuration time: with no system properties set all eight suites are excluded and the pre-existing `bwc.*IT` exclusion is unaffected; with `-Dtests.analytics.parquet_indices=true` the analytics-engine suites are no longer excluded while the other two groups remain.

### Not included: the security package

`integTest` also excludes `org/opensearch/sql/security/**` because those suites run in `:integTestWithSecurity`. That does not carry over: `integTestWithSecurity` uses its own `configureSecurityPlugin()` cluster and does not cover the remote case, and `integTestRemote` forwards `https`, `user` and `password` precisely so it can target a secured cluster — where those suites are meaningful. Whether they can run depends on the target cluster, which Gradle cannot determine at configuration time, so that case needs a runtime check in the tests rather than a static exclusion. Left for separate work.

### Related Issues

No separate tracking issue.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added.
- [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

Unchecked items are not applicable: this changes a test task's exclusion list and adds no functionality, API surface or user-facing behaviour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
