### PR TITLE
Support flat_object field type in PPL projection

### DIFF
--- a/docs/user/general/datatypes.rst
+++ b/docs/user/general/datatypes.rst
@@ -101,6 +101,8 @@ The table below list the mapping between OpenSearch Data Type, OpenSearch SQL Da
 +-----------------+---------------------+-----------+
 | object          | struct              | STRUCT    |
 +-----------------+---------------------+-----------+
+| flat_object     | struct              | STRUCT    |
++-----------------+---------------------+-----------+
 | nested          | array               | STRUCT    |
 +-----------------+---------------------+-----------+
 

--- a/docs/user/ppl/general/datatypes.md
+++ b/docs/user/ppl/general/datatypes.md
@@ -49,6 +49,7 @@ The table below list the mapping between OpenSearch Data Type, PPL Data Type and
 | ip | ip | VARCHAR |
 | binary | binary | VARBINARY |
 | object | struct | STRUCT |
+| flat_object | struct | STRUCT |
 | nested | array | STRUCT |
   
 Notes: Not all the PPL Type has correspond OpenSearch Type. e.g. data and time. To use function which required such data type, user should explicit convert the data type.

--- a/docs/user/ppl/limitations/limitations.md
+++ b/docs/user/ppl/limitations/limitations.md
@@ -13,7 +13,7 @@ PPL does not support all [OpenSearch data types](https://docs.opensearch.org/lat
 | --- | --- |
 | knn_vector | Ignored |
 | Range field types | Ignored |
-| Object - flat_object | Ignored |
+| Object - flat_object | Partial — see [Flat Object Field Behavior](#flat-object-field-behavior) |
 | Object - join | Ignored |
 | String - Match-only text | Ignored |
 | String - Wildcard | Ignored |
@@ -37,6 +37,37 @@ For a field to be queryable in PPL, the following index settings must be enabled
 | index: true | Enables field indexing | Required for filtering, search, and aggregations |
 | doc_values: true | Enables columnar access for aggregations/sorting | Required for `stats`, `sort` |
   
+## Flat Object Field Behavior
+
+`flat_object` fields are returned in query results and their top-level keys are addressable, but the
+type carries limitations that come from how OpenSearch indexes it and from how PPL resolves dotted
+paths.
+
+Supported:
+
+* The field is listed by `describe` (as type `struct`) and returned by `source` and `fields`.
+* A top-level key is addressable and keeps its `_source` type — given
+  `{"flat": {"s": "x", "n": 7}}`, `fields flat.s` returns the string `x` and `fields flat.n` returns
+  the integer `7`.
+* Filtering on a top-level key works, for example `where flat.s = 'x'`.
+
+Not supported:
+
+* **Subfield paths deeper than one level resolve to `NULL`.** For `{"flat": {"a": {"b": 1}}}`,
+  `fields flat.a.b` returns `NULL` rather than `1`, and no error is raised.
+* **A nested value is returned as JSON text**, not as a structure — `fields flat.a` returns the
+  string `{"b":1}`.
+* **Aggregating on a subfield cannot be pushed down.** OpenSearch reports `flat_object` as
+  non-aggregatable, so `stats ... by flat.a` cannot use a native aggregation.
+* **Sorting on a subfield is not meaningful.** OpenSearch sorts on an internal representation that
+  spans every subfield of the object.
+* `flatten` and `expand` cannot enumerate a `flat_object`, because subfield names are not present in
+  the index mapping.
+
+Subfield names are resolved lazily by OpenSearch per query and are absent from the mapping, so PPL
+cannot discover them at planning time; a `flat_object` therefore contributes exactly one column to
+the schema. Use `spath` to reach deeper paths within the returned JSON.
+
 ## Nested Field Behavior  
 
 * There are [limitations](https://github.com/opensearch-project/sql/issues/4625) regarding the nested levels and query types that need improvement.  

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/1604.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/1604.yml
@@ -1,0 +1,160 @@
+# Issue: https://github.com/opensearch-project/sql/issues/1604
+#        https://github.com/opensearch-project/sql/issues/3067
+# flat_object fields used to be dropped by OpenSearchDataType.parseMapping ("unknown type, skip
+# it"), so they vanished from query results entirely and could not be referenced at all. This
+# covers the projection contract: the field is visible, selectable, and round-trips its _source
+# JSON, on both the Calcite and the v2 engine.
+setup:
+  - do:
+      indices.create:
+        index: issue1604
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+            properties:
+              eventName:
+                type: keyword
+              requestParameters:
+                type: flat_object
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "issue1604", "_id": "1"}}'
+          - '{"eventName": "CreateInstanceExportTask", "requestParameters": {"instanceId": "i-123", "nextToken": "abc"}}'
+          - '{"index": {"_index": "issue1604", "_id": "2"}}'
+          - '{"eventName": "DescribeInstances", "requestParameters": {"instanceId": "i-456"}}'
+          - '{"index": {"_index": "issue1604", "_id": "3"}}'
+          - '{"eventName": "RunInstances", "requestParameters": {"instanceId": "i-789", "filter": {"state": "running"}}}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: issue1604
+        ignore_unavailable: true
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+---
+"Issue 1604: flat_object field is projected with Calcite enabled":
+  - skip:
+      features:
+        - headers
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+            plugins.calcite.fallback.allowed: false
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=issue1604 | where eventName = ''DescribeInstances'' | fields requestParameters'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "requestParameters", "type": "struct"}]}
+  - match: {"datarows": [[{"instanceId": "i-456"}]]}
+
+---
+"Issue 1604: flat_object field is projected with Calcite disabled":
+  - skip:
+      features:
+        - headers
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: false
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=issue1604 | where eventName = ''DescribeInstances'' | fields requestParameters'
+  - match: {"total": 1}
+  - match: {"schema": [{"name": "requestParameters", "type": "struct"}]}
+  - match: {"datarows": [[{"instanceId": "i-456"}]]}
+
+---
+"Issue 1604: flat_object subfield is addressable":
+  - skip:
+      features:
+        - headers
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+            plugins.calcite.fallback.allowed: false
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=issue1604 | sort eventName | fields requestParameters.instanceId'
+  - match: {"total": 3}
+  - match: {"datarows": [["i-123"], ["i-456"], ["i-789"]]}
+
+---
+"Issue 1604: flat_object field appears in describe":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'describe issue1604 | where COLUMN_NAME = ''requestParameters'' | fields COLUMN_NAME, TYPE_NAME'
+  - match: {"total": 1}
+  # PPL reports the PPL type name (struct), matching how object fields are described.
+  # The SQL surface reports legacyTypeName() = flat_object; that divergence predates this change.
+  - match: {"datarows": [["requestParameters", "struct"]]}
+
+---
+# Known limitations of this first increment, pinned so any future change is deliberate rather
+# than accidental. Tracked by https://github.com/opensearch-project/sql/issues/1604 item 2.
+#
+#  * A nested value is stringified by OpenSearchExprValueFactory#parseContent, which has no
+#    object branch (the Content interface has no isObject() predicate). See issue 3751.
+#  * A subfield path deeper than one level resolves to NULL: QualifiedNameResolver#resolveFieldAccess
+#    joins the remaining parts into a single ITEM key ('filter.state'), which cannot match.
+"Issue 1604: nested values are stringified and depth-2 paths resolve to null":
+  - skip:
+      features:
+        - headers
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled: true
+            plugins.calcite.fallback.allowed: false
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=issue1604 | where eventName = ''RunInstances'' | fields requestParameters.filter'
+  - match: {"total": 1}
+  - match: {"datarows": [["{\"state\":\"running\"}"]]}
+
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: 'source=issue1604 | where eventName = ''RunInstances'' | fields requestParameters.filter.state'
+  - match: {"total": 1}
+  - match: {"datarows": [[null]]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchAliasType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchAliasType.java
@@ -20,7 +20,7 @@ public class OpenSearchAliasType extends OpenSearchDataType {
   public static final String typeName = "alias";
   public static final String pathPropertyName = "path";
   public static final Set<MappingType> objectFieldTypes =
-      Set.of(MappingType.Object, MappingType.Nested);
+      Set.of(MappingType.Object, MappingType.Nested, MappingType.FlatObject);
   private final String path;
   @Getter private final OpenSearchDataType originalType;
 

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/type/OpenSearchDataType.java
@@ -38,6 +38,7 @@ public class OpenSearchDataType implements ExprType, Serializable {
     Date("date", ExprCoreType.TIMESTAMP),
     DateNanos("date_nanos", ExprCoreType.TIMESTAMP),
     Object("object", ExprCoreType.STRUCT),
+    FlatObject("flat_object", ExprCoreType.STRUCT),
     Nested("nested", ExprCoreType.ARRAY),
     Byte("byte", ExprCoreType.BYTE),
     Short("short", ExprCoreType.SHORT),
@@ -149,6 +150,10 @@ public class OpenSearchDataType implements ExprType, Serializable {
     OpenSearchDataType res =
         instances.getOrDefault(mappingType.toString(), new OpenSearchDataType(mappingType));
     switch (mappingType) {
+      // flat_object has no declared `properties`; it shares the Object arm so that it gets a
+      // fresh instance with a mutable (empty) property map rather than the cached singleton,
+      // whose immutable map would break cross-index merging in DESCRIBE.
+      case FlatObject:
       case Object:
       // TODO: use Object type once it has been added
       case Nested:


### PR DESCRIPTION
### Description

`flat_object` fields are currently invisible to PPL — not merely unsupported. This PR registers `FlatObject("flat_object", ExprCoreType.STRUCT)` in `MappingType`. Because `@EqualsAndHashCode` excludes `mappingType`, the existing struct machinery then applies with no further edits — `OpenSearchExprValueFactory` routes it to `parseStruct`, and `OpenSearchTypeFactory` maps `STRUCT` to `MAP(VARCHAR, ANY)`. The value factory is untouched.

Two supporting changes:

* `flat_object` is routed through the `Object`/`Nested` arm of `of()` rather than the `default:` arm. The default arm hands out the cached singleton whose `properties` field is the class-level `ImmutableMap`, which fails cross-index merging in `DESCRIBE` (`DeepMergeRule` → `LatestRule.put` → `UnsupportedOperationException`). The Object arm yields a fresh instance with a mutable `LinkedHashMap`.
* `OpenSearchAliasType.objectFieldTypes` now includes `FlatObject`, so `alias -> flat_object` is rejected instead of producing a field that `DESCRIBE` lists but `SOURCE` cannot select.

### Behavior change

Measured at the schema layer with the same mapping, before and after:

```
BEFORE  parseMapping=[eventName]           flat=ABSENT
AFTER   parseMapping=[eventName, flat]     flat=FLAT_OBJECT, core=STRUCT, props=LinkedHashMap
```

User-visible, for `{"flat": {"s": "x", "n": 7, "a": {"b": 1}}}`:

| Query | Before | After |
|---|---|---|
| `source=idx` | field omitted entirely | `{s=x, n=7, a={"b":1}}` |
| `describe idx` | row absent | `flat \| struct` |
| `fields flat.s` | resolution failure | `x` |
| `fields flat.n` | resolution failure | `7` (`_source` type preserved) |
| `where flat.s = 'x'` | resolution failure | filters correctly |
| `fields flat.a` | resolution failure | `{"b":1}` — JSON text, not a struct |
| `fields flat.a.b` | resolution failure | `NULL` |

### Scope

This PR covers **querying the field**. It does **not** implement searching sub-fields.

Subfield names are not present in the index mapping — OpenSearch resolves them lazily per query via `FlatObjectFieldType.keyedFieldType`, and `_field_caps` does not expose them either. Since row types are built eagerly from `IndexMapping` → `parseMapping` → `traverseAndFlatten`, a `flat_object` contributes exactly one column, and no plan-time hook can produce `flat.a` as a schema column.

Two known limitations follow, and both are **pinned by tests** so any future change is deliberate:

* **Nested values are returned as JSON text.** `OpenSearchExprValueFactory#parseContent` has no object branch and falls through to `new ExprStringValue(content.objectValue().toString())`. The `Content` interface has no `isObject()` predicate, so a recursive branch cannot be written without extending `Content` and both implementations. Related: #3751.
* **Paths deeper than one level resolve to `NULL`.** `QualifiedNameResolver#resolveFieldAccess` joins the remaining parts into a single `ITEM` key (`'a.b'`), which cannot match a nested tuple.

Also out of scope, and documented rather than worked around:

* **Aggregation on a subfield cannot be pushed down** — `FlatObjectFieldType.isAggregatable()` returns `false` upstream (OpenSearch#14225 is open). This is an external limit, not a gap in this plugin.
* **Sorting on a subfield is not meaningful** — OpenSearch orders on an internal representation spanning every subfield of the object.
* **No predicate pushdown for subpaths.** `SqlKind.ITEM` is whitelisted in `PredicateAnalyzer.supportedRexCall` but has no case in `visitCall`'s switch. Filters on `flat.*` currently run on the coordinator.

### Note on the DESCRIBE type name

PPL reports `struct` and SQL reports `flat_object`, because `OpenSearchDescribeIndexRequest` uses `langSpec.typeName(getExprType())` for PPL and `legacyTypeName()` for SQL. This mirrors the existing contract for `object` fields and is deliberately unchanged here. Happy to revisit if reviewers would rather `DESCRIBE` distinguish `flat_object`, since the query semantics do differ.

### Testing

* `integ-test/.../rest-api-spec/test/issues/1604.yml` — 5 cases covering projection with Calcite enabled and disabled, subfield addressability, `DESCRIBE`, and the two pinned limitations. `tests=5 skipped=0 failures=0 errors=0`.
* Unit tests: 338 suites / 6969 tests, 0 failures.
* Rebased on `d9d15b1b3` (Migrate to Jackson 3.x APIs) and re-verified, since that commit touches `OpenSearchJsonContent`, `ObjectContent` and `OpenSearchExprValueFactory` — the decode path these tests assert on.

### Related Issues

Addresses item 1 of #1604 ("Support querying such fields, for example in `select *` query"). Item 2 ("Support search for sub-fields") is out of scope — see Scope above.
Addresses the primary complaint in #3067 (`flat_object` fields missing from query results).
Part of #3695.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
