### PR TITLE
[Bug Fix] Resolve dotted source paths in pushed-down Calcite scripts

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMixedFieldTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMixedFieldTypeIT.java
@@ -8,6 +8,7 @@ package org.opensearch.sql.calcite.remote;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 import static org.opensearch.sql.util.MatcherUtils.schema;
 import static org.opensearch.sql.util.MatcherUtils.verifyDataRows;
+import static org.opensearch.sql.util.MatcherUtils.verifyDataRowsInOrder;
 import static org.opensearch.sql.util.MatcherUtils.verifySchema;
 import static org.opensearch.sql.util.TestUtils.createIndexByRestClient;
 import static org.opensearch.sql.util.TestUtils.isIndexExist;
@@ -33,6 +34,7 @@ public class CalciteMixedFieldTypeIT extends PPLIntegTestCase {
   private static final String OBJ_TEXT_INDEX = "test_obj_text_5702";
   private static final String OBJ_KEYWORD_INDEX = "test_obj_keyword_5702";
   private static final String OBJ_SINGLE_INDEX = "test_single_obj_5702";
+  private static final String OBJ_GROUP_INDEX = "test_group_obj_5702";
 
   @Override
   public void init() throws Exception {
@@ -108,6 +110,21 @@ public class CalciteMixedFieldTypeIT extends PPLIntegTestCase {
       bulkReq.setJsonEntity(
           "{\"index\":{\"_id\":\"1\"}}\n"
               + "{\"log\":{\"user_agent\":\"requests/2.32.3\",\"idx\":1}}\n");
+      performRequest(client(), bulkReq);
+    }
+
+    // Several documents with repeating values, to catch grouping and ordering that silently
+    // collapse when the subfield resolves to null.
+    if (!isIndexExist(client(), OBJ_GROUP_INDEX)) {
+      String mapping =
+          "{\"mappings\":{\"properties\":{\"log\":{\"properties\":{"
+              + "\"ua\":{\"type\":\"text\"}}},\"id\":{\"type\":\"integer\"}}}}";
+      createIndexByRestClient(client(), OBJ_GROUP_INDEX, mapping);
+      Request bulkReq = new Request("POST", "/" + OBJ_GROUP_INDEX + "/_bulk?refresh=true");
+      bulkReq.setJsonEntity(
+          "{\"index\":{\"_id\":\"1\"}}\n{\"log\":{\"ua\":\"bbb\"},\"id\":1}\n"
+              + "{\"index\":{\"_id\":\"2\"}}\n{\"log\":{\"ua\":\"aaa\"},\"id\":2}\n"
+              + "{\"index\":{\"_id\":\"3\"}}\n{\"log\":{\"ua\":\"aaa\"},\"id\":3}\n");
       performRequest(client(), bulkReq);
     }
   }
@@ -193,5 +210,27 @@ public class CalciteMixedFieldTypeIT extends PPLIntegTestCase {
                 + " | fields log.user_agent, log.idx");
     verifySchema(result, schema("log.user_agent", "string"), schema("log.idx", "int"));
     verifyDataRows(result, rows("requests/2.32.3", 1));
+  }
+
+  @Test
+  public void testStatsGroupByTextObjectSubField() throws IOException {
+    // The grouping key is read by an aggregation script through _source. Resolving it to null
+    // collapsed every document into a single null bucket, which looks like a valid result.
+    JSONObject result =
+        executeQuery("source=" + OBJ_GROUP_INDEX + " | stats count() as c by log.ua | sort log.ua");
+    verifySchema(result, schema("c", "bigint"), schema("log.ua", "string"));
+    verifyDataRows(result, rows(2, "aaa"), rows(1, "bbb"));
+  }
+
+  @Test
+  public void testSortOnEvaluatedTextObjectSubField() throws IOException {
+    // The sort script reads the subfield through _source as well; a null value left the rows
+    // in their original order instead of the requested one.
+    JSONObject result =
+        executeQuery(
+            "source=" + OBJ_GROUP_INDEX + " | eval u = upper(log.ua) | sort u, id | fields id, u");
+    verifySchema(result, schema("id", "int"), schema("u", "string"));
+    // Ordering is the point here, so assert it in order.
+    verifyDataRowsInOrder(result, rows(2, "AAA"), rows(3, "AAA"), rows(1, "BBB"));
   }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMixedFieldTypeIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteMixedFieldTypeIT.java
