### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/get-sonatype-credentials.sh
+++ b/.github/get-sonatype-credentials.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
 # Script to retrieve Sonatype credentials from AWS Secrets Manager
 
 SONATYPE_USERNAME=op://opensearch-infra-secrets/maven-central-portal-credentials/username

--- a/.github/maven-publish-utils.sh
+++ b/.github/maven-publish-utils.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Utility functions for publishing artifacts to Maven and managing commit mappings
 
 set -e

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,41 @@
+{
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".xml",
+    ".rst",
+    ".ppl",
+    ".g4",
+    ".config",
+    ".png",
+    ".jar",
+    ".gz",
+    ".lock",
+    ".toml",
+    ".ini",
+    ".bat",
+    ".properties",
+    ".git",
+    ".gitignore",
+    ".whitesource",
+    ".lycheeignore",
+    "buildSrc/src/main/groovy/com/wiredforcode/",
+    ".gradle",
+    "gradle/wrapper",
+    "settings.gradle",
+    "**/build/",
+    "licenses/",
+    "src/test/resources/",
+    "**/test/resources/",
+    "docs/",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfig.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.config;
 
 import lombok.Builder;

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplier.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/config/SparkExecutionEngineConfigSupplier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.config;
 
 import org.opensearch.sql.spark.asyncquery.model.AsyncQueryRequestContext;

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/config/SparkSubmitParameterModifier.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/config/SparkSubmitParameterModifier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.config;
 
 import org.opensearch.sql.spark.parameter.SparkSubmitParametersBuilder;

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryResponse.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/dispatcher/model/DispatchQueryResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.dispatcher.model;
 
 import lombok.Builder;

--- a/async-query-core/src/main/java/org/opensearch/sql/spark/execution/xcontent/XContentSerializerUtil.java
+++ b/async-query-core/src/main/java/org/opensearch/sql/spark/execution/xcontent/XContentSerializerUtil.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.execution.xcontent;
 
 import com.google.common.collect.ImmutableMap;

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/execution/statestore/StateModelTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/execution/statestore/StateModelTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.execution.statestore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/async-query-core/src/test/java/org/opensearch/sql/spark/execution/xcontent/XContentSerializerUtilTest.java
+++ b/async-query-core/src/test/java/org/opensearch/sql/spark/execution/xcontent/XContentSerializerUtilTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.execution.xcontent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/async-query/src/test/java/org/opensearch/sql/spark/config/OpenSearchAsyncQuerySchedulerConfigComposerTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/config/OpenSearchAsyncQuerySchedulerConfigComposerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.config;
 
 import static org.junit.Assert.assertNull;

--- a/async-query/src/test/java/org/opensearch/sql/spark/rest/RestAsyncQueryManagementActionTest.java
+++ b/async-query/src/test/java/org/opensearch/sql/spark/rest/RestAsyncQueryManagementActionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.spark.rest;
 
 import com.google.gson.Gson;

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 apply plugin: 'groovy'
 apply plugin: 'java'
 

--- a/datasources/src/main/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactory.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactory.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.glue;
 
 import java.net.URISyntaxException;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/glue/SecurityLakeDataSourceFactory.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/glue/SecurityLakeDataSourceFactory.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.glue;
 
 import java.util.Map;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceLoaderCache.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceLoaderCache.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.service;
 
 import org.opensearch.sql.datasource.model.DataSource;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImpl.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImpl.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.service;
 
 import com.google.common.cache.Cache;

--- a/datasources/src/main/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtils.java
+++ b/datasources/src/main/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.utils;
 
 import java.net.URI;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactoryTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/glue/GlueDataSourceFactoryTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.glue;
 
 import static org.mockito.Mockito.when;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/glue/SecurityLakeSourceFactoryTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/glue/SecurityLakeSourceFactoryTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.glue;
 
 import static org.mockito.Mockito.when;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/rest/RestDataSourceQueryActionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.rest;
 
 import com.google.gson.Gson;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImplTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/service/DataSourceLoaderCacheImplTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.service;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportCreateDataSourceActionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.transport;
 
 import static java.util.Collections.emptyList;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportDeleteDataSourceActionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.transport;
 
 import static java.util.Collections.emptyList;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportGetDataSourceActionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.transport;
 
 import static java.util.Collections.emptyList;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportPatchDataSourceActionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.transport;
 
 import static java.util.Collections.emptyList;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceActionTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/transport/TransportUpdateDataSourceActionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.transport;
 
 import static java.util.Collections.emptyList;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtilsTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/utils/DatasourceValidationUtilsTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.utils;
 
 import java.util.Collections;

--- a/datasources/src/test/java/org/opensearch/sql/datasources/utils/XContentParserUtilsTest.java
+++ b/datasources/src/test/java/org/opensearch/sql/datasources/utils/XContentParserUtilsTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sql.datasources.utils;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/doctest/bootstrap.sh
+++ b/doctest/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 DIR=$(dirname "$0")
 
 if hash python3.8 2> /dev/null; then

--- a/doctest/markdown_parser.py
+++ b/doctest/markdown_parser.py
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Markdown-based doctest parser for clean copy-paste documentation.
 

--- a/scripts/bwctest-full-restart.sh
+++ b/scripts/bwctest-full-restart.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 function usage() {

--- a/scripts/bwctest-rolling-upgrade.sh
+++ b/scripts/bwctest-rolling-upgrade.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 function usage() {

--- a/scripts/docs_exporter/convert_rst_to_md.py
+++ b/scripts/docs_exporter/convert_rst_to_md.py
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 #!/usr/bin/env python3
 """
 Convert RST PPL documentation to Markdown format.

--- a/scripts/docs_exporter/export_to_docs_website.py
+++ b/scripts/docs_exporter/export_to_docs_website.py
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 #!/usr/bin/env python3
 """
 Markdown docs exporter for PPL documentation to documentation-website.

--- a/scripts/docs_exporter/fix_markdown_formatting.py
+++ b/scripts/docs_exporter/fix_markdown_formatting.py
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 #!/usr/bin/env python3
 """
 Comprehensive markdown formatting script for docs/user/ppl/**/*.md

--- a/spark/build.gradle
+++ b/spark/build.gradle
@@ -1,0 +1,5 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files

### Related Issues
[#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
