### PR TITLE
Map Calcite ROW to STRUCT in convertSqlTypeNameToExprType

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -252,6 +252,11 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
           INTERVAL;
       case ARRAY -> ARRAY;
       case MAP -> STRUCT;
+      // Calcite spells a struct as ROW. convertExprTypeToRelDataType builds STRUCT as
+      // MAP<VARCHAR, ANY> since the v2 path only passes _source JSON through, so a genuine ROW —
+      // from an engine that builds a struct out of typed columns — matched nothing and fell
+      // through to UNKNOWN.
+      case ROW -> STRUCT;
       case GEOMETRY -> GEO_POINT;
       case NULL, ANY, OTHER -> UNDEFINED;
       default -> UNKNOWN;

--- a/core/src/test/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactoryTest.java
+++ b/core/src/test/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactoryTest.java
@@ -286,6 +286,12 @@ public class OpenSearchTypeFactoryTest {
     assertTrue(result.isNullable());
   }
 
+  @Test
+  public void testConvertRowReturnsStructExprType() {
+    assertEquals(
+        ExprCoreType.STRUCT, OpenSearchTypeFactory.convertSqlTypeNameToExprType(SqlTypeName.ROW));
+  }
+
   // ---------- convertAnalyticsEngineRelDataTypeToExprType ----------
   // UDT-aware variant for the response-schema path. Must agree with the
   // planner-internal convertRelDataTypeToExprType on every non-UDT input.


### PR DESCRIPTION
### Description
convertExprTypeToRelDataType builds STRUCT as MAP<VARCHAR, ANY>, since the v2 path only passes _source JSON through and needs no field types. So the reverse mapping only had `case MAP -> STRUCT` — a genuine Calcite ROW matched nothing, fell through to `default -> UNKNOWN`, and surfaced as "type": "unknown" in the response schema.

That is reachable from the analytics engine, which materializes an `object` field as a real ROW built from typed columns. Before, `fields city` reported "unknown"; now "struct", matching what a lucene-only cluster returns for the same mapping.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
