### PR TITLE
test(integ-test): isolate invalid datetime evaluation from scans

### DIFF
--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLBuiltinDatetimeFunctionInvalidIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLBuiltinDatetimeFunctionInvalidIT.java
@@ -5,26 +5,21 @@
 
 package org.opensearch.sql.calcite.remote;
 
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_FORMATS_WITH_NULL;
 import static org.opensearch.sql.util.Capability.INVALID_DATETIME_ERROR_SHAPE;
 import static org.opensearch.sql.util.MatcherUtils.verifyErrorMessageContains;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.exception.ExpressionEvaluationException;
-import org.opensearch.sql.legacy.SQLIntegTestCase;
 import org.opensearch.sql.ppl.PPLIntegTestCase;
 import org.opensearch.sql.util.RequiresCapability;
 
 public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase {
+  private static final String TEST_SOURCE = "makeresults count=1";
+
   @Override
   public void init() throws Exception {
     super.init();
     enableCalcite();
-
-    loadIndex(SQLIntegTestCase.Index.STATE_COUNTRY);
-    loadIndex(SQLIntegTestCase.Index.STATE_COUNTRY_WITH_NULL);
-    loadIndex(SQLIntegTestCase.Index.DATE_FORMATS);
-    loadIndex(SQLIntegTestCase.Index.DATE_FORMATS_WITH_NULL);
   }
 
   @Test
@@ -35,8 +30,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  | eval `YEARWEEK('2020-08-26')` = YEARWEEK('2020-15-26')",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  | eval `YEARWEEK('2020-08-26')` = YEARWEEK('2020-15-26')",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e, "unsupported format");
   }
 
