### PR TITLE
Reject object and array fields where PPL coerces to a string

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -3887,9 +3887,7 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
                         + " instead.",
                     fieldName)
                 : StringUtils.format(
-                    "Cannot chart by [%s] because it holds multiple values. Use a field with a"
-                        + " single value instead.",
-                    fieldName));
+                    "Cannot chart by [%s] because it holds multiple values.", fieldName));
       }
       colSplit =
           relBuilder.alias(

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -3878,12 +3878,18 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     if (!SqlTypeUtil.isCharacter(colSplit.getType())) {
       // Object, array and other non-scalar types have no string representation to pivot on
       if (!SqlTypeUtil.isAtomic(colSplit.getType())) {
+        String containerType = OpenSearchTypeFactory.getContainerTypeName(colSplit.getType());
+        String fieldName = StringUtils.unquoteIdentifier(columnSplitName);
         throw new IllegalArgumentException(
-            StringUtils.format(
-                "Cannot split by field [%s] of type %s: a chart split field must be a scalar type."
-                    + " Use a scalar field instead, such as a sub-field of an object.",
-                columnSplitName,
-                OpenSearchTypeFactory.getLegacyTypeName(colSplit.getType(), context.queryType)));
+            "object".equals(containerType)
+                ? StringUtils.format(
+                    "Cannot chart by [%s] because it is an object. Use one of its sub-fields"
+                        + " instead.",
+                    fieldName)
+                : StringUtils.format(
+                    "Cannot chart by [%s] because it holds multiple values. Use a field with a"
+                        + " single value instead.",
+                    fieldName));
       }
       colSplit =
           relBuilder.alias(

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -3879,15 +3879,12 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
       // Object, array and other non-scalar types have no string representation to pivot on
       if (!SqlTypeUtil.isAtomic(colSplit.getType())) {
         String containerType = OpenSearchTypeFactory.getContainerTypeName(colSplit.getType());
-        String fieldName = StringUtils.unquoteIdentifier(columnSplitName);
+        String reason =
+            "object".equals(containerType) ? "it is an object" : "it holds multiple values";
         throw new IllegalArgumentException(
-            "object".equals(containerType)
-                ? StringUtils.format(
-                    "Cannot chart by [%s] because it is an object. Use one of its sub-fields"
-                        + " instead.",
-                    fieldName)
-                : StringUtils.format(
-                    "Cannot chart by [%s] because it holds multiple values.", fieldName));
+            StringUtils.format(
+                "Cannot chart by [%s] because %s.",
+                StringUtils.unquoteIdentifier(columnSplitName), reason));
       }
       colSplit =
           relBuilder.alias(

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -3876,6 +3876,15 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
     RexNode colSplit = relBuilder.field(1);
     String columnSplitName = relBuilder.peek().getRowType().getFieldNames().get(1);
     if (!SqlTypeUtil.isCharacter(colSplit.getType())) {
+      // Object, array and other non-scalar types have no string representation to pivot on
+      if (!SqlTypeUtil.isAtomic(colSplit.getType())) {
+        throw new IllegalArgumentException(
+            StringUtils.format(
+                "Cannot split by field [%s] of type %s: a chart split field must be a scalar type."
+                    + " Use a scalar field instead, such as a sub-field of an object.",
+                columnSplitName,
+                OpenSearchTypeFactory.getLegacyTypeName(colSplit.getType(), context.queryType)));
+      }
       colSplit =
           relBuilder.alias(
               context.rexBuilder.makeCast(

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -931,6 +931,17 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
         OpenSearchTypeFactory.convertExprTypeToRelDataType(node.getDataType().getCoreType());
     RelDataType nullableType =
         context.rexBuilder.getTypeFactory().createTypeWithNullability(type, true);
+    // Object and array values have no scalar representation, and the cast would only fail later
+    // while the generated code is compiled
+    switch (expr.getType().getSqlTypeName()) {
+      case MAP, ARRAY, ROW ->
+          throw new IllegalArgumentException(
+              StringUtils.format(
+                  "Cannot cast a value of type %s to %s",
+                  OpenSearchTypeFactory.getLegacyTypeName(expr.getType(), context.queryType),
+                  OpenSearchTypeFactory.getLegacyTypeName(type, context.queryType)));
+      default -> {}
+    }
     // call makeCast() instead of cast() because the saft parameter is true could avoid exception.
     return context.rexBuilder.makeCast(nullableType, expr, true, true);
   }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -933,14 +933,12 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
         context.rexBuilder.getTypeFactory().createTypeWithNullability(type, true);
     // Object and array values have no scalar representation, and the cast would only fail later
     // while the generated code is compiled
-    switch (expr.getType().getSqlTypeName()) {
-      case MAP, ARRAY, ROW ->
-          throw new IllegalArgumentException(
-              StringUtils.format(
-                  "Cannot cast a value of type %s to %s",
-                  OpenSearchTypeFactory.getLegacyTypeName(expr.getType(), context.queryType),
-                  OpenSearchTypeFactory.getLegacyTypeName(type, context.queryType)));
-      default -> {}
+    String containerType = OpenSearchTypeFactory.getContainerTypeName(expr.getType());
+    if (containerType != null) {
+      throw new IllegalArgumentException(
+          StringUtils.format(
+              "Cannot cast an %s to %s",
+              containerType, OpenSearchTypeFactory.getLegacyTypeName(type, context.queryType)));
     }
     // call makeCast() instead of cast() because the saft parameter is true could avoid exception.
     return context.rexBuilder.makeCast(nullableType, expr, true, true);

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -265,6 +265,18 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
         .toUpperCase(Locale.ROOT);
   }
 
+  /**
+   * Name a multi-value type the way a query author sees it in a mapping, for error messages:
+   * "object" for an object field, "array" for an array one. Returns null for scalar types.
+   */
+  public static @Nullable String getContainerTypeName(RelDataType relDataType) {
+    return switch (relDataType.getSqlTypeName()) {
+      case MAP, ROW -> "object";
+      case ARRAY, MULTISET -> "array";
+      default -> null;
+    };
+  }
+
   /** Converts a Calcite data type to OpenSearch ExprCoreType. */
   public static ExprType convertRelDataTypeToExprType(RelDataType type) {
     if (isUserDefinedType(type)) {

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/non_scalar_coercion.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/non_scalar_coercion.yml
@@ -1,0 +1,99 @@
+setup:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : true
+  - do:
+      indices.create:
+        index: chart_object_split
+        body:
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              body:
+                type: text
+              attributes:
+                properties:
+                  cluster:
+                    properties:
+                      name:
+                        type: keyword
+  - do:
+      bulk:
+        index: chart_object_split
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2026-09-08T16:10:00Z", "body": "logtype=access foo", "attributes": {"cluster": {"name": "c1"}}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2026-09-08T16:20:00Z", "body": "logtype=access bar", "attributes": {"cluster": {"name": "c2"}}}'
+
+---
+teardown:
+  - do:
+      query.settings:
+        body:
+          transient:
+            plugins.calcite.enabled : false
+  - do:
+      indices.delete:
+        index: chart_object_split
+        ignore: 404
+
+---
+"timechart split by an object field returns 400 bad_request":
+  - skip:
+      features:
+        - headers
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=chart_object_split | timechart span=1m count() by `attributes.cluster`"
+  - match: {"$body": "/Cannot\\s+split\\s+by\\s+field.*attributes.cluster.*of\\s+type\\s+STRUCT/"}
+
+---
+"chart split by an object field returns 400 bad_request":
+  - skip:
+      features:
+        - headers
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=chart_object_split | chart count() over body by `attributes.cluster`"
+  - match: {"$body": "/Cannot\\s+split\\s+by\\s+field.*attributes.cluster.*of\\s+type\\s+STRUCT/"}
+
+---
+"cast of an object field returns 400 bad_request":
+  - skip:
+      features:
+        - headers
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=chart_object_split | eval c = cast(`attributes.cluster` as string) | fields c"
+  - match: {"$body": "/Cannot\\s+cast\\s+a\\s+value\\s+of\\s+type\\s+STRUCT\\s+to\\s+STRING/"}
+
+---
+"timechart split by a scalar sub-field of an object still works":
+  - skip:
+      features:
+        - headers
+  - do:
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=chart_object_split | where match(body, 'logtype=access') | timechart span=1m count() by `attributes.cluster.name`"
+  - match: {"total": 2}
+  - match: {"datarows": [["2026-09-08 16:10:00", "c1", 1], ["2026-09-08 16:20:00", "c2", 1]]}

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/non_scalar_coercion.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/non_scalar_coercion.yml
@@ -22,15 +22,20 @@ setup:
                         type: keyword
                       uid:
                         type: keyword
+              tags:
+                type: nested
+                properties:
+                  name:
+                    type: keyword
   - do:
       bulk:
         index: app_logs_object
         refresh: true
         body:
           - '{"index": {}}'
-          - '{"@timestamp": "2026-01-01T00:01:00Z", "message": "request served", "dimensions": {"pod": {"name": "pod-a", "uid": "u-1"}}}'
+          - '{"@timestamp": "2026-01-01T00:01:00Z", "message": "request served", "dimensions": {"pod": {"name": "pod-a", "uid": "u-1"}}, "tags": [{"name": "t1"}, {"name": "t2"}]}'
           - '{"index": {}}'
-          - '{"@timestamp": "2026-01-01T00:02:00Z", "message": "request served", "dimensions": {"pod": {"name": "pod-b", "uid": "u-2"}}}'
+          - '{"@timestamp": "2026-01-01T00:02:00Z", "message": "request served", "dimensions": {"pod": {"name": "pod-b", "uid": "u-2"}}, "tags": [{"name": "t3"}]}'
 
 ---
 teardown:
@@ -85,6 +90,34 @@ teardown:
         body:
           query: "source=app_logs_object | eval c = cast(`dimensions.pod` as string) | fields c"
   - match: {"$body": "/Cannot\\s+cast\\s+an\\s+object\\s+to\\s+STRING/"}
+
+---
+"timechart split by a multi-value field returns 400 bad_request":
+  - skip:
+      features:
+        - headers
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=app_logs_object | timechart span=1m count() by tags"
+  - match: {"$body": "/Cannot\\s+chart\\s+by.*tags.*because\\s+it\\s+holds\\s+multiple\\s+values/"}
+
+---
+"cast of a multi-value field returns 400 bad_request":
+  - skip:
+      features:
+        - headers
+  - do:
+      catch: bad_request
+      headers:
+        Content-Type: 'application/json'
+      ppl:
+        body:
+          query: "source=app_logs_object | eval t = cast(tags as string) | fields t"
+  - match: {"$body": "/Cannot\\s+cast\\s+an\\s+array\\s+to\\s+STRING/"}
 
 ---
 "timechart split by a scalar sub-field of an object still works":

--- a/integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/non_scalar_coercion.yml
+++ b/integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/non_scalar_coercion.yml
@@ -6,29 +6,31 @@ setup:
             plugins.calcite.enabled : true
   - do:
       indices.create:
-        index: chart_object_split
+        index: app_logs_object
         body:
           mappings:
             properties:
               "@timestamp":
                 type: date
-              body:
+              message:
                 type: text
-              attributes:
+              dimensions:
                 properties:
-                  cluster:
+                  pod:
                     properties:
                       name:
                         type: keyword
+                      uid:
+                        type: keyword
   - do:
       bulk:
-        index: chart_object_split
+        index: app_logs_object
         refresh: true
         body:
           - '{"index": {}}'
-          - '{"@timestamp": "2026-09-08T16:10:00Z", "body": "logtype=access foo", "attributes": {"cluster": {"name": "c1"}}}'
+          - '{"@timestamp": "2026-01-01T00:01:00Z", "message": "request served", "dimensions": {"pod": {"name": "pod-a", "uid": "u-1"}}}'
           - '{"index": {}}'
-          - '{"@timestamp": "2026-09-08T16:20:00Z", "body": "logtype=access bar", "attributes": {"cluster": {"name": "c2"}}}'
+          - '{"@timestamp": "2026-01-01T00:02:00Z", "message": "request served", "dimensions": {"pod": {"name": "pod-b", "uid": "u-2"}}}'
 
 ---
 teardown:
@@ -39,7 +41,7 @@ teardown:
             plugins.calcite.enabled : false
   - do:
       indices.delete:
-        index: chart_object_split
+        index: app_logs_object
         ignore: 404
 
 ---
@@ -53,8 +55,8 @@ teardown:
         Content-Type: 'application/json'
       ppl:
         body:
-          query: "source=chart_object_split | timechart span=1m count() by `attributes.cluster`"
-  - match: {"$body": "/Cannot\\s+split\\s+by\\s+field.*attributes.cluster.*of\\s+type\\s+STRUCT/"}
+          query: "source=app_logs_object | timechart span=1m count() by `dimensions.pod`"
+  - match: {"$body": "/Cannot\\s+chart\\s+by.*dimensions.pod.*because\\s+it\\s+is\\s+an\\s+object/"}
 
 ---
 "chart split by an object field returns 400 bad_request":
@@ -67,8 +69,8 @@ teardown:
         Content-Type: 'application/json'
       ppl:
         body:
-          query: "source=chart_object_split | chart count() over body by `attributes.cluster`"
-  - match: {"$body": "/Cannot\\s+split\\s+by\\s+field.*attributes.cluster.*of\\s+type\\s+STRUCT/"}
+          query: "source=app_logs_object | chart count() over message by `dimensions.pod`"
+  - match: {"$body": "/Cannot\\s+chart\\s+by.*dimensions.pod.*because\\s+it\\s+is\\s+an\\s+object/"}
 
 ---
 "cast of an object field returns 400 bad_request":
@@ -81,8 +83,8 @@ teardown:
         Content-Type: 'application/json'
       ppl:
         body:
-          query: "source=chart_object_split | eval c = cast(`attributes.cluster` as string) | fields c"
-  - match: {"$body": "/Cannot\\s+cast\\s+a\\s+value\\s+of\\s+type\\s+STRUCT\\s+to\\s+STRING/"}
+          query: "source=app_logs_object | eval c = cast(`dimensions.pod` as string) | fields c"
+  - match: {"$body": "/Cannot\\s+cast\\s+an\\s+object\\s+to\\s+STRING/"}
 
 ---
 "timechart split by a scalar sub-field of an object still works":
@@ -94,6 +96,6 @@ teardown:
         Content-Type: 'application/json'
       ppl:
         body:
-          query: "source=chart_object_split | where match(body, 'logtype=access') | timechart span=1m count() by `attributes.cluster.name`"
+          query: "source=app_logs_object | where message = 'request served' | timechart span=1m count() by `dimensions.pod.name`"
   - match: {"total": 2}
-  - match: {"datarows": [["2026-09-08 16:10:00", "c1", 1], ["2026-09-08 16:20:00", "c2", 1]]}
+  - match: {"datarows": [["2026-01-01 00:01:00", "pod-a", 1], ["2026-01-01 00:02:00", "pod-b", 1]]}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java
@@ -73,10 +73,7 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
             () -> getRelNode("source=app_logs | timechart span=1m count() by `dimensions.pod`"));
     assertTrue(
         e.getMessage(),
-        e.getMessage()
-            .equals(
-                "Cannot chart by [dimensions.pod] because it is an object. Use one of its"
-                    + " sub-fields instead."));
+        e.getMessage().equals("Cannot chart by [dimensions.pod] because it is an object."));
   }
 
   @Test
@@ -87,10 +84,7 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
             () -> getRelNode("source=app_logs | chart count() over message by `dimensions.pod`"));
     assertTrue(
         e.getMessage(),
-        e.getMessage()
-            .equals(
-                "Cannot chart by [dimensions.pod] because it is an object. Use one of its"
-                    + " sub-fields instead."));
+        e.getMessage().equals("Cannot chart by [dimensions.pod] because it is an object."));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.ppl.calcite;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.plan.RelTraitDef;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.Statistics;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.test.CalciteAssert;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Programs;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Test;
+
+/**
+ * Coercing an object or array field to a scalar has no valid implementation: the generated code
+ * fails to compile with {@code Cannot cast "java.util.Map" to "java.lang.String"}. Verifies the
+ * places where PPL coerces implicitly (chart and timechart split field) or explicitly ({@code
+ * cast}) reject such a field with a client error instead.
+ */
+public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
+
+  public CalcitePPLNonScalarCoercionTest() {
+    super(CalciteAssert.SchemaSpec.SCOTT_WITH_TEMPORAL);
+  }
+
+  @Override
+  protected Frameworks.ConfigBuilder config(CalciteAssert.SchemaSpec... schemaSpecs) {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    final SchemaPlus schema = CalciteAssert.addSchema(rootSchema, schemaSpecs);
+    ImmutableList<Object[]> rows =
+        ImmutableList.of(
+            new Object[] {0L, "access", Map.of("name", "c1"), List.of("x")},
+            new Object[] {60000L, "access", Map.of("name", "c2"), List.of("y")});
+    schema.add("objlogs", new ObjectFieldTable(rows));
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(schema)
+        .traitDefs((List<RelTraitDef>) null)
+        .programs(Programs.heuristicJoinOrder(Programs.RULE_SET, true, 2));
+  }
+
+  @Test
+  public void timechartByObjectFieldIsRejected() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> getRelNode("source=objlogs | timechart span=1m count() by cluster"));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().startsWith("Cannot split by field [cluster] of type STRUCT: a chart split"));
+  }
+
+  @Test
+  public void chartByObjectFieldIsRejected() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> getRelNode("source=objlogs | chart count() over body by cluster"));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().startsWith("Cannot split by field [cluster] of type STRUCT: a chart split"));
+  }
+
+  @Test
+  public void chartByArrayFieldIsRejected() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> getRelNode("source=objlogs | chart count() over body by tags"));
+    assertTrue(
+        e.getMessage(),
+        e.getMessage().startsWith("Cannot split by field [tags] of type ARRAY: a chart split"));
+  }
+
+  @Test
+  public void castObjectFieldIsRejected() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> getRelNode("source=objlogs | eval s = cast(cluster as string)"));
+    assertEquals("Cannot cast a value of type STRUCT to STRING", e.getMessage());
+  }
+
+  @Test
+  public void castArrayFieldIsRejected() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> getRelNode("source=objlogs | eval s = cast(tags as int)"));
+    assertEquals("Cannot cast a value of type ARRAY to INT", e.getMessage());
+  }
+
+  @Test
+  public void castScalarFieldStillWorks() {
+    verifyResultCount(getRelNode("source=objlogs | eval s = cast(body as int) | fields s"), 2);
+  }
+
+  /** limit=0 skips the top-N pivot, so the split field is never coerced to a string. */
+  @Test
+  public void chartWithoutLimitKeepsObjectField() {
+    verifyLogical(
+        getRelNode("source=objlogs | chart limit=0 count() over body by cluster"),
+        "LogicalSort(sort0=[$0], dir0=[ASC])\n"
+            + "  LogicalAggregate(group=[{0, 1}], count()=[COUNT()])\n"
+            + "    LogicalProject(body=[$1], cluster=[$2])\n"
+            + "      LogicalFilter(condition=[IS NOT NULL($1)])\n"
+            + "        LogicalTableScan(table=[[scott, objlogs]])\n");
+  }
+
+  @RequiredArgsConstructor
+  public static class ObjectFieldTable implements ScannableTable {
+    private final ImmutableList<Object[]> rows;
+
+    protected final RelProtoDataType protoRowType =
+        factory ->
+            factory
+                .builder()
+                .add("@timestamp", SqlTypeName.TIMESTAMP)
+                .nullable(true)
+                .add("body", SqlTypeName.VARCHAR)
+                .nullable(true)
+                .add(
+                    "cluster",
+                    factory.createTypeWithNullability(
+                        factory.createMapType(
+                            factory.createSqlType(SqlTypeName.VARCHAR),
+                            factory.createSqlType(SqlTypeName.ANY)),
+                        true))
+                .add(
+                    "tags",
+                    factory.createTypeWithNullability(
+                        factory.createArrayType(factory.createSqlType(SqlTypeName.VARCHAR), -1),
+                        true))
+                .build();
+
+    @Override
+    public Enumerable<@Nullable Object[]> scan(DataContext root) {
+      return Linq4j.asEnumerable(rows);
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+      return protoRowType.apply(typeFactory);
+    }
+
+    @Override
+    public Statistic getStatistic() {
+      return Statistics.of(2d, ImmutableList.of(), RelCollations.createSingleton(0));
+    }
+
+    @Override
+    public Schema.TableType getJdbcTableType() {
+      return Schema.TableType.TABLE;
+    }
+
+    @Override
+    public boolean isRolledUp(String column) {
+      return false;
+    }
+
+    @Override
+    public boolean rolledUpColumnValidInsideAgg(
+        String column,
+        SqlCall call,
+        @Nullable SqlNode parent,
+        @Nullable CalciteConnectionConfig config) {
+      return false;
+    }
+  }
+}

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java
@@ -55,9 +55,9 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
     final SchemaPlus schema = CalciteAssert.addSchema(rootSchema, schemaSpecs);
     ImmutableList<Object[]> rows =
         ImmutableList.of(
-            new Object[] {0L, "access", Map.of("name", "c1"), List.of("x")},
-            new Object[] {60000L, "access", Map.of("name", "c2"), List.of("y")});
-    schema.add("objlogs", new ObjectFieldTable(rows));
+            new Object[] {0L, "request served", Map.of("name", "pod-a"), List.of("x")},
+            new Object[] {60000L, "request served", Map.of("name", "pod-b"), List.of("y")});
+    schema.add("app_logs", new ObjectFieldTable(rows));
     return Frameworks.newConfigBuilder()
         .parserConfig(SqlParser.Config.DEFAULT)
         .defaultSchema(schema)
