### PR TITLE
test(integ-test): stabilize join subsearch maxout assertion across shards

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJoinIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJoinIT.java
@@ -1120,22 +1120,42 @@ public class CalcitePPLJoinIT extends PPLIntegTestCase {
     verifyNumOfRows(actual, 8);
   }
 
+  // The maxout cap bounds how many subsearch rows are joined against, not which ones: the limit
+  // takes its collation from the subsearch, which is unsorted here, so the discarded row is
+  // whichever one the scan yields last. Here the right side is the whole index and only three of
+  // its rows match the join key, so a cap of two guarantees at most two matching rows survive and
+  // the join cannot exceed 5 x 2 rows -- a bound that holds whichever rows the cap keeps. A cap of
+  // five would not bound anything, since five already exceeds the three matching rows. The exact
+  // count under a cap is asserted in testJoinSubsearchMaxOutOnFilteredSubsearch.
   @Test
   public void testJoinSubsearchMaxOut() throws IOException {
-    setJoinSubsearchMaxOut(5);
-    JSONObject actual =
-        executeQuery(
-            String.format(
-                "source=%s | where country = 'Canada' | join type=inner max=0 country %s",
-                TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    verifyNumOfRows(actual, 10);
+    String query =
+        String.format(
+            "source=%s | where country = 'Canada' | join type=inner max=0 country %s",
+            TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION);
+    setJoinSubsearchMaxOut(2);
+    int cappedRows = executeQuery(query).getJSONArray("datarows").length();
+    assertTrue(
+        "A subsearch capped at 2 rows can join at most 5 x 2 = 10 rows, but got " + cappedRows,
+        cappedRows <= 10);
     resetJoinSubsearchMaxOut();
-    actual =
-        executeQuery(
-            String.format(
-                "source=%s | where country = 'Canada' | join type=inner max=0 country %s",
-                TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION));
-    verifyNumOfRows(actual, 15);
+    verifyNumOfRows(executeQuery(query), 15);
+  }
+
+  // Same cap, but with the subsearch filtered to the join key so every retained row joins
+  // identically. That makes the capped count exact rather than a bound: 5 left rows times
+  // min(cap, 3) retained rows, no matter which rows the cap keeps.
+  @Test
+  public void testJoinSubsearchMaxOutOnFilteredSubsearch() throws IOException {
+    String query =
+        String.format(
+            "source=%s | where country = 'Canada' | join type=inner max=0 country [ source=%s |"
+                + " where country = 'Canada' ]",
+            TEST_INDEX_STATE_COUNTRY, TEST_INDEX_OCCUPATION);
+    setJoinSubsearchMaxOut(2);
+    verifyNumOfRows(executeQuery(query), 10);
+    resetJoinSubsearchMaxOut();
+    verifyNumOfRows(executeQuery(query), 15);
   }
 
   @Test


### PR DESCRIPTION
## Description

`CalcitePPLJoinIT.testJoinSubsearchMaxOut` passed on a single shard and failed on five with `expected:<10> but was:<15>`.

**The fix:** lower the cap so it actually bounds the result, assert that bound on the original query, and add a companion test that filters the subsearch to the join key so the capped count is exact again. Test-only change, no production behavior is touched.

### Why the original assertion could not hold

`plugins.ppl.join.subsearch_maxout` bounds how many subsearch rows are joined against, not which ones. `LogicalSystemLimit` takes its collation from its input, and an unsorted subsearch has none, so the discarded row is whichever one the scan yields last. The user documentation and `join.md` both specify only a maximum row count.

The fixture makes that decisive. Three of the six `occupation` rows match `country = 'Canada'`, and the left side has five matching rows:

```
cap discards a Canada row      ->  5 x 2 = 10
cap discards a non-Canada row  ->  5 x 3 = 15
```

Both satisfy a cap of five, so the assertion inferred cap enforcement from the identity of an arbitrarily discarded row. A cap of five cannot bound this result at all, since five already exceeds the three matching rows.

### What changed

| Test | Cap | Assertion |
| --- | --- | --- |
| `testJoinSubsearchMaxOut` | 2 | joined rows `<= 10`, then exactly `15` uncapped |
| `testJoinSubsearchMaxOutOnFilteredSubsearch` (new) | 2 | exactly `10`, then exactly `15` uncapped |

With a cap of two, at most two matching rows can survive, so the join cannot exceed `5 x 2` whichever rows are kept. That bound is what the setting actually promises. Filtering the subsearch to the join key makes every retained row join identically, which recovers an exact count without depending on row identity.

Scope notes:

- One test file. No fixture, mapping, enum or constant is touched, and no new index is added.
- The original method name and its query are unchanged, so the bare-index right side stays covered under a cap.
- The uncapped expectation of `15` is unchanged in both tests.
- No production code changes, and no engine behavior is asserted differently. The cap was already enforced correctly.

## Validation

Both tests, both pushdown modes, one and five shards: **8 executions, all pass**. Shard counts are confirmed from the cluster log rather than assumed, and each result file was attributed to its pushdown mode by inspecting the recorded setting rather than by fork order.

| Cell | Before | After |
| --- | --- | --- |
| 5 shards, pushdown on | FAIL `expected:<10> but was:<15>` | PASS |
| 5 shards, no pushdown | PASS | PASS |
| 1 shard, pushdown on | PASS | PASS |
| 1 shard, no pushdown | PASS | PASS |

The five-shard failure reproduced locally before the change, and only with pushdown enabled. That the same code passes with pushdown disabled is further evidence that the retained subset varies with execution strategy and was never fixed.

The new bound is not vacuous. Mutating only `testJoinSubsearchMaxOut`'s cap to `0` makes it fail in both modes with `can join at most 5 x 2 = 10 rows, but got 15`, while the companion test keeps passing. So an unenforced cap is still caught.

`spotlessJavaCheck`, `compileTestJava` and `git diff --check` pass.

## Related Issues

None. The engine behavior is correct and unchanged; only the test oracle assumed more than the setting guarantees.

## Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