@@ -20,13 +20,19 @@ import org.opensearch.client.Request;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 
 /**
- * Integration tests for querying wildcard indices where a field has conflicting types (e.g., text
- * vs keyword) across different indices. See GitHub issue #4659.
+ * Integration tests for field resolution in pushed-down scripts.
+ *
+ * <p>Covers querying wildcard indices where a field has conflicting types (e.g., text vs keyword)
+ * across different indices (GitHub issue #4659), and the same resolution applied to object
+ * subfields addressed by a dotted path (GitHub issue #5702).
  */
 public class CalciteMixedFieldTypeIT extends PPLIntegTestCase {
 
   private static final String LOG_TEXT_INDEX = "test_log_text_4659";
   private static final String LOG_KEYWORD_INDEX = "test_log_keyword_4659";
+  private static final String OBJ_TEXT_INDEX = "test_obj_text_5702";
+  private static final String OBJ_KEYWORD_INDEX = "test_obj_keyword_5702";
+  private static final String OBJ_SINGLE_INDEX = "test_single_obj_5702";
 
   @Override
   public void init() throws Exception {
@@ -57,6 +63,51 @@ public class CalciteMixedFieldTypeIT extends PPLIntegTestCase {
       Request bulkReq = new Request("POST", "/" + LOG_KEYWORD_INDEX + "/_bulk?refresh=true");
       bulkReq.setJsonEntity(
           "{\"index\":{\"_id\":\"1\"}}\n" + "{\"msg\":\"status=200\",\"idx\":2}\n");
+      performRequest(client(), bulkReq);
+    }
+
+    // Object subfield that is text-with-keyword-subfield in one index and keyword in another.
+    // Merging downgrades it to text without a keyword subfield, which routes the pushed-down
+    // script through _source instead of doc_values. See issue #5702.
+    if (!isIndexExist(client(), OBJ_TEXT_INDEX)) {
+      String mapping =
+          "{\"mappings\":{\"properties\":{\"log\":{\"properties\":{"
+              + "\"user_agent\":{\"type\":\"text\",\"fields\":{\"keyword\":"
+              + "{\"type\":\"keyword\",\"ignore_above\":256}}},"
+              + "\"idx\":{\"type\":\"integer\"}}}}}}";
+      createIndexByRestClient(client(), OBJ_TEXT_INDEX, mapping);
+      Request bulkReq = new Request("POST", "/" + OBJ_TEXT_INDEX + "/_bulk?refresh=true");
+      bulkReq.setJsonEntity(
+          "{\"index\":{\"_id\":\"1\"}}\n"
+              + "{\"log\":{\"user_agent\":\"requests/2.32.3\",\"idx\":1}}\n");
+      performRequest(client(), bulkReq);
+    }
+
+    if (!isIndexExist(client(), OBJ_KEYWORD_INDEX)) {
+      String mapping =
+          "{\"mappings\":{\"properties\":{\"log\":{\"properties\":{"
+              + "\"user_agent\":{\"type\":\"keyword\"},"
+              + "\"idx\":{\"type\":\"integer\"}}}}}}";
+      createIndexByRestClient(client(), OBJ_KEYWORD_INDEX, mapping);
+      Request bulkReq = new Request("POST", "/" + OBJ_KEYWORD_INDEX + "/_bulk?refresh=true");
+      bulkReq.setJsonEntity(
+          "{\"index\":{\"_id\":\"1\"}}\n"
+              + "{\"log\":{\"user_agent\":\"requests/2.32.3\",\"idx\":2}}\n");
+      performRequest(client(), bulkReq);
+    }
+
+    // Single index, no type conflict at all: an object subfield mapped as plain text already
+    // resolves through _source, so it exercises the same dotted-path lookup.
+    if (!isIndexExist(client(), OBJ_SINGLE_INDEX)) {
+      String mapping =
+          "{\"mappings\":{\"properties\":{\"log\":{\"properties\":{"
+              + "\"user_agent\":{\"type\":\"text\"},"
+              + "\"idx\":{\"type\":\"integer\"}}}}}}";
+      createIndexByRestClient(client(), OBJ_SINGLE_INDEX, mapping);
+      Request bulkReq = new Request("POST", "/" + OBJ_SINGLE_INDEX + "/_bulk?refresh=true");
+      bulkReq.setJsonEntity(
+          "{\"index\":{\"_id\":\"1\"}}\n"
+              + "{\"log\":{\"user_agent\":\"requests/2.32.3\",\"idx\":1}}\n");
       performRequest(client(), bulkReq);
     }
   }
@@ -106,5 +157,41 @@ public class CalciteMixedFieldTypeIT extends PPLIntegTestCase {
     verifySchema(
         result, schema("msg", "string"), schema("idx", "int"), schema("statusCode", "string"));
     verifyDataRows(result, rows("status=200", 1, "200"), rows("status=200", 2, "200"));
+  }
+
+  @Test
+  public void testWildcardQueryWithMixedTypeOnObjectSubField() throws IOException {
+    // The filter on the object subfield is pushed down as a script reading _source. The subfield
+    // is addressed as "log.user_agent" while _source nests it under "log", so a flat lookup
+    // silently matched nothing. See issue #5702.
+    JSONObject result =
+        executeQuery(
+            "source=test_obj_*_5702 | where log.user_agent = 'requests/2.32.3'"
+                + " | fields log.user_agent, log.idx | sort log.idx");
+    verifySchema(result, schema("log.user_agent", "string"), schema("log.idx", "int"));
+    verifyDataRows(result, rows("requests/2.32.3", 1), rows("requests/2.32.3", 2));
+  }
+
+  @Test
+  public void testWildcardQueryWithScriptFilterOnMixedTypeObjectSubField() throws IOException {
+    JSONObject result =
+        executeQuery(
+            "source=test_obj_*_5702 | where upper(log.user_agent) = 'REQUESTS/2.32.3'"
+                + " | fields log.user_agent, log.idx | sort log.idx");
+    verifySchema(result, schema("log.user_agent", "string"), schema("log.idx", "int"));
+    verifyDataRows(result, rows("requests/2.32.3", 1), rows("requests/2.32.3", 2));
+  }
+
+  @Test
+  public void testFilterOnTextObjectSubFieldWithoutTypeConflict() throws IOException {
+    // No cross-index conflict here: a plain text object subfield resolves through _source too.
+    JSONObject result =
+        executeQuery(
+            "source="
+                + OBJ_SINGLE_INDEX
+                + " | where log.user_agent = 'requests/2.32.3'"
+                + " | fields log.user_agent, log.idx");
+    verifySchema(result, schema("log.user_agent", "string"), schema("log.idx", "int"));
+    verifyDataRows(result, rows("requests/2.32.3", 1));
   }
 }

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5702.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5702.yml
@@ -1,0 +1,98 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+  - do:
+      indices.create:
+        index: log_obj_text_5702
+        body:
+          mappings:
+            properties:
+              log:
+                properties:
+                  user_agent:
+                    type: text
+                    fields:
+                      keyword:
+                        type: keyword
+                        ignore_above: 256
+                  idx:
+                    type: integer
+  - do:
+      indices.create:
+        index: log_obj_keyword_5702
+        body:
+          mappings:
+            properties:
+              log:
+                properties:
+                  user_agent:
+                    type: keyword
+                  idx:
+                    type: integer
+  - do:
+      bulk:
+        index: log_obj_text_5702
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"log": {"user_agent": "requests/2.32.3", "idx": 1}}'
+  - do:
+      bulk:
+        index: log_obj_keyword_5702
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"log": {"user_agent": "requests/2.32.3", "idx": 2}}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+  - do:
+      indices.delete:
+        index: log_obj_text_5702
+        ignore: 404
+  - do:
+      indices.delete:
+        index: log_obj_keyword_5702
+        ignore: 404
+
+---
+"PPL filter on an object subfield with mixed text/keyword types across indices":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=log_obj_*_5702 | where log.user_agent = 'requests/2.32.3' | fields log.user_agent, log.idx | sort log.idx"
+  - match: {"total": 2}
+  - match: {"datarows": [["requests/2.32.3", 1], ["requests/2.32.3", 2]]}
+
+---
+"PPL script filter on an object subfield with mixed text/keyword types across indices":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=log_obj_*_5702 | where upper(log.user_agent) = 'REQUESTS/2.32.3' | fields log.user_agent, log.idx | sort log.idx"
+  - match: {"total": 2}
+  - match: {"datarows": [["requests/2.32.3", 1], ["requests/2.32.3", 2]]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/CalciteScriptEngine.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/storage/script/CalciteScriptEngine.java
@@ -240,7 +240,11 @@ public class CalciteScriptEngine implements ScriptEngine {
     }
 
     public Object getFromSource(String name) {
-      return this.sourceLookup.get(name);
+      // Resolve the field through the source path, not a flat map lookup: object subfields are
+      // addressed as dotted paths (e.g. "log.user_agent") while _source stores them nested.
+      // SourceLookup#extractValue delegates to XContentMapValues, which walks the nested maps and
+      // still falls back to a literal dotted key when the document has one.
+      return this.sourceLookup.extractValue(name, null);
     }
   }
 