@@ -70,10 +70,13 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class,
-            () -> getRelNode("source=objlogs | timechart span=1m count() by cluster"));
+            () -> getRelNode("source=app_logs | timechart span=1m count() by `dimensions.pod`"));
     assertTrue(
         e.getMessage(),
-        e.getMessage().startsWith("Cannot split by field [cluster] of type STRUCT: a chart split"));
+        e.getMessage()
+            .equals(
+                "Cannot chart by [dimensions.pod] because it is an object. Use one of its"
+                    + " sub-fields instead."));
   }
 
   @Test
@@ -81,10 +84,13 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class,
-            () -> getRelNode("source=objlogs | chart count() over body by cluster"));
+            () -> getRelNode("source=app_logs | chart count() over message by `dimensions.pod`"));
     assertTrue(
         e.getMessage(),
-        e.getMessage().startsWith("Cannot split by field [cluster] of type STRUCT: a chart split"));
+        e.getMessage()
+            .equals(
+                "Cannot chart by [dimensions.pod] because it is an object. Use one of its"
+                    + " sub-fields instead."));
   }
 
   @Test
@@ -92,10 +98,13 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class,
-            () -> getRelNode("source=objlogs | chart count() over body by tags"));
+            () -> getRelNode("source=app_logs | chart count() over message by tags"));
     assertTrue(
         e.getMessage(),
-        e.getMessage().startsWith("Cannot split by field [tags] of type ARRAY: a chart split"));
+        e.getMessage()
+            .equals(
+                "Cannot chart by [tags] because it holds multiple values. Use a field with a single"
+                    + " value instead."));
   }
 
   @Test
