### PR TITLE
test(integ-test): stabilize floating window SUM cases

### DIFF
--- a/integ-test/src/test/resources/correctness/queries/window.txt
+++ b/integ-test/src/test/resources/correctness/queries/window.txt
@@ -5,7 +5,7 @@ SELECT DistanceMiles, ROW_NUMBER() OVER (ORDER BY DistanceMiles DESC) AS num FRO
 SELECT DistanceMiles, RANK() OVER (ORDER BY DistanceMiles DESC) AS rnk FROM opensearch_dashboards_sample_data_flights
 SELECT DistanceMiles, DENSE_RANK() OVER (ORDER BY DistanceMiles DESC) AS rnk FROM opensearch_dashboards_sample_data_flights
 SELECT DistanceMiles, COUNT(DistanceMiles) OVER () AS num FROM opensearch_dashboards_sample_data_flights
-SELECT DistanceMiles, SUM(DistanceMiles) OVER () AS num FROM opensearch_dashboards_sample_data_flights
+SELECT DistanceMiles, SUM(CAST(DistanceMiles AS DOUBLE)) OVER () AS num FROM opensearch_dashboards_sample_data_flights
 SELECT DistanceMiles, AVG(DistanceMiles) OVER () AS num FROM opensearch_dashboards_sample_data_flights
 SELECT DistanceMiles, MAX(DistanceMiles) OVER () AS num FROM opensearch_dashboards_sample_data_flights
 SELECT DistanceMiles, MIN(DistanceMiles) OVER () AS num FROM opensearch_dashboards_sample_data_flights
@@ -13,7 +13,7 @@ SELECT AvgTicketPrice, STDDEV_POP(AvgTicketPrice) OVER () AS num FROM opensearch
 SELECT AvgTicketPrice, STDDEV_SAMP(AvgTicketPrice) OVER () AS num FROM opensearch_dashboards_sample_data_flights
 SELECT AvgTicketPrice, VAR_POP(AvgTicketPrice) OVER () AS num FROM opensearch_dashboards_sample_data_flights
 SELECT AvgTicketPrice, VAR_SAMP(AvgTicketPrice) OVER () AS num FROM opensearch_dashboards_sample_data_flights
-SELECT FlightDelayMin, DistanceMiles, SUM(DistanceMiles) OVER (ORDER BY FlightDelayMin) AS num FROM opensearch_dashboards_sample_data_flights
+SELECT FlightDelayMin, DistanceMiles, SUM(CAST(DistanceMiles AS DOUBLE)) OVER (ORDER BY FlightDelayMin) AS num FROM opensearch_dashboards_sample_data_flights ORDER BY FlightDelayMin, DistanceMiles, FlightNum
 SELECT FlightDelayMin, DistanceMiles, AVG(DistanceMiles) OVER (ORDER BY FlightDelayMin) AS num FROM opensearch_dashboards_sample_data_flights
 SELECT FlightDelayMin, DistanceMiles, MAX(DistanceMiles) OVER (ORDER BY FlightDelayMin) AS num FROM opensearch_dashboards_sample_data_flights
 SELECT FlightDelayMin, DistanceMiles, MIN(DistanceMiles) OVER (ORDER BY FlightDelayMin) AS num FROM opensearch_dashboards_sample_data_flights


### PR DESCRIPTION
## Description

Two SQL correctness cases were unstable when the flights fixture used multiple shards:

- `SUM(DistanceMiles) OVER ()` intermittently differed from H2 and SQLite by `0.01`.
- `SUM(DistanceMiles) OVER (ORDER BY FlightDelayMin)` also compared rows positionally even though 17 rows share the same ordering key and the query had no outer `ORDER BY`.

The correctness runner rounds floating cells to two decimals with `CEILING` and then compares them exactly. The legacy SQL engine preserves `SUM(FLOAT)` as `FLOAT`, so shard-dependent input order can move the single-precision result across a cent boundary without changing the window semantics.

This change casts only the summed operand in these two queries to `DOUBLE`. It also adds a unique outer ordering to the ordered case. The internal window order and its default `RANGE` frame remain unchanged.

No production code, shared comparator, or fixture is modified.

## Validation

Focused tests used the official SQL correctness comparison framework against OpenSearch, H2, and SQLite.

| Fixture shards | Repeated runs | Result |
| --- | ---: | --- |
| 1 | 1 | Pass |
| 3 | 5 | 5/5 pass |
| 5 | 10 | 10/10 pass |

Mutation checks:

- Removing only the `DOUBLE` casts reproduced floating SUM failures in 10/10 five-shard runs.
- Removing only the outer tiebreaker reproduced positional failures in 3/3 five-shard runs.

`compileTestJava` and `git diff --check` pass.

## Related Issues

None. This is a test-only alignment with the existing approximate floating-point contract.

## Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
