### PR TITLE
test(integ-test): add explicit ordering to order-dependent integration tests

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteBinCommandIT.java
@@ -109,10 +109,14 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testBinValueFieldOnly() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. Sort on a unique key to fix which
+    // rows are selected; the expected values are unchanged.
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | bin value span=2000 | fields value | head 3", TEST_INDEX_TIME_DATA));
+                "source=%s | sort `@timestamp` | bin value span=2000 | fields value | head 3",
+                TEST_INDEX_TIME_DATA));
     verifySchema(result, schema("value", null, "string"));
 
     verifyDataRows(result, rows("8000-10000"), rows("6000-8000"), rows("8000-10000"));
@@ -517,10 +521,14 @@ public class CalciteBinCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testBinSpanWithStartEndNeverShrinkRange() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. Sort on a unique key to fix which
+    // rows are selected; the expected values are unchanged.
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | bin age span=1 start=25 end=35 as cate | fields cate, age | head 6",
+                "source=%s | sort account_number | bin age span=1 start=25 end=35 as cate | fields"
+                    + " cate, age | head 6",
                 TEST_INDEX_BANK));
 
     verifySchema(result, schema("cate", null, "string"), schema("age", null, "int"));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteConvertCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteConvertCommandIT.java
@@ -29,10 +29,14 @@ public class CalciteConvertCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testConvertAutoFunction() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. Sort on a unique key to fix which
+    // rows are selected; the expected values are unchanged.
     JSONObject result =
         executeQuery(
             String.format(
-                "search source=%s | convert auto(balance) | fields balance | head 3",
+                "search source=%s | sort account_number | convert auto(balance) | fields balance |"
+                    + " head 3",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("balance", null, "double"));
     verifyDataRows(result, rows(39225.0), rows(5686.0), rows(32838.0));
@@ -52,10 +56,14 @@ public class CalciteConvertCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testConvertNumFunction() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. Sort on a unique key to fix which
+    // rows are selected; the expected values are unchanged.
     JSONObject result =
         executeQuery(
             String.format(
-                "search source=%s | convert num(balance) | fields balance | head 3",
+                "search source=%s | sort account_number | convert num(balance) | fields balance |"
+                    + " head 3",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("balance", null, "double"));
     verifyDataRows(result, rows(39225.0), rows(5686.0), rows(32838.0));
@@ -63,11 +71,14 @@ public class CalciteConvertCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testConvertWithAlias() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. Sort on a unique key to fix which
+    // rows are selected; the expected values are unchanged.
     JSONObject result =
         executeQuery(
             String.format(
-                "search source=%s | convert auto(balance) AS balance_num | fields balance,"
-                    + " balance_num | head 3",
+                "search source=%s | sort account_number | convert auto(balance) AS balance_num |"
+                    + " fields balance, balance_num | head 3",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("balance", null, "bigint"), schema("balance_num", null, "double"));
     verifyDataRows(result, rows(39225, 39225.0), rows(5686, 5686.0), rows(32838, 32838.0));
@@ -75,10 +86,14 @@ public class CalciteConvertCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testConvertMultipleFunctions() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. Sort on a unique key to fix which
+    // rows are selected; the expected values are unchanged.
     JSONObject result =
         executeQuery(
             String.format(
-                "search source=%s | convert auto(balance), num(age) | fields balance, age | head 3",
+                "search source=%s | sort account_number | convert auto(balance), num(age) | fields"
+                    + " balance, age | head 3",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("balance", null, "double"), schema("age", null, "double"));
     verifyDataRows(result, rows(39225.0, 32.0), rows(5686.0, 36.0), rows(32838.0, 28.0));
@@ -194,10 +209,14 @@ public class CalciteConvertCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testConvertNoneFunction() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. Sort on a unique key to fix which
+    // rows are selected; the expected values are unchanged.
     JSONObject result =
         executeQuery(
             String.format(
-                "search source=%s | convert none(account_number) | fields account_number | head 3",
+                "search source=%s | sort account_number | convert none(account_number) | fields"
+                    + " account_number | head 3",
                 TEST_INDEX_BANK));
     verifySchema(result, schema("account_number", null, "bigint"));
     verifyDataRows(result, rows(1), rows(6), rows(13));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteEvalCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteEvalCommandIT.java
@@ -218,11 +218,14 @@ public class CalciteEvalCommandIT extends PPLIntegTestCase {
 
   @Test
   public void testEvalStringConcatenationWithExistingData() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. Sort on a unique key to fix which
+    // rows are selected; the expected values are unchanged.
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | eval full_name = firstname + ' ' + lastname | head 3 | fields"
-                    + " firstname, lastname, full_name",
+                "source=%s | sort account_number | eval full_name = firstname + ' ' + lastname |"
+                    + " head 3 | fields firstname, lastname, full_name",
                 TEST_INDEX_BANK));
     verifySchema(
         result,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMVAppendFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMVAppendFunctionIT.java
@@ -123,11 +123,15 @@ public class CalciteMVAppendFunctionIT extends PPLIntegTestCase {
 
   @Test
   public void testMvappendWithFieldsAndLiterals() throws IOException {
+    // `head` without a preceding sort selects an undefined row, so the asserted age only holds by
+    // accident of scan order. Sort by account_number as the neighbouring real-field tests do; the
+    // expected values are unchanged.
     JSONObject actual =
         executeQuery(
             source(
                 TEST_INDEX_BANK,
-                "eval result = mvappend(age, 'years', 'old') | head 1 | fields age, result"));
+                "eval result = mvappend(age, 'years', 'old') | sort account_number | head 1 |"
+                    + " fields age, result"));
 
     verifySchema(actual, schema("age", "int"), schema("result", "array"));
     verifyDataRows(actual, rows(32, List.of(32, "years", "old")));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultiValueStatsIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMultiValueStatsIT.java
@@ -141,9 +141,14 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
 
   @Test
   public void testListFunctionWithTime() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. `key` is unique in this fixture, so
+    // sorting on it fixes which rows `head` takes without changing the expected values.
     JSONObject response =
         executeQuery(
-            String.format("source=%s | head 1 | stats list(time1) as time_list", TEST_INDEX_CALCS));
+            String.format(
+                "source=%s | sort key | head 1 | stats list(time1) as time_list",
+                TEST_INDEX_CALCS));
     verifySchema(response, schema("time_list", "array"));
     // Time values are stored as strings in the test data
     verifyDataRows(response, rows(List.of("19:36:22")));
@@ -189,9 +194,13 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
 
   @Test
   public void testListFunctionWithNullValues() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. `key` is unique in this fixture, so
+    // sorting on it fixes which rows `head` takes without changing the expected values.
     JSONObject response =
         executeQuery(
-            String.format("source=%s | head 5 | stats list(int0) as int_list", TEST_INDEX_CALCS));
+            String.format(
+                "source=%s | sort key | head 5 | stats list(int0) as int_list", TEST_INDEX_CALCS));
     verifySchema(response, schema("int_list", "array"));
     // Nulls are filtered out by list function
     verifyDataRows(response, rows(List.of("1", "7")));
@@ -212,10 +221,14 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
 
   @Test
   public void testListFunctionMultipleFields() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. `key` is unique in this fixture, so
+    // sorting on it fixes which rows `head` takes without changing the expected values.
     JSONObject response =
         executeQuery(
             String.format(
-                "source=%s | head 3 | stats list(str2) as str_list, list(int2) as int_list",
+                "source=%s | sort key | head 3 | stats list(str2) as str_list, list(int2) as"
+                    + " int_list",
                 TEST_INDEX_CALCS));
     verifySchema(response, schema("str_list", "array"), schema("int_list", "array"));
 
@@ -276,10 +289,14 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
 
   @Test
   public void testListFunctionWithArithmeticExpression() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. `key` is unique in this fixture, so
+    // sorting on it fixes which rows `head` takes without changing the expected values.
     JSONObject response =
         executeQuery(
             String.format(
-                "source=%s | head 3 | stats list(int3 + 1) as arithmetic_list", TEST_INDEX_CALCS));
+                "source=%s | sort key | head 3 | stats list(int3 + 1) as arithmetic_list",
+                TEST_INDEX_CALCS));
     verifySchema(response, schema("arithmetic_list", "array"));
     verifyDataRows(response, rows(List.of("9", "14", "3")));
   }