@@ -103,8 +112,8 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class,
-            () -> getRelNode("source=objlogs | eval s = cast(cluster as string)"));
-    assertEquals("Cannot cast a value of type STRUCT to STRING", e.getMessage());
+            () -> getRelNode("source=app_logs | eval s = cast(`dimensions.pod` as string)"));
+    assertEquals("Cannot cast an object to STRING", e.getMessage());
   }
 
   @Test
@@ -112,25 +121,28 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class,
-            () -> getRelNode("source=objlogs | eval s = cast(tags as int)"));
-    assertEquals("Cannot cast a value of type ARRAY to INT", e.getMessage());
+            () -> getRelNode("source=app_logs | eval s = cast(tags as int)"));
+    assertEquals("Cannot cast an array to INT", e.getMessage());
   }
 
   @Test
   public void castScalarFieldStillWorks() {
-    verifyResultCount(getRelNode("source=objlogs | eval s = cast(body as int) | fields s"), 2);
+    verifyResultCount(getRelNode("source=app_logs | eval s = cast(message as int) | fields s"), 2);
   }
 
-  /** limit=0 skips the top-N pivot, so the split field is never coerced to a string. */
+  /**
+   * limit=0 skips the top-N pivot, so the split field is never coerced to a string. The quoted
+   * column name is a pre-existing chart naming quirk, unrelated to this guard.
+   */
   @Test
   public void chartWithoutLimitKeepsObjectField() {
     verifyLogical(
-        getRelNode("source=objlogs | chart limit=0 count() over body by cluster"),
+        getRelNode("source=app_logs | chart limit=0 count() over message by `dimensions.pod`"),
         "LogicalSort(sort0=[$0], dir0=[ASC])\n"
             + "  LogicalAggregate(group=[{0, 1}], count()=[COUNT()])\n"
-            + "    LogicalProject(body=[$1], cluster=[$2])\n"
+            + "    LogicalProject(message=[$1], `dimensions.pod`=[$2])\n"
             + "      LogicalFilter(condition=[IS NOT NULL($1)])\n"
-            + "        LogicalTableScan(table=[[scott, objlogs]])\n");
+            + "        LogicalTableScan(table=[[scott, app_logs]])\n");
   }
 
   @RequiredArgsConstructor
