### PR TITLE
Force snakeyaml_engine version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,7 @@ allprojects {
         resolutionStrategy.force 'org.apache.commons:commons-text:1.11.0'
         resolutionStrategy.force 'commons-io:commons-io:2.15.0'
         resolutionStrategy.force 'org.yaml:snakeyaml:2.2'
+        resolutionStrategy.force "org.snakeyaml:snakeyaml-engine:${versions.snakeyaml_engine}"
         // Align Calcite 1.42.0's bumped transitive deps under strict conflict resolution
         resolutionStrategy.force 'com.jayway.jsonpath:json-path:2.10.0'
         resolutionStrategy.force 'org.jooq:joou-java-6:0.9.5'


### PR DESCRIPTION
### Description
Fixes

```
[0](https://github.com/opensearch-project/sql/actions/runs/34537191302/job/103071491521#step:6:391)
   > Could not resolve org.snakeyaml:snakeyaml-engine:3.1.1.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
     Required by:
         project ':opensearch-sql-plugin' > project :ppl > project :core
         project ':opensearch-sql-plugin' > org.opensearch:opensearch:3.9.0-SNAPSHOT:20260910.203459-124 > org.opensearch:opensearch-x-content:3.9.0-SNAPSHOT:20260910.203459-124
      > Conflict found for module 'org.snakeyaml:snakeyaml-engine': between versions 3.1.1 and 3.0.1
> There is 1 more failure with an identical cause.
```

### Related Issues
See please https://build.ci.opensearch.org/job/distribution-build-opensearch/12192

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
