### PR TITLE
Editing analyze rule and adding CI

### DIFF
--- a/core/src/main/java/org/opensearch/sql/executor/analyze/ExpensiveSortRule.java
+++ b/core/src/main/java/org/opensearch/sql/executor/analyze/ExpensiveSortRule.java
@@ -29,7 +29,11 @@ class ExpensiveSortRule implements RecommendationRule {
       return recommendations;
     }
     for (PlanNode node : view.planNodes()) {
-      if (!node.getNode().toLowerCase(Locale.ROOT).contains("sort")) {
+      // Match standalone sorts and bounded sorts fused with a limit. A top-level PPL sort is
+      // typically merged with the query-size-limit into CalciteEnumerableTopK, whose name contains
+      // no "sort" -- but a TopK is always a sort (it extends EnumerableLimitSort), so it qualifies.
+      String name = node.getNode().toLowerCase(Locale.ROOT);
+      if (!name.contains("sort") && !name.contains("topk")) {
         continue;
       }
       long rowsIn = ProfileView.rowsIn(node);

--- a/core/src/test/java/org/opensearch/sql/executor/analyze/AnalyzeRecommendationBuilderTest.java
+++ b/core/src/test/java/org/opensearch/sql/executor/analyze/AnalyzeRecommendationBuilderTest.java
@@ -100,6 +100,21 @@ class AnalyzeRecommendationBuilderTest {
   }
 
   @Test
+  void expensiveSortFiresForFusedTopKNode() {
+    // A top-level sort fuses with the query-size-limit into CalciteEnumerableTopK (no "sort" in
+    // the name). It is still a sort, so it must trip the rule: 30ms self-time of 100 (30% > 20%),
+    // 60k input rows (> 50k).
+    PlanNode scan = new PlanNode("EnumerableMergeJoin", 10.0, 60_000, null);
+    PlanNode topK = new PlanNode("CalciteEnumerableTopK", 40.0, 100, List.of(scan));
+    List<Recommendation> recs = new AnalyzeRecommendationBuilder(profile(1, 100, topK)).build();
+
+    Recommendation r = ruleOf(recs, "Expensive Sort").orElseThrow();
+    assertEquals(RecommendationSeverityLevel.WARNING, r.getSeverity());
+    assertEquals("CalciteEnumerableTopK", r.getAffected_node());
+    assertTrue(r.getMessage().contains("Sorting 60000 rows"));
+  }
+
+  @Test
   void expensiveSortSilentWhenSelfTimeIsSmall() {
     // sort cumulative 90ms but its child took 89ms -> self-time only 1ms, not expensive
     PlanNode scan = new PlanNode("scan", 89.0, 60_000, null);

--- a/docs/user/ppl/interfaces/endpoint.md
+++ b/docs/user/ppl/interfaces/endpoint.md
@@ -261,7 +261,7 @@ Expected output (trimmed):
 - Analyze output is only returned when the query finishes successfully.
 - Analyze requires the Calcite engine to be enabled (`plugins.calcite.enabled=true`).
 - The `profile` section uses the same format as the `profile` endpoint.
-- In rule calculation: rows_in` is the sum of an operator's child row counts; self-time is an operator's own duration (`time_ms − max(child time_ms)`), since profile `time_ms` is cumulative
+- In rule calculation: `rows_in` is the sum of an operator's child row counts; self-time is an operator's own duration (`time_ms − max(child time_ms)`), since profile `time_ms` is cumulative
   wall-time.
 
 

--- a/docs/user/ppl/interfaces/endpoint.md
+++ b/docs/user/ppl/interfaces/endpoint.md
@@ -247,6 +247,18 @@ Expected output (trimmed):
 | `size` | Integer | Number of result rows returned. |
 
 
+### Rules For Recommendations
+  | Rule | Severity | Trigger | Default threshold | Suggestion |
+  |------|----------|---------------|-------------------|------------|
+  | Ineffective Filter | WARNING | An in-memory filter operator passes through nearly all of its input rows (`rows_out / rows_in`). | ratio > 0.95 | Consider removing the filter or making it more selective. |
+  | Join Row Explosion | WARNING / CRITICAL | A join produces far more rows than its combined inputs (`rows_out / rows_in`). | ratio > 5 (WARNING); ≥ 20 (CRITICAL) | Add filters to the subqueries before the join to reduce rows. |
+  | Expensive Sort | WARNING | A sort (including a limit-fused top-N) runs in-memory over a large input and consumes a large share of execution time. | self-time > 20% of execute and input rows > 50,000 | Filter or limit rows before sorting (e.g. add `head` or a `where`). |
+  | Bottleneck Stage | INFO | A single operator's self-time dominates total execution time. | self-time > 75% of execute | — |
+  | Optimize Phase Dominates | INFO | Query planning takes longer than execution. | optimize > execute **and** optimize > 75 ms | — |
+
+  > **Note:** `rows_in` is the sum of an operator's child row counts; self-time is an operator's own duration (`time_ms − max(child time_ms)`), since profile `time_ms` is cumulative
+  wall-time.
+
 ### Notes
 - Analyze output is only returned when the query finishes successfully.
 - Analyze requires the Calcite engine to be enabled (`plugins.calcite.enabled=true`).

--- a/docs/user/ppl/interfaces/endpoint.md
+++ b/docs/user/ppl/interfaces/endpoint.md
@@ -248,22 +248,21 @@ Expected output (trimmed):
 
 
 ### Rules For Recommendations
-  | Rule | Severity | Trigger | Default threshold | Suggestion |
-  |------|----------|---------------|-------------------|------------|
-  | Ineffective Filter | WARNING | An in-memory filter operator passes through nearly all of its input rows (`rows_out / rows_in`). | ratio > 0.95 | Consider removing the filter or making it more selective. |
-  | Join Row Explosion | WARNING / CRITICAL | A join produces far more rows than its combined inputs (`rows_out / rows_in`). | ratio > 5 (WARNING); ≥ 20 (CRITICAL) | Add filters to the subqueries before the join to reduce rows. |
-  | Expensive Sort | WARNING | A sort (including a limit-fused top-N) runs in-memory over a large input and consumes a large share of execution time. | self-time > 20% of execute and input rows > 50,000 | Filter or limit rows before sorting (e.g. add `head` or a `where`). |
-  | Bottleneck Stage | INFO | A single operator's self-time dominates total execution time. | self-time > 75% of execute | — |
-  | Optimize Phase Dominates | INFO | Query planning takes longer than execution. | optimize > execute **and** optimize > 75 ms | — |
+| Rule | Severity | Trigger | Default threshold | Suggestion |
+|------|----------|---------------|-------------------|------------|
+| Ineffective Filter | WARNING | An in-memory filter operator passes through nearly all of its input rows (`rows_out / rows_in`). | ratio > 0.95 | Consider removing the filter or making it more selective. |
+| Join Row Explosion | WARNING / CRITICAL | A join produces far more rows than its combined inputs (`rows_out / rows_in`). | ratio > 5 (WARNING); ≥ 20 (CRITICAL) | Add filters to the subqueries before the join to reduce rows. |
+| Expensive Sort | WARNING | A sort (including a limit-fused top-N) runs in-memory over a large input and consumes a large share of execution time. | self-time > 20% of execute and input rows > 50,000 | Filter or limit rows before sorting (e.g. add `head` or a `where`). |
+| Bottleneck Stage | INFO | A single operator's self-time dominates total execution time. | self-time > 75% of execute | — |
+| Optimize Phase Dominates | INFO | Query planning takes longer than execution. | optimize > execute **and** optimize > 75 ms | — |
 
-  > **Note:** `rows_in` is the sum of an operator's child row counts; self-time is an operator's own duration (`time_ms − max(child time_ms)`), since profile `time_ms` is cumulative
-  wall-time.
 
 ### Notes
 - Analyze output is only returned when the query finishes successfully.
 - Analyze requires the Calcite engine to be enabled (`plugins.calcite.enabled=true`).
 - The `profile` section uses the same format as the `profile` endpoint.
-
+- In rule calculation: rows_in` is the sum of an operator's child row counts; self-time is an operator's own duration (`time_ms − max(child time_ms)`), since profile `time_ms` is cumulative
+  wall-time.
 
 
 ## Profile (Experimental) (Deprecated)


### PR DESCRIPTION
### Description
- Updating Expensive Sort analyze rule to account for CalciteEnumerableTopK case
- Adding IT as well
- Adding rules to `endpoint.md`


Currently, a `head` + `sort` command becomes a CalciteEnumerableTopK, so this rule will miss `sort` operations if the query also contains `head` (which it will with `fetch_size`). Added "topk" in rule check to fix. 

### Related Issues
Related to #5658 
Related to #5568
Related to #5500 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