@@ -338,10 +355,14 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
 
   @Test
   public void testValuesFunctionWithNullValues() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. `key` is unique in this fixture, so
+    // sorting on it fixes which rows `head` takes without changing the expected values.
     JSONObject response =
         executeQuery(
             String.format(
-                "source=%s | head 5 | stats values(int0) as int_values", TEST_INDEX_CALCS));
+                "source=%s | sort key | head 5 | stats values(int0) as int_values",
+                TEST_INDEX_CALCS));
     verifySchema(response, schema("int_values", "array"));
     // Nulls are filtered out by values function
     // VALUES returns sorted unique values
@@ -350,10 +371,14 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
 
   @Test
   public void testValuesFunctionGroupBy() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. `key` is unique in this fixture, so
+    // sorting on it fixes which rows `head` takes without changing the expected values.
     JSONObject response =
         executeQuery(
             String.format(
-                "source=%s | head 5 | stats values(num0) as num_values by str0", TEST_INDEX_CALCS));
+                "source=%s | sort key | head 5 | stats values(num0) as num_values by str0",
+                TEST_INDEX_CALCS));
     verifySchema(response, schema("num_values", "array"), schema("str0", null, "string"));
 
     // Group by str0 field - should have different groups with their respective unique num0 values
@@ -369,10 +394,14 @@ public class CalciteMultiValueStatsIT extends PPLIntegTestCase {
 
   @Test
   public void testValuesFunctionMultipleFields() throws IOException {
+    // `head` without a preceding sort selects an undefined set of rows, so the exact values
+    // asserted below only hold by accident of scan order. `key` is unique in this fixture, so
+    // sorting on it fixes which rows `head` takes without changing the expected values.
     JSONObject response =
         executeQuery(
             String.format(
-                "source=%s | head 3 | stats values(str2) as str_values, values(int2) as int_values",
+                "source=%s | sort key | head 3 | stats values(str2) as str_values, values(int2) as"
+                    + " int_values",
                 TEST_INDEX_CALCS));
     verifySchema(response, schema("str_values", "array"), schema("int_values", "array"));
 

--- a/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/ppl/StandaloneIT.java
@@ -104,7 +104,9 @@ public class StandaloneIT extends PPLIntegTestCase {
     request2.setJsonEntity("{\"name\": \"world\", \"age\": 30}");
     client().performRequest(request2);
 
-    String actual = executeByStandaloneQueryEngine("source=test | fields name");
+    // Two documents with no ordering specified: assert against a defined order rather than
+    // relying on scan order, which differs once the index has more than one shard.
+    String actual = executeByStandaloneQueryEngine("source=test | sort name | fields name");
     assertEquals(
         "{\n"
             + "  \"schema\": [\n"

--- a/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/sql/RawFormatIT.java
@@ -33,7 +33,9 @@ public class RawFormatIT extends SQLIntegTestCase {
     String result =
         executeQuery(
             String.format(
-                Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE),
+                Locale.ROOT,
+                "SELECT firstname, lastname FROM %s ORDER BY account_number",
+                TEST_INDEX_BANK_RAW_SANITIZE),
             "raw");
 
     assertRowsEqual(
@@ -52,7 +54,9 @@ public class RawFormatIT extends SQLIntegTestCase {
     String result =
         executeQuery(
             String.format(
-                Locale.ROOT, "SELECT firstname, lastname FROM %s", TEST_INDEX_BANK_RAW_SANITIZE),
+                Locale.ROOT,
+                "SELECT firstname, lastname FROM %s ORDER BY account_number",
+                TEST_INDEX_BANK_RAW_SANITIZE),
             "raw",
             Map.of("pretty", "true"));
     assertEquals(


### PR DESCRIPTION
### Description

Seven integration-test classes assert exact values or exact output over a query whose row order was never defined. All are test-side: every changed file is under `src/test`, no production code is touched, and **no expected value changes** — each fix adds an ordering that reproduces what the test already expects.

**Why one shard passes and multiple shards fail:** with a single shard there is one segment order, so an unordered scan returns rows in a stable incidental order and an assertion depending on it passes by luck. With multiple shards the coordinator merges per-shard results, that incidental order changes, and the assertion breaks.

**Why these are test defects and not engine bugs:** in each case the engine returns correct data for whichever rows it was given — what differs is *which rows reach the assertion*, or *in what order they are printed*, neither of which the query constrained.

### 1. `CalciteMultiValueStatsIT` — `head N` with no sort

Seven tests run `head N` over an unordered scan and then assert exact values. `head` selects an undefined set of rows, so a 5-shard index feeds `stats` a different set:

```
source=<calcs> | head 5 | stats values(num0) as num_values by str0

1 shard : FURNITURE, FURNITURE, OFFICE SUPPLIES, OFFICE SUPPLIES, OFFICE SUPPLIES
5 shards: OFFICE SUPPLIES, OFFICE SUPPLIES, TECHNOLOGY, OFFICE SUPPLIES, TECHNOLOGY
```

Real failures:

```
testValuesFunctionGroupBy                AssertionError: expected:<2> but was:<3>
testListFunctionMultipleFields           expected: [[one, two, three], [5, -4, 5]]
                                         but was:  [["one","six"], ["5","-5","2"]]
testListFunctionWithTime                 expected: [[19:36:22]]  but was: [["22:50:16"]]
testListFunctionWithArithmeticExpression expected: [[9, 14, 3]]   but was: [["9","6","8"]]
testValuesFunctionWithNullValues         expected: [[1, 7]]       but was: [["1","3","4"]]
```

Note `testValuesFunctionGroupBy`: the group *count* differs, which normally suggests broken aggregation. It does not here — the input set differs, so a different number of `str0` groups is present. Grouping itself is correct.

`key` is unique in the CALCS fixture (17 distinct over 17 documents), so `sort key` fixes the selection. Verified per test that 1-shard and 5-shard become identical **and** every existing expectation still holds:

| | 1sh == 5sh | expectation preserved |
|---|---|---|
| all 7 tests | yes | yes |

Four other `head` tests in this class are deliberately left alone — they assert only schema and non-emptiness, so no exact value depends on the selection.

### 2. `RawFormatIT` — rendered table compared row by row

Two tests compare a fully rendered table against a query with no `ORDER BY`:

```
org.junit.ComparisonFailure:
expected:<... |lastname  [+Amber JOHnny|Duke Willmington+ -Hattie |Bond- =Nanette |Bates=] @Dale ...>
```

`account_number` is unique and ascends in exactly the order already asserted — 1, 6, 13, 18, 20 → Amber, Hattie, Nanette, Dale, Elinor — so ordering by it leaves the expected output byte for byte unchanged. All rows are retained.

### 3. `StandaloneIT` — whole response body compared

`testSourceFieldQuery` indexes two documents and compares the entire response body, `datarows` included, against a query with no sort:

```
org.junit.ComparisonFailure:
expected:<..."[hello" ], [ "world]" ]...>  but was:<..."[world" ], [ "hello]"...>
```

Sorting by `name` yields the same `hello, world` order the test already expects, so the expected body is unchanged.


### 4. `CalciteConvertCommandIT`, `CalciteEvalCommandIT`, `CalciteMVAppendFunctionIT` — `head N` on BANK

Seven more tests share the same defect against the seven-row BANK fixture. Sorting by `account_number` selects accounts 1, 6, 13, whose values are exactly what the tests already assert:

```
account_number  1 ->  balance 39225  age 32  Amber JOHnny / Duke Willmington
account_number  6 ->  balance  5686  age 36  Hattie / Bond
account_number 13 ->  balance 32838  age 28  Nanette / Bates
```

- `CalciteConvertCommandIT`: `testConvertAutoFunction`, `testConvertNumFunction`, `testConvertWithAlias`, `testConvertMultipleFunctions`, `testConvertNoneFunction`
- `CalciteEvalCommandIT`: `testEvalStringConcatenationWithExistingData`
- `CalciteMVAppendFunctionIT`: `testMvappendWithFieldsAndLiterals` — the neighbouring real-field tests in that class already sort by `account_number`, so this matches the existing local convention

### 5. `CalciteBinCommandIT` — `head N` with exact bins

- `testBinValueFieldOnly`: `@timestamp` is unique across all 100 `time_test_data` documents, and the three earliest values (8945, 7623, 9187) give exactly the asserted bins `8000-10000`, `6000-8000`, `8000-10000`.
- `testBinSpanWithStartEndNeverShrinkRange`: takes six of the seven BANK documents; sorting by `account_number` yields ages 32, 36, 28, 33, 36, 39 — the existing expectations.

`testBinTimestampSpan6Days` and `testBinTimestampSpan7Days` are **deliberately left failing**. They already sort, but they sort *after* `bin` has replaced `@timestamp` with the bin label, so every row shares one key and the sort is not a total order. Correcting them needs either a pipeline reorder or new expected values, neither of which belongs in this change.

### Testing

`integTestRemote` against the same cluster at both shard counts, to confirm the changes did not trade one failure mode for another:

| | 1 shard | 5 shards |
|---|---|---|
| all seven classes | 288 tests, **0 failures** | 288 tests, 2 failures — the two `bin` timestamp tests excluded above |
| `CalciteMultiValueStatsIT` | 31/31 | 31/31 — both pushdown and no-pushdown routes |

Deliberately **not** included, since each involves command semantics or engine behaviour rather than an undefined order: the two `bin` timestamp tests above, `head | sort` (`testHeadThenSort` is already annotated `HEAD_WITHOUT_STABLE_SORT` and branches its expectation per route, so moving the sort would change the operation under test), `reverse`, `streamstats`, `FIRST`/`LAST`, `TAKE`, and consecutive `dedup`. Nothing requiring an expected-value rewrite is included.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

Remaining items are not applicable: this changes integration-test queries only, and adds no functionality or user-facing behaviour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
