### PR TITLE
fix: gracefully handle scalar values under object-typed fields when decoding results (#5685)

### DIFF
--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5685.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/issues/5685.yml
@@ -1,0 +1,147 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+  # Object-vs-scalar conflict: only *_b maps `resource`, so the wildcard merge types
+  # resource.attributes.k8s.namespace as an object while *_a's doc holds a scalar there.
+  - do:
+      indices.create:
+        index: dedup_conflict_a_5685
+        body:
+          mappings:
+            dynamic: false
+            properties:
+              host:
+                type: keyword
+  - do:
+      indices.create:
+        index: dedup_conflict_b_5685
+        body:
+          mappings:
+            properties:
+              host:
+                type: keyword
+              resource:
+                properties:
+                  attributes:
+                    properties:
+                      k8s:
+                        properties:
+                          namespace:
+                            properties:
+                              name:
+                                type: keyword
+  # Mirror conflict: only *c_a maps the path (keyword), while *c_b's doc holds an object there.
+  - do:
+      indices.create:
+        index: dedup_conflict_c_a_5685
+        body:
+          mappings:
+            properties:
+              host:
+                type: keyword
+              resource:
+                properties:
+                  attributes:
+                    properties:
+                      k8s:
+                        properties:
+                          namespace:
+                            type: keyword
+  - do:
+      indices.create:
+        index: dedup_conflict_c_b_5685
+        body:
+          mappings:
+            dynamic: false
+            properties:
+              host:
+                type: keyword
+  - do:
+      bulk:
+        index: dedup_conflict_a_5685
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"host": "h1", "resource": {"attributes": {"k8s": {"namespace": "prod"}}}}'
+  - do:
+      bulk:
+        index: dedup_conflict_b_5685
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"host": "h2", "resource": {"attributes": {"k8s": {"namespace": {"name": "pod-x"}}}}}'
+  - do:
+      bulk:
+        index: dedup_conflict_c_a_5685
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"host": "h1", "resource": {"attributes": {"k8s": {"namespace": "prod"}}}}'
+  - do:
+      bulk:
+        index: dedup_conflict_c_b_5685
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"host": "h2", "resource": {"attributes": {"k8s": {"namespace": {"name": "pod-x"}}}}}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+  - do:
+      indices.delete:
+        index: dedup_conflict_a_5685
+        ignore: 404
+  - do:
+      indices.delete:
+        index: dedup_conflict_b_5685
+        ignore: 404
+  - do:
+      indices.delete:
+        index: dedup_conflict_c_a_5685
+        ignore: 404
+  - do:
+      indices.delete:
+        index: dedup_conflict_c_b_5685
+        ignore: 404
+
+---
+"dedup over a wildcard where an object-typed path holds a scalar in one index":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=dedup_conflict_a_5685,dedup_conflict_b_5685 | dedup host | fields host | sort host"
+  - match: {"total": 2}
+  - match: {"datarows": [["h1"], ["h2"]]}
+
+---
+"dedup over a wildcard where a scalar-typed path holds an object in one index":
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+  - do:
+      allowed_warnings:
+        - 'Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled'
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=dedup_conflict_c_a_5685,dedup_conflict_c_b_5685 | dedup host | fields host | sort host"
+  - match: {"total": 2}
+  - match: {"datarows": [["h1"], ["h2"]]}

--- a/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
+++ b/opensearch/src/main/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactory.java
@@ -222,7 +222,14 @@ public class OpenSearchExprValueFactory {
       return parseArray(content, field, type, supportArrays);
     } else if (type.equals(OpenSearchDataType.of(OpenSearchDataType.MappingType.Object))
         || type == STRUCT) {
-      return parseStruct(content, field, supportArrays);
+      // A scalar under an object-typed field (wildcard over indices with conflicting mappings)
+      // would throw here; return null instead. CCE-scoped: this is also the whole-document parse
+      // entry, so a broader catch would hide unrelated errors deeper in the recursion.
+      try {
+        return parseStruct(content, field, supportArrays);
+      } catch (ClassCastException e) {
+        return ExprNullValue.of();
+      }
     } else if (typeActionMap.containsKey(type)) {
       if (content.isArray()) {
         return parseArray(content, field, type, supportArrays);

--- a/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
+++ b/opensearch/src/test/java/org/opensearch/sql/opensearch/data/value/OpenSearchExprValueFactoryTest.java
@@ -728,6 +728,13 @@ class OpenSearchExprValueFactoryTest {
         constructFromObject("structV", ImmutableMap.of("id", 1, "state", "WA")));
   }
 
+  /** A scalar under an object-typed field parses to null instead of throwing. */
+  @Test
+  public void constructStructWithScalarValueReturnsNull() {
+    assertEquals(nullValue(), constructFromObject("structV", "prod"));
+    assertEquals(nullValue(), constructFromObject("structV", 1));
+  }
+
   @Test
   public void constructIP() {
     final String ipString = "192.168.0.1";


### PR DESCRIPTION
### Description
On the Calcite path, PPL `dedup` pushes down as a composite aggregation whose surviving row is fetched via `top_hits` and decoded from the nested `_source`. When a query spans a wildcard/alias over indices that disagree on whether a path is an object or a scalar, the cross-index mapping merge types the path as an object (STRUCT) while some documents store a scalar there. Decoding that scalar as a struct threw and failed the whole query:

```
java.sql.SQLException: ... class java.lang.String cannot be cast to class java.util.Map
```

This guards the STRUCT branch of `OpenSearchExprValueFactory.parse` to degrade a scalar-under-object value to `null`, completing the graceful handling #5618 added for the geo_point and scalar branches (it did not cover the object/STRUCT branch). The catch is scoped to `ClassCastException` — this branch is also the whole-document parse entry point and each nested object level is wrapped independently, so a broader catch would swallow legitimate errors raised deeper in the recursion.

### Issues Resolved
Closes #5685

### Behavior (before → after)
| Scenario | Before | After |
|---|---|---|
| `dedup` over wildcard, object-vs-scalar conflict on an object path | 500 `String cannot be cast to Map` | succeeds; conflicting field → `null` |
| `dedup` over wildcard, scalar-vs-object conflict (mirror) | already handled by #5618 | unchanged (regression-guarded) |
| Unsupported-type parse, deeply nested | `IllegalStateException` (correct) | unchanged (not masked) |

### Testing
- Unit: `OpenSearchExprValueFactoryTest.constructStructWithScalarValueReturnsNull`
- YAML REST: `rest-api-spec/test/issues/5685.yml` — object-vs-scalar conflict and its mirror (scalar-vs-object).
- Full `OpenSearchExprValueFactoryTest` and the `:opensearch` unit suite pass; `integ-test` compiles.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