### PR DESCRIPTION
### Description

When a PPL query pushes work down as a Calcite script that reads a field from `_source`, the field is addressed by its **flattened** name (e.g. `log.user_agent`), while `_source` stores object subfields **nested** (`{"log": {"user_agent": ...}}`). The lookup was a flat `Map#get`:

```java
public Object getFromSource(String name) {
  return this.sourceLookup.get(name);
}
```

So any object subfield resolved to `null`. No error was raised — the query simply produced a wrong answer.

### What was actually wrong

All five pushed-down script types — filter, aggregation, string sort, number sort, and field — funnel through this one method via `CalciteScript` → `ScriptDataContext`. Measured against `main`:

| query on an object subfield | before | after |
| --- | --- | --- |
| `where log.user_agent = 'requests/2.32.3'` | **0 rows** | 2 rows |
| `where upper(log.user_agent) = '...'` | **0 rows** | 2 rows |
| `stats count() by log.ua` | **`[[3, null]]`** — every document in one null bucket | `[[2,"aaa"],[1,"bbb"]]` |
| `eval u = upper(log.ua) \| sort u, id` | **`[[1,BBB],[2,AAA],[3,AAA]]`** — ordering not applied | `[[2,AAA],[3,AAA],[1,BBB]]` |

The aggregation case is the most dangerous of the four: a filter returning zero rows is visibly empty, but a `stats ... by` that silently collapses every document into a single `null` bucket returns a result that looks entirely plausible.

