### PR TITLE
test(integ-test): stabilize eval max/min schema assertions across shards

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEvalMaxMinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLEvalMaxMinFunctionIT.java
@@ -29,6 +29,9 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
     loadIndex(Index.NULL_MISSING);
   }
 
+  // `new` has no plan-time type, so its reported type is taken from the first result row. Filtering
+  // to a single row makes that row deterministic under any shard count. Both directions are kept so
+  // the int-selected and bigint-selected results stay covered.
   @Test
   @RequiresCapability(
       value = EVAL_MAX_MIN_INT_WIDENING,
@@ -37,9 +40,21 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | eval new = max(1, 3, age) | fields age, new", TEST_INDEX_DOG));
+                "source=%s | where age = 2 | eval new = max(1, 3, age) | fields age, new",
+                TEST_INDEX_DOG));
     verifySchema(result, schema("age", "bigint"), schema("new", "int"));
-    verifyDataRows(result, rows(2, 3), rows(4, 4));
+    verifyDataRows(result, rows(2, 3));
+  }
+
+  @Test
+  public void testEvalMaxNumericWhenFieldSelected() throws Exception {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where age = 4 | eval new = max(1, 3, age) | fields age, new",
+                TEST_INDEX_DOG));
+    verifySchema(result, schema("age", "bigint"), schema("new", "bigint"));
+    verifyDataRows(result, rows(4, 4));
   }
 
   @Test
@@ -76,9 +91,24 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | eval new = min(14, 3, age) | fields age, new", TEST_INDEX_DOG));
+                "source=%s | where age = 2 | eval new = min(14, 3, age) | fields age, new",
+                TEST_INDEX_DOG));
     verifySchema(result, schema("age", "bigint"), schema("new", "bigint"));
-    verifyDataRows(result, rows(2, 2), rows(4, 3));
+    verifyDataRows(result, rows(2, 2));
+  }
+
+  @Test
+  @RequiresCapability(
+      value = EVAL_MAX_MIN_INT_WIDENING,
+      note = "min(14, 3, age) selects an int-valued result; the AE route reports it as bigint.")
+  public void testEvalMinNumericWhenLiteralSelected() throws Exception {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where age = 4 | eval new = min(14, 3, age) | fields age, new",
+                TEST_INDEX_DOG));
+    verifySchema(result, schema("age", "bigint"), schema("new", "int"));
+    verifyDataRows(result, rows(4, 3));
   }
 
   @Test
@@ -136,11 +166,30 @@ public class CalcitePPLEvalMaxMinFunctionIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(
             String.format(
-                "source=%s | eval new = min(dbl, 5) | fields dbl, new", TEST_INDEX_NULL_MISSING));
+                "source=%s | where key = 'values' | eval new = min(dbl, 5) | fields dbl, new",
+                TEST_INDEX_NULL_MISSING));
     verifySchema(result, schema("dbl", "double"), schema("new", "double"));
+    verifyDataRows(result, rows(3.1415, 3.1415));
+  }
+
+  // Keeps the null-skipping assertion on its own rows, covering both explicit-null and
+  // missing-field documents. Every row here selects the int literal, so the reported type no longer
+  // depends on which row arrives first.
+  @Test
+  @RequiresCapability(
+      value = EVAL_MAX_MIN_INT_WIDENING,
+      note =
+          "min(dbl, 5) over null-valued rows selects the int literal; the AE route reports the"
+              + " column using the wider double type.")
+  public void testEvalMinIgnoresNullsWhenLiteralSelected() throws Exception {
+    JSONObject result =
+        executeQuery(
+            String.format(
+                "source=%s | where key != 'values' | eval new = min(dbl, 5) | fields dbl, new",
+                TEST_INDEX_NULL_MISSING));
+    verifySchema(result, schema("dbl", "double"), schema("new", "int"));
     verifyDataRows(
         result,
-        rows(3.1415, 3.1415),
         rows(null, 5),
         rows(null, 5),
         rows(null, 5),


### PR DESCRIPTION
## Description

`CalcitePPLEvalMaxMinFunctionIT` had three tests that passed on a single shard and failed on five.

`eval max()/min()` carries no plan-time result type, so the reported type of the computed column is taken from the first row of the result set. `OpenSearchExecutionEngine` does this deliberately as a documented workaround for `ANY`-typed columns. With one shard the first row is always the same document and the reported type is stable. With more shards the arriving row varies, and because the winning operand differs per row, so does the type.

```
source=opensearch-sql_test_index_dog | eval new = max(1, 3, age) | fields age, new

age=2  ->  new=3  from the int literal
age=4  ->  new=4  from the bigint field
```

Both rows are correct. Only the column label moves, between `int` and `bigint`, depending on which row arrives first. The failures were always in `verifySchema`, never in `verifyDataRows`.

The three affected tests now filter to a single known document, which makes the sampled row deterministic under any shard count. Each one gained a companion test for the other selection direction, so the pair still asserts everything the original two-row query asserted.

| Test | Query scope | Selected value | Reported type |
| --- | --- | --- | --- |
| `testEvalMaxNumeric` | `where age = 2` | literal `3` | `int` |
| `testEvalMaxNumericWhenFieldSelected` (new) | `where age = 4` | field `4` | `bigint` |
| `testEvalMinNumeric` | `where age = 2` | field `2` | `bigint` |
| `testEvalMinNumericWhenLiteralSelected` (new) | `where age = 4` | literal `3` | `int` |
| `testEvalMinIgnoresNulls` | `where key = 'values'` | field `3.1415` | `double` |
| `testEvalMinIgnoresNullsWhenLiteralSelected` (new) | `where key != 'values'` | literal `5` | `int` |

The three tests that assert `int` are gated on `EVAL_MAX_MIN_INT_WIDENING`, since the analytics-engine route reports a wider type for the same value.

Scope notes:

- One test file. No shared fixture, mapping, enum or constant is touched, and no new index is added.
- The original method names are kept and no test is removed.
- `testEvalMaxIgnoresNulls` and the four string and mixed-type tests are unchanged. `max(int, 3)` is an `int` on every row, so that test was already shard-stable.
- The null case still covers both explicit-null and missing-field documents, matching the original row coverage.
- No production code changes. This makes the assertions shard-independent and does not alter what `max()` or `min()` return.

## Validation

Run on an external cluster, comparing the same class before and after the change.

| Cell | Before | After |
| --- | --- | --- |
| 1 shard | 8 pass | 11 pass |
| 5 shards | 5 pass, 3 fail | 11 pass, 0 skipped |

The five-shard run before the change reproduced exactly the three reported failures, and the cluster log confirms the fixtures were created with five primary shards.

`spotlessJavaCheck`, `compileTestJava` and `git diff --check` pass.

This class is not a member of the `CalciteNoPushdownIT` suite, so that mode is unaffected. The analytics-engine lane was reasoned from the capability gate rather than executed locally, because that plugin is not available in this tree.

## Related Issues

The underlying limitation is that the result type is recovered from data rather than declared at plan time. That is a separate product discussion and is not addressed here.

## Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
