### PR TITLE
Exclude license header check for `HighlightFunctionIT`

### DIFF
--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -171,6 +171,8 @@ ext {
 
 tasks.withType(licenseHeaders.class) {
     additionalLicense 'AL   ', 'Apache', 'Licensed under the Apache License, Version 2.0 (the "License")'
+    // RAT 0.18 misdetects this 256-byte prefix as IBM424_rtl due to FULLTEXT_RELEVANCE_FUNC.
+    excludes << 'org/opensearch/sql/sql/HighlightFunctionIT.java'
 }
 
 validateNebulaPom.enabled = false


### PR DESCRIPTION
### Description

Excludes `HighlightFunctionIT` from license-header checks because RAT 0.18 misdetects its first 256 bytes (import `FULLTEXT_RELEVANCE_FUNC`) as unsupported `IBM424_rtl` charset. This began failing today because https://github.com/opensearch-project/OpenSearch/pull/22770 upgraded Apache RAT from 0.15 to 0.18. Remove after the upstream RAT fix.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
