### PR TITLE
Drop the pointer to the bucket functions from the function list

### DIFF
--- a/docs/user/dql/functions.rst
+++ b/docs/user/dql/functions.rst
@@ -15,8 +15,6 @@ There is support for a wide variety of functions shared by SQL/PPL. We are inten
 
 Most of the specifications can be self explained just as a regular function with data type as argument. The only notation that needs elaboration is generic type ``T`` which binds to an actual type and can be used as return type. For example, ``ABS(NUMBER T) -> T`` means function ``ABS`` accepts an numerical argument of type ``T`` which could be any sub-type of ``NUMBER`` type and returns the actual type of ``T`` as return type. The actual type binds to generic type at runtime dynamically.
 
-The bucket functions ``date_histogram`` and ``histogram`` are not listed here because they are only valid as a grouping key, please see also: `Aggregations <aggregations.rst>`_
-
 
 Type Conversion
 ===============


### PR DESCRIPTION
### Description

Follow-up to [this comment](https://github.com/opensearch-project/sql/pull/5700#discussion_r3825563218) on #5700.

`functions.rst` gained a line pointing at the bucket functions, saying they are documented under GROUP BY rather than in the function list. Calling them bucket functions is already the name other databases use, so a reader looking for them under that name does not need the signpost.

The section it pointed at — `Bucket Function`, under GROUP BY Clause in `aggregations.rst` — stays as it is.

### Related Issues

Follow-up to #5700

### Check List
- [x] New functionality includes testing.
  - Doctest run on both files: `functions.rst` and `aggregations.rst`.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.
