### PR TITLE
Register missing `TAN` function for analytics engine

### DIFF
--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -238,6 +238,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.SUBTRAC
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.SUM;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.SYSDATE;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.TAKE;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.TAN;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.TIME;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.TIMEDIFF;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.TIMESTAMP;
@@ -1080,6 +1081,7 @@ public class PPLFuncImpTable {
       registerOperator(SIGN, SqlStdOperatorTable.SIGN);
       registerOperator(SIGNUM, SqlStdOperatorTable.SIGN);
       registerOperator(SIN, SqlStdOperatorTable.SIN);
+      registerOperator(TAN, SqlStdOperatorTable.TAN);
       registerOperator(CBRT, SqlStdOperatorTable.CBRT);
 
       registerOperator(IFNULL, SqlStdOperatorTable.COALESCE);

--- a/docs/user/ppl/functions/math.md
+++ b/docs/user/ppl/functions/math.md
@@ -1426,3 +1426,33 @@ fetched rows / total rows = 1/1
 +-----------+
 ```
   
+## TAN
+
+**Usage**: `TAN(x)`
+
+Calculates the tangent of `x`, where `x` is given in radians.
+
+**Parameters**:
+
+- `x` (Required): An `INTEGER`, `LONG`, `FLOAT`, or `DOUBLE` value.
+
+**Return type**: `DOUBLE`
+
+### Example
+  
+```ppl
+source=people
+| eval `TAN(0)` = TAN(0)
+| fields `TAN(0)`
+```
+  
+The query returns the following results:
+  
+```text
+fetched rows / total rows = 1/1
++--------+
+| TAN(0) |
+|--------|
+| 0.0    |
++--------+
+```

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLBuiltinFunctionIT.java
@@ -193,6 +193,18 @@ public class CalcitePPLBuiltinFunctionIT extends PPLIntegTestCase {
   }
 
   @Test
+  public void testTan() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval tan = tan(pi() / 4) | head 1 | fields tan",
+                TEST_INDEX_STATE_COUNTRY));
+
+    verifySchema(actual, schema("tan", "double"));
+    verifyDataRows(actual, closeTo(1.0));
+  }
+
+  @Test
   public void testCrc32AndAbs() throws IOException {
     JSONObject actual =
         executeQuery(

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMathFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLMathFunctionTest.java
@@ -334,4 +334,11 @@ public class CalcitePPLMathFunctionTest extends CalcitePPLAbstractTest {
     String expectedSparkSql = "SELECT POWER(4, 5E-1) `SQRT`\nFROM `scott`.`EMP`";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
+
+  @Test
+  public void testTan() {
+    withPPLQuery("source=EMP | eval TAN = tan(0) | fields TAN")
+        .expectLogical("LogicalProject(TAN=[TAN(0)])\n  LogicalTableScan(table=[[scott, EMP]])\n")
+        .expectSparkSQL("SELECT TAN(0) `TAN`\nFROM `scott`.`EMP`");
+  }
 }


### PR DESCRIPTION
### Description

`TAN` was already declared in both the SQL and PPL grammars, and it works on the V2 engine, but `PPLFuncImpTable` registered every other trigonometric function and omitted this one. On the PPL V3 and analytics engine path, the resolution therefore failed with `IllegalStateException: Cannot resolve function: TAN`. This PR registers the operator against `SqlStdOperatorTable.TAN`, fixing both SQL and PPL path.

### Related Issues
Part of https://github.com/opensearch-project/sql/issues/5248

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