@@ -143,10 +155,10 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
                 .builder()
                 .add("@timestamp", SqlTypeName.TIMESTAMP)
                 .nullable(true)
-                .add("body", SqlTypeName.VARCHAR)
+                .add("message", SqlTypeName.VARCHAR)
                 .nullable(true)
                 .add(
-                    "cluster",
+                    "dimensions.pod",
                     factory.createTypeWithNullability(
                         factory.createMapType(
                             factory.createSqlType(SqlTypeName.VARCHAR),

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java
@@ -101,10 +101,7 @@ public class CalcitePPLNonScalarCoercionTest extends CalcitePPLAbstractTest {
             () -> getRelNode("source=app_logs | chart count() over message by tags"));
     assertTrue(
         e.getMessage(),
-        e.getMessage()
-            .equals(
-                "Cannot chart by [tags] because it holds multiple values. Use a field with a single"
-                    + " value instead."));
+        e.getMessage().equals("Cannot chart by [tags] because it holds multiple values."));
   }
 
   @Test


### PR DESCRIPTION
### Description

`timechart span=1m count() by <object field>` returns a 500 whose message is a multi-kilobyte `RelNode` dump; the real cause, visible only in the response `details`, is `Cannot cast "java.util.Map" to "java.lang.String"`.

`timechart` desugars to `chart`, which pivots the column split into series names and compares them to the `otherstr`/`nullstr` literals, so the split key must be a string. `visitChart` guards that coercion with `isCharacter` — "is it already a string?" — but not `isAtomic` — "can it become one?". An OpenSearch `object` field is `ExprCoreType.STRUCT`, which converts to Calcite `MAP(VARCHAR, ANY)`, so it falls into the cast. `RexBuilder.makeCast` builds the `SAFE_CAST` without operand type checking, planning succeeds, and Enumerable codegen then emits a bare `(String) input_value0` over a `java.util.Map`, which Janino rejects as provably impossible. Array split fields fail the same way, and `visitCast` has the same unchecked `makeCast`, so `cast(<object field> as string)` 500s identically.

This guards both sites and fails the query as a client error instead:

- `CalciteRelNodeVisitor.visitChart` — reject a non-`isAtomic` split field.
- `CalciteRexNodeVisitor.visitCast` — reject `MAP`/`ARRAY`/`ROW` operands.

Both mirror `visitXyseries`, which already rejects a non-atomic y-name-field before casting it. `IllegalArgumentException` maps to 400 through `RestPPLQueryAction.isClientError`.

**Before**

```
"reason": "Error while preparing plan [LogicalSystemLimit(sort0=[$0], sort1=[$1], ... 20 more lines ...]"
"details": "Line 64, Column 37: Cannot cast \"java.util.Map\" to \"java.lang.String\""
"status": 500
```

**After**

```
"reason": "Cannot split by field [dimensions.pod] of type STRUCT: a chart split field must be
           a scalar type. Use a scalar field instead, such as a sub-field of an object."
"status": 400
```

Behaviour on an object field, measured on a live cluster before and after:

| Query | Before | After |
| --- | --- | --- |
| `timechart span=1m count() by dimensions.pod` | 500 (plan dump) | **400** with the message above |
| `chart count() over message by dimensions.pod` | 500 (plan dump) | **400** |
| `eval p = cast(dimensions.pod as string)` | 500 (plan dump) | **400** `Cannot cast a value of type STRUCT to STRING` |
| `timechart span=1m count() by dimensions.pod.name` (scalar leaf) | 200, correct split | 200, unchanged |
| `timechart span=1m limit=0 count() by dimensions.pod` | 200 (returns before the coercion block) | 200, unchanged |
| `stats count() by dimensions.pod` | 200 (no coercion) | 200, unchanged |
| `xyseries message dimensions.pod count()` | 400 (already guarded) | 400, unchanged |

Scalar split fields (numeric, boolean, date, ip) stay `isAtomic` and keep their working cast, so no existing behaviour changes.

Out of scope, noted in the issue: when a wildcard spans indices that disagree on whether a path is an object or a scalar, the merged type is decided by `LatestRule` (last-write-wins over mapping iteration order), so such a field may resolve either way across requests. A deterministic object-vs-scalar merge rule belongs with #5610 and is the schema-type counterpart to #5685.

### Related Issues
Resolves #5750

### Testing

- `ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLNonScalarCoercionTest.java` — 7 cases: chart, timechart and cast rejected for MAP and ARRAY split fields; scalar cast and the `limit=0` plan shape unchanged. All 7 fail on `main` without the guards.
- `integ-test/src/yamlRestTest/resources/rest-api-spec/test/ppl/non_scalar_coercion.yml` — 4 cases over HTTP against a real object mapping: 400 for timechart, chart and cast, and a scalar sub-field split still returning rows.

| Suite | Result |
| --- | --- |
| `:core:test` + `:ppl:test` + all module unit tests (`./gradlew test`) | pass |
| `:integ-test:yamlRestTest -Dtests.rest.suite=ppl/non_scalar_coercion` | 4/4 pass |
| `CalciteChartCommandIT`, `CalciteBinChartNullIT` | 17/17 pass |
| `CalciteTimechartCommandIT`, `CalciteTimechartPerFunctionIT` | 31/31 pass |
| `CalcitePPLCastFunctionIT`, `CastFunctionIT` | 37/37 pass |
| `*Json*IT`, `*Spath*IT`, `*Sort*IT`, `*Nested*IT` | pass |

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