@@ -45,20 +40,14 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
     Throwable e =
         assertThrowsWithReplace(
             ExpressionEvaluationException.class,
-            () ->
-                executeQuery(
-                    String.format(
-                        "source=%s  | eval a = YEAR('2020-15-26')",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+            () -> executeQuery(String.format("%s  | eval a = YEAR('2020-15-26')", TEST_SOURCE)));
     verifyErrorMessageContains(e, "unsupported format");
     Throwable e1 =
         assertThrowsWithReplace(
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  | eval a = YEAR('2020-12-26 25:00:00')",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  | eval a = YEAR('2020-12-26 25:00:00')", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
   }
 
@@ -67,11 +56,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
     Throwable e1 =
         assertThrowsWithReplace(
             ExpressionEvaluationException.class,
-            () ->
-                executeQuery(
-                    String.format(
-                        "source=%s  | eval a = WEEK('2020-15-26')",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+            () -> executeQuery(String.format("%s  | eval a = WEEK('2020-15-26')", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -79,9 +64,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  | eval a = WEEK('2020-12-26 25:00:00')",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  | eval a = WEEK('2020-12-26 25:00:00')", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
   }
 
@@ -93,8 +76,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TO_SECONDS('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TO_SECONDS('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -102,9 +84,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=TO_SECONDS('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=TO_SECONDS('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
     Throwable e3 =
         assertThrowsWithReplace(
@@ -112,8 +92,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TO_SECONDS('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TO_SECONDS('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -125,18 +105,14 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DATE('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DATE('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
     Throwable e2 =
         assertThrowsWithReplace(
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DATE('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DATE('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
     Throwable e3 =
         assertThrowsWithReplace(
@@ -144,8 +120,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATE('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -157,9 +132,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=TIME('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=TIME('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -167,9 +140,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=TIME('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=TIME('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -178,8 +149,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIME('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIME('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -191,9 +161,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DAY('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DAY('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -201,9 +169,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DAY('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DAY('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -212,8 +178,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -230,9 +195,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DAYNAME('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DAYNAME('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(
         e1, "date:2025-13-02 in unsupported format, please use 'yyyy-MM-dd'");
 
@@ -241,9 +204,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DAYNAME('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DAYNAME('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "date:16:00:61 in unsupported format, please use 'yyyy-MM-dd'");
 
     Throwable e3 =
@@ -252,8 +213,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYNAME('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYNAME('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(
         e3, "date:2025-12-01 15:02:61 in unsupported format, please use 'yyyy-MM-dd'");
   }
@@ -267,8 +227,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYOFMONTH('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYOFMONTH('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -276,9 +235,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DAYOFMONTH('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DAYOFMONTH('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "date:16:00:61 in unsupported format, please use 'yyyy-MM-dd'");
 
     Throwable e3 =
@@ -287,8 +244,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYOFMONTH('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYOFMONTH('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(
         e3, "date:2025-12-01 15:02:61 in unsupported format, please use 'yyyy-MM-dd'");
   }
@@ -302,8 +259,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_MONTH('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_MONTH('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(
         e1, "date:2025-13-02 in unsupported format, please use 'yyyy-MM-dd'");
 
@@ -313,8 +269,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_MONTH('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_MONTH('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -323,8 +278,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_MONTH('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_MONTH('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -337,8 +292,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYOFWEEK('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYOFWEEK('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -346,9 +300,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DAYOFWEEK('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DAYOFWEEK('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -357,8 +309,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYOFWEEK('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYOFWEEK('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
 
     Throwable e4 =
@@ -367,8 +318,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYOFWEEK('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYOFWEEK('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e4, "unsupported format");
 
     Throwable e5 =
@@ -376,9 +326,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DAYOFWEEK('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DAYOFWEEK('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e5, "unsupported format");
 
     Throwable e6 =
@@ -387,8 +335,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYOFWEEK('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYOFWEEK('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e6, "unsupported format");
   }
 
@@ -401,8 +348,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_WEEK('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_WEEK('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -411,8 +357,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_WEEK('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_WEEK('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -421,8 +366,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_WEEK('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_WEEK('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -435,8 +380,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYOFYEAR('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYOFYEAR('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -444,9 +388,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=DAYOFYEAR('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=DAYOFYEAR('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -455,8 +397,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAYOFYEAR('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAYOFYEAR('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -469,8 +410,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_YEAR('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_YEAR('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -479,8 +419,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_YEAR('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_YEAR('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -489,8 +428,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DAY_OF_YEAR('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DAY_OF_YEAR('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -502,9 +441,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=HOUR('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=HOUR('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -512,9 +449,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=HOUR('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=HOUR('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -523,8 +458,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=HOUR('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=HOUR('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -537,8 +471,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=HOUR_OF_DAY('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=HOUR_OF_DAY('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -547,8 +480,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=HOUR_OF_DAY('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=HOUR_OF_DAY('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -557,8 +489,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=HOUR_OF_DAY('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=HOUR_OF_DAY('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -570,9 +502,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=LAST_DAY('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=LAST_DAY('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -580,9 +510,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=LAST_DAY('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=LAST_DAY('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -591,8 +519,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=LAST_DAY('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=LAST_DAY('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -604,9 +531,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=MINUTE('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=MINUTE('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -614,9 +539,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=MINUTE('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=MINUTE('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -625,8 +548,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MINUTE('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MINUTE('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -639,8 +561,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MINUTE_OF_DAY('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MINUTE_OF_DAY('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -649,8 +570,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MINUTE_OF_DAY('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MINUTE_OF_DAY('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -659,8 +579,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MINUTE_OF_DAY('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MINUTE_OF_DAY('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -673,8 +593,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MINUTE_OF_HOUR('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MINUTE_OF_HOUR('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -683,8 +602,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MINUTE_OF_HOUR('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MINUTE_OF_HOUR('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -693,8 +611,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MINUTE_OF_HOUR('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MINUTE_OF_HOUR('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -706,9 +624,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=MONTH('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=MONTH('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -716,9 +632,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=MONTH('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=MONTH('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -727,8 +641,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MONTH('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MONTH('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -741,8 +654,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MONTH_OF_YEAR('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MONTH_OF_YEAR('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -751,8 +663,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MONTH_OF_YEAR('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MONTH_OF_YEAR('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -761,8 +672,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MONTH_OF_YEAR('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MONTH_OF_YEAR('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -780,8 +691,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MONTHNAME('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MONTHNAME('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(
         e1, "date:2025-13-02 in unsupported format, please use 'yyyy-MM-dd'");
 
@@ -790,9 +700,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=MONTHNAME('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=MONTHNAME('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "date:16:00:61 in unsupported format, please use 'yyyy-MM-dd'");
 
     Throwable e3 =
@@ -801,8 +709,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=MONTHNAME('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=MONTHNAME('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(
         e3, "date:2025-12-01 15:02:61 in unsupported format, please use 'yyyy-MM-dd'");
   }
@@ -815,9 +722,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=QUARTER('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=QUARTER('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -825,9 +730,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=QUARTER('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=QUARTER('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -836,8 +739,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=QUARTER('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=QUARTER('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -849,9 +751,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=SECOND('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=SECOND('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -859,9 +759,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=SECOND('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=SECOND('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -870,8 +768,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SECOND('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SECOND('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -884,8 +781,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SECOND_OF_MINUTE('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SECOND_OF_MINUTE('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -894,8 +790,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SECOND_OF_MINUTE('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SECOND_OF_MINUTE('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -904,8 +799,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SECOND_OF_MINUTE('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SECOND_OF_MINUTE('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -918,8 +813,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIME_TO_SEC('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIME_TO_SEC('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -928,8 +822,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIME_TO_SEC('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIME_TO_SEC('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -938,8 +831,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIME_TO_SEC('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIME_TO_SEC('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -952,8 +845,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMP('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMP('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -961,9 +853,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=TIMESTAMP('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=TIMESTAMP('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -972,8 +862,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
 
     Throwable e4 =
@@ -982,8 +871,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMP('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMP('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e4, "unsupported format");
 
     Throwable e5 =
@@ -991,9 +879,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=TIMESTAMP('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=TIMESTAMP('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e5, "unsupported format");
 
     Throwable e6 =
@@ -1002,8 +888,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e6, "unsupported format");
 
     Throwable e7 =
@@ -1012,8 +897,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMP('2025-13-02', '2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMP('2025-13-02', '2025-13-02') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e7, "unsupported format");
 
     Throwable e8 =
@@ -1022,8 +907,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMP('16:00:61', '16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMP('16:00:61', '16:00:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e8, "unsupported format");
 
     Throwable e9 =
@@ -1032,9 +917,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61', '2025-12-01"
+                        "%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61', '2025-12-01"
                             + " 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e9, "unsupported format");
   }
 
@@ -1046,9 +931,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=TO_DAYS('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=TO_DAYS('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1056,9 +939,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=TO_DAYS('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=TO_DAYS('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1067,8 +948,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TO_DAYS('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TO_DAYS('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1080,9 +960,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=YEAR('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=YEAR('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1090,9 +968,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=YEAR('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=YEAR('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1101,8 +977,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=YEAR('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=YEAR('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1114,9 +989,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=WEEK('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=WEEK('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1124,9 +997,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=WEEK('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=WEEK('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1135,8 +1006,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=WEEK('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=WEEK('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1149,8 +1019,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=WEEK_OF_YEAR('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=WEEK_OF_YEAR('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1159,8 +1028,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=WEEK_OF_YEAR('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=WEEK_OF_YEAR('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1169,8 +1037,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=WEEK_OF_YEAR('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=WEEK_OF_YEAR('2025-12-01 15:02:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1182,9 +1050,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=WEEKDAY('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=WEEKDAY('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1192,9 +1058,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=WEEKDAY('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=WEEKDAY('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1203,8 +1067,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=WEEKDAY('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=WEEKDAY('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1216,9 +1079,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=YEARWEEK('2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=YEARWEEK('2025-13-02') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1226,9 +1087,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=YEARWEEK('16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=YEARWEEK('16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1237,8 +1096,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=YEARWEEK('2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=YEARWEEK('2025-12-01 15:02:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1251,8 +1109,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=ADDDATE('2025-13-02', INTERVAL 1 HOUR) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=ADDDATE('2025-13-02', INTERVAL 1 HOUR) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1261,8 +1119,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=ADDDATE('16:00:61', INTERVAL 1 HOUR) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=ADDDATE('16:00:61', INTERVAL 1 HOUR) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1271,9 +1129,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=ADDDATE('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
+                        "%s  |  eval a=ADDDATE('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
                             + " fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
 
     Throwable e4 =
@@ -1282,8 +1140,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=ADDDATE('2025-13-02', 1) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=ADDDATE('2025-13-02', 1) | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e4, "unsupported format");
 
     Throwable e5 =
@@ -1291,9 +1148,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=ADDDATE('16:00:61', 1) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=ADDDATE('16:00:61', 1) | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e5, "unsupported format");
 
     Throwable e6 =
@@ -1302,8 +1157,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=ADDDATE('2025-12-01 15:02:61', 1) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=ADDDATE('2025-12-01 15:02:61', 1) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e6, "unsupported format");
   }
 
@@ -1316,8 +1171,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=ADDTIME('2025-13-02', '2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=ADDTIME('2025-13-02', '2025-13-02') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1326,8 +1181,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=ADDTIME('16:00:61', '16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=ADDTIME('16:00:61', '16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1336,9 +1190,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=ADDTIME('2025-12-01 15:02:61', '2025-12-01"
+                        "%s  |  eval a=ADDTIME('2025-12-01 15:02:61', '2025-12-01"
                             + " 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1351,8 +1205,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_ADD('2025-13-02', INTERVAL 1 HOUR) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATE_ADD('2025-13-02', INTERVAL 1 HOUR) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1361,8 +1215,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_ADD('16:00:61', INTERVAL 1 HOUR) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATE_ADD('16:00:61', INTERVAL 1 HOUR) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1371,9 +1225,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_ADD('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
+                        "%s  |  eval a=DATE_ADD('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
                             + " fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1386,8 +1240,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_SUB('2025-13-02', INTERVAL 1 HOUR) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATE_SUB('2025-13-02', INTERVAL 1 HOUR) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1396,8 +1250,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_SUB('16:00:61', INTERVAL 1 HOUR) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATE_SUB('16:00:61', INTERVAL 1 HOUR) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1406,9 +1260,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_SUB('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
+                        "%s  |  eval a=DATE_SUB('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
                             + " fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1421,8 +1275,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATEDIFF('2025-13-02', '2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATEDIFF('2025-13-02', '2025-13-02') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1431,8 +1285,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATEDIFF('16:00:61', '16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATEDIFF('16:00:61', '16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1441,9 +1294,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATEDIFF('2025-12-01 15:02:61', '2025-12-01"
+                        "%s  |  eval a=DATEDIFF('2025-12-01 15:02:61', '2025-12-01"
                             + " 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1456,8 +1309,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SUBDATE('2025-13-02', INTERVAL 1 HOUR) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SUBDATE('2025-13-02', INTERVAL 1 HOUR) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1466,8 +1319,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SUBDATE('16:00:61', INTERVAL 1 HOUR) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SUBDATE('16:00:61', INTERVAL 1 HOUR) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1476,9 +1329,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SUBDATE('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
+                        "%s  |  eval a=SUBDATE('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
                             + " fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
 
     Throwable e4 =
@@ -1487,8 +1340,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SUBDATE('2025-13-02', 1) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SUBDATE('2025-13-02', 1) | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e4, "unsupported format");
 
     Throwable e5 =
@@ -1496,9 +1348,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             ExpressionEvaluationException.class,
             () ->
                 executeQuery(
-                    String.format(
-                        "source=%s  |  eval a=SUBDATE('16:00:61', 1) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                    String.format("%s  |  eval a=SUBDATE('16:00:61', 1) | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e5, "unsupported format");
 
     Throwable e6 =
@@ -1507,8 +1357,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SUBDATE('2025-12-01 15:02:61', 1) | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SUBDATE('2025-12-01 15:02:61', 1) | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e6, "unsupported format");
   }
 
@@ -1520,8 +1370,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SUBTIME('2025-13-02', '2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SUBTIME('2025-13-02', '2025-13-02') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1530,8 +1380,7 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SUBTIME('16:00:61', '16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=SUBTIME('16:00:61', '16:00:61') | fields a", TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1540,9 +1389,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=SUBTIME('2025-12-01 15:02:61', '2025-12-01"
+                        "%s  |  eval a=SUBTIME('2025-12-01 15:02:61', '2025-12-01"
                             + " 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1555,8 +1404,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMPADD(HOUR, 1, '2025-13-02') | fields" + " a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMPADD(HOUR, 1, '2025-13-02') | fields" + " a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1565,8 +1414,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMPADD(HOUR, 1, '16:00:61') | fields" + " a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMPADD(HOUR, 1, '16:00:61') | fields" + " a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1575,9 +1424,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMPADD(HOUR, 1, '2025-12-01 15:02:61')"
+                        "%s  |  eval a=TIMESTAMPADD(HOUR, 1, '2025-12-01 15:02:61')"
                             + " | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1590,9 +1439,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMPDIFF(HOUR, '2025-13-02',"
+                        "%s  |  eval a=TIMESTAMPDIFF(HOUR, '2025-13-02',"
                             + " '2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1601,9 +1450,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMPDIFF(HOUR, '16:00:61', '16:00:61')"
-                            + " | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIMESTAMPDIFF(HOUR, '16:00:61', '16:00:61')" + " | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1612,9 +1460,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIMESTAMPDIFF(HOUR, '2025-12-01 15:02:61',"
+                        "%s  |  eval a=TIMESTAMPDIFF(HOUR, '2025-12-01 15:02:61',"
                             + " '2025-12-01 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1627,8 +1475,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_FORMAT('2025-13-02', '2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATE_FORMAT('2025-13-02', '2025-13-02') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1637,8 +1485,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_FORMAT('16:00:61', '16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=DATE_FORMAT('16:00:61', '16:00:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1647,9 +1495,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=DATE_FORMAT('2025-12-01 15:02:61', '2025-12-01"
+                        "%s  |  eval a=DATE_FORMAT('2025-12-01 15:02:61', '2025-12-01"
                             + " 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 
@@ -1662,8 +1510,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIME_FORMAT('2025-13-02', '2025-13-02') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIME_FORMAT('2025-13-02', '2025-13-02') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e1, "unsupported format");
 
     Throwable e2 =
@@ -1672,8 +1520,8 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIME_FORMAT('16:00:61', '16:00:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        "%s  |  eval a=TIME_FORMAT('16:00:61', '16:00:61') | fields a",
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e2, "unsupported format");
 
     Throwable e3 =
@@ -1682,9 +1530,9 @@ public class CalcitePPLBuiltinDatetimeFunctionInvalidIT extends PPLIntegTestCase
             () ->
                 executeQuery(
                     String.format(
-                        "source=%s  |  eval a=TIME_FORMAT('2025-12-01 15:02:61', '2025-12-01"
+                        "%s  |  eval a=TIME_FORMAT('2025-12-01 15:02:61', '2025-12-01"
                             + " 15:02:61') | fields a",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+                        TEST_SOURCE)));
     verifyErrorMessageContains(e3, "unsupported format");
   }
 }


### PR DESCRIPTION
## Description

`CalcitePPLBuiltinDatetimeFunctionInvalidIT` verifies that invalid datetime literals fail at runtime with the expected exception class and message. The class contains 146 assertions, but none of its queries reference an indexed field. The existing one-document index is used only to produce a row for expression evaluation.

Scanning that index also brings shard and point-in-time lifecycle behavior into tests whose goal is limited to function validation. With multiple shards, repeated failing scans can exhaust the PIT context limit before the remaining datetime assertions run.

This change uses `makeresults count=1` as the common source for every query. It still produces one row and evaluates the same invalid literals at runtime, while removing the unrelated index scan. The four fixture loads are no longer needed and are removed.

All exception types and message assertions remain unchanged. This is a test-only scope correction; it does not change production behavior or address the separate PIT cleanup path.

## Validation

- Direct Calcite path: 45/45 methods pass
- No-pushdown suite: 45/45 methods pass
- All 146 assertions use `makeresults count=1`
- No indexed source or `loadIndex` call remains in the class
- Mutation check: changing the source to `makeresults count=0` makes `testYearInvalid` fail in both modes because no row evaluates the expression
- `spotlessJavaCheck`, `compileTestJava`, and `git diff --check` pass

The large line-count diff is mechanical: the same source substitution is applied to all 146 assertions, and Spotless collapses the now-shorter `String.format` expressions.

## Related Issues

None.

## Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff` or `-s`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