### Root cause note

The issue hypothesised that `DeepMergeRule` handles nested fields differently from the fix in #5358. That is **not** the cause — the merge is correct for nested fields:

```
NESTED merged log.user_agent mappingType = text
NESTED keywordSubField                   = null   <- correctly downgraded
```

`TextKeywordConflictRule` does apply to nested subfields through `DeepMergeRule`, and the engine correctly switches to `Source.SOURCE` as a result. The explain output confirms the retrieval mode was chosen correctly:

```
SOURCES:[1,2]  DIGESTS:["log.user_agent", "requests/2.32.3"]
```

`SOURCES=1` is `Source.SOURCE` — doc_values were correctly avoided. The defect is one level further down, in how that source value is read.

### Scope is wider than mixed-type indices

A cross-index type conflict is **not** required. A single index whose object subfield is plain `text` already resolves through `_source` and hit the same path. Mixed `text`/`keyword` types merge down to text-without-keyword-subfield, which routes *more* fields through `_source` — that is how #5702 surfaced, but it is not the precondition.

### Behaviour comparison against baseline

Edge cases were run on `main` and on this branch to isolate the change:

| case | baseline | this PR |
| --- | --- | --- |
| literal dotted key under `enabled: false` object | ok | ok (unchanged) |
| multi-value select `["a", null, "b"]` | `["a",null,"b"]` | `["a",null,"b"]` (unchanged) |
| multi-value in an expression | 0 | 0 (unchanged — documented limitation) |
| `nested`-type field filter | 0 | 0 (unchanged — see #4625) |
| 3-level deep object filter | **0** | **1** (also fixed) |
| object subfield absent from some docs | **0** | **1** (also fixed) |
| `isnull(o.v)` | 2 | 2 (unchanged) |
| direct `sort log.ua` (doc_values path) | ok | ok (unchanged) |
| `stats sum(log.n)` on an integer subfield | 6 | 6 (unchanged) |

No unintended behaviour changes; two further latent cases are fixed as a side effect.

### Related Issues
Resolves #5702
Follow-up to #5358 / #4659

### Testing

`CalciteMixedFieldTypeIT` — 5 new cases covering filter, script filter, the single-index no-conflict case, `stats ... by` on an object subfield, and sort on one. Reverting the one-line fix fails exactly these 5 and leaves the 4 pre-existing #4659 cases green.

The sort case asserts with `verifyDataRowsInOrder`; `verifyDataRows` compares without regard to order and cannot observe an ordering defect.

`integ-test/src/yamlRestTest/.../issues/5702.yml` — 2 new scenarios, mirroring `4659.yml`.

`CalciteMixedFieldTypeIT` is already registered in `CalciteNoPushdownIT`, so the new cases also run with pushdown disabled.

| suite | result |
| --- | --- |
| full `integTest` | 382 classes, 7227 tests, 0 failures |
| `CalciteNoPushdownIT` | 2312 tests, 0 failures |
| full `yamlRestTest` | 180 tests, 0 failures |
| all module unit tests | pass |
| `spotlessCheck` | pass |

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
